### PR TITLE
Add action to update metadata group after its creation.

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/metadata/UpdateGroupOwner.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/UpdateGroupOwner.java
@@ -1,0 +1,105 @@
+//=============================================================================
+//===	Copyright (C) 2001-2014 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.services.metadata;
+
+
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.exceptions.OperationNotAllowedEx;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.Updater;
+import org.fao.geonet.services.NotInReadOnlyModeService;
+import org.fao.geonet.services.Utils;
+import org.jdom.Element;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Update the metadata group owner.
+ *
+ * For batch update see BatchNewOwner.
+ */
+public class UpdateGroupOwner extends NotInReadOnlyModeService {
+
+    /**
+     * @param appPath
+     * @param params
+     * @throws Exception
+     */
+    public void init(String appPath, ServiceConfig params) throws Exception {
+    }
+
+    /**
+     * @param params
+     * @param context
+     * @return
+     * @throws Exception
+     */
+    public Element serviceSpecificExec(Element params, ServiceContext context) throws Exception {
+        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+        DataManager dataMan = gc.getBean(DataManager.class);
+        AccessManager accessMan = gc.getBean(AccessManager.class);
+
+        String id = Utils.getIdentifierFromParameters(params, context);
+        String groupOwner = Util.getParam(params, "groupid");
+
+        int iLocalId = Integer.parseInt(id);
+        if (!dataMan.existsMetadata(iLocalId)) {
+            throw new IllegalArgumentException("Metadata with identifier '" + id + "' not found.");
+        }
+
+        if (!accessMan.canEdit(context, id)) {
+            throw new OperationNotAllowedEx();
+        }
+
+        int iGroupOwner = Integer.parseInt(groupOwner);
+        Group group = context.getBean(GroupRepository.class).findOne(iGroupOwner);
+        if (group == null) {
+            throw new IllegalArgumentException("Group with identifier '" + groupOwner + "' not found.");
+        }
+
+        //--- Update groupOwner
+        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        Metadata metadata = metadataRepository.findOne(iLocalId);
+        metadata.getSourceInfo().setGroupOwner(iGroupOwner);
+        metadataRepository.save(metadata);
+
+        //--- index metadata
+        dataMan.indexMetadata(id, true);
+
+        //--- return id for showing
+        return new Element(Jeeves.Elem.RESPONSE).
+                addContent(new Element(Geonet.Elem.ID).
+                        setText(id));
+    }
+}

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorDirective.js
@@ -1,0 +1,61 @@
+(function() {
+  goog.provide('gn_editor_directive');
+
+  var module = angular.module('gn_editor_directive', ['gn_editor']);
+
+  /**
+   * @ngdoc directive
+   * @name gn_editor_directive.directive:gnMetadataGroupUpdater
+   * @restrict A
+   * @requires gnMetadataGroupUpdater
+   *
+   * @description
+   * The `gnMetadataGroupUpdater` directive provides a
+   * dropdown button which allows to update the metadata
+   * group.
+   */
+  module.directive('gnMetadataGroupUpdater', [
+    'gnEditor', '$rootScope', '$translate', '$http',
+    function(gnEditor, $rootScope, $translate, $http) {
+
+      return {
+        restrict: 'A',
+        replace: true,
+        templateUrl: '../../catalog/components/metadatamanager/partials/' +
+            'metadatagroupupdater.html',
+        scope: {
+          groupOwner: '=gnMetadataGroupUpdater'
+        },
+        link: function(scope) {
+          scope.lang = scope.$parent.lang;
+
+          var init = function() {
+            $http.get('admin.group.list@json', {cache: true}).
+                success(function(data) {
+                  scope.groups = data !== 'null' ? data : null;
+                });
+          };
+
+          scope.sortByLabel = function(group) {
+            return group.label[scope.lang];
+          };
+
+          scope.assignGroup = function(g) {
+            gnEditor.assignGroup(g.id)
+              .then(function() {
+                  scope.groupOwner = g.id;
+                }, function(error) {
+                  $rootScope.$broadcast('StatusUpdated', {
+                    title: $translate('changeGroupError'),
+                    error: error,
+                    timeout: 0,
+                    type: 'danger'});
+                });
+            return false;
+          };
+
+          init();
+        }
+      };
+    }]);
+})();

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -188,6 +188,18 @@
              $(gnCurrentEdit.formId).
              find('input[id="version"]').val(version);
            },
