### PR TITLE
Fix protocol name without tabulation instead of spaces

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/ara/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/ara/labels.xml
@@ -2009,8 +2009,7 @@
 		<label>Protocol</label>
 		<description>Connection protocol to be used</description>
 		<helper>
-			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File
-				(*.AXL)</option>
+			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File (*.AXL)</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service</option>
 			<option show="-" value="ESRI:AIMS--http-get-image">ArcIMS Internet Image Map Service</option>
 			<option show="y" value="GLG:KML-2.0-http-get-map">Google Earth KML service (ver 2.0)</option>
@@ -2026,24 +2025,19 @@
 			<option show="-" value="OGC:SPS">OGC-SPS Sensor Planning Service</option>
 			<option show="-" value="OGC:SAS">OGC-SAS Sensor Alert Service</option>
 			<option show="-" value="OGC:WCS">OGC-WCS Web Coverage Service</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)</option>
 			<option show="-" value="OGC:WMS">OGC-WMS Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver 1.3.0)</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC Web Map Service (ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">OGC Web Map Service (ver 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="OGC:WNS">OGC-WNS Web Notification Service</option>
 			<option show="-" value="OGC:WPS">OGC-WPS Web Processing Service</option>
 			<option show="-" value="FILE:GEO">GIS file</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/cat/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/cat/labels.xml
@@ -1721,8 +1721,7 @@
 		<label>Protocol</label>
 		<description>Protocol de connexió a utilitzar</description>
 		<helper>
-			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Arxiu de
-				configuració (*.AXL)</option>
+			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Arxiu de configuració (*.AXL)</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service</option>
 			<option show="-" value="ESRI:AIMS--http-get-image">ArcIMS Internet Image Map Service</option>
 			<option show="y" value="GLG:KML-2.0-http-get-map">Google Earth KML service (ver 2.0)</option>
@@ -1744,10 +1743,8 @@
 			<option show="-" value="DB:ORACLE">ORACLE database table</option>
 			<option show="y" value="WWW:LINK-1.0-http--opendap">OPeNDAP URL</option>
 			<option show="y" value="RBNB:DATATURBINE">Data Turbine</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
@@ -1758,8 +1755,7 @@
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">Servei de Mapes OGC-WMS (ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">Servei de Mapes OGC-WMS (ver 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="OGC:WNS">OGC-WNS Web Notification Service</option>
 			<option show="-" value="OGC:WPS">OGC-WPS Web Processing Service</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-ftp--download">Arxiu per la descàrrega (FTP)</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/chi/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/chi/labels.xml
@@ -2025,10 +2025,8 @@
 			<option show="-" value="OGC:SPS">OGC-SPS Sensor Planning Service</option>
 			<option show="-" value="OGC:SAS">OGC-SAS Sensor Alert Service</option>
 			<option show="-" value="OGC:WCS">OGC-WCS Web Coverage Service</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
@@ -2039,8 +2037,7 @@
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC-WMS地图服务(ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">OGC-WMS地图服务(ver 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-ftp--download">下载文件 (FTP)</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-http--download">下载文件</option>
 			<option show="-" value="DB:POSTGIS">PostGIS database table</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/dut/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/dut/labels.xml
@@ -1958,8 +1958,7 @@
 		<label>Protocol</label>
 		<description>Protocol waarmee de webkoppeling benaderbaar is</description>
 		<helper>
-			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuratie Bestand
-				(*.AXL)</option>
+			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuratie Bestand (*.AXL)</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service</option>
 			<option show="-" value="ESRI:AIMS--http-get-image">ArcIMS Internet Image Map Service</option>
 			<option show="y" value="GLG:KML-2.0-http-get-map">Google Earth KML service (ver 2.0)</option>
@@ -1980,24 +1979,19 @@
 			<option show="-" value="DB:ORACLE">ORACLE database table</option>
 			<option show="y" value="WWW:LINK-1.0-http--opendap">OPeNDAP URL</option>
 			<option show="y" value="RBNB:DATATURBINE">Data Turbine</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)</option>
 			<option show="-" value="OGC:WMS">OGC-WMS Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver 1.3.0)</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC Web Map Service (ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">OGC Web Map Service (ver 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-ftp--download">Bestand ter download dmv FTP</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-http--download">Bestand ter download</option>
 			<option show="-" value="DB:POSTGIS">PostGIS database table</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/eng/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/eng/labels.xml
@@ -1895,8 +1895,7 @@
 		<label>Protocol</label>
 		<description>Connection protocol to be used</description>
 		<helper sort="true">
-			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File
-				(*.AXL)
+			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File (*.AXL)
 			</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service
 			</option>
@@ -1923,11 +1922,9 @@
 			</option>
 			<option show="-" value="OGC:SAS">OGC-SAS Sensor Alert Service</option>
 			<option show="-" value="OGC:WCS">OGC-WCS Web Coverage Service</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)
 			</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service
 			</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)
