### PR TITLE
allow user to change its user details and password. close #1258

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -53,14 +53,12 @@
             >resetPassword</span></button>
           <button type="button" class="btn btn-primary pull-right"
             data-ng-disabled="!gnUserEdit.$valid && !gnUserEdit.dirty"
-            data-ng-show="user.isUserAdminOrMore()"
             data-ng-click="saveUser('#gn-user-edit')" id="gn-btn-user-save">
             <i class="fa fa-save"></i> <span data-translate=""
             >saveUser</span></button>
           <button type="button" class="btn pull-right btn-danger"
             data-ng-disabled="searchResults.count > 0"
             data-ng-show="user.isUserAdminOrMore()"
-            data-ng-hide="userSelected.id == ''"
             data-ng-click="deleteUser(userSelected.id)" id="gn-btn-user-delete">
             <i class="fa fa-times"></i> <span data-translate=""
             >deleteUser</span></button>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -87,7 +87,6 @@
       <li data-ng-show="authenticated">
         <a href="admin.console#/organization/users?userOrGroup={{user.username}}"
            title="{{'userDetails' | translate}}"
-           data-ng-disabled="!user.isUserAdminOrMore()"
            class="hidden-xs btn btn-link">
           <img class="img-circle"
                data-ng-src="http://gravatar.com/avatar/{{user.email | md5}}?s=18"/>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -224,10 +224,10 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.group.update.labels!?.*" access="hasRole('Administrator')"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.group.remove!?.*" access="hasRole('Administrator')"/>
 
-                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user!?.*" access="hasRole('UserAdmin')"/>
-                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.list!?.*" access="hasRole('Editor')"/>
-                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.update!?.*" access="hasRole('UserAdmin')"/>
-                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.resetpassword\?.*" access="hasRole('UserAdmin')"/>
+                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user!?\?.*" access="hasRole('RegisteredUser')"/>
+                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.list!?.*" access="hasRole('RegisteredUser')"/>
+                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.update!?.*" access="hasRole('RegisteredUser')"/>
+                <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.resetpassword\?.*" access="hasRole('RegisteredUser')"/>
                 <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.remove!?.*" access="hasRole('UserAdmin')"/>
 
 


### PR DESCRIPTION
This PR revert this https://github.com/geonetwork/core-geonetwork/commit/712559e51bfd9b730c82f18303678c95e6be219b commit ( see top-toolbar.html in this PR) in order to make accessible the admin section to any RegisteredUser. 
In this way ant user will be able to change their own details and password. If the user has no higher profile than RegisteredUser will see only itself in the user list but he won't be able to delete himself nor change its own groups assignment.

@fxprunayre is this ok? I couldn't understand if you disabled the link in the topbar due to the fact that a RegisteredUser before wasn't actually able to change its own details or if because he **must not do it**. In the latter case I think it should be at least allowed to change its own password.