### PR TITLE
Fix bug edit linkresource service selection

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/Catalogue.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/Catalogue.js
@@ -375,7 +375,8 @@ GeoNetwork.Catalogue = Ext.extend(Ext.util.Observable, {
             logoUrl: this.URL + '/images/logos/',
             imgUrl: this.URL + '/images/',
             harvesterLogoUrl: this.URL + '/images/harvesting/',
-            getImportXSL: serviceUrl + 'get.conversions.xsl'
+            getImportXSL: serviceUrl + 'get.conversions.xsl',
+            proxy: this.URL + '/proxy'
         };
         
         // TODO : init only once required (ie. metadata show)

--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/LinkResourcesWindow.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/LinkResourcesWindow.js
@@ -742,7 +742,7 @@ GeoNetwork.editor.LinkResourcesWindow = Ext.extend(Ext.Window, {
             if (self.type === 'service') {
                 Ext.each(record.data.links, function (link) {
                     // FIXME: restrict
-                    if (self.protocolForServices.join(',').indexOf(link.protocol) !== -1) {
+                    if (self.protocolForServices.join(',').indexOf(link.type) !== -1) {
                         links += '<li><a target="_blank" href="' + link.href + '">' + link.href + '</a></li>';
                         // FIXME : when service contains multiple URL 
                         record.data.serviceUrl = link.href;


### PR DESCRIPTION
In editor : service link resource windows. If you select an WMS service, then the layers are never retrieved because no proxy is set, and protocols never match.
