### PR TITLE
Explicit sudo false to trigger container based Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo:false
+sudo: false
 language: java
 jdk:
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo:false
 language: java
 jdk:
   - openjdk7


### PR DESCRIPTION
To speed up development add sudo:false to trigger container based CI. This will cache all maven dependencies.