### PR TITLE
Allow harvesting history to be accessible via an XML interface.

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-harvesting.xml
+++ b/web/src/main/webapp/WEB-INF/config-harvesting.xml
@@ -78,6 +78,12 @@
 			<class name=".services.harvesting.Info" />
 		</service>
 
+				<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+		<service name="xml.harvesting.history">
+			<class name=".services.harvesting.History" />
+		</service>
+
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
 		<service name="harvesting.log">

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -152,6 +152,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/xml.harvesting.info!?.*" access="hasRole('UserAdmin')"></sec:intercept-url>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/xml.harvesting.clone!?.*" access="hasRole('UserAdmin')"></sec:intercept-url>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/xml.harvesting.clear!?.*" access="hasRole('UserAdmin')"></sec:intercept-url>
+                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/xml.harvesting.history!?.*" access="hasRole('UserAdmin')"></sec:intercept-url>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/harvesting.history.full!?.*" access="hasRole('UserAdmin')"></sec:intercept-url>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/harvesting.history!?.*" access="hasRole('UserAdmin')"></sec:intercept-url>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/harvesting.history.delete!?.*" access="hasRole('UserAdmin')"></sec:intercept-url>


### PR DESCRIPTION
From the [documentation](http://geonetwork-opensource.org/manuals/2.10.3/eng/developer/xml_services/services_harvesting.html#retrieve-harvesting-history-xml-harvesting-history) it indicates that harvesting history is accessible via XML.

For a project I had to alter the codebase to make it so using this patch.
