### PR TITLE
HTTP Post - Content type

### DIFF
--- a/core/src/main/java/org/geonetwork/http/proxy/HttpProxyServlet.java
+++ b/core/src/main/java/org/geonetwork/http/proxy/HttpProxyServlet.java
@@ -335,7 +335,15 @@ public class HttpProxyServlet extends HttpServlet {
                 PrintWriter out = response.getWriter();
                 String body = RequestUtil.inputStreamAsString(request);
 
-                final ContentType contentType1 = ContentType.create(request.getContentType(),
+                String ct = request.getContentType();
+                if (ct != null) {
+                    String[] cts = ct.split(";");
+                    ct = cts[0].trim();
+                } else {
+                    ct = "text/plain";
+                }
+
+                final ContentType contentType1 = ContentType.create(ct,
                         request.getCharacterEncoding());
                 StringEntity entity = new StringEntity(body, contentType1);
                 httpPost.setEntity(entity);


### PR DESCRIPTION
Sometimes, browsers (e.g. firefox) automatically add a charset
after the content-type header:

'Content-Type: application/json;charset=UTF-8'

But the ContentType.create(String, String) method expects as first
argument a string without some characters, including ";". We need to
split the string on ";" to get the most significant part of the
content-type before calling ContentType.create().