### PR TITLE
Fixing schema xsd validation. 

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-overrides.xsd
+++ b/web/src/main/webapp/WEB-INF/config-overrides.xsd
@@ -213,6 +213,7 @@
 			</xs:attribute>
 		</xs:complexType>
 	</xs:element>
+	</xs:element>
 
 	<xs:element name="file">
 		<xs:annotation>


### PR DESCRIPTION
There was a missing xs:element closing "spring" element
