### PR TITLE
#1239: Fix SQL queries for case sensitive db.

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/statistics/SearchStatistics.java
+++ b/services/src/main/java/org/fao/geonet/services/statistics/SearchStatistics.java
@@ -56,15 +56,15 @@ import static org.springframework.data.jpa.domain.Specifications.where;
 public class SearchStatistics extends NotInReadOnlyModeService {
 
     private static final String NUMBER_OF_SEARCH_QUERY = "SELECT COUNT(*) AS total " +
-                                                         "FROM requests WHERE service = ?";
+                                                         "FROM Requests WHERE service = ?";
 
-    private static final String NUMBER_SEARCH_BY_X_QUERY = "SELECT count(*) / ? AS avg FROM requests " +
+    private static final String NUMBER_SEARCH_BY_X_QUERY = "SELECT count(*) / ? AS avg FROM Requests " +
                                                            "WHERE service = ? ";
 
-    private static final String NUMBER_VIEWS_BY_X_QUERY = "SELECT sum(popularity) / ? AS avg FROM metadata";
+    private static final String NUMBER_VIEWS_BY_X_QUERY = "SELECT sum(popularity) / ? AS avg FROM Metadata";
 
     private static final String NUMBER_OF_SEARCHES_WITH_NO_HITS_QUERY =
-            "SELECT count(*) AS total FROM requests WHERE hits = 0 AND service = ?";
+            "SELECT count(*) AS total FROM Requests WHERE hits = 0 AND service = ?";
 
     private static final String SERVICE_PARAM = "service";
 

--- a/web/src/main/java/org/fao/geonet/DatabaseMigration.java
+++ b/web/src/main/java/org/fao/geonet/DatabaseMigration.java
@@ -282,7 +282,7 @@ public class DatabaseMigration implements BeanPostProcessor, ApplicationContextA
     private String newLookup(Statement statement, String key) throws SQLException {
         ResultSet results = null;
         try {
-            final String newGetVersion = "SELECT value FROM settings WHERE name = '" + key + "'";
+            final String newGetVersion = "SELECT value FROM Settings WHERE name = '" + key + "'";
             results = statement.executeQuery(newGetVersion);
             if (results.next()) {
                 return results.getString(1);
@@ -298,7 +298,7 @@ public class DatabaseMigration implements BeanPostProcessor, ApplicationContextA
     private String oldLookup(Statement statement, int key) throws SQLException {
         ResultSet results = null;
         try {
-            final String newGetVersion = "SELECT value FROM settings WHERE id = " + key;
+            final String newGetVersion = "SELECT value FROM Settings WHERE id = " + key;
             results = statement.executeQuery(newGetVersion);
             if (results.next()) {
                 return results.getString(1);


### PR DESCRIPTION
This is an attempt to fix http://trac.osgeo.org/geonetwork/ticket/1239. The workaround (setting MySQL global lower_case_table_names parameter to 1) is not always applicable, e.g. for our case, the server is shared with other databases used by other applications. 

I previously created a big patch fixing all the queries, applied them to 2.10.1 source and tested them on our local instance. However, I noticed the develop branch has changed significantly and the queries seem to be done in a more sophisticated way.

I am not sure if the static fields in Param and Geonet.Elem are also used for SQL queries (e.g. Params.GROUPS, Geonet.Elem.GROUPS). If they do, then we need to update them as well, since they're all in lower case, whereas the table names start with upper case. 
