### PR TITLE
Fix delete icon always shown.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -242,12 +242,12 @@
             // on touchscreen delete action will not be visible
 
             element.addClass('field-bg');
-            element.find('i.btn.fa-times.text-danger')
+            element.find('a').has('.fa-times.text-danger')
               .css('visibility', 'visible');
           });
           element.on('mouseout', function() {
             element.removeClass('field-bg');
-            element.find('i.btn.fa-times.text-danger')
+            element.find('a').has('.fa-times.text-danger')
               .css('visibility', 'hidden');
           });
         }


### PR DESCRIPTION
Change the selector for the delete button since it has changed its
structure using an 'a' element. Now it show/hides the 'a' instead the
icon. See issue #953.