### PR TITLE
Metadata StatusValue table for init scripts by db.

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-db2.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-db2.sql
@@ -323,6 +323,7 @@ CREATE TABLE StatusValues
     id        int           not null,
     name      varchar(32)   not null,
     reserved  char(1)       default 'n' not null,
+    displayorder int,
     primary key(id)
   );
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-mysql.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-mysql.sql
@@ -376,6 +376,7 @@ CREATE TABLE StatusValues
     id        int           not null,
     name      varchar(32)   not null,
     reserved  char(1)       default 'n' not null,
+    displayorder int,
     primary key(id)
   );
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-oracle.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-oracle.sql
@@ -319,6 +319,7 @@ CREATE TABLE StatusValues
     id        int           not null,
     name      varchar2(32)  not null,
     reserved  char(1)       default 'n' not null,
+    displayorder int,
     primary key(id)
   );
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-postgis.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-postgis.sql
@@ -376,6 +376,7 @@ CREATE TABLE StatusValues
     id        int           not null,
     name      varchar(32)   not null,
     reserved  char(1)       default 'n' not null,
+    displayorder int,
     primary key(id)
   );
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-postgres.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-postgres.sql
@@ -376,6 +376,7 @@ CREATE TABLE StatusValues
     id        int           not null,
     name      varchar(32)   not null,
     reserved  char(1)       default 'n' not null,
+    displayorder int,
     primary key(id)
   );
 


### PR DESCRIPTION
The #228 issue has changed the columns of this table (adding one more) and his initialize, but only in 'create-db-default.sql'.

I've added this change to the specific creater script by db.
