### PR TITLE
Add metadata action allowing the transfer a metadata from one user to another.  

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -271,8 +271,8 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
 
 		// build response
 		Element response =  new Element("response");
-		response.setAttribute("from",  getFrom()+"");
-		response.setAttribute("to",    getTo()+"");
+		response.setAttribute("from", getFrom() + "");
+		response.setAttribute("to", getTo() + "");
         if(Log.isDebugEnabled(Geonet.SEARCH_ENGINE))
             Log.debug(Geonet.SEARCH_ENGINE, Xml.getString(response));
 
@@ -363,6 +363,9 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         HashSet<ReservedOperation> operations;
         if (isOwner) {
             operations = Sets.newHashSet(Arrays.asList(ReservedOperation.values()));
+            if (owner != null) {
+                addElement(infoEl, "ownerId", owner.toString());
+            }
         } else {
             final Collection<Integer> groups = accessManager.getUserGroups(context.getUserSession(), context.getIpAddress(), false);
             operations = Sets.newHashSet();

--- a/core/src/test/java/org/fao/geonet/kernel/search/LuceneSearcherPresentTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/LuceneSearcherPresentTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class LuceneSearcherPresentTest extends AbstractCoreIntegrationTest {
@@ -47,6 +48,7 @@ public class LuceneSearcherPresentTest extends AbstractCoreIntegrationTest {
 
             assertEqualsText("true", info, "edit");
             assertEqualsText("true", info, "owner");
+            assertNotNull("Expected ownerId to be one of the elements in : " + Xml.getString(info), info.getChild("ownerId"));
             assertEqualsText("true", info, "view");
             assertEqualsText("true", info, "notify");
             assertEqualsText("true", info, "download");

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -540,6 +540,12 @@
       isPublished: function() {
         return this['geonet:info'].isPublishedToAll === 'true';
       },
+      isOwned: function() {
+        return this['geonet:info'].owner === 'true';
+      },
+      getOwnerId: function() {
+        return this['geonet:info'].ownerId;
+      },
       publish: function() {
         this['geonet:info'].isPublishedToAll = this.isPublished() ?
             'false' : 'true';

--- a/web-ui/src/main/resources/catalog/components/common/share/ShareDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/share/ShareDirective.js
@@ -90,7 +90,7 @@
                   scope.$emit('PrivilegesUpdated', true);
                   scope.$emit('StatusUpdated', {
                     msg: $translate('privilegesUpdated'),
-                    timeout: 2,
+                    timeout: 0,
                     type: 'success'});
                 }, function(data) {
                   scope.$emit('PrivilegesUpdated', false);

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -192,6 +192,14 @@
         }, scope, 'CategoriesUpdated');
       };
 
+      this.openTransferOwnership = function(md, scope) {
+        var uuid = md ? md.getUuid() : '';
+        var ownerId = md ? md.getOwnerId() : '';
+        openModal({
+          title: 'transferOwnership',
+          content: '<div gn-transfer-ownership="'+uuid +'" gn-transfer-md-owner="'+ownerId+'"></div>'
+        }, scope, 'TransferOwnership');
+      };
       /**
        * Duplicate the given metadata. Open the editor in new page.
        * @param {string} md

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -148,8 +148,8 @@
    * group.
    */
   module.directive('gnMetadataGroupUpdater', [
-    'gnMetadataActions', '$translate', '$http',
-    function(gnMetadataActions, $translate, $http) {
+    'gnMetadataActions', '$translate', '$http', '$rootScope',
+    function(gnMetadataActions, $translate, $http, $rootScope) {
 
       return {
         restrict: 'A',
@@ -208,6 +208,150 @@
           setTimeout(function() {
             element.find(':input').select();
           }, 300);
+        }
+      };
+    }]
+  );
+
+
+  /**
+   * @ngdoc directive
+   * @name gn_mdactions_directive.directive:gnTransferOwnership
+   * @restrict A
+   * @requires gnHttp
+   *
+   * @description
+   * The `gnTransferOwnership` directive provides a
+   * dropdown button which allows can be added to a metadata actions
+   * menu or to a selection menu.  If integrated into a metadata actions
+   * menu then the metadata id and the owner of the metadata to be updated
+   * must be provided.
+   *
+   * The metadata id should be the value of the gn-transfer-ownership attribute
+   * and the metadata owner id should be the value of the gn-transfer-md-owner attribute
+   */
+  module.directive('gnTransferOwnership',  [
+    '$translate', '$http', 'gnHttp', '$rootScope',
+    function($translate, $http, gnHttp, $rootScope) {
+      return {
+        restrict: 'A',
+        replace: false,
+        templateUrl: '../../catalog/components/metadataactions/partials/' +
+            'transferownership.html',
+        link: function(scope, element, attrs) {
+          var ownerId = parseInt(attrs['gnTransferMdOwner']);
+          var mdUuid = attrs['gnTransferOwnership'];
+          scope.users = [];
+          scope.selectedUser = null;
+          scope.groups = [];
+          scope.selectedGroup = null;
+          scope.userLoading = true;
+          scope.groupLoading = false;
+
+          scope.selectUser = function(user) {
+            scope.selectedUser = user;
+            scope.groupLoading = true;
+            $http.get("admin.usergroups.list?_content_type=json&id="+user.id).success(function(groups){
+              scope.groups = [];
+              var added = {};
+              angular.forEach(groups, function(g) {
+                if (!angular.isDefined(added[g.id]) && g.reserved !== 'true') {
+                  added[g.id] = true;
+                  scope.groups.push({
+                    name: g.name,
+                    id: g.id,
+                    desc: g.description
+                  });
+                }
+              })
+            }).error(function(error){
+              $rootScope.$broadcast('StatusUpdated', {
+                msg: $translate('loadUserGroupsError'),
+                timeout: 0,
+                type: 'danger'});
+            }).then(function(){
+              scope.groupLoading = false;
+            });
+          };
+
+          scope.selectGroup = function(group) {
+            scope.selectedGroup = group;
+          };
+          $http.get("admin.user.list?_content_type=json").success(function(data) {
+            var isEditor = function(user) {
+              var hasEditorAuth = false;
+              var auths = user.authorities;
+              if (!angular.isArray(auths)) {
+                auths = [auths];
+              }
+              angular.forEach(auths, function(auth) {
+                if (!hasEditorAuth && auth.authority === 'Editor') {
+                  hasEditorAuth = true;
+                }
+              });
+
+              return hasEditorAuth;
+            };
+            angular.forEach(data.users, function(user) {
+              user = user.value;
+              if (isEditor(user)) {
+                var userObj = {
+                  name: user.name + " " + user.surname,
+                  username: user.username,
+                  id: user.id
+                };
+                scope.users.push(userObj);
+
+                if (user.id === ownerId) {
+                  scope.selectUser(userObj);
+                }
+              }
+            });
+          }).error(function(error){
+            $rootScope.$broadcast('StatusUpdated', {
+              msg: $translate('loadUsersError'),
+              timeout: 0,
+              type: 'danger'});
+          }).then(function(){
+            scope.userLoading = false;
+          });
+
+          var updateSelection = function() {
+            return $http({
+              method: 'GET',
+              url: "metadata.batch.newowner?userId="+scope.selectedUser.id+"&groupId="+scope.selectedGroup.id,
+              headers: {
+                'Content-Type': 'application/json'
+              }
+            }).success(function(result){
+              scope.$emit('TransferOwnership', true);
+              var msg = $translate('transferOwnershipSuccessMsg', result);
+              $rootScope.$broadcast('StatusUpdated', {
+                msg: msg,
+                timeout: 2,
+                type: 'success'})
+            }).error(function(){
+              scope.$emit('TransferOwnership', false);
+              $rootScope.$broadcast('StatusUpdated', {
+                msg: $translate('transferOwnershipError'),
+                timeout: 0,
+                type: 'danger'});
+            });
+          };
+          scope.save = function () {
+            if (scope.selectedUser && scope.selectedGroup) {
+              if (angular.isDefined(mdUuid)) {
+                return gnHttp.callService('mdSelect', {
+                  selected: 'add',
+                  id: mdUuid
+                }).success(function () {
+                  updateSelection();
+                });
+              } else {
+                return updateSelection();
+              }
+            }
+          };
         }
       };
     }]

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
@@ -1,0 +1,43 @@
+<div class="row" data-ng-hide="loading">
+    <div class="col-md-6">
+        <div class="panel panel-default">
+            <div class="panel-heading">Select New Owner</div>
+            <div class="panel-body">
+                <div class="list-group">
+                    <a class="list-group-item" data-ng-show="userLoading">
+                        <i class="fa fa-spinner fa-spin fa-2x"></i>
+                    </a>
+                    <a class="list-group-item"
+                       data-ng-repeat="user in users"
+                       data-ng-click="selectUser(user)"
+                       data-ng-class="user === selectedUser ? 'active' : ''">{{user.name}} ({{user.username}})</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="panel panel-default">
+            <div class="panel-heading">Select Group</div>
+            <div class="panel-body">
+                <div class="list-group">
+                    <a class="list-group-item" data-ng-show="groupLoading">
+                        <i class="fa fa-spinner fa-spin fa-2x"></i>
+                    </a>
+                    <a class="list-group-item"
+                       data-ng-repeat="g in groups | orderBy:name"
+                       data-ng-click="selectGroup(g)"
+                       data-ng-class="g === selectedGroup ? 'active' : ''"
+                       title="{{g.desc}}">{{g.name}}</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="btn-toolbar col-md-12">
+        <button type="button"
+                class="btn btn-primary pull-right"
+                data-ng-class="selectedUser && selectedGroup ? '' : 'disabled'"
+                data-gn-click-and-spin="save()"><i class="fa fa-save"></i>&nbsp; <span
+                data-translate="" class="ng-scope">Save</span></button>
+    </div>
+</div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -44,6 +44,9 @@
     <li ng-if="user.isReviewerOrMore()" class="disabgit led">
       <a ng-click="mdService.publish(undefined, 'off')" >
       <i class="fa fa-lock"></i>&nbsp;<span translate>unpublish</span></a></li>
+    <li ng-if="user.isUserAdminOrMore()">
+      <a href="" data-ng-click="mdService.openTransferOwnership(md, getCatScope())">
+      <i class="fa fa-user"></i>&nbsp;<span translate>transferOwnership</span></a></li>
     <li class="divider" data-ng-if="user.isConnected()"></li>
     <li ng-if="user.isEditorOrMore()">
       <a href="" ng-click="mdService.openCategoriesBatchPanel(getCatScope())">

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -271,6 +271,10 @@
   "intersectWith": "Intersects with",
   "fullyOutsideOf": "Fully outside of",
   "encloses": "Enclosing",
-  "within": "Within"
-
+  "within": "Within",
+  "transferOwnership": "Transfer Ownership",
+  "loadUsersError":"Error loading users",
+  "loadUserGroupsError": "Error loading user groups",
+  "transferOwnershipError": "Error transferring metadata ownership",
+  "transferOwnershipSuccessMsg": "<h4>Successfully transferred metadata to a new Owner.</h4><dl class=\"dl-horizontal\"><dt>Transferred:</dt><dd>{{done}}</dd><dt>Not Owned:</dt><dd>{{notOwner}}</dd><dt>Not found:</dt><dd>{{notFound}}</dd></dl>"
 }

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -30,6 +30,12 @@
       <i class="fa fa-key"></i>&nbsp;
       <span data-translate="">privileges</span>
     </a></li>
+    <li data-ng-if="md.isOwned() && user.isUserAdminOrMore()">
+        <a data-ng-href=""
+           data-ng-click="mdService.openTransferOwnership(md, getCatScope())">
+      <i class="fa fa-user"></i>&nbsp;
+      <span data-translate="">transferOwnership</span>
+    </a></li>
     <li data-ng-if="user.canEditRecord(md) && user.isReviewerOrMore()">
       <a data-ng-click="mdService.publish(md)">
         <i class="fa"

--- a/web-ui/src/main/resources/catalog/views/geocat/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/geocat/directives/partials/mdactionmenu.html
@@ -21,6 +21,12 @@
         <li><a ng-href="" data-ng-click="mdService.duplicate(md)"><i class="fa fa-copy"></i><span translate>duplicate</span></a></li>
         <li><a ng-href="" data-ng-click="mdService.createChild(md)"><i class="fa fa-sitemap"></i><span translate>createChild</span></a></li>
         <li><a ng-href="" data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())"><i class="fa fa-key"></i><span translate>privileges</span></a></li>
