### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1121,7 +1121,7 @@
     <pluginRepository>
       <name>oss.sonatype.org - github-releases</name>
       <id>oss.sonatype.org-github-releases</id>
-      <url>http://oss.sonatype.org/content/repositories/github-releases</url>
+      <url>https://oss.sonatype.org/content/repositories/github-releases</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
Sonatype repositories moved away from http to https. Since this change, some maven versions are unable to correctly follow 301 permanent redirects, resulting in a pollution of the local maven repository and potentially build failures.

We faced the same issue on geOrchestra some months ago, and fixed the same way as this commit.

Tests: Locally by launching `mvn clean install`.