### PR TITLE
Postgres Postgis database configuration that allows storing the spati…

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-db/jdbc.properties
+++ b/web/src/main/webapp/WEB-INF/config-db/jdbc.properties
@@ -2,6 +2,7 @@ jdbc.username=admin
 jdbc.password=gnos
 jdbc.database=geonetwork
 jdbc.host=localhost
+jdbc.port=5432
 jdbc.basic.removeAbandoned=true
 jdbc.basic.removeAbandonedTimeout=120
 jdbc.basic.logAbandoned=true

--- a/web/src/main/webapp/WEB-INF/config-db/postgres-postgis.xml
+++ b/web/src/main/webapp/WEB-INF/config-db/postgres-postgis.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans default-lazy-init="true"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+	">
+    <!--  Postgresql database with postgis extenstion to allow storing spatial index in postgres. -->
+
+    <!-- allow loading properties from the tomcat conf directory. If not found the default jdbc.properties will be used. Uncomment to use. -->
+    <!-- context:property-placeholder location="file:${catalina.home}/conf/jdbc.properties" ignore-resource-not-found="true" file-encoding="UTF-8" ignore-unresolvable="true" order="0"/-->
+
+    <import resource="defaultJdbcDataSource.xml"/>
+    <import resource="postgis-alternate-datasource.xml"/>
+
+    <bean id="jpaVendorAdapterDatabaseParam" class="java.lang.String">
+        <constructor-arg value="POSTGRESQL"/>
+    </bean>
+
+    <bean id="jdbcDriverClassName" class="java.lang.String">
+        <constructor-arg value="org.postgis.DriverWrapper"/>
+    </bean>
+
+    <bean id="jdbcURL" class="java.lang.String">
+    <constructor-arg value="jdbc:postgresql_postGIS://${jdbc.host}:${jdbc.port}/${jdbc.database}"/>
+    </bean>
+</beans>

--- a/web/src/main/webapp/WEB-INF/config-node/srv.xml
+++ b/web/src/main/webapp/WEB-INF/config-node/srv.xml
@@ -21,4 +21,5 @@
  	<!--<import resource="../config-db/db2.xml"/> -->
  	<!--<import resource="../config-db/postgres.xml"/>-->
  	<!--<import resource="../config-db/sqlserver.xml"/> -->
+	<!--<import resource="../config-db/postgres-postgis.xml"/> -->
 </beans>


### PR DESCRIPTION
There currently isn't a sample configuration with posgres/postgis that stores indexes in postgis.
This configuration also demonstrates how to put the jdbc.properties in the tomcat config directory.
The jdbc.properties have been extended with a jdbc.port because it was referenced by: postgis-alternate-datasource.xml