### PR TITLE
Fix db migration by ensuring field exists before setting its value (#…

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/MapServer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MapServer.java
@@ -273,7 +273,7 @@ public class MapServer {
      * as the layer and datastore or in the global styles/ dir
      */
 
-    @Column(name="pushstyleinworkspace", nullable = false, length = 1)
+    @Column(name="pushstyleinworkspace", length = 1)
     protected char getPushStyleInWorkspace_JpaWorkaround() {
         return _pushstyleinworkspace;
     }

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v303/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v303/migrate-default.sql
@@ -5,9 +5,11 @@ DELETE FROM Settings WHERE name LIKE 'system/shib/%';
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadatacreate/generateUuid', 'true', 2, 9100, 'n');
 
+ALTER TABLE Users ADD COLUMN enabled boolean;
 UPDATE Users SET enabled = true;
 
-ALTER TABLE Mapservers ADD COLUMN pushstyleinworkspace varchar(1) default 'n';
+ALTER TABLE Mapservers ADD COLUMN pushstyleinworkspace varchar(1);
+UPDATE Mapservers set pushstyleinworkspace = 'n';
 
 UPDATE Settings SET value='3.0.3' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
…1342)

While here remove nullable constraint on pushstyleinworkspace.

Migration works okay between 3.0.2 and 3.0.3, new fields are added and correctly initialized in both tables.