### PR TITLE
Reinstate ACL-controlled access to filedownloads (#1015).

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -204,10 +204,10 @@
 				<gmd:URL>
 					<xsl:choose>
 						<xsl:when test="/root/env/system/downloadservice/simple='true'">
-							<xsl:value-of select="concat($serviceUrl,'resources.get?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=public')"/>
+							<xsl:value-of select="concat($serviceUrl,'resources.get?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=private')"/>
 						</xsl:when>
 						<xsl:when test="/root/env/system/downloadservice/withdisclaimer='true'">
-							<xsl:value-of select="concat($serviceUrl,'file.disclaimer?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=public')"/>
+							<xsl:value-of select="concat($serviceUrl,'file.disclaimer?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=private')"/>
 						</xsl:when>
 						<xsl:otherwise> <!-- /root/env/config/downloadservice/leave='true' -->
 							<xsl:value-of select="gmd:linkage/gmd:URL"/>

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherService.js
@@ -22,7 +22,7 @@
           if (node) {
             return gnHttp.callService('geoserverNodes', {
               metadataId: gnCurrentEdit.id,
-              access: 'public',
+              access: 'private',
               action: 'GET',
               nodeId: node,
               file: fileName
@@ -38,7 +38,7 @@
               metadataUuid: gnCurrentEdit.uuid,
               metadataTitle: title,
               metadataAbstract: moreInfo,
-              access: 'public',
+              access: 'private',
               action: 'CREATE',
               nodeId: node,
               file: fileName
@@ -50,7 +50,7 @@
           if (node) {
             return gnHttp.callService('geoserverNodes', {
               metadataId: gnCurrentEdit.id,
-              access: 'public',
+              access: 'private',
               action: 'DELETE',
               nodeId: node,
               file: fileName

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -75,7 +75,6 @@
               </div>
               <input name="process" value="onlinesrc-add" data-ng-hide="true"/>
               <input name="id" data-ng-model="metadataId" data-ng-hide="true"/>
-              <input name="access" value="public" data-ng-hide="true"/>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Partly reverts https://github.com/geonetwork/core-geonetwork/commit/c33d2fc6dc08b65090214110e1963221d822578d#diff-1a0a7bc96168e03d2bd8b32895099ecf, https://github.com/geonetwork/core-geonetwork/commit/c33d2fc6dc08b65090214110e1963221d822578d#diff-78b0d16ed3df0ea30f648609e976be6f and https://github.com/geonetwork/core-geonetwork/commit/afa9817c2097ebef430cb7efebd0a1bdb6c2cd9e#diff-d0f1c5cf311c5385384ae575a49ff445

See https://github.com/geonetwork/core-geonetwork/issues/1015#issuecomment-157034667 for details
