### PR TITLE
Improvement/iso19139/index topiccategory enumeration translation in keyword

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -10,6 +10,10 @@ import java.util.regex.Pattern;
 import jeeves.component.ProfileManager;
 
 import jeeves.server.context.ServiceContext;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.search.CodeListTranslator;
+import org.fao.geonet.kernel.search.Translator;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.fao.geonet.constants.Geonet;
@@ -226,6 +230,30 @@ public final class XslUtil
             return "";
         }
     }
+
+
+    /**
+     * Return a translation for a codelist or enumeration element.
+     *
+     * @param codelist The codelist name (eg. gmd:MD_TopicCategoryCode)
+     * @param value The value to search for in the translation file
+     * @param langCode  The language
+     * @return  The translation or the code list value if not found.
+     */
+    public static String getCodelistTranslation(Object codelist, Object value, Object langCode) {
+        String translation;
+        String codeListValue = (String) value;
+        try {
+            final GeonetContext gc = (GeonetContext) ServiceContext.get().getHandlerContext(Geonet.CONTEXT_NAME);
+            Translator t = new CodeListTranslator(gc.getBean(SchemaManager.class), (String) langCode, (String) codelist);
+            translation = t.translate(codeListValue);
+        } catch (Exception e) {
+            Log.error(Geonet.GEONETWORK, "Failed to translate codelist " + e.getMessage());
+            translation = codeListValue;
+        }
+        return translation;
+    }
+
     /**
      * Return 2 iso lang code from a 3 iso lang code. If any error occurs return "".
      *

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
@@ -6,7 +6,9 @@
 										xmlns:geonet="http://www.fao.org/geonetwork"
 										xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 										xmlns:gmx="http://www.isotc211.org/2005/gmx"
-                                        xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+                    xmlns:util="java:org.fao.geonet.util.XslUtil"
+                    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                    exclude-result-prefixes="#all">
 
 	<xsl:include href="convert/functions.xsl"/>
 	<xsl:include href="../../../xsl/utils-fn.xsl"/>
@@ -47,13 +49,13 @@
   <xsl:variable name="indexAllKeywordDetails" select="true()"/>
 
 
+  <!-- The main metadata language -->
+  <xsl:variable name="isoLangId">
+    <xsl:call-template name="langId19139"/>
+  </xsl:variable>
+
   <!-- ========================================================================================= -->
-
-	<xsl:template match="/">
-	    <xsl:variable name="isoLangId">
-	  	    <xsl:call-template name="langId19139"/>
-        </xsl:variable>
-
+  <xsl:template match="/">
 		<Document locale="{$isoLangId}">
 			<Field name="_locale" string="{$isoLangId}" store="true" index="true"/>
 
@@ -349,7 +351,10 @@
 	
 			<xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode">
 				<Field name="topicCat" string="{string(.)}" store="true" index="true"/>
-				<Field name="keyword" string="{string(.)}" store="true" index="true"/>
+        <Field name="keyword"
+               string="{util:getCodelistTranslation('gmd:MD_TopicCategoryCode', string(.), string($isoLangId))}"
+               store="true"
+               index="true"/>
 			</xsl:for-each>
 
 			<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->		

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/language-index-fields.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/language-index-fields.xsl
@@ -82,6 +82,7 @@
 		
 				<xsl:apply-templates select="/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']" mode="metadata">
 					<xsl:with-param name="langId" select="$poundLangId"/>
+          <xsl:with-param name="isoLangId" select="$isoLangId"/>
 				</xsl:apply-templates>
 
 				<xsl:apply-templates mode="index" select="*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']">
@@ -102,6 +103,8 @@
 
 	<xsl:template match="*" mode="metadata">
 		<xsl:param name="langId" />
+    <xsl:param name="isoLangId"/>
+
 		<!-- === Data or Service Identification === -->
 
 		<!-- the double // here seems needed to index MD_DataIdentification when
@@ -236,7 +239,10 @@
 
 			<xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode">
 				<Field name="topicCat" string="{string(.)}" store="true" index="true"/>
-				<Field name="subject" string="{string(.)}" store="true" index="true"/>
+				<Field name="keyword"
+               string="{java:getCodelistTranslation('gmd:MD_TopicCategoryCode', string(.), string($isoLangId))}"
+               store="true"
+               index="true"/>
 			</xsl:for-each>
 
 			<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->


### PR DESCRIPTION
Add a new method in XslUtil to retrieve translation for codelist and use it to properly index topic category enumeration.

Replace https://github.com/geonetwork/core-geonetwork/pull/494
