### PR TITLE
Do not show thumbnails from sibling metadatas

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
@@ -22,6 +22,14 @@
       <relation type="thumbnail">
         <id><xsl:value-of select="gmd:fileName/gco:CharacterString"/></id>
         <title><xsl:value-of select="gmd:fileDescription/gco:CharacterString"/></title>
+        <xsl:choose>
+          <xsl:when test="./ancestor::sibling">
+            <sibling>true</sibling>
+          </xsl:when>
+          <xsl:otherwise>
+            <sibling>false</sibling>
+          </xsl:otherwise>
+        </xsl:choose>
       </relation>
     </xsl:for-each>
     

--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/data/MetadataRelationStore.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/data/MetadataRelationStore.js
@@ -43,6 +43,9 @@ GeoNetwork.data.MetadataRelationStore = function(url, params, grouping){
     }, {
         name: 'title'
     }, {
+        name: 'sibling',
+        type: 'bool'
+    }, {
         name: 'abstract'
     }, {
         name: 'keyword'
@@ -52,7 +55,7 @@ GeoNetwork.data.MetadataRelationStore = function(url, params, grouping){
     }, {
         name: 'subType',
         mapping: '@subType'
-		}];
+    }];
     
     if (grouping) {
         var reader = new Ext.data.XmlReader({

--- a/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/LinkedMetadataPanel.js
+++ b/web-client/src/main/resources/apps/js/GeoNetwork/lib/GeoNetwork/widgets/editor/LinkedMetadataPanel.js
@@ -358,7 +358,7 @@ GeoNetwork.editor.LinkedMetadataPanel = Ext.extend(Ext.Panel, {
             '<ul class="gn-relation-{type}">',
             '<tpl for=".">',
               '<tpl for="data">',
-                '<tpl if="type === \'thumbnail\'">',
+                '<tpl if="type === \'thumbnail\' && sibling === false">',
                   '<li alt="{title}">',
                      '<tpl if="(typeof id != \'undefined\') && id != \'\'">',
                         '<a rel="lightbox-set" href="{id}"><img class="thumb-small" src="{id}"/></a>',


### PR DESCRIPTION
When editing, if the MD as several siblings, the thumbnails of the related MDs are also displayed. This commit aims to keep the informations of the thumbnails available from the webservice (xml.relations), but does not display them anymore on the interface.