### PR TITLE
- Added support for Stamen, as context background layer.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1440,6 +1440,14 @@
                   }),
                   title: 'Bing Aerial'
                 });
+              case 'stamen':
+                return new ol.layer.Tile({
+                  source: new ol.source.Stamen({
+                    //We make watercolor the default layer
+                    layer: (opt && opt.name ? opt.name : 'watercolor')
+                  }),
+                  title: 'Stamen'
+                });
               case 'wmts':
                 var that = this;
                 if (opt.name && opt.url) {

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -128,16 +128,22 @@
         var layers = context.resourceList.layer;
         var i, j, olLayer, bgLayers = [];
         var self = this;
-        var re = /type\s*=\s*([^,|^}|^\s]*)/;
         var promises = [];
         for (i = 0; i < layers.length; i++) {
           var layer = layers[i];
           if (layer.name) {
+            var re = this.getREForPar('type');
             if (layer.group == 'Background layers' &&
                 layer.name.match(re)) {
               var type = re.exec(layer.name)[1];
+              re = this.getREForPar('layer');
+              var opt;
+              if (layer.name.match(re)) {
+                var lyr = re.exec(layer.name)[1];
+                opt = {name: lyr};
+              }
               if (type != 'wmts') {
-                var olLayer = gnMap.createLayerForType(type);
+                var olLayer = gnMap.createLayerForType(type, opt);
                 if (olLayer) {
                   bgLayers.push({layer: olLayer, idx: i});
                   olLayer.displayInLayerManager = false;
@@ -268,6 +274,8 @@
             name = '{type=mapquest}';
           } else if (source instanceof ol.source.BingMaps) {
             name = '{type=bing_aerial}';
+          } else if (source instanceof ol.source.Stamen) {
+            name = '{type=stamen}';
           } else if (source instanceof ol.source.WMTS) {
             name = '{type=wmts,name=' + layer.get('name') + '}';
             params.server = [{
@@ -420,6 +428,23 @@
               }).catch (function() {});
         }
       };
+
+      /**
+       * @ngdoc method
+       * @name gnOwsContextService#getREForPar
+       * @methodOf gn_viewer.service:gnOwsContextService
+       *
+       * @description
+       * Creates a regular expression for a given parameter
+       *
+       * * @param {Object} context parameter
+       */
+        this.getREForPar = function(par) {
+
+            return re = new RegExp(par + '\\s*=\\s*([^,|^}|^\\s]*)');
+
+        };
+
     }
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -105,13 +105,8 @@
 
           var searchMap = new ol.Map({
             controls:[],
-            layers: [new ol.layer.Tile({
-              source: new ol.source.OSM()
-            })],
-            view: new ol.View({
-              center: mapsConfig.center,
-              zoom: 2
-            })
+            layers: viewerMap.getLayers(),
+            view: new ol.View(mapsConfig)
           });
 
 

--- a/web/src/main/webapp/WEB-INF/data/data/resources/map/config-viewer.xml
+++ b/web/src/main/webapp/WEB-INF/data/data/resources/map/config-viewer.xml
@@ -10,7 +10,7 @@
   <ows-context:ResourceList>
     <ows-context:Layer name="{type=mapquest}"
                        group="Background layers"
-                       hidden="false"
+                       hidden="true"
                        opacity="1">
       <ows:Title>MapQuest</ows:Title>
     </ows-context:Layer>
@@ -26,6 +26,12 @@
                        hidden="true"
                        opacity="1">
       <ows:Title>Bing Aerial</ows:Title>
+    </ows-context:Layer>
+    <ows-context:Layer name="{type=stamen,layer=watercolor}"
+                       group="Background layers"
+                       hidden="false"
+                       opacity="1">
+      <ows:Title>Stamen Watercolor</ows:Title>
     </ows-context:Layer>
   </ows-context:ResourceList>
 </ows-context:OWSContext>


### PR DESCRIPTION
- Set Stamen as default background layer.
- Added support for extracting map parameters (other than type) from config-viewer.xml.
- Added support for defining a Stamen layer in config-viewer.xml.
- Defined 'watercolor' as default Stamen layer (when no layer is defined in config-viewer.xml).
- Synchronised map on MapSearch with map on MapViewer, reproducing the behaviour of GN2.x