### PR TITLE
Update README.md

### DIFF
--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -22,7 +22,7 @@ sudo easy_install http://closure-linter.googlecode.com/files/closure_linter-late
 cd /path/to/closure-library-parent-dir
 git clone http://code.google.com/p/closure-library/
 cd closure-library
-wget http://closure-compiler.googlecode.com/files/compiler-latest.zip
+wget http://dl.google.com/closure-compiler/compiler-latest.zip
 unzip compiler-latest.zip
 ```
 


### PR DESCRIPTION
The previous link (http://closure-compiler.googlecode.com/files/compiler-latest.zip) only contains a README file which indicates that the link is no longer valid, and gives another url to get the actual compiler-latest.zip file (which is http://dl.google.com/closure-compiler/compiler-latest.zip).
