### PR TITLE
Minimum height for pupular and latest metadata, so it is visible at all times

### DIFF
--- a/web-client/src/main/resources/apps/html5ui/css/main.css
+++ b/web-client/src/main/resources/apps/html5ui/css/main.css
@@ -1542,6 +1542,11 @@ ul li.tag-cloud a {
 #latest-metadata header h1 span,#popular-metadata header h1 span{
 	padding:12px;
 	background: white;
+	min-height: 20px;
+}
+
+#latest-metadata, #popular-metadata {
+	min-height: 100px;
 }
 
 #latest-metadata input {


### PR DESCRIPTION
fixes  #104
