### PR TITLE
Improve WPS client with bounding box parameters

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -644,7 +644,6 @@
    * @name gn_formfields.directive:gnBboxInput
    * @restrict A
    * @requires gnMap
-   * @requires gnSearchSettings
    * @requires ngeoDecorateInteraction
    *
    * @description
@@ -653,29 +652,8 @@
   // Inspired from https://github.com/camptocamp/geocat/blob/geocat_develop/web-ui/src/main/resources/catalog/geocat-shared-objects/js/extent-directive.js
   .directive('gnBboxInput', [
     'gnMap',
-    'gnSearchSettings',
     'ngeoDecorateInteraction',
-    function(gnMap, gnSearchSettings, goDecoI){
-
-      // Create overlay to draw bbox and polygon
-      var featureOverlay = new ol.FeatureOverlay({
-        style: gnSearchSettings.olStyles.drawBbox
-      });
-      var map = gnSearchSettings.viewerMap;
-      featureOverlay.setMap(map);
-
-      var dragboxInteraction = new ol.interaction.DragBox({
-        style: gnSearchSettings.olStyles.drawBbox
-      });
-      map.addInteraction(dragboxInteraction);
-
-      var clearMap = function() {
-        featureOverlay.getFeatures().clear();
-      }
-
-      dragboxInteraction.on('boxstart', clearMap);
-      goDecoI(dragboxInteraction);
-      dragboxInteraction.active = false;
+    function(gnMap, goDecoI){
 
       var extentFromValue = function(value) {
         if (!value) {
@@ -692,13 +670,43 @@
         restrict: 'AE',
         scope: {
           crs: '=',
-          value: '='
+          value: '=',
+          map: '='
         },
         templateUrl: '../../catalog/components/search/formfields/' +
           'partials/bboxInput.html',
 
         link: function(scope, element, attrs) {
           scope.crs = scope.crs || 'EPSG:4326';
+
+          var style = new ol.style.Style({
+            fill: new ol.style.Fill({
+              color: 'rgba(255,0,0,0.2)'
+            }),
+            stroke: new ol.style.Stroke({
+              color: '#FF0000',
+              width: 1.25
+            })
+          });
+
+          var dragboxInteraction = new ol.interaction.DragBox({
+            style: style
+          });
+          scope.map.addInteraction(dragboxInteraction);
+
+          // Create overlay to show bbox
+          var featureOverlay = new ol.FeatureOverlay({
+            style: style
+          });
+          featureOverlay.setMap(scope.map);
+
+          var clearMap = function() {
+            featureOverlay.getFeatures().clear();
+          };
+
+          dragboxInteraction.on('boxstart', clearMap);
+          goDecoI(dragboxInteraction);
+          dragboxInteraction.active = false;
 
           scope.clear = function() {
             scope.value = '';
@@ -714,7 +722,7 @@
             var coordinates, geom, f;
             coordinates = gnMap.getPolygonFromExtent(scope.extent);
             geom = new ol.geom.Polygon(coordinates)
-              .transform(scope.crs, map.getView().getProjection());
+              .transform(scope.crs, scope.map.getView().getProjection());
             f = new ol.Feature();
             f.setGeometry(geom);
             featureOverlay.addFeature(f);
@@ -724,7 +732,7 @@
             dragboxInteraction.active = false;
             var g = dragboxInteraction.getGeometry().clone();
             var geom = g.clone()
-              .transform(map.getView().getProjection(), scope.crs);
+              .transform(scope.map.getView().getProjection(), scope.crs);
             scope.extent = geom.getExtent();
             scope.value = valueFromExtent(scope.extent);
             scope.updateMap();
@@ -738,6 +746,7 @@
 
           element.on('$destroy', function() {
             clearMap();
+            scope.map.removeLayer(featureOverlay);
           });
         }
       };

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -636,7 +636,111 @@
 
           }
         };
-      }]);
+      }])
 
 
+  /**
+   * @ngdoc directive
+   * @name gn_formfields.directive:gnBboxInput
+   * @restrict A
+   * @requires gnMap
+   * @requires gnSearchSettings
+   * @requires ngeoDecorateInteraction
+   *
+   * @description
+   * The `gnBboxInput` directive provides an input widget for bounding boxes.
+   */
+  // Inspired from https://github.com/camptocamp/geocat/blob/geocat_develop/web-ui/src/main/resources/catalog/geocat-shared-objects/js/extent-directive.js
+  .directive('gnBboxInput', [
+    'gnMap',
+    'gnSearchSettings',
+    'ngeoDecorateInteraction',
+    function(gnMap, gnSearchSettings, goDecoI){
+
+      // Create overlay to draw bbox and polygon
+      var featureOverlay = new ol.FeatureOverlay({
+        style: gnSearchSettings.olStyles.drawBbox
+      });
+      var map = gnSearchSettings.viewerMap;
+      featureOverlay.setMap(map);
+
+      var dragboxInteraction = new ol.interaction.DragBox({
+        style: gnSearchSettings.olStyles.drawBbox
+      });
+      map.addInteraction(dragboxInteraction);
+
+      var clearMap = function() {
+        featureOverlay.getFeatures().clear();
+      }
+
+      dragboxInteraction.on('boxstart', clearMap);
+      goDecoI(dragboxInteraction);
+      dragboxInteraction.active = false;
+
+      var extentFromValue = function(value) {
+        if (!value) {
+          return ['', '', '', ''];
+        }
+        return value.split(',');
+      };
+
+      var valueFromExtent = function(extent) {
+        return extent.join(',');
+      };
+
+      return {
+        restrict: 'AE',
+        scope: {
+          crs: '=',
+          value: '='
+        },
+        templateUrl: '../../catalog/components/search/formfields/' +
+          'partials/bboxInput.html',
+
+        link: function(scope, element, attrs) {
+          scope.crs = scope.crs || 'EPSG:4326';
+
+          scope.clear = function() {
+            scope.value = '';
+            scope.extent = extentFromValue(scope.value);
+            scope.updateMap();
+          };
+
+          scope.updateMap = function() {
+            featureOverlay.getFeatures().clear();
+            if (scope.extent == ['', '', '', '']) {
+              return;
+            }
+            var coordinates, geom, f;
+            coordinates = gnMap.getPolygonFromExtent(scope.extent);
+            geom = new ol.geom.Polygon(coordinates)
+              .transform(scope.crs, map.getView().getProjection());
+            f = new ol.Feature();
+            f.setGeometry(geom);
+            featureOverlay.addFeature(f);
+          };
+
+          dragboxInteraction.on('boxend', function() {
+            dragboxInteraction.active = false;
+            var g = dragboxInteraction.getGeometry().clone();
+            var geom = g.clone()
+              .transform(map.getView().getProjection(), scope.crs);
+            scope.extent = geom.getExtent();
+            scope.value = valueFromExtent(scope.extent);
+            scope.updateMap();
+          });
+          scope.dragboxInteraction = dragboxInteraction;
+
+          scope.onBboxChange = function() {
+            scope.value = valueFromExtent(scope.extent);
+            scope.updateMap();
+          };
+
+          element.on('$destroy', function() {
+            clearMap();
+          });
+        }
+      };
+    }
+  ]);
 })();

