### PR TITLE
Filesystem harvest can harvest subtemplates

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -77,7 +77,8 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
         
         settingMan.add( "id:"+siteId, "icon", lp.icon);
 		settingMan.add( "id:"+siteId, "recurse", lp.recurse);
-		settingMan.add( "id:"+siteId, "directory", lp.directoryname);
+        settingMan.add( "id:"+siteId, "directory", lp.directoryname);
+        settingMan.add( "id:"+siteId, "recordType", lp.recordType);
 		settingMan.add( "id:"+siteId, "nodelete", lp.nodelete);
         settingMan.add( "id:"+siteId, "checkFileLastModifiedForUpdate", lp.checkFileLastModifiedForUpdate);
 	}
@@ -218,7 +219,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
         metadata.getDataInfo().
                 setSchemaId(schema).
                 setRoot(xml.getQualifiedName()).
-                setType(MetadataType.METADATA).
+                setType(MetadataType.lookup(params.recordType)).
                 setCreateDate(new ISODate(createDate)).
                 setChangeDate(new ISODate(createDate));
         metadata.getSourceInfo().

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemParams.java
@@ -41,6 +41,7 @@ public class LocalFilesystemParams extends AbstractParams {
 	public boolean recurse;
     public boolean checkFileLastModifiedForUpdate;
 	public boolean nodelete;
+    public String recordType;
 	
 	public LocalFilesystemParams(DataManager dm) {
 		super(dm);
@@ -83,7 +84,7 @@ public class LocalFilesystemParams extends AbstractParams {
         nodelete = (nodeleteString.equals("on") || nodeleteString.equals("true"));
         String checkFileLastModifiedForUpdateString = Util.getParam(site, "checkFileLastModifiedForUpdate", "true");
         checkFileLastModifiedForUpdate = (checkFileLastModifiedForUpdateString.equals("on") || checkFileLastModifiedForUpdateString.equals("true"));
-        
+        recordType = Util.getParam(site, "recordType",   "n");
     }
 
 	public LocalFilesystemParams copy() {
@@ -94,6 +95,7 @@ public class LocalFilesystemParams extends AbstractParams {
 		copy.recurse = recurse;
 		copy.nodelete = nodelete;
         copy.checkFileLastModifiedForUpdate = checkFileLastModifiedForUpdate;
+        copy.recordType = recordType;
 		return copy;
 	}
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
@@ -24,6 +24,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -123,7 +124,29 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
                         return FileVisitResult.CONTINUE; // skip this one
                     }
 
-                    String uuid = dataMan.extractUUID(schema, xml);
+                    String uuid = null;
+                    try {
+                        uuid = dataMan.extractUUID(schema, xml);
+                    } catch (Exception e) {
+                        log.warning("Failed to extract metadata UUID for file " + filePath
+                                +
+                                ". Error is: " + e.getMessage());
+
+                        // Extract UUID from uuid attribute in subtemplates
+                        String uuidAttribute = xml.getAttributeValue("uuid");
+                        if (uuidAttribute != null) {
+                            log.warning("Using uuid attribute " + uuidAttribute +
+                                    " for file " + filePath +
+                                    ".");
+                            uuid = uuidAttribute;
+                        } else {
+                            // Assigning a new UUID
+                            uuid = UUID.randomUUID().toString();
+                            log.warning("Using random uuid " + uuid +
+                                    " for file " + filePath +
+                                    ".");
+                        }
+                    }
                     if (uuid == null || uuid.equals("")) {
                         result.badFormat++;
                     } else {

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -608,7 +608,7 @@
 
   /**
    * @ngdoc directive
-   * @name gn_formfields.directive:recordtypesCombo
+   * @name gn_formfields.directive:gnRecordtypesCombo
    * @restrict A
    *
    * @description
@@ -617,14 +617,14 @@
    *  - metadata
    *  - subtemplate
    */
-  .directive('recordtypesCombo', ['$http', function($http) {
+  .directive('gnRecordtypesCombo', ['$http', function($http) {
     return {
 
       restrict: 'A',
       templateUrl: '../../catalog/components/search/formfields/' +
           'partials/recordTypesCombo.html',
       scope: {
-        template: '=recordtypesCombo'
+        template: '=gnRecordtypesCombo'
       },
 
       link: function (scope, element, attrs) {

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -604,5 +604,39 @@
               }
             }
           };
-        }]);
+        }])
+
+  /**
+   * @ngdoc directive
+   * @name gn_formfields.directive:recordtypesCombo
+   * @restrict A
+   *
+   * @description
+   * Provide a select input for all types of record
+   *  - template
+   *  - metadata
+   *  - subtemplate
+   */
+  .directive('recordtypesCombo', ['$http', function($http) {
+    return {
+
+      restrict: 'A',
+      templateUrl: '../../catalog/components/search/formfields/' +
+          'partials/recordTypesCombo.html',
+      scope: {
+        template: '=recordtypesCombo'
+      },
+
+      link: function (scope, element, attrs) {
+        scope.recordTypes = [
+          {key: 'METADATA', value: 'n'},
+          {key: 'TEMPLATE', value: 'y'},
+          {key: 'SUB_TEMPLATE', value: 's'}
+        ];
+
+      }
+    }
+  }]);
+
+
 })();