+        <li data-ng-if="md.isOwned() && user.isUserAdminOrMore()">
+          <a data-ng-href=""
+             data-ng-click="mdService.openTransferOwnership(md, getCatScope())">
+            <i class="fa fa-user"></i>&nbsp;
+            <span data-translate="">transferOwnership</span>
+          </a></li>
       </ul>
     </li>
     <li class="dropdown-submenu">

--- a/web/src/main/webapp/WEB-INF/config-metadata.xml
+++ b/web/src/main/webapp/WEB-INF/config-metadata.xml
@@ -141,26 +141,6 @@
 
         <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
-        <service name="metadata.batch.newowner">
-            <class name=".services.metadata.BatchNewOwner" />
-
-            <output sheet="metadata-batch-results.xsl">
-                <xml name="info" file="xml/metadata-batchNewOwner.xml" />
-            </output>
-        </service>
-
-        <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-        <service name="metadata.batch.newowner.form">
-            <class name=".services.metadata.PrepareBatchNewOwner" />
-
-            <output sheet="metadata-batchownership.xsl">
-                <xml name="info" file="xml/metadata-batchNewOwner.xml" />
-            </output>
-        </service>
-
-        <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
         <service name="metadata.batch.status.form">
             <class name=".services.metadata.PrepareBatchUpdateStatus" />
 


### PR DESCRIPTION
Add metadata action for selection and individual metadata that allows an admin or UserAdmin to transfer a metadata from one user to another.  

This is different from the administration transfer option in that it only migrates the one metadata or the selected metadata to the new user and group
