### PR TITLE
Fix NPE when LDAP user login (#708).

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/AbstractLDAPUserDetailsContextMapper.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/AbstractLDAPUserDetailsContextMapper.java
@@ -188,7 +188,6 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
 				p.setCn(cn);
 				ldapManager.createUser(p.createUserDetails());
 			}
-
 			LDAPUtils.saveUser(userDetails, userRepo, groupRepo, userGroupRepo,
 					importPrivilegesFromLdap, createNonExistingLdapGroup);
 		} catch (Exception e) {

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
@@ -58,10 +58,14 @@ public class LDAPUtils {
         User loadedUser = userRepo.findOneByUsername(userName);
         User toSave;
         if (loadedUser != null) {
-            if (importPrivilegesFromLdap) {
-                loadedUser.setProfile(user.getUser().getProfile());
+            // If we don't import privileges from LDAP
+            // Set the LDAP user profile to be the one set
+            // in the local database. If not, the db profile
+            // would be always reset by merge.
+            if (!importPrivilegesFromLdap) {
+                user.getUser().setProfile(loadedUser.getProfile());
             }
-            loadedUser.mergeUser(user.getUser(), true);
+            loadedUser.mergeUser(user.getUser(), false);
             if (Log.isDebugEnabled(Geonet.LDAP)) {
                 Log.debug(Geonet.LDAP, "  - Update LDAP user " + user.getUsername() + " (" + loadedUser.getId() + ") in local database.");
             }

--- a/domain/src/main/java/org/fao/geonet/domain/Address.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Address.java
@@ -1,5 +1,6 @@
 package org.fao.geonet.domain;
 
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.entitylistener.AddressEntityListenerManager;
 
 import javax.persistence.*;
@@ -151,19 +152,19 @@ public class Address extends GeonetEntity implements Serializable {
      * @param mergeNullData if true then also set null values from other address. If false then only merge non-null data
      */
     public void mergeAddress(final Address otherAddress, final boolean mergeNullData) {
-        if (mergeNullData || otherAddress.getAddress() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherAddress.getAddress())) {
             setAddress(otherAddress.getAddress());
         }
-        if (mergeNullData || otherAddress.getCity() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherAddress.getCity())) {
             setCity(otherAddress.getCity());
         }
-        if (mergeNullData || otherAddress.getState() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherAddress.getState())) {
             setState(otherAddress.getState());
         }
-        if (mergeNullData || otherAddress.getZip() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherAddress.getZip())) {
             setZip(otherAddress.getZip());
         }
-        if (mergeNullData || otherAddress.getCountry() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherAddress.getCountry())) {
             setCountry(otherAddress.getCountry());
         }
     }

--- a/domain/src/main/java/org/fao/geonet/domain/LDAPUser.java
+++ b/domain/src/main/java/org/fao/geonet/domain/LDAPUser.java
@@ -118,6 +118,11 @@ public class LDAPUser extends InetOrgPerson implements UserDetails {
      */
     @Override
     public int hashCode() {
-    	return super.hashCode();
+        // Fix for https://github.com/geonetwork/core-geonetwork/issues/708
+        if (this.getDn() != null) {
+            return super.hashCode();
+        } else {
+            return this.getUsername().hashCode();
+        }
     }
 }

--- a/domain/src/main/java/org/fao/geonet/domain/User.java
+++ b/domain/src/main/java/org/fao/geonet/domain/User.java
@@ -1,5 +1,6 @@
 package org.fao.geonet.domain;
 
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.entitylistener.UserEntityListenerManager;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -379,50 +380,53 @@ public class User extends GeonetEntity implements UserDetails {
      * @param mergeNullData if true then also set null values from other user. If false then only merge non-null data
      */
     public void mergeUser(User otherUser, boolean mergeNullData) {
-        if (mergeNullData || otherUser.getUsername() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherUser.getUsername())) {
             setUsername(otherUser.getUsername());
         }
-        if (mergeNullData || otherUser.getSurname() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherUser.getSurname())) {
             setSurname(otherUser.getSurname());
         }
-        if (mergeNullData || otherUser.getName() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherUser.getName())) {
             setName(otherUser.getName());
         }
