### PR TITLE
Change templates to use the _logo index field for logo path.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -591,7 +591,7 @@ public class DataManager {
                 if (group != null) {
                     moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_OWNER, String.valueOf(groupOwner), true, true));
                     moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_WEBSITE, group.getWebsite(), true, false));
-                    if (group.getLogo() != null) {
+                    if (group.getLogo() != null && settingMan.getValueAsBool(SettingManager.SYSTEM_PREFER_GROUP_LOGO, true)) {
                         logoUUID = group.getLogo();
                     }
                 }

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -590,8 +590,11 @@ public class DataManager {
                 final Group group = groupRepository.findOne(groupOwner);
                 if (group != null) {
                     moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_OWNER, String.valueOf(groupOwner), true, true));
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_WEBSITE, group.getWebsite(), true, false));
-                    if (group.getLogo() != null && settingMan.getValueAsBool(SettingManager.SYSTEM_PREFER_GROUP_LOGO, true)) {
+                    final boolean preferGroup = settingMan.getValueAsBool(SettingManager.SYSTEM_PREFER_GROUP_LOGO, true);
+                    if (group.getWebsite() != null && !group.getWebsite().isEmpty() && preferGroup) {
+                        moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_WEBSITE, group.getWebsite(), true, false));
+                    }
+                    if (group.getLogo() != null && preferGroup) {
                         logoUUID = group.getLogo();
                     }
                 }

