### PR TITLE
West bound should use value-of instead of copy-of just like the rest.

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/convert/OGCWxSGetCapabilitiesto19119/identification.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/convert/OGCWxSGetCapabilitiesto19119/identification.xsl
@@ -346,7 +346,7 @@
 									</xsl:variable>
 											
 									<westBoundLongitude>
-										<gco:Decimal><xsl:copy-of select="math:min(exslt:node-set($boxes)/*[name(.)='xmin'])"/></gco:Decimal>
+										<gco:Decimal><xsl:value-of select="math:min(exslt:node-set($boxes)/*[name(.)='xmin'])"/></gco:Decimal>
 									</westBoundLongitude>
 									<eastBoundLongitude>
 										<gco:Decimal><xsl:value-of select="math:max(exslt:node-set($boxes)/*[name(.)='xmax'])"/></gco:Decimal>
@@ -756,7 +756,7 @@
 									</xsl:variable>
 											
 									<westBoundLongitude>
-										<gco:Decimal><xsl:copy-of select="exslt:node-set($boxes)/*[name(.)='xmin']"/></gco:Decimal>
+										<gco:Decimal><xsl:value-of select="exslt:node-set($boxes)/*[name(.)='xmin']"/></gco:Decimal>
 									</westBoundLongitude>
 									<eastBoundLongitude>
 										<gco:Decimal><xsl:value-of select="exslt:node-set($boxes)/*[name(.)='xmax']"/></gco:Decimal>


### PR DESCRIPTION
When you view iso19139 records as XML, you'll see the westBound appears with gmd:xmin e.g.:

gmd:EX_GeographicBoundingBox
gmd:westBoundLongitude
gco:Decimal
gmd:xmin105.53333332790065/gmd:xmin
/gco:Decimal
/gmd:westBoundLongitude
gmd:eastBoundLongitude
gco:Decimal129.01666666127286/gco:Decimal
/gmd:eastBoundLongitude
gmd:southBoundLatitude
gco:Decimal-35.033522303030146/gco:Decimal
/gmd:southBoundLatitude
gmd:northBoundLatitude
gco:Decimal-10.415345166691509/gco:Decimal
/gmd:northBoundLatitude
/gmd:EX_GeographicBoundingBox

It could be ignored with classic view, but using the HTML5 UI, it causes GeoNetwork to hang when viewing the record.
