### PR TITLE
Ammended defaultPort, cross merge from develop to 3.0.x branch.

### DIFF
--- a/common/src/test/java/org/fao/geonet/utils/GeonetHttpRequestFactoryTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/GeonetHttpRequestFactoryTest.java
@@ -164,7 +164,7 @@ public class GeonetHttpRequestFactoryTest {
 
         assertTrue(httpRequestBase instanceof HttpGet);
         assertEquals("host", httpRequestBase.getURI().getHost());
-        assertEquals(80, httpRequestBase.getURI().getPort());
+        assertEquals(-1, httpRequestBase.getURI().getPort());
         assertEquals("http", httpRequestBase.getURI().getScheme());
         assertEquals("/path", httpRequestBase.getURI().getPath());
         assertEquals("queryString", httpRequestBase.getURI().getQuery());
@@ -180,7 +180,7 @@ public class GeonetHttpRequestFactoryTest {
 
         assertTrue(httpRequestBase instanceof HttpGet);
         assertEquals("host", httpRequestBase.getURI().getHost());
-        assertEquals(443, httpRequestBase.getURI().getPort());
+        assertEquals(-1, httpRequestBase.getURI().getPort());
         assertEquals("https", httpRequestBase.getURI().getScheme());
         assertEquals("/path", httpRequestBase.getURI().getPath());
         assertEquals("queryString", httpRequestBase.getURI().getQuery());


### PR DESCRIPTION
The values for port are -1 in the GeonetHttpRequestFactory if they are the default port. The CSW test cannot handle :80 or :443 at the end of a URI.