### PR TITLE
Update commons-email to v1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -525,7 +525,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-email</artifactId>
-        <version>1.1</version>
+        <version>1.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
Commons-mail v1.1 has a bug when sending a HtmlEmail and attaching files. In this case the HTML content is attached too and the email appears in blank. Upgrading to commons-email v1.4 fix this.