### PR TITLE
Add ID field to invalid metadata records

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -305,7 +305,7 @@ public class Aligner
         // validate it here if requested
         if (params.validate) {
             if(!dataMan.validate(md))  {
-                log.info("Ignoring invalid metadata");
+                log.info("Ignoring invalid metadata uuid"+ri.uuid);
                 result.doesNotValidate++;
                 return null;
             }
@@ -581,7 +581,7 @@ public class Aligner
         // validate it here if requested
         if (params.validate) {
             if(!dataMan.validate(md))  {
-                log.info("Ignoring invalid metadata");
+                log.info("Ignoring invalid metadata uuid"+ri.uuid+" id "+id);
                 result.doesNotValidate++;
                 return;
             }

--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
@@ -361,7 +361,7 @@ public class Aligner
             // validate it here if requested
             if (params.validate) {
                 if(!dataMan.validate(md))  {
-                    log.info("Ignoring invalid metadata");
+                    log.info("Ignoring invalid metadata id"+id);
                     result.doesNotValidate++;
                     return null;
                 }


### PR DESCRIPTION
When harvesting and updating records from GeoNetwork nodes it would be helpful to know which record ID is invalid. This PR adds the ID to the log message.