+           assignGroup: function(groupId) {
+             var defer = $q.defer();
+             $http.get('md.group.update?id=' + gnCurrentEdit.id +
+                 '&groupid=' + groupId)
+               .success(function(data) {
+               defer.resolve(data);
+             })
+               .error(function(data) {
+               defer.reject(data);
+             });
+             return defer.promise;
+           },
            /**
             * Called after the edit form has been loaded.
             * Fill gnCurrentEdit all the info of the current

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/partials/metadatagroupupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/partials/metadatagroupupdater.html
@@ -1,0 +1,20 @@
+<div class="btn-group">
+  <button type="button"
+          class="btn btn-primary dropdown-toggle"
+          data-toggle="dropdown">
+    <i class="fa fa-group"></i>&nbsp;<span class="caret"></span>&nbsp;
+  </button>
+  <ul class="dropdown-menu pull-right" role="menu">
+    <li role="presentation" class="dropdown-header"
+        data-translate="">setMetadataGroup</li>
+    <li data-ng-repeat="g in groups | orderBy:sortByLabel"
+        data-ng-class="g.id == groupOwner ? 'disabled' : ''">
+      <a
+          data-ng-click="assignGroup(g)"
+          href="">
+        <span data-translate="">{{g.label[lang]}}</span>
+        <span data-ng-show="g.id == groupOwner">(<span data-translate="">current</span>)</span>
+      </a>
+    </li>
+  </ul>
+</div>

--- a/web-ui/src/main/resources/catalog/js/GnEditorModule.js
+++ b/web-ui/src/main/resources/catalog/js/GnEditorModule.js
@@ -19,10 +19,22 @@
 
 
 
+
+
+
+
+
+
+
+
+
+
+
   goog.require('gn');
   goog.require('gn_batch_service');
   goog.require('gn_draggable_directive');
   goog.require('gn_editor_controller');
+  goog.require('gn_editor_directive');
   goog.require('gn_geopublisher');
   goog.require('gn_onlinesrc');
   goog.require('gn_ows');
@@ -40,7 +52,8 @@
     'gn_editor_controller',
     'gn_ows',
     'gn_geopublisher',
-    'gn_batch_service'
+    'gn_batch_service',
+    'gn_editor_directive'
   ]);
 
   // Define the translation files to load

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -68,14 +68,15 @@
       };
 
       var init = function() {
-        $http.get('admin.group.list@json').success(function(data) {
-          $scope.groups = data !== 'null' ? data : null;
+        $http.get('admin.group.list@json', {cache: true}).
+            success(function(data) {
+              $scope.groups = data !== 'null' ? data : null;
 
-          // Select by default the first group.
-          if ($scope.ownerGroup === null && data) {
-            $scope.ownerGroup = data[0]['id'];
-          }
-        });
+              // Select by default the first group.
+              if ($scope.ownerGroup === null && data) {
+                $scope.ownerGroup = data[0]['id'];
+              }
+            });
 
         searchEntries();
       };
@@ -119,8 +120,6 @@
         return false;
       };
 
-
-
       /**
        * Update the form according to the target tab
        * properties and save.
@@ -137,6 +136,37 @@
       /**
        * FIXME: duplicate from EditorController
        */
