### PR TITLE
web - missing dependency in pom.xml

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -158,6 +158,10 @@
       <groupId>org.geotools</groupId>
       <artifactId>gt-epsg-hsql</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.geotools.jdbc</groupId>
+      <artifactId>gt-jdbc-postgis</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
At runtime, jetty complains about a missing dependency when GN is
configured to use a postgis alternate datasource
(see config-db/postgis-alternate-datasource.xml). This commit adds the
missing GeoTools module.

Tests: runtime tested, launching jetty via maven (mvn jetty:run)