### PR TITLE
If metadata contains invalid layer name, when trying to add the layer to...

### DIFF
--- a/web-client/src/main/resources/apps/html5ui/js/map/MapApp.js
+++ b/web-client/src/main/resources/apps/html5ui/js/map/MapApp.js
@@ -1567,8 +1567,17 @@ GeoNetwork.mapApp = function() {
                         ol_layer.dimensions = layerCap.dimensions;
                         ol_layer.metadataURLs = layerCap.metadataURLs;
                         ol_layer.abstractInfo = layerCap['abstract'];
+                        map.addLayer(ol_layer);
+                    } else {
+                        //Someone used the wrong layername. doh!
+                        //let them correct it
+                        //show wms layer selection
+                        GeoNetwork.WindowManager.showWindow("addwms");
+                        var panel = Ext.getCmp(GeoNetwork.WindowManager
+                                .getWindow("addwms").browserPanel.id);
+                        panel.setURL(caps.capability.request.getcapabilities.href);
                     }
-                    map.addLayer(ol_layer);
+
                 }
             }
 


### PR DESCRIPTION
... the map, it shows a wms layer selection window
