### PR TITLE
Option to speed up geoNetwork harvester using changeDate

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/RecordInfo.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/RecordInfo.java
@@ -96,6 +96,10 @@ public class RecordInfo
 
 		ISODate remoteDate = new ISODate(changeDate);
 		ISODate localDate  = new ISODate(localChangeDate);
+        
+        if(remoteDate.timeDifferenceInSeconds(localDate) == 0) {
+            return false;
+        }
 
         //--- modified:  we accept metadata modified from 24 hours before
         //--- to harvest several changes during a day (if short date format used) or date local differences

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -1,24 +1,24 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
+//===    Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===    United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===    and United Nations Environment Programme (UNEP)
 //===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
+//===    This program is free software; you can redistribute it and/or modify
+//===    it under the terms of the GNU General Public License as published by
+//===    the Free Software Foundation; either version 2 of the License, or (at
+//===    your option) any later version.
 //===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
+//===    This program is distributed in the hope that it will be useful, but
+//===    WITHOUT ANY WARRANTY; without even the implied warranty of
+//===    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===    General Public License for more details.
 //===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===    You should have received a copy of the GNU General Public License
+//===    along with this program; if not, write to the Free Software
+//===    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 //===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
+//===    Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===    Rome - Italy. email: geonetwork@osgeo.org
 //==============================================================================
 
 package org.fao.geonet.kernel.harvest.harvester.geonet;
@@ -84,26 +84,26 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Aligner extends BaseAligner
 {
-	//--------------------------------------------------------------------------
-	//---
-	//--- Constructor
-	//---
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //---
+    //--- Constructor
+    //---
+    //--------------------------------------------------------------------------
 
-	public Aligner(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, XmlRequest req,
+    public Aligner(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, XmlRequest req,
                    GeonetParams params, Element remoteInfo)
-	{
+    {
         super(cancelMonitor);
-		this.log     = log;
-		this.context = context;
-		this.request = req;
-		this.params  = params;
+        this.log     = log;
+        this.context = context;
+        this.request = req;
+        this.params  = params;
 
-		GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
-		dataMan = gc.getBean(DataManager.class);
-		result  = new HarvestResult();
+        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+        dataMan = gc.getBean(DataManager.class);
+        result  = new HarvestResult();
 
-		//--- save remote categories and groups into hashmaps for a fast access
+        //--- save remote categories and groups into hashmaps for a fast access
 
         // Before 2.11 response contains groups. Now group is used.
         Element groups = remoteInfo.getChild("groups");
@@ -115,12 +115,12 @@ public class Aligner extends BaseAligner
             List<Element> list = groups.getChildren("group");
             setupLocEntity(list, hmRemoteGroups);
         }
-	}
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private void setupLocEntity(List<Element> list, HashMap<String, HashMap<String, String>> hmEntity)
-	{
+    private void setupLocEntity(List<Element> list, HashMap<String, HashMap<String, String>> hmEntity)
+    {
 
         for (Element entity : list) {
             String name = entity.getChildText("name");
@@ -135,25 +135,25 @@ public class Aligner extends BaseAligner
                 hm.put(el.getName(), el.getText());
             }
         }
-	}
+    }
 
-	//--------------------------------------------------------------------------
-	//---
-	//--- Alignment method
-	//---
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //---
+    //--- Alignment method
+    //---
+    //--------------------------------------------------------------------------
 
-	public HarvestResult align(Set<RecordInfo> records, List<HarvestError> errors) throws Exception
-	{
-		log.info("Start of alignment for : "+ params.getName());
+    public HarvestResult align(Set<RecordInfo> records, List<HarvestError> errors) throws Exception
+    {
+        log.info("Start of alignment for : "+ params.getName());
 
         //-----------------------------------------------------------------------
-		//--- retrieve all local categories and groups
-		//--- retrieve harvested uuids for given harvesting node
+        //--- retrieve all local categories and groups
+        //--- retrieve harvested uuids for given harvesting node
 
-		localCateg = new CategoryMapper(context);
-		localGroups= new GroupMapper(context);
-		localUuids = new UUIDMapper(context.getBean(MetadataRepository.class), params.getUuid());
+        localCateg = new CategoryMapper(context);
+        localGroups= new GroupMapper(context);
+        localUuids = new UUIDMapper(context.getBean(MetadataRepository.class), params.getUuid());
 
         dataMan.flush();
 
@@ -161,12 +161,12 @@ public class Aligner extends BaseAligner
                 HarvesterUtil.parseXSLFilter(params.xslfilter, log);
         processName = filter.one();
         processParams = filter.two();
-		
-		//-----------------------------------------------------------------------
-		//--- remove old metadata
+        
+        //-----------------------------------------------------------------------
+        //--- remove old metadata
 
-		for (String uuid : localUuids.getUUIDs()) {
-		    //FIXME can we do it on one step?
+        for (String uuid : localUuids.getUUIDs()) {
+            //FIXME can we do it on one step?
             if (cancelMonitor.get()) {
                 return this.result;
             }
@@ -182,8 +182,8 @@ public class Aligner extends BaseAligner
                 result.locallyRemoved++;
             }
         }
-		//-----------------------------------------------------------------------
-		//--- insert/update new metadata
+        //-----------------------------------------------------------------------
+        //--- insert/update new metadata
 // Load preferred schema and set to iso19139 by default
         preferredSchema = context.getBean(ServiceConfig.class).getMandatoryValue("preferredSchema");
         if (preferredSchema == null) {
@@ -200,38 +200,38 @@ public class Aligner extends BaseAligner
             // Mef full format provides ISO19139 records in both the profile
             // and ISO19139 so we could be able to import them as far as
             // ISO19139 schema is installed by default.
-			if (!dataMan.existsSchema(ri.schema) && !ri.schema.startsWith("iso19139.")) {
+            if (!dataMan.existsSchema(ri.schema) && !ri.schema.startsWith("iso19139.")) {
                 if(log.isDebugEnabled())
                     log.debug("  - Metadata skipped due to unknown schema. uuid:"+ ri.uuid
-						 	+", schema:"+ ri.schema);
-				result.unknownSchema++;
-			} else {
-				String id = dataMan.getMetadataId(ri.uuid);
+                             +", schema:"+ ri.schema);
+                result.unknownSchema++;
+            } else {
+                String id = dataMan.getMetadataId(ri.uuid);
 
-				// look up value of localrating/enable
-				GeonetContext  gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
-				SettingManager settingManager = gc.getBean(SettingManager.class);
-				boolean localRating = settingManager.getValueAsBool("system/localrating/enable", false);
-				
-				if (id == null) {
+                // look up value of localrating/enable
+                GeonetContext  gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+                SettingManager settingManager = gc.getBean(SettingManager.class);
+                boolean localRating = settingManager.getValueAsBool("system/localrating/enable", false);
+                
+                if (id == null) {
                     addMetadata(ri, localRating);
                 } else {
-					updateMetadata(ri, id, localRating, params.useChangeDateForUpdate(), localUuids.getChangeDate(ri.uuid));
-				}
-			}
-		}
+                    updateMetadata(ri, id, localRating, params.useChangeDateForUpdate(), localUuids.getChangeDate(ri.uuid));
+                }
+            }
+        }
 
-		log.info("End of alignment for : "+ params.getName());
+        log.info("End of alignment for : "+ params.getName());
 
-		return result;
-	}
+        return result;
+    }
 
 
-	//--------------------------------------------------------------------------
-	//---
-	//--- Private methods : addMetadata
-	//---
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //---
+    //--- Private methods : addMetadata
+    //---
+    //--------------------------------------------------------------------------
     private Element extractValidMetadataForImport (DirectoryStream<Path> files, Element info) throws IOException, JDOMException {
         Element metadataValidForImport;
         final String finalPreferredSchema = preferredSchema;
@@ -310,16 +310,16 @@ public class Aligner extends BaseAligner
 
         return metadataValidForImport;
     }
