### PR TITLE
Formatter cache

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -624,8 +624,8 @@ public final class Geonet {
         public static final String XLINK = "_xlink";
         public static final String ROOT = "_root";
         public static final String SCHEMA = "_schema";
-        public static final String CREATE_DATE = "_createDate";
-        public static final String CHANGE_DATE = "_changeDate";
+        public static final String DATABASE_CREATE_DATE = "_createDate";
+        public static final String DATABASE_CHANGE_DATE = "_changeDate";
         public static final String SOURCE = "_source";
         public static final String IS_TEMPLATE = "_isTemplate";
         public static final String UUID = "_uuid";

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -1456,15 +1456,10 @@ public class DataManager implements ApplicationEventPublisherAware {
         // READONLYMODE
         if (!srvContext.getBean(NodeInfo.class).isReadOnly()) {
             // Update the popularity in database
-            Integer iId = Integer.valueOf(id);
-            _metadataRepository.update(iId, new Updater<Metadata>() {
-                @Override
-                public void apply(@Nonnull Metadata entity) {
-                    final MetadataDataInfo dataInfo = entity.getDataInfo();
-                    int popularity = dataInfo.getPopularity();
-                    dataInfo.setPopularity(popularity + 1);
-                }
-            });
+            int iId = Integer.parseInt(id);
+            _metadataRepository.incrementPopularity(iId);
+            _entityManager.flush();
+            _entityManager.clear();
 
             // And register the metadata to be indexed in the near future
             final IndexingList list = srvContext.getBean(IndexingList.class);

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -552,8 +552,8 @@ public class DataManager {
 
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.ROOT,        root,        true, true));
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.SCHEMA,      schema,      true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.CREATE_DATE,  createDate,  true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.CHANGE_DATE,  changeDate,  true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DATABASE_CREATE_DATE,  createDate,  true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DATABASE_CHANGE_DATE,  changeDate,  true, true));
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.SOURCE,      source,      true, true));
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.IS_TEMPLATE,  metadataType.codeString,  true, true));
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.UUID,        uuid,        true, true));

--- a/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierManager.java
+++ b/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierManager.java
@@ -38,13 +38,13 @@ import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 
 /**
@@ -142,7 +142,7 @@ public class MetadataNotifierManager {
                 return _metadataNotifierRepository.findAllByEnabled(true);
             } catch (Exception ex) {
                 Log.error("MetadataNotifierManager", "loadNotifiers: " + ex.getMessage(), ex);
-                throw new MetadataNotifierException(ex.getMessage());
+                throw new MetadataNotifierException(ex.getMessage(), ex);
             }
     }
 
@@ -150,6 +150,10 @@ public class MetadataNotifierManager {
     static final class MetadataNotifierException extends Exception {
         public MetadataNotifierException(String newMessage) {
             super(newMessage);
+        }
+
+        public MetadataNotifierException(String message, Exception ex) {
+            super(message, ex);
         }
     }
 

--- a/domain/src/main/java/org/fao/geonet/domain/Metadata.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Metadata.java
@@ -45,11 +45,12 @@ import javax.persistence.Transient;
  * @author Jesse
  */
 @Entity
-@Table(name = "Metadata")
+@Table(name = Metadata.TABLENAME)
 @Access(AccessType.PROPERTY)
 @EntityListeners(MetadataEntityListenerManager.class)
 @SequenceGenerator(name=Metadata.ID_SEQ_NAME, initialValue=100, allocationSize=1)
 public class Metadata extends GeonetEntity {
+    public static final String TABLENAME = "Metadata";
     static final String ID_SEQ_NAME = "metadata_id_seq";
 
     public static final String METADATA_CATEG_JOIN_TABLE_NAME = "MetadataCateg";

--- a/domain/src/main/java/org/fao/geonet/repository/MetadataRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataRepository.java
@@ -2,10 +2,12 @@ package org.fao.geonet.repository;
 
 import org.fao.geonet.domain.Metadata;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * Data Access object for the {@link Metadata} entities.
@@ -31,4 +33,11 @@ public interface MetadataRepository extends GeonetRepository<Metadata, Integer>,
      */
     @Nonnull
     List<Metadata> findAllByHarvestInfo_Uuid(@Nonnull String uuid);
-}
+
+    /**
+     * Increment popularity of metadata by 1.
+     * @param mdId the id of the metadata
+     */
+    @Modifying
+    @Query("UPDATE "+Metadata.TABLENAME+" m SET m.dataInfo.popularity = m.dataInfo.popularity + 1 WHERE m.id = ?1")
+    void incrementPopularity(int mdId);}

--- a/domain/src/main/java/org/fao/geonet/repository/MetadataRepositoryCustom.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataRepositoryCustom.java
@@ -90,4 +90,5 @@ public interface MetadataRepositoryCustom {
      * @return a map of metadataId -> SourceInfo
      */
     Map<Integer, MetadataSourceInfo> findAllSourceInfo(Specification<Metadata> spec);
+
 }

--- a/domain/src/test/java/org/fao/geonet/repository/MetadataRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/MetadataRepositoryTest.java
@@ -44,6 +44,19 @@ public class MetadataRepositoryTest extends AbstractSpringDataTest {
     AtomicInteger _inc = new AtomicInteger();
 
     @Test
+    public void testIncrementPopularity() throws Exception {
+        final Metadata template = newMetadata();
+        template.getDataInfo().setPopularity(32);
+        Metadata metadata = _repo.save(template);
+
+        _repo.incrementPopularity(metadata.getId());
+        _entityManager.flush();
+        _entityManager.clear();
+
+        assertEquals(33, _repo.findOne(metadata.getId()).getDataInfo().getPopularity());
+    }
+
+    @Test
     public void testFindByUUID() throws Exception {
         Metadata metadata = _repo.save(newMetadata());
 

--- a/events/src/main/java/org/fao/geonet/events/hooks/md/MetadataModified.java
+++ b/events/src/main/java/org/fao/geonet/events/hooks/md/MetadataModified.java
@@ -38,8 +38,6 @@ public class MetadataModified implements GeonetworkEntityListener<Metadata>,
     /**
      * @see org.fao.geonet.entitylistener.GeonetworkEntityListener#handleEvent(org.fao.geonet.entitylistener.PersistentEventType,
      *      java.lang.Object)
-     * @param arg0
-     * @param arg1
      */
     @Override
     public void handleEvent(PersistentEventType type, Metadata entity) {

--- a/events/src/main/java/org/fao/geonet/events/md/MetadataIndexCompleted.java
+++ b/events/src/main/java/org/fao/geonet/events/md/MetadataIndexCompleted.java
@@ -1,0 +1,24 @@
+/**
+ *
+ */
+package org.fao.geonet.events.md;
+
+import org.fao.geonet.domain.Metadata;
+
+/**
+ * Event launched when the indexation of a metadata record is finished
+ *
+ * @author delawen
+ */
+public class MetadataIndexCompleted extends MetadataEvent {
+
+    private static final long serialVersionUID = 6646733956246220509L;
+
+    /**
+     * @param metadata
+     */
+    public MetadataIndexCompleted(Metadata metadata) {
+        super(metadata);
+    }
+
+}

--- a/schemas-test/src/test/java/cswrecord/FullViewFormatterTest.java
+++ b/schemas-test/src/test/java/cswrecord/FullViewFormatterTest.java
@@ -9,6 +9,7 @@ import org.jdom.Text;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ public class FullViewFormatterTest extends AbstractFormatterTest {
 //        measureFormatterPerformance(request, formatterId);
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, request, response);
+        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, new ServletWebRequest(request, response));
         final String view = response.getContentAsString();
 //        Files.write(view, new File("e:/tmp/view.html"), Constants.CHARSET);
 

--- a/schemas-test/src/test/java/cswrecord/XmlViewFormatterTest.java
+++ b/schemas-test/src/test/java/cswrecord/XmlViewFormatterTest.java
@@ -9,6 +9,7 @@ import org.jdom.Text;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.util.List;
@@ -29,7 +30,7 @@ public class XmlViewFormatterTest extends AbstractFormatterTest {
 //        measureFormatterPerformance(request, formatterId);
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, request, response);
+        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, new ServletWebRequest(request, response));
         String view = response.getContentAsString();
 //        Files.write(view, new File("e:/tmp/view.html"), Constants.CHARSET);
         view = view.replaceAll("\\s+", " ");

--- a/schemas-test/src/test/java/dublincore/FullViewFormatterTest.java
+++ b/schemas-test/src/test/java/dublincore/FullViewFormatterTest.java
@@ -9,6 +9,7 @@ import org.jdom.Text;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.util.List;
@@ -29,7 +30,7 @@ public class FullViewFormatterTest extends AbstractFormatterTest {
 //        measureFormatterPerformance(request, formatterId);
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, request, response);
+        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, new ServletWebRequest(request, response));
         final String view = response.getContentAsString();
 //        Files.write(view, new File("e:/tmp/view.html"), Constants.CHARSET);
 

--- a/schemas-test/src/test/java/dublincore/XmlViewFormatterTest.java
+++ b/schemas-test/src/test/java/dublincore/XmlViewFormatterTest.java
@@ -9,6 +9,7 @@ import org.jdom.Text;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.util.List;
@@ -29,7 +30,7 @@ public class XmlViewFormatterTest extends AbstractFormatterTest {
 //        measureFormatterPerformance(request, formatterId);
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, request, response);
+        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, new ServletWebRequest(request, response));
         String view = response.getContentAsString();
 //        Files.write(view, new File("e:/tmp/view.html"), Constants.CHARSET);
         view = view.replaceAll("\\s+", " ");

--- a/schemas-test/src/test/java/iso19139/AbstractFullViewFormatterTest.java
+++ b/schemas-test/src/test/java/iso19139/AbstractFullViewFormatterTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.util.List;
@@ -132,7 +133,8 @@ public abstract class AbstractFullViewFormatterTest extends AbstractFormatterTes
             functions = new Functions(fparams, env);
 
 //            formatService.exec("eng", FormatType.html.name(), "" + id, null, formatterId, "true", false, request, response);
-            formatService.exec(getRequestLanguage(), formatType.name(), "" + id, null, formatterId, "true", false, request, response);
+            formatService.exec(getRequestLanguage(), formatType.name(), "" + id, null, formatterId, "true", false,
+                    new ServletWebRequest(request, response));
             view = response.getContentAsString();
 //            Files.write(view, new File("e:/tmp/view.html"), Constants.CHARSET);
 

