### PR TITLE
Restrict resource filtering on web-client and web-ui so that only the specific files that need filtering are filtered.

### DIFF
--- a/web-client/pom.xml
+++ b/web-client/pom.xml
@@ -29,9 +29,26 @@
 
   <build>
     <resources>
+        <!-- The resource that are filtered should only be the fewest possible because
+             It makes the build take longer and if a file that should not have replacements done is filtered
+             the resulting file in the webapp can be wrong.  
+             
+             So only include the specific files to be filtered to keep the build as performant as possible
+             and reduce potential for bugs
+        -->
       <resource>
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
+          <includes>
+              <include>**/web-client-wro-sources.xml</include>
+          </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+          <excludes>
+              <exclude>**/web-client-wro-sources.xml</exclude>
+          </excludes>
       </resource>
     </resources>
     <plugins>

--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -34,9 +34,26 @@
 
   <build>
     <resources>
+        <!-- The resource that are filtered should only be the fewest possible because
+             It makes the build take longer and if a file that should not have replacements done is filtered
+             the resulting file in the webapp can be wrong.  
+             
+             So only include the specific files to be filtered to keep the build as performant as possible
+             and reduce potential for bugs
+        -->
       <resource>
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
+          <includes>
+              <include>**/web-ui-wro-sources.xml</include>
+          </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+          <excludes>
+              <exclude>**/web-ui-wro-sources.xml</exclude>
+          </excludes>
       </resource>
     </resources>
   </build>


### PR DESCRIPTION
In web-client especially there are many cases where ${...} is used in javascript files but are not intended to be replaced by maven build because they are used for string formatting.  If the build machine has one of those strings as
a system property or environment variable it will be replaced resulting in javascript that is incorrect.

I also encountered a problem where font files where processed and the resulting file was corrupted in the final webapp.  

This pull request should fix all these types of problems.  In the future the level of filtering should be very specific.
