### PR TITLE
Bump log4j requirement to 1.2.17.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
       <dependency>
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
-        <version>1.2.13</version>
+        <version>1.2.17</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
1.2.14 ships with rollingPolicy in log4j.dtd
1.2.16 allows to configure rollingPolicy via properties files

Refs: http://stackoverflow.com/questions/5117758/configuring-rollingfileappender-in-log4j & http://stackoverflow.com/a/13037467. Tested 3.0.4-SNAPSHOT working fine with log4j 1.2.17.