### PR TITLE
Wro4j config path should not be based on build path #877.

### DIFF
--- a/web/src/main/webResources/WEB-INF/wro.properties
+++ b/web/src/main/webResources/WEB-INF/wro.properties
@@ -20,8 +20,12 @@ preProcessors=stripGoog,googleClosureSimple,geonetLessCompiler,cssMinJawr${debug
 postProcessors=
 uriLocators=servletContext,uri,classpath,closureDependencyURILocator,templateURILocator
 modelFactory=geonetwork
-wroSources=${build.webapp.resources}/WEB-INF/wro-sources.xml
+wroSources=WEB-INF/wro-sources.xml
 cacheStrategy=${cacheStrategy}
 lruSize=${lruSize}
 # if cacheStrategy == disk-memory then this is the path to the database file to use
-cacheDB=${build.webapp.resources}/WEB-INF/wro4jcache
+# H2 database use for cache.
+# Default location is relative to where the start script is.
+cacheDB=./wro4jcache
+# Use full path to define custom location
+#cacheDB=/tmp/wro4jcache


### PR DESCRIPTION
A way to improve https://github.com/geonetwork/core-geonetwork/issues/877.

The cacheDB is then located at the same place as the GN default H2 db.