### PR TITLE
XSL transformation / Add support for datatype in xsl:param.

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -390,19 +390,19 @@ public final class Xml
     /**
      * Transforms an xml tree into another using a stylesheet on disk and pass parameters.
      *
+     *
      * @param xml
      * @param styleSheetPath
      * @param params
      * @return
      * @throws Exception
      */
-	public static Element transform(Element xml, String styleSheetPath, Map<String,String> params) throws Exception
+	public static Element transform(Element xml, String styleSheetPath, Map<String, Object> params) throws Exception
 	{
 		JDOMResult resXml = new JDOMResult();
 		transform(xml, styleSheetPath, resXml, params);
 		return (Element)resXml.getDocument().getRootElement().detach();
 	}
-
 	//--------------------------------------------------------------------------
 
     /**
@@ -499,13 +499,14 @@ public final class Xml
     /**
      * Transforms an xml tree putting the result to a stream with optional parameters.
      *
+     *
      * @param xml
      * @param styleSheetPath
      * @param result
      * @param params
      * @throws Exception
      */
-	public static void transform(Element xml, String styleSheetPath, Result result, Map<String,String> params) throws Exception
+	public static void transform(Element xml, String styleSheetPath, Result result, Map<String, Object> params) throws Exception
 	{
 		File styleSheet = new File(styleSheetPath);
 		Source srcXml   = new JDOMSource(new Document((Element)xml.detach()));
@@ -529,14 +530,13 @@ public final class Xml
 		} finally {
 			Transformer t = transFact.newTransformer(srcSheet);
 			if (params != null) {
-				for (Map.Entry<String,String> param : params.entrySet()) {
+				for (Map.Entry<String,Object> param : params.entrySet()) {
 					t.setParameter(param.getKey(),param.getValue());
 				}
 			}
 			t.transform(srcXml, result);
 		}
 	}
