### PR TITLE
Update LocalFsHarvesterFileVisitor.java

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
@@ -194,7 +194,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
                                 String changeDate = new ISODate(fileDate.getTime(), false).getDateAndTime();
 
                                 log.debug(" File date is: " + fileDate.toString() + " / record date is: " + modified);
-                                if (recordDate.before(fileDate)) {
+                                if (resetMilliseconds(recordDate).before(resetMilliseconds(fileDate))) {
                                     log.debug("  Db record is older than file. Updating record with id: " + id);
                                     harvester.updateMetadata(xml, id, localGroups, localCateg, changeDate, aligner);
                                     result.updatedMetadata++;
@@ -229,6 +229,15 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
         }
         return FileVisitResult.CONTINUE;
     }
+
+    /** Reset the milliseconds of a date */
+	private Date resetMilliseconds(Date recordDate) {
+		GregorianCalendar recordDateCal = new GregorianCalendar();
+		recordDateCal.setTime(recordDate);
+		recordDateCal.set(Calendar.MILLISECOND, 0);
+		Date recordDate0Mill = recordDateCal.getTime();
+		return recordDate0Mill;
+	}
 
     public HarvestResult getResult() {
         return result;


### PR DESCRIPTION
The recordDate, when initializated with metadata.getDataInfo().getChangeDate(), doesn't contains the milliseconds got from the database, but it contains a randomic milliseconds (it depends from the execution time): so the metadata file could be considered as changed if the current milliseconds are before to the milliseconds of fileDate (the date of the file, that instead keep the right number of milliseconds, and it is equals at every check).
Compare the recordDate and the fileDate without the milliseconds fix the problem.