--- a/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
@@ -75,6 +75,7 @@ public class SettingManager {
     public static final String SYSTEM_INSPIRE_ENABLE = "system/inspire/enable";
     public static final String SYSTEM_INSPIRE_ATOM = "system/inspire/atom";
     public static final String SYSTEM_INSPIRE_ATOM_SCHEDULE = "system/inspire/atomSchedule";
+    public static final java.lang.String SYSTEM_PREFER_GROUP_LOGO = "system/metadata/prefergrouplogo";
 
     @Autowired
     private SettingRepository _repo;
@@ -227,7 +228,11 @@ public class SettingManager {
      */
     public boolean getValueAsBool(String key, boolean defaultValue) {
         String value = getValue(key);
-        return (value != null) ? Boolean.parseBoolean(value) : defaultValue;
+        if (value != null) {
+            return "y".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value) || Boolean.parseBoolean(value);
+        } else {
+            return defaultValue;
+        }
     }
 
     /**

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/geocat.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/geocat.html
@@ -53,7 +53,7 @@
         </h4>
 
         <a class="pull-left">
-          <img ng-src="../../images/logos/{{md.source}}.gif" class="media-object"/>
+          <img ng-src="../..{{md.logo}}" class="media-object"/>
         </a>
         <p class="text-justify" dd-text-collapse dd-text-collapse-max-length="350" dd-text-collapse-text="{{md.abstract}}"></p>
         <p class="md-date" ng-if="showDate.date">(<i translate>{{showDate.type}}</i> : {{showDate.date}})</p>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/geocat.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/geocat.html
@@ -52,9 +52,13 @@
           <a href="" gn-metadata-open="md" gn-metadata-open-selector=".gn-resultview" title="{{md.title || md.defaultTitle}}">{{md.title || md.defaultTitle}}</a>
         </h4>
 
-        <a class="pull-left">
+        <a class="pull-left" ng-if="md.groupWebsite" href="{{md.groupWebsite}}" target="_blank">
           <img ng-src="../..{{md.logo}}" class="media-object"/>
         </a>
+        <a class="pull-left" ng-if="!md.groupWebsite">
+          <img ng-src="../..{{md.logo}}" class="media-object"/>
+        </a>
+
         <p class="text-justify" dd-text-collapse dd-text-collapse-max-length="350" dd-text-collapse-text="{{md.abstract}}"></p>
         <p class="md-date" ng-if="showDate.date">(<i translate>{{showDate.type}}</i> : {{showDate.date}})</p>
         <p class="md-owner">

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -15,8 +15,10 @@
       </a>
 
       <!--Source catalog Logo-->
-      <img ng-src="../..{{md.logo}}"
-             class="gn-source-logo"/>
+        <a ng-if="md.groupWebsite" href="{{md.groupWebsite}}" target="_blank">
+            <img ng-src="../..{{md.logo}}" class="gn-source-logo"/>
+        </a>
+        <img ng-if="!md.groupWebsite" ng-src="../..{{md.logo}}" class="gn-source-logo"/>
 
       <!-- Thumbnail -->
       <div class="gn-md-thumbnail">

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -15,7 +15,7 @@
       </a>
 
       <!--Source catalog Logo-->
-      <img ng-src="../../images/logos/{{md.source}}.gif"
+      <img ng-src="../..{{md.logo}}"
              class="gn-source-logo"/>
 
       <!-- Thumbnail -->

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -17,7 +17,7 @@
 
       <!--Catalog Logo-->
       <a class="pull-left">
-        <img ng-src="../../images/logos/{{md.source}}.gif" class="media-object"/>
+        <img ng-src="../..{{md.logo}}" class="media-object"/>
       </a>
 
       <div class="media-body">

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -16,9 +16,12 @@
       </div>
 
       <!--Catalog Logo-->
-      <a class="pull-left">
-        <img ng-src="../..{{md.logo}}" class="media-object"/>
-      </a>
+        <a class="pull-left" ng-if="md.groupWebsite" href="{{md.groupWebsite}}" target="_blank">
+            <img ng-src="../..{{md.logo}}" class="media-object"/>
+        </a>
+        <a class="pull-left" ng-if="!md.groupWebsite">
+            <img ng-src="../..{{md.logo}}" class="media-object"/>
+        </a>
 
       <div class="media-body">
         <h4>

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -735,6 +735,7 @@
     "system/localrating/enable": "Local rating",
     "system/localrating/enable-help": "If set, GeoNetwork will calculate user ratings for metadata from this node only (not distributed among other GeoNetwork nodes).",
     "system/metadata": "Metadata views",
+    "system/metadata/prefergrouplogo": "Prefer Group Logo",
     "system/metadata/defaultView": "Default view",
     "system/metadata/enableInspireView": "INSPIRE view",
     "system/metadata/enableIsoView": "ISO view",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -627,6 +627,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/level1', 'false', 2, 9026, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/level2', 'false', 2, 9027, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/level3', 'false', 2, 9028, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/prefergrouplogo', 'y', 0, 9111, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/enableSimpleView', 'true', 2, 9110, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/enableIsoView', 'true', 2, 9120, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/enableInspireView', 'false', 2, 9130, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v300/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v300/migrate-default.sql
@@ -11,3 +11,4 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atom', 'disabled', 0, 7230, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atomSchedule', '0 0 0/24 ? * *', 0, 7240, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atomProtocol', 'INSPIRE-ATOM', 0, 7250, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/prefergrouplogo', 'y', 0, 9111, 'y');

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -144,6 +144,7 @@
       <field name="_indexingErrorMsg" tagName="idxMsg"/>
       <field name="_op0" tagName="publishedForGroup"/>
       <field name="_groupOwner" tagName="groupOwner"/>
+      <field name="_logo" tagName="logo"/>
     </dumpFields>
   </search>
 

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -145,6 +145,7 @@
       <field name="_op0" tagName="publishedForGroup"/>
       <field name="_groupOwner" tagName="groupOwner"/>
       <field name="_logo" tagName="logo"/>
+      <field name="_groupWebsite" tagName="groupWebsite"/>
     </dumpFields>
   </search>
 


### PR DESCRIPTION
_logo is chosen as follows:

If metadata.groupOwner != null && metadata.group.logo != null && settings.prefergrouplogo {
  _logo = /resources/logo/{{metadata.group.logo}}.<ext>
} else {
  _logo = /resources/logo/{{metadata.source.uuid}}.<ext>
}

<ext> is chosen by searching the resources/logo directory for an image with the prefix source.uuid or group.logo (according to above algorithm).  This ensures that the image is valid irregardless of whether the user uploaded a gif or png or tif or... and is not hardcoded as a .gif like many old solutions of logo were.

This will not change any behaviour of existing systems because most current sytems will not have group.logo since that is a new geocat 3.0 feature.  additionally there is a setting that will force the logo to always be based on the metadata source.


Change 2 (commit 2): If the group has a website and preferGroupLogo is true (in settings) then the logo will be a link to the group website

