### PR TITLE
Keyword / improve relation search (#147)

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/KeywordBean.java
+++ b/web/src/main/java/org/fao/geonet/kernel/KeywordBean.java
@@ -61,7 +61,6 @@ public class KeywordBean {
 	private final Map<String, String> definitions = new LinkedHashMap<String,String>();
     private IsoLanguagesMapper isoLanguageMapper;
     private String defaultLang;
-    private String broader;
 	/**
 	 * Create keyword bean with the default IsoLanguageMapper
 	 */
@@ -689,15 +688,6 @@ public class KeywordBean {
      */
     public KeywordBean removeDefinition(String lang) {
         definitions.remove(lang);
-        return this;
-    }
-
-    public String getBroaderRelationship() {
-        return broader;
-    }
-    
-    public KeywordBean setBroaderRelationship(String broader) {
-        this.broader = broader;
         return this;
     }
     

--- a/web/src/main/java/org/fao/geonet/kernel/rdf/KeywordResultInterpreter.java
+++ b/web/src/main/java/org/fao/geonet/kernel/rdf/KeywordResultInterpreter.java
@@ -47,7 +47,6 @@ class KeywordResultInterpreter extends ResultInterpreter<KeywordBean> {
             .setCoordNorth(coordNorth)
             .setCoordSouth(coordSouth)
             .setCoordWest(coordWest)
-            .setBroaderRelationship(broader)
 			.setDownloadUrl(thesaurus.getDownloadUrl())
 			.setKeywordUrl(thesaurus.getKeywordUrl());
             

--- a/web/src/main/java/org/fao/geonet/kernel/rdf/QueryBuilder.java
+++ b/web/src/main/java/org/fao/geonet/kernel/rdf/QueryBuilder.java
@@ -85,7 +85,6 @@ public class QueryBuilder<Q> {
                 .selectId()
                 .select(UPPER_CORNER, requireBoundedBy)
                 .select(LOWER_CORNER, requireBoundedBy)
-                .select(BROADER, false)
                 .interpreter(new KeywordResultInterpreter(languages));
             
         for (String lang : languages) {

--- a/web/src/main/java/org/fao/geonet/kernel/search/KeywordsSearcher.java
+++ b/web/src/main/java/org/fao/geonet/kernel/search/KeywordsSearcher.java
@@ -153,9 +153,12 @@ public class KeywordsSearcher {
      * @throws Exception hmm
      */
 	public void searchForRelated(String id, String sThesaurusName, KeywordRelation request, String... languages) throws Exception {
-	    Thesaurus thesaurus = _thesaurusFinder.getThesaurusByName(sThesaurusName);
+	    _results.clear();
+        Thesaurus thesaurus = _thesaurusFinder.getThesaurusByName(sThesaurusName);
 	    Query<KeywordBean> query = QueryBuilder.keywordQueryBuilder(_isoLanguageMapper, languages).select(Selectors.related(id,request), true).build();
-	    _results = query.execute(thesaurus);
+	    for (KeywordBean keywordBean : query.execute(thesaurus)) {
+            _results.add(keywordBean);
+        }
 	}
 
     /**

--- a/web/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSearchParamsBuilder.java
+++ b/web/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSearchParamsBuilder.java
@@ -12,6 +12,8 @@ import jeeves.utils.Util;
 
 import org.fao.geonet.kernel.KeywordBean;
 import org.fao.geonet.kernel.rdf.QueryBuilder;
+import org.fao.geonet.kernel.rdf.Selector;
+import org.fao.geonet.kernel.rdf.Selectors;
 import org.fao.geonet.kernel.rdf.Where;
 import org.fao.geonet.kernel.rdf.Wheres;
 import org.fao.geonet.languages.IsoLanguagesMapper;
@@ -30,6 +32,7 @@ public class KeywordSearchParamsBuilder {
     private int offset = -1;
     private int maxResults = -1;
     private LinkedList<SearchClause> searchClauses = new LinkedList<SearchClause>();
+    private LinkedList<Selector> selectClauses = new LinkedList<Selector>();
     private boolean lenient;
     private boolean requireBoundedBy = false;
     
@@ -208,9 +211,16 @@ public class KeywordSearchParamsBuilder {
                 where = where.or(nextClause.toWhere(langs));
             }
         }
+        
         QueryBuilder<KeywordBean> builder = QueryBuilder.keywordQueryBuilder(isoLangMapper, new ArrayList<String>(langs), requireBoundedBy)
                 .offset(offset)
                 .where(where);
+        
+        if(!selectClauses.isEmpty()) {
+            for (Selector s : selectClauses) {
+                builder.select(s, false);
+            }
+        }
         
         return builder;
     }
@@ -293,6 +303,7 @@ public class KeywordSearchParamsBuilder {
         return this;
     }
     public void relationship(String relatedId, KeywordRelation relation, KeywordSearchType searchType, boolean ignoreCase) {
+        this.selectClauses.add(Selectors.BROADER);
         this.searchClauses.add(new RelationShipClause(relation, relatedId, searchType, ignoreCase));
         
     }

--- a/web/src/main/java/org/fao/geonet/services/thesaurus/GetNarrowerBroader.java
+++ b/web/src/main/java/org/fao/geonet/services/thesaurus/GetNarrowerBroader.java
@@ -68,6 +68,7 @@ public class GetNarrowerBroader implements Service {
 		searcher = new KeywordsSearcher(thesaurusMan);
 		
 		String request = Util.getParam(params, "request");
+        String conceptId = Util.getParam(params, "id");
 		
 		if (request.equals("broader") 
 				|| request.equals("narrower")
@@ -86,9 +87,9 @@ public class GetNarrowerBroader implements Service {
 			searcher.sortResults(KeywordSort.defaultLabelSorter(SortDirection.DESC));
 			
 			// Build response
-			Element keywordType = new Element(reqType.name);
-			keywordType.addContent(searcher.getResults());
-			response.addContent(keywordType);
+			response.setAttribute("relation", request);
+            response.setAttribute("to", conceptId);
+			response.addContent(searcher.getXmlResults());
 		}else  
 			throw new Exception("unknown request type: " + request);
 			


### PR DESCRIPTION
- KeywordBean / Remove simple String broader field which could be multiple
- Regions / Category is the first broader relation found
- Fix duplicates in search results (due to broader in select clause)
- Fix search for broader/related/narrower relation types
- Fix searchForRelated which does not return List<KeywordBean> like search does
