### PR TITLE
Check that the md extent is valid before calling fit() (#1308)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
@@ -70,10 +70,12 @@
                 // TODO : Zoom to all extent if more than one defined
                 if (angular.isArray(gnCurrentEdit.extent) &&
                     gnCurrentEdit.extent.length > 0) {
-                  map.getView().fit(
-                      gnMap.reprojExtent(gnCurrentEdit.extent[0],
-                      'EPSG:4326', gnMap.getMapConfig().projection),
-                      map.getSize());
+                  var mdExtent = gnMap.reprojExtent(gnCurrentEdit.extent[0],
+                      'EPSG:4326', gnMap.getMapConfig().projection);
+                  // check that the extent is valid, see #1308
+                  if (mdExtent.filter(isFinite).length == 4) {
+                    map.getView().fit(mdExtent, map.getSize());
+                  }
                 }
 
                 /**

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
@@ -194,7 +194,10 @@
                   scope.isPublished = false;
                 }
                 else if (angular.isObject(data.layer)) {
-                  addLayerToMap(data.layer);
+                  gnMap.addWmsFromScratch(map, gsNode.wmsUrl, data.layer.name, false).
+                    then(function(layer) {
+                      gnMap.zoomLayerToExtent(layer, map);
+                    });
                   scope.isPublished = true;
                   if (action == 'check') {
                     scope.statusCode = $translate('datasetFound');


### PR DESCRIPTION
When the bbox is default (ie [-180, -90, 180, 90]) reprojecting it
to EPSG:4326 triggers an ol3 bug since one of the bounds is -Infinity

See https://github.com/openlayers/ol3/issues/3925