+      $scope.add = function(ref, name, insertRef, position, attribute) {
+        if (attribute) {
+          // save the form and add attribute
+          // after save is done. When adding an attribute
+          // the snippet returned contains the current field
+          // and the newly created attributes.
+          // Save to not lose current edits in main field.
+          gnEditor.save(false)
+            .then(function() {
+                gnEditor.add(gnCurrentEdit.id, ref, name,
+                    insertRef, position, attribute);
+              });
+        } else {
+          gnEditor.add(gnCurrentEdit.id, ref, name,
+              insertRef, position, attribute);
+        }
+        return false;
+      };
+      $scope.addChoice = function(ref, name, insertRef, position) {
+        gnEditor.addChoice(gnCurrentEdit.id, ref, name,
+            insertRef, position);
+        return false;
+      };
+      $scope.remove = function(ref, parent, domRef) {
+        gnEditor.remove(gnCurrentEdit.id, ref, parent, domRef);
+        return false;
+      };
+      $scope.removeAttribute = function(ref) {
+        gnEditor.removeAttribute(gnCurrentEdit.id, ref);
+        return false;
+      };
       $scope.save = function(refreshForm) {
         gnEditor.save(refreshForm)
           .then(function(form) {
@@ -173,7 +203,6 @@
         return false;
       };
 
-
       /**
        * When the form is loaded, this function is called.
        * Use it to retrieve form variables or initialize
@@ -208,7 +237,6 @@
           });
 
           $scope.gnCurrentEdit = gnCurrentEdit;
-
           $scope.editorFormUrl = gnEditor
             .buildEditUrlPrefix('md.edit') +
               '&starteditingsession=yes&random=' + i++;

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -153,6 +153,7 @@
             $scope.metadataNotFoundId = $routeParams.id;
 
             $scope.mdSchema = data.metadata[0]['geonet:info'].schema;
+            $scope.groupOwner = data.metadata[0].groupOwner;
             $scope.mdTitle = data.metadata[0].title ||
                 data.metadata[0].defaultTitle;
 

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -165,5 +165,7 @@
     "file": "File",
     "error": "Error",
     "importRecords": "Import",
-    "importFromDirReport": "{{success}}/{{records}} record(s) imported successfully in {{time}} seconds."
+    "importFromDirReport": "{{success}}/{{records}} record(s) imported successfully in {{time}} seconds.",
+    "setMetadataGroup": "Change metadata group",
+    "current": "current"
 }

--- a/web-ui/src/main/resources/catalog/locales/fr-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-editor.json
@@ -170,5 +170,7 @@
     "file": "Fichier",
     "error": "Erreur",
     "importRecords": "Importer",
-    "importFromDirReport": "{{success}}/{{records}} fiches(s) importée(s) en {{time}} secondes."
+    "importFromDirReport": "{{success}}/{{records}} fiches(s) importée(s) en {{time}} secondes.",
+    "setMetadataGroup": "Changer le groupe de la fiche",
+    "current": "actuel"
 }

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -40,7 +40,7 @@
               <li class="list-group-item"
                 data-ng-repeat="e in searchResults.records"
                 data-ng-class="e['geonet:info'].id === activeEntry['geonet:info'].id ? 'active' : ''">
-                <a href="" data-ng-click="selectEntry(e)"> {{e.title}} </a>
+                <a href="" data-ng-click="selectEntry(e)">{{e.title}}</a>
                 <div class="pull-right">
                   <a href="" data-ng-click="copyEntry(e)">
                     <i class="fa fa-copy"/>
@@ -99,24 +99,30 @@
       <div class="panel-default panel">
         <div class="panel-heading">
           <span data-translate="">{{activeEntry.title || activeEntry.defaultTitle}}</span>
-          
-          <div class="btn-toolbar">
-            <button type="button" class="btn btn-danger pull-right fa fa-sign-out"
+          <div class="pull-right">
+            <div data-gn-metadata-group-updater="activeEntry.groupOwner"/>
+
+            <button type="button" class="btn btn-primary"
+                    data-ng-click="startSharing()"
+                    data-ng-disabled="activeEntry['geonet:info'].edit !== 'true'">
+              <i class="fa fa-link"></i>&nbsp;<span data-translate="">share</span>
+            </button>
+
+            <button type="button" class="btn btn-primary"
+                    data-ng-click="save()"
+                    data-ng-disabled="activeEntry['geonet:info'].edit !== 'true'">
+              <i class="fa fa-save"></i>&nbsp;<span data-translate="">save</span>
+            </button>
+
+            <button type="button" class="btn btn-danger"
                     data-ng-click="close()"
                     data-ng-disabled="activeEntry['geonet:info'].edit !== 'true'"
               title="{{'closeEditor' | translate}}">
-            </button>
-            <button type="button" class="btn btn-primary pull-right fa fa-save"
-                    data-ng-click="save()"
-                    data-ng-disabled="activeEntry['geonet:info'].edit !== 'true'">
-              <span data-translate="">save</span>
-            </button>
-            <button type="button" class="btn btn-primary pull-right fa fa-link"
-                    data-ng-click="startSharing()"
-                    data-ng-disabled="activeEntry['geonet:info'].edit !== 'true'">
-              <span data-translate="">share</span>
+              <i class="fa fa-sign-out"></i>&nbsp;
             </button>
           </div>
+          <br/>
+          <br/>
         </div>
         <div class="panel-body">
           <fieldset data-ng-disabled="activeEntry['geonet:info'].edit !== 'true'">

--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -38,6 +38,9 @@
       <i class="fa fa-lock"/>
       <span data-translate="">share</span>
     </button>-->
+
+    <div data-gn-metadata-group-updater="groupOwner"/>
+
     <button type="button" class="btn btn-primary navbar-btn" data-ng-click="save()">
       <i class="fa fa-save"/>
       <span data-translate="">save</span>

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -130,6 +130,7 @@
       <field name="_indexingError" tagName="idxError"/>
       <field name="_indexingErrorMsg" tagName="idxMsg"/>
       <field name="_op0" tagName="publishedForGroup"/>
+      <field name="_groupOwner" tagName="groupOwner"/>
     </dumpFields>
   </search>
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -501,6 +501,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.delete!?.*" access="hasRole('Editor')"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.insert!?.*" access="hasRole('Editor')"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.import!?.*" access="hasRole('Editor')"/>
+                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.group.update!?.*" access="hasRole('Editor')"/>
 
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.view!?.*" access="hasRole('Editor')"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.edit!?.*" access="hasRole('Editor')"/>

--- a/web/src/main/webapp/WEB-INF/config/config-ui-metadata.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-ui-metadata.xml
@@ -74,6 +74,18 @@
       <class name=".services.metadata.BatchUpdatePrivileges" />
     </service>
 
+    <service name="md.group.update">
+      <documentation><![CDATA[
+          Change the group the metadata is in. Groupowner database column.
+
+          Parameters are:
+          * id: Metadata identifier
+          * groupid: Group identifier
+          ]]></documentation>
+      <class name=".services.metadata.UpdateGroupOwner"/>
+      <error sheet="../xslt/common/error.xsl"/>
+    </service>
+
     <service name="md.insert">
       <documentation><![CDATA[
         Insert a metadata sending an XML document.


### PR DESCRIPTION
Metadata groupowner is defined when user create a new record. There was no option for the metadata author to easily update the groupowner. This action is added to the editor toolbar to choose the group to put this metadata in using a dropbown button containing the list of groups.

![image](https://cloud.githubusercontent.com/assets/1701393/2697602/371d5ada-c3f0-11e3-986e-1afcd17218fa.png)
