### PR TITLE
Placeholder fix proposed by Juan

### DIFF
--- a/web-ui/src/main/resources/catalog/lib/bootstrap.ext/tagsinput/bootstrap-tagsinput-angular.js
+++ b/web-ui/src/main/resources/catalog/lib/bootstrap.ext/tagsinput/bootstrap-tagsinput-angular.js
@@ -26,6 +26,10 @@ angular.module('bootstrap-tagsinput', [])
           scope.model = [];
 
         var select = $('select', element);
+        
+        if (attrs.placeholder) {
++          select.attr('placeholder', attrs.placeholder);
++        }
 
         select.tagsinput({
           typeahead : {


### PR DESCRIPTION
The placeholder was showing empty so adding this JQuery function we can add or recuperate the value of an attribute of an element
http://api.jquery.com/attr/ so we ask the values of tagsinput