### PR TITLE
Local FS harvesting - fixing memory consumption

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -411,7 +411,7 @@ public class DataManager {
      * @param context context object
      * @param metadataIds the metadata ids to index
      */
-    public void batchIndexInThreadPool(ServiceContext context, List<String> metadataIds) {
+    public void batchIndexInThreadPool(ServiceContext context, List<?> metadataIds) {
 
         TransactionStatus transactionStatus = null;
         try {
@@ -441,7 +441,7 @@ public class DataManager {
                 Log.debug(Geonet.INDEX_ENGINE, "Indexing records from " + start + " to " + nbRecords);
             }
 
-            List<String> subList = metadataIds.subList(start, nbRecords);
+            List subList = metadataIds.subList(start, nbRecords);
 
             if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
                 Log.debug(Geonet.INDEX_ENGINE, subList.toString());

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 final class IndexMetadataTask implements Runnable {
 
     private final ServiceContext _context;
-    private final List<String> _metadataIds;
+    private final List<?> _metadataIds;
     private final TransactionStatus _transactionStatus;
     private final Set<IndexMetadataTask> _batchIndex;
     private final SearchManager searchManager;
@@ -32,11 +32,11 @@ final class IndexMetadataTask implements Runnable {
      * Constructor.
      *
      * @param context           context object
-     * @param metadataIds       the metadata ids to index
+     * @param metadataIds       the metadata ids to index (either integers or strings)
      * @param batchIndex
      * @param transactionStatus if non-null, wait for the transaction to complete before indexing
      */
-    IndexMetadataTask(@Nonnull ServiceContext context, @Nonnull List<String> metadataIds, Set<IndexMetadataTask> batchIndex,
+    IndexMetadataTask(@Nonnull ServiceContext context, @Nonnull List<?> metadataIds, Set<IndexMetadataTask> batchIndex,
                       @Nullable TransactionStatus transactionStatus, @Nonnull AtomicInteger indexed) {
         this.indexed = indexed;
         this._transactionStatus = transactionStatus;
@@ -76,7 +76,7 @@ final class IndexMetadataTask implements Runnable {
 
             DataManager dataManager = _context.getBean(DataManager.class);
             // servlet up so safe to index all metadata that needs indexing
-            for (String metadataId : _metadataIds) {
+            for (Object metadataId : _metadataIds) {
                 this.indexed.incrementAndGet();
                 if (this.indexed.compareAndSet(500, 0)) {
                     try {
@@ -87,7 +87,7 @@ final class IndexMetadataTask implements Runnable {
                 }
 
                 try {
-                    dataManager.indexMetadata(metadataId, false);
+                    dataManager.indexMetadata(metadataId.toString(), false);
                 } catch (Exception e) {
                     Log.error(Geonet.INDEX_ENGINE, "Error indexing metadata '" + metadataId + "': " + e.getMessage()
                                                    + "\n" + Util.getStackTrace(e));

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -41,6 +41,7 @@ import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.SourceRepository;
+import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.resources.Resources;
 import org.fao.geonet.utils.IO;
 import org.jdom.Element;
@@ -123,25 +124,23 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 			}
 		}
 		result = visitor.getResult();
-		List<String> idsForHarvestingResult = visitor.getIdsForHarvestingResult();
+		List<Integer> idsForHarvestingResult = visitor.getIdsForHarvestingResult();
 		if (!params.nodelete) {
 			//
 			// delete locally existing metadata from the same source if they
 			// were
 			// not in this harvesting result
 			//
-            List<Metadata> existingMetadata = context.getBean(MetadataRepository.class).findAllByHarvestInfo_Uuid(params.getUuid());
-            for (Metadata existingId : existingMetadata) {
+		    List<Integer> existingMetadata = context.getBean(MetadataRepository.class).findAllIdsBy(MetadataSpecs.hasHarvesterUuid(params.getUuid()));
+            for (Integer existingId : existingMetadata) {
 
 				if (cancelMonitor.get()) {
 					return this.result;
 				}
-
-				String ex$ = String.valueOf(existingId.getId());
-				if (!idsForHarvestingResult.contains(ex$)) {
-					log.debug("  Removing: " + ex$);
-					dataMan.deleteMetadata(context, ex$);
-					result.locallyRemoved++;
+                if (!idsForHarvestingResult.contains(existingId)) {
+                    log.debug("  Removing: " + existingId);
+                    dataMan.deleteMetadata(context, existingId.toString());
+                    result.locallyRemoved++;
 				}
 			}
 		}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -46,6 +46,8 @@ import org.fao.geonet.resources.Resources;
 import org.fao.geonet.utils.IO;
 import org.jdom.Element;
 
+import com.google.common.collect.Sets;
+
 import java.io.File;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -53,6 +55,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -125,6 +128,8 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 		}
 		result = visitor.getResult();
 		List<Integer> idsForHarvestingResult = visitor.getIdsForHarvestingResult();
+		Set<Integer> idsResultHs = Sets.newHashSet(idsForHarvestingResult);
+
 		if (!params.nodelete) {
 			//
 			// delete locally existing metadata from the same source if they
@@ -137,7 +142,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 				if (cancelMonitor.get()) {
 					return this.result;
 				}
-                if (!idsForHarvestingResult.contains(existingId)) {
+                if (!idsResultHs.contains(existingId)) {
                     log.debug("  Removing: " + existingId);
                     dataMan.deleteMetadata(context, existingId.toString());
                     result.locallyRemoved++;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -131,7 +131,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 			// were
 			// not in this harvesting result
 			//
-		    List<Integer> existingMetadata = context.getBean(MetadataRepository.class).findAllIdsBy(MetadataSpecs.hasHarvesterUuid(params.getUuid()));
+            List<Integer> existingMetadata = context.getBean(MetadataRepository.class).findAllIdsBy(MetadataSpecs.hasHarvesterUuid(params.getUuid()));
             for (Integer existingId : existingMetadata) {
 
 				if (cancelMonitor.get()) {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
@@ -45,7 +45,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
     private Path thisXslt;
     private final CategoryMapper localCateg;
     private final GroupMapper localGroups;
-    private final List<String> idsForHarvestingResult = Lists.newArrayList();
+    private final List<Integer> idsForHarvestingResult = Lists.newArrayList();
 
     public LocalFsHarvesterFileVisitor(AtomicBoolean cancelMonitor, ServiceContext context, LocalFilesystemParams params, Logger log, LocalFilesystemHarvester harvester) throws Exception {
         this.aligner = new BaseAligner(cancelMonitor) {};
@@ -194,7 +194,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
                                 result.updatedMetadata++;
                             }
                         }
-                        idsForHarvestingResult.add(id);
+                        idsForHarvestingResult.add(new Integer(id));
                     }
                 }
             }
@@ -208,7 +208,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
         return result;
     }
 
-    public List<String> getIdsForHarvestingResult() {
+    public List<Integer> getIdsForHarvestingResult() {
         return idsForHarvestingResult;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
@@ -194,7 +194,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
                                 result.updatedMetadata++;
                             }
                         }
-                        idsForHarvestingResult.add(new Integer(id));
+                        idsForHarvestingResult.add(Integer.valueOf(id));
                     }
                 }
             }


### PR DESCRIPTION
When the harvester is configured to delete old previously harvested elements, a query is made to fetch *every* (java object) Metadata for this specific harvester, from the database.

On regular directories, containing less than a hundred or thousands of MD, that is not a problem, but our customer is willing to harvest a directory containing +230k metadata, which obviously won't fit, even on a server with a huge amount of RAM.

Most problematic line of code is here:

https://github.com/geonetwork/core-geonetwork/blob/develop/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java#L133

This commit proposes to address the problem by:

- Constructing a list of Integers instead of strings (this can reduce the amount of mermory used by java objects created on the heap by a factor between 1.4 and 4.4, from a little test which compares constructing lists of +2M elements of List\<String\> vs List\<Integer\>) ;

- Getting only a List<Integer> instead of a List<Metadata>, when checking which MDs have to be deleted.

Tests: runtime tested, on a tomcat with -Xmx2048M
Test suite: fails, but on the following one:
```
  InspireAtomFeedRepositoryTest.testCleanAtomDocumentsByMetadataId: DataIntegrityViolation
```
So I'm not sure this commit introduced this as a regression.