### PR TITLE
Send the metadataAbstract when publishing a layer to GeoServer (#1232)

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/EditorPanel.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/EditorPanel.js
@@ -298,7 +298,7 @@ GeoNetwork.editor.EditorPanel = Ext.extend(Ext.Panel, {
      *  :param  extent: ``String`` Initial map extent.
      *
      */
-    showGeoPublisherPanel: function(id, uuid, title, name, accessStatus, nodeName, insertNodeRef, extent){
+    showGeoPublisherPanel: function(id, uuid, title, mdabstract, name, accessStatus, nodeName, insertNodeRef, extent){
         //Ext.QuickTips.init();
         var editorPanel = this;
         
@@ -362,7 +362,7 @@ GeoNetwork.editor.EditorPanel = Ext.extend(Ext.Panel, {
                 iconCls: 'repository'
             });
         }
-        this.geoPublisherWindow.items.get(0).setRef(id, uuid, title, name, accessStatus);
+        this.geoPublisherWindow.items.get(0).setRef(id, uuid, title, mdabstract, name, accessStatus);
         this.geoPublisherWindow.setTitle(OpenLayers.i18n('geoPublisherWindowTitle') + " " + name);
         this.geoPublisherWindow.show();
         

--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/GeoPublisherPanel.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/GeoPublisherPanel.js
@@ -78,6 +78,11 @@ GeoNetwork.editor.GeoPublisherPanel = Ext.extend(Ext.form.FormPanel, {
      */
     metadataTitle: null,
     
+    /** api: property[metadataAbstract] 
+     *  ``String`` Metadata abstract to be added to mapserver configuration
+     */
+    metadataAbstract: null,
+    
     /** api: property[fileName] 
      *  ``String`` The resource name to publish (file or db url)
      */
@@ -228,6 +233,7 @@ GeoNetwork.editor.GeoPublisherPanel = Ext.extend(Ext.form.FormPanel, {
                         metadataId: this.metadataId,
                         metadataUuid: this.metadataUuid,
                         metadataTitle: this.metadataTitle,
+                        metadataAbstract: this.metadataAbstract,
                         nodeId: this.nodeId,
                         file: this.fileName,
                         access: this.accessStatus,
@@ -563,10 +569,11 @@ GeoNetwork.editor.GeoPublisherPanel = Ext.extend(Ext.form.FormPanel, {
      *  Set the element reference : metadata
      *  identifier and file name.
      */
-    setRef: function(id, uuid, title, fileName, accessStatus){
+    setRef: function(id, uuid, title, mdabstract, fileName, accessStatus){
         this.metadataId = id;
         this.metadataUuid = uuid;
         this.metadataTitle = title;
+        this.metadataAbstract = mdabstract;
         this.fileName = fileName;
         this.accessStatus = accessStatus;
         if (this.fileName.indexOf('jdbc') !== -1) {

--- a/web/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/web/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -181,7 +181,7 @@ public class GeoServerRest {
 	 * @return
 	 * @throws IOException
 	 */
-	public boolean createCoverage(String ws, String cs, File f, String metadataUuid, String metadataTitle)
+	public boolean createCoverage(String ws, String cs, File f, String metadataUuid, String metadataTitle, String metadataAbstract)
 			throws IOException {
 		String contentType = "image/tiff";
 		if (f.getName().toLowerCase().endsWith(".zip")) {
@@ -191,7 +191,7 @@ public class GeoServerRest {
 				+ "/coveragestores/" + cs + "/file.geotiff", null, f,
 				contentType, false);
 		
-		createCoverageForStore(ws, cs, null, metadataUuid, metadataTitle);
+		createCoverageForStore(ws, cs, null, metadataUuid, metadataTitle, metadataAbstract);
 		
 		return status == 201;
 	}
@@ -205,7 +205,7 @@ public class GeoServerRest {
 	 * @return
 	 * @throws IOException
 	 */
-	public boolean createCoverage(String ws, String cs, String file, String metadataUuid, String metadataTitle)
+	public boolean createCoverage(String ws, String cs, String file, String metadataUuid, String metadataTitle, String metadataAbstract)
 			throws IOException {
 		String contentType = "image/tiff";
 		String extension = "geotiff";
@@ -231,12 +231,12 @@ public class GeoServerRest {
 				+ "/coveragestores/" + cs + "/" + type + "." + extension, file,
 				null, contentType, false);
 		
-		createCoverageForStore(ws, cs, file, metadataUuid, metadataTitle);
+		createCoverageForStore(ws, cs, file, metadataUuid, metadataTitle, metadataAbstract);
 		return status == 201;
 	}
 
 	private void createCoverageForStore(String ws, String cs, String file,
-			String metadataUuid, String metadataTitle)
+			String metadataUuid, String metadataTitle, String metadataAbstract)
 			throws IOException {
 		String xml = "<coverageStore><name>" + cs + "</name><title>"
 			+ (metadataTitle != null ? metadataTitle : cs)
@@ -271,9 +271,9 @@ public class GeoServerRest {
 	 * @return
 	 * @throws IOException
 	 */
-	public boolean createCoverage(String cs, File f, String metadataUuid, String metadataTitle) throws IOException {
+	public boolean createCoverage(String cs, File f, String metadataUuid, String metadataTitle, String metadataAbstract) throws IOException {
 		// TODO : check default workspace is not null ?
-		return createCoverage(getDefaultWorkspace(), cs, f, metadataUuid, metadataTitle);
+		return createCoverage(getDefaultWorkspace(), cs, f, metadataUuid, metadataTitle, metadataAbstract);
 	}
 
 	/**
@@ -286,8 +286,8 @@ public class GeoServerRest {
 	 * @return
 	 * @throws IOException
 	 */
-	public boolean createCoverage(String cs, String f, String metadataUuid, String metadataTitle) throws IOException {
-		return createCoverage(getDefaultWorkspace(), cs, f, metadataUuid, metadataTitle);
+	public boolean createCoverage(String cs, String f, String metadataUuid, String metadataTitle, String metadataAbstract) throws IOException {
+		return createCoverage(getDefaultWorkspace(), cs, f, metadataUuid, metadataTitle, metadataAbstract);
 	}
 
 	/**
@@ -298,9 +298,9 @@ public class GeoServerRest {
 	 * @return
 	 * @throws IOException
 	 */
-	public boolean updateCoverage(String ws, String ds, File f, String metadataUuid, String metadataTitle)
+	public boolean updateCoverage(String ws, String ds, File f, String metadataUuid, String metadataTitle, String metadataAbstract)
 			throws IOException {
-		return createCoverage(ws, ds, f, metadataUuid, metadataTitle);
+		return createCoverage(ws, ds, f, metadataUuid, metadataTitle, metadataAbstract);
 	}
 
 	/**
@@ -310,8 +310,8 @@ public class GeoServerRest {
 	 * @return
 	 * @throws IOException
 	 */
-	public boolean updateCoverage(String ds, File f, String metadataUuid, String metadataTitle) throws IOException {
-		return createCoverage(getDefaultWorkspace(), ds, f, metadataUuid, metadataTitle);
+	public boolean updateCoverage(String ds, File f, String metadataUuid, String metadataTitle, String metadataAbstract) throws IOException {
+		return createCoverage(getDefaultWorkspace(), ds, f, metadataUuid, metadataTitle, metadataAbstract);
 	}
 
 	/**
@@ -547,13 +547,13 @@ public class GeoServerRest {
 	}
 
 	public boolean createFeatureType(String ds, String ft, boolean createStyle,
-			String metadataUuid, String metadataTitle) throws IOException {
+			String metadataUuid, String metadataTitle, String metadataAbstract) throws IOException {
 		return createFeatureType(getDefaultWorkspace(), ds, ft, createStyle,
-				metadataUuid, metadataTitle);
+				metadataUuid, metadataTitle, metadataAbstract);
 	}
 
 	public boolean createFeatureType(String ws, String ds, String ft,
-			boolean createStyle, String metadataUuid, String metadataTitle)
+			boolean createStyle, String metadataUuid, String metadataTitle, String metadataAbstract)
 			throws IOException {
 		String xml = "<featureType><name>" + ft + "</name><title>" + ft
 				+ "</title>" + "</featureType>";
@@ -564,7 +564,9 @@ public class GeoServerRest {
 
 		xml = "<featureType><title>"
 				+ (metadataTitle != null ? metadataTitle : ft)
-				+ "</title><enabled>true</enabled>" 
+				+ "</title><abstract>"
+				+ (metadataAbstract != null ? metadataAbstract : ft)
+				+ "</abstract><enabled>true</enabled>" 
 				+ "<metadataLinks>"
 					+ "<metadataLink>" 
 						+ "<type>text/xml</type>"

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/metadata-edit.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/metadata-edit.xsl
@@ -2968,10 +2968,15 @@
         <xsl:apply-templates mode="escapeXMLEntities" select="/root/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString"/>
       </xsl:variable>
     
+      <xsl:variable name="abstract">
+        <xsl:apply-templates mode="escapeXMLEntities" select="/root/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:abstract/gco:CharacterString"/>
+      </xsl:variable>
+    
       <button type="button" class="content repository" 
         onclick="javascript:Ext.getCmp('editorPanel').showGeoPublisherPanel('{/root/*/geonet:info/id}',
         '{/root/*/geonet:info/uuid}', 
         '{$title}',
+        '{$abstract}',
         '{$layer}', 
         '{$access}', 'gmd:onLine', '{ancestor::gmd:MD_DigitalTransferOptions/geonet:element/@ref}', [{$bbox}]);" 
         alt="{/root/gui/strings/publishHelp}" 


### PR DESCRIPTION
A bit more invasive change : lets push the metadataAbstract to geoserver's abstract when geopublishing.