-        if (mergeNullData || otherUser.getOrganisation() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherUser.getOrganisation())) {
             setOrganisation(otherUser.getOrganisation());
         }
-        if (mergeNullData || otherUser.getKind() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherUser.getKind())) {
             setKind(otherUser.getKind());
         }
-        if (mergeNullData || otherUser.getProfile() != null) {
+        if (mergeNullData || StringUtils.isNotBlank(otherUser.getProfile().name())) {
             setProfile(otherUser.getProfile());
         }
 
-        _email.clear();
-        _email.addAll(otherUser.getEmailAddresses());
-
-        ArrayList<Address> otherAddresses = new ArrayList<Address>(otherUser.getAddresses());
-
-        for (Iterator<Address> iterator = _addresses.iterator(); iterator.hasNext(); ) {
-            Address address = iterator.next();
-            boolean found = false;
-
-            for (Iterator<Address> iterator2 = otherAddresses.iterator(); iterator.hasNext(); ) {
-                Address otherAddress = iterator2.next();
-                if (otherAddress.getId() == address.getId()) {
-                    address.mergeAddress(otherAddress, mergeNullData);
-                    found = true;
-                    iterator2.remove();
-                    break;
-                }
-            }
-
-            if (!found) {
-                iterator.remove();
-            }
+        if (mergeNullData || !otherUser.getEmailAddresses().isEmpty()) {
+            _email.clear();
+            _email.addAll(otherUser.getEmailAddresses());
         }
 
-        _addresses.addAll(otherAddresses);
+        ArrayList<Address> otherAddresses = new ArrayList<Address>(otherUser.getAddresses());
+        if (mergeNullData || !otherAddresses.isEmpty()) {
+            for (Iterator<Address> iterator = _addresses.iterator(); iterator.hasNext(); ) {
+                Address address = iterator.next();
+                boolean found = false;
+
+                for (Iterator<Address> iterator2 = otherAddresses.iterator(); iterator.hasNext(); ) {
+                    Address otherAddress = iterator2.next();
+                    if (otherAddress.getId() == address.getId()) {
+                        address.mergeAddress(otherAddress, mergeNullData);
+                        found = true;
+                        iterator2.remove();
+                        break;
+                    }
+                }
+
+                if (!found) {
+                    iterator.remove();
+                }
+            }
+            _addresses.addAll(otherAddresses);
+        }
+
         getSecurity().mergeSecurity(otherUser.getSecurity(), mergeNullData);
     }
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-ldap.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-ldap.xml
@@ -71,6 +71,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
         <property name="profileMapping">
             <map/>
         </property>
+        <property name="ldapBaseDn" value="${ldap.base.dn}"/>
         <property name="importPrivilegesFromLdap" value="${ldap.privilege.import}"/>
         <property name="createNonExistingLdapGroup" value="${ldap.privilege.create.nonexisting.groups}" />
 		<property name="createNonExistingLdapUser" value="${ldap.privilege.create.nonexisting.users}" />

--- a/web/src/main/webapp/WEB-INF/config-security/config-security.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security.properties
@@ -19,10 +19,15 @@ ldap.base.dn.pattern=uid={0},${ldap.base.search.base}
 # Define if groups and profile information are imported from LDAP. If not, local database is used.
 # When a new user connect first, the default profile is assigned. A user administrator can update
 # privilege information.
-ldap.privilege.import=true
+ldap.privilege.import=false
 
+# Define if LDAP groups should be create in catalog
+# database if they do not exist.
 ldap.privilege.create.nonexisting.groups=true
-ldap.privilege.create.nonexisting.users=true
+
+# Define if users should be saved in the LDAP
+ldap.privilege.create.nonexisting.users=false
+
 
 
 # Define the way to extract profiles and privileges from the LDAP


### PR DESCRIPTION
NPE may occurs in 2 places depending on the configuration: 
* when hashcode on DN which may be null
* when ldapBaseDn is not set

Do not reset profile using LDAP info, if configuration says to use the local db value.
Do not reset user information if LDAP info are empty (and not only if null). With this, LDAP user info could still be set in the database even if not available in the LDAP.

Try to add doc to ldap.privilege.create.nonexisting.users property.


