### PR TITLE
Bug fix: Pressing <Enter> key instead [Search] button sends only Simple Search request.

### DIFF
--- a/web/src/main/webapp/xsl/header.xsl
+++ b/web/src/main/webapp/xsl/header.xsl
@@ -40,6 +40,25 @@
 			<xsl:if test="//service/@name = 'main.home'">
 			document.onkeyup = alertkey;
 
+            function getCookie(c_name) {
+                var c_value = document.cookie;
+                var c_start = c_value.indexOf(" " + c_name + "=");
+                if (c_start == -1) {
+                    c_start = c_value.indexOf(c_name + "=");
+                }
+                if (c_start == -1) {
+                    c_value = null;
+                } else {
+                    c_start = c_value.indexOf("=", c_start) + 1;
+                    var c_end = c_value.indexOf(";", c_start);
+                    if (c_end == -1) {
+                        c_end = c_value.length;
+                    }
+                c_value = unescape(c_value.substring(c_start,c_end));
+                }
+                return c_value;
+            }
+
 			function alertkey(e) {
 				if (!e) {
 					if (window.event) {
@@ -56,11 +75,15 @@
 						return;
 						}
 					</xsl:if>
-					if (document.cookie.indexOf("search=advanced")!=-1)
-						runAdvancedSearch();
-					else
+				    var searchCookie = getCookie("search");
+                    var doAdvancedSearch = (searchCookie == "o:searchTab=s%3Aadvanced");
+                    var doSimpleSearch = (searchCookie == "o:searchTab=s%3Adefault");
+                    if (doAdvancedSearch) {
+                        runAdvancedSearch();
+                    } else if (doSimpleSearch) {
 						runSimpleSearch();
 					}
+                }
 				};
 			</xsl:if>
 		</script><xsl:text>&#10;</xsl:text>


### PR DESCRIPTION
Fix for the bug: Pressing <Enter> key instead [Search] button sends only Simple Search request: Bug: http://trac.osgeo.org/geonetwork/ticket/1041
Discussion: 
http://osgeo-org.1560.x6.nabble.com/GeoNetwork-opensource-Developer-website-1041-Pressing-lt-Enter-gt-key-instead-Search-button-sends-on-td5000720.html
