### PR TITLE
Add a new navbar in admin pages

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/AdminController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminController.js
@@ -114,9 +114,9 @@
    */
   module.controller('GnAdminController', [
     '$scope', '$http', '$q', '$rootScope', '$route', '$routeParams',
-    'gnUtilityService',
+    'gnUtilityService', '$location',
     function($scope, $http, $q, $rootScope, $route, $routeParams,
-        gnUtilityService) {
+        gnUtilityService,$location) {
       /**
        * Define admin console menu for each type of user
        */
@@ -196,6 +196,14 @@
       $scope.getMenu = function() {
         return $scope.menu[$scope.user.profile];
       };
+      
+      /**
+       * Active element in the admin menu list
+       */
+      $scope.isActive = function(route) {
+        return route.slice(1) === $location.path().slice(1).split('/')[0];
+      };
+
     }]);
 
 })();

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -1,5 +1,6 @@
 @import "gn.less";
 @import "timeline.less";
+@import "gn_admin_navbar.less";
 
 .gn-chart{
   height:500px;

--- a/web-ui/src/main/resources/catalog/style/gn_admin_navbar.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin_navbar.less
@@ -1,0 +1,66 @@
+.dashboardMenu-left {
+    position:   fixed;  
+    z-index: 2;
+    padding-left: 0px;
+    padding-right: 0px;
+    position: fixed;
+    button{
+        margin-bottom:5px;
+    }
+    ul {
+        list-style-type: none;
+        padding: 0;
+        margin-bottom: 0px;
+        background-color: #CCCCCC;
+    }
+    li {
+        a {
+            display: block;
+            color: #000;
+            text-decoration: none;
+            p {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+        a.active {
+            background-color: #4CAF50;
+            color: white;
+        }
+        a:hover:not(.active) {
+            background-color: #555;
+            color: white;
+        }
+    }
+}
+.dashboardMenu-lg {
+    width: 12%;
+    max-width: 170px;
+    }
+.menu {
+    display: none;
+}
+.dashboardMenu-lg:hover {
+    min-width: 115px;
+    .menu {
+        display : initial;
+        .li {
+            min-width: 115px;
+        }
+    }
+}
+.dashboardMenu-xs {
+    width: 40px;
+}
+.menu-xs {
+    display: none;
+}
+.dashboardMenu-xs:hover {
+    .menu-xs {
+        display : initial;
+    }
+}
+
+
+

--- a/web-ui/src/main/resources/catalog/templates/admin/page-layout.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/page-layout.html
@@ -1,14 +1,39 @@
 <div data-ng-controller="GnAdminController">
-  <ul class="nav nav-pills">
-    <li data-ng-repeat="t in pageMenu.tabs"
-        data-ng-class="type === t.type && 'active'">
-      <a href="{{t.href}}">
-        <i class="fa {{t.icon || 'fa-fw'}}"/>
-        <span data-translate="">{{t.label}}</span>
-      </a>
-    </li>
-  </ul>
-  <br/>
-
-  <div class="col-lg-12" data-ng-include="getTpl(pageMenu)"></div>
+  <div class="column col-sm-2 col-xs-1 sidebar-offcanvas">
+  <div class="dashboardMenu-left dashboardMenu-lg hidden-xs">
+    <button type="button" class="btn btn-warning hidden-xs"><i class="fa fa-th fa-1x"/>&nbsp;<span data-translate="">Admin links</span></button>
+    <ul class="nav hidden-xs menu" id="lg-menu">
+      <li data-ng-repeat="m in getMenu()">
+        <a href="{{getMenuUrl(m)}}" ng-class="{active: isActive('{{getMenuUrl(m)}}')}" >
+          <p><i class="fa {{m.icon}} fa-1x"/>&nbsp;<span data-translate="">{{m.name}}</span></p>
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="dashboardMenu-left dashboardMenu-xs visible-xs">
+    <button type="button" class="btn btn-warning visible-xs"><i class="fa fa-th fa-1x"/></button>
+    <div class="visible-xs">
+    <ul class="nav menu-xs" id="xs-menu">
+      <li data-ng-repeat="m in getMenu()"> 
+        <a href="{{getMenuUrl(m)}}" ng-class="{active: isActive('{{getMenuUrl(m)}}')}" title="{{m.name | translate}}">
+          <i class="fa {{m.icon}} fa-1x"/>
+        </a>
+      </li>
+    </ul>
+    </div>
+  </div>
+  </div>    
+  <div class="col-lg-10 col-sm-10 col-xs-11">
+    <ul class="nav nav-pills">
+      <li data-ng-repeat="t in pageMenu.tabs"
+          data-ng-class="type === t.type && 'active'">
+        <a href="{{t.href}}">
+          <i class="fa {{t.icon || 'fa-fw'}}"/>
+          <span data-translate="">{{t.label}}</span>
+        </a>
+      </li>
+    </ul>
+    <br/>
+    <div class="col-lg-12" data-ng-include="getTpl(pageMenu)"></div> 
+  </div>
 </div>


### PR DESCRIPTION
Add a navigation bar in the different pages of the admin. The user must not go back to the admin console once again aiming to navigate between the different sections of the admin. 

![capture](https://cloud.githubusercontent.com/assets/576292/12327509/45e54494-bad7-11e5-9cf1-1e54c1894cf5.PNG)


![capture1](https://cloud.githubusercontent.com/assets/576292/12327519/56400752-bad7-11e5-9774-56f9ed19a21f.PNG)

On small device:
![capture2](https://cloud.githubusercontent.com/assets/576292/12328062/0a171a3e-bada-11e5-953f-184bbf617385.PNG)
