### PR TITLE
Get username from userSession before updating metadataFileDownload fr…

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceDownloadHandler.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceDownloadHandler.java
@@ -155,6 +155,7 @@ public class DefaultResourceDownloadHandler implements IResourceDownloadHandler 
                                           final String downloadDate) {
         final MetadataFileUploadRepository uploadRepository = context.getBean(MetadataFileUploadRepository.class);
         final MetadataFileDownloadRepository repo = context.getBean(MetadataFileDownloadRepository.class);
+        final String userName = context.getUserSession().getUsername();
 
         threadPool.runTask(new Runnable() {
             @Override
@@ -183,7 +184,7 @@ public class DefaultResourceDownloadHandler implements IResourceDownloadHandler 
                     metadataFileDownload.setRequesterOrg(requesterOrg);
                     metadataFileDownload.setRequesterComments(requesterComments);
                     metadataFileDownload.setDownloadDate(downloadDate);
-                    metadataFileDownload.setUserName(context.getUserSession().getUsername());
+                    metadataFileDownload.setUserName(userName);
                     metadataFileDownload.setFileUploadId(metadataFileUpload.getId());
 
                     repo.save(metadataFileDownload);


### PR DESCRIPTION
…om a task (#1298)

Otherwise username ends up null, because context has lost session.

Tested working fine and fixing #1298 here.
Candidate for backport to 3.0.x..