### PR TITLE
Add loaded event to NewMetadataPanel

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/NewMetadataPanel.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/NewMetadataPanel.js
@@ -57,11 +57,29 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
     isChild: undefined,
     filter: undefined,
     createBt: undefined,
+    nbStore: 2, // number of store to be loaded
+    storeLoaded: 0, // number of store currently loaded
     validate: function(){
         if (this.selectedGroup !== undefined && this.selectedTpl !== undefined) {
             this.createBt.setDisabled(false);
         } else {
             this.createBt.setDisabled(true);
+        }
+    },
+    
+    /**
+     * manageLoadedEvent
+     * Check if groupStore and templateStore are loaded. When both are loaded,
+     * fires the dataLoaded event with the current template and current group.
+     * The event has the following arguments :
+     *   - this (newMetadataPnel)
+     *   - template store value
+     *   - group store value
+     */
+    manageLoadedEvent: function() {
+        this.storeLoaded++;
+        if(this.storeLoaded >= this.nbStore) {
+            this.fireEvent('dataLoaded', this, this.selectedTpl, this.selectedGroup);
         }
     },
     
@@ -72,6 +90,7 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
         Ext.applyIf(this, this.defaultConfig);
         var checkboxSM, colModel;
         
+        this.addEvents('dataLoaded');
         
         this.createBt = new Ext.Button({
             text: OpenLayers.i18n('create'),
@@ -161,7 +180,8 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
             grid.getStore().on('load', function(store) {
                 grid.getSelectionModel().selectFirstRow();
                 grid.getView().focusEl.focus();
-            }, grid);
+                this.manageLoadedEvent();
+            }, this);
             cmp.push(grid);
             this.catalogue.search({E_template: 'y', E_hitsperpage: 150}, null, null, 1, true, this.tplStore, null);
         }
@@ -216,6 +236,7 @@ GeoNetwork.editor.NewMetadataPanel = Ext.extend(Ext.Panel, {
                         this.validate();
                     }
                 }
+                this.manageLoadedEvent();
             },
             scope: this
         });


### PR DESCRIPTION
Send an event when template store and group store are loaded and send the current value of those stores in the event.

This is used to automatically create a new metadata with the default template and group wihout showing the NewMetadataPanel.
