### PR TITLE
introduce header/footer for no-js ui

### DIFF
--- a/web/src/main/webapp/xslt/base-layout-nojs.xsl
+++ b/web/src/main/webapp/xslt/base-layout-nojs.xsl
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+  The main entry point for all user interface generated
+  from XSLT. 
+-->
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                exclude-result-prefixes="#all">
+
+  <xsl:output omit-xml-declaration="yes" method="html" doctype-system="html" indent="yes"
+    encoding="UTF-8"/>
+
+  <xsl:include href="common/base-variables.xsl"/>
+  <xsl:include href="skin/default/skin.xsl"/>
+  <xsl:include href="base-layout-cssjs-loader.xsl"/>
+
+  <xsl:template match="/">
+    <html>
+      <head>
+        <title><!-- todo: md title / md desc / md keywords -->
+          <xsl:value-of select="concat($env/system/site/name, ' - ', $env/system/site/organization)"
+          />
+        </title>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
+        <meta name="apple-mobile-web-app-capable" content="yes"/>
+
+        <meta name="description" content=""/>
+        <meta name="keywords" content=""/>
+
+
+        <link rel="icon" sizes="16x16 32x32 48x48" type="image/png" href="../../images/logos/favicon.png"/>
+        <link href="rss.search?sortBy=changeDate" rel="alternate" type="application/rss+xml"
+          title="{concat($env/system/site/name, ' - ', $env/system/site/organization)}"/>
+        <link href="portal.opensearch" rel="search" type="application/opensearchdescription+xml"
+          title="{concat($env/system/site/name, ' - ', $env/system/site/organization)}"/>
+
+        <xsl:call-template name="css-load"/>
+      </head>
+
+
+      <!-- The GnCatController takes care of 
+      loading site information, check user login state
+      and a facet search to get main site information.
+      -->
+      <body>
+        <div class="gn-full">
+              <xsl:call-template name="header"/>
+              <xsl:apply-templates mode="content" select="."/>
+              <xsl:call-template name="footer"/>
+        </div>               
+      </body>
+    </html>
+  </xsl:template>
+
+
+
+
+</xsl:stylesheet>

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -76,7 +76,7 @@
     else if ($service = 'catalog.viewer') then 'gn_viewer'
     else if ($service = 'catalog.search') then 'gn_search'
     else if ($service = 'md.viewer') then 'gn_formatter_viewer'
-    else 'gn'"/>
+    else 'gn_search'"/>
 
   <xsl:variable name="customFilename" select="concat($angularApp, '_', $searchView)"></xsl:variable>
 

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -74,9 +74,11 @@
     else if ($service = 'contact.us') then 'gn_contact_us'
     else if ($service = 'catalog.edit') then 'gn_editor'
     else if ($service = 'catalog.viewer') then 'gn_viewer'
-    else if ($service = 'catalog.search') then 'gn_search'
+    else if ($service = 'catalog.search' 
+      or $service = 'catalog.search.nojs' 
+      or $service = 'md.format.html') then 'gn_search'
     else if ($service = 'md.viewer') then 'gn_formatter_viewer'
-    else 'gn_search'"/>
+    else 'gn'"/>
 
   <xsl:variable name="customFilename" select="concat($angularApp, '_', $searchView)"></xsl:variable>
 

--- a/web/src/main/webapp/xslt/skin/default/skin.xsl
+++ b/web/src/main/webapp/xslt/skin/default/skin.xsl
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  The main entry point for all user interface generated
+  from XSLT. 
+-->
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                exclude-result-prefixes="#all">
+
+
+
+<xsl:template name="header">
+
+<div class="navbar navbar-default gn-top-bar ng-scope" role="navigation">
+<div class="container-fluid ng-scope">
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+  <div id="navbar" class="navbar-collapse collapse">
+    <ul class="nav navbar-nav">
+      <li class="active">
+        <a href=".">
+          <img class="gn-logo"  
+          src="../../images/harvesting/GN3.png"/>
+          <span class="visible-lg ng-binding">GeoNetwork</span>
+        </a>
+      </li>
+      <li>
+        <a title="Search" href=".">
+          <i class="fa fa-search"></i>
+          <span class="visible-lg ng-scope" >Search</span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+</div>
+</xsl:template>
+
+<xsl:template name="footer">
+
+<footer class="navbar">
+<div class="navbar navbar-default gn-bottom-bar ng-scope">
+  <ul class="nav navbar-nav">
+    <li><a href="http://geonetwork-opensource.org/">
+      <i class="fa fa-fw"></i>
+      <span  class="ng-scope">About</span></a>
+    </li>
+   
+    <li>
+      <a href="rss.search?sortBy=changeDate&amp;georss=simplepoint" title="Latest news">
+        <i class="fa fa-rss"></i>
+      </a>
+    </li>
+  </ul>
+</div>
+</footer>
+</xsl:template>
+
+
+</xsl:stylesheet>

