### PR TITLE
Move metadata.select calls outside of loop that sets checkboxes

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/MetadataResultsView.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/MetadataResultsView.js
@@ -818,13 +818,13 @@ GeoNetwork.MetadataResultsView = Ext.extend(Ext.DataView, {
         var checkboxes = Ext.DomQuery.select('input.selector'), idx;
         for (idx = 0; idx < checkboxes.length; ++idx) {
             checkboxes[idx].checked = true;
-            Ext.each(this.getRecords(this.getNodes()), function(r){
-                var uuid = r.get('uuid');
-                this.catalogue.metadataSelect('add', [uuid]);
-            }, this);
-            // FIXME : selection calls may not end in call order
-            // then selection indicator may be wrong
         }
+        Ext.each(this.getRecords(this.getNodes()), function(r){
+        	var uuid = r.get('uuid');
+        	this.catalogue.metadataSelect('add', [uuid]);
+        }, this);
+        // FIXME : selection calls may not end in call order
+        // then selection indicator may be wrong
     },
     selectNone: function(){
         var checkboxes = Ext.DomQuery.select('input.selector'), idx;


### PR DESCRIPTION
removes storm of unnecessary metadata.select server calls
