### PR TITLE
Search on keyword code depending on type of search parameter (eg. equals, contains, startswith)

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSearchParamsBuilder.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSearchParamsBuilder.java
@@ -56,7 +56,7 @@ public class KeywordSearchParamsBuilder {
         if(keyword != null) {
             KeywordSearchType searchType = KeywordSearchType.parseString(Util.getParam(params, XmlParams.pTypeSearch, KeywordSearchType.MATCH.name()));
             parsedParams.keyword(keyword, searchType, true);
-            parsedParams.uri(keyword);
+            parsedParams.uri(keyword, searchType, true);
         }
         
         String uri = Util.getParam(params, XmlParams.pUri, null);
@@ -96,6 +96,8 @@ public class KeywordSearchParamsBuilder {
         
         return parsedParams;
     }
+
+
     /**
      * if set to true then the params will not throw exceptions when incorrectly configured.
      * 
@@ -305,6 +307,11 @@ public class KeywordSearchParamsBuilder {
         this.searchClauses.add(new URISearchClause(keywordURI));
         return this;
     }
+    public KeywordSearchParamsBuilder uri(String keywordURI, KeywordSearchType searchType, boolean ignoreCase) {
+        this.searchClauses.add(new URISearchClause(searchType, keywordURI, ignoreCase));
+        return this;
+    }
+
     public void relationship(String relatedId, KeywordRelation relation, KeywordSearchType searchType, boolean ignoreCase) {
         this.selectClauses.add(Selectors.BROADER);
         this.searchClauses.add(new RelationShipClause(relation, relatedId, searchType, ignoreCase));

--- a/core/src/main/java/org/fao/geonet/kernel/search/keyword/URISearchClause.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/keyword/URISearchClause.java
@@ -13,20 +13,37 @@ import org.jdom.Element;
  */
 public class URISearchClause implements SearchClause {
 
+    KeywordSearchType searchType;
     private String uri;
+    boolean ignoreCase;
 
     public URISearchClause(String uri) {
         this.uri = uri;
     }
 
+    public URISearchClause(KeywordSearchType searchType, String keywordURI, boolean ignoreCase) {
+        this.searchType = searchType;
+        this.uri = keywordURI;
+        this.ignoreCase = ignoreCase;
+    }
+
     @Override
     public Where toWhere(Set<String> langs) {
-        return Wheres.ID(this.uri);
+        if (this.searchType != null) {
+            return searchType.toWhere("id", this.uri, this.ignoreCase);
+        } else {
+            return Wheres.ID(this.uri);
+        }
     }
 
     @Override
     public void addXmlParams(Element params) {
         params.addContent(new Element(XmlParams.pUri).setText(this.uri));
+        KeywordSearchParamsBuilder.addXmlParam(params, XmlParams.pUri, this.uri);
+        if (this.searchType != null) {
+            KeywordSearchParamsBuilder.addXmlParam(params,
+                    XmlParams.pTypeSearch, "" + searchType.ordinal());
+        }
     }
 
 }


### PR DESCRIPTION


Actually when running a keyword search, both the labels and the code are used for the search.
The label search is based on the search type parameter but the code search is equal only.

Use the search type parameter to search in keyword codes like on labels.

This will allows user to search keyword by code without knowning the full URI
eg. http://www.eionet.europa.eu/gemet/concept/12349 should be used for now to search
for "beach cleansing" concept in GEMET. With this change 12349 could also be used.

This is useful when codes may have meanings or when users know concept codes.