-	private void addMetadata(final RecordInfo ri, final boolean localRating) throws Exception
-	{
-		final String  id[] = { null };
-		final Element md[] = { null };
+    private void addMetadata(final RecordInfo ri, final boolean localRating) throws Exception
+    {
+        final String  id[] = { null };
+        final Element md[] = { null };
 
-		//--- import metadata from MEF file
+        //--- import metadata from MEF file
 
-		Path mefFile = retrieveMEF(ri.uuid);
+        Path mefFile = retrieveMEF(ri.uuid);
 
-		try {
+        try {
             String fileType = "mef";
             MEFLib.Version version = MEFLib.getMEFVersion(mefFile);
             if (version != null && version.equals(MEFLib.Version.V2)) {
@@ -329,27 +329,27 @@ public class Aligner extends BaseAligner
             IVisitor visitor = fileType.equals("mef2") ? new MEF2Visitor() : new MEFVisitor();
 
             MEFLib.visit(mefFile, visitor, new IMEFVisitor()
-		{
-				public void handleMetadata(Element mdata, int index) throws Exception
-				{
-					md[index] = mdata;
-				}
+        {
+                public void handleMetadata(Element mdata, int index) throws Exception
+                {
+                    md[index] = mdata;
+                }
 
-				//--------------------------------------------------------------------
-				
+                //--------------------------------------------------------------------
+                
                 public void handleMetadataFiles(DirectoryStream<Path> files, Element info, int index) throws Exception {
                     // Import valid metadata
                     Element metadataValidForImport = extractValidMetadataForImport(files, info);
-				
+                
                     if (metadataValidForImport != null) {
                         handleMetadata(metadataValidForImport, index);
                     }
                 }
-				
-				//--------------------------------------------------------------------
+                
+                //--------------------------------------------------------------------
 
-				public void handleInfo(Element info, int index) throws Exception
-				{
+                public void handleInfo(Element info, int index) throws Exception
+                {
 
                     final Element metadata = md[index];
                     String schema = dataMan.autodetectSchema(metadata, null);
@@ -362,78 +362,78 @@ public class Aligner extends BaseAligner
                             }
                         }
                     }
-					id[index] = addMetadata(ri, md[index], info, localRating);
-				}
+                    id[index] = addMetadata(ri, md[index], info, localRating);
+                }
 
-				//--------------------------------------------------------------------
+                //--------------------------------------------------------------------
 
-				public void handlePublicFile(String file, String changeDate, InputStream is, int index) throws IOException
-				{
+                public void handlePublicFile(String file, String changeDate, InputStream is, int index) throws IOException
+                {
                     if (id[index] == null) return;
 
                     if(log.isDebugEnabled()) log.debug("    - Adding remote public file with name:"+ file);
-					Path pubDir = Lib.resource.getDir(context, "public", id[index]);
+                    Path pubDir = Lib.resource.getDir(context, "public", id[index]);
 
-					Path outFile = pubDir.resolve(file);
-					try (OutputStream os = Files.newOutputStream(outFile)){
-    					BinaryFile.copy(is, os);
-    					IO.touch(outFile, FileTime.from(new ISODate(changeDate).getTimeInSeconds(), TimeUnit.SECONDS));
-					}
-				}
-				
-				public void handleFeatureCat(Element md, int index)
-						throws Exception {
-					// Feature Catalog not managed for harvesting
-				}
+                    Path outFile = pubDir.resolve(file);
+                    try (OutputStream os = Files.newOutputStream(outFile)){
+                        BinaryFile.copy(is, os);
+                        IO.touch(outFile, FileTime.from(new ISODate(changeDate).getTimeInSeconds(), TimeUnit.SECONDS));
+                    }
+                }
+                
+                public void handleFeatureCat(Element md, int index)
+                        throws Exception {
+                    // Feature Catalog not managed for harvesting
+                }
 
-				public void handlePrivateFile(String file, String changeDate,
-						InputStream is, int index) throws IOException {
-				    if (params.mefFormatFull) {
+                public void handlePrivateFile(String file, String changeDate,
+                        InputStream is, int index) throws IOException {
+                    if (params.mefFormatFull) {
                         if(log.isDebugEnabled())
                             log.debug("    - Adding remote private file with name:" + file + " available for download for user used for harvester.");
-	                    Path dir = Lib.resource.getDir(context, "private", id[index]);
-	                    Path outFile = dir.resolve(file);
-	                    try (OutputStream os = Files.newOutputStream(outFile)){
-    	                    BinaryFile.copy(is, os);
-    	                    IO.touch(outFile, FileTime.from(new ISODate(changeDate).getTimeInSeconds(), TimeUnit.SECONDS));
-	                    }
-				    }
-				}
-			});
-		}
-		catch(Exception e)
-		{
-			//--- we ignore the exception here. Maybe the metadata has been removed just now
+                        Path dir = Lib.resource.getDir(context, "private", id[index]);
+                        Path outFile = dir.resolve(file);
+                        try (OutputStream os = Files.newOutputStream(outFile)){
+                            BinaryFile.copy(is, os);
+                            IO.touch(outFile, FileTime.from(new ISODate(changeDate).getTimeInSeconds(), TimeUnit.SECONDS));
+                        }
+                    }
+                }
+            });
+        }
+        catch(Exception e)
+        {
+            //--- we ignore the exception here. Maybe the metadata has been removed just now
             if(log.isDebugEnabled())
                 log.debug("  - Skipped unretrievable metadata (maybe has been removed) with uuid:"+ ri.uuid);
-			result.unretrievable++;
-			e.printStackTrace();
-		}
-		finally
-		{
+            result.unretrievable++;
+            e.printStackTrace();
+        }
+        finally
+        {
             try {
                 Files.deleteIfExists(mefFile);
             } catch (IOException e) {
-		         log.warning("Unable to delete mefFile: "+mefFile);
-		     }
-		}
-	}
+                 log.warning("Unable to delete mefFile: "+mefFile);
+             }
+        }
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private String addMetadata(RecordInfo ri, Element md, Element info, boolean localRating) throws Exception
-	{
-		Element general = info.getChild("general");
+    private String addMetadata(RecordInfo ri, Element md, Element info, boolean localRating) throws Exception
+    {
+        Element general = info.getChild("general");
 
-		String createDate = general.getChildText("createDate");
-		String changeDate = general.getChildText("changeDate");
-		String isTemplate = general.getChildText("isTemplate");
-		String siteId     = general.getChildText("siteId");
-		String popularity = general.getChildText("popularity");
+        String createDate = general.getChildText("createDate");
+        String changeDate = general.getChildText("changeDate");
+        String isTemplate = general.getChildText("isTemplate");
+        String siteId     = general.getChildText("siteId");
+        String popularity = general.getChildText("popularity");
         String schema = general.getChildText("schema");
 
-		if ("true".equals(isTemplate))	isTemplate = "y";
-			else 									isTemplate = "n";
+        if ("true".equals(isTemplate))    isTemplate = "y";
+            else                                     isTemplate = "n";
 
         if(log.isDebugEnabled()) log.debug("  - Adding metadata with remote uuid:"+ ri.uuid);
 
@@ -472,19 +472,19 @@ public class Aligner extends BaseAligner
 
         String id = String.valueOf(metadata.getId());
 
-		if(!localRating) {
-			String rating = general.getChildText("rating");
-			if (rating != null) {
+        if(!localRating) {
+            String rating = general.getChildText("rating");
+            if (rating != null) {
                 metadata.getDataInfo().setRating(Integer.valueOf(rating));
             }
-		}
+        }
 
-		if (popularity != null) {
+        if (popularity != null) {
             metadata.getDataInfo().setPopularity(Integer.valueOf(popularity));
         }
 
 
-		Path pubDir = Lib.resource.getDir(context, "public",  id);
+        Path pubDir = Lib.resource.getDir(context, "public",  id);
         Path priDir = Lib.resource.getDir(context, "private", id);
 
         Files.createDirectories(pubDir);
@@ -504,120 +504,120 @@ public class Aligner extends BaseAligner
         context.getBean(MetadataRepository.class).save(metadata);
 
         dataMan.indexMetadata(id, true);
-		result.addedMetadata++;
+        result.addedMetadata++;
 
-		return id;
-	}
+        return id;
+    }
 
-	//--------------------------------------------------------------------------
-	//--- Privileges
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //--- Privileges
+    //--------------------------------------------------------------------------
 
-	private void addPrivilegesFromGroupPolicy(String id, Element privil) throws Exception
-	{
-		Map<String, Set<String>> groupOper = buildPrivileges(privil);
+    private void addPrivilegesFromGroupPolicy(String id, Element privil) throws Exception
+    {
+        Map<String, Set<String>> groupOper = buildPrivileges(privil);
 
-		for (Group remoteGroup : params.getGroupCopyPolicy())
-		{
-			//--- get operations allowed to remote group
-			Set<String> oper = groupOper.get(remoteGroup.name);
+        for (Group remoteGroup : params.getGroupCopyPolicy())
+        {
+            //--- get operations allowed to remote group
+            Set<String> oper = groupOper.get(remoteGroup.name);
 
-			//--- if we don't find any match, maybe the remote group has been removed
+            //--- if we don't find any match, maybe the remote group has been removed
 
-			if (oper == null)
-				log.info("    - Remote group has been removed or no privileges exist : "+ remoteGroup.name);
-			else
-			{
-				String localGrpId = localGroups.getID(remoteGroup.name);
+            if (oper == null)
+                log.info("    - Remote group has been removed or no privileges exist : "+ remoteGroup.name);
+            else
+            {
+                String localGrpId = localGroups.getID(remoteGroup.name);
 
-				if (localGrpId == null)
-				{
-					//--- group does not exist locally
+                if (localGrpId == null)
+                {
+                    //--- group does not exist locally
 
-					if (remoteGroup.policy == Group.CopyPolicy.CREATE_AND_COPY)
-					{
+                    if (remoteGroup.policy == Group.CopyPolicy.CREATE_AND_COPY)
+                    {
                         if(log.isDebugEnabled()) log.debug("    - Creating local group : "+ remoteGroup.name);
-						localGrpId = createGroup(remoteGroup.name);
+                        localGrpId = createGroup(remoteGroup.name);
 
-						if (localGrpId == null)
-							log.info("    - Specified group was not found remotely : "+ remoteGroup.name);
-						else
-						{
+                        if (localGrpId == null)
+                            log.info("    - Specified group was not found remotely : "+ remoteGroup.name);
+                        else
+                        {
                             if(log.isDebugEnabled()) log.debug("    - Setting privileges for group : "+ remoteGroup.name);
-							addOperations(id, localGrpId, oper);
-						}
-					}
-				}
-				else
-				{
-					//--- group exists locally
+                            addOperations(id, localGrpId, oper);
+                        }
+                    }
+                }
+                else
+                {
+                    //--- group exists locally
 
-					if (remoteGroup.policy == Group.CopyPolicy.COPY_TO_INTRANET)
-					{
+                    if (remoteGroup.policy == Group.CopyPolicy.COPY_TO_INTRANET)
+                    {
                         if(log.isDebugEnabled()) log.debug("    - Setting privileges for 'intranet' group");
-						addOperations(id, "0", oper);
-					}
-					else
-					{
+                        addOperations(id, "0", oper);
+                    }
+                    else
+                    {
                         if(log.isDebugEnabled()) log.debug("    - Setting privileges for group : "+ remoteGroup.name);
-						addOperations(id, localGrpId, oper);
-					}
-				}
-			}
-		}
-	}
+                        addOperations(id, localGrpId, oper);
+                    }
+                }
+            }
+        }
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private Map<String, Set<String>> buildPrivileges(Element privil)
-	{
-		Map<String, Set<String>> map = new HashMap<String, Set<String>>();
+    private Map<String, Set<String>> buildPrivileges(Element privil)
+    {
+        Map<String, Set<String>> map = new HashMap<String, Set<String>>();
 
-		for (Object o : privil.getChildren("group"))
-		{
-			Element group = (Element) o;
-			String  name  = group.getAttributeValue("name");
+        for (Object o : privil.getChildren("group"))
+        {
+            Element group = (Element) o;
+            String  name  = group.getAttributeValue("name");
 
-			Set<String> set = new HashSet<String>();
-			map.put(name, set);
+            Set<String> set = new HashSet<String>();
+            map.put(name, set);
 
-			for (Object op : group.getChildren("operation"))
-			{
-				Element oper = (Element) op;
-				name = oper.getAttributeValue("name");
-				set.add(name);
-			}
-		}
+            for (Object op : group.getChildren("operation"))
+            {
+                Element oper = (Element) op;
+                name = oper.getAttributeValue("name");
+                set.add(name);
+            }
+        }
 
-		return map;
-	}
+        return map;
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private void addOperations(String id, String groupId, Set<String> oper) throws Exception
-	{
-		for (String opName : oper)
-		{
-			int opId = dataMan.getAccessManager().getPrivilegeId(opName);
+    private void addOperations(String id, String groupId, Set<String> oper) throws Exception
+    {
+        for (String opName : oper)
+        {
+            int opId = dataMan.getAccessManager().getPrivilegeId(opName);
 
-			//--- allow only: view, download, dynamic, featured
-			if (opId == 0 || opId == 1 || opId == 5 || opId == 6) {
+            //--- allow only: view, download, dynamic, featured
+            if (opId == 0 || opId == 1 || opId == 5 || opId == 6) {
                 if(log.isDebugEnabled()) log.debug("       --> "+ opName);
-				dataMan.setOperation(context, id, groupId, opId +"");
-			} else {
+                dataMan.setOperation(context, id, groupId, opId +"");
+            } else {
                 if(log.isDebugEnabled()) log.debug("       --> "+ opName +" (skipped)");
             }
-		}
-	}
+        }
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private String createGroup(String name) throws Exception
-	{
-		Map<String, String> hm = hmRemoteGroups.get(name);
+    private String createGroup(String name) throws Exception
+    {
+        Map<String, String> hm = hmRemoteGroups.get(name);
 
-		if (hm == null)
-			return null;
+        if (hm == null)
+            return null;
 
         org.fao.geonet.domain.Group group = new org.fao.geonet.domain.Group()
                 .setName(name);
@@ -626,33 +626,33 @@ public class Aligner extends BaseAligner
         group = context.getBean(GroupRepository.class).save(group);
 
         int id = group.getId();
-		localGroups.add(name, id +"");
+        localGroups.add(name, id +"");
 
-		return id +"";
-	}
+        return id +"";
+    }
 
-	//--------------------------------------------------------------------------
-	//---
-	//--- Private methods : updateMetadata
-	//---
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //---
+    //--- Private methods : updateMetadata
+    //---
+    //--------------------------------------------------------------------------
 
-	private void updateMetadata(final RecordInfo ri, final String id, final boolean localRating, 
-	        final boolean useChangeDate, String localChangeDate) throws Exception
-	{
-		final Element md[]     = { null };
-		final Element publicFiles[] = { null };
-		final Element privateFiles[] = { null };
+    private void updateMetadata(final RecordInfo ri, final String id, final boolean localRating, 
+            final boolean useChangeDate, String localChangeDate) throws Exception
+    {
+        final Element md[]     = { null };
+        final Element publicFiles[] = { null };
+        final Element privateFiles[] = { null };
 
-		if (localUuids.getID(ri.uuid) == null) {
+        if (localUuids.getID(ri.uuid) == null) {
             if(log.isDebugEnabled())
                 log.debug("  - Skipped metadata managed by another harvesting node. uuid:"+ ri.uuid +", name:"+ params.getName());
         } else {
             if(!useChangeDate || ri.isMoreRecentThan(localChangeDate)) {
-    			Path mefFile = retrieveMEF(ri.uuid);
+                Path mefFile = retrieveMEF(ri.uuid);
     
-    			try
-    			{
+                try
+                {
                     String fileType = "mef";
                     MEFLib.Version version = MEFLib.getMEFVersion(mefFile);
                     if (version != null && version.equals(MEFLib.Version.V2)) {
@@ -662,76 +662,76 @@ public class Aligner extends BaseAligner
                     IVisitor visitor = fileType.equals("mef2") ? new MEF2Visitor() : new MEFVisitor();
     
                     MEFLib.visit(mefFile, visitor, new IMEFVisitor()
-    				{
-    					public void handleMetadata(Element mdata, int index) throws Exception
-    					{
-    						md[index] = mdata;
-    					}
+                    {
+                        public void handleMetadata(Element mdata, int index) throws Exception
+                        {
+                            md[index] = mdata;
+                        }
     
-    					//-----------------------------------------------------------------
-    					
-    					public void handleMetadataFiles(DirectoryStream<Path> files, Element info, int index) throws Exception
-    					{
+                        //-----------------------------------------------------------------
+                        
+                        public void handleMetadataFiles(DirectoryStream<Path> files, Element info, int index) throws Exception
+                        {
                             // Import valid metadata
                             Element metadataValidForImport = extractValidMetadataForImport(files, info);
     
                             if (metadataValidForImport != null) {
                                 handleMetadata(metadataValidForImport, index);
-    					}
                         }
-    					
-    					public void handleInfo(Element info, int index) throws Exception
-    					{
-    						updateMetadata(ri, id, md[index], info, localRating);
-    						publicFiles[index] = info.getChild("public");
-    						privateFiles[index] = info.getChild("private");
-    					}
+                        }
+                        
+                        public void handleInfo(Element info, int index) throws Exception
+                        {
+                            updateMetadata(ri, id, md[index], info, localRating);
+                            publicFiles[index] = info.getChild("public");
+                            privateFiles[index] = info.getChild("private");
+                        }
     
-    					//-----------------------------------------------------------------
+                        //-----------------------------------------------------------------
     
-    					public void handlePublicFile(String file, String changeDate, InputStream is, int index) throws IOException
-    					{
-    						updateFile(id, file, "public", changeDate, is, publicFiles[index]);
-    					}
+                        public void handlePublicFile(String file, String changeDate, InputStream is, int index) throws IOException
+                        {
+                            updateFile(id, file, "public", changeDate, is, publicFiles[index]);
+                        }
     
-    					public void handleFeatureCat(Element md, int index)
-    							throws Exception {
-    						// Feature Catalog not managed for harvesting
-    					}
+                        public void handleFeatureCat(Element md, int index)
+                                throws Exception {
+                            // Feature Catalog not managed for harvesting
+                        }
     
-    					public void handlePrivateFile(String file,
-    							String changeDate, InputStream is, int index)
-    							throws IOException {
-    	                       updateFile(id, file, "private", changeDate, is, privateFiles[index]);
-    					}
-    					
-    				});
-    			}
-    			catch(Exception e)
-    			{
-    				//--- we ignore the exception here. Maybe the metadata has been removed just now
-    				result.unretrievable++;
-    			}
-    			finally
-    			{
+                        public void handlePrivateFile(String file,
+                                String changeDate, InputStream is, int index)
+                                throws IOException {
+                               updateFile(id, file, "private", changeDate, is, privateFiles[index]);
+                        }
+                        
+                    });
+                }
+                catch(Exception e)
+                {
+                    //--- we ignore the exception here. Maybe the metadata has been removed just now
+                    result.unretrievable++;
+                }
+                finally
+                {
                     try{
                         Files.deleteIfExists(mefFile);
                     } catch (IOException e) {
-    	                 log.warning("Unable to delete mefFile: "+mefFile);
-    	             }
+                         log.warning("Unable to delete mefFile: "+mefFile);
+                     }
     
-    			}
+                }
             } else {
                 result.unchangedMetadata++;
             }
-		}
-	}
+        }
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private void updateMetadata(RecordInfo ri, String id, Element md, Element info, boolean localRating) throws Exception
-	{
-		String date = localUuids.getChangeDate(ri.uuid);
+    private void updateMetadata(RecordInfo ri, String id, Element md, Element info, boolean localRating) throws Exception
+    {
+        String date = localUuids.getChangeDate(ri.uuid);
 
 
         try {
@@ -747,12 +747,12 @@ public class Aligner extends BaseAligner
         if (!ri.isMoreRecentThan(date)) {
             if(log.isDebugEnabled())
                 log.debug("  - XML not changed for local metadata with uuid:"+ ri.uuid);
-			result.unchangedMetadata++;
+            result.unchangedMetadata++;
             metadata = metadataRepository.findOne(id);
             if (metadata == null) {
                 throw new NoSuchElementException("Unable to find a metadata with ID: "+id);
             }
-		} else {
+        } else {
             if (!params.xslfilter.equals("")) {
                 md = HarvesterUtil.processMetadata(dataMan.getSchema(ri.schema),
                         md, processName, processParams, log);
@@ -770,34 +770,34 @@ public class Aligner extends BaseAligner
                     updateDateStamp);
             metadata = metadataRepository.findOne(id);
             result.updatedMetadata++;
-		}
+        }
 
         metadata.getCategories().clear();
         addCategories(metadata, params.getCategories(), localCateg, context, log, null, true);
         metadata = metadataRepository.findOne(id);
 
-		Element general = info.getChild("general");
+        Element general = info.getChild("general");
 
-		String popularity = general.getChildText("popularity");
+        String popularity = general.getChildText("popularity");
 
-		if(!localRating) {
-			String rating = general.getChildText("rating");
-			if (rating != null) {
-				metadata.getDataInfo().setRating(Integer.valueOf(rating));
+        if(!localRating) {
+            String rating = general.getChildText("rating");
+            if (rating != null) {
+                metadata.getDataInfo().setRating(Integer.valueOf(rating));
             }
-		}
-		
-		if (popularity != null) {
+        }
+        
+        if (popularity != null) {
             metadata.getDataInfo().setPopularity(Integer.valueOf(popularity));
         }
 
-		if (params.createRemoteCategory) {
+        if (params.createRemoteCategory) {
             Element categs = info.getChild("categories");
             if (categs != null) {
                 Importer.addCategoriesToMetadata(metadata, categs, context);
             }
         }
-		
+        
         OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
         repository.deleteAllByIdAttribute(OperationAllowedId_.metadataId, Integer.parseInt(id));
         if (((ArrayList<Group>)params.getGroupCopyPolicy()).size() == 0) {
@@ -810,32 +810,32 @@ public class Aligner extends BaseAligner
 //        dataMan.flush();
 
         dataMan.indexMetadata(id, true);
-	}
+    }
 
 
-	//--------------------------------------------------------------------------
-	//--- Public file update methods
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //--- Public file update methods
+    //--------------------------------------------------------------------------
 
-	private void updateFile(String id, String file, String dir, String changeDate,
-									InputStream is, Element files) throws IOException
-	{
-		if (files == null)
-		{
+    private void updateFile(String id, String file, String dir, String changeDate,
+                                    InputStream is, Element files) throws IOException
+    {
+        if (files == null)
+        {
             if(log.isDebugEnabled()) log.debug("  - No file found in info.xml. Cannot update file:" + file);
-		}
-		else
-		{
-			removeOldFile(id, files, dir);
-			updateChangedFile(id, file, dir, changeDate, is);
-		}
-	}
+        }
+        else
+        {
+            removeOldFile(id, files, dir);
+            updateChangedFile(id, file, dir, changeDate, is);
+        }
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private void removeOldFile(String id, Element infoFiles, String dir)
-	{
-		Path resourcesDir = Lib.resource.getDir(context, dir, id);
+    private void removeOldFile(String id, Element infoFiles, String dir)
+    {
+        Path resourcesDir = Lib.resource.getDir(context, dir, id);
 
         try (DirectoryStream<Path> paths = Files.newDirectoryStream(resourcesDir)) {
             for (Path file : paths) {
@@ -853,13 +853,13 @@ public class Aligner extends BaseAligner
         } catch (IOException e) {
             log.error("  - Cannot scan directory for " + dir + " files : "+ resourcesDir.toAbsolutePath().normalize());
         }
-	}
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private boolean existsFile(String fileName, Element files)
-	{
-		@SuppressWarnings("unchecked")
+    private boolean existsFile(String fileName, Element files)
+    {
+        @SuppressWarnings("unchecked")
         List<Element> list = files.getChildren("file");
 
         for (Element elem : list) {
@@ -870,91 +870,91 @@ public class Aligner extends BaseAligner
             }
         }
 
-		return false;
-	}
+        return false;
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private void updateChangedFile(String id, String file, String dir,
-											 String changeDate, InputStream is) throws IOException
-	{
-		Path resourcesDir  = Lib.resource.getDir(context, dir, id);
-		Path   locFile = resourcesDir.resolve(file);
+    private void updateChangedFile(String id, String file, String dir,
+                                             String changeDate, InputStream is) throws IOException
+    {
+        Path resourcesDir  = Lib.resource.getDir(context, dir, id);
+        Path   locFile = resourcesDir.resolve(file);
 
-		ISODate locIsoDate = new ISODate(Files.getLastModifiedTime(locFile).toMillis(), false);
-		ISODate remIsoDate = new ISODate(changeDate);
+        ISODate locIsoDate = new ISODate(Files.getLastModifiedTime(locFile).toMillis(), false);
+        ISODate remIsoDate = new ISODate(changeDate);
 
-		if (!Files.exists(locFile) || remIsoDate.timeDifferenceInSeconds(locIsoDate) > 0) {
+        if (!Files.exists(locFile) || remIsoDate.timeDifferenceInSeconds(locIsoDate) > 0) {
             if(log.isDebugEnabled()){ log.debug("  - Adding remote " + dir + "  file with name:"+ file);}
 
-			try (OutputStream os = Files.newOutputStream(locFile)) {
-    			BinaryFile.copy(is, os);
-    			IO.touch(locFile, FileTime.from(remIsoDate.getTimeInSeconds(), TimeUnit.SECONDS));
-			}
-		}
-		else
-		{
+            try (OutputStream os = Files.newOutputStream(locFile)) {
+                BinaryFile.copy(is, os);
+                IO.touch(locFile, FileTime.from(remIsoDate.getTimeInSeconds(), TimeUnit.SECONDS));
+            }
+        }
+        else
+        {
             if(log.isDebugEnabled()){ log.debug("  - Nothing to do in dir " + dir + " for file with name:"+ file);}
-		}
-	}
+        }
+    }
 
-	//--------------------------------------------------------------------------
-	//---
-	//--- Private methods
-	//---
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //---
+    //--- Private methods
+    //---
+    //--------------------------------------------------------------------------
 
-	/** Return true if the uuid is present in the remote node */
+    /** Return true if the uuid is present in the remote node */
 
-	private boolean exists(Set<RecordInfo> records, String uuid)
-	{
-		for(RecordInfo ri : records)
-			if (uuid.equals(ri.uuid))
-				return true;
+    private boolean exists(Set<RecordInfo> records, String uuid)
+    {
+        for(RecordInfo ri : records)
+            if (uuid.equals(ri.uuid))
+                return true;
 
-		return false;
-	}
+        return false;
+    }
 
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
-	private Path retrieveMEF(String uuid) throws IOException
-	{
-		request.clearParams();
-		request.addParam("uuid",   uuid);
-		request.addParam("format", (params.mefFormatFull ? "full" : "partial"));
+    private Path retrieveMEF(String uuid) throws IOException
+    {
+        request.clearParams();
+        request.addParam("uuid",   uuid);
+        request.addParam("format", (params.mefFormatFull ? "full" : "partial"));
 
         // Request MEF2 format - if remote node is old
         // it will ignore this parameter and return a MEF1 format
         // which will be handle in addMetadata/updateMetadata.
         request.addParam("version", "2");
         request.addParam("relation", "false");
-		request.setAddress(params.getServletPath() + "/" + params.getNode()
-				+ "/en/" + Geonet.Service.MEF_EXPORT);
+        request.setAddress(params.getServletPath() + "/" + params.getNode()
+                + "/en/" + Geonet.Service.MEF_EXPORT);
 
-		Path tempFile = Files.createTempFile("temp-", ".dat");
-		request.executeLarge(tempFile);
+        Path tempFile = Files.createTempFile("temp-", ".dat");
+        request.executeLarge(tempFile);
 
-		return tempFile;
-	}
+        return tempFile;
+    }
 
-	//--------------------------------------------------------------------------
-	//---
-	//--- Variables
-	//---
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //---
+    //--- Variables
+    //---
+    //--------------------------------------------------------------------------
 
-	private Logger         log;
-	private ServiceContext context;
-	private XmlRequest     request;
-	private GeonetParams   params;
-	private DataManager    dataMan;
-	private HarvestResult   result;
+    private Logger         log;
+    private ServiceContext context;
+    private XmlRequest     request;
+    private GeonetParams   params;
+    private DataManager    dataMan;
+    private HarvestResult   result;
 
-	private CategoryMapper localCateg;
-	private GroupMapper    localGroups;
-	private UUIDMapper     localUuids;
-	
-	private String processName;
+    private CategoryMapper localCateg;
+    private GroupMapper    localGroups;
+    private UUIDMapper     localUuids;
+    
+    private String processName;
     private String preferredSchema;
     private Map<String, Object> processParams = new HashMap<String, Object>();
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
@@ -122,7 +122,8 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult>
         super.setParams(params);
 
         settingMan.add("id:"+siteId, "host",    params.host);
-		settingMan.add("id:" + siteId, "node", params.getNode());
+        settingMan.add("id:"+siteId, "node", params.getNode());
+        settingMan.add("id:"+siteId, "useChangeDateForUpdate", params.useChangeDateForUpdate());
 		settingMan.add("id:"+siteId, "createRemoteCategory", params.createRemoteCategory);
 		settingMan.add("id:"+siteId, "mefFormatFull", params.mefFormatFull);
 		settingMan.add("id:"+siteId, "xslfilter", params.xslfilter);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetParams.java
@@ -66,7 +66,8 @@ public class GeonetParams extends AbstractParams
 
 		host    = Util.getParam(site, "host",    "");
 
-		this.setNode(Util.getParam(site, "node",    "srv"));
+        this.setNode(Util.getParam(site, "node",    "srv"));
+        this.setUseChangeDateForUpdate(Util.getParam(site, "useChangeDateForUpdate", false));
 
 		createRemoteCategory = Util.getParam(site, "createRemoteCategory", false);
 		mefFormatFull = Util.getParam(site, "mefFormatFull", false);
@@ -92,7 +93,8 @@ public class GeonetParams extends AbstractParams
 		Element policy   = node.getChild("groupsCopyPolicy");
 
 		host    = Util.getParam(site, "host",    host);
-		this.setNode(Util.getParam(site, "node",    this.getNode()));
+		this.setNode(Util.getParam(site, "node",    this.getNode())); 
+		this.setUseChangeDateForUpdate(Util.getParam(site, "useChangeDateForUpdate", false));
         createRemoteCategory = Util.getParam(site, "createRemoteCategory", createRemoteCategory);
         mefFormatFull = Util.getParam(site, "mefFormatFull", mefFormatFull);
         xslfilter = Util.getParam(site, "xslfilter", "");
@@ -143,6 +145,7 @@ public class GeonetParams extends AbstractParams
 
 		copy.host    = host;
 		copy.node    = node;
+		copy.useChangeDateForUpdate = useChangeDateForUpdate;
 		copy.createRemoteCategory = createRemoteCategory;
 		copy.mefFormatFull = mefFormatFull;
 		copy.xslfilter = xslfilter;
@@ -212,10 +215,25 @@ public class GeonetParams extends AbstractParams
 		this.node = node;
 	}
 
-	public String  host;
+	public boolean useChangeDateForUpdate() {
+	    if(this.useChangeDateForUpdate == null) {
+	        this.setUseChangeDateForUpdate(false);
+	    }
+        return useChangeDateForUpdate;
+    }
+
+    public void setUseChangeDateForUpdate(Boolean useChangeDateForUpdate) {
+        if(useChangeDateForUpdate == null) {
+            useChangeDateForUpdate = false;
+        }
+        this.useChangeDateForUpdate = useChangeDateForUpdate;
+    }
+
+    public String  host;
 	private String node;
 	public boolean createRemoteCategory;
 	public boolean mefFormatFull;
+	private Boolean useChangeDateForUpdate;
 	
 	/**
 	 * The filter is a process (see schema/process folder) which depends on the schema.

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -335,6 +335,8 @@
     "geonetwork-hostHelp": "URL with catalog name only eg. http://www.fao.org/geonetwork.",
     "geonetwork-mefFormatFull": "Use full MEF format",
     "geonetwork-mefFormatFullHelp": "Recommended to retrieve remotes files.",
+    "geonetwork-useChangeDateForUpdate": "Use change date for comparison",
+    "geonetwork-useChangeDateForUpdateHelp": "Use change date to detect changes on remote server. This will not update minor changes but improves speed on harvester.",
     "geonetwork-xslfilter": "XSL filter name to apply",
     "geonetwork-xslfilterHelp": "The XSL filter is applied to each metadata record",
     "groupDeleteError": "Error when deleting group",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.html
@@ -105,6 +105,14 @@
 
         <div>
             <label class="control-label">
+                <input type="checkbox" data-ng-model="harvesterSelected.site.useChangeDateForUpdate"/>
+                <span data-translate="">geonetwork-useChangeDateForUpdate</span>
+            </label>
+            <p class="help-block" data-translate="">geonetwork-useChangeDateForUpdateHelp</p>
+        </div>
+
+        <div>
+            <label class="control-label">
                 <input type="checkbox" data-ng-model="harvesterSelected.site.createRemoteCategory"/>
                 <span data-translate="">geonetwork-createRemoteCategory</span>
             </label>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.js
@@ -17,7 +17,8 @@ var gnHarvestergeonetwork = {
           "password": ""
         },
         "host": [],
-              "node": "srv",
+        "node": "srv",
+        "useChangeDateForUpdate": false,
         "createRemoteCategory": false,
         "mefFormatFull": false,
         "xslfilter": []
@@ -69,7 +70,8 @@ var gnHarvestergeonetwork = {
       + $scope.buildTranslations(h)
       + '    <host>' + h.site.host.replace(/&/g, '&amp;') + '</host>'
       + '    <node>' + h.site.node + '</node>'
-     + '    <createRemoteCategory>' + h.site.createRemoteCategory + '</createRemoteCategory>'
+      + '    <useChangeDateForUpdate>' + h.site.useChangeDateForUpdate + '</useChangeDateForUpdate>'
+      + '    <createRemoteCategory>' + h.site.createRemoteCategory + '</createRemoteCategory>'
       + '    <icon>' + h.site.icon + '</icon>'
       + '    <mefFormatFull>' + h.site.mefFormatFull + '</mefFormatFull>'
       + '    <xslfilter>' + h.site.xslfilter + '</xslfilter>'

--- a/web/src/main/webapp/xsl/xml/harvesting/geonetwork.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/geonetwork.xsl
@@ -12,7 +12,8 @@
 
 	<xsl:template match="*" mode="site">
 		<host><xsl:value-of    select="host/value" /></host>
-	    <node><xsl:value-of    select="node/value" /></node>
+        <node><xsl:value-of    select="node/value" /></node>
+        <useChangeDateForUpdate><xsl:value-of    select="useChangeDateForUpdate/value" /></useChangeDateForUpdate>
 	    <createRemoteCategory><xsl:value-of select="createRemoteCategory/value"/></createRemoteCategory>
 	    <mefFormatFull><xsl:value-of select="mefFormatFull"/></mefFormatFull>
 		<xslfilter><xsl:value-of select="xslfilter"/></xslfilter>

--- a/web/src/main/webapp/xsl/xml/harvesting/geonetwork30.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/geonetwork30.xsl
@@ -13,6 +13,7 @@
 	<xsl:template match="*" mode="site">
 		<host><xsl:value-of    select="host/value" /></host>
 	    <node><xsl:value-of    select="node/value" /></node>
+        <useChangeDateForUpdate><xsl:value-of    select="useChangeDateForUpdate/value" /></useChangeDateForUpdate>
 	    <createRemoteCategory><xsl:value-of select="createRemoteCategory/value"/></createRemoteCategory>
 	    <mefFormatFull><xsl:value-of select="mefFormatFull"/></mefFormatFull>
 		<xslfilter><xsl:value-of select="xslfilter"/></xslfilter>


### PR DESCRIPTION
New option on geoNetwork harvester settings to use the changedate as reference to know if we should update the metadata. 

Less mef.export calls to remote geoNetwork server. The harvester reduces A LOT time spent. In just a couple of seconds, if there are no changes, the harvester ends.

Also, comparison between dates on harvester now is strictly great than. If the dates are exactly the same, right now it returns true, which doesn't make much sense...