### PR TITLE
Change log4j.logger.jeeves from DEBUG to INFO

### DIFF
--- a/web/src/main/webapp/WEB-INF/log4j.cfg
+++ b/web/src/main/webapp/WEB-INF/log4j.cfg
@@ -36,7 +36,7 @@ log4j.logger.org.springframework.security.ldap = WARN
 
 ### JEEVES SETTINGS ############################################################
 
-log4j.logger.jeeves      = DEBUG, console, jeeves
+log4j.logger.jeeves      = INFO, console, jeeves
 log4j.logger.jeeves.dbms = WARN
 
 # If resourcetracking is set to DEBUG then each time a resource


### PR DESCRIPTION
This is a possible fix for Issue #176 

DEBUG should probably not be a default
   DEBUG was causing all the config overrides to be placed in the log files - in some cases this was username passwords for the database.
