### PR TITLE
Suggestion / Add the possibility to search on a field and suggest on another

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -623,7 +623,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
             String[] items = summaryItemsEl.getValue().split(",");
 
             for (String item : items) {
-                if (item.equals("any")) {
+                if (item.startsWith("any")) {
                     tmpConfig = _summaryConfig;
                     break;
                 }

--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/form/OpenSearchSuggestionTextField.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/form/OpenSearchSuggestionTextField.js
@@ -82,6 +82,14 @@ GeoNetwork.form.OpenSearchSuggestionTextField = Ext.extend(Ext.form.ComboBox, {
          *  Default any (ie. full text search).
          */
         field: 'any',
+        /** api: config[suggestionField]
+         *  ``String`` Optional, GeoNetwork Lucene field to use for suggestion.
+         *  If undefined, field is used. That could be useful to restrict the suggestion
+         *  to a subset of values for this field. For example any match any text
+         *  in a metadata record, but suggestion could be limited to title, abstract, keywords
+         *  stored in the anylight field.
+         */
+        suggestionField: '',
         /** api: config[fieldName] 
          *  ``String`` Optional, Field name.
          */
@@ -155,7 +163,7 @@ GeoNetwork.form.OpenSearchSuggestionTextField = Ext.extend(Ext.form.ComboBox, {
             url: this.url,
             rootId: 1,
             baseParams: {
-                field: this.field,
+                field: this.suggestionField || this.field,
 //                withFrequency: true, // To display frequency info
                 sortBy: this.sortBy
             }

--- a/web-client/src/main/resources/apps/search/js/App.js
+++ b/web-client/src/main/resources/apps/search/js/App.js
@@ -336,6 +336,7 @@ GeoNetwork.app = function () {
                 new GeoNetwork.form.OpenSearchSuggestionTextField({
                     hideLabel: true,
                     minChars: 2,
+                    suggestionField: 'anylight',
                     loadingText: '...',
                     hideTrigger: true,
                     url: catalogue.services.opensearchSuggest

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -276,6 +276,7 @@
    -->
   <tokenized>
     <Field name="any"/>
+    <Field name="anylight"/>
     <Field name="abstract"/>
     <Field name="title"/>
     <Field name="altTitle"/>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
@@ -130,7 +130,6 @@
                     <!-- not tokenized title for sorting -->
                     <Field name="_title" string="{string(.)}" store="false" index="true"/>
 				</xsl:for-each>
-	
 				<xsl:for-each select="gmd:alternateTitle/gco:CharacterString">
 					<Field name="altTitle" string="{string(.)}" store="true" index="true"/>
 				</xsl:for-each>
@@ -180,7 +179,7 @@
             <xsl:for-each select="gmd:pointOfContact[1]/*/gmd:role/*/@codeListValue">
             	<Field name="responsiblePartyRole" string="{string(.)}" store="true" index="true"/>
             </xsl:for-each>
-            
+
 			<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->		
 	
 			<xsl:for-each select="gmd:abstract/gco:CharacterString">
@@ -694,7 +693,27 @@
 				</xsl:for-each>
 			</xsl:attribute>
 		</Field>
-				
+
+    <xsl:variable name="identification" select="gmd:identificationInfo//gmd:MD_DataIdentification|
+			gmd:identificationInfo//*[contains(@gco:isoType, 'MD_DataIdentification')]|
+			gmd:identificationInfo/srv:SV_ServiceIdentification"/>
+
+
+    <Field name="anylight" store="false" index="true">
+      <xsl:attribute name="string">
+        <xsl:for-each
+            select="$identification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString|
+                    $identification/gmd:citation/gmd:CI_Citation/gmd:alternateTitle/gco:CharacterString|
+                    $identification/gmd:abstract/gco:CharacterString|
+                    $identification/gmd:credit/gco:CharacterString|
+                    $identification//gmd:organisationName/gco:CharacterString|
+                    $identification/gmd:supplementalInformation/gco:CharacterString|
+                    $identification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString|
+                    $identification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gmx:Anchor">
+          <xsl:value-of select="concat(., ' ')"/>
+        </xsl:for-each>
+      </xsl:attribute>
+    </Field>
 		<!--<xsl:apply-templates select="." mode="codeList"/>-->
 		
 	</xsl:template>


### PR DESCRIPTION
Add the possibility to have a search field on a specific lucene field and the suggestion list based on another field. The main idea is to restrict the list of possibilities for a full text field which will suggest numbers, uuids, filepath fragments, ... which could be complex to understand for the end-user. For example:

![image](https://cloud.githubusercontent.com/assets/1701393/3030335/c901ff12-e03f-11e3-9c97-553803c66100.png)

In that case, a new field named anylight is created only indexing title, abstracts, keywords from which the suggestion will come from for the full text search field.
