### PR TITLE
Fix testsuite java7/8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ sudo: false
 language: java
 jdk:
   - openjdk7
-  - openjdk8
+  - oraclejdk8
 before_install:
   - export MAVEN_OPTS="-Xmx512M -XX:MaxPermSize=256M"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ sudo: false
 language: java
 jdk:
   - openjdk7
+  - openjdk8
 before_install:
   - export MAVEN_OPTS="-Xmx512M -XX:MaxPermSize=256M"
-script: mvn test

--- a/common/src/test/java/org/fao/geonet/utils/XmlTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/XmlTest.java
@@ -100,6 +100,7 @@ public class XmlTest {
 
     protected void doTestTransform() throws Exception {
         final GenericApplicationContext applicationContext = new GenericApplicationContext();
+        applicationContext.refresh();
         applicationContext.getBeanFactory().registerSingleton("systemInfo", SystemInfo.createForTesting(SystemInfo.STAGE_DEVELOPMENT));
         ApplicationContextHolder.set(applicationContext);
 

--- a/core/src/main/java/jeeves/server/overrides/OverridesMetadataSource.java
+++ b/core/src/main/java/jeeves/server/overrides/OverridesMetadataSource.java
@@ -7,8 +7,8 @@ import org.springframework.security.web.access.expression.DefaultWebSecurityExpr
 import org.springframework.security.web.access.expression.ExpressionBasedFilterInvocationSecurityMetadataSource;
 import org.springframework.security.web.access.intercept.DefaultFilterInvocationSecurityMetadataSource;
 import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
-import org.springframework.security.web.util.RegexRequestMatcher;
-import org.springframework.security.web.util.RequestMatcher;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.ReflectionUtils;
 
 import javax.annotation.Nullable;

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -460,7 +460,7 @@ public class EditLib {
      * @return the number of updates.
      */
     public int addElementOrFragmentFromXpaths(Element metadataRecord,
-                                              Map<String, AddElemValue> xmlAndXpathInputs,
+                                              LinkedHashMap<String, AddElemValue> xmlAndXpathInputs,
                                               MetadataSchema metadataSchema,
                                               boolean createXpathNodeIfNotExist) {
 
@@ -476,7 +476,6 @@ public class EditLib {
                 numUpdated ++;
             }
         }
-
         return numUpdated;
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/search/KeywordsSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/KeywordsSearcher.java
@@ -23,7 +23,16 @@
 
 package org.fao.geonet.kernel.search;
 
-import jeeves.server.context.ServiceContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.exceptions.TermNotFoundException;
@@ -36,14 +45,7 @@ import org.fao.geonet.kernel.search.keyword.KeywordSearchParamsBuilder;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.jdom.Element;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nullable;
+import jeeves.server.context.ServiceContext;
 
 /**
  *
@@ -288,7 +290,7 @@ public class KeywordsSearcher {
 		@SuppressWarnings("unchecked")
         List<Element> listIdKeywordsSelected = params.getChildren("pIdKeyword");
 		
-		Set<String> ids = new HashSet<String>();
+		Set<String> ids = new LinkedHashSet<String>();
         for (Element el : listIdKeywordsSelected) {
             ids.add(el.getTextTrim());
         }

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneConfig.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneConfig.java
@@ -23,7 +23,19 @@
 
 package org.fao.geonet.kernel.search;
 
-import jeeves.server.overrides.ConfigurationOverrides;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.ServletContext;
+
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.search.TopFieldCollector;
 import org.apache.lucene.util.NumericUtils;
@@ -42,18 +54,7 @@ import org.jdom.JDOMException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.servlet.ServletContext;
+import jeeves.server.overrides.ConfigurationOverrides;
 
 /**
  * Lucene configuration class load Lucene XML configuration file.
@@ -68,7 +69,7 @@ public class LuceneConfig {
 	private static final int DOC_BOOST_CLASS = 3;
 
 	private Path configurationFile;
-	private HashSet<String> fuzzyMatching;
+	private LinkedHashSet<String> fuzzyMatching;
 
 	/**
 	 * Lucene numeric field configuration
@@ -170,7 +171,7 @@ public class LuceneConfig {
 	private double nrtManagerReopenThreadMinStaleSec = 0.1f;
 	
 	private Version LUCENE_VERSION = Geonet.LUCENE_VERSION;
-	private Set<String> multilingualSortFields = new HashSet<String>();
+	private Set<String> multilingualSortFields = new LinkedHashSet<String>();
 
     private Facets facets;
     private SummaryTypes summaryTypes;
@@ -295,7 +296,7 @@ public class LuceneConfig {
 
 			// Tokenized fields
 			elem = luceneConfig.getChild("tokenized");
-			tokenizedFields = new HashSet<String>();
+			tokenizedFields = new LinkedHashSet<String>();
 			if (elem != null) {
 				for (Object o : elem.getChildren()) {
 					if (o instanceof Element) {
@@ -314,7 +315,7 @@ public class LuceneConfig {
 			// similarity fields
 			elem = luceneConfig.getChild("fuzzyMatching");
 			if (elem != null && "true".equalsIgnoreCase(elem.getAttributeValue("enabled"))) {
-				fuzzyMatching = new HashSet<String>();
+				fuzzyMatching = new LinkedHashSet<String>();
 				for (Object o : elem.getChildren()) {
 					if (o instanceof Element) {
 						String name = ((Element) o).getAttributeValue("name");

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneConfig.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneConfig.java
@@ -49,6 +49,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -131,7 +132,7 @@ public class LuceneConfig {
 		
 	}
 
-	private Set<String> tokenizedFields = new HashSet<String>();
+	private Set<String> tokenizedFields = new LinkedHashSet<String>();
 	private Map<String, LuceneConfigNumericField> numericFields = new HashMap<String, LuceneConfigNumericField>();
 	private Map<String, String> dumpFields = new HashMap<String, String>();
 

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryBuilder.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryBuilder.java
@@ -23,18 +23,25 @@
 
 package org.fao.geonet.kernel.search;
 
-import com.google.common.base.Splitter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.StringTokenizer;
 
-import org.fao.geonet.kernel.search.LuceneConfig.LuceneConfigNumericField;
-import org.fao.geonet.kernel.setting.SettingInfo;
-import org.fao.geonet.utils.Log;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.facet.FacetsConfig;
-import org.apache.lucene.facet.taxonomy.CategoryPath;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
@@ -49,21 +56,10 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.automaton.LevenshteinAutomata;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Pair;
+import org.fao.geonet.kernel.setting.SettingInfo;
+import org.fao.geonet.utils.Log;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Scanner;
-import java.util.Set;
-import java.util.StringTokenizer;
+import com.google.common.base.Splitter;
 
 /**
  * Class to create a Lucene query from a {@link LuceneQueryInput} representing a
@@ -165,7 +161,7 @@ public class LuceneQueryBuilder {
 
     private Query buildBaseQuery(LuceneQueryInput luceneQueryInput) {
         // Remember which range fields have been processed
-        Set<String> processedRangeFields = new HashSet<String>();
+        Set<String> processedRangeFields = new LinkedHashSet<String>();
 
         // top query to hold all sub-queries for each search parameter
          BooleanQuery query = new BooleanQuery();
@@ -185,7 +181,7 @@ public class LuceneQueryBuilder {
         // here such _OR_ fields are parsed, an OR searchCriteria map is created, and they're removed from vanilla
         // searchCriteria map.
         //
-        Map<String, Set<String>> searchCriteriaOR = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> searchCriteriaOR = new LinkedHashMap<String, Set<String>>();
 
         for (Iterator<Entry<String, Set<String>>> i = searchCriteria.entrySet().iterator(); i.hasNext();) {
             Entry<String, Set<String>> entry = i.next();
@@ -225,13 +221,13 @@ public class LuceneQueryBuilder {
 
                         field = "any";
                         Set<String> values = searchCriteriaOR.get(field);
-                        if(values == null) values = new HashSet<String>();
+                        if(values == null) values = new LinkedHashSet<String>();
                         values.addAll(fieldValues);
                         searchCriteriaOR.put(field, values);
                     }
                     else {
                             Set<String> values = searchCriteriaOR.get(field);
-                            if(values == null) values = new HashSet<String>();
+                            if(values == null) values = new LinkedHashSet<String>();
                             values.addAll(fieldValues);
                             searchCriteriaOR.put(field, values);
                     }
@@ -301,7 +297,7 @@ public class LuceneQueryBuilder {
         }
 
         // Avoid search by field who control privileges
-        Set<String> fields = new HashSet<String>();
+        Set<String> fields = new LinkedHashSet<String>();
         for(String requestedField : searchCriteria.keySet()) {
             if(!(UserQueryInput.SECURITY_FIELDS.contains(requestedField) || SearchParameter.EDITABLE.equals(requestedField))) {
                 fields.add(requestedField);

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryInput.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryInput.java
@@ -28,6 +28,7 @@ import org.fao.geonet.kernel.setting.SettingInfo;
 import org.jdom.Element;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -70,7 +71,7 @@ public class LuceneQueryInput extends UserQueryInput {
         @SuppressWarnings("unchecked")
         List<Element> groupsE = (List<Element>)jdom.getChildren(SearchParameter.GROUP);
         if(groupsE != null) {
-            Set<String> groups = new HashSet<String>();
+            Set<String> groups = new LinkedHashSet<String>();
             for(Element groupE : groupsE) {
                 groups.add(groupE.getText());
             }
@@ -78,7 +79,7 @@ public class LuceneQueryInput extends UserQueryInput {
         }
         @SuppressWarnings("unchecked")
         List<Element> groupOwnersE = (List<Element>)jdom.getChildren(SearchParameter.GROUPOWNER);
-        Set<String> groupOwners = new HashSet<String>();
+        Set<String> groupOwners = new LinkedHashSet<String>();
         for(Element groupOwnerE : groupOwnersE) {
             groupOwners.add(groupOwnerE.getText());
         }

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryInput.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryInput.java
@@ -23,14 +23,13 @@
 
 package org.fao.geonet.kernel.search;
 
-import org.apache.commons.lang.StringUtils;
-import org.fao.geonet.kernel.setting.SettingInfo;
-import org.jdom.Element;
-
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.kernel.setting.SettingInfo;
+import org.jdom.Element;
 
 /**
  * Input to {@link LuceneQueryBuilder}, consisting of user-provided parameters plus system-provided parameters.
@@ -133,7 +132,7 @@ public class LuceneQueryInput extends UserQueryInput {
 
     public void setGroups(Set<String> groups) {
         if(this.groups == null) {
-            this.groups = new HashSet<String>();
+            this.groups = new LinkedHashSet<String>();
         }
         this.groups = groups;
     }
@@ -176,7 +175,7 @@ public class LuceneQueryInput extends UserQueryInput {
 
     public void setGroupOwners(Set<String> groupOwners) {
         if(this.groupOwners == null) {
-            this.groupOwners = new HashSet<String>();
+            this.groupOwners = new LinkedHashSet<String>();
         }
         this.groupOwners = groupOwners;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -23,15 +23,26 @@
 
 package org.fao.geonet.kernel.search;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.WKTReader;
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Constructor;
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.analysis.TokenStream;
@@ -102,23 +113,16 @@ import org.jdom.Content;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.lang.reflect.Constructor;
-import java.text.CharacterIterator;
-import java.text.StringCharacterIterator;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.WKTReader;
+
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * search metadata locally using lucene.
@@ -485,7 +489,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         search(srvContext, elData, config);
 
         if (getTo() > 0) {
-            Set<String> encountered = new HashSet<String>();
+            Set<String> encountered = new LinkedHashSet<String>();
             final Iterator descendants = _elSummary.getDescendants();
             while (descendants.hasNext()) {
                 Content next = (Content) descendants.next();
@@ -1524,7 +1528,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         addElement(info, Edit.Info.Elem.CHANGE_DATE, changeDate);
         addElement(info, Edit.Info.Elem.SOURCE,      source);
 
-        HashSet<String> addedTranslation = new HashSet<String>();
+        HashSet<String> addedTranslation = new LinkedHashSet<String>();
         if ((dumpAllField || dumpFields != null) && searchLang != null && multiLangSearchTerm != null) {
             // get the translated fields and dump those instead of the non-translated
             for (String fieldName : multiLangSearchTerm) {

--- a/core/src/main/java/org/fao/geonet/kernel/search/StopwordFileParser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/StopwordFileParser.java
@@ -1,10 +1,5 @@
 package org.fao.geonet.kernel.search;
 
-import org.fao.geonet.Constants;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.utils.IO;
-import org.fao.geonet.utils.Log;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,9 +7,14 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Scanner;
 import java.util.Set;
+
+import org.fao.geonet.Constants;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Log;
 
 /**
  * Parses stopword files. Stopword files have lines with zero or more stopwords. Any content from the character | until
@@ -49,7 +49,7 @@ public class StopwordFileParser {
                         Set<String> stopwordsFromLine = parseLine(scanner.nextLine());
                         if (stopwordsFromLine != null) {
                             if (stopwords == null) {
-                                stopwords = new HashSet<String>();
+                                stopwords = new LinkedHashSet<String>();
                             }
                             stopwords.addAll(stopwordsFromLine);
                         }
@@ -95,7 +95,7 @@ public class StopwordFileParser {
             while (whitespaceTokenizer.hasNext()) {
                 String stopword = whitespaceTokenizer.next();
                 if (stopwords == null) {
-                    stopwords = new HashSet<String>();
+                    stopwords = new LinkedHashSet<String>();
                 }
                 stopwords.add(stopword);
             }

--- a/core/src/main/java/org/fao/geonet/kernel/search/UserQueryInput.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/UserQueryInput.java
@@ -23,18 +23,19 @@
 
 package org.fao.geonet.kernel.search;
 
-import org.apache.commons.lang.StringUtils;
-import org.fao.geonet.constants.Geonet;
-import org.jdom.Element;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.constants.Geonet;
+import org.jdom.Element;
 
 /**
  * Search parameters that can be provided by a search client.
@@ -82,7 +83,7 @@ public class UserQueryInput {
 
     private String similarity;
     private String editable;
-    private static Map<String, String> searchParamToLuceneField = new HashMap<String, String>();
+    private static Map<String, String> searchParamToLuceneField = new LinkedHashMap<String, String>();
     static {
         // Populate map for search parameter to Lucene mapping
         searchParamToLuceneField.put(SearchParameter.SITEID, LuceneIndexField.SOURCE);
@@ -97,10 +98,10 @@ public class UserQueryInput {
         searchParamToLuceneField.put(SearchParameter.OP_DYNAMIC,  LuceneIndexField._OP5);
         searchParamToLuceneField.put(SearchParameter.OP_FEATURED, LuceneIndexField._OP6);
     }
-    private Map<String, Set<String>> searchCriteria = new HashMap<String, Set<String>>();
-    private Map<String, Set<String>> searchPrivilegeCriteria = new HashMap<String, Set<String>>();
-    private Map<String, String> searchOption = new HashMap<String, String>();
-    private Set<String> facetQueries = new HashSet<String>();
+    private Map<String, Set<String>> searchCriteria = new LinkedHashMap<String, Set<String>>();
+    private Map<String, Set<String>> searchPrivilegeCriteria = new LinkedHashMap<String, Set<String>>();
+    private Map<String, String> searchOption = new LinkedHashMap<String, String>();
+    private Set<String> facetQueries = new LinkedHashSet<String>();
 
     /**
      * Return all search criteria.
@@ -144,7 +145,7 @@ public class UserQueryInput {
      * @return
      */
     public Map<String, Set<String>> getTextCriteria() {
-        Map<String, Set<String>> textCriteria = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> textCriteria = new LinkedHashMap<String, Set<String>>();
         for (String criteria : searchCriteria.keySet()) {
             if (!NO_TEXT_FIELDS.contains(criteria)) {
                 textCriteria.put(criteria, searchCriteria.get(criteria));
@@ -231,7 +232,7 @@ public class UserQueryInput {
 
         try {
             if (currentValues == null) {
-                HashSet<String> values = new HashSet<String>();
+                Set<String> values = new LinkedHashSet<String>();
                 values.add(URLDecoder.decode(nodeValue, "UTF-8"));
                 hash.put(nodeName, values);
             } else {

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/FSDirectoryFactory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/FSDirectoryFactory.java
@@ -1,6 +1,20 @@
 package org.fao.geonet.kernel.search.index;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.Nonnull;
+
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.NRTCachingDirectory;
@@ -11,19 +25,7 @@ import org.fao.geonet.kernel.search.LuceneConfig;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.Nonnull;
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Create filesystem based Directory objects.
@@ -191,7 +193,7 @@ public class FSDirectoryFactory implements DirectoryFactory {
     @Override
     public Set<String> listIndices() throws IOException {
         init();
-        Set<String> indices = new HashSet<>();
+        Set<String> indices = new LinkedHashSet<>();
         if (Files.exists(this.indexFile)) {
             try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(this.indexFile)) {
                 for (Path file : dirStream) {

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -3,7 +3,6 @@ package org.fao.geonet.kernel;
 import com.google.common.collect.Lists;
 import junit.framework.Assert;
 
-import org.eclipse.jetty.util.log.Log;
 import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
@@ -656,8 +655,6 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
 
     @Test
     public void testMultiUpdate() throws JDOMException {
-    	for (String b : new String[] {Geonet.EDITORFILLELEMENT, Geonet.EDITOR, Geonet.EDITOREXPANDELEMENT, Geonet.EDITORADDELEMENT})
-    		Log.getLogger(b).setDebugEnabled(true);
         SchemaManager manager = _schemaManager;
         MetadataSchema schema = manager.getSchema("iso19139");
         final Element metadataElement = new Element("MD_Metadata", GMD);
@@ -684,8 +681,6 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
     @Test
     @Ignore
     public void testAddAttributeExistingElement() throws JDOMException {
-    	for (String b : new String[] {Geonet.EDITORFILLELEMENT, Geonet.EDITOR, Geonet.EDITOREXPANDELEMENT, Geonet.EDITORADDELEMENT})
-    		Log.getLogger(b).setDebugEnabled(true);
         SchemaManager manager = _schemaManager;
         MetadataSchema schema = manager.getSchema("iso19139");
         final Element metadataElement = new Element("MD_Metadata", GMD);

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -2,7 +2,10 @@ package org.fao.geonet.kernel;
 
 import com.google.common.collect.Lists;
 import junit.framework.Assert;
+
+import org.eclipse.jetty.util.log.Log;
 import org.fao.geonet.AbstractCoreIntegrationTest;
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.utils.Xml;
@@ -10,11 +13,13 @@ import org.jdom.Content;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static junit.framework.TestCase.assertEquals;
@@ -650,17 +655,19 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
 
 
     @Test
-    public void multiUpdate() throws JDOMException {
+    public void testMultiUpdate() throws JDOMException {
+    	for (String b : new String[] {Geonet.EDITORFILLELEMENT, Geonet.EDITOR, Geonet.EDITOREXPANDELEMENT, Geonet.EDITORADDELEMENT})
+    		Log.getLogger(b).setDebugEnabled(true);
         SchemaManager manager = _schemaManager;
         MetadataSchema schema = manager.getSchema("iso19139");
         final Element metadataElement = new Element("MD_Metadata", GMD);
-        HashMap<String, AddElemValue> updates = new HashMap<String, AddElemValue>();
+        LinkedHashMap<String, AddElemValue> updates = new LinkedHashMap<String, AddElemValue>();
         final String text = "text";
         final String att = "att";
         final String charStringXpath = "gmd:fileIdentifier/gco:CharacterString";
         final String attXPath = "gmd:fileIdentifier/@att";
-        updates.put(charStringXpath, new AddElemValue(text));
         updates.put(attXPath, new AddElemValue(att));
+        updates.put(charStringXpath, new AddElemValue(text));
 
         final int numUpdates = new EditLib(_schemaManager).addElementOrFragmentFromXpaths(metadataElement, updates, schema, true);
 
@@ -669,6 +676,37 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
         assertEqualsText(text, metadataElement, charStringXpath, GMD, GCO);
         Assert.assertEquals(att, Xml.selectString(metadataElement, attXPath, Arrays.asList(GMD, GCO)));
     }
+    
+    /*
+     * BUG: This test exposes a bug in the EditLib. If the xpath points to an existing element,
+     * adding an attribute to the existing element does not work.
+     */
+    @Test
+    @Ignore
+    public void testAddAttributeExistingElement() throws JDOMException {
+    	for (String b : new String[] {Geonet.EDITORFILLELEMENT, Geonet.EDITOR, Geonet.EDITOREXPANDELEMENT, Geonet.EDITORADDELEMENT})
+    		Log.getLogger(b).setDebugEnabled(true);
+        SchemaManager manager = _schemaManager;
+        MetadataSchema schema = manager.getSchema("iso19139");
+        final Element metadataElement = new Element("MD_Metadata", GMD);
+        LinkedHashMap<String, AddElemValue> updates = new LinkedHashMap<String, AddElemValue>();
+        final String text = "text";
+        final String att = "att";
+        final String charStringXpath = "gmd:fileIdentifier/gco:CharacterString";
+        final String attXPath = "gmd:fileIdentifier/@att";
+        updates.put(attXPath, new AddElemValue(att));
+        updates.put(charStringXpath, new AddElemValue(text));
+
+        EditLib el = new EditLib(_schemaManager);
+        boolean a1 = el.addElementOrFragmentFromXpath(metadataElement, schema, charStringXpath, new AddElemValue(text), true);
+        boolean a2 = el.addElementOrFragmentFromXpath(metadataElement, schema, attXPath, new AddElemValue(att), true);
+        
+        assertEquals(2, a1 && a2);
+
+        assertEqualsText(text, metadataElement, charStringXpath, GMD, GCO);
+        assertEquals(att, Xml.selectString(metadataElement, attXPath, Arrays.asList(GMD, GCO)));
+    }
+    
 
     @Test
     public void testAddElementFromXpath_Extent() throws Exception {

--- a/core/src/test/java/org/fao/geonet/kernel/search/LuceneQueryTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/LuceneQueryTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,7 +23,6 @@ import org.fao.geonet.kernel.search.facet.Facets;
 import org.fao.geonet.kernel.search.facet.SummaryType;
 import org.fao.geonet.kernel.search.facet.SummaryTypes;
 import org.fao.geonet.utils.IO;
-import org.fao.geonet.utils.Xml;
 import org.jdom.DefaultJDOMFactory;
 import org.jdom.Element;
 import org.jdom.JDOMFactory;
@@ -126,7 +124,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(category:yyy inspiretheme:xxx title:xxx any:yyy) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx title:xxx category:yyy any:yyy) +_isTemplate:n", query.toString());
     }
 
     /**
@@ -197,7 +195,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx inspiretheme:xxx any:xxx) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx title:xxx any:xxx) +_isTemplate:n", query.toString());
     }
 
 
@@ -220,7 +218,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx title:zzz inspiretheme:xxx zzz (+any:xxx +any:zzz)) +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx zzz title:xxx title:zzz (+any:xxx +any:zzz)) +_isTemplate:n",
                 query.toString());
     }
 
@@ -265,8 +263,8 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx title:zzz inspiretheme:xxx inspiretheme:zzz any:xxx any:zzz) " +
-                                                "+_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx inspiretheme:zzz title:xxx title:zzz "
+        		+ "any:xxx any:zzz) +_isTemplate:n", query.toString());
     }
 
     /**
@@ -288,7 +286,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx _uuid:xxx) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(_uuid:xxx title:xxx) +_isTemplate:n", query.toString());
     }
 
     /**
@@ -310,7 +308,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx title:yyy _uuid:xxx _uuid:yyy) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(_uuid:xxx _uuid:yyy title:xxx title:yyy) +_isTemplate:n", query.toString());
     }
 
     @Test
@@ -988,7 +986,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(+topicCat:environment* +topicCat:boundaries +topicCat:biota*) +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+(+topicCat:environment* +topicCat:biota* +topicCat:boundaries) +_isTemplate:n",
                 query.toString());
     }
 
@@ -1356,7 +1354,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(+inspiretheme:Hydrography* +inspiretheme:\"Cadastral parcels\") +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+(+inspiretheme:\"Cadastral parcels\" +inspiretheme:Hydrography*) +_isTemplate:n",
                 query.toString());
     }
 
@@ -1727,7 +1725,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(_op0:nou moe _op2:nou moe _op0:hatsjekidee _op2:hatsjekidee) +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+(_op0:hatsjekidee _op2:hatsjekidee _op0:nou moe _op2:nou moe) +_isTemplate:n",
                 query.toString());
     }
 
@@ -1753,7 +1751,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(_op0:nou moe _op2:nou moe _op0:hatsjekidee _op2:hatsjekidee) +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+(_op0:hatsjekidee _op2:hatsjekidee _op0:nou moe _op2:nou moe) +_isTemplate:n",
                 query.toString());
     }
 
@@ -1779,7 +1777,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(_op0:nou moe _op2:nou moe _op0:hatsjekidee _op2:hatsjekidee _owner:yeah!) " +
+        assertEquals("unexpected Lucene query", "+(_op0:hatsjekidee _op2:hatsjekidee _op0:nou moe _op2:nou moe _owner:yeah!) " +
                                                 "+_isTemplate:n", query.toString());
     }
 
@@ -1805,7 +1803,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(_op0:nou moe _op2:nou moe _op0:hatsjekidee _op2:hatsjekidee _dummy:0) " +
+        assertEquals("unexpected Lucene query", "+(_op0:hatsjekidee _op2:hatsjekidee _op0:nou moe _op2:nou moe _dummy:0) " +
                                                 "+_isTemplate:n", query.toString());
     }
 
@@ -2077,8 +2075,8 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(_op0:1 _op2:1 _op0:0 _op2:0) +westBL:[-180.0 TO 180.0] +eastBL:[-180.0 TO 180.0] " +
-                                                "+northBL:[-90.0 TO 90.0] +southBL:[-90.0 TO 90.0] +title:hoi +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+(_op0:0 _op2:0 _op0:1 _op2:1) +westBL:[-180.0 TO 180.0] +eastBL:[-180.0 TO 180.0] "
+        		+ "+northBL:[-90.0 TO 90.0] +southBL:[-90.0 TO 90.0] +title:hoi +_isTemplate:n",
                 query.toString());
     }
 

--- a/core/src/test/java/org/fao/geonet/kernel/search/LuceneQueryTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/LuceneQueryTest.java
@@ -1,6 +1,15 @@
 package org.fao.geonet.kernel.search;
 
-import jeeves.server.ServiceConfig;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
@@ -15,6 +24,7 @@ import org.fao.geonet.kernel.search.facet.Facets;
 import org.fao.geonet.kernel.search.facet.SummaryType;
 import org.fao.geonet.kernel.search.facet.SummaryTypes;
 import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Xml;
 import org.jdom.DefaultJDOMFactory;
 import org.jdom.Element;
 import org.jdom.JDOMFactory;
@@ -24,14 +34,7 @@ import org.mockito.Mockito;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import jeeves.server.ServiceConfig;
 
 /**
  * Unit test for building Lucene queries.
@@ -330,9 +333,10 @@ public class LuceneQueryTest {
 
     /**
      * Tests parameters for disjunctions. They are of the form paramA_OR_paramB.
+     * @throws InterruptedException 
      */
     @Test
-    public void testSingleORSingleValueWithALL() {
+    public void testSingleORSingleValueWithALL() throws InterruptedException {
         // create request object
         JDOMFactory factory = new DefaultJDOMFactory();
         Element request = factory.element("request");
@@ -347,7 +351,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx any:xxx) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(any:xxx title:xxx) +_isTemplate:n", query.toString());
     }
 
 

--- a/core/src/test/java/org/fao/geonet/kernel/search/LuceneQueryTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/LuceneQueryTest.java
@@ -98,7 +98,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx any:xxx) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(any:xxx title:xxx) +_isTemplate:n", query.toString());
     }
 
     /**
@@ -124,7 +124,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx title:xxx category:yyy any:yyy) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx title:xxx any:yyy category:yyy) +_isTemplate:n", query.toString());
     }
 
     /**
@@ -172,7 +172,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx title:zzz (+any:xxx +any:zzz)) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+((+any:xxx +any:zzz) title:xxx title:zzz) +_isTemplate:n", query.toString());
 
     }
 
@@ -195,7 +195,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx title:xxx any:xxx) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(any:xxx title:xxx inspiretheme:xxx) +_isTemplate:n", query.toString());
     }
 
 
@@ -218,7 +218,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx zzz title:xxx title:zzz (+any:xxx +any:zzz)) +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+((+any:xxx +any:zzz) title:xxx title:zzz inspiretheme:xxx zzz) +_isTemplate:n",
                 query.toString());
     }
 
@@ -263,8 +263,8 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(inspiretheme:xxx inspiretheme:zzz title:xxx title:zzz "
-        		+ "any:xxx any:zzz) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(any:xxx any:zzz title:xxx title:zzz inspiretheme:xxx "
+        		+ "inspiretheme:zzz) +_isTemplate:n", query.toString());
     }
 
     /**
@@ -373,7 +373,7 @@ public class LuceneQueryTest {
         LuceneQueryBuilder luceneQueryBuilder = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null);
         Query query = luceneQueryBuilder.build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(title:xxx title:yyy (+any:xxx +any:yyy)) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+((+any:xxx +any:yyy) title:xxx title:yyy) +_isTemplate:n", query.toString());
     }
 
 
@@ -483,7 +483,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(+any:demo +any:hoeperdepoep) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(+any:hoeperdepoep +any:demo) +_isTemplate:n", query.toString());
     }
 
     @Test
@@ -986,7 +986,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(+topicCat:environment* +topicCat:biota* +topicCat:boundaries) +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+(+topicCat:biota* +topicCat:boundaries +topicCat:environment*) +_isTemplate:n",
                 query.toString());
     }
 
@@ -1415,7 +1415,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(+keyword:\"zat op de stoep\" +keyword:hoeperdepoep) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(+keyword:hoeperdepoep +keyword:\"zat op de stoep\") +_isTemplate:n", query.toString());
     }
 
     /**
@@ -1609,7 +1609,7 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(+_cat:\"zat op de stoep\" +_cat:hoeperdepoep) +_isTemplate:n", query.toString());
+        assertEquals("unexpected Lucene query", "+(+_cat:hoeperdepoep +_cat:\"zat op de stoep\") +_isTemplate:n", query.toString());
     }
 
     @Test
@@ -2075,8 +2075,8 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+(_op0:0 _op2:0 _op0:1 _op2:1) +westBL:[-180.0 TO 180.0] +eastBL:[-180.0 TO 180.0] "
-        		+ "+northBL:[-90.0 TO 90.0] +southBL:[-90.0 TO 90.0] +title:hoi +_isTemplate:n",
+        assertEquals("unexpected Lucene query", "+(_op0:0 _op2:0 _op0:1 _op2:1) +title:hoi +westBL:[-180.0 TO 180.0] "
+        		+ "+eastBL:[-180.0 TO 180.0] +northBL:[-90.0 TO 90.0] +southBL:[-90.0 TO 90.0] +_isTemplate:n",
                 query.toString());
     }
 
@@ -2192,8 +2192,8 @@ public class LuceneQueryTest {
         // build lucene query
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
         // verify query
-        assertEquals("unexpected Lucene query", "+_isTemplate:n +westBL:[-180.0 TO 180.0] +eastBL:[-180.0 TO 180.0] +northBL:[-90.0 TO " +
-                                                "90.0] +southBL:[-90.0 TO 90.0]", query.toString());
+        assertEquals("unexpected Lucene query", "+westBL:[-180.0 TO 180.0] +eastBL:[-180.0 TO 180.0] +northBL:[-90.0 TO 90.0] "
+        		+ "+southBL:[-90.0 TO 90.0] +_isTemplate:n", query.toString());
     }
 
 
@@ -2387,7 +2387,7 @@ public class LuceneQueryTest {
         );
         LuceneQueryInput lQI = new LuceneQueryInput(request);
         Query query = new LuceneQueryBuilder(luceneConfig, _tokenizedFieldSet, _analyzer, null).build(lQI);
-        assertEquals("unexpected Lucene query", "+(+_isTemplate:n) +ConstantScore($facets:keywordoceanchemistry $facets:keywordoceansalinity $facets:keywordoceantemperature)^0.0", query.toString());
+        assertEquals("unexpected Lucene query", "+(+_isTemplate:n) +ConstantScore($facets:keywordoceansalinity $facets:keywordoceanchemistry $facets:keywordoceantemperature)^0.0", query.toString());
     }
 
     private Element buildSingleDrilldownQuery(String drilldownPath) {

--- a/core/src/test/java/org/fao/geonet/kernel/search/facet/DimensionTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/facet/DimensionTest.java
@@ -32,6 +32,7 @@ public class DimensionTest {
     public void testDimensionSetLocalized() throws JDOMException {
         Dimension dimension = new Dimension("test", "index", "Test");
         final GenericApplicationContext applicationContext = new GenericApplicationContext();
+        applicationContext.refresh();
         applicationContext.getBeanFactory().registerSingleton("languages", Sets.newHashSet("eng", "fre", "ger"));
         dimension.setApplicationContext(applicationContext);
         dimension.setLocalized(true);

--- a/core/src/test/resources/test-spring-config.xml
+++ b/core/src/test/resources/test-spring-config.xml
@@ -7,7 +7,7 @@
 		http://www.springframework.org/schema/beans 
 		http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/security
-        http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+        http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
 	<bean id="testBeanFull" class="jeeves.server.overrides.ExampleBean">
         <property name="basicProp" value="basicPropOriginalValue" />

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.18.1</version>
             <configuration>
-                <argLine>-Dfile.encoding=UTF-8  -Xmx2048M</argLine>
+                <argLine>-Dfile.encoding=UTF-8 -Xmx512M</argLine>
                 <!--<rerunFailingTestsCount>5</rerunFailingTestsCount>-->
                 <runOrder>alphabetical</runOrder>
                 <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/pom.xml
+++ b/pom.xml
@@ -191,65 +191,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
-
     <plugins>
-<!--      <plugin>
-          <groupId>org.codehaus.groovy.maven</groupId>
-          <artifactId>gmaven-plugin</artifactId>
-          <version>1.0</version>
-          <executions>
-              <execution>
-                  <id>Check memory settings</id>
-                  <goals>
-                      <goal>execute</goal>
-                  </goals>
-                  <phase>initialize</phase>
-                  <configuration>
-                      <source><![CDATA[
-                          def converters = [
-                                  "k": 1/10124,
-                                  "m": 1.0,
-                                  "g": 1024.0
-                          ]
-                          def parseInt = {value ->
-                              def intVal = Integer.parseInt(value.substring(0, value.length() - 1));
-                              def unit = value.substring(value.length() - 1).toLowerCase()
-                              def converter = converters[unit]
-                              if (converter == null) {
-                                  throw new AssertionError("unit: $unit is not a recognized unit.  One of k,m,g is required in : $value")
-                              }
-                              return intVal * converter
-                          }
-
-                          final String MAX_PREFIX = "-Xmx"
-                          final String PERMGEN_PREFIX = "-XX:MaxPermSize="
-                          def arguments = java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()
-                          def mx = -1;
-                          def permgen = -1;
-                          arguments.each{param ->
-                              if (param.startsWith(MAX_PREFIX)) {
-                                  mx = parseInt (param.substring(MAX_PREFIX.length()))
-                              } else if (param.startsWith(PERMGEN_PREFIX)) {
-                                  permgen = parseInt (param.substring(PERMGEN_PREFIX.length()))
-                              }
-                          }
-
-                          log.info("\n\tMax Heap Memory: "+mx+" MB\n\tMax PermGen Size: "+permgen+" MB")
-                          if (permgen < 0 || mx < 0) {
-                              def mavenOpts = "MAVEN_OPTS=\"${MAX_PREFIX}512M ${PERMGEN_PREFIX}256M\""
-                              def errorMsg = "\n\nIn order for the build to complete both the $MAX_PREFIX parameter and the "+
-                                      "$PERMGEN_PREFIX must be set.  The e2e tests require this because the start Geonetwork and run " +
-                                      "tests against it which takes a lot of memory.\n\nCmd/Powershell:"+
-                                      "\n\n\t \$Env:${mavenOpts}\n\nBash/SH:\n\n\texport ${mavenOpts}"
-                              log.error(errorMsg);
-                              throw new AssertionError(errorMsg);
-                          }
-                          ]]></source>
-                  </configuration>
-              </execution>
-          </executions>
-      </plugin>-->
-      <!--     Compilation.                                        -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -292,8 +234,7 @@
           <configuration>
             <home>${project.build.directory}/test-server</home>
             <properties>
-              <!-- Cargo VMARGS are not working. FIXME -->
-              <cargo.jvmargs>-Xms48m -Xmx512m -Xss2M -XX:MaxPermSize=128m</cargo.jvmargs>
+              <cargo.jvmargs>-Xms48m -Xmx512m -Xss2M</cargo.jvmargs>
               <cargo.servlet.port>8080</cargo.servlet.port>
             </properties>
             <deployables>
@@ -333,7 +274,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.18.1</version>
             <configuration>
-                <argLine>-Dfile.encoding=UTF-8  -Xmx512M -XX:MaxPermSize=256M</argLine>
+                <argLine>-Dfile.encoding=UTF-8  -Xmx2048M</argLine>
                 <!--<rerunFailingTestsCount>5</rerunFailingTestsCount>-->
                 <runOrder>alphabetical</runOrder>
                 <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/pom.xml
+++ b/pom.xml
@@ -1139,8 +1139,8 @@
     <jetty.version>8.1.9.v20130131</jetty.version>
     <geotools.version>8.6</geotools.version>
     <lucene.version>4.9.0</lucene.version>
-    <spring.version>3.2.5.RELEASE</spring.version>
-    <spring.security.version>3.1.4.RELEASE</spring.security.version>
+    <spring.version>4.2.4.RELEASE</spring.version>
+    <spring.security.version>3.2.0.RELEASE</spring.security.version>
     <metrics.version>2.1.1</metrics.version>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH'\:'mm'\:'ssZ</maven.build.timestamp.format>
     <build.timestamp>${maven.build.timestamp}</build.timestamp>

--- a/schemas-test/src/test/java/iso19139/FullViewFormatterLocalizationTest.java
+++ b/schemas-test/src/test/java/iso19139/FullViewFormatterLocalizationTest.java
@@ -16,7 +16,7 @@ public class FullViewFormatterLocalizationTest extends AbstractFullViewFormatter
     @Autowired
     private IsoLanguagesMapper mapper;
 
-    @Test @DirtiesContext
+    @Test
     @SuppressWarnings("unchecked")
     public void testPrintFormatLocales() throws Exception {
         final FormatType formatType = FormatType.testpdf;

--- a/schemas-test/src/test/java/iso19139/FullViewFormatterServiceTest.java
+++ b/schemas-test/src/test/java/iso19139/FullViewFormatterServiceTest.java
@@ -17,8 +17,8 @@ public class FullViewFormatterServiceTest extends AbstractFullViewFormatterTest 
     @Test
     public void testDummy(){}
 
+    @Test
     @Ignore
-    @DirtiesContext
     public void testServiceMdFormatting() throws Exception {
         super.testPrintFormat();
     }

--- a/schemas-test/src/test/java/iso19139/FullViewFormatterTest.java
+++ b/schemas-test/src/test/java/iso19139/FullViewFormatterTest.java
@@ -16,8 +16,8 @@ public class FullViewFormatterTest extends AbstractFullViewFormatterTest {
     public void testDummy(){}
 
 
+    @Test
     @Ignore
-    @DirtiesContext
     public void testServiceMdFormatting() throws Exception {
         super.testPrintFormat();
     }

--- a/services/src/main/java/org/fao/geonet/services/metadata/AjaxEditUtils.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/AjaxEditUtils.java
@@ -20,6 +20,7 @@ import org.jdom.filter.Filter;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -104,7 +105,7 @@ public class AjaxEditUtils extends EditUtils {
 
         // Store XML fragments to be handled after other elements update
         Map<String, String> xmlInputs = new HashMap<String, String>();
-        Map<String, AddElemValue> xmlAndXpathInputs = new HashMap<String, AddElemValue>();
+        LinkedHashMap<String, AddElemValue> xmlAndXpathInputs = new LinkedHashMap<String, AddElemValue>();
 
         // --- update elements
         for (Map.Entry<String, String> entry : changes.entrySet()) {

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/FormatIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/FormatIntegrationTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.annotation.DirtiesContext;
@@ -268,10 +269,8 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
         MockHttpServletRequest request = new MockHttpServletRequest(context, "GET", "http://localhost:8080/geonetwork/srv/eng/md.formatter");
         request.setPathInfo("/eng/md.formatter");
 
-        WebApplicationContext webAppContext = new GenericWebApplicationContext((DefaultListableBeanFactory) _applicationContext.getBeanFactory());
-
         final String applicationContextAttributeKey = "srv";
-        request.getServletContext().setAttribute(applicationContextAttributeKey, webAppContext);
+        request.getServletContext().setAttribute(applicationContextAttributeKey, _applicationContext);
         ServletRequestAttributes requestAttributes = new ServletRequestAttributes(request);
 
         RequestContextHolder.setRequestAttributes(requestAttributes);

--- a/services/src/test/java/org/fao/geonet/services/metadata/format/FormatIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/format/FormatIntegrationTest.java
@@ -38,6 +38,7 @@ import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -149,7 +150,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
             request.setMethod("GET");
             response = new MockHttpServletResponse();
 
-            request.addHeader("If-Modified-Since", Long.valueOf(lastModified));
+            request.addHeader("If-Modified-Since", lastModified);
             formatService.exec("eng", "html", "" + id, null, formatterName, "true", false, _100,new ServletWebRequest(request, response));
             assertEquals(HttpStatus.SC_NOT_MODIFIED, response.getStatus());
             final ISODate newChangeDate = new ISODate();
@@ -166,7 +167,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
             request.setMethod("GET");
             response = new MockHttpServletResponse();
 
-            request.addHeader("If-Modified-Since", Long.valueOf(lastModified));
+            request.addHeader("If-Modified-Since", lastModified);
             formatService.exec("eng", "html", "" + id, null, formatterName, "true", false, _100, new ServletWebRequest(request, response));
              assertEquals(HttpStatus.SC_OK, response.getStatus());
         } finally {
@@ -322,7 +323,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
         assertTrue(view.contains("KML (1)"));
     }
 
-    @Test @DirtiesContext
+    @Test
     public void testXmlFormatUrl() throws Exception {
         final Element sampleMetadataXml = getSampleMetadataXml();
         final Element element = Xml.selectElement(sampleMetadataXml, "*//gmd:MD_Format", Lists.newArrayList(ISO19139Namespaces.GMD));
@@ -341,7 +342,7 @@ public class FormatIntegrationTest extends AbstractServiceIntegrationTest {
         assertTrue(view.contains("Format"));
     }
 
-    @Test @DirtiesContext
+    @Test
     public void testXmlFormatRelativeUrl() throws Exception {
         final Element sampleMetadataXml = getSampleMetadataXml();
         final Element element = Xml.selectElement(sampleMetadataXml, "*//gmd:MD_Format", Lists.newArrayList(ISO19139Namespaces.GMD));

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-cas-database.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-cas-database.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd" 
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd"
           xmlns:sec="http://www.springframework.org/schema/security"
           xmlns:ctx="http://www.springframework.org/schema/context"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-cas-ldap.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-cas-ldap.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd" 
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd"
           xmlns:sec="http://www.springframework.org/schema/security"
           xmlns:ctx="http://www.springframework.org/schema/context"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-cas.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-cas.xml
@@ -5,7 +5,7 @@
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd"
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd"
 	xmlns:sec="http://www.springframework.org/schema/security" xmlns:ctx="http://www.springframework.org/schema/context"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans">
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <beans
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd"
-	xmlns:sec="http://www.springframework.org/schema/security" xmlns:ctx="http://www.springframework.org/schema/context"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans">
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd"
+          xmlns:sec="http://www.springframework.org/schema/security"
+          xmlns:ctx="http://www.springframework.org/schema/context"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.springframework.org/schema/beans">
 
 	<alias name="filterChainProxy" alias="springSecurityFilterChain" />
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-ecas.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-ecas.xml
@@ -23,7 +23,7 @@ geonetwork.https.url=https://ec.europa.eu:8443/geonetwork
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd"
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd"
     xmlns:sec="http://www.springframework.org/schema/security" xmlns:ctx="http://www.springframework.org/schema/context"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans">
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-ldap.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-ldap.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd" 
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd"
           xmlns:sec="http://www.springframework.org/schema/security"
           xmlns:ctx="http://www.springframework.org/schema/context"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd" xmlns:sec="http://www.springframework.org/schema/security" xmlns:ctx="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans">
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd" xmlns:sec="http://www.springframework.org/schema/security" xmlns:ctx="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans">
     <bean class="org.springframework.security.web.access.intercept.FilterSecurityInterceptor" id="filterSecurityInterceptor">
         <property name="authenticationManager" ref="authenticationManager"></property>
         <property name="accessDecisionManager" ref="accessDecisionManager"></property>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
@@ -6,7 +6,7 @@
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd"
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd"
 	xmlns:sec="http://www.springframework.org/schema/security" xmlns:ctx="http://www.springframework.org/schema/context"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans">
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/context
           http://www.springframework.org/schema/context/spring-context-3.0.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.1.xsd" 
+          http://www.springframework.org/schema/security/spring-security-3.2.xsd"
           xmlns:sec="http://www.springframework.org/schema/security"
           xmlns:ctx="http://www.springframework.org/schema/context"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/web/src/test/java/org/fao/geonet/wro4j/Wro4jJsCssCompilationTest.java
+++ b/web/src/test/java/org/fao/geonet/wro4j/Wro4jJsCssCompilationTest.java
@@ -45,6 +45,7 @@ public class Wro4jJsCssCompilationTest {
         dataDirectory.setSchemaPluginsDir(webDir.resolve("WEB-INF/data/config/schema_plugins"));
         dataDirectory.setFormatterDir(webDir.resolve("WEB-INF/data/data/formatter"));
         GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+        applicationContext.refresh();
         applicationContext.getBeanFactory().registerSingleton("geonetworkDataDirectory", dataDirectory);
         ApplicationContextHolder.set(applicationContext);
 


### PR DESCRIPTION
Currently develop testsuite works usually only on Java7. This changes made by @pmauduit fix the tests on Java 7 and 8.

The main change is update to Spring 4 and Spring security 3.2.

Sometimes tests are still failing (for unknown reason) with:
```
  UserRepositoryTest.testFindAllByGroupOwnerNameAndProfile:168 expected:<username9(239) - Editor> but was:<username10(240) - Reviewer>

  KeywordsSearcherTest.testSearchNoContextMultiLangNoSearchAllThesauri:183->assertSearchNoContextMultiLangNoSearchAllThesauri:196 expected:<1040> but was:<1085>
```

