### PR TITLE
Add a startwith param on suggestion search service

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/form/OpenSearchSuggestionTextField.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/form/OpenSearchSuggestionTextField.js
@@ -73,6 +73,7 @@ GeoNetwork.form.OpenSearchSuggestionTextField = Ext.extend(Ext.form.ComboBox, {
 
     defaultConfig: {
         hideLabel: true,
+        startwith: false,
         width: 400,
         minChars: 2,
         loadingText: '...',
@@ -102,6 +103,9 @@ GeoNetwork.form.OpenSearchSuggestionTextField = Ext.extend(Ext.form.ComboBox, {
      *
      */
     fieldLabel: undefined,
+    
+    /** boolean tell if the suggestion have to startwith the requested word or can just contain the queryparam **/
+    startwith: undefined,
     
     displayField: 'value',
     
@@ -151,7 +155,8 @@ GeoNetwork.form.OpenSearchSuggestionTextField = Ext.extend(Ext.form.ComboBox, {
             url: this.url,
             rootId: 1,
             baseParams: {
-                field: this.field
+                field: this.field,
+                startwith: this.startwith
             }
         });
     }

--- a/web/src/main/java/org/fao/geonet/services/main/SearchSuggestion.java
+++ b/web/src/main/java/org/fao/geonet/services/main/SearchSuggestion.java
@@ -119,17 +119,19 @@ public class SearchSuggestion implements Service {
 		// The minimum frequency for a term value to be proposed in suggestion -
 		// only apply while searching terms
 		int threshold = Util.getParam(params, "threshold", _threshold);
+		
+		// if true, return only the matching suggestions which start with q
+		boolean onlyStartWith = Util.getParam(params, "startwith", false);
 
 		if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE)) {
 			Log.debug(Geonet.SEARCH_ENGINE, "Autocomplete on field: '"
 					+ fieldName + "'" + "\tsearching: '" + searchValue + "'"
 					+ "\tthreshold: '" + threshold + "'"
 					+ "\tmaxNumberOfTerms: '" + maxNumberOfTerms + "'"
+					+ "\tstartwith: '" + onlyStartWith + "'"
 					+ "\tfrom: '" + origin + "'"
 					);
 		}
-
-
 
 		GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
 		SearchManager sm = gc.getSearchmanager();
@@ -168,6 +170,14 @@ public class SearchSuggestion implements Service {
 				listOfSuggestions.add(freq.getTerm());
 				// Term frequency not returned :
 				// String.valueOf(freq.getFrequency());
+			}
+		}
+		
+		if(onlyStartWith && !searchValue.trim().isEmpty()) {
+			Iterator<String> it = listOfSuggestions.iterator();
+			while( it.hasNext() ) {
+			  String suggest = it.next();
+			  if(!suggest.startsWith(searchValue)) it.remove();
 			}
 		}
 		


### PR DESCRIPTION
http://trac.osgeo.org/geonetwork/ticket/1148
## 

 http://localhost:8080/geonetwork/srv/fre/main.search.suggest?field=any&startwith=true&q=cor

if startwith=true, then main.search.suggest will return only suggestions that startwith the q param

OpenSearchSuggestionTextField? UI class will now take the param startwith (by default false) to active or not this feature.
