### PR TITLE
Fix for Issue #274

### DIFF
--- a/web/src/main/webapp/xsl/metadata-fop.xsl
+++ b/web/src/main/webapp/xsl/metadata-fop.xsl
@@ -333,13 +333,22 @@
       <xsl:with-param name="content">
         <xsl:choose>
           <xsl:when test="$remote=false()"><fo:basic-link text-decoration="underline" color="blue">
-              <xsl:attribute name="external-destination"> url('<xsl:value-of
-                select="concat($server/protocol, '://', $server/host,':', $server/port, /root/gui/url,'?uuid=', $metadata/geonet:info/uuid)"
-                />') </xsl:attribute>
+							<xsl:choose>
+								<xsl:when test="/root/gui/config/client/@widget='true'">
+									<xsl:attribute name="external-destination"> url('<xsl:value-of
+										select="concat($server/protocol, '://', $server/host,':', $server/port, /root/gui/url, '/apps/tabsearch/', /root/gui/config/client/@url,'?uuid=', $metadata/geonet:info/uuid , '&amp;hl=', /root/gui/language)"
+									/>') </xsl:attribute>
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:attribute name="external-destination"> url('<xsl:value-of
+										select="concat($server/protocol, '://', $server/host,':', $server/port, /root/gui/url, '/srv/',/root/gui/language, '/' ,/root/gui/config/client/@url,'?uuid=', $metadata/geonet:info/uuid)"
+									/>') </xsl:attribute>
+								</xsl:otherwise>
+							</xsl:choose>
               <xsl:value-of select="$gui/strings/show"/>
           </fo:basic-link> | <fo:basic-link text-decoration="underline" color="blue">
             <xsl:attribute name="external-destination"> url('<xsl:value-of
-              select="concat($server/protocol, '://', $server/host,':', $server/port, /root/gui/url, '/srv/en/xml.metadata.get?uuid=', $metadata/geonet:info/uuid)"
+              select="concat($server/protocol, '://', $server/host,':', $server/port, /root/gui/url, '/srv/',/root/gui/language,'/xml.metadata.get?uuid=', $metadata/geonet:info/uuid)"
             />') </xsl:attribute>
             <xsl:value-of select="$gui/strings/show"/> (XML)
           </fo:basic-link> | </xsl:when>


### PR DESCRIPTION
Fix metadata links in the pdf so that it works in the widgets and classic interface. Also it keeps the language of the interface that the pdf was created in.
