### PR TITLE
Allow a global administrator to have other roles in groups (#1297)

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/user/Update.java
+++ b/services/src/main/java/org/fao/geonet/services/user/Update.java
@@ -148,13 +148,10 @@ public class Update {
                     User adminUser = adminEnabledList.get(0);
                     if (adminUser.getId() == Integer.parseInt(id)) {
                         throw new IllegalArgumentException(
-                                "Trying to disable all adminstrator users is not allowed");
+                                "Trying to disable all administrator users is not allowed");
                     }
                 }
-
             }
-
-            groups.clear();
         }
 
 

--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -300,12 +300,6 @@
         }
         $scope.userUpdated = true;
         if ($scope.userIsAdmin) {
-          // Unselect all groups option
-          for (var i = 0; i < $scope.profiles.length; i++) {
-            if ($scope.profiles[i] !== 'Administrator') {
-              $('#groups_' + $scope.profiles[i])[0].selectedIndex = -1;
-            }
-          }
           $scope.userSelected.profile = 'Administrator';
         } else {
           // Define the highest profile for user

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -217,7 +217,7 @@
                 <span data-translate="">isAdministrator</span>
               </label>
 
-              <div data-ng-hide="userSelected.profile == 'Administrator'">
+              <div>
 
                 <h3 data-translate="">RegisteredUser</h3>
                 <select multiple="multiple" id="groups_RegisteredUser" name="groups_RegisteredUser"


### PR DESCRIPTION
- stop removing all groups if the user is an admin
- don't hide the group selection form and stop unselecting all group profiles
if the current profile is Administrator


Tested locally with a global admin, i'm now able to put him as reviewer in one or several groups, and the groups are persisted/kept if the global admin flag is toggled.