### PR TITLE
Fixing shibboleth configuration for latest changes

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
@@ -53,6 +53,9 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setSurnameKey(String surnameKey) {
+        if(surnameKey == null) {
+            surnameKey = "";
+        }
         this.surnameKey = surnameKey;
     }
 
@@ -61,6 +64,9 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setFirstnameKey(String firstnameKey) {
+        if(firstnameKey == null) {
+            firstnameKey = "";
+        }
         this.firstnameKey = firstnameKey;
     }
 
@@ -69,6 +75,9 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setProfileKey(String profileKey) {
+        if(profileKey == null) {
+            profileKey = "";
+        }
         this.profileKey = profileKey;
     }
 
@@ -77,6 +86,9 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setGroupKey(String groupKey) {
+        if(groupKey == null) {
+            groupKey = "";
+        }
         this.groupKey = groupKey;
     }
 
@@ -85,6 +97,9 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setDefaultGroup(String defaultGroup) {
+        if(defaultGroup == null) {
+            defaultGroup = "";
+        }
         this.defaultGroup = defaultGroup;
     }
 
@@ -115,6 +130,9 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setEmailKey(String emailKey) {
+        if(emailKey == null) {
+            emailKey = "";
+        }
         this.emailKey = emailKey;
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
@@ -221,6 +221,10 @@ public class ShibbolethUserUtils {
 
 	protected static String getHeader(HttpServletRequest req, String name,
 			String defValue) {
+	    
+	    if(name == null || name.trim().isEmpty()) {
+	        return defValue;
+	    }
 
 		String value = req.getHeader(name);
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
@@ -18,16 +18,11 @@
 	<!-- the shibboleth authentication filter -->
 	<bean id="shibbolethPreAuthFilter"
 		class="org.fao.geonet.kernel.security.shibboleth.ShibbolethPreAuthFilter">
-		<property name="utils" ref="shibbolethUserUtils" />
-		<property name="configuration" ref="shibbolethConfiguration" />
 		<!--<property name="requestCache" ref="requestCache" /> -->
 	</bean>
 
 	<bean id="shibbolethUserUtils"
 		class="org.fao.geonet.kernel.security.shibboleth.ShibbolethUserUtils">
-		<property name="_userRepository" ref="userRepository" />
-		<property name="_groupRepository" ref="groupRepository" />
-		<property name="authProvider" ref="geonetworkAuthenticationProvider" />
 		<!-- <property name="userDetailsManager" ref="ldapUserDetailsService" /> -->
 		<!-- <property name="udetailsmapper" ref="ldapUserContextMapper"/> -->
 	</bean>
@@ -46,14 +41,6 @@
 		<property name="updateProfile" value="${shibbolethConfiguration.updateProfile}" />
 	</bean>
 
-	<!-- replace the default entry point -->
-	<bean id="shibAuthenticationEntryPoint"
-		class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
-		<property name="loginFormUrl" value="/login.jsp" /> 
-	</bean>
-
-	<alias name="shibAuthenticationEntryPoint" alias="authenticationEntryPoint" />
-
 	<!-- The filter chain for the shib.user.login service -->
 	<alias name="shibFilterChainImplementation" alias="shibFilterChainPlaceholder" />
 
@@ -69,24 +56,24 @@
 		</constructor-arg>
 	</bean>
 
-	<bean id="filterChainFilters" class="java.util.ArrayList">
-		<constructor-arg>
-			<list>
-				<ref bean="securityContextPersistenceFilter" />
-				<ref bean="exceptionTranslationFilter" />
-				<!--<ref bean="requestCacheFilter" /> -->
-				<ref bean="logoutFilter" />
-
-				<ref bean="shibbolethPreAuthFilter" />
-
-				<ref bean="basicAuthenticationFilter" />
-				<ref bean="requestCacheFilter" />
-				<ref bean="anonymousFilter" />
-				<ref bean="sessionMgmtFilter" />
-				<ref bean="exceptionTranslationFilter" />
-				<ref bean="filterSecurityInterceptor" />
-			</list>
-		</constructor-arg>
-	</bean>
-
+    <bean id="filterChainFilters" class="java.util.ArrayList">
+        <constructor-arg>
+            <list>
+                <ref bean="securityContextPersistenceFilter" />
+                <ref bean="logoutFilter" />
+                <!-- A filter that check if an external service already authenticated user
+                     (default implementation does nothing but can be overridden) -->
+                <ref bean="multiNodeAuthenticationFilter" />
+                <ref bean="preAuthenticationFilter" />
+                <ref bean="shibbolethPreAuthFilter" />
+                <ref bean="basicAuthenticationFilter" />
+                <ref bean="formLoginFilter" />
+                <ref bean="requestCacheFilter" />
+                <ref bean="anonymousFilter" />
+                <ref bean="sessionMgmtFilter" />
+                <ref bean="exceptionTranslationFilter" />
+                <ref bean="filterSecurityInterceptor" />
+            </list>
+        </constructor-arg>
+    </bean>
 </beans>


### PR DESCRIPTION
New filterchain for authentication and some non-autowired objects.
Allow empty header names for very basic SAML authentication (only username).