### PR TITLE
Updated MEF load process to generate better debugging messages and bette...

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/web/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -107,6 +107,7 @@ public class Importer {
 
 			public void handleMetadataFiles(File[] Files, int index)
 					throws Exception {
+                String lastUnknownMetadataFolderName=null;
                 if(Log.isDebugEnabled(Geonet.MEF))
                     Log.debug(Geonet.MEF, "Multiple metadata files");
 
@@ -128,7 +129,7 @@ public class Importer {
                             if (metadataSchema.equals(preferredSchema)) {
                                 if(Log.isDebugEnabled(Geonet.MEF)) {
                                     Log.debug(Geonet.MEF, "Found metadata file "
-                                        + file.getName()
+                                        + file.getParentFile().getParentFile().getName() + File.separator + file.getParentFile().getName() + File.separator + file.getName()
                                         + " with preferred schema ("
                                         + preferredSchema + ").");
                                 }
@@ -138,12 +139,18 @@ public class Importer {
                             else {
                                 if(Log.isDebugEnabled(Geonet.MEF)) {
                                     Log.debug(Geonet.MEF, "Found metadata file "
-                                        + file.getName() + " with known schema ("
+                                        + file.getParentFile().getParentFile().getName() + File.separator + file.getParentFile().getName() + File.separator + file.getName()
+                                        + " with known schema ("
                                         + metadataSchema + ").");
                                 }
                                 metadataValidForImport = metadata;
                             }
                         } catch (NoSchemaMatchesException e) {
+                            // Important folder name to identify metadata should be ../../
+                            lastUnknownMetadataFolderName=file.getParentFile().getParentFile().getName() + File.separator + file.getParentFile().getName() + File.separator;
+                            Log.debug(Geonet.MEF, "No schema match for "
+                                + lastUnknownMetadataFolderName + file.getName() 
+                                + ".");
                             continue;
                         }
                     }
@@ -156,8 +163,8 @@ public class Importer {
 							.debug(Geonet.MEF,
 									"Importing metadata with valide schema but not preferred one.");
 					handleMetadata(metadataValidForImport, index);
-                } else
-					throw new BadFormatEx("No valid metadata file found.");
+                } else 
+					throw new BadFormatEx("No valid metadata file found" + ((lastUnknownMetadataFolderName==null)?"":(" in " + lastUnknownMetadataFolderName)) + ".");
 			}
 
 			// --------------------------------------------------------------------


### PR DESCRIPTION
...r error message so that it would be easier to identify where the error is.

By better, in this case it meant adding the folder to the error message otherwise it would generally only specify "metadata.xml" which is the default filename...
