### PR TITLE
log4j customization - allow configuring an external dir

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/config/LogUtils.java
+++ b/services/src/main/java/org/fao/geonet/services/config/LogUtils.java
@@ -1,13 +1,10 @@
 package org.fao.geonet.services.config;
 
+import java.io.File;
 import java.net.URL;
-
-import jeeves.server.context.ServiceContext;
 
 import org.apache.log4j.xml.DOMConfigurator;
 import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Setting;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -30,6 +27,17 @@ public class LogUtils {
         SettingRepository repository =
                 ApplicationContextHolder.get().getBean(SettingRepository.class);
         Setting setting = repository.findOne(SettingManager.SYSTEM_SERVER_LOG);
+
+        // if logPlaceHolder is defined, use it instead of the resources
+        // defined in the classpath
+        try {
+            Object logov = ApplicationContextHolder.get().getBean("logPlaceHolder");
+            File logFile = new File(logov.toString(), setting != null ? setting.getValue() : DEFAULT_LOG_FILE);
+            DOMConfigurator.configure(logFile.toURI().toURL());
+            return;
+        } catch (Throwable e) {
+            // ignore, and continue with the old behaviour
+        }
 
         // get log config from db settings
         String log4jProp = setting != null ? setting.getValue() : DEFAULT_LOG_FILE;


### PR DESCRIPTION
This is a requirement for georchestra configuration standards which could be of interest in GN from my PoV: it allows the possibility to define a log placeholder bean (a simple string which points to an
existing directory) which would contain the log4j.xml configuration files, instead of forcing the files to be nested into the webapp war.

You can see how it is configured in geOrchestra here:

https://github.com/georchestra/geonetwork/pull/25/files#diff-9847927f449b401f2844e90bd30019ea

Tests: runtime OK
Tests in error (unrelated to the current modifications):
- GetKeywordByIdTest.testExecAllThesaurus:61 » IndexOutOfBounds Index: 0, Size: ...
- GetKeywordByIdTest.testExecMD_Keywords:103 » IndexOutOfBounds Index: 0, Size: ...
- GetKeywordByIdTest.testExecMD_KeywordsAsXlinkAllThesaurus:125 » IndexOutOfBounds
- GetKeywordByIdTest.testExecTextGroupOnly:80 » IndexOutOfBounds Index: 0, Size:...
