### PR TITLE
Check if current opAllowed is a notify operation, continue otherwise …

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/resources/Download.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/Download.java
@@ -144,6 +144,8 @@ public class Download {
                 List<OperationAllowed> opsAllowed = opAllowedRepo.findByMetadataId(id);
                 
 				for (OperationAllowed opAllowed : opsAllowed) {
+					if (opAllowed.getId().getOperationId() != ReservedOperation.notify.getId())
+						continue;
                     Group group = groupRepository.findOne(opAllowed.getId().getGroupId());
 					String  name  = group.getName();
 					String  email = group.getEmail();


### PR DESCRIPTION
…(#1299)

Avoids sending multiple emails when a file is downloaded, even when notify isnt enabled.

Also candidate for merge to 3.0.x, fixes multiple emails here.