### PR TITLE
Enforce dependency on httpclient 4.3.2 to fix SNI support (#1368)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -212,6 +212,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+            <version>4.3.2</version>
         </dependency>
         <dependency>
             <groupId>commons-net</groupId>


### PR DESCRIPTION
Dunno if it'd be better to bump the dep on avalon-framework-impl, if it's the cause of having httpclient 4.3.1 - and i dont know maven enough.