### PR TITLE
take into account amount of requests when bumping the initial hibernate_sequence value (#1373)

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v2110/2-migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v2110/2-migrate-default.sql
@@ -3,7 +3,6 @@
 ALTER TABLE operations DROP COLUMN reserved;
 ALTER TABLE ServiceParameters DROP CONSTRAINT IF EXISTS serviceparameters_service_fkey;
 ALTER TABLE ServiceParameters DROP COLUMN IF EXISTS id;
-ALTER TABLE services DROP COLUMN IF EXISTS id;
 
 
 ALTER TABLE Settings ALTER name TYPE varchar(512);

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v300/SetSequenceValueToMaxOfMetadataAndStats.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v300/SetSequenceValueToMaxOfMetadataAndStats.java
@@ -17,6 +17,7 @@ public class SetSequenceValueToMaxOfMetadataAndStats implements DatabaseMigratio
         try (Statement statement = connection.createStatement()) {
             final String numberOfMetadataSQL = "SELECT max(id) as NB FROM Metadata";
             final String numberOfParamsSQL = "SELECT max(id) as NB FROM Params";
+            final String numberOfRequestsSQL = "SELECT max(id) as NB FROM Requests";
 
             ResultSet metadataResultSet = statement.executeQuery(numberOfMetadataSQL);
             int numberOfMetadata = 0;
@@ -41,8 +42,18 @@ public class SetSequenceValueToMaxOfMetadataAndStats implements DatabaseMigratio
                 paramsResultSet.close();
             }
 
+            int numberOfRequests = 0;
+            ResultSet requestsResultSet = statement.executeQuery(numberOfRequestsSQL);
             try {
-                int newSequenceValue = Math.max(numberOfMetadata, numberOfParams) + 1;
+                if (requestsResultSet.next()) {
+                    numberOfRequests = requestsResultSet.getInt(1);
+                }
+                Log.debug(Geonet.DB, "  Number of requests (statistics): " + numberOfRequests);
+            } finally {
+                requestsResultSet.close();
+            }
+            try {
+                int newSequenceValue = Math.max(numberOfMetadata, Math.max(numberOfParams, numberOfRequests)) + 1;
                 Log.debug(Geonet.DB, "  Set sequence to value: " + newSequenceValue);
                 final String updateSequenceSQL = "ALTER SEQUENCE HIBERNATE_SEQUENCE " +
                         "RESTART WITH " + newSequenceValue;


### PR DESCRIPTION
Should fix the remaining migration issues - works for me, tested locally with postgres and 480k+ entries in requests.