@@ -1936,11 +1933,9 @@
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)
 			</option>
 			<option show="-" value="OGC:WMS">OGC-WMS Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.1.1)
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver 1.1.1)
 			</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.3.0)
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver 1.3.0)
 			</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC Web Map Service (ver 1.1.1)
 			</option>
@@ -1948,8 +1943,7 @@
 			</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)
 			</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)
 			</option>
 			<option show="-" value="OGC:WNS">OGC-WNS Web Notification Service
 			</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/fin/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/fin/labels.xml
@@ -2278,8 +2278,7 @@
 			ladattavaan tiedostoon, valitse FTP. Jos linkki on palveluun, valitse
 			kyseisen palvelun tyyppi.</description>
 		<helper>
-			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File
-				(*.AXL)</option>
+			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File (*.AXL)</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service</option>
 			<option show="-" value="ESRI:AIMS--http-get-image">ArcIMS Internet Image Map Service</option>
 			<option show="y" value="GLG:KML-2.0-http-get-map">Google Earth KML service (ver 2.0)</option>
@@ -2295,26 +2294,21 @@
 			<option show="-" value="OGC:SPS">OGC-SPS Sensor Planning Service</option>
 			<option show="-" value="OGC:SAS">OGC-SAS Sensor Alert Service</option>
 			<option show="-" value="OGC:WCS">OGC-WCS Web Coverage Service</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)</option>
 			<option show="-" value="OGC:WMS">OGC-WMS Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver 1.3.0)</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC Web Map Service (ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">OGC Web Map Service (ver 1.3.0)</option>
 			<option show="-" value="OGC:WNS">OGC-WNS Web Notification Service</option>
 			<option show="-" value="OGC:WPS">OGC-WPS Web Processing Service</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-ftp--download">Ladattava tiedosto (FTP-protokolla)</option>
 			<option show="-" value="FILE:GEO">GIS file</option>
 			<option show="-" value="FILE:RASTER">GIS RASTER file</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/ger/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/ger/labels.xml
@@ -2351,24 +2351,19 @@
 			<option show="y" value="WWW:LINK-1.0-http--opendap">OPeNDAP URL</option>
 			<option show="y" value="RBNB:DATATURBINE">Data Turbine</option>
 			<option show="-" value="UKST">Unknown Service Type</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)</option>
 			<option show="-" value="OGC:WMS">OGC-WMS Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver 1.3.0)</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC Web Map Service (ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">OGC Web Map Service (ver 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="FILE:GEO">GIS file</option>
 			<option show="-" value="FILE:RASTER">GIS RASTER file</option>
 		</helper>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/ita/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/ita/labels.xml
@@ -1752,8 +1752,7 @@ elementi quali il software, il sistema operativo del computer, nome del file, e 
 		<label>Protocollo</label>
 		<description>Protocollo di connessione utilizzato</description>
 		<helper>
-			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service: file di
-				configurazione (*.AXL)</option>
+			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service: file di configurazione (*.AXL)</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service
 			</option>
 			<option show="-" value="ESRI:AIMS--http-get-image">ArcIMS Internet Image Map Service
@@ -1779,29 +1778,23 @@ elementi quali il software, il sistema operativo del computer, nome del file, e 
 			</option>
 			<option show="-" value="OGC:SAS">OGC-SAS Sensor Alert Service</option>
 			<option show="-" value="OGC:WCS">OGC-WCS Web Coverage Service</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
-			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)
-			</option>
+			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)
 			</option>
 			<option show="-" value="OGC:WMS">OGC-WMS Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver 1.3.0)</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC Web Map Service (ver 1.1.1)
 			</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">OGC Web Map Service (ver 1.3.0)
 			</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)
 			</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="OGC:WNS">OGC-WNS Web Notification Service
 			</option>
 			<option show="-" value="OGC:WPS">OGC-WPS Web Processing Service</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/nor/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/nor/labels.xml
