### PR TITLE
Administration / Import / Restore the capability to load subtemplates.

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/schema-ident.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/schema-ident.xml
@@ -7,6 +7,8 @@
 	<autodetect xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
 		<elements type="root">
 			<gmd:MD_Metadata/>
+			<!-- Identify responsible party subtemplate as ISO19139 -->
+			<gmd:CI_ResponsibleParty/>
 		</elements>
 	</autodetect>
 </schema>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/set-uuid.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/set-uuid.xsl
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
-						xmlns:gco="http://www.isotc211.org/2005/gco"
-						xmlns:gmd="http://www.isotc211.org/2005/gmd" exclude-result-prefixes="gmd">
-
+	xmlns:gco="http://www.isotc211.org/2005/gco"
+	xmlns:gmd="http://www.isotc211.org/2005/gmd" exclude-result-prefixes="gmd">
+	
 	<!-- ================================================================= -->
 	
 	<xsl:template match="/root">
-		 <xsl:apply-templates select="gmd:MD_Metadata"/>
+		<xsl:apply-templates select="*[name() != 'env']"/>
 	</xsl:template>
-
+	
 	<!-- ================================================================= -->
 	
 	<xsl:template match="gmd:MD_Metadata">
-		 <xsl:copy>
-		 		<xsl:copy-of select="@*"/>
-	 			<gmd:fileIdentifier>
-					<gco:CharacterString><xsl:value-of select="/root/env/uuid"/></gco:CharacterString>
-				</gmd:fileIdentifier>
-			  <xsl:apply-templates select="node()"/>
-		 </xsl:copy>
+		<xsl:copy>
+			<xsl:copy-of select="@*"/>
+			<gmd:fileIdentifier>
+				<gco:CharacterString><xsl:value-of select="/root/env/uuid"/></gco:CharacterString>
+			</gmd:fileIdentifier>
+			<xsl:apply-templates select="node()"/>
+		</xsl:copy>
 	</xsl:template>
-
+	
 	<!-- ================================================================= -->
 	
 	<xsl:template match="gmd:fileIdentifier"/>
@@ -29,11 +29,11 @@
 	<!-- ================================================================= -->
 	
 	<xsl:template match="@*|node()">
-		 <xsl:copy>
-			  <xsl:apply-templates select="@*|node()"/>
-		 </xsl:copy>
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"/>
+		</xsl:copy>
 	</xsl:template>
-
+	
 	<!-- ================================================================= -->
-
+	
 </xsl:stylesheet>

--- a/web/src/main/webapp/xsl/metadata-batchimport.xsl
+++ b/web/src/main/webapp/xsl/metadata-batchimport.xsl
@@ -4,6 +4,18 @@
 	<xsl:include href="main.xsl"/>
 	<xsl:include href="metadata-insert-form-utils.xsl"/>
 	
+	<xsl:template mode="script" match="/">
+		<script type="text/javascript" language="JavaScript">
+			
+			function fileTypeXML(isXml) {
+				if (isXml) {
+					Element.show('gn.type');
+				} else {
+					Element.hide('gn.type');
+				}
+			}
+		</script>
+	</xsl:template>
 	<!--
 	page content
 	-->
@@ -39,11 +51,11 @@
 							<tr>
 								<td class="padded">
 									<label for="singleFile"><xsl:value-of select="/root/gui/strings/singleFile"/></label>
-									<input type="radio" id="singleFile" name="file_type" value="single" checked="true"/>
+									<input type="radio" id="singleFile" onclick="fileTypeXML(this.checked)" name="file_type" value="single" checked="true"/>
 								</td>
 								<td class="padded">
 									<label for="mefFile"><xsl:value-of select="/root/gui/strings/mefFile"/></label>
-									<input type="radio" id="mefFile" name="file_type" value="mef"/>
+									<input type="radio" id="mefFile" onclick="fileTypeXML(!this.checked)" name="file_type" value="mef"/>
 								</td>
 							</tr>
 						</table>

--- a/web/src/main/webapp/xsl/metadata-insert-form-utils.xsl
+++ b/web/src/main/webapp/xsl/metadata-insert-form-utils.xsl
@@ -89,7 +89,22 @@
                 <input class="content" type="checkbox" name="assign" id="assign"/>
             </td>
         </tr>
-
+        
+        <tr id="gn.type">
+            <th class="padded">
+                <label for="isTemplate">
+                    <xsl:value-of select="/root/gui/strings/kind"/>
+                </label>
+            </th>
+            <td>
+                <select class="content" name="template" size="1" id="metadata.type">
+                    <option value="n" selected="selected"><xsl:value-of select="/root/gui/strings/metadata"/></option>
+                    <option value="y"><xsl:value-of select="/root/gui/strings/template"/></option>
+                    <option value="s"><xsl:value-of select="/root/gui/strings/subtemplate"/></option>
+                </select>
+            </td>
+        </tr>
+        
 
         <!-- groups -->
         <tr id="gn.groups">

--- a/web/src/main/webapp/xsl/metadata-insert-form.xsl
+++ b/web/src/main/webapp/xsl/metadata-insert-form.xsl
@@ -12,18 +12,10 @@
 			function init() {
 				var modeValue = getModeValue();
                 
-                typeChanged();
                 insertMode(modeValue);
                 
                 if (modeValue == 1)
                     updateForm();
-			}
-
-			function typeChanged() {
-				var type = $F('metadata.type');
-
-				if (type == 's')	Element.show('metadata.title');
-					else			Element.hide('metadata.title');
 			}
 			
 			function getModeValue() {
@@ -55,6 +47,7 @@
                 if (value == 0) {
                     Element.hide('gn.fileUp');
                     Element.show('gn.xmlUp');
+                    Element.show('gn.type');
                     $('gn.fileType').style.display='none';
                     document.xmlinsert.enctype="application/x-www-form-urlencoded";
 					document.xmlinsert.encoding="application/x-www-form-urlencoded";
@@ -63,6 +56,7 @@
                 } else {
                     Element.hide('gn.xmlUp');
                     Element.show('gn.fileUp');
+                    Element.hide('gn.type');
                     $('gn.fileType').style.display='';
                     document.xmlinsert.enctype="multipart/form-data";
 					document.xmlinsert.encoding="multipart/form-data";
@@ -233,25 +227,6 @@
                                 </span>
                             </td>
                         </tr>
-						
-						<!-- type -->
-						<tr id="gn.type">
-							<th class="padded" valign="top"><xsl:value-of select="/root/gui/strings/type"/></th>
-							<td>
-								<select class="content" name="template" size="1" id="metadata.type" onchange="typeChanged()">
-									<option value="n"><xsl:value-of select="/root/gui/strings/metadata"/></option>
-									<option value="y"><xsl:value-of select="/root/gui/strings/template"/></option>
-									<!-- <option value="s"><xsl:value-of select="/root/gui/strings/subtemplate"/></option> -->
-								</select>
-								<div id="metadata.title">
-									<xsl:text>&#160;</xsl:text>
-									<xsl:value-of select="/root/gui/strings/subtemplateTitle"/>
-									<xsl:text>&#160;</xsl:text>
-									<input class="content" type="text" name="title"/>
-								</div>
-							</td>
-						</tr>
-
                         <xsl:call-template name="metadata-insert-common-form"/>
 
 						


### PR DESCRIPTION
- Update batch import and metadata import page in order to set the record type (metadata, template or subtemplate).
- The record type can only be set for XML records (not MEF).
- Subtemplate can only match ISO19139 schema. Only support CI_ResponsibleParty for the time being which is the main use case.
