### PR TITLE
Publish the style in the same workspace used for the datastore & layer

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/MapServer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MapServer.java
@@ -278,16 +278,17 @@ public class MapServer {
         return _pushstyleinworkspace;
     }
 
-    protected void setPushStyleInWorkspace_JpaWorkaround(char pushStyleInWorkspace) {
-        _pushstyleinworkspace = pushStyleInWorkspace;
+    protected void setPushStyleInWorkspace_JpaWorkaround(char _pushStyleInWorkspace) {
+        this._pushstyleinworkspace = _pushStyleInWorkspace;
     }
     @Transient
     public boolean pushStyleInWorkspace() {
         return Constants.toBoolean_fromYNChar(getPushStyleInWorkspace_JpaWorkaround());
     }
 
-    public void setPushStyleInWorkspace(boolean pushStyleInWorkspace) {
-        setPushStyleInWorkspace_JpaWorkaround(Constants.toYN_EnabledChar(pushStyleInWorkspace));
+    public MapServer setPushStyleInWorkspace(boolean _pushStyleInWorkspace) {
+        setPushStyleInWorkspace_JpaWorkaround(Constants.toYN_EnabledChar(_pushStyleInWorkspace));
+        return this;
     }
 
     @Override

--- a/domain/src/main/java/org/fao/geonet/domain/MapServer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MapServer.java
@@ -36,6 +36,7 @@ public class MapServer {
     private String _password;
     private String _namespaceprefix;
     private String _namespace;
+    private char _pushstyleinworkspace = Constants.YN_FALSE;
 
     /**
      * Get the id of the mapserver.
@@ -265,6 +266,28 @@ public class MapServer {
     public MapServer setNamespace(String _namespace) {
         this._namespace = _namespace;
         return this;
+    }
+
+    /**
+     * Check whether the sld style should be pushed in the same workspace
+     * as the layer and datastore or in the global styles/ dir
+     */
+
+    @Column(name="pushstyleinworkspace", nullable = false, length = 1)
+    protected char getPushStyleInWorkspace_JpaWorkaround() {
+        return _pushstyleinworkspace;
+    }
+
+    protected void setPushStyleInWorkspace_JpaWorkaround(char pushStyleInWorkspace) {
+        _pushstyleinworkspace = pushStyleInWorkspace;
+    }
+    @Transient
+    public boolean pushStyleInWorkspace() {
+        return Constants.toBoolean_fromYNChar(getPushStyleInWorkspace_JpaWorkaround());
+    }
+
+    public void setPushStyleInWorkspace(boolean pushStyleInWorkspace) {
+        setPushStyleInWorkspace_JpaWorkaround(Constants.toYN_EnabledChar(pushStyleInWorkspace));
     }
 
     @Override

--- a/services/src/main/java/org/fao/geonet/services/publisher/Do.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/Do.java
@@ -150,7 +150,8 @@ public class Do implements Service {
                     .setUsername(Util.getParam(params, "username", ""))
                     .setPassword(Util.getParam(params, "password", ""))
                     .setNamespace(Util.getParam(params, "namespace", ""))
-                    .setNamespacePrefix(Util.getParam(params, "namespaceprefix", ""));
+                    .setNamespacePrefix(Util.getParam(params, "namespaceprefix", ""))
+                    .setPushStyleInWorkspace(Util.getParam(params, "pushstyleinworkspace", false));
             context.getBean(MapServerRepository.class).save(m);
             return new Element(action.toString())
                         .setText("ok")
@@ -172,7 +173,8 @@ public class Do implements Service {
                     .setWcsurl(Util.getParam(params, "wcsurl", ""))
                     .setStylerurl(Util.getParam(params, "stylerurl", ""))
                     .setNamespace(Util.getParam(params, "namespace", ""))
-                    .setNamespacePrefix(Util.getParam(params, "namespaceprefix", ""));
+                    .setNamespacePrefix(Util.getParam(params, "namespaceprefix", ""))
+                    .setPushStyleInWorkspace(Util.getParam(params, "pushstyleinworkspace", false));
                 repo.save(m);
             }
             return new Element(action.toString()).setText("ok");
@@ -201,7 +203,7 @@ public class Do implements Service {
             final GeonetHttpRequestFactory requestFactory = context.getBean(GeonetHttpRequestFactory.class);
             GeoServerRest gs = new GeoServerRest(requestFactory, g.getUrl(),
                     g.getUsername(), g.getUserpassword(),
-                    g.getNamespacePrefix(), baseUrl);
+                    g.getNamespacePrefix(), baseUrl, m.pushStyleInWorkspace());
     
     		String file = Util.getParam(params, "file");
     		String access = Util.getParam(params, "access");
@@ -261,6 +263,10 @@ public class Do implements Service {
                 node.addContent(new Element("wfsUrl").setText(m.getWfsurl()));
                 node.addContent(new Element("wcsUrl").setText(m.getWcsurl()));
                 node.addContent(new Element("stylerUrl").setText(m.getStylerurl()));
+                if (m.pushStyleInWorkspace())
+                    node.addContent(new Element("pushStyleInWorkspace").setText("true"));
+                else
+                    node.addContent(new Element("pushStyleInWorkspace").setText("false"));
                 geoserverConfig.addContent(node);
             }
         }

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -510,18 +510,23 @@ public class GeoServerRest {
 
 			String body = "<style><name>" + layer + "_style</name><filename>"
 					+ layer + ".sld</filename></style>";
-			status = sendREST(GeoServerRest.METHOD_POST, "/workspaces/" + ws + "/styles", body, null,
+			String url = "/styles";
+			if (pushStyleInWorkspace)
+				url = "/workspaces/" + ws + "/styles";
+			status = sendREST(GeoServerRest.METHOD_POST, url, body, null,
 					"text/xml", true);
             checkResponseCode(status);
-
-			status = sendREST(GeoServerRest.METHOD_PUT, "/workspaces/" + ws + "/styles/" + layer
+			status = sendREST(GeoServerRest.METHOD_PUT, url + "/" + layer
 					+ "_style", currentStyle, null,
 					"application/vnd.ogc.sld+xml", true);
             checkResponseCode(status);
 
 			body = "<layer><defaultStyle><name>"
 					+ layer
-					+ "_style</name><workspace>" + ws + "</workspace></defaultStyle><enabled>true</enabled></layer>";
+					+ "_style</name>";
+			if (pushStyleInWorkspace)
+				body += "<workspace>" + ws + "</workspace>";
+			body += "</defaultStyle><enabled>true</enabled></layer>";
 
 			// Add the enable flag due to GeoServer bug
 			// http://jira.codehaus.org/browse/GEOS-3964

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -364,27 +364,18 @@ public class GeoServerRest {
 	 *            Name of the datastore
 	 * @param f
 	 *            Zip {@link java.io.File} to upload containing a shapefile
-	 * @param createStyle
-	 *            True to create a default style @see
-	 *            {@link #createStyle(String)}
 	 * @return
 	 * @throws java.io.IOException
 	 */
-	public boolean createDatastore(String ws, String ds, Path f,
-			boolean createStyle) throws IOException {
+	public boolean createDatastore(String ws, String ds, Path f) throws IOException {
 		int status = sendREST(GeoServerRest.METHOD_PUT, "/workspaces/" + ws
 				+ "/datastores/" + ds + "/file.shp", null, f,
 				"application/zip", false);
 
-		if (createStyle) {
-			createStyle(ws, ds);
-		}
-
 		return status == 201;
 	}
 
-	public boolean createDatastore(String ws, String ds, String file,
-			boolean createStyle) throws IOException {
+	public boolean createDatastore(String ws, String ds, String file) throws IOException {
 		String type = "";
 		String extension = file.substring(file.lastIndexOf('.'), file.length());
 		if (file.startsWith("http://")) {
@@ -397,10 +388,6 @@ public class GeoServerRest {
 				+ "/datastores/" + ds + "/" + type + extension, file, null,
 				"text/plain", false);
 
-		if (createStyle) {
-			createStyle(ws, ds);
-		}
-
 		return status == 201;
 	}
 
@@ -409,18 +396,17 @@ public class GeoServerRest {
 	 *
 	 * @param ds
 	 * @param f
-	 * @param createStyle
 	 * @return
 	 * @throws java.io.IOException
 	 */
-	public boolean createDatastore(String ds, Path f, boolean createStyle)
+	public boolean createDatastore(String ds, Path f)
 			throws IOException {
-		return createDatastore(getDefaultWorkspace(), ds, f, createStyle);
+		return createDatastore(getDefaultWorkspace(), ds, f);
 	}
 
-	public boolean createDatastore(String ds, String file, boolean createStyle)
+	public boolean createDatastore(String ds, String file)
 			throws IOException {
-		return createDatastore(getDefaultWorkspace(), ds, file, createStyle);
+		return createDatastore(getDefaultWorkspace(), ds, file);
 	}
 
 	/**
@@ -617,14 +603,14 @@ public class GeoServerRest {
 		return 201 == status;
 	}
 
-	public boolean createFeatureType(String ds, String ft, boolean createStyle,
+	public boolean createFeatureType(String ds, String ft,
 			String metadataUuid, String metadataTitle, String metadataAbstract) throws IOException {
-		return createFeatureType(getDefaultWorkspace(), ds, ft, createStyle,
+		return createFeatureType(getDefaultWorkspace(), ds, ft,
 				metadataUuid, metadataTitle, metadataAbstract);
 	}
 
 	public boolean createFeatureType(String ws, String ds, String ft,
-			boolean createStyle, String metadataUuid, String metadataTitle, String metadataAbstract)
+			String metadataUuid, String metadataTitle, String metadataAbstract)
 			throws IOException {
 		String xml = "<featureType><name>" + ft + "</name><title>" + ft
 				+ "</title>" + "</featureType>";
@@ -677,10 +663,6 @@ public class GeoServerRest {
 				"text/xml", false);
 
 		checkResponseCode(status);
-
-		if (createStyle) {
-			createStyle(ws, ft);
-		}
 
 		return 201 == status;
 	}

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -692,7 +692,7 @@ public class GeoServerRest {
         if(Log.isDebugEnabled(LOGGER_NAME)) {
             Log.debug(LOGGER_NAME, "url:" + url);
             Log.debug(LOGGER_NAME, "method:" + method);
-            Log.debug(LOGGER_NAME, "postData:" + postData);
+            if (postData != null) Log.debug(LOGGER_NAME, "postData:" + postData);
         }
 
 		HttpRequestBase m;

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -139,7 +139,7 @@ public class GeoServerRest {
 	 */
 	public boolean getLayer(String layer) throws IOException {
 		int status = sendREST(GeoServerRest.METHOD_GET, "/layers/" + layer
-				+ ".xml", null, null, null, true);
+				+ ".xml?quietOnNotFound=true", null, null, null, true);
 		return status == 200;
 	}
 
@@ -504,7 +504,7 @@ public class GeoServerRest {
 	public boolean createStyle(String ws, String layer, String sldbody) {
 		try {
 			int status = sendREST(GeoServerRest.METHOD_GET, "/layers/" + layer
-					+ ".xml", null, null, null, true);
+					+ ".xml?quietOnNotFound=true", null, null, null, true);
 
 			checkResponseCode(status);
 			Element layerProperties = Xml.loadString(getResponse(), false);
@@ -513,7 +513,7 @@ public class GeoServerRest {
 
 			/* get the default style (polygon, line, point) from the global styles */
 			status = sendREST(GeoServerRest.METHOD_GET, "/styles/" + styleName
-					+ ".sld", null, null, null, true);
+					+ ".sld?quietOnNotFound=true", null, null, null, true);
             checkResponseCode(status);
 
 			String currentStyle = getResponse();
@@ -538,7 +538,7 @@ public class GeoServerRest {
 				 * previous call always return 200 even when sld is invalid
 				 */
 				status = sendREST(GeoServerRest.METHOD_GET, url + "/" + layer
-						+ "_style.sld", null, null, null, true);
+						+ "_style.sld?quietOnNotFound=true", null, null, null, true);
 
 				if (status != 200)
 					Log.warning(Geonet.GEOPUBLISH,"The sld file was probably not valid, falling back to default");

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -76,6 +76,7 @@ public class GeoServerRest {
 	private String baseCatalogueUrl;
 	private String defaultWorkspace;
 	private String response;
+	private boolean pushStyleInWorkspace;
 	private int status;
 
 	private GeonetHttpRequestFactory factory;
@@ -89,14 +90,16 @@ public class GeoServerRest {
 	 * @param password
 	 * @param defaultns
 	 * @param baseCatalogueUrl
+	 * @param pushStyleInWorkspace
 	 *            TODO
 	 */
 	public GeoServerRest(GeonetHttpRequestFactory factory, String url, String username, String password,
-			String defaultns, String baseCatalogueUrl) {
+			String defaultns, String baseCatalogueUrl, boolean pushStyleInWorkspace) {
         this.restUrl = url;
         this.username = username;
         this.password = password;
         this.baseCatalogueUrl = baseCatalogueUrl;
+        this.pushStyleInWorkspace = pushStyleInWorkspace;
         this.factory = factory;
         Log.createLogger(LOGGER_NAME);
         this.defaultWorkspace = defaultns;

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -374,7 +374,7 @@ public class GeoServerRest {
 				"application/zip", false);
 
 		if (createStyle) {
-			createStyle(ds);
+			createStyle(ws, ds);
 		}
 
 		return status == 201;
@@ -395,7 +395,7 @@ public class GeoServerRest {
 				"text/plain", false);
 
 		if (createStyle) {
-			createStyle(ds);
+			createStyle(ws, ds);
 		}
 
 		return status == 201;
@@ -488,7 +488,7 @@ public class GeoServerRest {
 	 * @param layer
 	 * @return
 	 */
-	public int createStyle(String layer) {
+	public int createStyle(String ws, String layer) {
 		try {
 			int status = sendREST(GeoServerRest.METHOD_GET, "/layers/" + layer
 					+ ".xml", null, null, null, true);
@@ -498,6 +498,7 @@ public class GeoServerRest {
 			String styleName = layerProperties.getChild("defaultStyle")
 					.getChild("name").getText();
 
+			/* get the default style (polygon, line, point) from the global styles */
 			status = sendREST(GeoServerRest.METHOD_GET, "/styles/" + styleName
 					+ ".sld", null, null, null, true);
             checkResponseCode(status);
@@ -506,18 +507,18 @@ public class GeoServerRest {
 
 			String body = "<style><name>" + layer + "_style</name><filename>"
 					+ layer + ".sld</filename></style>";
-			status = sendREST(GeoServerRest.METHOD_POST, "/styles", body, null,
+			status = sendREST(GeoServerRest.METHOD_POST, "/workspaces/" + ws + "/styles", body, null,
 					"text/xml", true);
             checkResponseCode(status);
 
-			status = sendREST(GeoServerRest.METHOD_PUT, "/styles/" + layer
+			status = sendREST(GeoServerRest.METHOD_PUT, "/workspaces/" + ws + "/styles/" + layer
 					+ "_style", currentStyle, null,
 					"application/vnd.ogc.sld+xml", true);
             checkResponseCode(status);
 
 			body = "<layer><defaultStyle><name>"
 					+ layer
-					+ "_style</name></defaultStyle><enabled>true</enabled></layer>";
+					+ "_style</name><workspace>" + ws + "</workspace></defaultStyle><enabled>true</enabled></layer>";
 
 			// Add the enable flag due to GeoServer bug
 			// http://jira.codehaus.org/browse/GEOS-3964
@@ -528,7 +529,7 @@ public class GeoServerRest {
 		} catch (Exception e) {
 			if(Log.isDebugEnabled(LOGGER_NAME))
 				Log.debug(LOGGER_NAME, "Failed to create style for layer: "
-					+ layer + ", error is: " + e.getMessage());
+					+ layer + " in workspace " + ws + ", error is: " + e.getMessage());
 		}
 
 		return status;
@@ -627,7 +628,7 @@ public class GeoServerRest {
 		checkResponseCode(status);
 
 		if (createStyle) {
-			createStyle(ft);
+			createStyle(ws, ft);
 		}
 
 		return 201 == status;

--- a/web-ui/src/main/resources/catalog/js/admin/MapServerController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/MapServerController.js
@@ -55,7 +55,8 @@
           'username': '',
           'password': '',
           'namespaceUrl': '',
-          'namespacePrefix': ''
+          'namespacePrefix': '',
+          'pushStyleInWorkspace': ''
         };
       };
       $scope.saveMapServer = function(formId) {

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -588,6 +588,7 @@
     "processReportProcessedRecords": "Records processed",
     "processReportTotalRecords": "Records to process",
     "properties": "Field",
+    "pushStyleInWorkspace": "Push style in the workspace",
     "q": "Search",
     "qi": "Internal search",
     "quicklinks": "Quick links",

--- a/web-ui/src/main/resources/catalog/locales/fr-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-admin.json
@@ -581,6 +581,7 @@
     "processReportProcessedRecords": "Fiches traitées",
     "processReportTotalRecords": "Fiches à traiter",
     "properties": "Champ",
+    "pushStyleInWorkspace": "Publier le style dans l'espace de travail",
     "q": "Recherche",
     "qi": "Recherche interne",
     "quicklinks": "Liens rapides",

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
@@ -120,14 +120,6 @@
             </fieldset>
 
             <div class="form-group">
-              <label>
-                <input type="checkbox" name="pushStyleInWorkspace"
-                       data-ng-model="mapserverSelected.pushStyleInWorkspace"/>
-                  <span data-translate="">pushStyleInWorkspace</span>
-              </label>
-            </div>
-
-            <div class="form-group">
               <label class="control-label col-sm-3" data-translate="">workspace</label>
 
               <div class="col-sm-9 input-group">
@@ -144,6 +136,14 @@
               <div class="col-sm-9 col-sm-offset-3">
                 <p class="help-block" data-translate="">workspace-help</p>
               </div>
+            </div>
+
+            <div class="form-group">
+              <label class="control-label col-sm-3" data-translate="">pushStyleInWorkspace</label>
+              <div class="col-sm-9">
+                <input type="checkbox" name="pushstyleinworkspace"
+                       data-ng-checked="mapserverSelected.pushStyleInWorkspace == 'true'"/>
+                </div>
             </div>
 
 

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
@@ -119,6 +119,13 @@
               </div>
             </fieldset>
 
+            <div class="form-group">
+              <label>
+                <input type="checkbox" name="pushStyleInWorkspace"
+                       data-ng-model="mapserverSelected.pushStyleInWorkspace"/>
+                  <span data-translate="">pushStyleInWorkspace</span>
+              </label>
+            </div>
 
             <div class="form-group">
               <label class="control-label col-sm-3" data-translate="">workspace</label>

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v310/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v310/migrate-default.sql
@@ -1,2 +1,4 @@
+ALTER TABLE Mapservers ADD COLUMN pushstyleinworkspace varchar(1) default 'n';
+
 UPDATE Settings SET value='3.1.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
This is something i've been running with since 2.8, against geoserver 2.3, and tested still working here on geonetwork 3 against geoserver 2.5.4 - rationale is to publish the style in the same workspace as the datastore & layer are published - it helps keeping things organized, and in certain cases (catalog privacy settings) users dont have access to 'global' styles (or if you want to disable the global endpoint), so it's better if the styles are grouped with their layers.

Would love feedback from @fxprunayre wether this would work with mapserver-backed-through-rest publishing.