### PR TITLE
Don't log a warning when an upload request wasnt found

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceDownloadHandler.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceDownloadHandler.java
@@ -167,8 +167,6 @@ public class DefaultResourceDownloadHandler implements IResourceDownloadHandler 
                     metadataFileUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, fname);
 
                 } catch (org.springframework.dao.EmptyResultDataAccessException ex) {
-                    Log.warning(Geonet.RESOURCES, "Store file download request: No upload request for (metadataid, file): (" + metadataId + "," + fname + ")");
-
                     // No related upload is found
                     metadataFileUpload = null;
                 }


### PR DESCRIPTION
Otherwise you get two warning lines in logs each time someone visits
a metadata containing thumbnails uploaded before MetadataFileDowloads was added.

I know this code will be changed/revamped in #1385 but in the meantime that really uselessly fills logs at WARNING level, which is the default for geonetwork logger. Another option would be to demote that to DEBUG/INFO level..