### PR TITLE
CSW / Make the distinction between 'own' and 'http://www.isotc211.org/2005/gmd' for outputSchema.

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -290,11 +290,11 @@ public class SearchController {
         String prefix ;
         if (outputSchema == OutputSchema.OGC_CORE) {
             prefix = "ogc";
-        }
-        else if (outputSchema == OutputSchema.ISO_PROFILE || outputSchema == OutputSchema.OWN) {
+        } else if (outputSchema == OutputSchema.ISO_PROFILE) {
             prefix = "iso";
-        }
-        else {
+        } else if (outputSchema == OutputSchema.OWN) {
+            prefix = "own";
+        } else {
             throw new InvalidParameterValueEx("outputSchema not supported for metadata " + id + " schema.", schema);
         }
 

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/csw/own-brief.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/csw/own-brief.xsl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="iso-brief.xsl"/>
+</xsl:stylesheet>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/csw/own-full.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/csw/own-full.xsl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="iso-full.xsl"/>
+</xsl:stylesheet>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/csw/own-summary.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/csw/own-summary.xsl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="iso-summary.xsl"/>
+</xsl:stylesheet>


### PR DESCRIPTION
When adding a new schema (eg. ISO19115-1), user may require backward compatibility with ISO19139. In that case CSW request using 'csw:IsoRecord' or 'http://www.isotc211.org/2005/gmd' should return the record in ISO19139:

```
<?xml version="1.0"?>
<csw:GetRecordById xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
  service="CSW"
  version="2.0.2"
  outputSchema="http://www.isotc211.org/2005/gmd">
    <csw:Id>cecd1ebf-719e-4b1f-b6a7-86c17ed02c62</csw:Id>
    <csw:ElementSetName>brief</csw:ElementSetName>
</csw:GetRecordById>
```

If user wants to retrieve the original document in its own schema, then 'own' outputSchema could be used.

For a schema plugin which should return the same document in both cases (like iso19139), copy the iso19139 schema csw/own-*.xsl.

At a later stage, it may be relevant to register outputSchema from profile configuration (see https://github.com/geonetwork/core-geonetwork/blob/develop/csw-server/src/main/java/org/fao/geonet/csw/common/OutputSchema.java#L21). For exemple, one namespace in the schema (eg. http://www.isotc211.org/2005/mdb/1.0/2013-06-24) could define the conversion to apply in CSW request:

```
<?xml version="1.0"?>
<csw:GetRecordById xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
  service="CSW"
  version="2.0.2"
  outputSchema="http://www.isotc211.org/2005/mdb/1.0/2013-06-24">
    <csw:Id>cecd1ebf-719e-4b1f-b6a7-86c17ed02c62</csw:Id>
    <csw:ElementSetName>brief</csw:ElementSetName>
</csw:GetRecordById>
```

For the time being the 'own' value is a workaround for that.
