### PR TITLE
Improvement/csw/fix mandatory constraint param in get mode

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecords.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecords.java
@@ -331,8 +331,8 @@ public class GetRecords extends AbstractOperation implements CatalogService {
 
         //--- handle constraint
 
-        ConstraintLanguage language = ConstraintLanguage.parse(constrLang);
         if (constraint != null) {
+            ConstraintLanguage language = ConstraintLanguage.parse(constrLang);
             Element constr = new Element("Constraint", Csw.NAMESPACE_CSW);
             query.addContent(constr);
 


### PR DESCRIPTION
The request
http://localhost:8080/geonetwork/srv/eng/csw?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetRecords

return

```
<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2.0" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd">
<ows:Exception exceptionCode="MissingParameterValue" locator="constraintLanguage"/>
</ows:ExceptionReport>
```

And the equivalent using POST:

```
<?xml version="1.0"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" service="CSW" version="2.0.2">
    <csw:Query typeNames="csw:Record">
    </csw:Query>
</csw:GetRecords>
```

return :

```
<?xml version="1.0" encoding="UTF-8"?>
<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
  <csw:SearchStatus timestamp="2014-06-10T10:57:22" />
  <csw:SearchResults numberOfRecordsMatched="0" numberOfRecordsReturned="0" elementSet="summary" nextRecord="0" />
</csw:GetRecordsResponse>
```

Constraint must be not mandatory in GET mode.
