### PR TITLE
Updated "web-ui-docs" com.github.eirslett:frontend-maven-plugin dependency

### DIFF
--- a/web-ui-docs/pom.xml
+++ b/web-ui-docs/pom.xml
@@ -16,7 +16,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.26</version>
         <executions>
           <execution>
             <id>install node and npm</id>


### PR DESCRIPTION
Updated "web-ui-docs" com.github.eirslett:frontend-maven-plugin dependency to fix a required class missing error on build (org.slf4j.helpers.MarkerIgnoringBase).
Version of com.github.eirslett:frontend-maven-plugin prior to 0.0.26 doesn't work (missing node error).

The build was successful after the update

Before the update, I tried to empty all cache from Maven...