--- a/web-ui/src/main/resources/catalog/components/search/formfields/partials/bboxInput.html
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/partials/bboxInput.html
@@ -1,0 +1,54 @@
+<div class="gn-bbox-input">
+
+  <div class="bbox">
+    <div class="row">
+      <div class="col-sm-offset-3 col-sm-6">
+        <div class="form-group">
+          <input type="number" step="any"
+                 data-ng-model="extent[3]"
+                 data-ng-change="onBboxChange()"
+                 class="input-sm form-control" value="180">
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-6">
+        <div class="form-group">
+          <input type="number" step="any"
+                 data-ng-model="extent[0]"
+                 data-ng-change="onBboxChange()"
+                 class="input-sm form-control" value="90">
+        </div>
+      </div>
+      <div class="col-sm-6">
+        <div class="form-group">
+          <input type="number" step="any"
+                 data-ng-model="extent[2]"
+                 data-ng-change="onBboxChange()"
+                 class="input-sm form-control" value="-90">
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-offset-3 col-sm-6">
+        <div class="form-group">
+          <input type="number" step="any"
+                 data-ng-model="extent[1]"
+                 data-ng-change="onBboxChange()"
+                 class="input-sm form-control" value="-180">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!--Draw buttons-->
+  <div ngeo-btn-group>
+    <button class="btn btn-default" ng-model="dragboxInteraction.active" ngeo-btn>
+      <span class="fa fa-pencil-square-o"></span>
+    </button>
+    <button class="btn btn-default" data-ng-click="clear()">
+      <span class="fa fa-trash-o"></span>
+    </button>
+  </div>
+
+</div>

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -22,30 +22,17 @@
     'gnWpsService',
     function(gnWpsService) {
 
-      var inputTypeMapping = {
+      var inputTypes = {
         string: 'text',
         float: 'number'
-      };
-
-      var defaultValue = function(literalData) {
-        var value = undefined;
-        if (literalData.defaultValue != undefined) {
-          value = literalData.defaultValue;
-        }
-        if (literalData.dataType.value == 'float') {
-          value = parseFloat(value);
-        }
-        if (literalData.dataType.value == 'string') {
-          value = value || '';
-        }
-        return value;
       };
 
       return {
         restrict: 'AE',
         scope: {
           uri: '=',
-          processId: '='
+          processId: '=',
+          defaults: '='
         },
         templateUrl: function(elem, attrs) {
           return attrs.template ||
@@ -57,44 +44,69 @@
           scope.status = 'loading';
           gnWpsService.describeProcess(scope.uri, scope.processId)
           .then(
-              function(data) {
-                scope.processDescription = data.processDescription[0];
-                scope.title = scope.processDescription.title.value;
-                scope.inputs = [];
-                angular.forEach(scope.processDescription.dataInputs.input,
-                  function(input) {
-                    scope.inputs.push({
-                      name: input.identifier.value,
-                      title: input.title.value,
-                      type: inputTypeMapping[input.literalData.dataType.value],
-                      value: defaultValue(input.literalData),
-                      required: input.minOccurs == 1 ? true : false
-                    });
+            function(data) {
+              scope.processDescription = data.processDescription[0];
+              angular.forEach(scope.processDescription.dataInputs.input, function(input) {
+                if (input.literalData) {
+                  // Input type
+                  input.type = inputTypes[input.literalData.dataType.value];
+
+                  // Default value
+                  var value = undefined;
+                  if (input.literalData.defaultValue != undefined) {
+                    value = input.literalData.defaultValue;
                   }
-                );
-                scope.status = 'loaded';
-              },
-              function(data) {
-                scope.exception = data;
-                scope.status = 'error';
-              }
-              );
+                  if (scope.defaults[input.identifier.value]) {
+                    value = scope.defaults[input.identifier.value];
+                  }
+                  switch(input.literalData.dataType.value) {
+                  case 'float':
+                    value = parseFloat(value); break;
+                  case 'string':
+                    value = value || ''; break;
+                  }
+                  input.value = value;
+                }
+                if (input.boundingBoxData) {
+                  input.value = '';
+                }
+              });
+              scope.status = 'loaded';
+            },
+            function(data) {
+              scope.exception = data;
+              scope.status = 'error';
+            }
+          );
 
           scope.close = function() {
             element.remove();
           };
 
           scope.submit = function() {
-            var inputs = scope.inputs.reduce(function(o, v, i) {
-              o[v.name] = v.value.toString();
+            scope.validation_messages = [];
+            scope.exception = undefined;
+
+            // Validate inputs
+            var invalid = false;
+            angular.forEach(scope.processDescription.dataInputs.input, function(input) {
+              input.invalid = undefined;
+              if (input.minOccurs > 0 && (input.value === null || input.value === '')) {
+                input.invalid = input.title.value+' is mandatory';
+                invalid = true;
+              }
+            });
+            if (invalid) { return; }
+
+            var inputs = scope.processDescription.dataInputs.input.reduce(function(o, v, i) {
+              o[v.identifier.value] = v.value;
               return o;
             }, {});
             gnWpsService.execute(
                 scope.uri,
                 scope.processId,
                 inputs,
-                scope.processDescription.processOutputs.
-                output[0].identifier.value,
+                scope.processDescription.processOutputs.output[0].identifier.value,
                 false
             ).then(
                 function(data) {
@@ -102,7 +114,6 @@
                 },
                 function(data) {
                   scope.exception = data;
-                  scope.status = 'error';
                 }
             );
           };

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -32,7 +32,8 @@
         scope: {
           uri: '=',
           processId: '=',
-          defaults: '='
+          defaults: '=',
+          map: '='
         },
         templateUrl: function(elem, attrs) {
           return attrs.template ||

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -41,6 +41,7 @@
         },
 
         link: function(scope, element, attrs) {
+          var defaults = scope.defaults || {};
 
           scope.status = 'loading';
           gnWpsService.describeProcess(scope.uri, scope.processId)
@@ -57,8 +58,8 @@
                   if (input.literalData.defaultValue != undefined) {
                     value = input.literalData.defaultValue;
                   }
-                  if (scope.defaults[input.identifier.value]) {
-                    value = scope.defaults[input.identifier.value];
+                  if (defaults[input.identifier.value] != undefined) {
+                    value = defaults[input.identifier.value];
                   }
                   switch(input.literalData.dataType.value) {
                   case 'float':

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -141,17 +141,34 @@
               };
 
               var setInputData = function(input, data) {
-                var inputValue;
-                request.value.dataInputs.input.push({
-                  identifier: {
-                    value: input.identifier.value
-                  },
-                  data: {
-                    literalData: {
-                      value: data
+                if (input.literalData) {
+                  request.value.dataInputs.input.push({
+                    identifier: {
+                      value: input.identifier.value
+                    },
+                    data: {
+                      literalData: {
+                        value: data.toString()
+                      }
                     }
-                  }
-                });
+                  });
+                }
+                if (input.boundingBoxData) {
+                  var bbox = data.split(',');
+                  request.value.dataInputs.input.push({
+                    identifier: {
+                      value: input.identifier.value
+                    },
+                    data: {
+                      boundingBoxData: {
+                        crs: "EPSG:4326",
+                        dimensions: 2,
+                        lowerCorner: [bbox[0], bbox[1]],
+                        upperCorner: [bbox[2], bbox[3]]
+                      }
+                    }
+                  });
+                }
               };
 
               for (i = 0, ii = description.dataInputs.input.length;

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -9,10 +9,18 @@
 
     <div ng-switch-when="loaded">
       <form>
-        <h5>{{::title}}</h5>
-        <div ng-repeat="input in inputs" class="form-group" ng-class="{'gn-required': input.required}">
-          <label for="{{::input.name}}">{{::input.title}}</label>
-          <input type="{{::input.type}}" id="{{::input.name}}" class="form-control input-sm" ng-model="input.value"></input>
+        <h5>{{::processDescription.title.value}}</h5>
+        <div ng-repeat="input in processDescription.dataInputs.input" class="form-group" ng-class="{'gn-required': input.minOccurs}">
+          <label for="{{::input.identifier.value}}">{{::input.title.value}}</label>
+          <div ng-if="::input.literalData">
+            <input type="{{::input.type}}" id="{{::input.identifier.value}}" class="form-control input-sm" ng-model="input.value"></input>
+          </div>
+          <div ng-if="::input.boundingBoxData">
+            <gn-bbox-input id="{{::input.identifier.value}}" data-crs="input._default.crs" data-value="input.value"/>
+          </div>
+          <div ng-if="input.invalid">
+            <p class="text-danger">{{input.invalid}}</p>
+          </div>
         </div>
         <div class="form-group">
           <button type="submit" class="btn btn-default" data-ng-click="submit()" >
@@ -20,9 +28,23 @@
           </button>
         </div>
       </form>
+      <div ng-if="exception">
+          <h4>{{exception.msg|translate}}</h4>
+          <div ng-if="exception.owsExceptionReport">
+            <div ng-repeat="exception in exception.owsExceptionReport.exception">
+              <div ng-repeat="(key, value) in exception">
+                {{key}}: {{value}}
+              </div>
+            </div>
+          </div>
+          <div ng-if="exception.httpResponse">
+            <div><span translate>wpsErrorCodeReturned</span> {{exception.httpResponse.status}} - {{exception.httpResponse.statusText}}</div>
+            <div>{{exception.httpResponse.data}}</div>
+          </div>
+      </div>
     </div>
 
-    <div ng-switch-when="error">
+    <div ng-switch-when="load-error">
       <h4>{{exception.msg|translate}}</h4>
       <div ng-if="exception.owsExceptionReport">
         <div ng-repeat="exception in exception.owsExceptionReport.exception">

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -16,7 +16,11 @@
             <input type="{{::input.type}}" id="{{::input.identifier.value}}" class="form-control input-sm" ng-model="input.value"></input>
           </div>
           <div ng-if="::input.boundingBoxData">
-            <gn-bbox-input id="{{::input.identifier.value}}" data-crs="input._default.crs" data-value="input.value"/>
+            <gn-bbox-input id="{{::input.identifier.value}}"
+                data-crs="input._default.crs"
+                data-value="input.value"
+                data-map="map"
+                />
           </div>
           <div ng-if="input.invalid">
             <p class="text-danger">{{input.invalid}}</p>


### PR DESCRIPTION
Handle bounding box inputs.
Client side validation for mandatory fields.

Exemple use:
```
<gn-wps-process-form
    data-uri="wpsUri"
    data-process-id="wpsProcessId"
    data-defaults="wpsDefaults"
    data-map="map"
    ></gn-wps-process-form>
```