### PR TITLE
Activating Maven reporting tools

### DIFF
--- a/cachingxslt/pom.xml
+++ b/cachingxslt/pom.xml
@@ -58,7 +58,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
   </distributionManagement>
   <properties>

--- a/cachingxslt/pom.xml
+++ b/cachingxslt/pom.xml
@@ -20,45 +20,48 @@
 	<description>
     Caching xslt project.
   </description>
-
-	<licenses>
-		<license>
-			<name>General Public License (GPL)</name>
-			<url>http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
-	<dependencies>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-		<dependency>
-			<groupId>net.sf.saxon</groupId>
-			<artifactId>saxon</artifactId>
-		</dependency>
-	</dependencies>
-
-	<profiles>
-		<profile>
-			<id>run-static-analysis</id>
-			<activation>
-				<property>
-					<name>!skipTests</name>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>findbugs-maven-plugin</artifactId>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-	<properties>
-		<rootProjectDir>${basedir}/..</rootProjectDir>
-	</properties>
+  <licenses>
+    <license>
+      <name>General Public License (GPL)</name>
+      <url>http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <dependencies>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.saxon</groupId>
+      <artifactId>saxon</artifactId>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>run-static-analysis</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+  </distributionManagement>
+  <properties>
+    <rootProjectDir>${basedir}/..</rootProjectDir>
+  </properties>
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -123,27 +123,31 @@
             <artifactId>xom</artifactId>
         </dependency>
     </dependencies>
-
-
-	<profiles>
-		<profile>
-			<id>run-static-analysis</id>
-			<activation>
-				<property>
-					<name>!skipTests</name>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>findbugs-maven-plugin</artifactId>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-	<properties>
-		<rootProjectDir>${basedir}/..</rootProjectDir>
-	</properties>
+    <profiles>
+      <profile>
+        <id>run-static-analysis</id>
+        <activation>
+          <property>
+            <name>!skipTests</name>
+          </property>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
+    <properties>
+      <rootProjectDir>${basedir}/..</rootProjectDir>
+    </properties>
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -144,7 +144,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
     <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -400,7 +400,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
     <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -397,8 +397,13 @@
             </build>
         </profile>
     </profiles>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
     <properties>
         <rootProjectDir>${basedir}/..</rootProjectDir>
     </properties>
-
 </project>

--- a/csw-server/pom.xml
+++ b/csw-server/pom.xml
@@ -70,7 +70,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
   </distributionManagement>
   <properties>