@@ -1757,8 +1757,7 @@
 		<description>Protokoll som skal benyttes ved direktekobling</description>
 		<helper>
 			<option show="-" value="ESRI:AIMS--http-get-image">ArcIMS Internet Image Map Service</option>
-			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File
-				(*.AXL)</option>
+			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File (*.AXL)</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service</option>
 			<option show="y" value="GLG:KML-2.0-http-get-map">Google Earth KML service (ver 2.0)</option>
 			<option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
@@ -1779,24 +1778,19 @@
 			<option show="-" value="DB:ORACLE">ORACLE database table</option>
 			<option show="y" value="WWW:LINK-1.0-http--opendap">OPeNDAP URL</option>
 			<option show="y" value="RBNB:DATATURBINE">Data Turbine</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)</option>
 			<option show="-" value="OGC:WMS">OGC-WMS Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities service (ver 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver 1.3.0)</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC Web Map Service (ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">OGC Web Map Service (ver 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="OGC:WNS">OGC-WNS Web Notification Service</option>
 			<option show="-" value="OGC:WPS">OGC-WPS Web Processing Service</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-ftp--download">File for download through FTP</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/por/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/por/labels.xml
@@ -1937,8 +1937,7 @@
 		<label>Protocolo</label>
 		<description>Protocolo de conexão a ser usados</description>
 		<helper>
-			<option show="y" value="ESRI:AIMS--http--configuration">Ficheiro de configuração de ArcIMS Map
-				Service (*.AXL)</option>
+			<option show="y" value="ESRI:AIMS--http--configuration">Ficheiro de configuração de ArcIMS Map Service (*.AXL)</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service</option>
 			<option show="-" value="ESRI:AIMS--http-get-image">ArcIMS Internet Image Map Service</option>
 			<option show="y" value="GLG:KML-2.0-http-get-map">Google Earth KML Service (ver 2.0)</option>
@@ -1959,24 +1958,19 @@
 			<option show="-" value="DB:ORACLE">ORACLE database table</option>
 			<option show="y" value="WWW:LINK-1.0-http--opendap">OPeNDAP URL</option>
 			<option show="y" value="RBNB:DATATURBINE">Data Turbine</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)</option>
 			<option show="-" value="OGC:WMS">OGC-WMS Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities Service (ver
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">OGC-WMS Capabilities Service (ver 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">OGC-WMS Capabilities service (ver 1.3.0)</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">OGC Web Map Service (ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">OGC Web Map Service (ver 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="OGC:WNS">OGC-WNS Web Notification Service</option>
 			<option show="-" value="OGC:WPS">OGC-WPS Web Processing Service</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-ftp--download">Ficheiro para download por FTP</option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/rus/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/rus/labels.xml
@@ -2067,27 +2067,19 @@
 			<option show="-" value="DB:ORACLE">ORACLE database table</option>
 			<option show="y" value="WWW:LINK-1.0-http--opendap">OPeNDAP URL</option>
 			<option show="y" value="RBNB:DATATURBINE">Data Turbine</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">Сервис OGC-WCS Web Coverage Service
-				(версия 1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">Сервис OGC-WCS Web Coverage Service (версия 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
-			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">Сервис OGC-WFS Web Feature
-				Service(версия 1.0.0)</option>
+			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">Сервис OGC-WFS Web Feature Service(версия 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)</option>
 			<option show="-" value="OGC:WMS">Cервис OGC Web Map Service</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">Сервис OGC-WMS Capabilities
-				service(версия 1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">Сервис OGC-WMS Capabilities
-				service(версия 1.3.0)</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-map">Cервис OGC Web Map Service (версия
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-map">Cервис OGC Web Map Service (версия
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">Сервис OGC-WMS Capabilities service(версия 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">Сервис OGC-WMS Capabilities service(версия 1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-map">Cервис OGC Web Map Service (версия 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-map">Cервис OGC Web Map Service (версия 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-ftp--download">Файл для загрузки по FTP</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-http--download">Файл для загрузки</option>
 			<option show="-" value="DB:POSTGIS">Таблица базы данных PostGIS </option>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/spa/labels.xml
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/loc/spa/labels.xml
@@ -1981,8 +1981,7 @@
 		<label>Protocolo</label>
 		<description>Protocolo de conexión utilizado</description>
 		<helper>
-			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File
-				(*.AXL)</option>
+			<option show="y" value="ESRI:AIMS--http--configuration">ArcIMS Map Service Configuration File (*.AXL)</option>
 			<option show="y" value="ESRI:AIMS--http-get-feature">ArcIMS Internet Feature Map Service</option>
 			<option show="-" value="ESRI:AIMS--http-get-image">ArcIMS Internet Image Map Service</option>
 			<option show="y" value="GLG:KML-2.0-http-get-map">Google Earth KML service (ver 2.0)</option>
@@ -1998,24 +1997,19 @@
 			<option show="-" value="OGC:SPS">OGC-SPS Sensor Planning Service</option>
 			<option show="-" value="OGC:SAS">OGC-SAS Sensor Alert Service</option>
 			<option show="-" value="OGC:WCS">OGC-WCS Web Coverage Service</option>
-			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver
-				1.1.0)</option>
-			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation
-				Service</option>
+			<option show="y" value="OGC:WCS-1.1.0-http-get-capabilities">OGC-WCS Web Coverage Service (ver 1.1.0)</option>
+			<option show="-" value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
 			<option show="-" value="OGC:WFS">OGC-WFS Web Feature Service</option>
 			<option show="y" value="OGC:WFS-1.0.0-http-get-capabilities">OGC-WFS Web Feature Service (ver 1.0.0)</option>
 			<option show="-" value="OGC:WFS-G">OGC-WFS-G Gazzetteer Service</option>
 			<option show="y" value="OGC:WMC-1.1.0-http-get-capabilities">OGC-WMC Web Map Context (ver 1.1)</option>
 			<option show="-" value="OGC:WMS">Sevicio de Mapas OGC-WMS</option>
-			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">Servicio Capabilities OGC-WMS (ver
-				1.1.1)</option>
-			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">Servicio Capabilities OGC-WMS (ver
-				1.3.0)</option>
+			<option show="-" value="OGC:WMS-1.1.1-http-get-capabilities">Servicio Capabilities OGC-WMS (ver 1.1.1)</option>
+			<option show="-" value="OGC:WMS-1.3.0-http-get-capabilities">Servicio Capabilities OGC-WMS (ver 1.3.0)</option>
 			<option show="-" value="OGC:WMS-1.1.1-http-get-map">Sevicio de Mapas OGC-WMS (ver 1.1.1)</option>
 			<option show="-" value="OGC:WMS-1.3.0-http-get-map">Sevicio de Mapas OGC-WMS (ver 1.3.0)</option>
 			<option show="-" value="OGC:SOS-1.0.0-http-get-observation">OGC-SOS Get Observation (ver 1.0.0)</option>
-			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver
-				1.0.0)</option>
+			<option show="-" value="OGC:SOS-1.0.0-http-post-observation">OGC-SOS Get Observation (POST) (ver 1.0.0)</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-ftp--download">Fichero para la descarga (FTP)</option>
 			<option show="-" value="WWW:DOWNLOAD-1.0-http--download">Fichero para la descarga</option>
 			<option show="-" value="FILE:GEO">GIS file</option>


### PR DESCRIPTION
Protocol description were truncated cause of xml file auto format.

There was a missing space, and tabulations within the name.
This was causing a bug when a protocol combo, based on protocol store, were trying to match the value and the display fields.
