### PR TITLE
Resolving environment variables in overrides

### DIFF
--- a/core/src/main/java/jeeves/server/overrides/ConfigurationOverrides.java
+++ b/core/src/main/java/jeeves/server/overrides/ConfigurationOverrides.java
@@ -514,6 +514,11 @@ public class ConfigurationOverrides {
             String propKey = matcher.group(1);
             String propValue = properties.getProperty(propKey);
 
+            // if property begins with "env:", it will be replaced later on
+            if (propKey.startsWith("env:")) {
+                continue;
+            }
+
             if (propValue == null) {
                 throw new IllegalArgumentException("Found a reference to a variable: " + propKey + " which is not a valid property.  Check the spelling");
             }

--- a/core/src/test/java/jeeves/server/overrides/ConfigurationOverridesTest.java
+++ b/core/src/test/java/jeeves/server/overrides/ConfigurationOverridesTest.java
@@ -1,7 +1,24 @@
 package jeeves.server.overrides;
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import jeeves.config.springutil.JeevesApplicationContext;
+
 import org.apache.log4j.Level;
 import org.fao.geonet.Constants;
 import org.fao.geonet.utils.IO;
@@ -11,19 +28,6 @@ import org.jdom.JDOMException;
 import org.junit.Test;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.web.access.intercept.FilterSecurityInterceptor;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class ConfigurationOverridesTest {
 	private static final ClassLoader classLoader;
@@ -197,7 +201,49 @@ public class ConfigurationOverridesTest {
 
         assertEquals(Xml.selectString(unchanged,"default/gui/xml[@name = 'countries']/@file"), Xml.selectString(config,"default/gui/xml[@name = 'countries']/@file"));
     }
-    
+
+    @Test
+    public void resolveRessourcesWithEnvVariable() throws Exception {
+        // Ensures the testcase begins in correct conditions
+        System.clearProperty("geonetwork.datadir");
+        System.clearProperty("another_one");
+
+        // No properties defined, it should resolve as "//test.xml"
+
+        try {
+            boolean exCaught = false;
+            URL u = this.getClass().getResource("/");
+
+            try {
+                loader.loadXmlResource("${env:geonetwork.datadir}/${env:another_one}/test.xml");
+            } catch (Throwable e) {
+                System.out.println(e.getMessage());
+                exCaught = e.getMessage().contains("//test.xml");
+            }
+            assertTrue(
+                    "Expected to fail on loading //test.xml file, no exception encountered",
+                    exCaught);
+
+            // Same defining the previously missing env variables
+
+            System.setProperty("geonetwork.datadir", u.toURI().getPath());
+            System.setProperty("another_one", "test-spring-config.xml");
+
+            exCaught = false;
+            try {
+                loader.loadXmlResource("${env:geonetwork.datadir}/${env:another_one}");
+            } catch (Throwable e) {
+                exCaught = true;
+            }
+            assertFalse("Unexepected exception caught with a legit file.",
+                    exCaught);
+        } finally {
+            // Cleanup after testing
+            System.clearProperty("geonetwork.datadir");
+            System.clearProperty("another_one");
+        }
+    }
+
     // TODO no property
     // no overrides
     // invalid appPath


### PR DESCRIPTION
In geOrchestra, we are willing to stay the closest possible to the GN codebase, as a result, we use the overrides mechanism to resolve configuration customization files. But one limitation of this feature is that using java properties is not possible in the XML file. We are then forced to hardcode the paths in the provided XML overrides, see:

https://github.com/pmauduit/core-geonetwork/blob/georchestra-gn3-3.0.x/web/src/deb/resources/etc/georchestra/geonetwork/config/config-overrides-georchestra.xml

In our case, we generate a debian package for GeoNetwork, so we can guess that the files (for what we called the "georchestra datadir", hosting our configuration files), would end up in the right place (e.g.
/etc/georchestra/geonetwork), but an administrator could define his own datadir elsewhere, forcing him to update the overrides file.

Hence, the purpose of this PR allows the use of `${env:prop}` variables to load the extra XML configuration files.

Tests: unit tests added, ConfigurationOverridesTest OK (deactivating findbugs though), untested at runtime for now.

Drawbacks: The current code could be enhanced to ensure that the `${env:prop}` are resolved elsewhere, but I am considering this as a good start. Feedback of the community welcome.