--- a/schemas-test/src/test/java/iso19139/XmlViewFormatterTest.java
+++ b/schemas-test/src/test/java/iso19139/XmlViewFormatterTest.java
@@ -9,6 +9,7 @@ import org.jdom.Text;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.util.List;
@@ -29,7 +30,7 @@ public class XmlViewFormatterTest extends AbstractFormatterTest {
 //        measureFormatterPerformance(request, formatterId);
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, request, response);
+        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, new ServletWebRequest(request, response));
         String view = response.getContentAsString();
 //        Files.write(view, new File("e:/tmp/view.html"), Constants.CHARSET);
         view = view.replaceAll("\\s+", " ");

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/AbstractFormatService.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/AbstractFormatService.java
@@ -3,8 +3,10 @@ package org.fao.geonet.services.metadata.format;
 import jeeves.server.ServiceConfig;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.repository.MetadataRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -21,6 +23,8 @@ import static org.fao.geonet.services.metadata.format.FormatterConstants.VIEW_XS
  * @author jeichar
  */
 abstract class AbstractFormatService {
+    @Autowired
+    protected DataManager dataManager;
 
     protected static final DirectoryStream.Filter<Path> FORMATTER_FILTER = new DirectoryStream.Filter<Path>() {
         @Override
@@ -36,11 +40,8 @@ abstract class AbstractFormatService {
     public void init(Path appPath, ServiceConfig params) throws Exception {
     }
 
-    protected Metadata loadMetadata(MetadataRepository metadataRepository, String id) {
-        Metadata md = null;
-        if (id != null) {
-            md = metadataRepository.findOne(Integer.parseInt(id));
-        }
+    protected Metadata loadMetadata(MetadataRepository metadataRepository, int id) {
+        Metadata md = metadataRepository.findOne(id);
 
         if (md == null) {
             throw new IllegalArgumentException("No metadata found. id = " + id);
@@ -111,5 +112,20 @@ abstract class AbstractFormatService {
             }
         }
         return formatDir;
+    }
+
+    protected String resolveId(String id, String uuid) throws Exception {
+        String resolvedId;
+        if (id == null) {
+            resolvedId = dataManager.getMetadataId(uuid);
+        } else {
+            try {
+                Integer.parseInt(id);
+                resolvedId = id;
+            } catch (NumberFormatException e) {
+                resolvedId = dataManager.getMetadataId(id);
+            }
+        }
+        return resolvedId;
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/AbstractFormatService.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/AbstractFormatService.java
@@ -36,26 +36,14 @@ abstract class AbstractFormatService {
     public void init(Path appPath, ServiceConfig params) throws Exception {
     }
 
-    protected Metadata loadMetadata(MetadataRepository metadataRepository, String id, String uuid) {
+    protected Metadata loadMetadata(MetadataRepository metadataRepository, String id) {
         Metadata md = null;
         if (id != null) {
-            try {
-                md = metadataRepository.findOne(Integer.parseInt(id));
-            } catch (NumberFormatException e) {
-                md = metadataRepository.findOneByUuid(id);
-                if (md != null) {
-                    uuid = id;
-                }
-            }
-        }
-
-        if (md == null && uuid != null) {
-            md = metadataRepository.findOneByUuid(uuid);
+            md = metadataRepository.findOne(Integer.parseInt(id));
         }
 
         if (md == null) {
-            throw new IllegalArgumentException("No metadata found. id = " + id + ", uuid = " + uuid + ".  One of them must find a " +
-                                               "metadata");
+            throw new IllegalArgumentException("No metadata found. id = " + id);
         }
         return md;
     }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/Format.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/Format.java
@@ -365,7 +365,7 @@ public class Format extends AbstractFormatService implements ApplicationListener
         FormatterParams fparams = new FormatterParams();
         fparams.config = config;
         fparams.format = this;
-        fparams.servletRequest= request;
+        fparams.webRequest = request;
         fparams.context = context;
         fparams.formatDir = formatDir.toRealPath();
         fparams.metadata = metadata;

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/FormatterParams.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/FormatterParams.java
@@ -13,7 +13,7 @@ import java.nio.file.Path;
  */
 public class FormatterParams {
     public Format format;
-    public WebRequest servletRequest;
+    public WebRequest webRequest;
     public ServiceContext context;
     public Path formatDir;
     public Path viewFile;
@@ -27,7 +27,7 @@ public class FormatterParams {
     public boolean formatterInSchemaPlugin;
 
     public String param(String paramName, String defaultVal) {
-        String[] values = servletRequest.getParameterMap().get(paramName);
+        String[] values = webRequest.getParameterMap().get(paramName);
         if (values == null) {
             return defaultVal;
         }
@@ -56,7 +56,7 @@ public class FormatterParams {
     public FormatterParams copy() {
         FormatterParams formatterParams = new FormatterParams();
         formatterParams.config = this.config;
-        formatterParams.servletRequest = this.servletRequest;
+        formatterParams.webRequest = this.webRequest;
         formatterParams.context = this.context;
         formatterParams.format = this.format;
         formatterParams.schema = this.schema;

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/FormatterParams.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/FormatterParams.java
@@ -4,16 +4,16 @@ import jeeves.server.context.ServiceContext;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.Metadata;
 import org.jdom.Element;
+import org.springframework.web.context.request.WebRequest;
 
 import java.nio.file.Path;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Jesse on 10/15/2014.
  */
 public class FormatterParams {
     public Format format;
-    public HttpServletRequest servletRequest;
+    public WebRequest servletRequest;
     public ServiceContext context;
     public Path formatDir;
     public Path viewFile;

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/ListFormatters.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/ListFormatters.java
@@ -169,7 +169,7 @@ public class ListFormatters extends AbstractFormatService {
     ) throws Exception {
         if (id != null || uuid != null) {
             try {
-                loadMetadata(this.repository, id, uuid);
+                loadMetadata(this.repository, id);
             } catch (Throwable e) {
                 // its ok.  just can't use metadata
             }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/ListFormatters.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/ListFormatters.java
@@ -169,7 +169,7 @@ public class ListFormatters extends AbstractFormatService {
     ) throws Exception {
         if (id != null || uuid != null) {
             try {
-                loadMetadata(this.repository, id);
+                loadMetadata(this.repository, Integer.parseInt(resolveId(id, uuid)));
             } catch (Throwable e) {
                 // its ok.  just can't use metadata
             }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/XsltFormatter.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/XsltFormatter.java
@@ -96,10 +96,10 @@ public class XsltFormatter implements FormatterImpl {
         // an xsl:param should be defined
         // eg. <xsl:param name="view"/>
         Map<String, Object> requestParameters = new HashMap<String, Object>();
-        Iterator<String> iterator = fparams.servletRequest.getParameterMap().keySet().iterator();
+        Iterator<String> iterator = fparams.webRequest.getParameterMap().keySet().iterator();
         while (iterator.hasNext()) {
             String key = iterator.next();
-            requestParameters.put(key, fparams.servletRequest.getParameterMap().get(key));
+            requestParameters.put(key, fparams.webRequest.getParameterMap().get(key));
         }
         Element transformed = Xml.transform(root, fparams.viewFile, requestParameters);
 

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/AbstractCacheConfig.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/AbstractCacheConfig.java
@@ -14,7 +14,8 @@ public abstract class AbstractCacheConfig implements CacheConfig {
 
     @Override
     public final boolean allowCaching(Key key) {
-        return !systemInfo.isDevMode() && extraChecks(key);
+        final boolean isTesting = systemInfo == null;
+        return (isTesting || !systemInfo.isDevMode()) && extraChecks(key);
     }
 
     /**

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/AbstractCacheConfig.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/AbstractCacheConfig.java
@@ -1,0 +1,24 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import org.fao.geonet.SystemInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Has the standard functionality for caching control.
+ *
+ * @author Jesse on 3/7/2015.
+ */
+public abstract class AbstractCacheConfig implements CacheConfig {
+    @Autowired
+    private SystemInfo systemInfo;
+
+    @Override
+    public final boolean allowCaching(Key key) {
+        return !systemInfo.isDevMode() && extraChecks(key);
+    }
+
+    /**
+     * Perform extra checks to allow caching.  Return false to disallow caching
+     */
+    protected abstract boolean extraChecks(Key key);
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/CacheConfig.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/CacheConfig.java
@@ -1,0 +1,12 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+/**
+ * Controls which requests should be cached by the {@link org.fao.geonet.services.metadata.format.cache.FormatterCache}.
+ *
+ * For example which formatters to cache, what types (only html and xml).
+ *
+ * @author Jesse on 3/6/2015.
+ */
+public interface CacheConfig {
+    boolean allowCaching(Key key);
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidator.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidator.java
@@ -1,0 +1,24 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+/**
+ * Checks if the cache is up-to-date based on the changeDate.
+ *
+ * @author Jesse on 3/5/2015.
+ */
+public class ChangeDateValidator implements Validator {
+    private final long changeDate;
+
+    /**
+     * The latest change date of the metadata.
+     *
+     * @param changeDate The latest change date of the metadata.
+     */
+    public ChangeDateValidator(long changeDate) {
+        this.changeDate = changeDate;
+    }
+
+    @Override
+    public boolean isCacheVersionValid(StoreInfo info) {
+        return Math.abs(changeDate - info.changeDate) < 10;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidator.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidator.java
@@ -19,6 +19,6 @@ public class ChangeDateValidator implements Validator {
 
     @Override
     public boolean isCacheVersionValid(StoreInfo info) {
-        return Math.abs(changeDate - info.changeDate) < 10;
+        return Math.abs(changeDate - info.getChangeDate()) < 10;
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidator.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidator.java
@@ -19,6 +19,6 @@ public class ChangeDateValidator implements Validator {
 
     @Override
     public boolean isCacheVersionValid(StoreInfo info) {
-        return Math.abs(changeDate - info.getChangeDate()) < 10;
+        return Math.abs(changeDate - info.getChangeDate()) < 500;
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ConfigurableCacheConfig.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ConfigurableCacheConfig.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 /**
  * @author Jesse on 3/6/2015.
  */
-public class ConfigurableCacheConfig implements CacheConfig {
+public class ConfigurableCacheConfig extends AbstractCacheConfig {
     private Set<FormatType> allowedTypes = Sets.newHashSet(FormatType.values());
     private Set<String> allowedLanguages = null;
     private Set<String> formatterIds = null;
@@ -27,7 +27,7 @@ public class ConfigurableCacheConfig implements CacheConfig {
     }
 
     @Override
-    public boolean allowCaching(Key key) {
+    public boolean extraChecks(Key key) {
         if (typeExceptions != null && typeExceptions.contains(key.formatType)) {
             return false;
         }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ConfigurableCacheConfig.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ConfigurableCacheConfig.java
@@ -1,0 +1,91 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import com.google.common.collect.Sets;
+import org.fao.geonet.services.metadata.format.FormatType;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * @author Jesse on 3/6/2015.
+ */
+public class ConfigurableCacheConfig implements CacheConfig {
+    private Set<FormatType> allowedTypes = Sets.newHashSet(FormatType.values());
+    private Set<String> allowedLanguages = null;
+    private Set<String> formatterIds = null;
+    private boolean cacheFullMetadata = true;
+    private boolean cacheHideWithheld = true;
+
+    public ConfigurableCacheConfig() {
+        allowedTypes.remove(FormatType.pdf);
+        allowedTypes.remove(FormatType.testpdf);
+    }
+
+    @Override
+    public boolean allowCaching(Key key) {
+        if (!allowedTypes.contains(key.formatType)) {
+            return false;
+        }
+        if (allowedLanguages != null && !allowedLanguages.contains(key.lang)) {
+            return false;
+        }
+        if (formatterIds != null && !formatterIds.contains(key.formatterId)) {
+            return false;
+        }
+        if (formatterIds != null && !formatterIds.contains(key.formatterId)) {
+            return false;
+        }
+
+        if (key.hideWithheld && !cacheHideWithheld) {
+            return false;
+        }
+        if (!key.hideWithheld && !cacheFullMetadata) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Configure the {@link org.fao.geonet.services.metadata.format.FormatType}s to cache.
+     * By default all types except pdf will be cached.
+     *
+     * @param allowedTypes set of {@link org.fao.geonet.services.metadata.format.FormatType}s
+     */
+    public void setAllowedTypes(@Nonnull Set<FormatType> allowedTypes) {
+        this.allowedTypes = allowedTypes;
+    }
+
+    /**
+     * The languages to cache.  If null then all languages will be cached.
+     *
+     * By default all languages will be cached.
+     */
+    public void setAllowedLanguages(@Nullable Set<String> allowedLanguages) {
+        this.allowedLanguages = allowedLanguages;
+    }
+
+    /**
+     * The formatters to cache.  If null then all formatters will be cached.
+     *
+     * By default all formatters will be cached.
+     */
+    public void setFormatterIds(@Nullable Set<String> formatterIds) {
+        this.formatterIds = formatterIds;
+    }
+
+    /**
+     * If false then the full metadata will not be cached (when an editor obtains the metadata).
+     */
+    public void setCacheFullMetadata(boolean cacheFullMetadata) {
+        this.cacheFullMetadata = cacheFullMetadata;
+    }
+
+    /**
+     * If false then the metadata with hidden elements will not be cached.
+     */
+    public void setCacheHideWithheld(boolean cacheHideWithheld) {
+        this.cacheHideWithheld = cacheHideWithheld;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ConfigurableCacheConfig.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/ConfigurableCacheConfig.java
@@ -3,6 +3,7 @@ package org.fao.geonet.services.metadata.format.cache;
 import com.google.common.collect.Sets;
 import org.fao.geonet.services.metadata.format.FormatType;
 
+import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,6 +17,9 @@ public class ConfigurableCacheConfig implements CacheConfig {
     private Set<String> formatterIds = null;
     private boolean cacheFullMetadata = true;
     private boolean cacheHideWithheld = true;
+    private HashSet<FormatType> typeExceptions;
+    private HashSet<String> formatterExceptions;
+    private HashSet<String> langExceptions;
 
     public ConfigurableCacheConfig() {
         allowedTypes.remove(FormatType.pdf);
@@ -24,6 +28,15 @@ public class ConfigurableCacheConfig implements CacheConfig {
 
     @Override
     public boolean allowCaching(Key key) {
+        if (typeExceptions != null && typeExceptions.contains(key.formatType)) {
+            return false;
+        }
+        if (formatterExceptions != null && formatterExceptions.contains(key.formatterId)) {
+            return false;
+        }
+        if (langExceptions != null && langExceptions.contains(key.lang)) {
+            return false;
+        }
         if (!allowedTypes.contains(key.formatType)) {
             return false;
         }
@@ -87,5 +100,17 @@ public class ConfigurableCacheConfig implements CacheConfig {
      */
     public void setCacheHideWithheld(boolean cacheHideWithheld) {
         this.cacheHideWithheld = cacheHideWithheld;
+    }
+
+    public void setTypeExceptions(HashSet<FormatType> typeExceptions) {
+        this.typeExceptions = typeExceptions;
+    }
+
+    public void setFormatterExceptions(HashSet<String> formatterExceptions) {
+        this.formatterExceptions = formatterExceptions;
+    }
+
+    public void setLangExceptions(HashSet<String> langExceptions) {
+        this.langExceptions = langExceptions;
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
@@ -96,6 +96,17 @@ public class FilesystemStore implements PersistentStore {
             }
             initialized = true;
         }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    close();
+                } catch (SQLException | ClassNotFoundException e) {
+                    Log.error(Geonet.FORMATTER, "Error shutting down FilesystemStore Database", e);
+                }
+            }
+        }));
     }
 
     @PreDestroy

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
@@ -1,9 +1,31 @@
 package org.fao.geonet.services.metadata.format.cache;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 /**
  * A {@link org.fao.geonet.services.metadata.format.cache.PersistentStore} that saves the files to disk.
@@ -11,28 +33,236 @@ import javax.annotation.Nullable;
  * @author Jesse on 3/5/2015.
  */
 public class FilesystemStore implements PersistentStore {
+    private static final String BASE_CACHE_DIR = "formatter-cache";
+    private static final String INFO_TABLE = "info";
+    private static final String KEY = "keyhash";
+    private static final String CHANGE_DATE = "changedate";
+    private static final String PUBLISHED = "published";
+    private static final String PATH = "path";
+    private static final String STATS_TABLE = "stats";
+    private static final String NAME = "name";
+    private static final String CURRENT_SIZE = "currentsize";
+    private static final String VALUE = "value";
+
+    private static final String QUERY_GET_INFO = "SELECT * FROM " + INFO_TABLE + " WHERE " + KEY + "=?";
+    private static final String QUERY_GET_INFO_FOR_RESIZE = "SELECT " +KEY + "," + PATH + " FROM " + INFO_TABLE + " ORDER BY " + CHANGE_DATE + " ASC";
+    private static final String QUERY_PUT = "MERGE INTO " + INFO_TABLE + " (" + KEY + "," + CHANGE_DATE + "," + PUBLISHED + "," + PATH + ") VALUES (?,?,?, ?)";
+    private static final String QUERY_REMOVE = "DELETE FROM " + INFO_TABLE + " WHERE " + KEY + "=?";
+    public static final String QUERY_SETCURRENT_SIZE = "MERGE INTO "+STATS_TABLE + " (" + NAME + ", " + VALUE + ") VALUES ('" + CURRENT_SIZE + "', ?)";
+    public static final String QUERY_GETCURRENT_SIZE = "SELECT "+VALUE+" FROM " + STATS_TABLE + " WHERE "+NAME+" = '"+CURRENT_SIZE+"'";
+
     @Autowired
-    private GeonetworkDataDirectory dataDirectory;
+    private GeonetworkDataDirectory geonetworkDataDir;
+    @VisibleForTesting
+    Connection metadataDb;
+    @VisibleForTesting
+    boolean testing = false;
+    private volatile long maxSizeB = 10000;
+    private volatile long currentSize = 0;
 
+    @PostConstruct
+    void init() throws ClassNotFoundException, SQLException {
+        // using a h2 database and not normal geonetwork DB to ensure that the accesses are always on localhost and therefore
+        // hopefully quick.
+        Class.forName("org.h2.Driver");
 
-    @Override
-    public StoreInfoAndData get(Key key) {
-        throw new UnsupportedOperationException("to implement");
+        String[] initSql = {
+                "CREATE SCHEMA IF NOT EXISTS " + INFO_TABLE,
+                "CREATE TABLE IF NOT EXISTS " + INFO_TABLE + "(" + KEY + " INT PRIMARY KEY, " + CHANGE_DATE + " BIGINT NOT NULL, " +
+                PUBLISHED + " BOOL NOT NULL, " + PATH + " VARCHAR(256) NOT NULL)",
+                "CREATE TABLE IF NOT EXISTS " + STATS_TABLE + " (" + NAME + " VARCHAR(32) PRIMARY KEY, " + VALUE + " VARCHAR(32) NOT NULL)"
+        };
+        String init = ";INIT=" + Joiner.on("\\;").join(initSql) + ";DB_CLOSE_DELAY=-1";
+        String dbPath = testing ? "mem:" + UUID.randomUUID() : getBaseCacheDir().resolve("info-store").toString();
+        metadataDb = DriverManager.getConnection("jdbc:h2:" + dbPath + init, "fsStore", "");
+
+        try (
+                Statement statement = metadataDb.createStatement();
+                ResultSet rs = statement.executeQuery(QUERY_GETCURRENT_SIZE)) {
+            if (rs.next()) {
+                this.currentSize = Long.parseLong(rs.getString(1));
+            }
+        }
+    }
+
+    @PreDestroy
+    void close() throws ClassNotFoundException, SQLException {
+        metadataDb.close();
     }
 
     @Override
-    public StoreInfo getInfo(Key key) {
-        throw new UnsupportedOperationException("to implement");
+    public synchronized StoreInfoAndData get(@Nonnull Key key) throws IOException, SQLException {
+        StoreInfo info = getInfo(key);
+        if (info == null) {
+            return null;
+        }
+        byte[] data = Files.readAllBytes(getPrivatePath(key));
+        return new StoreInfoAndData(info, data);
     }
 
     @Override
-    public void put(Key key, StoreInfoAndData data) {
-        throw new UnsupportedOperationException("to implement");
+    public synchronized StoreInfo getInfo(@Nonnull Key key) throws SQLException {
+        try (PreparedStatement statement = this.metadataDb.prepareStatement(QUERY_GET_INFO)) {
+            statement.setInt(1, key.hashCode());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    long date = resultSet.getLong(CHANGE_DATE);
+                    boolean isPublished = resultSet.getBoolean(PUBLISHED);
+                    return new StoreInfo(date, isPublished);
+                } else {
+                    return null;
+                }
+            }
+        }
+    }
+
+    @Override
+    public synchronized void put(@Nonnull Key key, @Nonnull StoreInfoAndData data) throws IOException, SQLException {
+        resizeIfRequired(key, data);
+        final Path privatePath = getPrivatePath(key);
+
+        if (Files.exists(privatePath)) {
+            currentSize -= Files.size(privatePath);
+        }
+
+        Files.createDirectories(privatePath.getParent());
+        Files.write(privatePath, data.data);
+        currentSize += data.data.length;
+
+        updateDbCurrentSize();
+
+        Path publicPath = getPublicPath(key);
+        Files.deleteIfExists(publicPath);
+        if (data.isPublished()) {
+            Files.createDirectories(publicPath.getParent());
+            try {
+                Files.createLink(publicPath, privatePath);
+            } catch (UnsupportedOperationException | SecurityException e) {
+                // Link likely not supported on this FS use copy then.
+                Files.copy(privatePath, publicPath);
+            }
+        }
+        try (PreparedStatement statement = this.metadataDb.prepareStatement(QUERY_PUT)) {
+            statement.setInt(1, key.hashCode());
+            statement.setLong(2, data.getChangeDate());
+            statement.setBoolean(3, data.isPublished());
+            statement.setString(4, privatePath.toUri().toString());
+            statement.execute();
+        }
+    }
+
+    private void updateDbCurrentSize() throws SQLException {
+        try (PreparedStatement statement = this.metadataDb.prepareStatement(QUERY_SETCURRENT_SIZE)) {
+            statement.setString(1, String.valueOf(currentSize));
+            statement.execute();
+        }
+    }
+
+    private void resizeIfRequired(Key key, StoreInfoAndData data) throws IOException, SQLException {
+        if (this.currentSize + data.data.length > this.maxSizeB) {
+            final Path privatePath = getPrivatePath(key);
+            if (Files.exists(privatePath)) {
+                long fileSize = Files.size(privatePath);
+                if (currentSize - fileSize + data.data.length > this.maxSizeB) {
+                    resize();
+                }
+            } else {
+                resize();
+            }
+        }
+    }
+
+    private void resize() throws SQLException, IOException {
+        int targetSize = (int) (maxSizeB / 2);
+        Log.warning(Geonet.FORMATTER, "Resizing Formatter cache.  Required to reduce size by " + targetSize);
+        long startTime = System.currentTimeMillis();
+        try (
+                Statement statement = metadataDb.createStatement();
+                ResultSet resultSet = statement.executeQuery(QUERY_GET_INFO_FOR_RESIZE);
+        ) {
+            while (currentSize > targetSize && resultSet.next()) {
+                Path path = IO.toPath(new URI(resultSet.getString(PATH)));
+                doRemove(path, resultSet.getInt(KEY), false);
+            }
+        } catch (URISyntaxException e) {
+            throw new Error(e);
+        }
+        Log.warning(Geonet.FORMATTER, "Resize took " + (System.currentTimeMillis() - startTime) + "ms to complete");
     }
 
     @Nullable
     @Override
-    public String getPublic(Key key) {
-        throw new UnsupportedOperationException("to implement");
+    public byte[] getPublic(@Nonnull Key key) throws IOException {
+        final Path publicPath = getPublicPath(key);
+        if (Files.exists(publicPath)) {
+            return Files.readAllBytes(publicPath);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public synchronized void remove(@Nonnull Key key) throws IOException, SQLException {
+        final Path path = getPrivatePath(key);
+        final int keyHashCode = key.hashCode();
+        doRemove(path, keyHashCode, true);
+    }
+
+    private void doRemove(Path path, int keyHashCode, boolean updateDbCurrentSize) throws IOException, SQLException {
+        try {
+            if (Files.exists(path)) {
+                currentSize -= Files.size(path);
+                Files.delete(path);
+            }
+        } finally {
+            try {
+                Path relativePrivate = getBaseCacheDir().resolve(Params.Access.PRIVATE).relativize(path);
+                Files.deleteIfExists(getBaseCacheDir().resolve(Params.Access.PUBLIC).resolve(relativePrivate));
+            } finally {
+                try (PreparedStatement statement = metadataDb.prepareStatement(QUERY_REMOVE)) {
+                    statement.setInt(1, keyHashCode);
+                    statement.execute();
+                } finally {
+                    if (updateDbCurrentSize) {
+                        updateDbCurrentSize();
+                    }
+                }
+            }
+        }
+    }
+
+    public void setGeonetworkDataDir(GeonetworkDataDirectory geonetworkDataDir) {
+        this.geonetworkDataDir = geonetworkDataDir;
+    }
+
+    public Path getPrivatePath(Key key) {
+        return getCacheFile(key, false);
+    }
+
+    public Path getPublicPath(Key key) {
+        return getCacheFile(key, true);
+    }
+
+    private Path getCacheFile(Key key, boolean isPublicCache) {
+        final String accessDir = isPublicCache ? Params.Access.PUBLIC : Params.Access.PRIVATE;
+        final String sMdId = String.valueOf(key.mdId);
+        final Path metadataDir = Lib.resource.getMetadataDir(getBaseCacheDir().resolve(accessDir), sMdId);
+        return metadataDir.resolve(key.formatterId).resolve(key.lang).resolve(key.hashCode() + "." + key.formatType.name());
+    }
+
+    private Path getBaseCacheDir() {
+        return geonetworkDataDir.getHtmlCacheDir().resolve(BASE_CACHE_DIR);
+    }
+
+    public void setMaxSizeKb(long maxSize) {
+        this.maxSizeB = maxSize * 1024;
+    }
+
+    public void setMaxSizeMb(int maxSize) {
+        setMaxSizeKb(maxSize * 1024);
+    }
+
+    public void setMaxSizeGb(int maxSize) {
+        setMaxSizeMb(maxSize * 1024);
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
@@ -79,8 +79,8 @@ public class FilesystemStore implements PersistentStore {
             String[] initSql = {
                     "CREATE SCHEMA IF NOT EXISTS " + INFO_TABLE,
                     "CREATE TABLE IF NOT EXISTS " + INFO_TABLE + "(" + KEY + " INT PRIMARY KEY, " + CHANGE_DATE + " BIGINT NOT NULL, " +
-                    PUBLISHED + " BOOL NOT NULL, " + PATH + " VARCHAR(256) NOT NULL)",
-                    "CREATE TABLE IF NOT EXISTS " + STATS_TABLE + " (" + NAME + " VARCHAR(32) PRIMARY KEY, " + VALUE + " VARCHAR(32) NOT NULL)"
+                    PUBLISHED + " BOOL NOT NULL, " + PATH + " CLOB  NOT NULL)",
+                    "CREATE TABLE IF NOT EXISTS " + STATS_TABLE + " (" + NAME + " VARCHAR(64) PRIMARY KEY, " + VALUE + " VARCHAR(32) NOT NULL)"
 
             };
             String init = ";INIT=" + Joiner.on("\\;").join(initSql) + ";DB_CLOSE_DELAY=-1";

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
@@ -1,0 +1,16 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * A {@link org.fao.geonet.services.metadata.format.cache.PersistentStore} that saves the files to disk.
+ *
+ * @author Jesse on 3/5/2015.
+ */
+public class FilesystemStore implements PersistentStore {
+    @Autowired
+    private GeonetworkDataDirectory dataDirectory;
+
+
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FilesystemStore.java
@@ -3,6 +3,8 @@ package org.fao.geonet.services.metadata.format.cache;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.annotation.Nullable;
+
 /**
  * A {@link org.fao.geonet.services.metadata.format.cache.PersistentStore} that saves the files to disk.
  *
@@ -13,4 +15,24 @@ public class FilesystemStore implements PersistentStore {
     private GeonetworkDataDirectory dataDirectory;
 
 
+    @Override
+    public StoreInfoAndData get(Key key) {
+        throw new UnsupportedOperationException("to implement");
+    }
+
+    @Override
+    public StoreInfo getInfo(Key key) {
+        throw new UnsupportedOperationException("to implement");
+    }
+
+    @Override
+    public void put(Key key, StoreInfoAndData data) {
+        throw new UnsupportedOperationException("to implement");
+    }
+
+    @Nullable
+    @Override
+    public String getPublic(Key key) {
+        throw new UnsupportedOperationException("to implement");
+    }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCache.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCache.java
@@ -121,6 +121,10 @@ public class FormatterCache {
     @Nullable
     public byte[] get(Key key, Validator validator, Callable<StoreInfoAndDataLoadResult> loader,
                       boolean writeToStoreInCurrentThread) throws Exception {
+        if (!cacheConfig.allowCaching(key)) {
+            return loader.call().data;
+        }
+
         StoreInfoAndData cached = memoryCache.getIfPresent(key);
         boolean invalid = false;
         if (cached != null && !validator.isCacheVersionValid(cached)) {
@@ -135,10 +139,7 @@ public class FormatterCache {
         if (cached == null) {
             StoreInfoAndDataLoadResult loaded = loader.call();
             cached = loaded;
-            if (cacheConfig.allowCaching(key)) {
-                push(key, loaded, writeToStoreInCurrentThread);
-            }
-
+            push(key, loaded, writeToStoreInCurrentThread);
         }
 
         return cached.data;

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCache.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCache.java
@@ -8,6 +8,7 @@ import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import org.fao.geonet.domain.Pair;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
 import java.io.IOException;
@@ -46,13 +47,15 @@ import javax.annotation.PreDestroy;
  * @author Jesse on 3/5/2015.
  */
 public class FormatterCache {
+    @Autowired
+    private CacheConfig cacheConfig;
+
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final PersistentStore persistentStore;
     private final Cache<Key, StoreInfoAndData> memoryCache;
     private final Multimap<Integer, Pair<Key, StoreInfoAndData>> mdIdIndex = ArrayListMultimap.create();
     private final ExecutorService executor;
     private final BlockingQueue<Pair<Key, StoreInfoAndData>> storeRequests;
-    private final CacheConfig cacheConfig;
 
     public FormatterCache(PersistentStore persistentStore, int memoryCacheSize, int maxStoreRequests) {
         this(persistentStore, memoryCacheSize, maxStoreRequests, new ConfigurableCacheConfig());

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCache.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCache.java
@@ -1,0 +1,81 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.Nullable;
+
+/**
+ * Caches Formatter html files in memory (keeping the most recent and most accessed X formatters) and on disk.
+ * <p/>
+ * The Formatter cache has two caches.
+ * <ul>
+ * <li>
+ *      A fast access in-memory cache which is limitted to some X records.  The records kept are based on the last access/write of the
+ *      record and how often that record is accessed in the last X seconds.
+ * </li>
+ * <li>
+ *     A persistent cache which keeps a cache of every formatter that has been added to the cache.
+ * </li>
+ * </ul>
+ * <p/>
+ * When a value is added to the cache the value is added to the in-memory cache and to a queue for writing to the disk.
+ * A separate thread is responsible for reading from the queue and writing all the values to the persistent cache.  This allows the
+ * value to be written to the request in parallel with writing to the cache.
+ * <p/>
+ * Note: The Persistent cache used can be configured.
+ *
+ * @author Jesse on 3/5/2015.
+ */
+public class FormatterCache {
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final PersistentStore persistentStore;
+
+    public FormatterCache(PersistentStore persistentStore) {
+        this.persistentStore = persistentStore;
+    }
+
+    /**
+     * Get a value from the cache, or if it is not in the cache, load it with the loader and add it to the cache.
+     *
+     * @param key the lookup/store key
+     * @param validator a strategy for checking if the value should be reloaded (for example if the metadata has changed since last
+     *                  caching of the value)
+     * @param loader the strategy to use for loading the value if the value is not in the cache (or is out-of-date).
+     * @param writeToStoreInCurrentThread if true then the {@link org.fao.geonet.services.metadata.format.cache.PersistentStore} will
+     *                                    be updated in the current thread instead of in another thread.
+     */
+    @Nullable
+    public String get(Key key, Validator validator, Callable<StoreInfo> loader, boolean writeToStoreInCurrentThread) {
+        final Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+            throw new UnsupportedOperationException("todo");
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Get a pre-cached public value.  This will very quickly get a public metadata if it has been pre-cached.  It is intended to
+     * be a VERY fast lookup for search engine crawlers (for example).  If the metadata has not previously been cached it returns null.
+     *<p/>
+     * When a metadata is cached it is noted if it is public or not, if it the requested metadata public and cached then this method
+     * will return it.  If it is not public or not cached it will not be returned.
+     * <p/>
+     * @param key the lookup key
+     */
+    @Nullable
+    public String getPublic(Key key) {
+        final Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+            throw new UnsupportedOperationException("todo");
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheDeletionListener.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheDeletionListener.java
@@ -1,0 +1,33 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import org.fao.geonet.events.md.MetadataRemove;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+/**
+ * This class is responsible for listening for metadata index events and updating the cache's publication values so that it stays in
+ * sync with the actual metadata.
+ *
+ * @author Jesse on 3/6/2015.
+ */
+public class FormatterCacheDeletionListener implements ApplicationListener<MetadataRemove> {
+    @Autowired
+    private FormatterCache formatterCache;
+    @Autowired
+    private OperationAllowedRepository operationAllowedRepository;
+
+    @Override
+    public synchronized void onApplicationEvent(MetadataRemove event) {
+        final int metadataId = event.getMd().getId();
+        try {
+            formatterCache.removeAll(metadataId);
+        } catch (SQLException | IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCachePublishListener.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/FormatterCachePublishListener.java
@@ -1,0 +1,41 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.events.md.MetadataIndexCompleted;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.specification.OperationAllowedSpecs;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.io.IOException;
+
+import static org.springframework.data.jpa.domain.Specifications.where;
+
+/**
+ * This class is responsible for listening for metadata index events and updating the cache's publication values so that it stays in
+ * sync with the actual metadata.
+ *
+ * @author Jesse on 3/6/2015.
+ */
+public class FormatterCachePublishListener implements ApplicationListener<MetadataIndexCompleted> {
+    @Autowired
+    private FormatterCache formatterCache;
+    @Autowired
+    private OperationAllowedRepository operationAllowedRepository;
+
+    @Override
+    public synchronized void onApplicationEvent(MetadataIndexCompleted event) {
+        final int metadataId = event.getMd().getId();
+        final Specification<OperationAllowed> isPublished = OperationAllowedSpecs.isPublic(ReservedOperation.view);
+        final Specification<OperationAllowed> hasMdId = OperationAllowedSpecs.hasMetadataId(metadataId);
+        final OperationAllowed one = operationAllowedRepository.findOne(where(hasMdId).and(isPublished));
+        try {
+            formatterCache.setPublished(metadataId, one != null);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Key.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Key.java
@@ -8,11 +8,11 @@ import org.fao.geonet.services.metadata.format.FormatType;
  * @author Jesse on 3/5/2015.
  */
 public class Key {
-    final int mdId;
-    final String lang;
-    final FormatType formatType;
-    final String formatterId;
-    final boolean hideWithheld;
+    public final int mdId;
+    public final String lang;
+    public final FormatType formatType;
+    public final String formatterId;
+    public final boolean hideWithheld;
 
     public Key(int mdId, String lang, FormatType formatType, String formatterId, boolean hideWithheld) {
         this.mdId = mdId;

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Key.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Key.java
@@ -13,7 +13,6 @@ public class Key {
     final FormatType formatType;
     final String formatterId;
     final boolean hideWithheld;
-    private volatile int hash;
 
     public Key(int mdId, String lang, FormatType formatType, String formatterId, boolean hideWithheld) {
         this.mdId = mdId;
@@ -47,5 +46,16 @@ public class Key {
         result = 31 * result + formatterId.hashCode();
         result = 31 * result + (hideWithheld ? 1 : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Key{" +
+               "mdId=" + mdId +
+               ", lang='" + lang + '\'' +
+               ", formatType=" + formatType +
+               ", formatterId='" + formatterId + '\'' +
+               ", hideWithheld=" + hideWithheld +
+               '}';
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Key.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Key.java
@@ -42,7 +42,7 @@ public class Key {
     public int hashCode() {
         int result = mdId;
         result = 31 * result + lang.hashCode();
-        result = 31 * result + formatType.hashCode();
+        result = 31 * result + formatType.ordinal();
         result = 31 * result + formatterId.hashCode();
         result = 31 * result + (hideWithheld ? 1 : 0);
         return result;

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Key.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Key.java
@@ -1,0 +1,51 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import org.fao.geonet.services.metadata.format.FormatType;
+
+/**
+ * A key for storing a value in the cache.
+ *
+ * @author Jesse on 3/5/2015.
+ */
+public class Key {
+    final int mdId;
+    final String lang;
+    final FormatType formatType;
+    final String formatterId;
+    final boolean hideWithheld;
+    private volatile int hash;
+
+    public Key(int mdId, String lang, FormatType formatType, String formatterId, boolean hideWithheld) {
+        this.mdId = mdId;
+        this.lang = lang;
+        this.formatType = formatType;
+        this.formatterId = formatterId;
+        this.hideWithheld = hideWithheld;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Key key = (Key) o;
+
+        if (hideWithheld != key.hideWithheld) return false;
+        if (mdId != key.mdId) return false;
+        if (formatType != key.formatType) return false;
+        if (!formatterId.equals(key.formatterId)) return false;
+        if (!lang.equals(key.lang)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mdId;
+        result = 31 * result + lang.hashCode();
+        result = 31 * result + formatType.hashCode();
+        result = 31 * result + formatterId.hashCode();
+        result = 31 * result + (hideWithheld ? 1 : 0);
+        return result;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/NoCacheValidator.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/NoCacheValidator.java
@@ -1,0 +1,13 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+/**
+ * Always forces the formatter to be loaded.
+ *
+ * @author Jesse on 3/6/2015.
+ */
+public class NoCacheValidator implements Validator {
+    @Override
+    public boolean isCacheVersionValid(StoreInfo info) {
+        return false;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStore.java
@@ -40,7 +40,7 @@ public interface PersistentStore {
      * @param key the lookup key.
      */
     @Nullable
-    byte[] getPublic(@Nonnull Key key) throws IOException, SQLException;
+    byte[] getPublished(@Nonnull Key key) throws IOException, SQLException;
 
     /**
      * Remove values with the key from the cache.
@@ -48,4 +48,12 @@ public interface PersistentStore {
      * @param key the lookup key
      */
     void remove(@Nonnull Key key) throws IOException, SQLException;
+
+    /**
+     * Publish or unpublish all cached values related to the given metadata.
+     *
+     * @param metadataId the id of the metadata whose published state may have changed
+     * @param published  mark all cached values for this metadata
+     */
+    void setPublished(int metadataId, boolean published) throws IOException;
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStore.java
@@ -1,5 +1,8 @@
 package org.fao.geonet.services.metadata.format.cache;
 
+import java.io.IOException;
+import java.sql.SQLException;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -15,14 +18,14 @@ public interface PersistentStore {
      * @param key the key to use for retrieval.
      * @return return the value and associated data
      */
-    StoreInfoAndData get(Key key);
+    StoreInfoAndData get(@Nonnull Key key) throws IOException, SQLException;
 
     /**
      * Get the stored value from the store;
      * @param key the key to use for retrieval.
      * @return return the value and associated data
      */
-    StoreInfo getInfo(Key key);
+    StoreInfo getInfo(@Nonnull Key key) throws SQLException;
 
     /**
      * Put data in this store.
@@ -30,12 +33,19 @@ public interface PersistentStore {
      * @param key the cache key
      * @param data the data to cache
      */
-    void put(Key key, StoreInfoAndData data);
+    void put(@Nonnull Key key, @Nonnull StoreInfoAndData data) throws IOException, SQLException;
 
     /**
      * Return the cached value if it has been cached and is public, otherwise null.
      * @param key the lookup key.
      */
     @Nullable
-    String getPublic(Key key);
+    byte[] getPublic(@Nonnull Key key) throws IOException, SQLException;
+
+    /**
+     * Remove values with the key from the cache.
+     *
+     * @param key the lookup key
+     */
+    void remove(@Nonnull Key key) throws IOException, SQLException;
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStore.java
@@ -1,0 +1,11 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+/**
+ * The strategy used by {@link PersistentStore} for storing each record in a persistent
+ * fashion.
+ *
+* @author Jesse on 3/5/2015.
+*/
+public interface PersistentStore {
+
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStore.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStore.java
@@ -1,5 +1,7 @@
 package org.fao.geonet.services.metadata.format.cache;
 
+import javax.annotation.Nullable;
+
 /**
  * The strategy used by {@link PersistentStore} for storing each record in a persistent
  * fashion.
@@ -8,4 +10,32 @@ package org.fao.geonet.services.metadata.format.cache;
 */
 public interface PersistentStore {
 
+    /**
+     * Get the stored value from the store;
+     * @param key the key to use for retrieval.
+     * @return return the value and associated data
+     */
+    StoreInfoAndData get(Key key);
+
+    /**
+     * Get the stored value from the store;
+     * @param key the key to use for retrieval.
+     * @return return the value and associated data
+     */
+    StoreInfo getInfo(Key key);
+
+    /**
+     * Put data in this store.
+     *
+     * @param key the cache key
+     * @param data the data to cache
+     */
+    void put(Key key, StoreInfoAndData data);
+
+    /**
+     * Return the cached value if it has been cached and is public, otherwise null.
+     * @param key the lookup key.
+     */
+    @Nullable
+    String getPublic(Key key);
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStoreRunnable.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/PersistentStoreRunnable.java
@@ -1,0 +1,38 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.fao.geonet.domain.Pair;
+
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Runnable responsible for monitoring the FormatterCache storeRequest queue and pushing the requests to the persistent store.
+ *
+ * @author Jesse on 3/5/2015.
+ */
+public class PersistentStoreRunnable implements Runnable {
+    private final BlockingQueue<Pair<Key, StoreInfoAndData>> storeRequests;
+    private final PersistentStore store;
+
+    public PersistentStoreRunnable(BlockingQueue<Pair<Key, StoreInfoAndData>> storeRequests, PersistentStore store) {
+        this.storeRequests = storeRequests;
+        this.store = store;
+    }
+
+    @Override
+    public final void run() {
+        try {
+            while (true) {
+                final Pair<Key, StoreInfoAndData> request = storeRequests.take();
+                doStore(request);
+            }
+        } catch (InterruptedException e) {
+            return;
+        }
+    }
+
+    @VisibleForTesting
+    void doStore(Pair<Key, StoreInfoAndData> request) throws InterruptedException {
+        store.put(request.one(), request.two());
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfo.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfo.java
@@ -1,0 +1,17 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+/**
+ * Encapsulates the information when a formatter is executed.
+ * @author Jesse on 3/5/2015.
+ */
+public class StoreInfo {
+    public final String result;
+    public final long changeDate;
+    public final boolean published;
+
+    public StoreInfo(String result, long changeDate, boolean published) {
+        this.result = result;
+        this.changeDate = changeDate;
+        this.published = published;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfo.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfo.java
@@ -1,17 +1,24 @@
 package org.fao.geonet.services.metadata.format.cache;
 
 /**
- * Encapsulates the information when a formatter is executed.
+ * The metadata about the stored value.  Does not contain the value, only the data describing it like change data and published.
+ *
  * @author Jesse on 3/5/2015.
  */
 public class StoreInfo {
-    public final String result;
-    public final long changeDate;
-    public final boolean published;
+    private final long changeDate;
+    private final boolean published;
 
-    public StoreInfo(String result, long changeDate, boolean published) {
-        this.result = result;
+    public StoreInfo(long changeDate, boolean published, int popularity, long lastAccess) {
         this.changeDate = changeDate;
         this.published = published;
+    }
+
+    public long getChangeDate() {
+        return changeDate;
+    }
+
+    public boolean isPublished() {
+        return published;
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfo.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfo.java
@@ -9,7 +9,7 @@ public class StoreInfo {
     private final long changeDate;
     private final boolean published;
 
-    public StoreInfo(long changeDate, boolean published, int popularity, long lastAccess) {
+    public StoreInfo(long changeDate, boolean published) {
         this.changeDate = changeDate;
         this.published = published;
     }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfoAndData.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfoAndData.java
@@ -1,0 +1,18 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+/**
+ * Encapsulates the information when a formatter is executed.
+ * @author Jesse on 3/5/2015.
+ */
+public class StoreInfoAndData extends StoreInfo {
+    private final String result;
+
+    public StoreInfoAndData(String result, long changeDate, boolean published, long lastAccess, int popularity) {
+        super(changeDate, published, popularity, lastAccess);
+        this.result = result;
+    }
+
+    public String getResult() {
+        return result;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfoAndData.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfoAndData.java
@@ -1,18 +1,28 @@
 package org.fao.geonet.services.metadata.format.cache;
 
+import org.fao.geonet.Constants;
+
 /**
  * Encapsulates the information when a formatter is executed.
  * @author Jesse on 3/5/2015.
  */
 public class StoreInfoAndData extends StoreInfo {
-    private final String result;
+    public final byte[] data;
 
-    public StoreInfoAndData(String result, long changeDate, boolean published, long lastAccess, int popularity) {
-        super(changeDate, published, popularity, lastAccess);
-        this.result = result;
+    public StoreInfoAndData(String data, long changeDate, boolean published) {
+        this(data.getBytes(Constants.CHARSET), changeDate, published);
+    }
+    public StoreInfoAndData(byte[] data, long changeDate, boolean published) {
+        super(changeDate, published);
+        this.data = data;
     }
 
-    public String getResult() {
-        return result;
+    public StoreInfoAndData(StoreInfo info, byte[] data) {
+        super(info.getChangeDate(), info.isPublished());
+        this.data = data;
+    }
+
+    public String getDataAsString() {
+        return new String(data, Constants.CHARSET);
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfoAndData.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfoAndData.java
@@ -10,7 +10,7 @@ public class StoreInfoAndData extends StoreInfo {
     public final byte[] data;
 
     public StoreInfoAndData(String data, long changeDate, boolean published) {
-        this(data.getBytes(Constants.CHARSET), changeDate, published);
+        this(data == null ? null : data.getBytes(Constants.CHARSET), changeDate, published);
     }
     public StoreInfoAndData(byte[] data, long changeDate, boolean published) {
         super(changeDate, published);
@@ -23,6 +23,6 @@ public class StoreInfoAndData extends StoreInfo {
     }
 
     public String getDataAsString() {
-        return new String(data, Constants.CHARSET);
+        return data == null ? null : new String(data, Constants.CHARSET);
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfoAndDataLoadResult.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/StoreInfoAndDataLoadResult.java
@@ -1,0 +1,35 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import org.fao.geonet.Constants;
+
+import java.util.concurrent.Callable;
+import javax.annotation.Nullable;
+
+/**
+ * Encapsulates the information when a formatter is executed.
+ * @author Jesse on 3/5/2015.
+ */
+public class StoreInfoAndDataLoadResult extends StoreInfoAndData {
+
+    private final Key key;
+    private final Callable<StoreInfoAndDataLoadResult> toCache;
+
+    public StoreInfoAndDataLoadResult(String data, long changeDate, boolean published, @Nullable Key key,
+                                      @Nullable Callable<StoreInfoAndDataLoadResult> toCache) {
+        this(data == null ? null : data.getBytes(Constants.CHARSET), changeDate, published, key, toCache);
+    }
+    public StoreInfoAndDataLoadResult(byte[] data, long changeDate, boolean published, @Nullable Key key,
+                                      @Nullable Callable<StoreInfoAndDataLoadResult> toCache) {
+        super(data, changeDate, published);
+        this.toCache = toCache;
+        this.key = key;
+    }
+
+    public @Nullable Callable<StoreInfoAndDataLoadResult> getToCache() {
+        return toCache;
+    }
+
+    public @Nullable Key getKey() {
+        return key;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Validator.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/cache/Validator.java
@@ -1,0 +1,16 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+/**
+ * A strategy for checking if a value in the cache is still valid (For example, if the change date is the same in the cache as
+ * in the database or index).
+ *
+ * @author Jesse on 3/5/2015.
+ */
+public interface Validator {
+    /**
+     * Return true is the value stored in the cache is still valid.
+     *
+     * @param info the info from the cache, the result field will be null.
+     */
+    boolean isCacheVersionValid(StoreInfo info);
+}

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/groovy/EnvironmentImpl.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/groovy/EnvironmentImpl.java
@@ -48,7 +48,7 @@ public class EnvironmentImpl implements Environment {
     private final String locUrl;
     private final Element jdomMetadata;
     private final ServiceContext serviceContext;
-    private final WebRequest servletRequest;
+    private final WebRequest webRequest;
     private Multimap<String, String> indexInfo = null;
 
     public EnvironmentImpl(FormatterParams fparams, IsoLanguagesMapper mapper) {
@@ -60,12 +60,13 @@ public class EnvironmentImpl implements Environment {
         this.resourceUrl = fparams.getResourceUrl();
         this.locUrl = fparams.getLocUrl();
         this.metadataInfo = fparams.metadataInfo;
-        for (Map.Entry<String, String[]> entry : fparams.servletRequest.getParameterMap().entrySet()) {
+        for (Map.Entry<String, String[]> entry : fparams.webRequest.getParameterMap().entrySet()) {
             for (String value : entry.getValue()) {
                 this.params.put(entry.getKey(), new ParamValue(value));
             }
         }
-        this.servletRequest = fparams.servletRequest;
+
+        this.webRequest = fparams.webRequest;
         this.serviceContext = fparams.context;
     }
 
@@ -211,10 +212,10 @@ public class EnvironmentImpl implements Environment {
 
     @Override
     public Optional<String> getHeader(String name) {
-        return Optional.fromNullable(servletRequest.getHeader(name));
+        return Optional.fromNullable(webRequest.getHeader(name));
     }
 
     public Collection<String> getHeaders(final String name) {
-        return Arrays.asList(servletRequest.getHeaderValues(name));
+        return Arrays.asList(webRequest.getHeaderValues(name));
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/format/groovy/EnvironmentImpl.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/groovy/EnvironmentImpl.java
@@ -3,7 +3,6 @@ package org.fao.geonet.services.metadata.format.groovy;
 import com.google.common.base.Optional;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
 import jeeves.server.context.ServiceContext;
 import org.apache.lucene.document.Document;
@@ -27,13 +26,12 @@ import org.jdom.Element;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.WebRequest;
 
-import java.util.AbstractCollection;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * The actual Environment implementation.
@@ -50,7 +48,7 @@ public class EnvironmentImpl implements Environment {
     private final String locUrl;
     private final Element jdomMetadata;
     private final ServiceContext serviceContext;
-    private final HttpServletRequest servletRequest;
+    private final WebRequest servletRequest;
     private Multimap<String, String> indexInfo = null;
 
     public EnvironmentImpl(FormatterParams fparams, IsoLanguagesMapper mapper) {
@@ -217,25 +215,6 @@ public class EnvironmentImpl implements Environment {
     }
 
     public Collection<String> getHeaders(final String name) {
-        return new AbstractCollection<String>() {
-            int size = -1;
-            @Override
-            public Iterator<String> iterator() {
-                return Iterators.forEnumeration(servletRequest.getHeaders(name));
-            }
-
-            @Override
-            public int size() {
-                if (this.size == -1) {
-                    this.size = 0;
-                    final Iterator<String> iterator = iterator();
-                    while (iterator.hasNext()) {
-                        iterator.next();
-                        this.size++;
-                    }
-                }
-                return this.size;
-            }
-        };
+        return Arrays.asList(servletRequest.getHeaderValues(name));
     }
 }

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -36,14 +36,19 @@
 
 	<bean id="formatterCache" lazy-init="true"
 		class="org.fao.geonet.services.metadata.format.cache.FormatterCache">
-    <constructor-arg index="0">
-      <bean class="org.fao.geonet.services.metadata.format.cache.FilesystemStore">
-        <property name="maxSizeGb" value="500" />
-      </bean>
-    </constructor-arg>
+    <constructor-arg index="0" ref="fsStore"/>
     <constructor-arg index="1" value="500000" />
     <constructor-arg index="2" value="5000" />
+    <constructor-arg index="3" ref="formatterCacheConfig"/>
 	</bean>
+  <bean id="fsStore" class="org.fao.geonet.services.metadata.format.cache.FilesystemStore" lazy-init="true">
+    <property name="maxSizeGb" value="500" />
+  </bean>
+  <bean id="formatterCacheConfig" class="org.fao.geonet.services.metadata.format.cache.ConfigurableCacheConfig" lazy-init="true">
+     <!--This class allows you to configure which formatters, languages, content/type etc... to cache-->
+     <!--Simply add the properties.  -->
+     <!--By default everything is cached except pdf-->
+  </bean>
   <bean id="formatterCachePublishListener" class="org.fao.geonet.services.metadata.format.cache.FormatterCachePublishListener" />
   <bean id="formatterCacheDeletionListener" class="org.fao.geonet.services.metadata.format.cache.FormatterCacheDeletionListener" />
 </beans>

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -33,4 +33,11 @@
 	<bean id="multipartResolver"
 		class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
 	</bean>
+
+	<bean id="formatterCache"
+		class="org.fao.geonet.services.metadata.format.cache.FormatterCache">
+    <constructor-arg index="0">
+      <bean class="org.fao.geonet.services.metadata.format.cache.FilesystemStore" />
+    </constructor-arg>
+	</bean>
 </beans>

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -37,7 +37,9 @@
 	<bean id="formatterCache"
 		class="org.fao.geonet.services.metadata.format.cache.FormatterCache">
     <constructor-arg index="0">
-      <bean class="org.fao.geonet.services.metadata.format.cache.FilesystemStore" />
+      <bean class="org.fao.geonet.services.metadata.format.cache.FilesystemStore">
+        <property name="maxSizeGb" value="500" />
+      </bean>
     </constructor-arg>
     <constructor-arg index="1" value="500000" />
     <constructor-arg index="2" value="5000" />

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -39,7 +39,6 @@
     <constructor-arg index="0" ref="fsStore"/>
     <constructor-arg index="1" value="500000" />
     <constructor-arg index="2" value="5000" />
-    <constructor-arg index="3" ref="formatterCacheConfig"/>
 	</bean>
   <bean id="fsStore" class="org.fao.geonet.services.metadata.format.cache.FilesystemStore" lazy-init="true">
     <property name="maxSizeGb" value="500" />

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -47,6 +47,11 @@
      <!--This class allows you to configure which formatters, languages, content/type etc... to cache-->
      <!--Simply add the properties.  -->
      <!--By default everything is cached except pdf-->
+    <property name="formatterExceptions">
+      <set>
+        <value>hierarchy_view</value>
+      </set>
+    </property>
   </bean>
   <bean id="formatterCachePublishListener" class="org.fao.geonet.services.metadata.format.cache.FormatterCachePublishListener" />
   <bean id="formatterCacheDeletionListener" class="org.fao.geonet.services.metadata.format.cache.FormatterCacheDeletionListener" />

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans default-lazy-init="true"
-	xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="
+<beans default-lazy-init="true" xmlns="http://www.springframework.org/schema/beans"
+  xmlns:context="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="
 		http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
@@ -10,43 +8,37 @@
     ">
 
 
-	<context:component-scan base-package="org.fao.geonet" />
+  <context:component-scan base-package="org.fao.geonet" />
 
-	<bean id="RegionsDAO" class="org.fao.geonet.services.region.ThesaurusBasedRegionsDAO">
-		<constructor-arg ref="languages" />
-		<property name="cacheAllRegionsInMemory" value="true" />
-		<property name="thesaurusName" value="external.place.regions" />
-	</bean>
-	<bean id="MetadataRegionsDAO" class="org.fao.geonet.services.region.MetadataRegionDAO">
-		<property name="cacheAllRegionsInMemory" value="false" />
-	</bean>
+  <bean id="RegionsDAO" class="org.fao.geonet.services.region.ThesaurusBasedRegionsDAO">
+    <constructor-arg ref="languages" />
+    <property name="cacheAllRegionsInMemory" value="true" />
+    <property name="thesaurusName" value="external.place.regions" />
+  </bean>
+  <bean id="MetadataRegionsDAO" class="org.fao.geonet.services.region.MetadataRegionDAO">
+    <property name="cacheAllRegionsInMemory" value="false" />
+  </bean>
 
-	<bean id="resourceUploadHandler"
-		class="org.fao.geonet.services.resources.handlers.DefaultResourceUploadHandler" />
+  <bean id="resourceUploadHandler" class="org.fao.geonet.services.resources.handlers.DefaultResourceUploadHandler" />
 
-	<bean id="resourceDownloadHandler"
-		class="org.fao.geonet.services.resources.handlers.DefaultResourceDownloadHandler" />
+  <bean id="resourceDownloadHandler" class="org.fao.geonet.services.resources.handlers.DefaultResourceDownloadHandler" />
 
-	<bean id="resourceRemoveHandler"
-		class="org.fao.geonet.services.resources.handlers.DefaultResourceRemoveHandler" />
+  <bean id="resourceRemoveHandler" class="org.fao.geonet.services.resources.handlers.DefaultResourceRemoveHandler" />
 
-	<bean id="multipartResolver"
-		class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-	</bean>
+  <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver"></bean>
 
-	<bean id="formatterCache" lazy-init="true"
-		class="org.fao.geonet.services.metadata.format.cache.FormatterCache">
-    <constructor-arg index="0" ref="fsStore"/>
+  <bean id="formatterCache" lazy-init="true" class="org.fao.geonet.services.metadata.format.cache.FormatterCache">
+    <constructor-arg index="0" ref="fsStore" />
     <constructor-arg index="1" value="500000" />
     <constructor-arg index="2" value="5000" />
-	</bean>
+  </bean>
   <bean id="fsStore" class="org.fao.geonet.services.metadata.format.cache.FilesystemStore" lazy-init="true">
     <property name="maxSizeGb" value="500" />
   </bean>
   <bean id="formatterCacheConfig" class="org.fao.geonet.services.metadata.format.cache.ConfigurableCacheConfig" lazy-init="true">
-     <!--This class allows you to configure which formatters, languages, content/type etc... to cache-->
-     <!--Simply add the properties.  -->
-     <!--By default everything is cached except pdf-->
+    <!--This class allows you to configure which formatters, languages, content/type etc... to cache-->
+    <!--Simply add the properties.  -->
+    <!--By default everything is cached except pdf-->
     <property name="formatterExceptions">
       <set>
         <value>hierarchy_view</value>

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -39,5 +39,7 @@
     <constructor-arg index="0">
       <bean class="org.fao.geonet.services.metadata.format.cache.FilesystemStore" />
     </constructor-arg>
+    <constructor-arg index="1" value="500000" />
+    <constructor-arg index="2" value="5000" />
 	</bean>
 </beans>

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -34,7 +34,7 @@
 		class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
 	</bean>
 
-	<bean id="formatterCache"
+	<bean id="formatterCache" lazy-init="true"
 		class="org.fao.geonet.services.metadata.format.cache.FormatterCache">
     <constructor-arg index="0">
       <bean class="org.fao.geonet.services.metadata.format.cache.FilesystemStore">
@@ -44,4 +44,6 @@
     <constructor-arg index="1" value="500000" />
     <constructor-arg index="2" value="5000" />
 	</bean>
+  <bean id="formatterCachePublishListener" class="org.fao.geonet.services.metadata.format.cache.FormatterCachePublishListener" />
+  <bean id="formatterCacheDeletionListener" class="org.fao.geonet.services.metadata.format.cache.FormatterCacheDeletionListener" />
 </beans>

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
@@ -114,7 +114,7 @@ public abstract class AbstractFormatterTest extends AbstractCoreIntegrationTest 
         final ServletWebRequest webRequest = new ServletWebRequest(request);
 
         return this.formatService.loadMetadataAndCreateFormatterAndParams(getUILang(), getOutputType(),
-                "" + id, null, formatterId, true, false, webRequest);
+                "" + id, formatterId, true, false, webRequest);
     }
 
     protected void measureFormatterPerformance(final MockHttpServletRequest request, final String formatterId) throws Exception {

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
@@ -114,7 +114,7 @@ public abstract class AbstractFormatterTest extends AbstractCoreIntegrationTest 
         final ServletWebRequest webRequest = new ServletWebRequest(request);
 
         return this.formatService.loadMetadataAndCreateFormatterAndParams(getUILang(), getOutputType(),
-                "" + id, null, formatterId, "true", false, webRequest);
+                "" + id, null, formatterId, true, false, webRequest);
     }
 
     protected void measureFormatterPerformance(final MockHttpServletRequest request, final String formatterId) throws Exception {

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
@@ -114,7 +114,7 @@ public abstract class AbstractFormatterTest extends AbstractCoreIntegrationTest 
         final ServletWebRequest webRequest = new ServletWebRequest(request);
 
         return this.formatService.loadMetadataAndCreateFormatterAndParams(getUILang(), getOutputType(),
-                "" + id, formatterId, false, webRequest);
+                id, formatterId, false, webRequest);
     }
 
     protected void measureFormatterPerformance(final MockHttpServletRequest request, final String formatterId) throws Exception {

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
@@ -114,7 +114,7 @@ public abstract class AbstractFormatterTest extends AbstractCoreIntegrationTest 
         final ServletWebRequest webRequest = new ServletWebRequest(request);
 
         return this.formatService.loadMetadataAndCreateFormatterAndParams(getUILang(), getOutputType(),
-                "" + id, formatterId, true, false, webRequest);
+                "" + id, formatterId, false, webRequest);
     }
 
     protected void measureFormatterPerformance(final MockHttpServletRequest request, final String formatterId) throws Exception {

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/AbstractFormatterTest.java
@@ -34,6 +34,7 @@ import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.util.Collections;
@@ -110,16 +111,18 @@ public abstract class AbstractFormatterTest extends AbstractCoreIntegrationTest 
     }
 
     protected Pair<FormatterImpl, FormatterParams> getFormatterFormatterParamsPair(MockHttpServletRequest request, String formatterId) throws Exception {
+        final ServletWebRequest webRequest = new ServletWebRequest(request);
+
         return this.formatService.loadMetadataAndCreateFormatterAndParams(getUILang(), getOutputType(),
-                "" + id, null, formatterId, "true", false, request);
+                "" + id, null, formatterId, "true", false, webRequest);
     }
 
     protected void measureFormatterPerformance(final MockHttpServletRequest request, final String formatterId) throws Exception {
+        final ServletWebRequest webRequest = new ServletWebRequest(request, new MockHttpServletResponse());
         TestFunction testFunction = new TestFunction() {
             @Override
             public void exec() throws Exception{
-                formatService.exec(getUILang(), getOutputType().name(), "" + id, null, formatterId, "true", false, request,
-                        new MockHttpServletResponse());
+                formatService.exec(getUILang(), getOutputType().name(), "" + id, null, formatterId, "true", false, webRequest);
             }
         };
 

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/FormatIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/FormatIntegrationTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.support.GenericWebApplicationContext;
 
 import java.net.URL;
@@ -103,10 +104,10 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
 
     @Test(expected = AssertionError.class)
     public void testGroovyUseEnvDuringConfigStage() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        final ServletWebRequest webRequest = new ServletWebRequest(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FormatterParams fparams = new FormatterParams();
         fparams.context = this.serviceContext;
-        fparams.servletRequest = request;
+        fparams.servletRequest = webRequest;
         // make sure context is cleared
         EnvironmentProxy.setCurrentEnvironment(fparams, mapper);
 
@@ -120,7 +121,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
         Files.deleteIfExists(formatterDir.resolve(functionsXslName));
         IO.copyDirectoryOrFile(testFormatter.getParent().resolve(functionsXslName), formatterDir.resolve(functionsXslName), false);
 
-        formatService.exec("eng", "html", "" + id, null, formatterName, null, null, request, new MockHttpServletResponse());
+        formatService.exec("eng", "html", "" + id, null, formatterName, null, null, webRequest);
     }
 
     @Test
@@ -129,7 +130,8 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
         Level level = logger.getLevel();
         logger.setLevel(Level.ALL);
         try {
-            MockHttpServletRequest request = new MockHttpServletRequest();
+            final ServletWebRequest request = new ServletWebRequest(new MockHttpServletRequest(), new MockHttpServletResponse());
+
             final FormatterParams fparams = new FormatterParams();
             fparams.context = this.serviceContext;
             fparams.servletRequest = request;
@@ -147,7 +149,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
             IO.copyDirectoryOrFile(testFormatter.getParent().resolve(functionsXslName), formatterDir.resolve(functionsXslName), false);
 
 
-            formatService.exec("eng", "html", "" + id, null, formatterName, null, null, request, new MockHttpServletResponse());
+            formatService.exec("eng", "html", "" + id, null, formatterName, null, null, request);
 
             // no Error is success
         } finally {
@@ -167,7 +169,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
             JeevesDelegatingFilterProxy.setApplicationContextAttributeKey(srvAppContext);
             RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-            formatService.exec("eng", "html", "" + id, null, formatter.getId(), "true", false, request, response);
+            formatService.exec("eng", "html", "" + id, null, formatter.getId(), "true", false, new ServletWebRequest(request, response));
 
             final String view = response.getContentAsString();
             try {
@@ -178,7 +180,8 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
             }
             try {
                 response = new MockHttpServletResponse();
-                formatService.exec("eng", "testpdf", "" + id, null, formatter.getId(), "true", false, request, response);
+                formatService.exec("eng", "testpdf", "" + id, null, formatter.getId(), "true", false,
+                        new ServletWebRequest(request, response));
 //                Files.write(Paths.get("e:/tmp/view.pdf"), response.getContentAsByteArray());
 //                System.exit(0);
             } catch (Throwable t) {
@@ -211,7 +214,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
         JeevesDelegatingFilterProxy.setApplicationContextAttributeKey(applicationContextAttributeKey);
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterName, "true", false, request, response);
+        formatService.exec("eng", "html", "" + id, null, formatterName, "true", false, new ServletWebRequest(request, response));
         final String viewXml = response.getContentAsString();
         final Element view = Xml.loadString(viewXml, false);
         assertEqualsText("fromFunction", view, "*//p");
@@ -225,7 +228,8 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.execXml("eng", "xml", "partial_view", Xml.getString(element), null, "iso19139", request, response);
+        formatService.execXml("eng", "xml", "partial_view", Xml.getString(element), null, "iso19139",
+                new ServletWebRequest(request, response));
 
         final String view = response.getContentAsString();
         assertTrue(view.contains("KML (1)"));
@@ -244,7 +248,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.execXml("eng", "xml", "partial_view", null, url, "iso19139", request, response);
+        formatService.execXml("eng", "xml", "partial_view", null, url, "iso19139", new ServletWebRequest(request, response));
 
         final String view = response.getContentAsString();
         assertTrue(view.contains("KML (1)"));
@@ -264,7 +268,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.execXml("eng", "xml", "partial_view", null, "request", "iso19139", request, response);
+        formatService.execXml("eng", "xml", "partial_view", null, "request", "iso19139", new ServletWebRequest(request, response));
 
         final String view = response.getContentAsString();
         assertTrue(view.contains("KML (1)"));
@@ -294,7 +298,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
         request.addParameter("h2IdentInfo", "true");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterName, "true", false, request, response);
+        formatService.exec("eng", "html", "" + id, null, formatterName, "true", false, new ServletWebRequest(request, response));
         final String viewString = response.getContentAsString();
 //        com.google.common.io.Files.write(viewString, new File("e:/tmp/view.html"), Constants.CHARSET);
 

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/FormatIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/FormatIntegrationTest.java
@@ -164,7 +164,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
         final ServletWebRequest webRequest = new ServletWebRequest(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FormatterParams fparams = new FormatterParams();
         fparams.context = this.serviceContext;
-        fparams.servletRequest = webRequest;
+        fparams.webRequest = webRequest;
         // make sure context is cleared
         EnvironmentProxy.setCurrentEnvironment(fparams, mapper);
 
@@ -191,7 +191,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
 
             final FormatterParams fparams = new FormatterParams();
             fparams.context = this.serviceContext;
-            fparams.servletRequest = request;
+            fparams.webRequest = request;
             // make sure context is cleared
             EnvironmentProxy.setCurrentEnvironment(fparams, mapper);
 

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/XmlViewFormatterTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/XmlViewFormatterTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.util.List;
@@ -48,7 +49,7 @@ public class XmlViewFormatterTest extends AbstractFormatterTest {
 //        measureFormatterPerformance(request, formatterId);
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, request, response);
+        formatService.exec("eng", "html", "" + id, null, formatterId, "true", false, new ServletWebRequest(request, response));
         final String view = response.getContentAsString();
         Files.write(view, new File("e:/tmp/view.html"), Constants.CHARSET);
 

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidatorTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidatorTest.java
@@ -1,0 +1,24 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ChangeDateValidatorTest {
+
+    @Test
+    public void testIsCacheVersionValid() throws Exception {
+        final long date = 123456789;
+        StoreInfo info = new StoreInfo(null, date, false);
+        assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
+        info = new StoreInfo(null, date + 100, false);
+        assertFalse(new ChangeDateValidator(date).isCacheVersionValid(info));
+        info = new StoreInfo(null, date - 100, false);
+        assertFalse(new ChangeDateValidator(date).isCacheVersionValid(info));
+        info = new StoreInfo(null, date - 9, false);
+        assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
+        info = new StoreInfo(null, date + 9, false);
+        assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
+    }
+}

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidatorTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidatorTest.java
@@ -10,15 +10,13 @@ public class ChangeDateValidatorTest {
     @Test
     public void testIsCacheVersionValid() throws Exception {
         final long date = 123456789;
-        StoreInfo info = new StoreInfo(null, date, false);
+        StoreInfoAndData info = new StoreInfoAndData(null, date, false, 98345, 0);
         assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfo(null, date + 100, false);
+        info = new StoreInfoAndData(null, date + 100, false, 98345, 0);
         assertFalse(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfo(null, date - 100, false);
+        info = new StoreInfoAndData(null, date - 100, false, 98345, 0);
         assertFalse(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfo(null, date - 9, false);
-        assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfo(null, date + 9, false);
+        info = new StoreInfoAndData(null, date - 9, false, 98345, 0);
         assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidatorTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidatorTest.java
@@ -10,13 +10,13 @@ public class ChangeDateValidatorTest {
     @Test
     public void testIsCacheVersionValid() throws Exception {
         final long date = 123456789;
-        StoreInfoAndData info = new StoreInfoAndData(null, date, false, 98345, 0);
+        StoreInfoAndData info = new StoreInfoAndData(null, date, false);
         assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfoAndData(null, date + 100, false, 98345, 0);
+        info = new StoreInfoAndData(null, date + 100, false);
         assertFalse(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfoAndData(null, date - 100, false, 98345, 0);
+        info = new StoreInfoAndData(null, date - 100, false);
         assertFalse(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfoAndData(null, date - 9, false, 98345, 0);
+        info = new StoreInfoAndData(null, date - 9, false);
         assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidatorTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ChangeDateValidatorTest.java
@@ -10,13 +10,16 @@ public class ChangeDateValidatorTest {
     @Test
     public void testIsCacheVersionValid() throws Exception {
         final long date = 123456789;
-        StoreInfoAndData info = new StoreInfoAndData(null, date, false);
+        StoreInfoAndData info = new StoreInfoAndData((byte[]) null, date, false);
         assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfoAndData(null, date + 100, false);
+
+        info = new StoreInfoAndData((byte[]) null, date + 100, false);
         assertFalse(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfoAndData(null, date - 100, false);
+
+        info = new StoreInfoAndData((byte[]) null, date - 100, false);
         assertFalse(new ChangeDateValidator(date).isCacheVersionValid(info));
-        info = new StoreInfoAndData(null, date - 9, false);
+
+        info = new StoreInfoAndData((byte[]) null, date - 9, false);
         assertTrue(new ChangeDateValidator(date).isCacheVersionValid(info));
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ConfigurableCacheConfigTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/ConfigurableCacheConfigTest.java
@@ -1,0 +1,76 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import com.google.common.collect.Sets;
+import org.fao.geonet.services.metadata.format.FormatType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigurableCacheConfigTest {
+
+    @Test
+    public void testAllowCachingTypeExceptions() throws Exception {
+        final ConfigurableCacheConfig cacheConfig = new ConfigurableCacheConfig();
+        cacheConfig.setTypeExceptions(Sets.newHashSet(FormatType.xml));
+        assertTrue(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", true)));
+        assertFalse(cacheConfig.allowCaching(new Key(1, "eng", FormatType.xml, "fmtId", true)));
+    }
+
+    @Test
+    public void testAllowCachingAllowedTypes() throws Exception {
+        final ConfigurableCacheConfig cacheConfig = new ConfigurableCacheConfig();
+        cacheConfig.setAllowedTypes(Sets.newHashSet(FormatType.html));
+        assertTrue(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", true)));
+        assertFalse(cacheConfig.allowCaching(new Key(1, "eng", FormatType.xml, "fmtId", true)));
+    }
+
+    @Test
+    public void testAllowCachingFormatterExceptions() throws Exception {
+        final ConfigurableCacheConfig cacheConfig = new ConfigurableCacheConfig();
+        cacheConfig.setFormatterExceptions(Sets.newHashSet("fmtId2"));
+        assertTrue(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", true)));
+        assertFalse(cacheConfig.allowCaching(new Key(1, "eng", FormatType.xml, "fmtId2", true)));
+    }
+
+    @Test
+    public void testAllowCachingAllowedFormatters() throws Exception {
+        final ConfigurableCacheConfig cacheConfig = new ConfigurableCacheConfig();
+        cacheConfig.setFormatterIds(Sets.newHashSet("fmtId"));
+        assertTrue(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", true)));
+        assertFalse(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId2", true)));
+    }
+
+    @Test
+    public void testAllowCachingLangExceptions() throws Exception {
+        final ConfigurableCacheConfig cacheConfig = new ConfigurableCacheConfig();
+        cacheConfig.setLangExceptions(Sets.newHashSet("fre"));
+        assertTrue(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", true)));
+        assertFalse(cacheConfig.allowCaching(new Key(1, "fre", FormatType.xml, "fmtId2", true)));
+    }
+
+    @Test
+    public void testAllowCachingAllowedLangs() throws Exception {
+        final ConfigurableCacheConfig cacheConfig = new ConfigurableCacheConfig();
+        cacheConfig.setAllowedLanguages(Sets.newHashSet("eng"));
+        assertTrue(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", true)));
+        assertFalse(cacheConfig.allowCaching(new Key(1, "fre", FormatType.html, "fmtId", true)));
+    }
+
+    @Test
+    public void testAllowCachingHideWithheld() throws Exception {
+        final ConfigurableCacheConfig cacheConfig = new ConfigurableCacheConfig();
+        cacheConfig.setCacheHideWithheld(false);
+        assertTrue(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", false)));
+        assertFalse(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", true)));
+    }
+
+    @Test
+    public void testAllowCachingHideFullMetadata() throws Exception {
+        final ConfigurableCacheConfig cacheConfig = new ConfigurableCacheConfig();
+        cacheConfig.setCacheFullMetadata(false);
+        assertTrue(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", true)));
+        assertFalse(cacheConfig.allowCaching(new Key(1, "eng", FormatType.html, "fmtId", false)));
+    }
+
+}

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FilesystemStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FilesystemStoreTest.java
@@ -107,6 +107,26 @@ public class FilesystemStoreTest {
     }
 
     @Test
+    public void testDoNotPublishMdWithWithheld() throws IOException, SQLException {
+
+        StoreInfoAndData data = new StoreInfoAndData("result", 10000, true);
+        Key key = new Key(1, "eng", FormatType.html, "full_view", false);
+        store.put(key, data);
+        assertNull(store.getPublished(key));
+
+        store.setPublished(1, true);
+        assertNull(store.getPublished(key));
+
+        data = new StoreInfoAndData("result", 10000, true);
+        key = new Key(1, "eng", FormatType.html, "full_view", true);
+        store.put(key, data);
+        assertNotNull(store.getPublished(key));
+
+        store.setPublished(1, true);
+        assertNotNull(store.getPublished(key));
+    }
+
+    @Test
     public void testPublicPrivatePath() throws Exception {
         Key key = new Key(2, "eng", FormatType.html, "full_view", true);
         assertFalse(this.store.getPrivatePath(key).equals(this.store.getPublicPath(key)));
@@ -256,7 +276,7 @@ public class FilesystemStoreTest {
         Key key2 = new Key(1, "fre", FormatType.html, "full_view", true);
         Key key3 = new Key(1, "fre", FormatType.xml, "full_view", true);
         Key key4 = new Key(1, "fre", FormatType.html, "xml_view", true);
-        Key key5 = new Key(1, "fre", FormatType.html, "xml_view", false);
+        Key key5 = new Key(1, "fre", FormatType.html, "xml_view", true);
         store.put(key1, data);
         store.put(key2, data);
         store.put(key3, data);

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FilesystemStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FilesystemStoreTest.java
@@ -1,0 +1,279 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.services.metadata.format.FormatType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class FilesystemStoreTest {
+
+
+    private FileSystem fileSystem;
+    private FilesystemStore store;
+    private GeonetworkDataDirectory geonetworkDataDirectory;
+
+    @Before
+    public void setUp() throws Exception {
+        createDataDir();
+        initStore();
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        fileSystem.close();
+        store.close();
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        StoreInfoAndData data = new StoreInfoAndData("result", 10000, false);
+        final Key key = new Key(1, "eng", FormatType.html, "full_view", true);
+        store.put(key, data);
+        final StoreInfoAndData loaded = store.get(key);
+
+        assertEquals(data.getDataAsString(), loaded.getDataAsString());
+        assertEquals(data.getChangeDate(), loaded.getChangeDate());
+        assertEquals(data.isPublished(), loaded.isPublished());
+        assertTrue(0 < countFiles(geonetworkDataDirectory.getHtmlCacheDir()));
+    }
+
+    @Test
+    public void testGetInfo() throws Exception {
+        StoreInfoAndData data = new StoreInfoAndData("result", 10000, false);
+        final Key key = new Key(1, "eng", FormatType.html, "full_view", true);
+        store.put(key, data);
+        final StoreInfo loaded = store.getInfo(key);
+
+        assertFalse(loaded instanceof StoreInfoAndData);
+        assertEquals(data.getChangeDate(), loaded.getChangeDate());
+        assertEquals(data.isPublished(), loaded.isPublished());
+
+    }
+
+    @Test
+    public void testGetPublic() throws Exception {
+
+        StoreInfoAndData data = new StoreInfoAndData("result", 10000, false);
+        Key key = new Key(1, "eng", FormatType.html, "full_view", true);
+        store.put(key, data);
+        assertNull(store.getPublic(key));
+        assertEquals(1, countFiles(store.getPrivatePath(key)));
+        assertEquals(0, countFiles(store.getPublicPath(key)));
+
+        data = new StoreInfoAndData("two", 10000, true);
+        Key key2 = new Key(2, "eng", FormatType.html, "full_view", true);
+        store.put(key2, data);
+
+        assertNotNull(store.getPublic(key2));
+        assertNull(store.getPublic(key));
+        assertEquals(3, countFiles(geonetworkDataDirectory.getHtmlCacheDir()));
+
+        data = new StoreInfoAndData("three", 10000, true);
+        store.put(key, data);
+        assertNotNull(store.getPublic(key2));
+        assertNotNull(store.getPublic(key));
+        assertEquals(4, countFiles(geonetworkDataDirectory.getHtmlCacheDir()));
+
+        data = new StoreInfoAndData("four", 10000, false);
+        store.put(key2, data);
+        assertNull(store.getPublic(key2));
+        assertNotNull(store.getPublic(key));
+        assertEquals(3, countFiles(geonetworkDataDirectory.getHtmlCacheDir()));
+    }
+
+    @Test
+    public void testPublicPrivatePath() throws Exception {
+        Key key = new Key(2, "eng", FormatType.html, "full_view", true);
+        assertFalse(this.store.getPrivatePath(key).equals(this.store.getPublicPath(key)));
+    }
+
+    @Test
+    public void testDiskSizeRestrictionReduceSizeOnOverflow() throws Exception {
+        Key[] keys = prepareDiskSizeRestrictionTests();
+
+        store.put(keys[5], new StoreInfoAndData(new byte[200], 6, false));
+        assertStoreContains(keys, keys[3], keys[4], keys[5]);
+
+    }
+
+
+    @Test
+    public void testDiskSizeRestrictionReplace() throws Exception {
+        Key[] keys = prepareDiskSizeRestrictionTests();
+
+        store.put(keys[4], new StoreInfoAndData(new byte[200], 4, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[0], new StoreInfoAndData(new byte[200], 0, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[1], new StoreInfoAndData(new byte[200], 1, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[3], new StoreInfoAndData(new byte[200], 3, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[2], new StoreInfoAndData(new byte[200], 2, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        try (
+                Statement statement = store.metadataDb.createStatement();
+                ResultSet rs = statement.executeQuery(FilesystemStore.QUERY_GETCURRENT_SIZE)) {
+            assertTrue(rs.next());
+            assertEquals(1000L, Long.parseLong(rs.getString(1)));
+        }
+
+        store.put(keys[4], new StoreInfoAndData(new byte[100], 4, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[0], new StoreInfoAndData(new byte[300], 0, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[1], new StoreInfoAndData(new byte[200], 1, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[3], new StoreInfoAndData(new byte[100], 3, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[2], new StoreInfoAndData(new byte[300], 2, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+
+
+        store.put(keys[2], new StoreInfoAndData(new byte[400], 2, false));
+        assertStoreContains(keys, keys[2], keys[3], keys[4]);
+    }
+
+
+    @Test
+    public void testDiskSizeRestrictionRemove() throws Exception {
+        Key[] keys = prepareDiskSizeRestrictionTests();
+
+        store.put(keys[4], new StoreInfoAndData(new byte[200], 4, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.put(keys[0], new StoreInfoAndData(new byte[200], 0, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        store.remove(keys[1]);
+        assertStoreContains(keys, keys[0], keys[2], keys[3], keys[4]);
+        store.put(keys[3], new StoreInfoAndData(new byte[400], 3, false));
+        assertStoreContains(keys, keys[0], keys[2], keys[3], keys[4]);
+        store.put(keys[2], new StoreInfoAndData(new byte[200], 2, false));
+        assertStoreContains(keys, keys[0], keys[2], keys[3], keys[4]);
+    }
+
+    private Key[] prepareDiskSizeRestrictionTests() throws IOException, SQLException {
+        this.store.setMaxSizeKb(1);
+        Key[] keys = {new Key(0, "eng", FormatType.html, "full_view", true),
+                new Key(1, "eng", FormatType.html, "full_view", true),
+                new Key(2, "eng", FormatType.html, "full_view", true),
+                new Key(3, "eng", FormatType.html, "full_view", true),
+                new Key(4, "eng", FormatType.html, "full_view", true),
+                new Key(5, "eng", FormatType.html, "full_view", true)};
+
+        store.put(keys[0], new StoreInfoAndData(new byte[200], 0, false));
+        assertStoreContains(keys, keys[0]);
+        store.put(keys[1], new StoreInfoAndData(new byte[200], 1, false));
+        assertStoreContains(keys, keys[0], keys[1]);
+        store.put(keys[2], new StoreInfoAndData(new byte[200], 2, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2]);
+        store.put(keys[3], new StoreInfoAndData(new byte[200], 3, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3]);
+        store.put(keys[4], new StoreInfoAndData(new byte[200], 4, false));
+        assertStoreContains(keys, keys[0], keys[1], keys[2], keys[3], keys[4]);
+        return keys;
+    }
+
+    private void assertStoreContains(Key[] keys, Key... contained) throws SQLException {
+        HashSet<Key> expectedContained = Sets.newHashSet(contained);
+        HashSet<Key> actualContained = Sets.newHashSet();
+
+        for (Key key : keys) {
+            if (this.store.getInfo(key) != null) {
+                actualContained.add(key);
+            }
+        }
+
+        Sets.SetView<Key> diff = Sets.difference(expectedContained, actualContained);
+        assertEquals("Some values were missing: \n"+ Joiner.on("\n").join(diff), 0, diff.size());
+
+        Sets.SetView<Key> diff2 = Sets.difference(actualContained, expectedContained);
+        assertEquals("Some extra values were found: \n"+ Joiner.on("\n").join(diff2), 0, diff2.size());
+    }
+
+    @Test
+    public void testRemove() throws Exception {
+        StoreInfoAndData data = new StoreInfoAndData("result", 10000, true);
+        Key key = new Key(1, "eng", FormatType.html, "full_view", true);
+        store.put(key, data);
+        assertNotNull(store.get(key));
+        assertNotNull(store.getPublic(key));
+        assertNotNull(store.getInfo(key));
+        assertEquals(1, countFiles(store.getPrivatePath(key)));
+        assertEquals(1, countFiles(store.getPublicPath(key)));
+
+        store.remove(key);
+        assertNull(store.getInfo(key));
+        assertNull(store.getPublic(key));
+        assertNull(store.get(key));
+        assertEquals(0, countFiles(store.getPrivatePath(key)));
+        assertEquals(0, countFiles(store.getPublicPath(key)));
+
+        data = new StoreInfoAndData("result", 10000, false);
+        key = new Key(1, "eng", FormatType.html, "full_view", true);
+        store.put(key, data);
+        assertEquals(1, countFiles(store.getPrivatePath(key)));
+        assertEquals(0, countFiles(store.getPublicPath(key)));
+
+        store.remove(key);
+        assertNull(store.getInfo(key));
+        assertNull(store.getPublic(key));
+        assertNull(store.get(key));
+        assertEquals(0, countFiles(store.getPrivatePath(key)));
+        assertEquals(0, countFiles(store.getPublicPath(key)));
+
+        store.remove(key); // no exception ? good
+    }
+
+    private int countFiles(Path htmlCacheDir) throws IOException {
+        final int[] count = {0};
+        if (Files.exists(htmlCacheDir)) {
+            Files.walkFileTree(htmlCacheDir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    count[0] += 1;
+                    return super.visitFile(file, attrs);
+                }
+            });
+        }
+        return count[0];
+    }
+
+    private void initStore() throws SQLException, ClassNotFoundException {
+        this.store = new FilesystemStore();
+        this.store.testing = true;
+        store.setGeonetworkDataDir(geonetworkDataDirectory);
+        store.init();
+    }
+
+    private void createDataDir() {
+        this.geonetworkDataDirectory = Mockito.mock(GeonetworkDataDirectory.class);
+        this.fileSystem = Jimfs.newFileSystem("blarg", Configuration.unix());
+        Mockito.when(geonetworkDataDirectory.getHtmlCacheDir()).thenReturn(fileSystem.getPath("/html"));
+    }
+
+}

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheIntegrationTest.java
@@ -1,0 +1,104 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.mef.MEFLibIntegrationTest.ImportMetadata;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.specification.OperationAllowedSpecs;
+import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.fao.geonet.services.metadata.Publish;
+import org.fao.geonet.services.metadata.format.FormatType;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Date;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.springframework.data.jpa.domain.Specifications.where;
+
+@ContextConfiguration(inheritLocations = true, locations = "classpath:formatter-cache-test-context.xml")
+public class FormatterCacheIntegrationTest extends AbstractServiceIntegrationTest {
+
+    public static final MockHttpServletRequest SERVLET_REQUEST = new MockHttpServletRequest("GET", "requesturi");
+    @Autowired
+    private Publish publish;
+    @Autowired
+    private OperationAllowedRepository operationAllowedRepository;
+    @Autowired
+    private DataManager dataManager;
+    @PersistenceContext
+    EntityManager entityManager;
+    private FilesystemStore fsStore;
+    private FormatterCache formatterCache;
+
+    private String metadataId;
+
+    @Before
+    public void setUp() throws Exception {
+        ServiceContext context = createServiceContext();
+        ImportMetadata importer = new ImportMetadata(this, context);
+        importer.invoke();
+
+        this.metadataId = importer.getMetadataIds().get(0);
+
+        this.fsStore = _applicationContext.getBean(FilesystemStore.class);
+        this.formatterCache = _applicationContext.getBean(FormatterCache.class);
+    }
+
+    @Test
+    public void testUpdatesAfterMetadataUnpublished() throws Exception {
+        final Specification<OperationAllowed> isPublished = OperationAllowedSpecs.isPublic(ReservedOperation.view);
+        final Specification<OperationAllowed> hasMdId = OperationAllowedSpecs.hasMetadataId(metadataId);
+        final OperationAllowed one = operationAllowedRepository.findOne(where(hasMdId).and(isPublished));
+        final long changeDate = new Date().getTime();
+        final Key key = new Key(Integer.parseInt(metadataId), "eng", FormatType.html, "full_view", true);
+        formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("result", changeDate, one != null), true);
+
+        if (one != null) {
+            publish.unpublish("eng", SERVLET_REQUEST, metadataId, false);
+            assertPublished(key, false);
+        }
+
+        publish.publish("eng", new MockHttpServletRequest("GET", "requesturi"), metadataId, false);
+        assertPublished(key, true);
+
+        publish.unpublish("eng", new MockHttpServletRequest("GET", "requesturi"), metadataId, false);
+        assertPublished(key, false);
+
+        publish.publish("eng", new MockHttpServletRequest("GET", "requesturi"), metadataId, false);
+        assertPublished(key, true);
+    }
+
+    private void assertPublished(Key key, boolean published) throws IOException, SQLException {
+        assertEquals(published, formatterCache.getPublished(key) != null);
+        assertEquals(published, fsStore.getPublished(key) != null);
+    }
+
+    @Test
+    public void testUpdatesAfterMetadataDeleted() throws Exception {
+        final long changeDate = new Date().getTime();
+        final Key key = new Key(Integer.parseInt(metadataId), "eng", FormatType.html, "full_view", true);
+        formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("result", changeDate, true), true);
+
+        dataManager.deleteMetadata(createServiceContext(), metadataId);
+        entityManager.flush();
+
+        assertNull(formatterCache.getPublished(key));
+        assertNull(fsStore.getPublished(key));
+        assertNull(fsStore.get(key));
+        assertEquals("newValue",
+                formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("newValue", changeDate, true), true));
+    }
+}

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheTest.java
@@ -1,33 +1,182 @@
 package org.fao.geonet.services.metadata.format.cache;
 
-import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.services.metadata.format.FormatType;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Date;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 
-public class FormatterCacheTest extends AbstractCoreIntegrationTest {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class FormatterCacheTest {
+
+    private FormatterCache formatterCache;
+
+    @After
+    public void tearDown() throws Exception {
+        this.formatterCache.shutdown();
+    }
 
     @Test
     public void testGet() throws Exception {
-        final FormatterCache formatterCache = new FormatterCache(new MemoryPersistentStore());
-
+        final MemoryPersistentStore persistentStore = new MemoryPersistentStore();
+        this.formatterCache = new FormatterCache(persistentStore, 1);
 
         final boolean hideWithheld = true;
         final long changeDate = new Date().getTime();
-        formatterCache.get(new Key(1, "eng", FormatType.html, "full_view", hideWithheld), new ChangeDateValidator(changeDate), new Callable<StoreInfo>() {
+        final Key key = new Key(1, "eng", FormatType.html, "full_view", hideWithheld);
+        String result = formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("result", changeDate, false), true);
+        assertEquals("result", result);
+        StoreInfoAndData info = persistentStore.get(key);
+        assertEquals(changeDate, info.getChangeDate());
+        assertEquals(false, info.isPublished());
+        assertEquals("result", info.getResult());
+        StoreInfo basicInfo = persistentStore.getInfo(key);
+        assertEquals(changeDate, basicInfo.getChangeDate());
+        assertEquals(false, basicInfo.isPublished());
+
+        result = formatterCache.get(key, new ChangeDateValidator(changeDate), new Callable<StoreInfoAndData>() {
             @Override
-            public StoreInfo call() throws Exception {
-                return new StoreInfo("result", changeDate, false);
+            public StoreInfoAndData call() throws Exception {
+                throw new AssertionError("Should not be called because cache should be up-to-date");
             }
         }, true);
+        assertEquals("result", result);
 
-
+        final long updatedChangeDate = changeDate + 100;
+        result = formatterCache.get(key, new ChangeDateValidator(updatedChangeDate), new TestLoader("newVal", updatedChangeDate, false), true);
+        assertEquals("newVal", result);
+        info = persistentStore.get(key);
+        assertEquals(updatedChangeDate, info.getChangeDate());
+        assertEquals(false, info.isPublished());
+        assertEquals("newVal", info.getResult());
+        basicInfo = persistentStore.getInfo(key);
+        assertEquals(updatedChangeDate, basicInfo.getChangeDate());
+        assertEquals(false, basicInfo.isPublished());
     }
 
     @Test
     public void testGetPublic() throws Exception {
+        final MemoryPersistentStore persistentStore = new MemoryPersistentStore();
+        this.formatterCache = new FormatterCache(persistentStore, 100);
 
+        final boolean hideWithheld = true;
+        final long changeDate = new Date().getTime();
+        final Key key = new Key(1, "eng", FormatType.html, "full_view", hideWithheld);
+        formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("result", changeDate, false), true);
+
+        assertNull(formatterCache.getPublic(key));
+
+        formatterCache.get(key, new ChangeDateValidator(changeDate + 100), new TestLoader("published", changeDate, true), true);
+        assertEquals("published", formatterCache.getPublic(key));
+
+        formatterCache.get(key, new ChangeDateValidator(changeDate + 1000), new TestLoader("lastResult", changeDate, false), true);
+        assertNull(formatterCache.getPublic(key));
+    }
+
+    @Test
+    public void testMemoryCache() throws Exception {
+        final AtomicBoolean persistentStoreHit = new AtomicBoolean(false);
+        this.formatterCache = new FormatterCache(new PersistentStore() {
+            @Override
+            public StoreInfoAndData get(Key key) {
+                persistentStoreHit.set(true);
+                return new StoreInfoAndData("lksjdf", 234982734, false, 98345, 0);
+            }
+
+            @Override
+            public StoreInfo getInfo(Key key) {
+                return get(key);
+            }
+
+            @Override
+            public void put(Key key, StoreInfoAndData data) {
+                // ignore
+            }
+
+            @Nullable
+            @Override
+            public String getPublic(Key key) {
+                throw new UnsupportedOperationException("to implement");
+            }
+        }, 100);
+
+
+        final boolean hideWithheld = true;
+        final long changeDate = new Date().getTime();
+        final Key key = new Key(1, "eng", FormatType.html, "full_view", hideWithheld);
+        formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("result",changeDate, false), true);
+        assertEquals(true, persistentStoreHit.get());
+
+        persistentStoreHit.set(false);
+        String result = formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("result",changeDate, false), true);
+        assertEquals("result", result);
+        assertEquals(false, persistentStoreHit.get());
+    }
+
+    @Test
+    public void testThreadedPutWorks() throws Exception {
+        final MemoryPersistentStore persistentStore = new MemoryPersistentStore();
+        this.formatterCache = new FormatterCache(persistentStore, 100, new AbstractExecutorService() {
+            @Override
+            public void shutdown() {
+
+            }
+
+            @Override
+            public List<Runnable> shutdownNow() {
+                return null;
+            }
+
+            @Override
+            public boolean isShutdown() {
+                return false;
+            }
+
+            @Override
+            public boolean isTerminated() {
+                return false;
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+                return false;
+            }
+
+            @Override
+            public void execute(Runnable command) {
+
+            }
+        });
+
+
+        final boolean hideWithheld = true;
+        final long changeDate = new Date().getTime();
+        final Key key = new Key(1, "eng", FormatType.html, "full_view", hideWithheld);
+        formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("result", changeDate, false), false);
+    }
+
+    private static class TestLoader implements Callable<StoreInfoAndData> {
+        private final String resultToStore;
+        private final long changeDate;
+        private final boolean published;
+
+        public TestLoader(String resultToStore, long changeDate, boolean published) {
+            this.resultToStore = resultToStore;
+            this.changeDate = changeDate;
+            this.published = published;
+        }
+
+        @Override
+        public StoreInfoAndData call() throws Exception {
+            return new StoreInfoAndData(resultToStore, changeDate, published, 98345, 0);
+        }
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheTest.java
@@ -91,24 +91,26 @@ public class FormatterCacheTest {
         final AtomicBoolean persistentStoreHit = new AtomicBoolean(false);
         this.formatterCache = new FormatterCache(new PersistentStore() {
             @Override
-            public StoreInfoAndData get(Key key) {
+            @Nullable
+            public StoreInfoAndData get(@Nonnull Key key) {
                 persistentStoreHit.set(true);
                 return new StoreInfoAndData("lksjdf", 234982734, false);
             }
 
             @Override
-            public StoreInfo getInfo(Key key) {
+            @Nullable
+            public StoreInfo getInfo(@Nonnull Key key) {
                 return get(key);
             }
 
             @Override
-            public void put(Key key, StoreInfoAndData data) {
+            public void put(@Nonnull Key key, @Nonnull StoreInfoAndData data) {
                 // ignore
             }
 
             @Nullable
             @Override
-            public byte[] getPublished(Key key) {
+            public byte[] getPublished(@Nonnull Key key) {
                 throw new UnsupportedOperationException("to implement");
             }
 

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheTest.java
@@ -1,18 +1,18 @@
 package org.fao.geonet.services.metadata.format.cache;
 
+import org.fao.geonet.domain.Pair;
 import org.fao.geonet.services.metadata.format.FormatType;
 import org.junit.After;
 import org.junit.Test;
 
 import java.util.Date;
-import java.util.List;
-import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class FormatterCacheTest {
@@ -27,7 +27,7 @@ public class FormatterCacheTest {
     @Test
     public void testGet() throws Exception {
         final MemoryPersistentStore persistentStore = new MemoryPersistentStore();
-        this.formatterCache = new FormatterCache(persistentStore, 1);
+        this.formatterCache = new FormatterCache(persistentStore, 1, 5000);
 
         final boolean hideWithheld = true;
         final long changeDate = new Date().getTime();
@@ -65,7 +65,7 @@ public class FormatterCacheTest {
     @Test
     public void testGetPublic() throws Exception {
         final MemoryPersistentStore persistentStore = new MemoryPersistentStore();
-        this.formatterCache = new FormatterCache(persistentStore, 100);
+        this.formatterCache = new FormatterCache(persistentStore, 100, 5000);
 
         final boolean hideWithheld = true;
         final long changeDate = new Date().getTime();
@@ -106,7 +106,7 @@ public class FormatterCacheTest {
             public String getPublic(Key key) {
                 throw new UnsupportedOperationException("to implement");
             }
-        }, 100);
+        }, 100, 5000);
 
 
         final boolean hideWithheld = true;
@@ -121,46 +121,40 @@ public class FormatterCacheTest {
         assertEquals(false, persistentStoreHit.get());
     }
 
-    @Test
+    @Test(timeout = 1000L)
     public void testThreadedPutWorks() throws Exception {
         final MemoryPersistentStore persistentStore = new MemoryPersistentStore();
-        this.formatterCache = new FormatterCache(persistentStore, 100, new AbstractExecutorService() {
+        final AtomicBoolean waitForStartPut = new AtomicBoolean(false);
+        final AtomicBoolean waitForAllowPut = new AtomicBoolean(false);
+        final AtomicBoolean waitForDone = new AtomicBoolean(false);
+        this.formatterCache = new FormatterCache(persistentStore, 100, 5000) {
             @Override
-            public void shutdown() {
-
+            Runnable createPersistentStoreRunnable(BlockingQueue<Pair<Key, StoreInfoAndData>> storeRequests, PersistentStore store) {
+                return new PersistentStoreRunnable(storeRequests, store) {
+                    @Override
+                    void doStore(Pair<Key, StoreInfoAndData> request) throws InterruptedException {
+                        waitForStartPut.set(true);
+                        while(!waitForAllowPut.get()) {
+                            Thread.sleep(100);
+                        }
+                        super.doStore(request);
+                        waitForDone.set(true);
+                    }
+                };
             }
-
-            @Override
-            public List<Runnable> shutdownNow() {
-                return null;
-            }
-
-            @Override
-            public boolean isShutdown() {
-                return false;
-            }
-
-            @Override
-            public boolean isTerminated() {
-                return false;
-            }
-
-            @Override
-            public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-                return false;
-            }
-
-            @Override
-            public void execute(Runnable command) {
-
-            }
-        });
-
+        };
 
         final boolean hideWithheld = true;
         final long changeDate = new Date().getTime();
         final Key key = new Key(1, "eng", FormatType.html, "full_view", hideWithheld);
         formatterCache.get(key, new ChangeDateValidator(changeDate), new TestLoader("result", changeDate, false), false);
+        waitForStartPut.set(true);
+        assertNull(persistentStore.get(key));
+        waitForAllowPut.set(true);
+        while(!waitForDone.get()) {
+            Thread.sleep(100);
+        }
+        assertNotNull(persistentStore.get(key));
     }
 
     private static class TestLoader implements Callable<StoreInfoAndData> {

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/FormatterCacheTest.java
@@ -1,0 +1,33 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import org.fao.geonet.AbstractCoreIntegrationTest;
+import org.fao.geonet.services.metadata.format.FormatType;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.concurrent.Callable;
+
+public class FormatterCacheTest extends AbstractCoreIntegrationTest {
+
+    @Test
+    public void testGet() throws Exception {
+        final FormatterCache formatterCache = new FormatterCache(new MemoryPersistentStore());
+
+
+        final boolean hideWithheld = true;
+        final long changeDate = new Date().getTime();
+        formatterCache.get(new Key(1, "eng", FormatType.html, "full_view", hideWithheld), new ChangeDateValidator(changeDate), new Callable<StoreInfo>() {
+            @Override
+            public StoreInfo call() throws Exception {
+                return new StoreInfo("result", changeDate, false);
+            }
+        }, true);
+
+
+    }
+
+    @Test
+    public void testGetPublic() throws Exception {
+
+    }
+}

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
@@ -1,7 +1,10 @@
 package org.fao.geonet.services.metadata.format.cache;
 
+import java.io.IOException;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -10,27 +13,32 @@ import javax.annotation.Nullable;
 public class MemoryPersistentStore implements PersistentStore {
     Map<Key, StoreInfoAndData> dataMap = new HashMap<>();
     @Override
-    public StoreInfoAndData get(Key key) {
+    public StoreInfoAndData get(@Nonnull Key key) {
         return dataMap.get(key);
     }
 
     @Override
-    public StoreInfo getInfo(Key key) {
+    public StoreInfo getInfo(@Nonnull Key key) {
         return dataMap.get(key);
     }
 
     @Override
-    public void put(Key key, StoreInfoAndData data) {
+    public void put(@Nonnull Key key, @Nonnull StoreInfoAndData data) {
         this.dataMap.put(key, data);
     }
 
     @Nullable
     @Override
-    public String getPublic(Key key) {
+    public byte[] getPublic(@Nonnull Key key) {
         final StoreInfoAndData storeInfoAndData = dataMap.get(key);
         if (storeInfoAndData.isPublished()) {
-            return storeInfoAndData.getResult();
+            return storeInfoAndData.data;
         }
         return null;
+    }
+
+    @Override
+    public void remove(@Nonnull Key key) throws IOException, SQLException {
+        this.dataMap.remove(key);
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
@@ -1,7 +1,36 @@
 package org.fao.geonet.services.metadata.format.cache;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
 /**
  * @author Jesse on 3/5/2015.
  */
 public class MemoryPersistentStore implements PersistentStore {
+    Map<Key, StoreInfoAndData> dataMap = new HashMap<>();
+    @Override
+    public StoreInfoAndData get(Key key) {
+        return dataMap.get(key);
+    }
+
+    @Override
+    public StoreInfo getInfo(Key key) {
+        return dataMap.get(key);
+    }
+
+    @Override
+    public void put(Key key, StoreInfoAndData data) {
+        this.dataMap.put(key, data);
+    }
+
+    @Nullable
+    @Override
+    public String getPublic(Key key) {
+        final StoreInfoAndData storeInfoAndData = dataMap.get(key);
+        if (storeInfoAndData.isPublished()) {
+            return storeInfoAndData.getResult();
+        }
+        return null;
+    }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
@@ -1,5 +1,7 @@
 package org.fao.geonet.services.metadata.format.cache;
 
+import com.google.common.collect.Lists;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -29,7 +31,7 @@ public class MemoryPersistentStore implements PersistentStore {
 
     @Nullable
     @Override
-    public byte[] getPublic(@Nonnull Key key) {
+    public byte[] getPublished(@Nonnull Key key) {
         final StoreInfoAndData storeInfoAndData = dataMap.get(key);
         if (storeInfoAndData.isPublished()) {
             return storeInfoAndData.data;
@@ -40,5 +42,14 @@ public class MemoryPersistentStore implements PersistentStore {
     @Override
     public void remove(@Nonnull Key key) throws IOException, SQLException {
         this.dataMap.remove(key);
+    }
+
+    @Override
+    public void setPublished(int metadataId, boolean published) {
+        for (Map.Entry<Key, StoreInfoAndData> dataEntry : Lists.newArrayList(dataMap.entrySet())) {
+            final byte[] data = dataEntry.getValue().data;
+            final long changeDate = dataEntry.getValue().getChangeDate();
+            dataMap.put(dataEntry.getKey(), new StoreInfoAndData(data, changeDate, true));
+        }
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
@@ -1,0 +1,7 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+/**
+ * @author Jesse on 3/5/2015.
+ */
+public class MemoryPersistentStore implements PersistentStore {
+}

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/MemoryPersistentStore.java
@@ -33,7 +33,7 @@ public class MemoryPersistentStore implements PersistentStore {
     @Override
     public byte[] getPublished(@Nonnull Key key) {
         final StoreInfoAndData storeInfoAndData = dataMap.get(key);
-        if (storeInfoAndData.isPublished()) {
+        if (storeInfoAndData != null && storeInfoAndData.isPublished() && key.hideWithheld) {
             return storeInfoAndData.data;
         }
         return null;

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
@@ -1,0 +1,58 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * @author Jesse on 3/5/2015.
+ */
+public class NoCachingStore extends FormatterCache {
+    public NoCachingStore() {
+        super(new MemoryPersistentStore(), 10, 10, new AbstractExecutorService() {
+            @Override
+            public void shutdown() {
+
+            }
+
+            @Override
+            public List<Runnable> shutdownNow() {
+                return null;
+            }
+
+            @Override
+            public boolean isShutdown() {
+                return false;
+            }
+
+            @Override
+            public boolean isTerminated() {
+                return false;
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+                return false;
+            }
+
+            @Override
+            public void execute(Runnable command) {
+
+            }
+        });
+    }
+
+    @Nullable
+    @Override
+    public String get(Key key, Validator validator, Callable<StoreInfoAndData> loader, boolean writeToStoreInCurrentThread) throws Exception {
+        return loader.call().getResult();
+    }
+
+    @Nullable
+    @Override
+    public String getPublic(Key key) {
+        return null;
+    }
+}

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
@@ -47,12 +47,12 @@ public class NoCachingStore extends FormatterCache {
     @Nullable
     @Override
     public String get(Key key, Validator validator, Callable<StoreInfoAndData> loader, boolean writeToStoreInCurrentThread) throws Exception {
-        return loader.call().getResult();
+        return loader.call().getDataAsString();
     }
 
     @Nullable
     @Override
-    public String getPublic(Key key) {
+    public byte[] getPublic(Key key) {
         return null;
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
  */
 public class NoCachingStore extends FormatterCache {
     public NoCachingStore() {
-        super(new MemoryPersistentStore(), 10, 10, new AbstractExecutorService() {
+        super(new MemoryPersistentStore(), 10, 10, new ConfigurableCacheConfig(), new AbstractExecutorService() {
             @Override
             public void shutdown() {
 
@@ -46,8 +46,8 @@ public class NoCachingStore extends FormatterCache {
 
     @Nullable
     @Override
-    public String get(Key key, Validator validator, Callable<StoreInfoAndData> loader, boolean writeToStoreInCurrentThread) throws Exception {
-        return loader.call().getDataAsString();
+    public byte[] get(Key key, Validator validator, Callable<StoreInfoAndData> loader, boolean writeToStoreInCurrentThread) throws Exception {
+        return loader.call().data;
     }
 
     @Nullable

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
@@ -52,7 +52,7 @@ public class NoCachingStore extends FormatterCache {
 
     @Nullable
     @Override
-    public byte[] getPublic(Key key) {
+    public byte[] getPublished(Key key) {
         return null;
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/NoCachingStore.java
@@ -46,7 +46,8 @@ public class NoCachingStore extends FormatterCache {
 
     @Nullable
     @Override
-    public byte[] get(Key key, Validator validator, Callable<StoreInfoAndData> loader, boolean writeToStoreInCurrentThread) throws Exception {
+    public byte[] get(Key key, Validator validator, Callable<StoreInfoAndDataLoadResult> loader,
+                      boolean writeToStoreInCurrentThread) throws Exception {
         return loader.call().data;
     }
 

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/TestLoader.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/TestLoader.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Callable;
 /**
 * @author Jesse on 3/6/2015.
 */
-public class TestLoader implements Callable<StoreInfoAndData> {
+public class TestLoader implements Callable<StoreInfoAndDataLoadResult> {
     private final String resultToStore;
     private final long changeDate;
     private final boolean published;
@@ -17,7 +17,7 @@ public class TestLoader implements Callable<StoreInfoAndData> {
     }
 
     @Override
-    public StoreInfoAndData call() throws Exception {
-        return new StoreInfoAndData(resultToStore, changeDate, published);
+    public StoreInfoAndDataLoadResult call() throws Exception {
+        return new StoreInfoAndDataLoadResult(resultToStore, changeDate, published, null, null);
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/cache/TestLoader.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/cache/TestLoader.java
@@ -1,0 +1,23 @@
+package org.fao.geonet.services.metadata.format.cache;
+
+import java.util.concurrent.Callable;
+
+/**
+* @author Jesse on 3/6/2015.
+*/
+public class TestLoader implements Callable<StoreInfoAndData> {
+    private final String resultToStore;
+    private final long changeDate;
+    private final boolean published;
+
+    public TestLoader(String resultToStore, long changeDate, boolean published) {
+        this.resultToStore = resultToStore;
+        this.changeDate = changeDate;
+        this.published = published;
+    }
+
+    @Override
+    public StoreInfoAndData call() throws Exception {
+        return new StoreInfoAndData(resultToStore, changeDate, published);
+    }
+}

--- a/services/src/test/resources/formatter-cache-test-context.xml
+++ b/services/src/test/resources/formatter-cache-test-context.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans default-lazy-init="true" xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  <bean id="fsStore" class="org.fao.geonet.services.metadata.format.cache.FilesystemStore" lazy-init="true">
+    <property name="maxSizeGb" value="500" />
+    <property name="testing" value="true" />
+  </bean>
+
+  <bean id="formatterCache" class="org.fao.geonet.services.metadata.format.cache.FormatterCache"  lazy-init="true">
+    <constructor-arg index="0" ref="fsStore"/>
+    <constructor-arg index="1" value="500000" />
+    <constructor-arg index="2" value="5000" />
+  </bean>
+
+</beans>

--- a/services/src/test/resources/services-repository-test-context.xml
+++ b/services/src/test/resources/services-repository-test-context.xml
@@ -35,4 +35,8 @@
         <value>tur</value>
     </util:set>
 
+    <bean id="formatterCache"
+      class="org.fao.geonet.services.metadata.format.cache.NoCachingStore">
+    </bean>
+
 </beans>

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -95,6 +95,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import java.io.File;
 import java.net.URI;
@@ -477,7 +478,7 @@ public class Geonetwork implements ApplicationHandler {
                         final MockHttpServletResponse response = new MockHttpServletResponse();
                         try {
                             formatService.exec("eng", FormatType.html.toString(), mdId.toString(), null, formatterName,
-                                    Boolean.TRUE.toString(), false, servletRequest, response);
+                                    Boolean.TRUE.toString(), false, new ServletWebRequest(servletRequest, response));
                         } catch (Throwable t) {
                             Log.info(Geonet.GEONETWORK, "Error while initializing the Formatter with id: " + formatterName, t);
                         }

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -401,6 +401,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.format.xml!?.*" access="permitAll"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.format.pdf!?.*" access="permitAll"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.format.text!?.*" access="permitAll"/>
+                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.format.public.!?.*" access="permitAll"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.formatter.resource!?.*" access="permitAll"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.formatter.list!?.*" access="permitAll"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.formatter.register!?.*" access="hasRole('UserAdmin')"/>

--- a/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
@@ -101,6 +101,7 @@
     <util:list id="formattersToInitialize" value-type="java.lang.String" >
         <value>full_view</value>
         <value>xml_view</value>
+        <value>hierarchy_view</value>
     </util:list>
 
     <util:set id="formatterRemoteFormatAllowedHosts" value-type="java.lang.String">


### PR DESCRIPTION
This PR does 2 things:

1. Adds support for 304 and If-Modified-Since
2. Caches formatter results in memory and on disk

During Both 304 and FormatterCaching, the popularity is still updated and the access restriction is still checked.

## 304 Not Modified Support
The Change date is used to calculate the LastModified value for the document so that the browser will cache the formatter output and only reload when the metadata has been updated.  

## FormatterCache
A FormatterCache object has been added which caches the output of a formatter.  There is a Key object that encapsulates:

* The metadata Id
* The formatter id
* The language
* The format type (html, xml, pdf, etc...)
* If elements are withheld

Based on these parameters, a new cache entry will be created because each of these could result in a different output.  

If there are any parameters in the request besides these then the output is not cached (but 304 will still work).  The reason for this is that an attacker could try to pollute the cache by making requests with different parameters (each one causing a new cache entry).

In the default configuration there is a dual store.  An in-memory LRU cache and an on-disk cache.  The in-memory cache is used when possible for maximum performance but each cache entry is put both in the in-memory cache and written to disk.  Because the entries are all written to disk a cache of all metadata could be maintained.  For example each night the entire catalog could processed so that all metadata for a particular formatter is pre-generated making requests for the metadata very efficient.

In order to optimize for SCO, the cached entries for all published metadata are written to separate folder.  In this case you could indicate to google to index that folder or a site map could be generated from that folder.   There are listeners which will correctly remove the published entries when the associated metadata are unpublished or deleted.  

To ensure that no information leaks, only cache entries of metadata that are published and where the withheld elements are hidden.  For example, if an editor views his/her metadata a cache entry is created with all elements (for him/her) but in addition (if the metadata is public) a second cache entry will be made with the withheld elements hidden and that entry will be the one marked as published.

At the moment there are no listeners that listen for metadata update events for generating the cache but it would be natural to add that functionality in the future so the cache is always fresh.

The persistence store (in this case filesystem) is configurable and if desired other implementations could be developed.


## Cache Config
It is important to be able to control which requests are cached and which are not.  There is a CacheConfig object that allows which requests can be cached and which cannot.  

The config object is configured in the config-spring-geonetwork.xml that is in the services modules.

Some of the parameters that are cacheable are:

* Specify a set of formatters that can be cached
* Specify a set of formatters that can *not* be cached
* Specify a set of content types that can be cached
* Specify a set of content types that can *not* be cached

See org.fao.geonet.services.metadata.format.cache.ConfigurableCacheConfig for all the options.  

Caching is disabled during development.

The CacheConfig is checked for both 304 Not Modified calculation as well as when reading from the FormatterCache object.