--- a/csw-server/pom.xml
+++ b/csw-server/pom.xml
@@ -1,79 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<artifactId>geonetwork</artifactId>
-		<groupId>org.geonetwork-opensource</groupId>
-		<version>2.11.0-SNAPSHOT</version>
-	</parent>
-	<modelVersion>4.0.0</modelVersion>
-
-	<artifactId>csw-server</artifactId>
-    	<name>GeoNetwork CSW server</name>
-
-
-	<dependencies>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>jeeves</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>core</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>domain</artifactId>
-			<version>${project.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>core</artifactId>
-			<version>${project.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-		</dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-        </dependency>
-
-        <dependency>
-			<groupId>org.jdom</groupId>
-			<artifactId>jdom</artifactId>
-			<version>1.1.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
-		</dependency>
-	</dependencies>
-
-	<profiles>
-		<profile>
-			<id>run-static-analysis</id>
-			<activation>
-				<property>
-					<name>!skipTests</name>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>findbugs-maven-plugin</artifactId>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-	<properties>
-		<rootProjectDir>${basedir}/..</rootProjectDir>
-	</properties>
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>geonetwork</artifactId>
+    <groupId>org.geonetwork-opensource</groupId>
+    <version>2.11.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>csw-server</artifactId>
+  <name>GeoNetwork CSW server</name>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jeeves</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>domain</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>run-static-analysis</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+  </distributionManagement>
+  <properties>
+    <rootProjectDir>${basedir}/..</rootProjectDir>
+  </properties>
 </project>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -278,7 +278,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
   </distributionManagement>
   <properties>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -275,5 +275,13 @@
       </plugin>
     </plugins>
   </build>
-
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+  </distributionManagement>
+  <properties>
+    <rootProjectDir>${basedir}/..</rootProjectDir>
+  </properties>
 </project>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -151,6 +151,12 @@
             </build>
         </profile>
     </profiles>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
     <properties>
         <rootProjectDir>${basedir}/..</rootProjectDir>
     </properties>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -154,7 +154,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
     <properties>

--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -494,7 +494,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
 </project>

--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -83,6 +83,7 @@
         <sslAppPort>8443</sslAppPort>
         <jetty.stop.port>8012</jetty.stop.port>
         <geonetworkWar>${project.build.directory}/geonetworkWar</geonetworkWar>
+        <rootProjectDir>${basedir}/..</rootProjectDir>
     </properties>
     <build>
         <plugins>
@@ -490,4 +491,10 @@
             </properties>
         </profile>
     </profiles>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
 </project>

--- a/harvesters/pom.xml
+++ b/harvesters/pom.xml
@@ -87,7 +87,7 @@
         <distributionManagement>
           <site>
             <id>Maven generated site and reports</id>
-            <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+            <url>file://${rootProjectDir}/target/site/${artifactId}</url>
           </site>
         </distributionManagement>
         <properties>

--- a/harvesters/pom.xml
+++ b/harvesters/pom.xml
@@ -84,7 +84,13 @@
 			</build>
 		</profile>
 	</profiles>
-	<properties>
-		<rootProjectDir>${basedir}/..</rootProjectDir>
-	</properties>
+        <distributionManagement>
+          <site>
+            <id>Maven generated site and reports</id>
+            <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+          </site>
+        </distributionManagement>
+        <properties>
+          <rootProjectDir>${basedir}/..</rootProjectDir>
+        </properties>
 </project>

--- a/healthmonitor/pom.xml
+++ b/healthmonitor/pom.xml
@@ -71,7 +71,7 @@
         <distributionManagement>
           <site>
             <id>Maven generated site and reports</id>
-            <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+            <url>file://${rootProjectDir}/target/site/${artifactId}</url>
           </site>
         </distributionManagement>
 	<properties>

--- a/healthmonitor/pom.xml
+++ b/healthmonitor/pom.xml
@@ -68,6 +68,12 @@
 			</build>
 		</profile>
 	</profiles>
+        <distributionManagement>
+          <site>
+            <id>Maven generated site and reports</id>
+            <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+          </site>
+        </distributionManagement>
 	<properties>
 		<rootProjectDir>${basedir}/..</rootProjectDir>
 	</properties>

--- a/jeeves/pom.xml
+++ b/jeeves/pom.xml
@@ -177,26 +177,31 @@
             <artifactId>aspectjweaver</artifactId>
         </dependency>
     </dependencies>
-
-	<profiles>
-		<profile>
-			<id>run-static-analysis</id>
-			<activation>
-				<property>
-					<name>!skipTests</name>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>findbugs-maven-plugin</artifactId>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-	<properties>
-		<rootProjectDir>${basedir}/..</rootProjectDir>
-	</properties>
-</project>
+    <profiles>
+      <profile>
+        <id>run-static-analysis</id>
+        <activation>
+          <property>
+            <name>!skipTests</name>
+          </property>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
+    <properties>
+      <rootProjectDir>${basedir}/..</rootProjectDir>
+    </properties>
+  </project>

--- a/jeeves/pom.xml
+++ b/jeeves/pom.xml
@@ -198,7 +198,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
     <properties>

--- a/jmeter/pom.xml
+++ b/jmeter/pom.xml
@@ -180,7 +180,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
   </distributionManagement>
 </project>

--- a/jmeter/pom.xml
+++ b/jmeter/pom.xml
@@ -24,7 +24,7 @@
     <admin.password>admin</admin.password>
     <base.url>/geonetwork/srv/eng</base.url>
     <base.loc.url>/geonetwork/srv/eng</base.loc.url>
-    
+    <rootProjectDir>${basedir}/..</rootProjectDir>
     <!-- jetty properties -->
     <geonetworkWar>${basedir}/target/geonetworkWar</geonetworkWar>
   </properties>
@@ -177,4 +177,10 @@
       </build>
     </profile>
   </profiles>
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+  </distributionManagement>
 </project>

--- a/oaipmh/pom.xml
+++ b/oaipmh/pom.xml
@@ -20,48 +20,49 @@
 	<description>
     Oaipmh project.
   </description>
-
-	<licenses>
-		<license>
-			<name>General Public License (GPL)</name>
-			<url>http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
-
-	<dependencies>
-		<dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>jeeves</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-	</dependencies>
-
-
-	<profiles>
-		<profile>
-			<id>run-static-analysis</id>
-			<activation>
-				<property>
-					<name>!skipTests</name>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>findbugs-maven-plugin</artifactId>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-	<properties>
-		<rootProjectDir>${basedir}/..</rootProjectDir>
-	</properties>
+  <licenses>
+    <license>
+      <name>General Public License (GPL)</name>
+      <url>http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jeeves</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>run-static-analysis</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+  </distributionManagement>
+  <properties>
+    <rootProjectDir>${basedir}/..</rootProjectDir>
+  </properties>
 </project>

--- a/oaipmh/pom.xml
+++ b/oaipmh/pom.xml
@@ -59,7 +59,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
   </distributionManagement>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -140,11 +140,10 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>2.5.4</version>
           <configuration>
             <effort>Default</effort>
             <threshold>Default</threshold>
-            <xmlOutput>true</xmlOutput>
             <xmlOutput>true</xmlOutput>
             <excludeFilterFile>${rootProjectDir}/code_quality/findbugs-excludes.xml</excludeFilterFile>
             <debug>false</debug>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
             <excludeFilterFile>${rootProjectDir}/code_quality/findbugs-excludes.xml</excludeFilterFile>
             <debug>false</debug>
             <includeTests>false</includeTests>
+            <failOnError>false</failOnError>
           </configuration>
           <executions>
             <execution>
@@ -186,6 +187,49 @@
     </pluginManagement>
 
     <plugins>
+     <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <reportPlugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>2.7</version>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jxr-plugin</artifactId>
+              <version>2.1</version>
+              <configuration>
+                <aggregate>true</aggregate>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-report-plugin</artifactId>
+              <version>2.6</version>
+            </plugin>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>cobertura-maven-plugin</artifactId>
+              <version>2.4</version>
+              <configuration>
+                <formats>
+                  <format>xml</format>
+                  <format>html</format>
+                </formats>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-checkstyle-plugin</artifactId>
+              <version>2.6</version>
+            </plugin>
+          </reportPlugins>
+        </configuration>
+      </plugin>
       <plugin>
           <groupId>org.codehaus.groovy.maven</groupId>
           <artifactId>gmaven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,18 @@
               <artifactId>maven-checkstyle-plugin</artifactId>
               <version>2.6</version>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-project-info-reports-plugin</artifactId>
+              <version>2.4</version>
+              <configuration>
+                <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+                <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+              </configuration>
+              <reports>
+                <report>index</report>
+              </reports>
+            </plugin>
           </reportPlugins>
         </configuration>
       </plugin>
@@ -1178,6 +1190,10 @@
       <name>GeoNetwork opensource repositories</name>
       <url>scpexe://TO DEFINED</url>
     </snapshotRepository>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${project.build.directory}/site</url>
+    </site>
   </distributionManagement>
 
   <properties>

--- a/sde/pom.xml
+++ b/sde/pom.xml
@@ -31,5 +31,13 @@
 
   <dependencies>
   </dependencies>
-      
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+    </distributionManagement>
+    <properties>
+      <rootProjectDir>${basedir}/..</rootProjectDir>
+    </properties>
 </project>

--- a/sde/pom.xml
+++ b/sde/pom.xml
@@ -34,7 +34,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
     </distributionManagement>
     <properties>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -78,26 +78,31 @@
             </plugin>
         </plugins>
     </build>
-
     <profiles>
-		<profile>
-			<id>run-static-analysis</id>
-			<activation>
-				<property>
-					<name>!skipTests</name>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>findbugs-maven-plugin</artifactId>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-	<properties>
-		<rootProjectDir>${basedir}/..</rootProjectDir>
-	</properties>
-</project>
+      <profile>
+        <id>run-static-analysis</id>
+        <activation>
+          <property>
+            <name>!skipTests</name>
+          </property>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
+    <properties>
+      <rootProjectDir>${basedir}/..</rootProjectDir>
+    </properties>
+  </project>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -99,7 +99,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
     <properties>

--- a/web-client/pom.xml
+++ b/web-client/pom.xml
@@ -69,8 +69,14 @@
 
     </plugins>
   </build>
-
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+  </distributionManagement>
   <properties>
+    <rootProjectDir>${basedir}/..</rootProjectDir>
     <geonetwork.build.dir>${project.build.directory}/${project.build.finalName}</geonetwork.build.dir>
     <minify.verbose>false</minify.verbose>
   </properties>

--- a/web-client/pom.xml
+++ b/web-client/pom.xml
@@ -72,7 +72,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
   </distributionManagement>
   <properties>

--- a/web-itest/pom.xml
+++ b/web-itest/pom.xml
@@ -31,6 +31,7 @@
             Plugins
             TextResponse -->
     <logLevel>Error,Warning</logLevel>
+    <rootProjectDir>${basedir}/..</rootProjectDir>
     <jettyPort>8010</jettyPort>
     <jettySslPort>8011</jettySslPort>
     <jetty.stop.port>8012</jetty.stop.port>
@@ -206,4 +207,12 @@
       </plugin>-->
     </plugins>
   </build>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
+    <properties>
+    </properties>
 </project>

--- a/web-itest/pom.xml
+++ b/web-itest/pom.xml
@@ -210,7 +210,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
     <properties>

--- a/web-ui-docs/pom.xml
+++ b/web-ui-docs/pom.xml
@@ -107,7 +107,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
   </distributionManagement>
   <properties>

--- a/web-ui-docs/pom.xml
+++ b/web-ui-docs/pom.xml
@@ -104,5 +104,13 @@
       </plugin>
     </plugins>
   </build>
-
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+  </distributionManagement>
+  <properties>
+    <rootProjectDir>${basedir}/..</rootProjectDir>
+  </properties>
 </project>

--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -58,6 +58,7 @@
     </resources>
   </build>
   <properties>
+    <rootProjectDir>${basedir}/..</rootProjectDir>
     <geonetwork.build.dir>${project.build.directory}/${project.build.finalName}</geonetwork.build.dir>
     <closure.compile.level/>
   </properties>
@@ -181,4 +182,10 @@
             </build>
         </profile>
     </profiles>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
 </project>

--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -185,7 +185,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -818,7 +818,7 @@
   <distributionManagement>
     <site>
       <id>Maven generated site and reports</id>
-      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      <url>file://${rootProjectDir}/target/site/${artifactId}</url>
     </site>
   </distributionManagement>
   <properties>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -815,7 +815,12 @@
     </profile>
     
   </profiles>
-
+  <distributionManagement>
+    <site>
+      <id>Maven generated site and reports</id>
+      <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+    </site>
+  </distributionManagement>
   <properties>
     <geonetwork.version>${project.version}</geonetwork.version>
     <geonetwork.subversion>SNAPSHOT</geonetwork.subversion>

--- a/wro4j/pom.xml
+++ b/wro4j/pom.xml
@@ -98,7 +98,7 @@
     <distributionManagement>
       <site>
         <id>Maven generated site and reports</id>
-        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+        <url>file://${rootProjectDir}/target/site/${artifactId}</url>
       </site>
     </distributionManagement>
     <properties>

--- a/wro4j/pom.xml
+++ b/wro4j/pom.xml
@@ -95,6 +95,12 @@
             </build>
         </profile>
     </profiles>
+    <distributionManagement>
+      <site>
+        <id>Maven generated site and reports</id>
+        <url>file:${rootProjectDir}/target/site/${artifactId}</url>
+      </site>
+    </distributionManagement>
     <properties>
         <rootProjectDir>${basedir}/..</rootProjectDir>
     </properties>


### PR DESCRIPTION
This PR is the achievement of what I began and presented during the code-sprint week at Bolsena, the main idea is to make use of Maven tools to generate reports about the code (quality, errors by static analysis, coverage, tests results ...).

This needs some modifications into the pom.xml, so that every generated sites from the subprojects will deploy at the same place (i.e. in the `target/site` from the main project directory. I already run the current modifications onto my own jenkins, if you would like to have a look, the generated content is here:

https://ssl.beneth.fr/jenkins/job/core-geonetwork/site/

Since every poms have been affected, but I needed to modify the `geoserver` submodule, I need to open another PR related to the core-geoserver project.

To generate these reports, you have to launch the following target:

```
$ mvn site-deploy
```

Feedback welcome !