### PR TITLE
find UI - massive ownership update fix

### DIFF
--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/util/Old.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/util/Old.js
@@ -105,7 +105,7 @@ function radioModalUpdate(div, service, modalbox, title) {
 
 function addGroups(xmlRes){
     var list = xmlRes.getElementsByTagName('groups'), i;
-    Ext.getDom('group').options.length = 0;
+    Ext.getDom('record').options.length = 0;
     for (i = 0; i < list.length; i++) {
         var id = list[i].getElementsByTagName('id')[0].firstChild.nodeValue;
         var name = list[i].getElementsByTagName('name')[0].firstChild.nodeValue;


### PR DESCRIPTION
The group service now returns `<record>` anchors instead of `<groups>`. This is probably related to JPA migration.

Note: the interface is probably deprecated and will be abandoned soon, but it might worth fixing it for people (one of our client) who are still using it.