--- a/web-ui/src/main/resources/catalog/components/search/formfields/partials/recordTypesCombo.html
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/partials/recordTypesCombo.html
@@ -1,0 +1,6 @@
+ <select
+          class="form-control"
+          id="gn-typeOfRecord"
+          required=""
+          data-ng-model="template"
+          data-ng-options="t.value as (t.key | translate) for t in recordTypes"></select>

--- a/web-ui/src/main/resources/catalog/js/edit/ImportController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/ImportController.js
@@ -3,11 +3,13 @@
 
   goog.require('gn_category');
   goog.require('gn_importxsl');
+  goog.require('gn_formfields_directive');
 
   var module = angular.module('gn_import_controller', [
     'gn_importxsl',
     'gn_category',
-    'blueimp.fileupload'
+    'blueimp.fileupload',
+    'gn_formfields_directive'
   ]);
 
   /**
@@ -24,13 +26,6 @@
       $scope.file_type = 'single';
       $scope.uuidAction = 'nothing';
       $scope.importing = false;
-      $scope.recordTypes = [
-        {key: 'METADATA', value: 'n'},
-        {key: 'TEMPLATE', value: 'y'},
-        {key: 'SUB_TEMPLATE', value: 's'}
-      ];
-
-      $scope.template = $scope.recordTypes[0].value;
 
       /** Upload management */
       $scope.action = 'xml.mef.import.ui';

--- a/web-ui/src/main/resources/catalog/locales/du-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/du-editor.json
@@ -162,7 +162,6 @@
     "to-iso19139-keyword-with-anchor-help": "Nuttig voor het hebben van een hyperlink op het zoekwoord die meestal is het sleutelwoord identifier . Een gmx",
     "toggleAttributes": "meer details",
     "toggleTooltips": "tooltips",
-    "typeOfRecord": "Type record",
     "unknownType": "anderen",
     "unpublish": "depubliceren",
     "unpublishSuccess": "succesvolle unpublication",

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -239,5 +239,6 @@
     "valueCode": "Code",
     "addRecord": "Add new record",
     "ImportRecord": "Import new records",
-    "directoryManager": "Manage directory"
+    "directoryManager": "Manage directory",
+    "typeOfRecord": "Type of record"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -162,7 +162,6 @@
     "to-iso19139-keyword-with-anchor-help": "Useful for having an hyperlink on the keyword which usually is the keyword identifier. A gmx:Anchor element is used for each keywords.",
     "toggleAttributes": "More details",
     "toggleTooltips": "Tooltips",
-    "typeOfRecord": "Type of record",
     "unknownType": "Others",
     "unpublish": "Unpublish",
     "unpublishSuccess": "Successful unpublication",

--- a/web-ui/src/main/resources/catalog/locales/es-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/es-editor.json
@@ -162,7 +162,6 @@
     "to-iso19139-keyword-with-anchor-help": "Útil para crear un enlace en la palabra clave que es normalmente el identificador de dicha palabra clave. Un atributo gmx:Anchor se añadirá a cada palabra clave.",
     "toggleAttributes": "Más detalles",
     "toggleTooltips": "Tooltips",
-    "typeOfRecord": "Tipo de entrada",
     "unknownType": "Otros",
     "unpublish": "Despublicado",
     "unpublishSuccess": "Despublicación exitosa",

--- a/web-ui/src/main/resources/catalog/locales/fr-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-editor.json
@@ -162,7 +162,6 @@
     "to-iso19139-keyword-with-anchor-help": "Useful for having an hyperlink on the keyword which usually is the keyword identifier. A gmx:Anchor element is used for each keywords.",
     "toggleAttributes": "Plus de détails",
     "toggleTooltips": "Aide",
