### PR TITLE
Fix capabilities URL for OGC WxS harvesters

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -65,6 +65,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 
 //=============================================================================
@@ -520,7 +521,17 @@ class Harvester extends BaseAligner
 			reg.name 	= layer.getChild ("name", wcs).getValue ();
 		} else if (params.ogctype.substring(0,3).equals("SOS")) {
 			Namespace gml = Namespace.getNamespace("http://www.opengis.net/gml");
-			reg.name 	= layer.getChild ("name", gml).getValue ();
+                        if(layer.getChild ("name", gml) != null) {
+                            reg.name 	= layer.getChild ("name", gml).getValue ();
+                        }
+                        else if(layer.getAttribute("id", gml) != null) {
+                            reg.name    = layer.getAttribute("id", gml).getValue();
+                        }
+                        else {
+                            log.warning("Could not derive layer name from " + layer);
+                            String generatedName = layer.getName() + "_" + UUID.randomUUID().toString();
+                            reg.name    = Sha1Encoder.encodeString(generatedName);
+                        }
 		}
 		
 		log.info ("  - Loading layer: " + reg.name);

--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -192,7 +192,7 @@ class Harvester extends BaseAligner
         // Try to load capabilities document
 		this.capabilitiesUrl = getBaseUrl(params.url) +
         		"SERVICE=" + params.ogctype.substring(0,3) +
-        		"&VERSION=" + params.ogctype.substring(3) +
+        		"&ACCEPTVERSIONS=" + params.ogctype.substring(3) +
         		"&REQUEST=" + GETCAPABILITIES
         		;
 

--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -91,8 +91,8 @@ import java.util.UUID;
  * 	<li>ISO19139 for data's metadata</li>
  * </ul>
  * 
- *  Note : Layer stands for "Layer" for WMS, "FeatureType" for WFS
- *  and "Coverage" for WCS.
+ *  Note : Layer stands for "Layer" for WMS, "FeatureType" for WFS,
+ *  "Coverage" for WCS, and "ObservationOffering" for SOS.
  *  
  * <pre>  
  * <nodes>
@@ -242,7 +242,7 @@ class Harvester extends BaseAligner
 	
 	
 
-	/** 
+    /**
      * Add metadata to the node for a WxS service
      *  
 	 *  1.Use GetCapabilities Document

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCSOSGetCapabilitiesLayer-to-19139.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCSOSGetCapabilitiesLayer-to-19139.xsl
@@ -35,7 +35,7 @@
 
 	<!-- ============================================================================= -->
 	
-	<xsl:template match="sos:Capabilities[//sos:ObservationOffering/gml:name=$Name]">
+	<xsl:template match="sos:Capabilities[//sos:ObservationOffering/gml:name=$Name | //sos:ObservationOffering/@gml:id=$Name]">
 
 		<MD_Metadata>
 


### PR DESCRIPTION
Hi!

Simple fix to make GetCapabilities-URLs valid according to [Common XML specification](http://www.opengeospatial.org/standards/common).

As discussed in this email thread [here](http://sourceforge.net/p/geonetwork/mailman/message/34461085/), the harvesting of strict OGC web services is broken in 2.10.x. 

The GetCapabilities URL creation uses ``version``, which is not a valid parameter in GetCapabilities. Service implementations (more concretely: the 52°North SOS) that throw an exception on invalid parameters cannot be harvested (try for example http://sosmet.nerc-bas.ac.uk:8080/sosmet/sos, example request: http://sosmet.nerc-bas.ac.uk:8080/sosmet/sos?service=SOS&request=GetCapabilities&version=1.0.0).

I am open to fix this issue in other development branches (e.g. https://github.com/geonetwork/core-geonetwork/blob/develop/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java#L210) if this change is acceptable from your point of view.