### PR TITLE
remove trailing comma

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -196,5 +196,5 @@
     "addRecord": "Ajouter une fiche",
     "directoryManager": "Gestion des annuaires",
     "privilegesUpdated": "Privilèges mis à jour.",
-    "privilegesUpdatedError": "Échec lors de la sauvegarde des privilèges.",
+    "privilegesUpdatedError": "Échec lors de la sauvegarde des privilèges."
 }


### PR DESCRIPTION
Having that trailing comma leads to JSON parsing errors in firebug, and the inability to switch languages.