-    "typeOfRecord": "Type de fiche",
     "unknownType": "Autres",
     "unpublish": "Dé-publier",
     "unpublishSuccess": "Dépublication effectuée",

--- a/web-ui/src/main/resources/catalog/locales/ge-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/ge-editor.json
@@ -162,7 +162,6 @@
     "to-iso19139-keyword-with-anchor-help": "Useful for having an hyperlink on the keyword which usually is the keyword identifier. A gmx:Anchor element is used for each keywords.",
     "toggleAttributes": "Mehr Informationen",
     "toggleTooltips": "Tooltips",
-    "typeOfRecord": "Art des Datensatzes",
     "unknownType": "Weitere",
     "unpublish": "Zur Rücknahme der Veröffentlichung",
     "unpublishSuccess": "Depublikation erfolgreich",

--- a/web-ui/src/main/resources/catalog/locales/it-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/it-editor.json
@@ -162,7 +162,6 @@
     "to-iso19139-keyword-with-anchor-help": "Useful for having an hyperlink on the keyword which usually is the keyword identifier. A gmx:Anchor element is used for each keywords.",
     "toggleAttributes": "More details",
     "toggleTooltips": "Tooltips",
-    "typeOfRecord": "Type of record",
     "unknownType": "Others",
     "unpublish": "Annullare la pubblicazione",
     "unpublishSuccess": "Successful unpublication",

--- a/web-ui/src/main/resources/catalog/locales/ko-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-editor.json
@@ -162,7 +162,6 @@
     "to-iso19139-keyword-with-anchor-help": "일반적으로 하이퍼링크를 가지는 키워드는 해당 키워드의 식별을 유용하게 합니다. gmx:Anchor 엘리먼트는 각각의 키워드에 사용됩니다.",
     "toggleAttributes": "자세한 내용",
     "toggleTooltips": "툴팁",
-    "typeOfRecord": "레코드 유형",
     "unknownType": "기타",
     "unpublish": "게시 취소",
     "unpublishSuccess": "게시 취소 성공",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
@@ -20,7 +20,7 @@
       <!--Type of record-->
       <div>
         <label class="control-label" data-translate="">typeOfRecord</label>
-        <div recordtypes-combo="harvesterSelected.site.recordType"></div>
+        <div gn-recordtypes-combo="harvesterSelected.site.recordType"></div>
       </div>
 
     </fieldset>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
@@ -17,6 +17,12 @@
             <p class="help-block" data-translate="">filesystem-directoryHelp</p>
         </div>
 
+      <!--Type of record-->
+      <div>
+        <label class="control-label" data-translate="">typeOfRecord</label>
+        <div recordtypes-combo="harvesterSelected.site.recordType"></div>
+      </div>
+
     </fieldset>
 
 

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.js
@@ -15,6 +15,7 @@ var gnHarvesterfilesystem = {
                 "recurse" : true,
                 "nodelete" : true,
                 "checkFileLastModifiedForUpdate" : true,
+                "recordType" : 'n',
                 "icon" : "blank.png"
             },
             "content" : {
@@ -52,6 +53,7 @@ var gnHarvesterfilesystem = {
                 + '    <nodelete>' + h.site.nodelete + '</nodelete>'
                 + '    <checkFileLastModifiedForUpdate>' + h.site.checkFileLastModifiedForUpdate + '</checkFileLastModifiedForUpdate>'
                 + '    <directory>' + h.site.directory + '</directory>'
+                + '    <recordType>' + h.site.recordType + '</recordType>'
                 + '    <icon>' + h.site.icon + '</icon>'
                 + '  </site>' 
                 + '  <options>' 

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -124,12 +124,8 @@
                  class="col-sm-5 control-label"
                  data-translate="">typeOfRecord</label>
           <div class="col-sm-7">
-            <select
-                    class="form-control"
-                    id="gn-typeOfRecord"
-                    required=""
-                    data-ng-model="template"
-                    data-ng-options="t.value as (t.key | translate) for t in recordTypes"></select>
+            <div id="gn-typeOfRecord" gn-recordtypes-combo="template"></div>
+
             <input type="text" class="hidden" name="template" data-ng-model="template">
           </div>
         </div>


### PR DESCRIPTION
This PR aims to allow catalog admins to harvest subtemplates in local file system harvester.
It adds an option to tell what kind of metadata to create (metadata, template, subtemplate), and extend its capabilities to retrieve the uuid from XML content.
