### PR TITLE
Dont add the last link menu if it's empty (#1226)

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/MetadataResultsView.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/MetadataResultsView.js
@@ -622,7 +622,7 @@ GeoNetwork.MetadataResultsView = Ext.extend(Ext.DataView, {
                         
                     });
                     // Add the latest button
-                    if (linkButton !== null) {
+                    if (linkButton !== null && linkButton.length !== 0) {
                         view.addLinkMenu(linkButton, label, currentType, el);
                     }
                     


### PR DESCRIPTION
In ticket #1107 the display of wms/download links was reworked - the way it is now in master, if you have a metadata with WMS or download links, the code in MetadataResultsView?.js:displayLinks() will create a linkButton object regardless of allowDynamic/allowDownload and add it to the view - thus if you dont have rights to view in interactive map/download, an empty extjs menu will be created & added to the view but not populated.

This is probably because the latest linkButton is added in line 619 if it is not null while the length of the array should also be checked like its done on line 572.
