### PR TITLE
Formatter / Restore XML structure for XSLT formatter.

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/metadata/format/XsltFormatter.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/format/XsltFormatter.java
@@ -81,9 +81,12 @@ public class XsltFormatter implements FormatterImpl {
                     Element schemaEl = new Element(currentSchema);
                     schemas.addContent(schemaEl);
 
-                    schemaEl.addContent((Element) schemaLocalization.getLabels(fparams.context.getLanguage()).clone());
-                    schemaEl.addContent((Element) schemaLocalization.getCodelists(fparams.context.getLanguage()).clone());
-                    schemaEl.addContent((Element) schemaLocalization.getStrings(fparams.context.getLanguage()).clone());
+                    Element labels = schemaLocalization.getLabels(fparams.context.getLanguage());
+                    schemaEl.addContent((Element) labels.setName("labels").clone());
+                    Element strings = schemaLocalization.getStrings(fparams.context.getLanguage());
+                    schemaEl.addContent((Element) strings.setName("strings").clone());
+                    Element codelists = schemaLocalization.getCodelists(fparams.context.getLanguage());
+                    schemaEl.addContent((Element) codelists.setName("codelists").clone());
                 }
             }
         }


### PR DESCRIPTION
XSLT formatter used to have the following structure:
* root
 * schemas_id
   * strings
    * labels
    * codelist

Now it is:
* root
 * schemas_id
   * schemas_id containing strings
    * schemas_id containing labels
    * schemas_id containing codelist

It's not meaningfull and breaks compatibility with old formatter.

This restore previous XML structure for XSLT formatters.

2.10.x branch ref: https://github.com/geonetwork/core-geonetwork/blob/2.10.x/web/src/main/java/org/fao/geonet/services/metadata/format/Format.java#L219