### PR TITLE
Remove marc4j dependency, use mockito-all.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,11 +63,6 @@
             <artifactId>a2j</artifactId>
         </dependency>
         <dependency>
-            <groupId>marc4j</groupId>
-            <artifactId>marc4j</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-api</artifactId>
         </dependency>
@@ -220,7 +215,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/harvesters/pom.xml
+++ b/harvesters/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-all</artifactId>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -627,11 +627,6 @@
         <version>2.0.4</version>
       </dependency>
       <dependency>
-        <groupId>marc4j</groupId>
-        <artifactId>marc4j</artifactId>
-        <version>2.3.1</version>
-      </dependency>
-      <dependency>
         <groupId>jdbm</groupId>
         <artifactId>jdbm</artifactId>
         <version>1.0</version>
@@ -824,7 +819,7 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
+        <artifactId>mockito-all</artifactId>
         <version>1.9.5</version>
         <scope>test</scope>
       </dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -37,7 +37,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-all</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -106,11 +106,6 @@
       <artifactId>a2j</artifactId>
     </dependency>
     <dependency>
-      <groupId>marc4j</groupId>
-      <artifactId>marc4j</artifactId>
-    </dependency>
-    
-    <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-api</artifactId>
     </dependency>


### PR DESCRIPTION
marc4j sometimes fails to download and is not used by any code in codebase.  We are removing this in order to reduce number of dependencies and stabilize build