-
 	//--------------------------------------------------------------------------
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -898,7 +898,7 @@ public class DataManager {
                 String schemaTronXmlXslt = metadataSchema.getSchemaDir() + File.separator
                         + "schematron" + File.separator + rule;
                 try {
-                    Map<String,String> params = new HashMap<String,String>();
+                    Map<String,Object> params = new HashMap<String,Object>();
                     params.put("lang", lang);
                     params.put("rule", rule);
                     params.put("thesaurusDir", this.thesaurusDir);
@@ -1987,7 +1987,7 @@ public class DataManager {
                     report.setAttribute("required", requirement.toString(), Edit.NAMESPACE);
 
                     try {
-                        Map<String,String> params = new HashMap<String,String>();
+                        Map<String,Object> params = new HashMap<String,Object>();
                         params.put("lang", lang);
                         params.put("rule", ruleId);
                         params.put("thesaurusDir", this.thesaurusDir);
@@ -2878,20 +2878,21 @@ public class DataManager {
      * Children MUST be editable and also in the same schema of the parent.
      * If not, child is not updated.
      *
+     *
      * @param srvContext
      *            service context
      * @param parentUuid
      *            parent uuid
-     * @param params
-     *            parameters
      * @param children
      *            children
+     * @param params
+     *            parameters
      * @return
      * @throws Exception
      */
-    public Set<String> updateChildren(ServiceContext srvContext, String parentUuid, String[] children, Map<String, String> params) throws Exception {
-        String parentId = params.get(Params.ID);
-        String parentSchema = params.get(Params.SCHEMA);
+    public Set<String> updateChildren(ServiceContext srvContext, String parentUuid, String[] children, Map<String, Object> params) throws Exception {
+        String parentId = (String)params.get(Params.ID);
+        String parentSchema = (String)params.get(Params.SCHEMA);
 
         // --- get parent metadata in read/only mode
         boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = false;

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -1134,7 +1134,7 @@ public class SearchManager {
         try {
             String defaultStyleSheet = new File(schemaDir, "index-fields.xsl").getAbsolutePath();
             String otherLocalesStyleSheet = new File(schemaDir, "language-index-fields.xsl").getAbsolutePath();
-            Map<String, String> params = new HashMap<String, String>();
+            Map<String, Object> params = new HashMap<String, Object>();
             params.put("inspire", Boolean.toString(isInspireEnabled()));
             params.put("thesauriDir", _geonetworkDataDirectory.getThesauriDir().getAbsolutePath());
             Element defaultLang = Xml.transform(xml, defaultStyleSheet, params);

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -301,7 +301,7 @@ public class SearchController {
 		String schemaDir  = schemaManager.getSchemaCSWPresentDir(schema)+ File.separator;
 		String styleSheet = schemaDir + prefix +"-"+ elementSetName +".xsl";
 
-		Map<String, String> params = new HashMap<String, String>();
+		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("lang", displayLanguage);
 		params.put("displayInfo", resultType == ResultType.RESULTS_WITH_SUMMARY ? "true" : "false");
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -129,7 +129,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
      * @throws Exception hmm
      */
 	private Element transformSort(Element nodes, String sortField) throws Exception {
-		Map<String,String> params = new HashMap<String,String>();
+		Map<String,Object> params = new HashMap<String,Object>();
 		params.put("sortField", sortField);
 
 		return Xml.transform(nodes, xslPath + Geonet.File.SORT_HARVESTERS, params);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvesterUtil.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvesterUtil.java
@@ -14,10 +14,10 @@ import java.util.Map;
  * Created by francois on 3/7/14.
  */
 public class HarvesterUtil {
-    public static Pair<String, Map<String, String>> parseXSLFilter(String filter,
+    public static Pair<String, Map<String, Object>> parseXSLFilter(String filter,
                                 Logger log) {
         String processName = filter;
-        Map<String, String> processParams = new HashMap<String, String>();
+        Map<String, Object> processParams = new HashMap<String, Object>();
 
         // Parse complex xslfilter process_name?process_param1=value&process_param2=value...
         if (filter.contains("?")) {
@@ -49,15 +49,17 @@ public class HarvesterUtil {
     /**
      * Filter the metadata if process parameter is set and
      * corresponding XSL transformation exists.
+     *
      * @param metadataSchema
      * @param md
      *
+     * @param processParams
      * @return
      */
     public static Element processMetadata(MetadataSchema metadataSchema,
                                           Element md,
                                           String processName,
-                                          Map<String, String> processParams,
+                                          Map<String, Object> processParams,
                                           Logger log) {
 
         String filePath = metadataSchema.getSchemaDir() +

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -137,7 +137,7 @@ public class Aligner extends BaseAligner
 
         dataMan.flush();
 
-        Pair<String, Map<String, String>> filter =
+        Pair<String, Map<String, Object>> filter =
                 HarvesterUtil.parseXSLFilter(params.xslfilter, log);
         processName = filter.one();
         processParams = filter.two();
@@ -483,5 +483,5 @@ public class Aligner extends BaseAligner
     private GetRecordByIdRequest request;
 
     private String processName;
-    private Map<String, String> processParams = new HashMap<String, String>();
+    private Map<String, Object> processParams = new HashMap<String, Object>();
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -132,7 +132,7 @@ public class Aligner extends BaseAligner
 
         dataMan.flush();
 
-        Pair<String, Map<String, String>> filter =
+        Pair<String, Map<String, Object>> filter =
                 HarvesterUtil.parseXSLFilter(params.xslfilter, log);
         processName = filter.one();
         processParams = filter.two();
@@ -787,7 +787,7 @@ public class Aligner extends BaseAligner
 	private UUIDMapper     localUuids;
 	
 	private String processName;
-    private Map<String, String> processParams = new HashMap<String, String>();
+    private Map<String, Object> processParams = new HashMap<String, Object>();
 
     private HashMap<String, HashMap<String, String>> hmRemoteGroups = new HashMap<String, HashMap<String, String>>();
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -282,7 +282,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 
          if(log.isDebugEnabled()) log.debug ("  - XSLT transformation using " + styleSheet);
 		
-		Map<String, String> param = new HashMap<String, String>();
+		Map<String, Object> param = new HashMap<String, Object>();
 		param.put("lang", params.lang);
 		param.put("topic", params.topic);
 		param.put("uuid", uuid);
@@ -629,7 +629,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 		if (!loaded && params.useLayer){
 			try {
 				//--- set XSL param to filter on layer and set uuid
-				Map<String, String> param = new HashMap<String, String>();
+				Map<String, Object> param = new HashMap<String, Object>();
 				param.put("uuid", reg.uuid);
 				param.put("Name", reg.name);
 				param.put("lang", params.lang);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
@@ -338,7 +338,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 			//--- (not sure that this is what we should do here really - the catalog
 			//--- is a dataset and a service??
 			log.info("Creating service metadata for thredds catalog...");
-			Map<String, String> param = new HashMap<String, String>();
+			Map<String, Object> param = new HashMap<String, Object>();
 			param.put("lang",			params.lang);
 			param.put("topic",		params.topic);
 			param.put("uuid",			params.uuid);
@@ -1071,7 +1071,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 
             if(log.isDebugEnabled()) log.debug("  - XSLT transformation using "+serviceStyleSheet);
 
-			Map<String, String> param = new HashMap<String, String>();
+			Map<String, Object> param = new HashMap<String, Object>();
 			param.put("lang",		params.lang);
 			param.put("topic",	params.topic);
 			param.put("uuid",		sUuid);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WAFRemoteFile.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WAFRemoteFile.java
@@ -91,7 +91,7 @@ class WAFRemoteFile implements RemoteFile {
         // md5 the full capabilities URL
         String uuid = Sha1Encoder.encodeString (url); // is the service identifier
 
-        Map<String, String> param = new HashMap<String, String>();
+        Map<String, Object> param = new HashMap<String, Object>();
         param.put("uuid", uuid);
 
         el = Xml.transform (xml, styleSheet, param);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
@@ -390,7 +390,7 @@ class Harvester implements IHarvester<HarvestResult>
 	private UUIDMapper     localUuids;
 	private String	 		metadataGetService;
 	private String	 		 stylesheetDirectory;
-	private Map<String,String> ssParams = new HashMap<String,String>();
+	private Map<String,Object> ssParams = new HashMap<String,Object>();
     /**
      * Contains a list of accumulated errors during the executing of this harvest.
      */

--- a/services/src/main/java/org/fao/geonet/services/metadata/GetSuggestion.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/GetSuggestion.java
@@ -60,7 +60,7 @@ import java.util.Map;
  *   </suggestions>
  * }
  * </pre>
- * 
+ * A
  * The process attribute contains the process identifier.
  * </li>
  * <li>
@@ -94,7 +94,7 @@ public class GetSuggestion implements Service {
         String action = Util.getParam(params, "action", "list");
         @SuppressWarnings("unchecked")
         List<Element> children = params.getChildren();
-        Map<String, String> xslParameter = new HashMap<String, String>();
+        Map<String, Object> xslParameter = new HashMap<String, Object>();
         xslParameter.put("guiLang", context.getLanguage());
         xslParameter.put("siteUrl", sm.getSiteURL(context));
         xslParameter.put("baseUrl", context.getBaseUrl());

--- a/services/src/main/java/org/fao/geonet/services/metadata/UpdateChildren.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/UpdateChildren.java
@@ -68,7 +68,7 @@ public class UpdateChildren extends NotInReadOnlyModeService {
         // Transform params element into Map<String, String> for xsl transformation
         @SuppressWarnings("unchecked")
         List<Element> lstParams = params.getChildren();
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, Object> parameters = new HashMap<String, Object>();
         for (Element param : lstParams) {
             parameters.put(param.getName(), param.getTextTrim());
         }

--- a/services/src/main/java/org/fao/geonet/services/metadata/XslProcessing.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/XslProcessing.java
@@ -198,7 +198,7 @@ public class XslProcessing extends NotInReadOnlyModeService {
 	            // -- here we send parameters set by user from URL if needed.
 	            @SuppressWarnings("unchecked")
 	            List<Element> children = params.getChildren();
-	            Map<String, String> xslParameter = new HashMap<String, String>();
+	            Map<String, Object> xslParameter = new HashMap<String, Object>();
 	            xslParameter.put("guiLang", context.getLanguage());
 	            xslParameter.put("baseUrl", context.getBaseUrl());
                 xslParameter.put("catalogUrl", settingsMan.getSiteURL(context));

--- a/web/src/test/java/org/fao/geonet/kernel/schema/AbstractSchematronTest.java
+++ b/web/src/test/java/org/fao/geonet/kernel/schema/AbstractSchematronTest.java
@@ -39,7 +39,7 @@ public class AbstractSchematronTest {
     protected final static File WEBAPP_DIR = findWebappDir(CLASS_FILE);
     protected final static File SCHEMATRON_COMPILATION_FILE = new File(WEBAPP_DIR, "WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl");
     protected final static File SCHEMA_PLUGINS = new File(WEBAPP_DIR, "WEB-INF/data/config/schema_plugins/");
-    protected Map<String, String> params = new HashMap<String, String>();
+    protected Map<String, Object> params = new HashMap<String, Object>();
 
     protected static File THESAURUS_DIR;
     @Rule


### PR DESCRIPTION
```
Before that change all XSL parameters were defined as String and
XSL conversion may be required for example to convert string to boolean, ...

With this change, more strict type could be defined in XSLT.
eg. use as attribute to define the datatype:

  <xsl:param name="setParentIdentifierWithUUIDAttribute"
             select="true()"
             as="xs:boolean"/>

Saxon Java class mapping to XPath type is defined http://www.saxonica.com/documentation/javadoc/net/sf/saxon/Controller.html#setParameter(java.lang.String, java.lang.Object)
```
