### PR TITLE
Enforce dependency on httpclient 4.3.2 in toplevel pom.xml (#1368)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.3.1</version>
+        <version>4.3.2</version>
       </dependency>
       <dependency>
         <groupId>xerces</groupId>


### PR DESCRIPTION
Checked with `mvn dependency:tree`, thx to @pmauduit 
```
-[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.3.1:compile (version managed from 4.3.2)
-[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.3:compile
+[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.3.2:compile
+[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.3.1:compile

```
`grep :httpclient` in the output of the dep-tree doesnt yield 4.3.1 anymore.