--- a/web/src/main/webapp/xslt/skin/default/skin.xsl
+++ b/web/src/main/webapp/xslt/skin/default/skin.xsl
@@ -43,8 +43,7 @@
 </xsl:template>
 
 <xsl:template name="footer">
-
-<footer class="navbar">
+<!--<footer class="navbar">
 <div class="navbar navbar-default gn-bottom-bar ng-scope">
   <ul class="nav navbar-nav">
     <li><a href="http://geonetwork-opensource.org/">
@@ -59,7 +58,7 @@
     </li>
   </ul>
 </div>
-</footer>
+</footer>-->
 </xsl:template>
 
 

--- a/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
+++ b/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
@@ -26,32 +26,47 @@
   <!-- 
   Basic search interface which does not require JS.
   -->
-  <xsl:import href="../base-layout.xsl"/>
+  <xsl:import href="../base-layout-nojs.xsl"/>
 
   <xsl:template mode="content" match="/">
-    <div class="row">
-      <div class="col-lg-9">
-        <form action="catalog.search.nojs">
-          <fieldset>
+    <div class="row" style="padding-bottom:20px" >
+      <div class="col-md-push-3 col-md-6">
+        <form action="catalog.search.nojs" class="form-inline">
+         <div class="form-group">
+    		<input type="text" name="any" id="fldAny" class="form-control input-large gn-search-text" autofocus="" />
+  		 </div>
+  		 <div class="form-group">
+  			<input type="submit" class="btn btn-primary" value="Search" /> 
+  		</div>
             <input type="hidden" name="fast" value="index"/>
-            <div class="form-group">
-              <input type="text" name="any" class="form-control input-large gn-search-text" autofocus=""/>
-            </div>
-          </fieldset>
-        </form>
+        </form>        
+    </div>
+</div>
+
+
 
         <xsl:if test="/root/request/*">
-          <xsl:for-each select="/root/response/metadata">
-            <li>
-              <h2>
-                <xsl:value-of select="title"/>
-              </h2>
+
+<div class="row"  style="padding-bottom:20px">
+<div class="col-xs-12">
+From <b><xsl:value-of select="/root/request/from"/></b>
+to <b><xsl:value-of select="/root/request/to"/></b>
+out of <b><xsl:value-of select="/root/response/summary/@count"/></b> results.
+</div>
+</div>
+
+         <xsl:for-each select="/root/response/metadata">
+           <div class="row" style="padding-bottom:20px;">
+            <div class="col-xs-10">
+              <a href="../../metadata/{*[name()='geonet:info']/uuid}">
+                <xsl:value-of select="title|defaultTitle"/>
+              </a><br/>
               <xsl:value-of select="abstract"/>
-            </li>
+            </div>
+            </div>
           </xsl:for-each>
         </xsl:if>
-      </div>
-    </div>
+    
   </xsl:template>
 
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
+++ b/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
@@ -49,8 +49,8 @@
 
 <div class="row"  style="padding-bottom:20px">
 <div class="col-xs-12">
-From <b><xsl:value-of select="/root/request/from"/></b>
-to <b><xsl:value-of select="/root/request/to"/></b>
+From <b><xsl:value-of select="/root/response/@from"/></b>
+to <b><xsl:value-of select="/root/response/@to"/></b>
 out of <b><xsl:value-of select="/root/response/summary/@count"/></b> results.
 </div>
 </div>
@@ -66,6 +66,16 @@ out of <b><xsl:value-of select="/root/response/summary/@count"/></b> results.
             </div>
           </xsl:for-each>
         </xsl:if>
+    
+    
+    <div class="row" style="background-color:#999;color:white;padding:40px">
+    <h2>Browse by topic</h2>
+    <xsl:for-each select="root/response/summary/topicCats/topicCat">
+    <div class="col-xs-12 col-sm-6 col-lg-4" style="padding:15px">
+    	<a style="color:white" href="catalog.search.nojs?fast=index&amp;any={@name}"><xsl:value-of select="@label"/> (<xsl:value-of select="@count"/>)</a></div>
+    </xsl:for-each>
+    </div>
+    
     
   </xsl:template>
 


### PR DESCRIPTION
introduce header/footer for no-js ui
and link each search result to /metadata/{uuid} (urlrewrite can forward this to some formatter for the metadata)

The development indicates a way the layout of angular app can be reused partially (it includes the css from angular app) on the no-js interface. Idea behind improving the no-js interface is triggered from search engine crawlability, but off course no-js users/browsers will also profit