### PR TITLE
fixing NPE when CSW searching

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/statistic/LuceneQueryParamType.java
+++ b/domain/src/main/java/org/fao/geonet/domain/statistic/LuceneQueryParamType.java
@@ -123,11 +123,15 @@ public enum LuceneQueryParamType {
         protected Optional<SearchRequestParam> createTypeFrom(Query query) {
             if (query instanceof TermRangeQuery) {
                 TermRangeQuery rangeQuery = (TermRangeQuery) query;
-                SearchRequestParam param = new SearchRequestParam()
-                        .setLowerText(rangeQuery.getLowerTerm().utf8ToString())
-                        .setUpperText(rangeQuery.getUpperTerm().utf8ToString())
-                        .setTermField(rangeQuery.getField())
-                        .setQueryType(this);
+                SearchRequestParam param = new SearchRequestParam();
+                if (rangeQuery.getLowerTerm() != null) {
+                    param.setLowerText(rangeQuery.getLowerTerm().utf8ToString());
+                }
+                if (rangeQuery.getUpperTerm().utf8ToString() != null) {
+                    param.setUpperText(rangeQuery.getUpperTerm().utf8ToString());
+                }
+                param.setTermField(rangeQuery.getField());
+                param.setQueryType(this);
 
                 return Optional.of(param);
             } else {


### PR DESCRIPTION
In a case, it is possible to have no upper boundary,e.g. the following
filter:

```xml
<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml">
  <ogc:PropertyIsGreaterThanOrEqualTo matchCase="false">
      <ogc:PropertyName>csw:Modified</ogc:PropertyName>
      <ogc:Literal>2014-09-04</ogc:Literal>
  </ogc:PropertyIsGreaterThanOrEqualTo>
</ogc:Filter>
```

can lead to a NPE when creating the Lucene filter:

```
java.lang.NullPointerException
  at org.fao.geonet.domain.statistic.LuceneQueryParamType$7.createTypeFrom(LuceneQueryParamType.java:126)
  at org.fao.geonet.domain.statistic.LuceneQueryParamType.createRequestParam(LuceneQueryParamType.java:162)
  at org.fao.geonet.kernel.search.log.SearcherLogger.extractQueryTerms(SearcherLogger.java:144)
  at org.fao.geonet.kernel.search.log.SearcherLogger.extractQueryTerms(SearcherLogger.java:141)
  at org.fao.geonet.kernel.search.log.SearcherLogger.extractQueryTerms(SearcherLogger.java:141)
  at org.fao.geonet.kernel.search.log.SearcherLogger.logSearch(SearcherLogger.java:83)
  at org.fao.geonet.kernel.search.SearchLoggerTask.run(SearchLoggerTask.java:48)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
  at java.lang.Thread.run(Thread.java:745)
```

This fix proposes to avoid raising the Exception, by checking the input
of the param.

Tests: runtime tested, got an unrelated error on the following test,
when running the test suite:

```
  InspireAtomFeedRepositoryTest.testCleanAtomDocumentsByMetadataId:79 »
  DataIntegrityViolation
```