### PR TITLE
Added IS2_INCONSISTENT_SYNC for faviconMap

### DIFF
--- a/code_quality/findbugs-excludes.xml
+++ b/code_quality/findbugs-excludes.xml
@@ -73,7 +73,10 @@
       <Method name="harvest" />
     </Match>
     <Match>
-      <Class name="org.fao.geonet.kernel.harvest.harvester.AbstractHarvester"/>
+	  <Or>
+	    <Class name="org.fao.geonet.kernel.harvest.harvester.AbstractHarvester"/>
+	    <Class name="org.fao.geonet.resources.ResourceFilter"/>
+	  </Or>
       <Bug pattern="IS2_INCONSISTENT_SYNC"/>
     </Match>
     <Match>
@@ -187,7 +190,6 @@
         </Or>
         <Bug pattern="DMI_EMPTY_DB_PASSWORD" />
     </Match>
-
 
 <!-- The following bugs are hard to fix should be fixed because they can cause problems in servers with multiple geonetworks running -->	
 	<Match>


### PR DESCRIPTION
Excluded this for now in findbug filter.
[INFO] Inconsistent synchronization of org.fao.geonet.resources.ResourceFilter.faviconMap; locked 50% of time ["org.fao.geonet.resources.ResourceFilter"] At ResourceFilter.java:[lines 40-150]