### PR TITLE
Put default list width of some search criterias to auto

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/util/SearchFormTools.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/util/SearchFormTools.js
@@ -484,7 +484,8 @@ GeoNetwork.util.SearchFormTools = {
                 store: catStore,
                 valueField: 'id',
                 displayField: 'name',
-                tpl: tpl
+                tpl: tpl,
+                listWidth: 'width:auto'
             };
         
         if (multi) {
@@ -518,7 +519,8 @@ GeoNetwork.util.SearchFormTools = {
                 store: groupStore,
                 valueField: 'id',
                 displayField: 'name',
-                tpl: tpl
+                tpl: tpl,
+                listWidth: 'width:auto'
             };
         if (multi) {
             Ext.apply(config, {
@@ -558,7 +560,8 @@ GeoNetwork.util.SearchFormTools = {
                     data: [['n', OpenLayers.i18n('md')], ['y', OpenLayers.i18n('tpl')]]
                 }),
                 valueField: 'id',
-                displayField: 'name'
+                displayField: 'name',
+                listWidth: 'width:auto'
             };
         if (multi) {
             Ext.apply(config, {
@@ -594,7 +597,8 @@ GeoNetwork.util.SearchFormTools = {
             store: store,
             valueField: 'name',
             displayField: 'name',
-            tpl: tpl
+            tpl: tpl,
+            listWidth: 'width:auto'
         };
         if (multi) {
             var displaytpl = (imgUrl ?

--- a/web-client/src/main/resources/apps/search/js/App.js
+++ b/web-client/src/main/resources/apps/search/js/App.js
@@ -218,6 +218,7 @@ GeoNetwork.app = function () {
             valueField: 'value',
             displayField: 'value',
             valueDelimiter: ' or ',
+            listWidth: 'width:auto',
 //            tpl: tpl,
             fieldLabel: OpenLayers.i18n('org')
         });


### PR DESCRIPTION
Some search combo box have by default to small size to be readable.

Extent to auto width those combo (category, catalog, organism..).
##### Before:

![widthauto1](https://f.cloud.github.com/assets/1491924/787861/918cd1b0-eaea-11e2-828e-b8824adbb58e.png)
##### Now:

![widthauto](https://f.cloud.github.com/assets/1491924/787860/8ca56bf8-eaea-11e2-8de8-c7c03df4986e.png)
