### PR TITLE
Add OL style.css for minified js

### DIFF
--- a/web-client/src/main/resources/apps/search/index.html
+++ b/web-client/src/main/resources/apps/search/index.html
@@ -11,6 +11,7 @@
       <link rel="stylesheet" type="text/css" href="../js/ext/resources/css/ext-all.css"/>
       <link rel="stylesheet" type="text/css" href="../js/ext/resources/css/xtheme-gray.css"/>
       <link rel="stylesheet" type="text/css" href="../js/ext-ux/css/ext-ux.css"/>
+      <link rel="stylesheet" type="text/css" href="../js/OpenLayers/theme/default/style.css"/>
       <link rel="stylesheet" type="text/css" href="../css/geonetwork.css"/>
   </head>
   <body>

--- a/web-client/src/main/resources/apps/search/index_debug.html
+++ b/web-client/src/main/resources/apps/search/index_debug.html
@@ -20,6 +20,7 @@
     <link rel="stylesheet" type="text/css" href="../js/ext-ux/LightBox/lightbox.css"/>
     <link rel="stylesheet" type="text/css" href="../js/ext-ux/FileUploadField/file-upload.css"/>
     <link rel="stylesheet" type="text/css" href="../js/ext-ux/MultiselectItemSelector-3.0/Multiselect.css"/>
+    <link rel="stylesheet" type="text/css" href="../js/OpenLayers/theme/default/style.css"/>
     <link rel="stylesheet" type="text/css" href="../css/gndefault.css"/>
     <link rel="stylesheet" type="text/css" href="../css/gnmapdefault.css"/>
     <link rel="stylesheet" type="text/css" href="../css/gnmetadatadefault.css"/>

--- a/web-client/src/main/resources/apps/search/js/map/Settings.js
+++ b/web-client/src/main/resources/apps/search/js/map/Settings.js
@@ -57,12 +57,14 @@ GeoNetwork.map.MAP_OPTIONS = {
     maxExtent: GeoNetwork.map.EXTENT,
     restrictedExtent: GeoNetwork.map.EXTENT,
     resolutions: GeoNetwork.map.RESOLUTIONS,
-    controls: []
+    controls: [],
+    theme:null
 };
 GeoNetwork.map.MAIN_MAP_OPTIONS = {
     projection: GeoNetwork.map.PROJECTION,
     maxExtent: GeoNetwork.map.EXTENT,
     restrictedExtent: GeoNetwork.map.EXTENT,
     resolutions: GeoNetwork.map.RESOLUTIONS,
-    controls: []
+    controls: [],
+    theme:null
 };

--- a/web-client/src/main/resources/apps/tabsearch/index.html
+++ b/web-client/src/main/resources/apps/tabsearch/index.html
@@ -21,6 +21,7 @@
     <link rel="stylesheet" type="text/css" href="css/gndefault.css"/>
     <link rel="stylesheet" type="text/css" href="css/gnmapdefault.css"/>
     <link rel="stylesheet" type="text/css" href="css/gnmetadatadefault.css"/>
+    <link rel="stylesheet" type="text/css" href="../js/OpenLayers/theme/default/style.css"/>
     <link rel="stylesheet" type="text/css" href="../css/metadata-view.css"/>
 
     <style>

--- a/web-client/src/main/resources/apps/tabsearch/index_debug.html
+++ b/web-client/src/main/resources/apps/tabsearch/index_debug.html
@@ -20,6 +20,7 @@
     <link rel="stylesheet" type="text/css" href="../js/ext-ux/MultiselectItemSelector-3.0/Multiselect.css"/>
     <link rel="stylesheet" type="text/css" href="css/gndefault.css"/>
     <link rel="stylesheet" type="text/css" href="css/gnmapdefault.css"/>
+    <link rel="stylesheet" type="text/css" href="../js/OpenLayers/theme/default/style.css"/>
     <link rel="stylesheet" type="text/css" href="css/gnmetadatadefault.css"/>
     <link rel="stylesheet" type="text/css" href="../css/metadata-view.css"/>
 

--- a/web-client/src/main/resources/apps/tabsearch/js/map/Settings.js
+++ b/web-client/src/main/resources/apps/tabsearch/js/map/Settings.js
@@ -54,11 +54,13 @@ GeoNetwork.map.MAP_OPTIONS = {
     projection: GeoNetwork.map.PROJECTION,
     maxExtent: GeoNetwork.map.EXTENT,
     restrictedExtent: GeoNetwork.map.EXTENT,
-    controls: []
+    controls: [],
+    theme:null
 };
 GeoNetwork.map.MAIN_MAP_OPTIONS = {
     projection: GeoNetwork.map.PROJECTION,
     maxExtent: GeoNetwork.map.EXTENT,
     restrictedExtent: GeoNetwork.map.EXTENT,
-    controls: []
+    controls: [],
+    theme:null
 };


### PR DESCRIPTION
OL will search for OpenLayers.js to get relative path to style.css.
On modified mode, OpenLayers.js does not exist so the css can't be found.

Here we put manually the css link and say to the map object theme:null
