### PR TITLE
Update fronted-maven-plugin version to 0.0.23

### DIFF
--- a/web-ui-docs/pom.xml
+++ b/web-ui-docs/pom.xml
@@ -16,7 +16,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.23</version>
         <executions>
           <execution>
             <id>install node and npm</id>


### PR DESCRIPTION
Fix error during compilation : 

[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:0.0.11:install-node-and-npm (install node and npm) on project web-ui-docs: Execution install node and npm of goal com.github.eirslett:frontend-maven-plugin:0.0.11:install-node-and-npm failed: A required class was missing while executing com.github.eirslett:frontend-maven-plugin:0.0.11:install-node-and-npm: org/slf4j/helpers/MarkerIgnoringBase