### PR TITLE
Fix/1391 geopublisher fixes

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -547,13 +547,6 @@ public class GeoServerRest {
 						+ "_style", sldbody, null,
 						"application/vnd.ogc.sld+xml", true);
 
-				/**
-				 * check that the sld was validated by geoserver
-				 * previous call always return 200 even when sld is invalid
-				 */
-				status = sendREST(GeoServerRest.METHOD_GET, url + "/" + layer
-						+ "_style.sld?quietOnNotFound=true", null, null, null, true);
-
 				if (status != 200)
 					Log.warning(Geonet.GEOPUBLISH,"The sld file was probably not valid, falling back to default");
 			}

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -595,6 +595,8 @@ public class GeoServerRest {
 	private void checkResponseCode(int status2) {
 	    if(status2 > 399) {
 	        Log.warning(Geonet.GEOPUBLISH, "Warning a bad response code to message was returned:"+status2);
+		if (!response.isEmpty())
+			Log.warning(Geonet.GEOPUBLISH, "Response content:"+response);
 	    }
     }
 

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -675,12 +675,6 @@ public class GeoServerRest {
 				+ "/datastores/" + ds + "/featuretypes/" + ft, xml, null,
 				"text/xml", true);
 
-		// Create layer for feature type (require for MapServer REST API)
-		status = sendREST(GeoServerRest.METHOD_PUT, "/layers/" + ft, null, null,
-				"text/xml", false);
-
-		checkResponseCode(status);
-
 		return 201 == status;
 	}
 

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -382,6 +382,7 @@ public class GeoServerRest {
 	 * @throws java.io.IOException
 	 */
 	public boolean createDatastore(String ws, String ds, Path f) throws IOException {
+		Log.debug(Geonet.GEOPUBLISH, "Creating datastore " + ds + " in workspace " + ws + " from path " + f.toString());
 		int status = sendREST(GeoServerRest.METHOD_PUT, "/workspaces/" + ws
 				+ "/datastores/" + ds + "/file.shp", null, f,
 				"application/zip", false);
@@ -398,6 +399,7 @@ public class GeoServerRest {
 			type = "external";
 		}
 
+		Log.debug(Geonet.GEOPUBLISH, "Creating datastore " + ds + " in workspace " + ws + " from file " + file);
 		int status = sendREST(GeoServerRest.METHOD_PUT, "/workspaces/" + ws
 				+ "/datastores/" + ds + "/" + type + extension, file, null,
 				"text/plain", false);
@@ -567,6 +569,7 @@ public class GeoServerRest {
 			}
             checkResponseCode(status);
 
+			Log.debug(Geonet.GEOPUBLISH, "Adding enable flag to layer");
 			body = "<layer><defaultStyle><name>"
 					+ layer
 					+ "_style</name>";

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -571,9 +571,12 @@ public class GeoServerRest {
 				body += "<workspace>" + ws + "</workspace>";
 			body += "</defaultStyle><enabled>true</enabled></layer>";
 
+			url = "/layers/";
+			if (!ws.isEmpty())
+				url += ws + ":";
 			// Add the enable flag due to GeoServer bug
 			// http://jira.codehaus.org/browse/GEOS-3964
-			status = sendREST(GeoServerRest.METHOD_PUT, "/layers/" + layer,
+			status = sendREST(GeoServerRest.METHOD_PUT, url + layer,
 					body, null, "text/xml", true);
             checkResponseCode(status);
 

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -138,7 +138,14 @@ public class GeoServerRest {
 	 * @throws java.io.IOException
 	 */
 	public boolean getLayer(String layer) throws IOException {
-		int status = sendREST(GeoServerRest.METHOD_GET, "/layers/" + layer
+		return getLayer(getDefaultWorkspace(), layer);
+	}
+
+	public boolean getLayer(String ws, String layer) throws IOException {
+		String url = "/layers/";
+		if (!ws.isEmpty())
+			url += ws + ":";
+		int status = sendREST(GeoServerRest.METHOD_GET, url + layer
 				+ ".xml?quietOnNotFound=true", null, null, null, true);
 		return status == 200;
 	}
@@ -159,7 +166,14 @@ public class GeoServerRest {
 	 * @throws java.io.IOException
 	 */
 	public boolean deleteLayer(String layer) throws IOException {
-		int status = sendREST(GeoServerRest.METHOD_DELETE, "/layers/" + layer,
+		return deleteLayer(getDefaultWorkspace(), layer);
+	}
+
+	public boolean deleteLayer(String ws, String layer) throws IOException {
+		String url = "/layers/";
+		if (!ws.isEmpty())
+			url += ws + ":";
+		int status = sendREST(GeoServerRest.METHOD_DELETE, url + layer,
 				null, null, null, true);
 		// TODO : add force to remove ft, ds
 		return status == 200;

--- a/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/services/publisher/GeoServerRest.java
@@ -632,9 +632,15 @@ public class GeoServerRest {
 		String xml = "<featureType><name>" + ft + "</name><title>" + ft
 				+ "</title>" + "</featureType>";
 
-		status = sendREST(GeoServerRest.METHOD_POST, "/workspaces/" + ws
-				+ "/datastores/" + ds + "/featuretypes", xml, null, "text/xml",
-				true);
+		String url = "/workspaces/" + ws + "/datastores/" + ds + "/featuretypes";
+		Log.debug(Geonet.GEOPUBLISH, "Checking if a featuretype named " + ft + " already exists in workspace " + ws +", datastore " + ds);
+		status = sendREST(GeoServerRest.METHOD_GET, url + "/" + ft, null, null, null, true);
+		if (status != 200) {
+			Log.debug(Geonet.GEOPUBLISH, "Creating featuretype " + ft + " in workspace " + ws + " within datastore " + ds);
+			status = sendREST(GeoServerRest.METHOD_POST, url, xml, null, "text/xml",
+					true);
+			checkResponseCode(status);
+		}
 
 		xml = "<featureType><title>"
 				+ (metadataTitle != null ? metadataTitle : ft)
@@ -671,8 +677,7 @@ public class GeoServerRest {
 					+ "</metadataLink>"
 				+ "</metadataLinks>"
 			+ "</featureType>";
-		status = sendREST(GeoServerRest.METHOD_PUT, "/workspaces/" + ws
-				+ "/datastores/" + ds + "/featuretypes/" + ft, xml, null,
+		status = sendREST(GeoServerRest.METHOD_PUT, url + "/" + ft, xml, null,
 				"text/xml", true);
 
 		return 201 == status;

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
@@ -137,30 +137,6 @@
                     '?namespace=' + gsNode.namespacePrefix +
                     '&layer=' + scope.wmsLayerName);
               };
-              /**
-               * Dirty check if the node is a Mapserver REST API
-               * or a GeoServer REST API.
-               *
-               * @param {Object} gsNode
-               * @return {boolean}
-               */
-              var isMRA = function(gsNode) {
-                return gsNode.adminUrl &&
-                    gsNode.adminUrl.indexOf('/mra') !== -1;
-              };
-
-              /**
-               * Build WMS layername based on target map server.
-               *
-               * @param {Object} gsNode
-               */
-              var buildLayerName = function(gsNode) {
-                // Append prefix for GeoServer.
-                if (gsNode && !isMRA(gsNode)) {
-                  scope.wmsLayerName = gsNode.namespacePrefix +
-                      ':' + scope.wmsLayerName;
-                }
-              };
 
               /**
                * Add the layer of the node to the current
@@ -235,7 +211,6 @@
               scope.selectNode = function(nodeId) {
                 gsNode = getNodeById(nodeId);
                 scope.checkNode(nodeId);
-                buildLayerName(gsNode);
                 scope.hasStyler = !angular.isArray(gsNode.stylerUrl);
               };
 
@@ -315,7 +290,6 @@
                     .replace(/.*\//, '')
                     .replace(/.zip$|.tif$|.tiff$|.ecw$/, '');
                 }
-                buildLayerName(gsNode);
               };
             }
           };

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
@@ -220,6 +220,10 @@
                * a layer configuration if published.
                */
               scope.checkNode = function(nodeId) {
+                if (scope.isPublished) {
+                  map.getLayerGroup().getLayers().pop();
+                }
+                scope.isPublished = false;
                 var p = gnGeoPublisher.checkNode(nodeId, scope.name);
                 if (p) {
                   p.success(function(data) {

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/partials/geopublisher.html
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/partials/geopublisher.html
@@ -49,7 +49,7 @@
             </button>
             <!-- DROP DOWN CHECKBOX -->
             <div class="dropdown">
-                <button class="btn btn-link btn-xs" data-toggle="dropdown" data-ng-click="publish(nodeId)"
+                <button class="btn btn-link btn-xs" data-toggle="dropdown"
                   data-ng-class="{'disabled': (!isPublished || !nodeId)}">
                   <i class="fa fa-clipboard"></i>&nbsp;<span data-translate="">linkService</span>
                   <span class="caret"></span>

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/partials/geopublisher.html
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/partials/geopublisher.html
@@ -87,7 +87,7 @@
               </div>
           </div>
           <button class="btn btn-link btn-xs" data-ng-click="openStyler(nodeId)"
-                  data-ng-class="hasStyler ? '' : 'hidden'">
+                  data-ng-class="hasStyler ? ((isPublished || !nodeId) ? '': 'disabled') : 'hidden'">
             <i class="fa fa-pencil"></i>&nbsp;<span data-translate="">style</span>
           </button>
         </div>


### PR DESCRIPTION
This PR should fix lots of smallish issues in the geopublisher, and most importantly prepends the workspace name (if not empty) to the layername to ensure we check for layer existance in the correct workspace

Tested against GS 2.8 with various workspaces, with/without style in zip, lots of small logic issues in the publishing workflow fixed. There should be less 500 error codes in the REST transactions for nicer logs.