### PR TITLE
RemovedRedundantNullCheck

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializerSvn.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializerSvn.java
@@ -120,13 +120,7 @@ public class XmlSerializerSvn extends XmlSerializer {
 		// old XML comes from the database
 		updateDb(id, xml, changeDate, xml.getQualifiedName(), updateDateStamp, uuid);
 
-		if (svnMan == null) { // do nothing
-			Log.error(Geonet.DATA_MANAGER, "SVN repository for metadata enabled but no repository available");
-		} else {
-			// set subversion manager to record history on this metadata when commit
-			// takes place
-			svnMan.setHistory(id, context);
-		}
+    	svnMan.setHistory(id, context);
 
 	}
 


### PR DESCRIPTION
Removed a redundant null check, findbug suggestion:
[INFO] Redundant nullcheck of svnMan, which is known to be non-null in org.fao.geonet.kernel.XmlSerializerSvn.update(String, Element, String, boolean, String, ServiceContext) ["org.fao.geonet.kernel.XmlSerializerSvn"] At XmlSerializerSvn.java:[lines 41-152]