### PR TITLE
Removing special groups from "Create new metadata" window. 

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/NewMetadataPanel.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/NewMetadataPanel.js
@@ -47,6 +47,7 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
         layout: 'anchor'
     },
     editor: undefined,
+    combo : undefined,
     getGroupUrl: undefined,
     groupStore: undefined,
     catalogue: undefined,
@@ -97,7 +98,6 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
         GeoNetwork.editor.NewMetadataPanel.superclass.initComponent.call(this);
         
         this.groupStore = GeoNetwork.data.GroupStore(this.getGroupUrl + '&profile=Editor');
-        this.groupStore.load();
         
         var cmp = [];
         
@@ -166,7 +166,7 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
             this.catalogue.search({E_template: 'y', E_hitsperpage: 150}, null, null, 1, true, this.tplStore, null);
         }
         
-        cmp.push(new Ext.form.ComboBox({
+        this.combo = new Ext.form.ComboBox({
             name: 'E_group',
             mode: 'local',
             anchor: '100%',
@@ -185,7 +185,9 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
                 },
                 scope: this
             }
-        }));
+        });
+        
+        cmp.push(this.combo);
         
         cmp.push({
                     xtype: 'textfield',
@@ -195,6 +197,28 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
                 });
         
         this.add(cmp);
+        
+        // Remove special groups and select first group in the list
+        this.groupStore.load({
+            callback: function(){
+                this.groupStore.each(function(record) {
+                    if ((record.get('id') == '-1') || (record.get('id') == '0') || (record.get('id') == '1')) {
+                        this.remove(record);
+                    }
+                },  this.groupStore);
+
+
+                if (this.groupStore.getCount() > 0) {
+                    var recordSelected = this.groupStore.getAt(0);
+                    if (recordSelected) {
+                        this.selectedGroup = recordSelected.get('id');
+                        this.combo.setValue(recordSelected.data.label[GeoNetwork.Util.getCatalogueLang(OpenLayers.Lang.getCode())]);
+                        this.validate();
+                    }
+                }
+            },
+            scope: this
+        });
         
     }
 });


### PR DESCRIPTION
This means: no all, intranet or guest groups on the combo selection group.
