### PR TITLE
ISO19139 / Indexing / Topic category is an enumeration (not a label trans...

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-csw.xml
+++ b/web/src/main/webapp/WEB-INF/config-csw.xml
@@ -16,7 +16,7 @@
 				<!-- - - - - - - - - - - - - - -->
 				<!-- Core queryable properties -->
 				<!-- - - - - - - - - - - - - - -->
-                <parameter name="Subject" field="keyword" type="SupportedISOQueryables">
+                <parameter name="Subject" field="keywordAndTopicCategory" type="SupportedISOQueryables">
                     <xpath schema="iso19139" path="*/gmd:MD_Keywords/gmd:keyword/gco:CharacterString" />
                 </parameter>
 

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
@@ -224,6 +224,7 @@
         <xsl:for-each
             select="gmd:keyword/gco:CharacterString|gmd:keyword/gmx:Anchor|gmd:keyword/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString">
           <Field name="keyword" string="{string(.)}" store="true" index="true"/>
+          <Field name="keywordAndTopicCategory" string="{string(.)}" store="false" index="true"/>
           <xsl:if test="$inspire='true'">
             <xsl:if test="string-length(.) &gt; 0">
 
@@ -293,7 +294,7 @@
 	
 			<xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode">
 				<Field name="topicCat" string="{string(.)}" store="true" index="true"/>
-				<Field name="keyword" string="{string(.)}" store="true" index="true"/>
+				<Field name="keywordAndTopicCategory" string="{string(.)}" store="false" index="true"/>
 			</xsl:for-each>
 
 			<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->		


### PR DESCRIPTION
...lated) and should not be indexed as keyword. Add a dedicated field for the CSW Subject queryable.

Currently topic category is displayed in search results and facets. In future release, topic category should be translated when indexed with keyword ?
