### PR TITLE
Rename field 'key' for HarvesterData table as 'key' is a reserved word

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/HarvesterDataId.java
+++ b/domain/src/main/java/org/fao/geonet/domain/HarvesterDataId.java
@@ -50,6 +50,7 @@ public class HarvesterDataId implements Serializable {
      *
      * @return the key.
      */
+    @Column(name = "keyvalue", nullable = false, length = 255)
     public String getKey() {
         return key;
     }
@@ -58,7 +59,6 @@ public class HarvesterDataId implements Serializable {
      * Set the key identifying the data entity (within the scope of the harvester).  Max length is 255
      * @param key  identifying the data entity (within the scope of the harvester).
      */
-    @Column(nullable = false, length = 255)
     public void setKey(String key) {
         Assert.isTrue(key.length() <= 255);
         this.key = key;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v304/migrate-mysql.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v304/migrate-mysql.sql
@@ -1,4 +1,4 @@
 UPDATE Settings SET value='3.0.4' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 
-ALTER TABLE HarvesterData RENAME COLUMN "key" TO keyvalue;
+ALTER TABLE HarvesterData CHANGE `key` keyvalue varchar(255);


### PR DESCRIPTION
This avoid that the table is not created by Hibernate in some databases like MySql.