### PR TITLE
introduce search map to advanced search

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -337,27 +337,6 @@ ul.gn-resultview {
   }
 }
 
-[ngeo-map] {
-  height: 86vh;
-  &.gn-search-map {
-    height: 200px;
-    border: 1px solid #ccc;
-    border-radius: 3px;
-    right: 0;
-    bottom: 0;
-    position: fixed !important;
-    z-index: 99;
-    width: 200px !important;
-    heigth: 200px !important;
-    margin: 5px;
-    .btn {
-      position: absolute;
-      top: 4px;
-      left: 4px;
-      z-index: 10;
-    }
-  }
-}
 .gn-row-main {}
 
 .gn-row-info {}
@@ -507,4 +486,9 @@ html, body {
     //width: calc(~"33% - 15px");
   }
 }
+
+.search-map [ngeo-map] {
+	height:250px !important;
+}
+
 @import "gn_view.less";

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -51,7 +51,4 @@
     </div>
   </div>
 
-  <div ngeo-map="searchObj.searchMap" class="gn-search-map">
-    <button data-ng-click="location.setMap()" class="btn btn-default"><i class="fa fa-globe"></i></button>
-  </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -54,8 +54,11 @@
         <div data-ng-show="searchObj.advancedMode"
              class="gn-search-filter col-lg-12">
 
-
           <div class="row">
+		    <div class="col-md-4">
+				<h3 data-translate="">where</h3>
+				<div gn-map-field="searchObj.searchMap" gn-map-field-geom="searchObj.params.geometry" gn-map-field-opt="mapfieldOpt" class="search-map"></div>
+            </div>
             <div class="col-md-4">
               <h3 data-translate="">what</h3>
               <div class="form-group">
@@ -95,7 +98,7 @@
                 </div>
               </div>
             </div>
-            <div class="col-md-5">
+            <div class="col-md-4">
               <h3 data-translate="">when</h3>
               <div data-gn-period-chooser="resourcesCreatedTheLast"
                    data-date-from="searchObj.params.creationDateFrom"
@@ -107,9 +110,7 @@
                    data-date-to="searchObj.params.dateTo">
               </div>
             </div>
-            <div class="col-md-5">
-
-            </div>
+            
           </div>
         </div>
       </div>


### PR DESCRIPTION
this pull is to trigger a discussion on the position of the map on the default search page
the default view does not have a geographic search option. This pull adds it to advanced search panel in default view and also removes the current map from lower bottom in search results 