### PR TITLE
Support TLS mode for mail server configuration

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -62,7 +62,9 @@ import javax.annotation.Nullable;
 public class DefaultStatusActions implements StatusActions {
 
     private String host, port, username, password, from, fromDescr, replyTo, replyToDescr;
-    private boolean useSSL;    protected ServiceContext context;
+    private boolean useSSL;
+    private boolean useTLS;
+    protected ServiceContext context;
     protected String language;
     protected DataManager dm;
     protected String siteUrl;
@@ -101,6 +103,7 @@ public class DefaultStatusActions implements StatusActions {
         username = sm.getValue("system/feedback/mailServer/username");
         password = sm.getValue("system/feedback/mailServer/password");
         useSSL = sm.getValueAsBool("system/feedback/mailServer/ssl");
+        useTLS = sm.getValueAsBool("system/feedback/mailServer/tls");
         
         if (host == null || host.length() == 0) {
             context.error("Mail server host not configure");
@@ -350,7 +353,7 @@ public class DefaultStatusActions implements StatusActions {
             context.info("Would send email \nTo: " + sendTo + "\nSubject: " + subject + "\n Message:\n" + message);
         } else {
             MailSender sender = new MailSender(context);
-            sender.sendWithReplyTo(host, Integer.parseInt(port), username, password, useSSL, from, fromDescr,
+            sender.sendWithReplyTo(host, Integer.parseInt(port), username, password, useSSL, useTLS, from, fromDescr,
             		sendTo, null, replyTo, replyToDescr, subject, message);
         }
     }

--- a/core/src/main/java/org/fao/geonet/util/MailSender.java
+++ b/core/src/main/java/org/fao/geonet/util/MailSender.java
@@ -62,15 +62,21 @@ public class MailSender extends Thread
      * @param message
      * @throws EmailException
      */
-    private void setUp(String server, int port, String username, String password, boolean useSSL, String from, String fromDescr, String to, String subject, String message) throws EmailException {
+    private void setUp(String server, int port, String username, String password, boolean useSSL, boolean useTLS,
+                       String from, String fromDescr, String to, String subject, String message) throws EmailException {
         _mail.setHostName(server);
         _mail.setSmtpPort(port);
         _mail.setFrom(from, fromDescr);
         if(!"".equals(username)) {
             _mail.setAuthentication(username, password);
         }
+        if(useTLS) {
+            _mail.setStartTLSEnabled(true);
+            _mail.setStartTLSRequired(true);
+        }
         if(useSSL) {
-            _mail.setSSL(useSSL);
+            _mail.setSSLOnConnect(useSSL);
+            _mail.setSslSmtpPort(port + "");
         }
         _mail.addTo(to);
         _mail.setSubject(subject);
@@ -96,11 +102,11 @@ public class MailSender extends Thread
      * @param subject
      * @param message
      */
-	public void send(String server, int port, String username, String password, boolean useSSL, 
+	public void send(String server, int port, String username, String password, boolean useSSL,boolean useTLS,
 	        String from, String fromDescr, String to, String toDescr, String subject, String message) {
 		_mail = new SimpleEmail();
 		try {
-            setUp(server, port, username, password, useSSL, from, fromDescr, to, subject, message);
+            setUp(server, port, username, password, useSSL, useTLS, from, fromDescr, to, subject, message);
             start();
 		}
 		catch(EmailException e) {
@@ -123,12 +129,12 @@ public class MailSender extends Thread
      * @param subject
      * @param message
      */
-	public void sendWithReplyTo(String server, int port, String username, String password, boolean useSSL, 
+	public void sendWithReplyTo(String server, int port, String username, String password, boolean useSSL, boolean useTLS,
 	        String from, String fromDescr, String to, String toDescr, 
 	        String replyTo, String replyToDesc, String subject, String message) {
 		_mail = new SimpleEmail();
 		try {
-            setUp(server, port, username, password, useSSL, from, fromDescr, to, subject, message);
+            setUp(server, port, username, password, useSSL, useTLS, from, fromDescr, to, subject, message);
             List<InternetAddress> addressColl = new ArrayList<InternetAddress>();
 			addressColl.add(new InternetAddress(replyTo, replyToDesc));
 			_mail.setReplyTo(addressColl);

--- a/core/src/main/java/org/fao/geonet/util/MailUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/MailUtil.java
@@ -66,7 +66,7 @@ public class MailUtil {
      * 
      * @param toAddress
      * @param subject
-     * @param htmlMessage
+     * @param message
      * @param settings
      * @throws EmailException
      */
@@ -83,7 +83,6 @@ public class MailUtil {
             e1.printStackTrace();
             return false;
         }
-        email.setSSL(true);
 
         // send to all mails extracted from settings
         for (String add : toAddress) {
@@ -186,7 +185,6 @@ public class MailUtil {
             e1.printStackTrace();
             return false;
         }
-        email.setSSL(true);
 
         // send to all mails extracted from settings
         for (String add : toAddress) {
@@ -203,24 +201,34 @@ public class MailUtil {
 
     private static Boolean send(final Email email) {
         try {
-        	Thread t = new Thread() {
-        		@Override
-        		public void run() {
-        			super.run();
-                    try {
-						email.send();
-					} catch (EmailException e) {
-						e.printStackTrace();
-					}
-        		}
-        	};
-        	
-        	t.start();
-        } catch (Exception e) {
+            email.send();
+
+        } catch (EmailException e) {
             e.printStackTrace();
             return false;
         }
+
         return true;
+    }
+
+    private static void sendWithThread(final Email email) {
+        try {
+            Thread t = new Thread() {
+                @Override
+                public void run() {
+                    super.run();
+                    try {
+                        email.send();
+                    } catch (EmailException e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+
+            t.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -250,7 +258,6 @@ public class MailUtil {
             e1.printStackTrace();
             return false;
         }
-        email.setSSL(true);
 
         // send to all mails extracted from settings
         for (String add : toAddress) {
@@ -358,4 +365,33 @@ public class MailUtil {
         return sendMail(to_, subject, message, sm, replyTo, replyToDescr);
     }
 
+    public static void testSendMail(String to, String subject, String message,
+                                   SettingManager sm, String replyTo, String replyToDescr) throws Exception {
+        List<String> to_ = new ArrayList<String>(1);
+        to_.add(to);
+        testSendMail(to_, subject, message, sm, replyTo, replyToDescr);
+    }
+
+    public static void testSendMail(List<String> toAddress, String subject,
+                                   String message, SettingManager settings, String replyTo,
+                                   String replyToDesc) throws Exception {
+        // Create data information to compose the mail
+        Email email = new SimpleEmail();
+        configureBasics(settings, email);
+
+        List<InternetAddress> addressColl = new ArrayList<InternetAddress>();
+
+        addressColl.add(new InternetAddress(replyTo, replyToDesc));
+        email.setReplyTo(addressColl);
+
+        email.setSubject(subject);
+        email.setMsg(message);
+
+        // send to all mails extracted from settings
+        for (String add : toAddress) {
+            email.addBcc(add);
+        }
+
+        email.send();
+    }
 }

--- a/harvesters/src/main/java/org/fao/geonet/component/harvester/csw/Harvest.java
+++ b/harvesters/src/main/java/org/fao/geonet/component/harvester/csw/Harvest.java
@@ -853,6 +853,7 @@ public class Harvest extends AbstractOperation implements CatalogService {
                     settingManager.getValue("system/feedback/mailServer/username"), 
                     settingManager.getValue("system/feedback/mailServer/password"), 
                     settingManager.getValueAsBool("system/feedback/mailServer/ssl"), 
+                    settingManager.getValueAsBool("system/feedback/mailServer/tls"),
                     "noreply@geonetwork.org",
                     "GeoNetwork CSW Server", to, null, "Asynchronous CSW Harvest results delivery", harvestResponse);
         }

--- a/services/src/main/java/org/fao/geonet/services/api/tools/mail/MailApi.java
+++ b/services/src/main/java/org/fao/geonet/services/api/tools/mail/MailApi.java
@@ -91,11 +91,16 @@ public class MailApi {
                 "mail_config_test_subject"),
                 sm.getSiteName(),
                 to);
-        if (!MailUtil.sendMail(to, subject, "Empty message", sm, to, "")) {
+        try {
+            MailUtil.testSendMail(to, subject, "Empty message", sm, to, "");
             return new ResponseEntity<>(String.format(
-                    messages.getString("mail_error")), HttpStatus.PRECONDITION_FAILED);
+                    messages.getString("mail_config_test_success"), to), HttpStatus.CREATED);
+        } catch (Exception ex) {
+            String error = ex.getMessage();
+            if (ex.getCause() != null) error = error + ". " + ex.getCause().getMessage();
+            return new ResponseEntity<>(String.format(
+                    error), HttpStatus.PRECONDITION_FAILED);
         }
-        return new ResponseEntity<>(String.format(
-                messages.getString("mail_config_test_success"), to), HttpStatus.CREATED);
+
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/feedback/Insert.java
+++ b/services/src/main/java/org/fao/geonet/services/feedback/Insert.java
@@ -77,6 +77,7 @@ public class Insert implements Service
 		        sm.getValue("system/feedback/mailServer/username"), 
 		        sm.getValue("system/feedback/mailServer/password"), 
 		        sm.getValueAsBool("system/feedback/mailServer/ssl"), 
+				sm.getValueAsBool("system/feedback/mailServer/tls"),
 		        email, name +" ("+org+")", to, null, subject, comments);
 
 		return new Element("response").addContent(params.cloneContent());

--- a/services/src/main/java/org/fao/geonet/services/resources/Download.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/Download.java
@@ -167,6 +167,7 @@ public class Download {
 							        sm.getValue("system/feedback/mailServer/username"), 
 							        sm.getValue("system/feedback/mailServer/password"), 
 							        sm.getValueAsBool("system/feedback/mailServer/ssl"), 
+								sm.getValueAsBool("system/feedback/mailServer/tls"),
 							        from, fromDescr, email, null, subject, message);
 						}
 						catch (Exception e)

--- a/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
@@ -388,6 +388,7 @@ public class DownloadArchive implements Service
 							        sm.getValue("system/feedback/mailServer/username"), 
 							        sm.getValue("system/feedback/mailServer/password"), 
 							        sm.getValueAsBool("system/feedback/mailServer/ssl"), 
+								sm.getValueAsBool("system/feedback/mailServer/tls"),
 							        from, fromDescr, email, null, subject, message);
 						} catch (Exception e) {
 							e.printStackTrace();

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -212,7 +212,7 @@
               title: response.data});
           }, function(response) {
             $rootScope.$broadcast('StatusUpdated', {
-              title: response.statusText,
+              title: response.data,
               timeout: 0,
               type: 'danger'});
           });

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -740,6 +740,7 @@
     "system/feedback/mailServer/password": "Password",
     "system/feedback/mailServer/port": "SMTP port",
     "system/feedback/mailServer/ssl": "Use SSL",
+    "system/feedback/mailServer/tls": "Use TLS",
     "system/feedback/mailServer/username": "User name",
     "system/harvester": "Harvesters",
     "system/harvester/enableEditing": "Allow editing on harvested records",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -578,6 +578,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/username', '', 0, 642, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/password', '', 0, 643, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/ssl', 'false', 2, 641, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/tls', 'false', 2, 644, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/removedMetadata/dir', 'WEB-INF/data/removed', 0, 710, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/selectionmanager/maxrecords', '1000', 1, 910, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/csw/enable', 'true', 2, 1210, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v310/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v310/migrate-default.sql
@@ -1,2 +1,4 @@
 UPDATE Settings SET value='3.1.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
+
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/tls', 'false', 2, 644, 'y');


### PR DESCRIPTION
Add TLS support, code cleanup in MailUtil, removing the thread in send mail as return of function was not reliable and fixes for mail tester feature, to display the error message returned by the server, not a generic "Precondition Failed" message.