### PR TITLE
Fixes for GeoPublish workflow

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/nio/NioPathHolder.java
+++ b/common/src/main/java/org/fao/geonet/utils/nio/NioPathHolder.java
@@ -52,9 +52,13 @@ public class NioPathHolder {
                     // failed
                 }
             } else {
-                Path srcPath = ACTUAL_RELATIVE_TO.get().resolve(systemId);
-                if (Files.isRegularFile(srcPath)) {
-                    return srcPath;
+                try {
+                    Path srcPath = ACTUAL_RELATIVE_TO.get().resolve(systemId);
+                    if (Files.isRegularFile(srcPath)) {
+                        return srcPath;
+                    }
+                } catch (RuntimeException e) {
+                    return null;
                 }
             }
         }

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -204,10 +204,10 @@
 				<gmd:URL>
 					<xsl:choose>
 						<xsl:when test="/root/env/system/downloadservice/simple='true'">
-							<xsl:value-of select="concat($serviceUrl,'resources.get?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=private')"/>
+							<xsl:value-of select="concat($serviceUrl,'resources.get?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=public')"/>
 						</xsl:when>
 						<xsl:when test="/root/env/system/downloadservice/withdisclaimer='true'">
-							<xsl:value-of select="concat($serviceUrl,'file.disclaimer?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=private')"/>
+							<xsl:value-of select="concat($serviceUrl,'file.disclaimer?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=public')"/>
 						</xsl:when>
 						<xsl:otherwise> <!-- /root/env/config/downloadservice/leave='true' -->
 							<xsl:value-of select="gmd:linkage/gmd:URL"/>

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
@@ -68,7 +68,7 @@
                 map.setTarget(scope.mapId);
 
                 // TODO : Zoom to all extent if more than one defined
-                if (angular.isArray(gnCurrentEdit.extent)) {
+                if (angular.isArray(gnCurrentEdit.extent) && gnCurrentEdit.extent.length > 0) {
                   map.getView().fitExtent(
                       gnMap.reprojExtent(gnCurrentEdit.extent[0],
                       'EPSG:4326', gnMap.getMapConfig().projection),

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherService.js
@@ -22,7 +22,7 @@
           if (node) {
             return gnHttp.callService('geoserverNodes', {
               metadataId: gnCurrentEdit.id,
-              access: 'private',
+              access: 'public',
               action: 'GET',
               nodeId: node,
               file: fileName
@@ -38,7 +38,7 @@
               metadataUuid: gnCurrentEdit.uuid,
               metadataTitle: title,
               metadataAbstract: moreInfo,
-              access: 'private',
+              access: 'public',
               action: 'CREATE',
               nodeId: node,
               file: fileName
@@ -50,7 +50,7 @@
           if (node) {
             return gnHttp.callService('geoserverNodes', {
               metadataId: gnCurrentEdit.id,
-              access: 'private',
+              access: 'public',
               action: 'DELETE',
               nodeId: node,
               file: fileName


### PR DESCRIPTION
Fixes for GeoPublish workflow
Workflow is:

* upload shapefile zip file
* Publish to Geoserver
* Add WMS/WFS links to Geoserver layer
* Get Suggestions
* Update extent/Thumbnail/spatial info using WMS suggestion

Fixes that needed to be done to make this work:

* Make access == public in update-fixed-info.xsl and GeoPublisherService
* Update GeoPublisherDirective so it checks if there is an extent before trying to show the extent on map
* Update NioPathHolder to not throw an exception when trying to resolve http://...  paths