### PR TITLE
Updated hard coded French Help link so that it will link any proper language if it exists

### DIFF
--- a/web/src/main/webapp/xsl/banner.xsl
+++ b/web/src/main/webapp/xsl/banner.xsl
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:java="java:org.fao.geonet.util.XslUtil"
                 exclude-result-prefixes="#all">
+
+    <xsl:function name="java:file-exists" xmlns:file="java.io.File" as="xs:boolean">
+      <xsl:param name="file" as="xs:string"/>
+      <xsl:sequence select="file:exists(file:new($file))"/>
+    </xsl:function>
 
     <xsl:variable name="modal" select="count(/root/gui/config/search/use-modal-box-for-banner-functions)"/>
 
@@ -91,8 +97,8 @@
                     |
                     <!-- Help section to be displayed according to GUI language -->
                     <xsl:choose>
-                        <xsl:when test="/root/gui/language='fr'">
-                            <a class="banner" href="{/root/gui/url}/docs/fra/users" target="_blank"><xsl:value-of select="/root/gui/strings/help"/></a>
+                        <xsl:when test="java:file-exists(concat(resolve-uri('../', replace(static-base-uri(), 'file:', '')), 'docs/', /root/gui/language, '/users/index.html'))">
+                            <a class="banner" href="{/root/gui/url}/docs/{/root/gui/language}/users" target="_blank"><xsl:value-of select="/root/gui/strings/help"/></a>
                         </xsl:when>
                         <xsl:otherwise>
                             <a class="banner" href="{/root/gui/url}/docs/eng/users" target="_blank"><xsl:value-of select="/root/gui/strings/help"/></a>


### PR DESCRIPTION
Francois,

This change fixes an issue where the French help link was not working due to 2 errors. One it was looking for "fr"  and it was also looking for the non standard "fra" (should be "fre")

While fixing the bug I updated it so that it will work with any language that contains the file "docs/{current lang}/users/index.html".  This means that "fra" as a language is no longer acceptable and will have to be changed to "fre".

It would be nice to change "docs/fra" to "docs/fre" but I'm not sure if that will cause any issues. So for now I simply use the following in web/pom.xml

```
 <resource>
          <directory>../docs/fra/users/build/html</directory>
          <targetPath>docs/fre/users</targetPath>
   </resource> 
```

You may want to test this patch to make sure it does not affect any of your existing applications.

Thank you
