### PR TITLE
SchemaPlugin / Add ISOPlugin interface to be able to customize basic type

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -37,11 +37,8 @@ import org.apache.commons.jxpath.ri.parser.XPathParser;
 import org.apache.commons.jxpath.ri.parser.XPathParserConstants;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Geonet.Namespaces;
 import org.fao.geonet.domain.Pair;
-import org.fao.geonet.kernel.schema.MetadataAttribute;
-import org.fao.geonet.kernel.schema.MetadataSchema;
-import org.fao.geonet.kernel.schema.MetadataType;
+import org.fao.geonet.kernel.schema.*;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jaxen.JaxenException;
@@ -1005,7 +1002,10 @@ public class EditLib {
      */
     private void fillElement(MetadataSchema schema, SchemaSuggestions sugg, String parentName, Element element) throws Exception {
         String elemName = element.getQualifiedName();
-        
+        SchemaPlugin plugin = schema.getSchemaPlugin();
+        boolean isISOPlugin = plugin instanceof ISOPlugin;
+        ISOPlugin isoPlugin = isISOPlugin ? (ISOPlugin) plugin : null;
+
         boolean isSimpleElement = schema.isSimpleElement(elemName,parentName);
         
         if(Log.isDebugEnabled(Geonet.EDITORFILLELEMENT)) {
@@ -1127,8 +1127,10 @@ public class EditLib {
                         // Add it to the element
                         element.addContent(child);
                         
-                        if (childHasOnlyCharacterStringSuggestion) {
-                            child.addContent(new Element("CharacterString", Namespaces.GCO));
+                        if (childHasOnlyCharacterStringSuggestion &&
+                                isISOPlugin) {
+                            child.addContent(isoPlugin.createBasicTypeCharacterString()
+                            );
                         }
                         
                         // Continue ....
@@ -1136,8 +1138,9 @@ public class EditLib {
                     } else {
                         // Logging some cases to avoid
                         if(Log.isDebugEnabled(Geonet.EDITORFILLELEMENT)) {
-                            if (elemType.isOrType()) {
-                                 if (elemType.getElementList().contains("gco:CharacterString") 
+                            if (elemType.isOrType() && isISOPlugin) {
+                                 if (elemType.getElementList().contains(
+                                         isoPlugin.getBasicTypeCharacterStringName())
                                          && !childHasOneSuggestion) {
                                     Log.debug(Geonet.EDITORFILLELEMENT,"####   - (INNER) Requested expansion of an OR element having gco:CharacterString substitute and no suggestion: " + element.getName());
                                  } else {
@@ -1148,14 +1151,17 @@ public class EditLib {
                     }
                 }
             }
-        } else if (type.getElementList().contains("gco:CharacterString") && !hasSuggestion) {
+        } else if (isISOPlugin &&
+                   type.getElementList().contains(
+                        isoPlugin.getBasicTypeCharacterStringName()) &&
+                   !hasSuggestion) {
             // expand element which have no suggestion
             // and have a gco:CharacterString substitute.
             // gco:CharacterString is the default.
             if(Log.isDebugEnabled(Geonet.EDITORFILLELEMENT)) {
                 Log.debug(Geonet.EDITORFILLELEMENT, "####   - Requested expansion of an OR element having gco:CharacterString substitute and no suggestion: " + element.getName());
             }
-            Element child = new Element("CharacterString", Namespaces.GCO);
+            Element child = isoPlugin.createBasicTypeCharacterString();
             element.addContent(child);
         } else {
             // TODO: this could be supported if only one suggestion defined for an or element ?

--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -32,6 +32,7 @@ import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.guiservices.XmlFile;
 import jeeves.server.overrides.ConfigurationOverrides;
 import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
 import org.fao.geonet.ZipUtil;
 import org.fao.geonet.constants.Geonet;
@@ -46,6 +47,7 @@ import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.repository.SchematronCriteriaGroupRepository;
 import org.fao.geonet.repository.SchematronRepository;
+import org.fao.geonet.schema.iso19139.ISO19139SchemaPlugin;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.nio.NioPathAwareCatalogResolver;
@@ -243,22 +245,26 @@ public class SchemaManager {
 		}
 	}
 
-    public static SchemaPlugin getSchemaPlugin(ServiceContext context, String schemaIdentifier) {
+    public static SchemaPlugin getSchemaPlugin(String schemaIdentifier) {
         String schemaBeanIdentifier = schemaIdentifier + "SchemaPlugin";
         SchemaPlugin schemaPlugin = null;
         try {
-            schemaPlugin = (SchemaPlugin) context.getApplicationContext().getBean(schemaBeanIdentifier);
+            if (ApplicationContextHolder.get() != null) {
+                schemaPlugin = (SchemaPlugin) ApplicationContextHolder.
+                        get().
+                        getBean(schemaBeanIdentifier);
 
-            String iso19139SchemaIdentifier = "iso19139";
-            if (schemaPlugin == null && schemaIdentifier.startsWith(iso19139SchemaIdentifier)){
-                // For ISO19139 profiles, get the ISO19139 bean if no custom one defined
-                // Can't depend here on ISO19139SchemaPlugin to avoid to introduce
-                // circular ref.
-                schemaBeanIdentifier = iso19139SchemaIdentifier + "SchemaPlugin";
-                schemaPlugin = (SchemaPlugin) context.getApplicationContext().getBean(schemaBeanIdentifier);
+                if (schemaPlugin == null &&
+                        schemaIdentifier.startsWith(ISO19139SchemaPlugin.IDENTIFIER)) {
+                    // For ISO19139 profiles, get the ISO19139 bean if no custom one defined
+                    // Can't depend here on ISO19139SchemaPlugin to avoid to introduce
+                    // circular ref.
+                    schemaBeanIdentifier = ISO19139SchemaPlugin.IDENTIFIER + "SchemaPlugin";
+                    schemaPlugin = (SchemaPlugin) ApplicationContextHolder.
+                            get().
+                            getBean(schemaBeanIdentifier);
+                }
             }
-
-
         } catch (Exception e) {
             // No bean for this schema
             if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -34,6 +34,7 @@ import org.fao.geonet.domain.SchematronCriteria;
 import org.fao.geonet.domain.SchematronCriteriaGroup;
 import org.fao.geonet.domain.SchematronCriteriaGroupId;
 import org.fao.geonet.domain.SchematronCriteriaType;
+import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.repository.SchematronCriteriaGroupRepository;
 import org.fao.geonet.repository.SchematronRepository;
 import org.fao.geonet.utils.Log;
@@ -83,6 +84,7 @@ public class MetadataSchema
 
     private SchematronRepository schemaRepo;
     private SchematronCriteriaGroupRepository criteriaGroupRepository;
+	private SchemaPlugin schemaPlugin;
 
 	//---------------------------------------------------------------------------
 	//---
@@ -94,7 +96,7 @@ public class MetadataSchema
         schemaName = "UNKNOWN";
         this.schemaRepo = schemaRepo;
         this.criteriaGroupRepository = criteriaGroupRepository;
-    }
+	}
 
 	//---------------------------------------------------------------------------
 	//---
@@ -119,6 +121,7 @@ public class MetadataSchema
 	public void setName(String inName)
 	{
 		schemaName = inName;
+		this.schemaPlugin = SchemaManager.getSchemaPlugin(schemaName);
 	}
 
 	//---------------------------------------------------------------------------
@@ -464,7 +467,11 @@ public class MetadataSchema
         return hmOperationFilters.get(operation.name());
     }
 
-    /**
+	public SchemaPlugin getSchemaPlugin() {
+		return schemaPlugin;
+	}
+
+	/**
 	 * Schematron rules filename is like "schematron-rules-iso.xsl
 	 * 
 	 */

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -3,6 +3,7 @@ package org.fao.geonet.schema.iso19139;
 import com.google.common.collect.ImmutableSet;
 import org.fao.geonet.kernel.schema.AssociatedResource;
 import org.fao.geonet.kernel.schema.AssociatedResourcesSchemaPlugin;
+import org.fao.geonet.kernel.schema.ISOPlugin;
 import org.fao.geonet.kernel.schema.MultilingualSchemaPlugin;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
@@ -20,7 +21,10 @@ import java.util.Set;
  */
 public class ISO19139SchemaPlugin
         extends org.fao.geonet.kernel.schema.SchemaPlugin
-        implements AssociatedResourcesSchemaPlugin, MultilingualSchemaPlugin {
+        implements
+                AssociatedResourcesSchemaPlugin,
+                MultilingualSchemaPlugin,
+                ISOPlugin {
     public static final String IDENTIFIER = "iso19139";
 
     private static ImmutableSet<Namespace> allNamespaces;
@@ -178,4 +182,13 @@ public class ISO19139SchemaPlugin
         freeTextElement.addContent(textGroupElement);
     }
 
+    @Override
+    public String getBasicTypeCharacterStringName() {
+        return "gco:CharacterString";
+    }
+
+    @Override
+    public Element createBasicTypeCharacterString() {
+        return new Element("CharacterString", ISO19139Namespaces.GCO);
+    }
 }

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -254,7 +254,7 @@
                           
                           <!-- Add the inspire field if it's one of the 34 themes -->
                           <xsl:if test="normalize-space($inspireannex)!=''">
-                            <Field name="inspiretheme" string="{string(.)}" store="false" index="true"/>
+                            <Field name="inspiretheme" string="{string(.)}" store="true" index="true"/>
                 <xsl:variable name="englishInspireTheme">
                   <xsl:call-template name="translateInspireThemeToEnglish">
                     <xsl:with-param name="keyword" select="string(.)"/>
@@ -262,7 +262,7 @@
                   </xsl:call-template>
                 </xsl:variable>
                 <Field name="inspiretheme_en" string="{$englishInspireTheme}" store="true" index="true"/>
-                          	<Field name="inspireannex" string="{$inspireannex}" store="false" index="true"/>
+                          	<Field name="inspireannex" string="{$inspireannex}" store="true" index="true"/>
                             <!-- FIXME : inspirecat field will be set multiple time if one record has many themes -->
                           	<Field name="inspirecat" string="true" store="false" index="true"/>
                           </xsl:if>

--- a/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/ISOPlugin.java
+++ b/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/ISOPlugin.java
@@ -1,0 +1,24 @@
+package org.fao.geonet.kernel.schema;
+
+import org.jdom.Element;
+
+/**
+ * Created by francois on 31/01/15.
+ */
+public interface ISOPlugin {
+    /**
+     * Return the name (with namespace prefix)
+     * for the basic default type.
+     *
+     * @return
+     */
+    String getBasicTypeCharacterStringName();
+
+    /**
+     * Return an element to be use as default
+     * when creating new elements.
+     *
+     * @return
+     */
+    Element createBasicTypeCharacterString();
+}

--- a/services/src/main/java/org/fao/geonet/guiservices/metadata/GetRelated.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/metadata/GetRelated.java
@@ -310,7 +310,7 @@ public class GetRelated implements Service, RelatedMetadata {
         }
 
         String schemaIdentifier = dm.getMetadataSchema(id);
-        SchemaPlugin instance = SchemaManager.getSchemaPlugin(context, schemaIdentifier);
+        SchemaPlugin instance = SchemaManager.getSchemaPlugin(schemaIdentifier);
         AssociatedResourcesSchemaPlugin schemaPlugin = null;
         if (instance instanceof AssociatedResourcesSchemaPlugin) {
             schemaPlugin = (AssociatedResourcesSchemaPlugin) instance;

--- a/services/src/main/java/org/fao/geonet/services/metadata/EditUtils.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/EditUtils.java
@@ -306,7 +306,7 @@ class EditUtils {
         if (ref.startsWith("lang")) {
             if (val.length() > 0) {
 
-                SchemaPlugin schemaPlugin = SchemaManager.getSchemaPlugin(context, schema);
+                SchemaPlugin schemaPlugin = SchemaManager.getSchemaPlugin(schema);
                 if (schemaPlugin instanceof MultilingualSchemaPlugin) {
                     String[] ids = ref.split("_");
                     // --- search element in current parent

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/groovy/Functions.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/groovy/Functions.java
@@ -37,7 +37,7 @@ public class Functions extends SchemaLocalizations {
         super(fparams.context.getApplicationContext(), env, fparams.schema, fparams.config.dependOn());
 
         this.env = env;
-        this.schemaPlugin = SchemaManager.getSchemaPlugin(fparams.context, fparams.schema);
+        this.schemaPlugin = SchemaManager.getSchemaPlugin(fparams.schema);
         this.fparams = fparams;
     }
 

--- a/web-ui/src/main/resources/catalog/components/common/schemamanager/SchemaManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/common/schemamanager/SchemaManagerService.js
@@ -14,11 +14,12 @@
     gts: 'http://www.isotc211.org/2005/gts',
     srv: 'http://www.isotc211.org/2005/srv',
     xlink: 'http://www.w3.org/1999/xlink',
-    cit: 'http://www.isotc211.org/namespace/cit/1.0/2014-07-11',
-    mdb: 'http://www.isotc211.org/namespace/mdb/1.0/2014-07-11',
-    mri: 'http://www.isotc211.org/namespace/mri/1.0/2014-07-11',
-    mrd: 'http://www.isotc211.org/namespace/mrd/1.0/2014-07-11',
-    mcc: 'http://www.isotc211.org/namespace/mcc/1.0/2014-07-11'
+    cit: 'http://standards.iso.org/19115/-3/cit/1.0/2014-12-25',
+    mdb: 'http://standards.iso.org/19115/-3/mdb/1.0/2014-12-25',
+    mri: 'http://standards.iso.org/19115/-3/mri/1.0/2014-12-25',
+    mrd: 'http://standards.iso.org/19115/-3/mrd/1.0/2014-12-25',
+    mcc: 'http://standards.iso.org/19115/-3/mcc/1.0/2014-12-25',
+    gco3: 'http://standards.iso.org/19139/gco/1.0/2014-12-25'
   });
 
   /**


### PR DESCRIPTION
When adding a simple element only gco:CharacterString were added. Some schema may have a different basic type.

For the time being only gco:CharacterString is customizable.

It's required for ISO19139 and ISO19115-3, the later using a new namespace for all basic types.