### PR TITLE
Provide default values for position and internal fields (issue #739)

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/Setting.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Setting.java
@@ -22,7 +22,7 @@ public class Setting extends GeonetEntity {
     private String name;
     private String value;
     private SettingDataType dataType;
-    private int position;
+    private int position = 0;
     private char internal = Constants.YN_TRUE;
 
     @Id
@@ -58,6 +58,7 @@ public class Setting extends GeonetEntity {
         return this;
     }
 
+    @Column(name = "position", nullable = false, columnDefinition="int default 0")
     public int getPosition() {
         return position;
     }
@@ -72,7 +73,7 @@ public class Setting extends GeonetEntity {
      * This is a workaround to allow this until future
      * versions of JPA that allow different ways of controlling how types are mapped to the database.
      */
-    @Column(name = "internal", nullable = false, length = 1)
+    @Column(name = "internal", nullable = false, length = 1, columnDefinition="char default 'y'")
     protected char getInternal_JpaWorkaround() {
         return internal;
     }


### PR DESCRIPTION
That commit fixes two of the three hibernate hdb2ddl issues:
```
ERROR [org.hibernate.tool.hbm2ddl.SchemaUpdate] - HHH000388: Unsuccessful: alter table Settings add column internal char(1) not null
ERROR [org.hibernate.tool.hbm2ddl.SchemaUpdate] - ERROR: column "internal" contains null values
ERROR [org.hibernate.tool.hbm2ddl.SchemaUpdate] - HHH000388: Unsuccessful: alter table Settings add column position int4 not null
ERROR [org.hibernate.tool.hbm2ddl.SchemaUpdate] - ERROR: column "position" contains null values
```

Whatever i try for the UserGroups profile field addition (which should be added between 2.8 and 2.10), it will still complain:

```
ERROR [org.hibernate.tool.hbm2ddl.SchemaUpdate] - HHH000388: Unsuccessful: alter table UserGroups add column profile int4 not null
2015-01-29 10:36:11,933 ERROR [org.hibernate.tool.hbm2ddl.SchemaUpdate] - ERROR: column "profile" contains null values
```

And in either cases, the sql migration scripts dont seem to run.