### PR TITLE
Allow harvesting to be forcibly stopped.

### DIFF
--- a/core/src/main/java/org/fao/geonet/arcgis/ArcSDEMetadataAdapter.java
+++ b/core/src/main/java/org/fao/geonet/arcgis/ArcSDEMetadataAdapter.java
@@ -27,12 +27,13 @@ import com.esri.sde.sdk.client.SeException;
 import com.esri.sde.sdk.client.SeQuery;
 import com.esri.sde.sdk.client.SeRow;
 import com.esri.sde.sdk.client.SeSqlConstruct;
+import org.fao.geonet.Constants;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-
-import org.fao.geonet.Constants;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Adapter to retrieve ISO metadata from an ArcSDE server. The metadata in ArcSDE is scanned for
@@ -52,7 +53,7 @@ public class ArcSDEMetadataAdapter extends ArcSDEConnection {
 	private static final String METADATA_COLUMN = "SDE.GDB_USERMETADATA.XML";
 	private static final String ISO_METADATA_IDENTIFIER = "MD_Metadata";
 	
-	public List<String> retrieveMetadata() throws Exception {
+	public List<String> retrieveMetadata(AtomicBoolean cancelMonitor) throws Exception {
 		System.out.println("start retrieve metadata");
 		List<String> results = new ArrayList<String>();
 		try {	
@@ -69,6 +70,9 @@ public class ArcSDEMetadataAdapter extends ArcSDEConnection {
 			// I'm assuming: query.fetch returns null (empiric tests indicate this assumption is correct).
 			boolean allRowsFetched = false;
 			while(! allRowsFetched) {
+                if (cancelMonitor.get()) {
+                    return Collections.emptyList();
+                }
 				SeRow row = query.fetch();
 				if(row != null) {
 					ByteArrayInputStream bytes = row.getBlob(0);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
@@ -14,6 +14,7 @@ import org.fao.geonet.repository.MetadataRepository;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * 
@@ -27,6 +28,13 @@ import java.util.Map;
  * @author heikki doeleman
  */
 public abstract class BaseAligner {
+
+    public final AtomicBoolean cancelMonitor;
+
+    public BaseAligner(AtomicBoolean cancelMonitor) {
+        this.cancelMonitor = cancelMonitor;
+    }
+
 
     /**
      * TODO Javadoc.

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/Common.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/Common.java
@@ -49,8 +49,12 @@ public class Common {
 
 		public static Status parse(String status) throws BadParameterEx
 		{
-			if ("active"  .equals(status))	return ACTIVE;
-			if ("inactive".equals(status))	return INACTIVE;
+
+            for (Status next : values()) {
+                if (next.name().equalsIgnoreCase(status)) {
+                    return next;
+                }
+            }
 
 			throw new BadParameterEx("type", status);
 		}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManager.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManager.java
@@ -7,9 +7,9 @@ import org.fao.geonet.kernel.harvest.harvester.AbstractHarvester;
 import org.jdom.Element;
 import org.quartz.SchedulerException;
 
+import java.sql.SQLException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.sql.SQLException;
 
 /**
  * API for adding/removing/running harvesters.
@@ -102,13 +102,13 @@ public interface HarvestManager {
     Common.OperResult start(String id) throws SQLException, SchedulerException;
 
     /**
-     * Set the harvester status to {@link org.fao.geonet.kernel.harvest.Common.Status#ACTIVE} and unschedule any scheduled jobs.
+     * Set the harvester status to the provided status and unschedule any scheduled jobs.
      *
      * @return {@link org.fao.geonet.kernel.harvest.Common.OperResult#ALREADY_INACTIVE} if the not currently enabled or {@link org.fao.geonet.kernel.harvest.Common.OperResult#OK}
      * @throws SQLException
      * @throws SchedulerException
      */
-    Common.OperResult stop(String id) throws SQLException, SchedulerException;
+    Common.OperResult stop(String id, Common.Status status) throws SQLException, SchedulerException;
 
     /**
      * Call {@link AbstractHarvester#start()} if status is currently {@link org.fao.geonet.kernel.harvest.Common.Status#INACTIVE}.  Trigger a harvester job to run immediately.

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -435,12 +435,13 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
      * TODO Javadoc.
      *
      * @param id
+     * @param status
      * @return
      * @throws SQLException
      * @throws SchedulerException
      */
 	@Override
-    public OperResult stop(String id) throws SQLException, SchedulerException {
+    public OperResult stop(String id, Common.Status status) throws SQLException, SchedulerException {
         if(Log.isDebugEnabled(Geonet.HARVEST_MAN)) {
             Log.debug(Geonet.HARVEST_MAN, "Stopping harvesting with id : "+ id);
         }
@@ -449,7 +450,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
 		if (ah == null){
 			return OperResult.NOT_FOUND;
         }
-		return ah.stop();
+		return ah.stop(status);
 	}
 
     /**

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvesterJob.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvesterJob.java
@@ -1,9 +1,11 @@
 package org.fao.geonet.kernel.harvest.harvester;
 
 import org.quartz.DisallowConcurrentExecution;
+import org.quartz.InterruptableJob;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.quartz.UnableToInterruptJobException;
 
 /**
  * A Quartz job that obtains the Harvester from the JobExecutionContext and executes it.
@@ -17,7 +19,7 @@ import org.quartz.JobExecutionException;
  * @author jeichar
  */
 @DisallowConcurrentExecution
-public class HarvesterJob implements Job {
+public class HarvesterJob implements Job, InterruptableJob {
     
     public static final String ID_FIELD = "harvesterId";
     String harvesterId;
@@ -45,5 +47,9 @@ public class HarvesterJob implements Job {
         this.harvester = harvester;
     }
 
-    
+
+    @Override
+    public void interrupt() throws UnableToInterruptJobException {
+        harvester.cancelMonitor.set(true);
+    }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
@@ -67,8 +67,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 
 	private ArcSDEParams params;
     //FIXME use custom class?
-    private BaseAligner aligner = new BaseAligner() {};
-	
+
 	static final String ARCSDE_LOG_MODULE_NAME = Geonet.HARVESTER + ".arcsde";
 	private static final String ARC_TO_ISO19115_TRANSFORMER = "ArcCatalog8_to_ISO19115.xsl";
 	private static final String ISO19115_TO_ISO19139_TRANSFORMER = "ISO19115-to-ISO19139.xsl";
@@ -144,7 +143,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
     public void doHarvest(Logger l) throws Exception {
 	    Log.info(ARCSDE_LOG_MODULE_NAME, "ArcSDE harvest starting");
 		ArcSDEMetadataAdapter adapter = new ArcSDEMetadataAdapter(params.server, params.port, params.database, params.username, params.password);
-		List<String> metadataList = adapter.retrieveMetadata();
+		List<String> metadataList = adapter.retrieveMetadata(cancelMonitor);
 		align(metadataList);
 		Log.info(ARCSDE_LOG_MODULE_NAME, "ArcSDE harvest finished");
 	}
@@ -164,6 +163,9 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 		//-----------------------------------------------------------------------
 		//--- insert/update metadata		
 		for(String metadata : metadataList) {
+            if (cancelMonitor.get()) {
+                return;
+            }
 			result.totalMetadata++;
 			// create JDOM element from String-XML
 			Element metadataElement = Xml.loadString(metadata, false);
@@ -192,17 +194,18 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
                         continue;
                     }
 
+                    BaseAligner aligner = new BaseAligner(cancelMonitor){};
 					//
 					// add / update the metadata from this harvesting result
 					//
 					String id = dataMan.getMetadataId(uuid);
 					if (id == null)	{
 					    Log.info(ARCSDE_LOG_MODULE_NAME, "adding new metadata");
-						id = addMetadata(iso19139, uuid, schema, localGroups, localCateg);
+						id = addMetadata(iso19139, uuid, schema, localGroups, localCateg, aligner);
 						result.addedMetadata++;
 					} else {
 					    Log.info(ARCSDE_LOG_MODULE_NAME, "updating existing metadata, id is: " + id);
-						updateMetadata(iso19139, id, localGroups, localCateg);
+						updateMetadata(iso19139, id, localGroups, localCateg, aligner);
 						result.updatedMetadata++;
 					}
 					idsForHarvestingResult.add(id);
@@ -215,6 +218,10 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 		//	
         List<Metadata> existingMetadata = context.getBean(MetadataRepository.class).findAllByHarvestInfo_Uuid(params.uuid);
         for(Metadata existingId : existingMetadata) {
+            if (cancelMonitor.get()) {
+                return;
+            }
+
             String ex$ = String.valueOf(existingId.getId());
 			if(!idsForHarvestingResult.contains(ex$)) {
 				dataMan.deleteMetadataGroup(context, ex$);
@@ -223,7 +230,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 		}			
 	}
 
-	private void updateMetadata(Element xml, String id, GroupMapper localGroups, final CategoryMapper localCateg) throws Exception {
+	private void updateMetadata(Element xml, String id, GroupMapper localGroups, final CategoryMapper localCateg, BaseAligner aligner) throws Exception {
 	    Log.info(ARCSDE_LOG_MODULE_NAME, "  - Updating metadata with id: "+ id);
         //
         // update metadata
@@ -264,9 +271,11 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 	 * @param schema
 	 * @param localGroups
 	 * @param localCateg
-	 * @throws Exception
+	 * @param aligner
+     * @throws Exception
 	 */
-	private String addMetadata(Element xml, String uuid, String schema, GroupMapper localGroups, final CategoryMapper localCateg) throws Exception {
+	private String addMetadata(Element xml, String uuid, String schema, GroupMapper localGroups, final CategoryMapper localCateg,
+                               BaseAligner aligner) throws Exception {
 	    Log.info(ARCSDE_LOG_MODULE_NAME, "  - Adding metadata with remote uuid: "+ uuid);
 
         //

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
@@ -170,7 +170,7 @@ public class CswHarvester extends AbstractHarvester<HarvestResult> {
      * @throws Exception
      */
     public void doHarvest(Logger log) throws Exception {
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -49,19 +49,22 @@ import org.jdom.Element;
 
 import java.net.URL;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 //=============================================================================
 
 class Harvester implements IHarvester<HarvestResult>
 {
-	//--------------------------------------------------------------------------
+    private final AtomicBoolean cancelMonitor;
+    //--------------------------------------------------------------------------
 	//---
 	//--- Constructor
 	//---
 	//--------------------------------------------------------------------------
 
-	public Harvester(Logger log, ServiceContext context, CswParams params)
+	public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, CswParams params)
 	{
+        this.cancelMonitor = cancelMonitor;
 		this.log    = log;
 		this.context= context;
 		this.params = params;
@@ -79,15 +82,22 @@ class Harvester implements IHarvester<HarvestResult>
 		log.info("Retrieving capabilities file for : "+ params.name);
 
 		CswServer server = retrieveCapabilities(log);
+        if (cancelMonitor.get()) {
+            return new HarvestResult();
+        }
 
-		//--- perform all searches
+        //--- perform all searches
 		
 		Set<RecordInfo> records = new HashSet<RecordInfo>();
 		
 		Search s = new Search();
 		
 		for (Element element : params.eltSearches) {
-			if (element.getChildText("value")!=null){
+            if (cancelMonitor.get()) {
+                return new HarvestResult();
+            }
+
+            if (element.getChildText("value")!=null){
 				if (!element.getChildText("value").trim().equals("")){
 					s.addAttribute(element.getName(), element.getChildText("value").trim());
 				}
@@ -113,7 +123,7 @@ class Harvester implements IHarvester<HarvestResult>
 
 		//--- align local node
 
-		Aligner aligner = new Aligner(log, context, server, params);
+		Aligner aligner = new Aligner(cancelMonitor, log, context, server, params);
 
 		return aligner.align(records, errors);
 	}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
@@ -58,6 +58,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 //=============================================================================
 /** 
@@ -72,14 +73,16 @@ public class FragmentHarvester extends BaseAligner {
 	//---------------------------------------------------------------------------
 	/** 
      * Constructor
-     *  
-     * @param log		
-     * @param context		Jeeves context
-     * @param params		Fragment harvesting configuration parameters
+     *
+     * @param cancelMonitor
+     * @param log
+     * @param context        Jeeves context
+     * @param params        Fragment harvesting configuration parameters
      * 
      */
-	public FragmentHarvester(Logger log, ServiceContext context, FragmentParams params) {
-		this.log    = log;
+	public FragmentHarvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, FragmentParams params) {
+        super(cancelMonitor);
+        this.log    = log;
 		this.context= context;
 		this.params = params;
 
@@ -143,7 +146,11 @@ public class FragmentHarvester extends BaseAligner {
         List<Element> recs = fragments.getChildren();
 		
 		for (Element rec : recs) {
-			addRecord(rec);
+            if (cancelMonitor.get()) {
+                break;
+            }
+
+            addRecord(rec);
 		}
 		
 		return harvestSummary;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/GeoPRESTHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/GeoPRESTHarvester.java
@@ -143,7 +143,7 @@ public class GeoPRESTHarvester extends AbstractHarvester<HarvestResult>
 
 	public void doHarvest(Logger log) throws Exception
 	{
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Harvester.java
@@ -23,20 +23,7 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geoPREST;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
 import jeeves.server.context.ServiceContext;
-
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.Constants;
 import org.fao.geonet.Logger;
@@ -53,20 +40,37 @@ import org.fao.geonet.utils.Xml;
 import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Element;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 
 
 //=============================================================================
 
 class Harvester implements IHarvester<HarvestResult>
 {
-	//--------------------------------------------------------------------------
+    private final AtomicBoolean cancelMonitor;
+    //--------------------------------------------------------------------------
 	//---
 	//--- Constructor
 	//---
 	//--------------------------------------------------------------------------
 
-	public Harvester(Logger log, ServiceContext context, GeoPRESTParams params)
+	public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, GeoPRESTParams params)
 	{
+
+        this.cancelMonitor = cancelMonitor;
 		this.log    = log;
 		this.context= context;
 		this.params = params;
@@ -79,18 +83,20 @@ class Harvester implements IHarvester<HarvestResult>
 	//---
 	//---------------------------------------------------------------------------
 
-	public HarvestResult harvest(Logger log) throws Exception
-	{
+	public HarvestResult harvest(Logger log) throws Exception {
 
 	    this.log = log;
 		//--- perform all searches
 
 		XmlRequest request = context.getBean(GeonetHttpRequestFactory.class).createXmlRequest(new URL(params.baseUrl+"/rest/find/document"));
 
-		Set<RecordInfo> records = new HashSet<RecordInfo>();
-
+        Set<RecordInfo> records = new HashSet<RecordInfo>();
 
         for (Search s : params.getSearches()) {
+            if (cancelMonitor.get()) {
+                return new HarvestResult();
+            }
+
             try {
                 records.addAll(search(request, s));
             } catch (Exception t) {
@@ -127,7 +133,7 @@ class Harvester implements IHarvester<HarvestResult>
 
 		//--- align local node
 
-		Aligner aligner = new Aligner(log, context, params);
+		Aligner aligner = new Aligner(cancelMonitor, log, context, params);
 
 		return aligner.align(records, errors);
 	}
@@ -164,7 +170,11 @@ class Harvester implements IHarvester<HarvestResult>
         List<Element> list = channel.getChildren();
 
 		for (Element record :list) {
-			if (!record.getName().equals("item")) continue; // skip all the other crap
+            if (cancelMonitor.get()) {
+                return Collections.emptySet();
+            }
+
+            if (!record.getName().equals("item")) continue; // skip all the other crap
 			RecordInfo recInfo = getRecordInfo((Element)record.clone());
 			if (recInfo != null) records.add(recInfo);
 		}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -78,6 +78,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 //=============================================================================
 
@@ -89,9 +90,10 @@ public class Aligner extends BaseAligner
 	//---
 	//--------------------------------------------------------------------------
 
-	public Aligner(Logger log, ServiceContext context, XmlRequest req,
-						GeonetParams params, Element remoteInfo)
+	public Aligner(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, XmlRequest req,
+                   GeonetParams params, Element remoteInfo)
 	{
+        super(cancelMonitor);
 		this.log     = log;
 		this.context = context;
 		this.request = req;
@@ -163,19 +165,22 @@ public class Aligner extends BaseAligner
 		//-----------------------------------------------------------------------
 		//--- remove old metadata
 
-		for (String uuid : localUuids.getUUIDs())
-			if (!exists(records, uuid))
-			{
-				String id = localUuids.getID(uuid);
+		for (String uuid : localUuids.getUUIDs()) {
+            if (cancelMonitor.get()) {
+                return this.result;
+            }
 
-                if(log.isDebugEnabled()) log.debug("  - Removing old metadata with id:"+ id);
-				dataMan.deleteMetadata(context, id);
+            if (!exists(records, uuid)) {
+                String id = localUuids.getID(uuid);
+
+                if (log.isDebugEnabled()) log.debug("  - Removing old metadata with id:" + id);
+                dataMan.deleteMetadata(context, id);
 
                 dataMan.flush();
 
                 result.locallyRemoved++;
-			}
-
+            }
+        }
 		//-----------------------------------------------------------------------
 		//--- insert/update new metadata
 // Load preferred schema and set to iso19139 by default
@@ -184,23 +189,22 @@ public class Aligner extends BaseAligner
             preferredSchema = "iso19139";
         }
 
-        for(RecordInfo ri : records)
-		{
-			result.totalMetadata++;
+        for(RecordInfo ri : records) {
+            if (cancelMonitor.get()) {
+                return this.result;
+            }
+
+            result.totalMetadata++;
 
             // Mef full format provides ISO19139 records in both the profile
             // and ISO19139 so we could be able to import them as far as
             // ISO19139 schema is installed by default.
-			if (!dataMan.existsSchema(ri.schema) &&
-                !ri.schema.startsWith("iso19139."))
-			{
+			if (!dataMan.existsSchema(ri.schema) && !ri.schema.startsWith("iso19139.")) {
                 if(log.isDebugEnabled())
                     log.debug("  - Metadata skipped due to unknown schema. uuid:"+ ri.uuid
 						 	+", schema:"+ ri.schema);
 				result.unknownSchema++;
-			}
-			else
-			{
+			} else {
 				String id = dataMan.getMetadataId(ri.uuid);
 
 				// look up value of localrating/enable
@@ -208,10 +212,9 @@ public class Aligner extends BaseAligner
 				SettingManager settingManager = gc.getBean(SettingManager.class);
 				boolean localRating = settingManager.getValueAsBool("system/localrating/enable", false);
 				
-				if (id == null)	{
-					addMetadata(ri, localRating);
-				}
-				else {
+				if (id == null) {
+                    addMetadata(ri, localRating);
+                } else {
 					updateMetadata(ri, id, localRating);
 				}
 			}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
@@ -184,7 +184,7 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult>
 
 	public void doHarvest(Logger log) throws Exception
 	{
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Geonet20Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Geonet20Harvester.java
@@ -244,17 +244,24 @@ public class Geonet20Harvester extends AbstractHarvester
 			if (!response.getName().equals("ok"))
 				throw new UserNotFoundEx(params.username);
 		}
+        if (cancelMonitor.get()) {
+            return ;
+        }
 
-		//--- search
+        //--- search
 
 		result = new GeonetResult();
 
-		Aligner aligner = new Aligner(log, req, params, dataMan, context,
+		Aligner aligner = new Aligner(cancelMonitor, log, req, params, dataMan, context,
 												localCateg);
 
 		for(Search s : params.getSearches())
 		{
-			log.info("Searching on : "+ name +"/"+ s.siteId);
+            if (cancelMonitor.get()) {
+                return;
+            }
+
+            log.info("Searching on : "+ name +"/"+ s.siteId);
 
 			req.setAddress(servletName +"/srv/en/"+ Geonet.Service.XML_SEARCH);
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -62,7 +62,6 @@ import java.util.UUID;
 public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 	
 	//FIXME Put on a different file?
-	private BaseAligner aligner = new BaseAligner() {};
 	private LocalFilesystemParams params;
 
 	
@@ -99,52 +98,57 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 		return id;
 	}
 
-    /**
-     * Aligns new results from filesystem harvesting. Contrary to practice in e.g. CSW Harvesting,
-     * files removed from the harvesting source are NOT removed from the database. Also, no checks
-     * on modification date are done; the result gets inserted or replaced if the result appears to
-     * be in a supported schema.
+	/**
+	 * Aligns new results from filesystem harvesting. Contrary to practice in e.g. CSW Harvesting,
+	 * files removed from the harvesting source are NOT removed from the database. Also, no checks
+	 * on modification date are done; the result gets inserted or replaced if the result appears to
+	 * be in a supported schema.
      *
      * @param root the directory to visit
-     * @throws Exception
-     */
+	 * @throws Exception
+	 */
     private HarvestResult align(Path root) throws Exception {
         log.debug("Start of alignment for : " + params.name);
-        final LocalFsHarvesterFileVisitor visitor = new LocalFsHarvesterFileVisitor(context, params, log, this);
+        final LocalFsHarvesterFileVisitor visitor = new LocalFsHarvesterFileVisitor(cancelMonitor, context, params, log, this);
         if (params.recurse) {
             Files.walkFileTree(root, visitor);
-        } else {
+					    } else {
             try (DirectoryStream<Path> paths = Files.newDirectoryStream(root)) {
                 for (Path path : paths) {
                     if (path != null && Files.isRegularFile(path)) {
                         visitor.visitFile(path, Files.readAttributes(path, BasicFileAttributes.class));
-                    }
-                }
-            }
-        }
+                            }
+                        }
+    					    }
+                            }
         result = visitor.getResult();
         List<String> idsForHarvestingResult = visitor.getIdsForHarvestingResult();
         if (!params.nodelete) {
-            //
-            // delete locally existing metadata from the same source if they were
-            // not in this harvesting result
-            //
+			//
+			// delete locally existing metadata from the same source if they were
+			// not in this harvesting result
+			//
             List<Metadata> existingMetadata = context.getBean(MetadataRepository.class).findAllByHarvestInfo_Uuid(params.uuid);
             for (Metadata existingId : existingMetadata) {
-                String ex$ = String.valueOf(existingId.getId());
-                if (!idsForHarvestingResult.contains(ex$)) {
-                    log.debug("  Removing: " + ex$);
-                    dataMan.deleteMetadata(context, ex$);
-                    result.locallyRemoved++;
+
+                if (cancelMonitor.get()) {
+                    return this.result;
                 }
-            }
-        }
+
+				String ex$ = String.valueOf(existingId.getId());
+                if (!idsForHarvestingResult.contains(ex$)) {
+				    log.debug("  Removing: " + ex$);
+					dataMan.deleteMetadata(context, ex$);
+					result.locallyRemoved++;
+				}
+			}			
+		}
         log.debug("End of alignment for : " + params.name);
-        return result;
-    }
+		return result;
+	}
 
 	void updateMetadata(Element xml, final String id, GroupMapper localGroups,
-                        final CategoryMapper localCateg, String changeDate) throws Exception {
+                        final CategoryMapper localCateg, String changeDate, BaseAligner aligner) throws Exception {
 		log.debug("  - Updating metadata with id: "+ id);
 
         //
@@ -179,9 +183,11 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 	 * @param localGroups
 	 * @param localCateg
 	 * @param createDate TODO
-	 * @throws Exception
+	 * @param aligner
+     * @throws Exception
 	 */
-    String addMetadata(Element xml, String uuid, String schema, GroupMapper localGroups, final CategoryMapper localCateg, String createDate) throws Exception {
+    String addMetadata(Element xml, String uuid, String schema, GroupMapper localGroups, final CategoryMapper localCateg,
+                       String createDate, BaseAligner aligner) throws Exception {
 		log.debug("  - Adding metadata with remote uuid: "+ uuid);
 
 		

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/OaiPmhHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/OaiPmhHarvester.java
@@ -149,9 +149,8 @@ public class OaiPmhHarvester extends AbstractHarvester<HarvestResult>
 	//---
 	//---------------------------------------------------------------------------
 
-	public void doHarvest(Logger log) throws Exception
-	{
-		Harvester h = new Harvester(log, context, params);
+	public void doHarvest(Logger log) throws Exception {
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -74,6 +74,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 
@@ -153,15 +154,18 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 	/** 
      * Constructor
      *  
-     * @param log		
-     * @param context		Jeeves context
-     * @param params	Information about harvesting configuration for the node
-     * 
+     *
+     * @param cancelMonitor
+     * @param log
+     * @param context        Jeeves context
+     * @param params    Information about harvesting configuration for the node
+     *
      * @return null
      */
-	public Harvester(Logger log, 
-						ServiceContext context, 
-						OgcWxSParams params) {
+	public Harvester(AtomicBoolean cancelMonitor, Logger log,
+                     ServiceContext context,
+                     OgcWxSParams params) {
+        super(cancelMonitor);
 		this.log    = log;
 		this.context= context;
 		this.params = params;
@@ -219,9 +223,12 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 
 		//-----------------------------------------------------------------------
 		//--- remove old metadata
-		for (String uuid : localUuids.getUUIDs())
-		{
-			String id = localUuids.getID (uuid);
+		for (String uuid : localUuids.getUUIDs()) {
+            if (cancelMonitor.get()) {
+                return this.result;
+            }
+
+            String id = localUuids.getID (uuid);
 
             if(log.isDebugEnabled()) log.debug ("  - Removing old metadata before update with id: " + id);
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/OgcWxSHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/OgcWxSHarvester.java
@@ -143,7 +143,7 @@ public class OgcWxSHarvester extends AbstractHarvester<HarvestResult>
 
 	public void doHarvest(Logger log) throws Exception
 	{
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
@@ -94,6 +94,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.net.ssl.SSLHandshakeException;
 
 //=============================================================================
@@ -181,14 +182,17 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 	/** 
 	 * Constructor
 	 *  
-	 * @param log		
-	 * @param context		Jeeves context
-	 * @param params	Information about harvesting configuration for the node
-	 * 
-	 * @return null
+	 *
+     * @param cancelMonitor
+     * @param log
+     * @param context        Jeeves context
+     * @param params    Information about harvesting configuration for the node
+     *
+     * @return null
      **/
 	
-	public Harvester(Logger log, ServiceContext context, ThreddsParams params) {
+	public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, ThreddsParams params) {
+        super(cancelMonitor);
 		this.log    = log;
 		this.context= context;
 		this.params = params;
@@ -206,12 +210,12 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 		
 		//--- Create fragment harvester for atomic datasets if required
 		if (params.createAtomicDatasetMd && params.atomicMetadataGeneration.equals(ThreddsParams.FRAGMENTS)) {
-			atomicFragmentHarvester = new FragmentHarvester(log, context, getAtomicFragmentParams());
+			atomicFragmentHarvester = new FragmentHarvester(cancelMonitor, log, context, getAtomicFragmentParams());
 		}
 		
 		//--- Create fragment harvester for collection datasets if required
 		if (params.createCollectionDatasetMd && params.collectionMetadataGeneration.equals(ThreddsParams.FRAGMENTS)) {
-			collectionFragmentHarvester = new FragmentHarvester(log, context, getCollectionFragmentParams());
+			collectionFragmentHarvester = new FragmentHarvester(cancelMonitor, log, context, getCollectionFragmentParams());
 		}
 	}
 
@@ -226,59 +230,67 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
      **/
 	
 	public HarvestResult harvest(Logger log) throws Exception {
-		this.log = log;
-		
-		Element xml = null;
-		log.info("Retrieving remote metadata information for : " + params.name);
-        
-		//--- Get uuid's and change dates of metadata records previously 
-		//--- harvested by this harvester grouping by harvest uri
-		localUris = new UriMapper(context, params.uuid);
+        this.log = log;
 
-		//--- Try to load thredds catalog document
-		String url = params.url;
-		try {
-			XmlRequest req = context.getBean(GeonetHttpRequestFactory.class).createXmlRequest();
-			req.setUrl(new URL(url));
-			req.setMethod(XmlRequest.Method.GET);
-			Lib.net.setupProxy(context, req);
+        Element xml = null;
+        log.info("Retrieving remote metadata information for : " + params.name);
 
-			xml = req.execute();
-		} catch (SSLHandshakeException e) {
-			throw new BadServerCertificateEx(
-				"Most likely cause: The thredds catalog "+url+" does not have a "+
-				"valid certificate. If you feel this is because the server may be "+
-				"using a test certificate rather than a certificate from a well "+
-				"known certification authority, then you can add this certificate "+
-				"to the GeoNetwork keystore using bin/installCert");
-		}
-		
-	    //--- Traverse catalog to create services and dataset metadata as required
-	    harvestCatalog(xml);
-	        
-		//--- Remove previously harvested metadata for uris that no longer exist on the remote site
-		for (String localUri : localUris.getUris()) {
-			if (!harvestUris.contains(localUri)) {
-				for (RecordInfo record: localUris.getRecords(localUri)) {
-                    if(log.isDebugEnabled()) log.debug ("  - Removing deleted metadata with id: " + record.id);
-					dataMan.deleteMetadata (context, record.id);
-		
-					if (record.isTemplate.equals("s")) {
-						//--- Uncache xlinks if a subtemplate
-						Processor.uncacheXLinkUri(metadataGetService+"?uuid=" + record.uuid);
-						result.subtemplatesRemoved++;
-					} else {
-						result.locallyRemoved++;
-					}
-				}
-			}
-		}
+        //--- Get uuid's and change dates of metadata records previously
+        //--- harvested by this harvester grouping by harvest uri
+        localUris = new UriMapper(context, params.uuid);
+
+        //--- Try to load thredds catalog document
+        String url = params.url;
+        try {
+            XmlRequest req = context.getBean(GeonetHttpRequestFactory.class).createXmlRequest();
+            req.setUrl(new URL(url));
+            req.setMethod(XmlRequest.Method.GET);
+            Lib.net.setupProxy(context, req);
+
+            xml = req.execute();
+        } catch (SSLHandshakeException e) {
+            throw new BadServerCertificateEx(
+                    "Most likely cause: The thredds catalog " + url + " does not have a " +
+                    "valid certificate. If you feel this is because the server may be " +
+                    "using a test certificate rather than a certificate from a well " +
+                    "known certification authority, then you can add this certificate " +
+                    "to the GeoNetwork keystore using bin/installCert");
+        }
+
+        //--- Traverse catalog to create services and dataset metadata as required
+        harvestCatalog(xml);
+
+        //--- Remove previously harvested metadata for uris that no longer exist on the remote site
+        for (String localUri : localUris.getUris()) {
+            if (cancelMonitor.get()) {
+                return this.result;
+            }
+
+            if (!harvestUris.contains(localUri)) {
+                for (RecordInfo record : localUris.getRecords(localUri)) {
+                    if (cancelMonitor.get()) {
+                        return this.result;
+                    }
+
+                    if (log.isDebugEnabled()) log.debug("  - Removing deleted metadata with id: " + record.id);
+                    dataMan.deleteMetadata(context, record.id);
+
+                    if (record.isTemplate.equals("s")) {
+                        //--- Uncache xlinks if a subtemplate
+                        Processor.uncacheXLinkUri(metadataGetService + "?uuid=" + record.uuid);
+                        result.subtemplatesRemoved++;
+                    } else {
+                        result.locallyRemoved++;
+                    }
+                }
+            }
+        }
 
         dataMan.flush();
 
         result.totalMetadata = result.serviceRecords + result.collectionDatasetRecords + result.atomicDatasetRecords;
-		return result;
-	}
+        return result;
+    }
 
 	//---------------------------------------------------------------------------
 	//---
@@ -339,7 +351,11 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 		log.info("Crawling the datasets in the catalog....");
 		List<InvDataset> dsets = catalog.getDatasets();
 		for (InvDataset ds : dsets) {
-			crawlDatasets(ds);
+            if (cancelMonitor.get()) {
+                return ;
+            }
+
+            crawlDatasets(ds);
 		}
 
 		//--- show how many datasets have been processed

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/ThreddsHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/ThreddsHarvester.java
@@ -160,7 +160,7 @@ public class ThreddsHarvester extends AbstractHarvester<HarvestResult>
 
 	public void doHarvest(Logger log) throws Exception
 	{
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WAFRetriever.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WAFRetriever.java
@@ -34,15 +34,18 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class WAFRetriever implements RemoteRetriever {
-	//--------------------------------------------------------------------------
+    private AtomicBoolean cancelMonitor;
+    //--------------------------------------------------------------------------
 	//---
 	//--- RemoteRetriever interface
 	//---
 	//--------------------------------------------------------------------------
 
-	public void init(Logger log, ServiceContext context, WebDavParams params) {
+	public void init(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, WebDavParams params) {
+        this.cancelMonitor = cancelMonitor;
 		this.log    = log;
 		this.params = params;
 	}
@@ -71,6 +74,11 @@ class WAFRetriever implements RemoteRetriever {
         Document doc = Jsoup.parse(new URL(wafurl),3000);
         Elements links = doc.select("a[href]");
         for (Element link : links) {
+            if (cancelMonitor.get()) {
+                files.clear();
+                return ;
+            }
+
             String url = link.attr("abs:href");
 
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WebDavHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WebDavHarvester.java
@@ -114,7 +114,7 @@ public class WebDavHarvester extends AbstractHarvester<HarvestResult> {
 	//---------------------------------------------------------------------------
     public void doHarvest(Logger log) throws Exception {
 		log.info("WebDav doHarvest start");
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 		log.info("WebDav doHarvest end");
 	}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
@@ -64,6 +64,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.xml.stream.FactoryConfigurationError;
 
 //=============================================================================
@@ -122,19 +123,23 @@ import javax.xml.stream.FactoryConfigurationError;
  */
 class Harvester implements IHarvester<HarvestResult>
 {
-	
-	
-	//---------------------------------------------------------------------------
+    private final AtomicBoolean cancelMonitor;
+
+
+    //---------------------------------------------------------------------------
 	/** 
      * Constructor
      *  
-     * @param log		
-     * @param context									Jeeves context
-     * @param params	harvesting configuration for the node
-     * 
+     *
+     * @param cancelMonitor
+     * @param log
+     * @param context                                    Jeeves context
+     * @param params    harvesting configuration for the node
+     *
      * @return null
      */
-	public Harvester(Logger log, ServiceContext context, WfsFeaturesParams params) {
+	public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, WfsFeaturesParams params) {
+        this.cancelMonitor = cancelMonitor;
 		this.log    = log;
 		this.context= context;
 		this.params = params;
@@ -213,7 +218,7 @@ class Harvester implements IHarvester<HarvestResult>
 		}
 
 		//--- harvest metadata and subtemplates from fragments using generic fragment harvester
-		FragmentHarvester fragmentHarvester = new FragmentHarvester(log, context, getFragmentHarvesterParams());
+		FragmentHarvester fragmentHarvester = new FragmentHarvester(cancelMonitor, log, context, getFragmentHarvesterParams());
 
 		if (params.streamFeatures) {
 			harvestFeatures(wfsQuery, fragmentHarvester);
@@ -275,6 +280,11 @@ class Harvester implements IHarvester<HarvestResult>
         try (InputStream fin = IO.newInputStream(tempFile)) {
             reader = new XmlElementReader(fin, "gml:featureMembers/*", namespaces);
         }
+
+        if (cancelMonitor.get()) {
+            return;
+        }
+
         if (!reader.hasNext()) {
             namespaces.add(Namespace.getNamespace("wfs", "http://www.opengis.net/wfs"));
             try (InputStream fin = IO.newInputStream(tempFile)) {
@@ -284,6 +294,10 @@ class Harvester implements IHarvester<HarvestResult>
         }
 
         while (reader.hasNext()) {
+            if (cancelMonitor.get()) {
+                return;
+            }
+
             stylesheetDirectory = schemaMan.getSchemaDir(params.outputSchema).resolve(Geonet.Path.WFS_STYLESHEETS);
             Element records = Xml.transform(reader.next(), stylesheetDirectory.resolve(params.stylesheet), ssParams);
 
@@ -297,21 +311,21 @@ class Harvester implements IHarvester<HarvestResult>
 	
 	private void harvest(Element xml, FragmentHarvester fragmentHarvester)
             throws Exception {
-		
-	    HarvestSummary fragmentResult = fragmentHarvester.harvest(xml, params.url);
 
-			deleteOrphanedMetadata(fragmentResult.updatedMetadata);
-	    	
-	    result.fragmentsReturned += fragmentResult.fragmentsReturned;
-	    result.fragmentsUnknownSchema += fragmentResult.fragmentsUnknownSchema;
-	    result.subtemplatesAdded += fragmentResult.fragmentsAdded;
-	    result.fragmentsMatched += fragmentResult.fragmentsMatched;
-	    result.recordsBuilt += fragmentResult.recordsBuilt;
-	    result.recordsUpdated += fragmentResult.recordsUpdated;
-	    result.subtemplatesUpdated += fragmentResult.fragmentsUpdated;
+        HarvestSummary fragmentResult = fragmentHarvester.harvest(xml, params.url);
 
-	    result.totalMetadata = result.subtemplatesAdded + result.addedMetadata;
-	    result.originalMetadata = result.fragmentsReturned;
+        deleteOrphanedMetadata(fragmentResult.updatedMetadata);
+
+        result.fragmentsReturned += fragmentResult.fragmentsReturned;
+        result.fragmentsUnknownSchema += fragmentResult.fragmentsUnknownSchema;
+        result.subtemplatesAdded += fragmentResult.fragmentsAdded;
+        result.fragmentsMatched += fragmentResult.fragmentsMatched;
+        result.recordsBuilt += fragmentResult.recordsBuilt;
+        result.recordsUpdated += fragmentResult.recordsUpdated;
+        result.subtemplatesUpdated += fragmentResult.fragmentsUpdated;
+
+        result.totalMetadata = result.subtemplatesAdded + result.addedMetadata;
+        result.originalMetadata = result.fragmentsReturned;
     }
 
 	/** 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/WfsFeaturesHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/WfsFeaturesHarvester.java
@@ -144,7 +144,7 @@ public class WfsFeaturesHarvester extends AbstractHarvester<HarvestResult>
 	public void doHarvest(Logger log) throws Exception
 	{
 
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/z3950/Z3950Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/z3950/Z3950Harvester.java
@@ -194,7 +194,7 @@ public class Z3950Harvester extends AbstractHarvester<Z3950ServerResults> {
 	}
 
 	public void doHarvest(Logger log) throws Exception {
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		serverResults = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/z3950Config/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/z3950Config/Harvester.java
@@ -39,23 +39,27 @@ import org.fao.geonet.utils.Xml;
 import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Element;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 //=============================================================================
 
 class Harvester implements IHarvester<HarvestResult>
 {
-	//--------------------------------------------------------------------------
+    private final AtomicBoolean cancelMonitor;
+    //--------------------------------------------------------------------------
 	//---
 	//--- Constructor
 	//---
 	//--------------------------------------------------------------------------
 
-	public Harvester(Logger log, ServiceContext context, Z3950ConfigParams params)
+	public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, Z3950ConfigParams params)
 	{
+        this.cancelMonitor = cancelMonitor;
 		this.log    = log;
 		this.params = params;
 		this.context = context;
@@ -79,8 +83,13 @@ class Harvester implements IHarvester<HarvestResult>
 
 		Set<RecordInfo> records = new HashSet<RecordInfo>();
 
-		for(Search s : params.getSearches())
-			records.addAll(search(req, s));
+		for(Search s : params.getSearches()) {
+            if (cancelMonitor.get()) {
+                return new HarvestResult();
+            }
+
+            records.addAll(search(req, s));
+        }
 
 		if (params.isSearchEmpty())
 			records.addAll(search(req, Search.createEmptySearch()));
@@ -89,7 +98,7 @@ class Harvester implements IHarvester<HarvestResult>
 
 		//--- config local node
 
-		Z3950Config  configer = new Z3950Config(log, context, req, params);
+		Z3950Config  configer = new Z3950Config(cancelMonitor, log, context, req, params);
 		HarvestResult result  = configer.config(records);
 
 		return result;
@@ -103,7 +112,11 @@ class Harvester implements IHarvester<HarvestResult>
 
 		for (Object o : doSearch(request, s).getChildren("metadata"))
 		{
-			Element md   = (Element) o;
+            if (cancelMonitor.get()) {
+                return Collections.emptySet();
+            }
+
+            Element md   = (Element) o;
 			Element info = md.getChild("info", Edit.NAMESPACE);
 
 			if (info == null)

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/z3950Config/Z3950Config.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/z3950Config/Z3950Config.java
@@ -39,19 +39,22 @@ import org.jdom.Element;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 //=============================================================================
 
 public class Z3950Config
 {
-	//--------------------------------------------------------------------------
+    private final AtomicBoolean cancelMonitor;
+    //--------------------------------------------------------------------------
 	//---
 	//--- Constructor
 	//---
 	//--------------------------------------------------------------------------
 
-	public Z3950Config(Logger log, ServiceContext context, XmlRequest req, Z3950ConfigParams params)
+	public Z3950Config(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, XmlRequest req, Z3950ConfigParams params)
 	{
+        this.cancelMonitor = cancelMonitor;
 		this.log     = log;
 		this.context = context;
 		this.request = req;
@@ -79,7 +82,11 @@ public class Z3950Config
 		//--- JZKitConfig.xml.tem
 
 		for(RecordInfo ri : records) {
-			result.totalMetadata++;
+            if (cancelMonitor.get()) {
+                return this.result;
+            }
+
+            result.totalMetadata++;
 
 			// get metadata from remote geonetwork machine (assume local for now)
 			addServerToZ3950Config(ri.uuid);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/z3950Config/Z3950ConfigHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/z3950Config/Z3950ConfigHarvester.java
@@ -145,7 +145,7 @@ public class Z3950ConfigHarvester extends AbstractHarvester<HarvestResult>
 
 	public void doHarvest(Logger log) throws Exception
 	{
-		Harvester h = new Harvester(log, context, params);
+		Harvester h = new Harvester(cancelMonitor, log, context, params);
 		result = h.harvest(log);
 	}
 

--- a/harvesters/src/main/java/org/fao/geonet/services/harvesting/Stop.java
+++ b/harvesters/src/main/java/org/fao/geonet/services/harvesting/Stop.java
@@ -26,6 +26,7 @@ package org.fao.geonet.services.harvesting;
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
+import org.fao.geonet.kernel.harvest.Common;
 import org.fao.geonet.kernel.harvest.Common.OperResult;
 import org.fao.geonet.kernel.harvest.HarvestManager;
 import org.jdom.Element;
@@ -52,11 +53,16 @@ public class Stop implements Service
 
 	public Element exec(Element params, ServiceContext context) throws Exception
 	{
-		return Util.exec(params, context, new Util.Job()
+        String statusParam = org.fao.geonet.Util.getParam(params, "status", Common.Status.INACTIVE.toString());
+        if (statusParam.isEmpty()) {
+            statusParam = Common.Status.INACTIVE.toString();
+        }
+        final Common.Status newStatus = Common.Status.parse(statusParam);
+        return Util.exec(params, context, new Util.Job()
 		{
 			public OperResult execute(HarvestManager hm, String id) throws Exception
 			{
-				return hm.stop(id);
+				return hm.stop(id, newStatus);
 			}
 		});
 	}

--- a/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/webdav/WebDavRetrieverTest.java
+++ b/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/webdav/WebDavRetrieverTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.*;
 
@@ -26,7 +27,7 @@ public class WebDavRetrieverTest {
         resources.add(baseResource);
         resources.add(otherResource);
 
-        final String baseURL = WebDavRetriever.calculateBaseURL("http://geonetwork.net/webdav/", resources);
+        final String baseURL = WebDavRetriever.calculateBaseURL(new AtomicBoolean(), "http://geonetwork.net/webdav/", resources);
 
         assertEquals("http://geonetwork.net", baseURL);
         assertEquals(1, resources.size());

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestController.js
@@ -254,7 +254,14 @@
       };
 
       $scope.refreshHarvester = function() {
-        loadHarvesters();
+        loadHarvesters().then(function() {
+          // Select the clone
+          angular.forEach($scope.harvesters, function (h) {
+            if (h['@id'] === $scope.harvesterSelected['@id']) {
+              $scope.selectHarvester(h);
+            }
+          });
+        });
       };
       $scope.deleteHarvester = function() {
         $http.get('admin.harvester.remove?_content_type=json&id=' +
@@ -291,11 +298,37 @@
             });
       };
       $scope.runHarvester = function() {
-        $http.get('admin.harvester.run@json?_content_type=json&id=' +
+        $http.get('admin.harvester.run?_content_type=json&id=' +
             $scope.harvesterSelected['@id'])
           .success(function(data) {
-              loadHarvesters();
+              loadHarvesters().then(function() {
+                // Refesh the harvester
+                angular.forEach($scope.harvesters, function (h) {
+                  if (h['@id'] === $scope.harvesterSelected['@id']) {
+                    $scope.selectHarvester(h);
+                  }
+                });
+              });
             });
+      };
+      $scope.stopping = false;
+      $scope.stopHarvester = function() {
+        var status =  $scope.harvesterSelected.options.status;
+        var id = $scope.harvesterSelected['@id'];
+        $scope.stopping = true;
+        $http.get('admin.harvester.stop?_content_type=json&id=' + id + '&status=' + status)
+          .success(function(data) {
+              loadHarvesters().then(function() {
+                // Refresh the harvester
+                angular.forEach($scope.harvesters, function (h) {
+                  if (h['@id'] === $scope.harvesterSelected['@id']) {
+                    $scope.selectHarvester(h);
+                  }
+                });
+              });
+            }).then(function() {
+              $scope.stopping = false;
+          });
       };
 
       $scope.setHarvesterSchedule = function() {

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -167,5 +167,6 @@
     "privileges": "Privileges",
     "whoCanAccess": "Who has access",
     "actions" : "Actions",
-    "reset" : "Reset"
+    "reset" : "Reset",
+    "stop": "Stop"
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest.html
@@ -82,10 +82,16 @@
 
       <div class="btn-toolbar">
         <button type="button" class="btn btn-primary pull-right fa fa-play"
-                data-ng-hide="harvesterSelected['@id'] == ''"
-                data-ng-click="runHarvester(harvesterSelected['@id'])"
-                data-ng-disabled="harvesterSelected.info.running === true">
+                data-ng-hide="harvesterSelected['@id'] == '' || harvesterSelected.info.running === true"
+                data-ng-click="runHarvester(harvesterSelected['@id'])">
           <span data-translate="">runHarvester</span>
+        </button>
+        <button type="button" class="btn btn-primary pull-right fa fa-stop"
+                data-ng-hide="harvesterSelected['@id'] == '' || harvesterSelected.info.running === false"
+                data-ng-click="stopHarvester(harvesterSelected['@id'])"
+                data-ng-disabled="stopping">
+            <span data-translate="">stop</span>
+            <i data-ng-show="stopping" class="fa fa-spinner fa-spin"></i>
         </button>
         <button type="button" class="btn btn-primary pull-right"
                 data-ng-click="saveHarvester('#gn-harvester-edit')">


### PR DESCRIPTION
This is useful when users are experimenting with configuring harvesters.

* Add cancelMonitor AtomicBoolean to AbstractHarvester.
* Update harvesters to check he flag and abort if it becomes true
* Update UI so that the run button is replaced by a stop button while a harvester is running.