### PR TITLE
Fixed typo in group services documentation for 2.10.x

### DIFF
--- a/docs/eng/developer/source/xml_services/group_xml_services.rst
+++ b/docs/eng/developer/source/xml_services/group_xml_services.rst
@@ -3,7 +3,7 @@
 Group services
 ==============
 
-Group List (xml.info&type=groups)
+Group List (xml.info?type=groups)
 ---------------------------------
 
 The **xml.info** service can be used to retrieve the user groups available in GeoNetwork. See :ref:`xml.info`.


### PR DESCRIPTION
URL for xml.info was incorrect