### PR TITLE
Fix for Issue #158 

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/web/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -2366,52 +2366,52 @@ public class DataManager {
      * @throws Exception
      */
     public void setOperation(ServiceContext context, Dbms dbms, int mdId, int grpId, int opId) throws Exception {
-        // Check user privileges
-        // Session may not be defined when a harvester is running
-        if (context.getUserSession() != null) {
-            String userProfile = context.getUserSession().getProfile();
-            if (! (userProfile.equals(Geonet.Profile.ADMINISTRATOR) || userProfile.equals(Geonet.Profile.USER_ADMIN)) ) {
-                int userId = Integer.parseInt(context.getUserSession()
-                        .getUserId());
-                // Reserved groups
-                if (grpId <= 1) {
-                    // If user is reviewer, user can change operation for groups
-                    // -1, 0, 1
-                    String isReviewerQuery = "SELECT groupId FROM UserGroups WHERE userId=? AND profile=?";
-                    Element isReviewerRes = dbms.select(isReviewerQuery,
-                            userId, Geonet.Profile.REVIEWER);
-                    if (isReviewerRes.getChildren().size() == 0) {
-                        throw new ServiceNotAllowedEx(
-                                "User can't set operation for group "
-                                        + grpId
-                                        + " because the user in not a Reviewer of any group.");
-                    }
-                } else {
-
-                    GeonetContext gc = (GeonetContext) context
-                            .getHandlerContext(Geonet.CONTEXT_NAME);
-                    String userGroupsOnly = settingMan
-                            .getValue("system/metadataprivs/usergrouponly");
-                    if (userGroupsOnly.equals("true")) {
-                        // If user is member of the group, user can set
-                        // operation
-                        String isMemberQuery = "SELECT groupId FROM UserGroups WHERE groupId=? AND userId=?";
-                        Element isMemberRes = dbms.select(isMemberQuery, grpId,
-                                userId);
-                        if (isMemberRes.getChildren().size() == 0) {
+        String query = "SELECT metadataId FROM OperationAllowed WHERE metadataId=? AND groupId=? AND operationId=?";
+        Element elRes = dbms.select(query, mdId, grpId, opId);
+        if (elRes.getChildren().size() == 0) {   
+            // Check user privileges
+            // Session may not be defined when a harvester is running
+            if (context.getUserSession() != null) {
+                String userProfile = context.getUserSession().getProfile();
+                if (! (userProfile.equals(Geonet.Profile.ADMINISTRATOR) || userProfile.equals(Geonet.Profile.USER_ADMIN)) ) {
+                    int userId = Integer.parseInt(context.getUserSession()
+                            .getUserId());
+                    // Reserved groups
+                    if (grpId <= 1) {
+                        // If user is reviewer, user can change operation for groups
+                        // -1, 0, 1
+                        String isReviewerQuery = "SELECT groupId FROM UserGroups WHERE userId=? AND profile=?";
+                        Element isReviewerRes = dbms.select(isReviewerQuery,
+                                userId, Geonet.Profile.REVIEWER);
+                        if (isReviewerRes.getChildren().size() == 0) {
                             throw new ServiceNotAllowedEx(
                                     "User can't set operation for group "
                                             + grpId
-                                            + " because the user in not member of this group.");
+                                            + " because the user in not a Reviewer of any group.");
+                        }
+                    } else {
+
+                        GeonetContext gc = (GeonetContext) context
+                                .getHandlerContext(Geonet.CONTEXT_NAME);
+                        String userGroupsOnly = settingMan
+                                .getValue("system/metadataprivs/usergrouponly");
+                        if (userGroupsOnly.equals("true")) {
+                            // If user is member of the group, user can set
+                            // operation
+                            String isMemberQuery = "SELECT groupId FROM UserGroups WHERE groupId=? AND userId=?";
+                            Element isMemberRes = dbms.select(isMemberQuery, grpId,
+                                    userId);
+                            if (isMemberRes.getChildren().size() == 0) {
+                                throw new ServiceNotAllowedEx(
+                                        "User can't set operation for group "
+                                                + grpId
+                                                + " because the user in not member of this group.");
+                            }
                         }
                     }
                 }
             }
-        }
-        // Set operation
-        String query = "SELECT metadataId FROM OperationAllowed WHERE metadataId=? AND groupId=? AND operationId=?";
-        Element elRes = dbms.select(query, mdId, grpId, opId);
-        if (elRes.getChildren().size() == 0) {
+            // Set operation
             dbms.execute("INSERT INTO OperationAllowed(metadataId, groupId, operationId) VALUES(?,?,?)", mdId, grpId, opId);
             if (svnManager != null) {
                 svnManager.setHistory(dbms, mdId+"", context);


### PR DESCRIPTION
Changed logic so that it will only check for the proper permission if there is a need to make a change. Since the user interface does now allow editor to change the group <= 1 they should not be any attempt to changes.

Note: this seems to fix the issue when editing the records manually. But it still fails when editing the records via MEF - but that is a different issue which I will log another issue for this.
