### PR TITLE
Only take the first IP address when parsing client IP.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
@@ -554,7 +554,7 @@ public class AccessManager {
             if (network != null && netmask != null) {
                 long lIntranetNet = getAddress(network.getValue());
                 long lIntranetMask = getAddress(netmask.getValue());
-                long lAddress = getAddress(ip);
+                long lAddress = getAddress(ip.split(",")[0]);
                 return (lAddress & lIntranetMask) == lIntranetNet;
             }
         } catch (Exception nfe) {


### PR DESCRIPTION
When there are several (reverse-)proxies between the client and the
server, the header might contain several IP addresses, separated
by a comma. This was leading to NumberFormatException at each client
request, trying to parse for example "109, 10"...

This can also be merged to 3.0.x, i've experienced the issue on 3.0.2.