### PR TITLE
A fix for the Geosource CSW Harvesting

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/AbstractHttpRequest.java
+++ b/common/src/main/java/org/fao/geonet/utils/AbstractHttpRequest.java
@@ -285,7 +285,7 @@ public class AbstractHttpRequest {
             }
         }
 
-        if (host == null || port < 0 || protocol == null) {
+        if (host == null || protocol == null) {
             throw new IllegalStateException(String.format(getClass().getSimpleName()+" is not ready to be executed: \n\tprotocol: '%s' " +
                                             "\n\tuserinfo: '%s'\n\thost: '%s' \n\tport: '%s' \n\taddress: '%s'\n\tquery '%s'" +
                                             "\n\tfragment: '%s'", protocol, userInfo, host, port, address, query, fragment));

--- a/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java
+++ b/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java
@@ -98,7 +98,7 @@ public class GeonetHttpRequestFactory {
      * @return the XmlRequest.
      */
     public final XmlRequest createXmlRequest(URL url) {
-        final int port = url.getPort() == -1 ? url.getDefaultPort() : url.getPort();
+        final int port = url.getPort();
         final XmlRequest request = createXmlRequest(url.getHost(), port,
                 url.getProtocol());
 
@@ -153,6 +153,7 @@ public class GeonetHttpRequestFactory {
         final HttpClientBuilder clientBuilder = getDefaultHttpClientBuilder();
         configurator.apply(clientBuilder);
         CloseableHttpClient httpClient = clientBuilder.build();
+
         if (r.isPreemptiveBasicAuth() || r.getHttpClientContext() != null) {
             return new AdaptingResponse(httpClient, httpClient.execute(request, r.getHttpClientContext()));
         } else {


### PR DESCRIPTION
The geosource installation instance has an odd configuration where if the URI in http client has the port number the request fails...  In the current implementation a port number was always set.  However it should typically be ok to not explicitly set the port number and so this change allows a port number of -1 (the flag for no-set) is permitted.