### PR TITLE
#1445: Implement INSPIRE Spatial Data Services (SDS)

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -132,11 +132,12 @@
     <name>gmd:projection</name>
     <name>gmd:ellipsoid</name>
     <name>gmd:attributes</name>
-    <name>gmd:verticalCRS</name>
     <name>gmd:geographicBox</name>
     <name>gmd:EX_TemporalExtent</name>
     <name>gmd:MD_Distributor</name>
     <name>srv:containsOperations</name>
+    <name>srv:SV_Parameter</name>
+    <name>srv:connectPoint</name>
     <name>srv:SV_CoupledResource</name>
     <name>gmd:metadataConstraints</name>
     <name>gmd:aggregationInfo</name>
@@ -785,6 +786,7 @@
           <field name="conformity" templateModeOnly="true"
                  xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/
                     gmd:report/gmd:DQ_DomainConsistency/gmd:result"
+                 if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification)=0"
                  del="../..">
             <template>
               <values>
@@ -859,6 +861,7 @@
 
           <action type="add" name="conformity" or="report"
                   forceLabel="true"
+                  if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification)=0"
                   in="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality">
             <template>
               <snippet>
@@ -945,9 +948,8 @@
           </action>
 
 
-
-
-
+          <!-- Access constraints for metadata about data.
+               Services have their own format, defined in the SDS tab -->
           <field name="accessConstraints"
             xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/
             gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints"
@@ -974,36 +976,6 @@
               </snippet>
             </template>
           </action>
-
-
-          <field
-            xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/
-            gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints"
-            if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0"/>
-
-          <action type="add" name="accessConstraints" or="resourceConstraints"
-            in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
-            if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0">
-            <template>
-              <snippet>
-                <gmd:resourceConstraints>
-                  <gmd:MD_LegalConstraints>
-                    <gmd:accessConstraints>
-                      <gmd:MD_RestrictionCode
-                        codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
-                        codeListValue="otherRestrictions"/>
-                    </gmd:accessConstraints>
-                    <gmd:useConstraints/>
-                    <gmd:otherConstraints gco:nilReason="missing">
-                      <gco:CharacterString/>
-                    </gmd:otherConstraints>
-                  </gmd:MD_LegalConstraints>
-                </gmd:resourceConstraints>
-              </snippet>
-            </template>
-          </action>
-
-
 
 
           <field
@@ -1072,75 +1044,6 @@
           <action type="add" name="pointOfContact" addDirective="data-gn-directory-entry-selector"
             or="pointOfContact"
             in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification">
-            <directiveAttributes
-                    data-template-add-action="true"
-                    data-template-type="contact"
-                    data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
-          </action>
-
-
-          <field name="pointOfContact" templateModeOnly="true" notDisplayedIfMissing="true"
-            xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact"
-            del="."
-            if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0">
-            <template>
-              <values readonlyIf="count(@xlink:href) > 0">
-                <key label="organisationName"
-                  xpath="gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString"/>
-                <key label="electronicMailAddress"
-                  xpath="gmd:CI_ResponsibleParty/gmd:contactInfo/
-                  gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString"
-                  use="email"/>
-                <key label="role"
-                  xpath="gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode/@codeListValue">
-                  <codelist name="gmd:CI_RoleCode"/>
-                </key>
-              </values>
-              <snippet>
-                <gmd:pointOfContact>
-                  <gmd:CI_ResponsibleParty>
-                    <gn:copy select="gmd:individualName"/>
-                    <gmd:organisationName>
-                      <gco:CharacterString>{{organisationName}}</gco:CharacterString>
-                      <gn:copy select="gmd:PT_FreeText"/>
-                    </gmd:organisationName>
-                    <gn:copy select="gmd:positionName"/>
-                    <gmd:contactInfo>
-                      <gmd:CI_Contact>
-                        <gn:copy select="gmd:phone"/>
-                        <gmd:address>
-                          <gmd:CI_Address>
-                            <gn:copy select="gmd:deliveryPoint"/>
-                            <gn:copy select="gmd:city"/>
-                            <gn:copy select="gmd:administrativeArea"/>
-                            <gn:copy select="gmd:postalCode"/>
-                            <gn:copy select="gmd:country"/>
-                            <gmd:electronicMailAddress>
-                              <gco:CharacterString>{{electronicMailAddress}}</gco:CharacterString>
-                              <gn:copy select="gmd:PT_FreeText"/>
-                            </gmd:electronicMailAddress>
-                          </gmd:CI_Address>
-                        </gmd:address>
-                        <gn:copy select="gmd:onlineResource"/>
-                        <gn:copy select="gmd:hoursOfService"/>
-                        <gn:copy select="gmd:contactInstructions"/>
-                      </gmd:CI_Contact>
-                    </gmd:contactInfo>
-                    <gmd:role>
-                      <gmd:CI_RoleCode
-                        codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode"
-                        codeListValue="{{role}}"/>
-                    </gmd:role>
-                  </gmd:CI_ResponsibleParty>
-                </gmd:pointOfContact>
-              </snippet>
-            </template>
-          </field>
-
-
-          <action type="add" name="pointOfContact" addDirective="data-gn-directory-entry-selector"
-            or="pointOfContact"
-            in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification">
             <directiveAttributes
                     data-template-add-action="true"
                     data-template-type="contact"
@@ -1220,7 +1123,657 @@
           <field xpath="/gmd:MD_Metadata/gmd:dateStamp"/>
         </section>
       </tab>
+
+      <tab id="inspire_sds"
+           mode="flat"
+           if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0">
+          
+          <section name="inspire_sds_cc1">
+
+              <!-- 4.4.1 TG4 : ensure gmd:DQ_DataQuality for service exists -->
+              <action type="process"
+                      process="sds-add-dataquality"
+                      if="count(gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service'])=0"/>
+
+              <!-- 4.4.1 rec 1 : replace CharacterString with Anchor-->
+              <action type="process"
+                      process="sds-fix-category"
+                      if="count(gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gco:CharacterString)>0"/>
+
+              <!-- 4.4.1 category -->
+              <field name="sds-category"
+                     xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title"/>
+
+              <!-- 4.4.1 pass -->
+              <field xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:pass"/>
+
+              <action type="add"
+                      name="inspire_add_pass"
+                      forceLabel="true"
+                      or="pass" in="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult">
+                  <template>
+                      <snippet>
+                          <gmd:pass>
+                              <gco:Boolean>true</gco:Boolean>
+                          </gmd:pass>
+                      </snippet>
+                  </template>
+              </action>
+
+
+              <!-- 4.4.2 Resource locator -->
+              <!-- 4.4.2 Function -->
+              <!-- *** accessPoint *** -->
+
+              <field name="sds-accesspoint"
+                     templateModeOnly="true"
+                     xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution//gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[gmd:CI_OnlineResource/gmd:description/gmx:Anchor/text() = 'accessPoint']"
+
+                     del=".">
+                  <template>
+                      <values>
+                          <key label="linkage" xpath="gmd:CI_OnlineResource/gmd:linkage/gmd:URL"/>
+                      </values>
+                      <snippet>
+                          <gmd:onLine>
+                              <gmd:CI_OnlineResource>
+                                  <gmd:linkage>
+                                      <gmd:URL>{{linkage}}</gmd:URL>
+                                  </gmd:linkage>
+                                  <gmd:description>
+                                      <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ResourceLocatorDescription/accessPoint">accessPoint</gmx:Anchor>
+                                  </gmd:description>
+                                  <gmd:function>
+                                      <gmd:CI_OnLineFunctionCode
+                                          codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                                          codeListValue="information">
+                                      </gmd:CI_OnLineFunctionCode>
+                                  </gmd:function>
+                              </gmd:CI_OnlineResource>
+                          </gmd:onLine>
+                      </snippet>
+                  </template>
+              </field>
+
+              <action type="add"
+                      name="sds-add-accesspoint"
+                      forceLabel="true"
+                      or="onLine"
+                      in="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution//gmd:transferOptions/gmd:MD_DigitalTransferOptions">
+                  <template>
+                      <snippet>
+                          <gmd:onLine>
+                              <gmd:CI_OnlineResource>
+                                  <gmd:linkage>
+                                      <gmd:URL>http://accesspoint.url</gmd:URL>
+                                  </gmd:linkage>
+                                  <gmd:description>
+                                      <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ResourceLocatorDescription/accessPoint">accessPoint</gmx:Anchor>
+                                  </gmd:description>
+                                  <gmd:function>
+                                      <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"></gmd:CI_OnLineFunctionCode>
+                                  </gmd:function>
+                              </gmd:CI_OnlineResource>
+                          </gmd:onLine>
+                      </snippet>
+                  </template>
+              </action>
+
+              <!-- 4.4.2 Resource locator -->
+              <!-- 4.4.2 Function -->
+              <!-- *** endPoint *** -->
+
+              <field name="sds-endpoint"
+                     templateModeOnly="true"
+                     xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution//gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[gmd:CI_OnlineResource/gmd:description/gmx:Anchor/text() = 'endPoint']"
+                     notDisplayedIfMissing="true"
+                     del=".">
+                  <template>
+                      <values>
+                          <key label="linkage" xpath="gmd:CI_OnlineResource/gmd:linkage/gmd:URL"/>
+                      </values>
+                      <snippet>
+                          <gmd:onLine>
+                              <gmd:CI_OnlineResource>
+                                  <gmd:linkage>
+                                      <gmd:URL>{{linkage}}</gmd:URL>
+                                  </gmd:linkage>
+                                  <gmd:description>
+                                      <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ResourceLocatorDescription/endPoint">endPoint</gmx:Anchor>
+                                  </gmd:description>
+                                  <gmd:function>
+                                      <gmd:CI_OnLineFunctionCode
+                                          codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                                          codeListValue="information">
+                                      </gmd:CI_OnLineFunctionCode>
+                                  </gmd:function>
+                              </gmd:CI_OnlineResource>
+                          </gmd:onLine>
+                      </snippet>
+                  </template>
+              </field>
+
+              <action type="add"
+                      name="sds-add-endpoint"
+                      forceLabel="true"
+                      or="onLine"
+                      in="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution//gmd:transferOptions/gmd:MD_DigitalTransferOptions">
+                  <template>
+                      <snippet>
+                          <gmd:onLine>
+                              <gmd:CI_OnlineResource>
+                                  <gmd:linkage>
+                                      <gmd:URL>http://endpoint.url</gmd:URL>
+                                  </gmd:linkage>
+                                  <gmd:description>
+                                      <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ResourceLocatorDescription/endPoint">endPoint</gmx:Anchor>
+                                  </gmd:description>
+                                  <gmd:function>
+                                      <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"></gmd:CI_OnLineFunctionCode>
+                                  </gmd:function>
+                              </gmd:CI_OnlineResource>
+                          </gmd:onLine>
+                      </snippet>
+                  </template>
+              </action>
+
+
+              <!-- 4.4.3 TG8: edit Technical specification -->
+
+              <field
+                    templateModeOnly="true"
+                    notDisplayedIfMissing="true"
+                    forceLabel="true"
+                    name="sds-tech-spec"
+                    del="../.."
+                    xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_FormatConsistency/gmd:result">
+                  <template>
+                      <values>
+                          <key label="conformity_linkage" xpath="gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href"/>
+                          <key label="conformity_desc"    xpath="gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gmx:Anchor/text()"
+                               tooltip="gmd:pass">
+                              <helper name="gmd:title" context="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_FormatConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title"/>
+                          </key>
+                          <key label="conformity_date" use="gn-date-picker"
+                               xpath="gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date" />
+                          <key label="explanation" use="text"
+                               xpath="gmd:DQ_ConformanceResult/gmd:explanation/gco:CharacterString" />
+                      </values>
+                      <snippet>
+                          <gmd:result>
+                              <gmd:DQ_ConformanceResult>
+                                  <gmd:specification>
+                                      <gmd:CI_Citation>
+                                          <gmd:title>
+                                              <gmx:Anchor xlink:href="{{conformity_linkage}}">{{conformity_desc}}</gmx:Anchor>
+                                          </gmd:title>
+                                          <gmd:date>
+                                              <gmd:CI_Date>
+                                                  <gmd:date>
+                                                      <gco:Date>{{conformity_date}}</gco:Date>
+                                                  </gmd:date>
+                                                  <gmd:dateType>
+                                                      <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
+                                                  </gmd:dateType>
+                                              </gmd:CI_Date>
+                                          </gmd:date>
+                                      </gmd:CI_Citation>
+                                  </gmd:specification>
+                                  <gmd:explanation>
+                                      <gco:CharacterString>{{explanation}}</gco:CharacterString>
+                                  </gmd:explanation>
+                                  <gmd:pass>
+                                      <gco:Boolean>true</gco:Boolean>
+                                  </gmd:pass>
+                              </gmd:DQ_ConformanceResult>
+                          </gmd:result>
+                      </snippet>              
+                  </template>
+              </field>
+
+              <!-- 4.4.3 TG8: add Technical specification entry -->
+
+              <action type="add"
+                      name="sds-add-tech-spec"
+                      forceLabel="true"
+                      or="report"
+                      in="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']">
+                  
+                  <template>
+                      <snippet>
+                          <gmd:report>
+                              <gmd:DQ_FormatConsistency>
+                                  <gmd:result>
+                                      <gmd:DQ_ConformanceResult>
+                                          <gmd:specification>
+                                              <gmd:CI_Citation>
+                                                  <gmd:title>
+                                                      <gmx:Anchor xlink:href=" http://link,to/the.technical.specification">Description of technical specification</gmx:Anchor>
+                                                  </gmd:title>
+                                                  <gmd:date>
+                                                      <gmd:CI_Date>
+                                                          <gmd:date>
+                                                              <gco:Date>2014-12-11</gco:Date>
+                                                          </gmd:date>
+                                                          <gmd:dateType>
+                                                              <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
+                                                          </gmd:dateType>
+                                                      </gmd:CI_Date>
+                                                  </gmd:date>
+                                              </gmd:CI_Citation>
+                                          </gmd:specification>
+                                          <gmd:explanation>
+                                              <gco:CharacterString>Conformant to the cited specifications.</gco:CharacterString>
+                                          </gmd:explanation>
+                                          <gmd:pass>
+                                              <gco:Boolean>true</gco:Boolean>
+                                          </gmd:pass>
+                                      </gmd:DQ_ConformanceResult>
+                                  </gmd:result>
+                              </gmd:DQ_FormatConsistency>
+                          </gmd:report>
+                      </snippet>
+                  </template>
+              </action>
+
+          </section>
+
+          <!-- CONFORMITY CLASS 2 -->
+          <section name="inspire_sds_cc2">
+          
+              <section name="sds-section-crs">
+                  <field xpath="gmd:MD_Metadata/gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:code/gmx:Anchor"
+                         del="." />
+                  <!-- The useXmlSnippet="true" attribute is a workaround to keep backward compatibility since often
+                  the data-gn-crs-selector directive is used specifying a snippet as below although the developer wanted
+                  to use the hardcoded snipped in EditorXMLService.js. We need a way to specify if we really want
+                  to use the snippet below. The attribute is used in the template render-element-template-field located in form-builder.xsl-->
+                  <action type="add" name="rsIdentifier" addDirective="data-gn-crs-selector" useXmlSnippet="true"
+                          or="referenceSystemInfo" in="/gmd:MD_Metadata">
+                      <template>
+                          <snippet>
+                              <gmd:referenceSystemInfo>
+                                  <gmd:MD_ReferenceSystem>
+                                      <gmd:referenceSystemIdentifier>
+                                          <gmd:RS_Identifier>
+                                              <gmd:code>
+                                                  <gmx:Anchor xlink:href='http://www.opengis.net/def/crs/EPSG/0/{{code}}'
+                                                              xlink:title='{{description}}'>{{code}}</gmx:Anchor>
+                                              </gmd:code>
+                                          </gmd:RS_Identifier>
+                                      </gmd:referenceSystemIdentifier>
+                                  </gmd:MD_ReferenceSystem>
+                              </gmd:referenceSystemInfo>
+                          </snippet>
+                      </template>
+                  </action>
+              </section>
+
+              <!-- 4.5.2 Ensure gmd:DQ_ConceptualConsistency mandatory elements for quality of service exists -->
+
+              <section name="sds-section-qos">
+
+                  <action type="process"
+                          process="sds-add-qualityofservice"
+                          if="(count(gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service'])>0 and
+                              (count(gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor[text()='availability'])=0 or
+                               count(gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor[text()='performance'])=0 or
+                               count(gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor[text()='capacity'])=0 ))" />
+
+                  <field xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_ConceptualConsistency"/>
+
+              </section>
+
+              <!-- 4.5.3 TG13 Conditions applying to access and use -->
+
+              <section name="accessConstraints">
+
+                  <!-- fixed values, user should only be able to remove the whole gmd:resourceConstraints element, and not edit it -->
+                  <field
+                      xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints[gmd:MD_LegalConstraints[gmd:accessConstraints]/gmd:otherConstraints/gmx:Anchor]" />
+
+                  <!-- editable value, user should be able to edit the characterstring element, or to remove the whole gmd:resourceConstraints element -->
+                  <field
+                        xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints[gmd:MD_LegalConstraints[gmd:accessConstraints]/gmd:otherConstraints[gco:CharacterString]]"
+                        templateModeOnly="true"
+                        notDisplayedIfMissing="true"
+                        forceLabel="true"
+                        name="sds-limitation"
+                        del=".">
+
+                      <template>
+                        <values>
+                            <key label="string" xpath="gmd:MD_LegalConstraints/gmd:otherConstraints/gco:CharacterString"/>
+                        </values>
+                          <snippet>
+                              <gmd:resourceConstraints>
+                                  <gmd:MD_LegalConstraints>
+                                      <gmd:accessConstraints>
+                                          <gmd:MD_RestrictionCode
+                                              codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                              codeListValue="otherRestrictions"/>
+                                      </gmd:accessConstraints>
+                                      <gmd:otherConstraints>
+                                          <gco:CharacterString>{{string}}</gco:CharacterString>
+                                      </gmd:otherConstraints>
+                                  </gmd:MD_LegalConstraints>
+                              </gmd:resourceConstraints>
+                          </snippet>
+                      </template>
+                  </field>
+
+                  <!-- accessConstraints: ADD "no constraints" if element not defined -->
+                  <action type="add"
+                          name="sds-addNoConstraints"
+                          forceLabel="true"
+                          or="resourceConstraints" in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
+                          check="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints[gmd:accessConstraints])"
+                          if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints[gmd:accessConstraints]) = 0">
+
+                  <template>
+                      <snippet>
+                          <gmd:resourceConstraints>
+                              <gmd:MD_LegalConstraints>
+                                  <gmd:accessConstraints>
+                                      <gmd:MD_RestrictionCode
+                                          codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                          codeListValue="otherRestrictions"/>
+                                  </gmd:accessConstraints>
+                                  <gmd:otherConstraints>
+                                      <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">No Conditions Apply</gmx:Anchor>
+                                  </gmd:otherConstraints>
+                              </gmd:MD_LegalConstraints>
+                          </gmd:resourceConstraints>
+                      </snippet>
+                  </template>
+                  </action>
+
+                  <!-- accessConstraints: ADD "unknown constraints" if element not defined -->
+                  <action type="add"
+                          name="sds-addUnknownConstraints"
+                          forceLabel="true"
+                          or="resourceConstraints" in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
+                          if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints[gmd:accessConstraints]) = 0">
+                      <template>
+                          <snippet>
+                              <gmd:resourceConstraints>
+                                  <gmd:MD_LegalConstraints>
+                                      <gmd:accessConstraints>
+                                          <gmd:MD_RestrictionCode
+                                              codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                              codeListValue="otherRestrictions"/>
+                                      </gmd:accessConstraints>
+                                      <gmd:otherConstraints>
+                                          <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ConditionsApplyingToAccessAndUse/conditionsUnknown">Conditions Unknown</gmx:Anchor>
+                                      </gmd:otherConstraints>
+                                  </gmd:MD_LegalConstraints>
+                              </gmd:resourceConstraints>
+                          </snippet>
+                      </template>
+                  </action>
+
+
+                  <!-- accessConstraints: ADD custom constraints if element not defined -->
+
+                  <action type="add"
+                          forceLabel="true"
+                          name="sds-addConstraints"
+                          or="resourceConstraints" in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
+                          if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints[gmd:accessConstraints]) = 0">
+                      <template>
+                          <snippet>
+                              <gmd:resourceConstraints>
+                                  <gmd:MD_LegalConstraints>
+                                      <gmd:accessConstraints>
+                                          <gmd:MD_RestrictionCode
+                                              codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                              codeListValue="otherRestrictions"/>
+                                      </gmd:accessConstraints>
+                                      <gmd:otherConstraints gco:nilReason="missing">
+                                          <gco:CharacterString/>
+                                      </gmd:otherConstraints>
+                                  </gmd:MD_LegalConstraints>
+                              </gmd:resourceConstraints>
+                          </snippet>
+                      </template>
+                  </action>
+
+              </section> <!-- access constraints -->
+
+              <section name="useConstraints">
+
+                  <!-- fixed values, user should only be able to remove the whole gmd:resourceConstraints element, and not edit it -->
+                  <field
+                      xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints[gmd:MD_LegalConstraints[gmd:useConstraints]/gmd:otherConstraints/gmx:Anchor]" />
+
+                  <!-- editable value, user should be able to edit the characterstring element, or to remove the whole gmd:resourceConstraints element -->
+                  <field
+                        xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints[gmd:MD_LegalConstraints[gmd:useConstraints]/gmd:otherConstraints[gco:CharacterString]]"
+                        templateModeOnly="true"
+                        notDisplayedIfMissing="true"
+                        forceLabel="true"
+                        name="sds-limitation"
+                        del=".">
+
+                      <template>
+                        <values>
+                            <key label="string" xpath="gmd:MD_LegalConstraints/gmd:otherConstraints/gco:CharacterString"/>
+                        </values>
+                          <snippet>
+                              <gmd:resourceConstraints>
+                                  <gmd:MD_LegalConstraints>
+                                      <gmd:useConstraints>
+                                          <gmd:MD_RestrictionCode
+                                              codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                              codeListValue="otherRestrictions"/>
+                                      </gmd:useConstraints>
+                                      <gmd:otherConstraints>
+                                          <gco:CharacterString>{{string}}</gco:CharacterString>
+                                      </gmd:otherConstraints>
+                                  </gmd:MD_LegalConstraints>
+                              </gmd:resourceConstraints>
+                          </snippet>
+                      </template>
+                  </field>
+
+                  <!-- useConstraints: ADD "no constraints" if element not defined -->
+                  <action type="add"
+                          name="sds-addNoConstraints"
+                          forceLabel="true"
+                          or="resourceConstraints" in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
+                          check="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints[gmd:useConstraints])"
+                          if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints[gmd:useConstraints]) = 0">
+
+                  <template>
+                      <snippet>
+                          <gmd:resourceConstraints>
+                              <gmd:MD_LegalConstraints>
+                                  <gmd:useConstraints>
+                                      <gmd:MD_RestrictionCode
+                                          codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                          codeListValue="otherRestrictions"/>
+                                  </gmd:useConstraints>
+                                  <gmd:otherConstraints>
+                                      <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">No Conditions Apply</gmx:Anchor>
+                                  </gmd:otherConstraints>
+                              </gmd:MD_LegalConstraints>
+                          </gmd:resourceConstraints>
+                      </snippet>
+                  </template>
+                  </action>
+
+                  <!-- useConstraints: ADD "unknown constraints" if element not defined -->
+                  <action type="add"
+                          name="sds-addUnknownConstraints"
+                          forceLabel="true"
+                          or="resourceConstraints" in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
+                          if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints[gmd:useConstraints]) = 0">
+                      <template>
+                          <snippet>
+                              <gmd:resourceConstraints>
+                                  <gmd:MD_LegalConstraints>
+                                      <gmd:useConstraints>
+                                          <gmd:MD_RestrictionCode
+                                              codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                              codeListValue="otherRestrictions"/>
+                                      </gmd:useConstraints>
+
+                                      <gmd:otherConstraints>
+                                          <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ConditionsApplyingToAccessAndUse/conditionsUnknown">Conditions Unknown</gmx:Anchor>
+                                      </gmd:otherConstraints>
+                                  </gmd:MD_LegalConstraints>
+                              </gmd:resourceConstraints>
+                          </snippet>
+                      </template>
+                  </action>
+
+
+                  <!-- useConstraints: ADD custom constraints if element not defined -->
+
+                  <action type="add"
+                          forceLabel="true"
+                          name="sds-addConstraints"
+                          or="resourceConstraints" in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
+                          if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints[gmd:useConstraints]) = 0">
+                      <template>
+                          <snippet>
+                              <gmd:resourceConstraints>
+                                  <gmd:MD_LegalConstraints>
+                                      <gmd:useConstraints>
+                                          <gmd:MD_RestrictionCode
+                                              codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                              codeListValue="otherRestrictions"/>
+                                      </gmd:useConstraints>
+                                      <gmd:otherConstraints gco:nilReason="missing">
+                                          <gco:CharacterString/>
+                                      </gmd:otherConstraints>
+                                  </gmd:MD_LegalConstraints>
+                              </gmd:resourceConstraints>
+                          </snippet>
+                      </template>
+                  </action>
+
+              </section> <!-- use constraints -->
+
+              <section name="sds-section-custodian">
+
+                  <field name="pointOfContact" 
+                         templateModeOnly="true"
+                         xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact[gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode/@codeListValue='custodian']"
+                         del="." >
+
+                      <template>
+                          <values readonlyIf="count(@xlink:href) > 0">
+                              <key label="organisationName"
+                                   xpath="gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString"/>
+                              <key label="electronicMailAddress"
+                                   xpath="gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString"
+                                   use="email"/>
+                          </values>
+                          <snippet>
+                              <gmd:pointOfContact>
+                                  <gmd:CI_ResponsibleParty>
+                                      <gn:copy select="gmd:individualName"/>
+                                      <gmd:organisationName>
+                                          <gco:CharacterString>{{organisationName}}</gco:CharacterString>
+                                          <gn:copy select="gmd:PT_FreeText"/>
+                                      </gmd:organisationName>
+                                      <gn:copy select="gmd:positionName"/>
+                                      <gmd:contactInfo>
+                                          <gmd:CI_Contact>
+                                              <gn:copy select="gmd:phone"/>
+                                              <gmd:address>
+                                                  <gmd:CI_Address>
+                                                      <gn:copy select="gmd:deliveryPoint"/>
+                                                      <gn:copy select="gmd:city"/>
+                                                      <gn:copy select="gmd:administrativeArea"/>
+                                                      <gn:copy select="gmd:postalCode"/>
+                                                      <gn:copy select="gmd:country"/>
+                                                      <gmd:electronicMailAddress>
+                                                          <gco:CharacterString>{{electronicMailAddress}}</gco:CharacterString>
+                                                          <gn:copy select="gmd:PT_FreeText"/>
+                                                      </gmd:electronicMailAddress>
+                                                  </gmd:CI_Address>
+                                              </gmd:address>
+                                              <gn:copy select="gmd:onlineResource"/>
+                                              <gn:copy select="gmd:hoursOfService"/>
+                                              <gn:copy select="gmd:contactInstructions"/>
+                                          </gmd:CI_Contact>
+                                      </gmd:contactInfo>
+                                      <gmd:role>
+                                          <gmd:CI_RoleCode
+                                              codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode"
+                                              codeListValue="custodian"/>
+                                      </gmd:role>
+                                  </gmd:CI_ResponsibleParty>
+                              </gmd:pointOfContact>
+                          </snippet>
+                      </template>
+                  </field>
+
+
+                  <action type="add" name="pointOfContact"
+                          addDirective="data-gn-directory-entry-selector"
+                          or="pointOfContact"
+                          in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification">
+                      <directiveAttributes
+                          data-template-add-action="true"
+                          data-template-type="contact"
+                          data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
+                  </action>
+              </section>
+
+          </section>
+
+          <!-- CONFORMITY CLASS 3 -->
+
+          <section name="inspire_sds_cc3">
+
+            <field
+                xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations" />
+
+            <action type="add"
+                    forceLabel="true"
+                    name="sds-addOperation"
+                    or="containsOperations" in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
+                    if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0">
+                <template>
+                    <snippet>
+                        <srv:containsOperations>
+                            <srv:SV_OperationMetadata>
+                                <srv:operationName>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </srv:operationName>
+                                <srv:DCP>
+                                    <srv:DCPList 
+                                        codeList="http://inspire.ec.europa.eu/metadata-codelist/DCPList"
+                                        codeListValue="webServices">Web services</srv:DCPList>
+                                </srv:DCP>
+                                <srv:connectPoint>
+                                    <gmd:CI_OnlineResource>
+                                        <gmd:linkage>
+                                            <gmd:URL>http://</gmd:URL>
+                                        </gmd:linkage>
+                                    </gmd:CI_OnlineResource>
+                                </srv:connectPoint>
+                            </srv:SV_OperationMetadata>
+                        </srv:containsOperations>
+                    </snippet>
+                </template>
+            </action>
+
+          </section>
+      </tab>
+
+      <!-- Elements that should not use the "flat" mode -->
+      <flatModeExceptions>
+        <for name="srv:containsOperations" />
+        <for name="srv:SV_OperationMetadata" />
+        <for name="srv:parameters" />
+      </flatModeExceptions>
+
     </view>
+
     <view name="default">
       <tab id="default" default="true" mode="flat">
         <section xpath="/gmd:MD_Metadata/gmd:identificationInfo"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-sds.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-sds.xsl
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gts="http://www.isotc211.org/2005/gts"
+  xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:gn="http://www.fao.org/geonetwork"
+  xmlns:gn-fn-core="http://geonetwork-opensource.org/xsl/functions/core"
+  xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
+  xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
+  xmlns:exslt="http://exslt.org/common"
+  exclude-result-prefixes="#all">
+
+
+  <!-- SDS: Category. Render an anchor as select box populating it with a codelist -->
+  <xsl:template mode="mode-iso19139" priority="2000" match="gmd:dataQualityInfo/*/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gmx:Anchor[$tab='inspire_sds']">
+    <xsl:call-template name="render-element">
+      <xsl:with-param name="label" select="$strings/sds-category"/>
+      <xsl:with-param name="value" select="@xlink:href"/>
+      <xsl:with-param name="cls" select="local-name()"/>
+      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+      <xsl:with-param name="type" select="'select'"/>
+      <xsl:with-param name="listOfValues" select="gn-fn-metadata:getCodeListValues($schema, 'SDS_category', $codelists, .)"/>
+      <xsl:with-param name="name" select="concat(gn:element/@ref,'_xlinkCOLONhref')"/>
+      <xsl:with-param name="editInfo" select="*/gn:element"/>
+      <xsl:with-param name="parentEditInfo" select="gn:element"/>
+      <xsl:with-param name="isDisabled" select="false()"/>
+    </xsl:call-template>
+
+    <script>
+        $( document ).ready(function(){
+	        var id = <xsl:value-of select="gn:element/@ref" />;
+	        var gnselect = "_" + id + "_xlinkCOLONhref";
+	        var gnhidden = "#_" + id;
+	        if(!$(gnhidden).value){
+	            getHiddenFiekdContent(gnselect, gnhidden);
+			}
+	    	$("select[name=" + gnselect + "]").on('change', function() {
+	  			getHiddenFiekdContent(gnselect, gnhidden);
+			})
+		});
+		function getHiddenFiekdContent(gnselect, gnhidden){
+			var value = $("select[name=" + gnselect + "]").val();
+	        var lastindexof = value.lastIndexOf("/")+1;
+	  		$(gnhidden).val(value.substring(lastindexof));
+		}
+    </script>
+
+    <input type="hidden">
+    	<xsl:attribute name="name" select="concat('_',gn:element/@ref)"/>
+    	<xsl:attribute name="id" select="concat('_',gn:element/@ref)"/>
+    </input>
+
+  </xsl:template>
+
+  <!-- SDS: CRS -->
+  <xsl:template mode="mode-iso19139" priority="2002" match="gmd:MD_Metadata/gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:code/gmx:Anchor[$tab='inspire_sds']">
+    <xsl:call-template name="render-element">
+      <xsl:with-param name="label" select="''" />
+      <xsl:with-param name="value" select="@xlink:title" />
+      <xsl:with-param name="name" select="gn:element/@ref" />
+      <xsl:with-param name="cls" select="local-name()" />
+      <xsl:with-param name="editInfo" select="../../../gn:element" />
+      <xsl:with-param name="isDisabled" select="false()" />
+    </xsl:call-template>
+  </xsl:template>
+
+  <!-- SDS: Quality of Service-->
+  <xsl:template mode="mode-iso19139" priority="2002" match="gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_ConceptualConsistency[/root/gui/currTab/text()='inspire_sds']">
+    <xsl:call-template name="render-boxed-element">
+      <xsl:with-param name="label" select="concat($strings/qos_measure, gmd:nameOfMeasure/gmx:Anchor/text())" />
+      <xsl:with-param name="editInfo" select="gn:element" />
+      <xsl:with-param name="subTreeSnippet">
+        <xsl:if test="gmd:result/gmd:DQ_QuantitativeResult/gmd:valueUnit/@xlink:href != ''">
+          <xsl:call-template name="render-element">
+            <xsl:with-param name="label" select="$strings/qos_uom" />
+            <xsl:with-param name="value" select="gmd:result/gmd:DQ_QuantitativeResult/gmd:valueUnit/@xlink:href" />
+            <xsl:with-param name="cls" select="local-name()" />
+            <xsl:with-param name="editInfo" select="gn:element" />
+            <xsl:with-param name="isDisabled" select="true()" />
+          </xsl:call-template>
+        </xsl:if>
+        <xsl:call-template name="render-element">
+          <xsl:with-param name="label" select="$strings/qos_value"/>
+          <xsl:with-param name="value" select="gmd:result/gmd:DQ_QuantitativeResult/gmd:value/gco:Record/text()" />
+          <xsl:with-param name="name" select="gmd:result/gmd:DQ_QuantitativeResult/gmd:value/gco:Record/gn:element/@ref" />
+          <xsl:with-param name="cls" select="local-name()" />
+          <xsl:with-param name="editInfo" select="gn:element" />
+        </xsl:call-template>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <!-- SDS: Render Constraints anchors -->
+  <xsl:template mode="mode-iso19139"
+                match="srv:SV_ServiceIdentification[$tab='inspire_sds']/gmd:resourceConstraints[gmd:MD_LegalConstraints/gmd:otherConstraints/gmx:Anchor]"
+                priority="2000">
+
+     <xsl:variable name="anchor" select="./gmd:MD_LegalConstraints/gmd:otherConstraints/gmx:Anchor"/>
+     <xsl:variable name="accessCode" select="substring-after($anchor/@xlink:href, 'ConditionsApplyingToAccessAndUse/')"/>
+
+    <xsl:call-template name="render-element">
+      <xsl:with-param name="label" select="$strings/sds-limitation"/>
+      <xsl:with-param name="value" select="$strings/sds/*[name()=$accessCode]"/>
+      <xsl:with-param name="cls" select="local-name()"/>
+      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+      <xsl:with-param name="name" select="concat(gn:element/@ref,'_xlinkCOLONhref')"/>
+      <xsl:with-param name="editInfo" select="*/gn:element"/>
+      <xsl:with-param name="parentEditInfo" select="gn:element"/>
+      <xsl:with-param name="isDisabled" select="false()"/>
+      <xsl:with-param name="isReadOnly" select="true()"/>
+    </xsl:call-template>
+  </xsl:template>
+
+  <!-- SDS: DCP codelist -->
+
+  <!--<xsl:template mode="mode-iso19139" priority="200" match="*[*/@codeList]">  -->
+  <xsl:template mode="mode-iso19139" priority="201" match="srv:SV_OperationMetadata/srv:DCP[$tab='inspire_sds']">
+    <xsl:param name="schema" select="$schema" required="no"/>
+    <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="codelists" select="$iso19139codelists" required="no"/>
+    <xsl:param name="overrideLabel" select="''" required="no"/>
+
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+    <xsl:variable name="elementName" select="name()"/>
+
+    <xsl:call-template name="render-element">
+      <xsl:with-param name="label"
+                      select="if ($overrideLabel != '') then $overrideLabel else gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)/label"/>
+      <xsl:with-param name="value" select="*/@codeListValue"/>
+      <xsl:with-param name="cls" select="local-name()"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="type" select="gn-fn-iso19139:getCodeListType(name())"/>
+      <xsl:with-param name="name"
+                      select="if ($isEditing) then concat(*/gn:element/@ref, '_codeListValue') else ''"/>
+      <xsl:with-param name="editInfo" select="*/gn:element"/>
+      <xsl:with-param name="parentEditInfo" select="gn:element"/>
+      <xsl:with-param name="listOfValues"
+                      select="gn-fn-metadata:getCodeListValues($schema, 'SDS_DCP', $codelists, .)"/>
+      <xsl:with-param name="isFirst" select="count(preceding-sibling::*[name() = $elementName]) = 0"/>
+    </xsl:call-template>
+
+  </xsl:template>
+
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -11,7 +11,8 @@
   xmlns:exslt="http://exslt.org/common" exclude-result-prefixes="#all">
 
   <xsl:include href="layout-custom-fields-keywords.xsl"/>
-
+  <xsl:include href="layout-custom-fields-sds.xsl"/>
+  
   <!-- Readonly elements -->
   <xsl:template mode="mode-iso19139" priority="2000" match="gmd:fileIdentifier|gmd:dateStamp">
 
@@ -137,4 +138,5 @@
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
+
 </xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/codelists.xml
@@ -2046,6 +2046,59 @@
 		</entry>
 	</codelist>
 
+	<!-- INSPIRE SDS  ================================================== -->
+
+	<codelist name="SDS_category">
+            <entry>
+                <code>http://inspire.ec.europa.eu/metadata-codelist/Category/harmonised</code>
+                <label>harmonised</label>
+                <description>Harmonised</description>
+            </entry>
+            <entry>
+                <code>http://inspire.ec.europa.eu/metadata-codelist/Category/interoperable</code>
+                <label>interoperable</label>
+                <description>Interoperable</description>
+            </entry>
+            <entry>
+                <code>http://inspire.ec.europa.eu/metadata-codelist/Category/invocable</code>
+                <label>invocable</label>
+                <description>Invocable</description>
+            </entry>
+	</codelist>
+
+	<codelist name="SDS_DCP">
+            <entry>
+                <code>xml</code>
+                <label>XML</label>
+                <description>XML</description>
+            </entry>
+            <entry>
+                <code>corba</code>
+                <label>CORBA</label>
+                <description>CORBA</description>
+            </entry>
+            <entry>
+                <code>java</code>
+                <label>JAVA</label>
+                <description>JAVA</description>
+            </entry>
+            <entry>
+                <code>com</code>
+                <label>COM</label>
+                <description>COM</description>
+            </entry>
+            <entry>
+                <code>sql</code>
+                <label>SQL</label>
+                <description>SQL</description>
+            </entry>
+            <entry>
+                <code>webServices</code>
+                <label>Web Services</label>
+                <description>Web Services</description>
+            </entry>
+        </codelist>
+
   <codelist name="gco:nilReason">
     <entry>
       <code>missing</code>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/schematron-rules-inspire-sds.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/schematron-rules-inspire-sds.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<strings>
+    <schematron.title>INSPIRE SDS Rules</schematron.title>
+
+    <precondition>Preconditions</precondition>
+    <precondition.noservice>The current metadata is not about a service.</precondition.noservice>
+    <precondition.service>The current metadata documents a service.</precondition.service>
+
+    <tg4>TG4: Service QualityInfo</tg4>
+    <tg4.missing>QualityInfo missing.           For each spatial data service, there shall be one and only one set of quality information (dataQualityInfo element) scoped to "service".</tg4.missing>
+    <tg4.toomany>Too many QualityInfo elements. For each spatial data service, there shall be one and only one set of quality information (dataQualityInfo element) scoped to "service".</tg4.toomany>
+    <tg4.ok>One QualityInfo element found.</tg4.ok>
+
+    <tg5.category>TG5: Service Category</tg5.category>
+    <tg5.category.noanchor>The gmx:Anchor describing the Category is missing</tg5.category.noanchor>
+    <tg5.category.anchorfound>Found the gmx:Anchor describing the Category</tg5.category.anchorfound>
+
+    <tg5.category.invalid>Unknown Category</tg5.category.invalid>
+    <tg5.category.valid>Valid category found</tg5.category.valid>
+
+    <tg6>TG6: QualityInfo pass</tg6>
+    <tg6.nopass>Pass element is missing</tg6.nopass>
+    <tg6.passfound>Pass element found</tg6.passfound>
+    <tg6.nobool>Pass/Boolean element is missing</tg6.nobool>
+    <tg6.boolfound>Pass/Boolean element found</tg6.boolfound>
+    <tg6.badbool>The value of the pass element shall be set to true.</tg6.badbool>
+    <tg6.passok>The value of the pass element is set to true.</tg6.passok>
+
+    <tg7.exists>TG7: Resource Locator</tg7.exists>
+    <tg7.exists.noanchor>No gmx:Anchor describing a Resource Locator could be found</tg7.exists.noanchor>
+    <tg7.exists.anchorfound>Found a gmx:Anchor describing the Resource Locator</tg7.exists.anchorfound>
+    <tg7.exists.noaccesspoint>No gmx:Anchor describing a Resource Locator access point</tg7.exists.noaccesspoint>
+    <tg7.exists.accesspointfound>Found a gmx:Anchor describing a Resource Locator access point</tg7.exists.accesspointfound>
+
+    <tg7.check>TG7: Resource Locator description</tg7.check>
+    <tg7.check.invalid>Invalid description found</tg7.check.invalid>
+    <tg7.check.valid>Valid description found</tg7.check.valid>
+
+    <tg8.exists>TG8: Technical Specification</tg8.exists>
+    <tg8.exists.noanchor>No gmx:Anchor describing a Technical Specification could be found</tg8.exists.noanchor>
+    <tg8.exists.anchorfound>Found a gmx:Anchor describing a Technical Specification</tg8.exists.anchorfound>
+
+    <tg10.exists>TG10: Coordinate Reference Systems Identifier</tg10.exists>
+    <tg10.exists.noanchor>No gmx:Anchor describing a CRS could be found</tg10.exists.noanchor>
+    <tg10.exists.anchorfound>Found a gmx:Anchor describing a CRS</tg10.exists.anchorfound>
+
+    <tg12>TG12: Quality of Service</tg12>
+    <tg12.noavail>No info about availability found</tg12.noavail>
+    <tg12.availfound>Found availability info</tg12.availfound>
+    <tg12.noperf>No info about performance found</tg12.noperf>
+    <tg12.perffound>Found performance info</tg12.perffound>
+    <tg12.nocapa>No info about capacity found</tg12.nocapa>
+    <tg12.capafound>Found capacity info</tg12.capafound>
+
+    <tg13.exists>TG13: Conditions applying to access and use</tg13.exists>
+    <tg13.exists.notfound>Constraints not found</tg13.exists.notfound>
+    <tg13.exists.found>Constraints found</tg13.exists.found>
+
+    <tg13>TG13: Conditions applying to access and use</tg13>
+    <tg13.othermissing>gmd:otherConstraints is missing</tg13.othermissing>
+    <tg13.both>The restriction element should define either an access or an use constraints</tg13.both>
+    <tg13.badcodelist>The constraint type should be "otherRestrictions"</tg13.badcodelist>
+
+    <tg13.accessfound>Access restriction found</tg13.accessfound>
+    <tg13.usefound>Use restriction found</tg13.usefound>
+    <tg13.okaccess>Access restriction properly defined</tg13.okaccess>
+    <tg13.okuse>Use restriction properly defined</tg13.okuse>
+
+    <tg15>TG15: Responsibly party</tg15>
+    <tg15.nopoc>Point of contact not found</tg15.nopoc>
+    <tg15.nocustodian>The PoC role should be set to "custodian"</tg15.nocustodian>
+    <tg15.okcustodian>Metadata custodian PoC found</tg15.okcustodian>
+
+
+</strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
@@ -17,6 +17,8 @@
   <default>Simple</default>
   <simple>Simple</simple>
   <inspire>INSPIRE</inspire>
+  <inspire_sds>SDS</inspire_sds>
+
   <resource>Resource</resource>
   <xml>XML</xml>
   <metadata>Metadata</metadata>
@@ -80,9 +82,61 @@
   <spatialResolution>Spatial resolution (scale)</spatialResolution>
   <spatialDistance>Spatial resolution (distance)</spatialDistance>
   <accessConstraints>Access constraints</accessConstraints>
+  <useConstraints>Use constraints</useConstraints>
   <useLimitation>Use limitation</useLimitation>
   <add-resource-id>Compute resource identifier</add-resource-id>
   <add-resource-idHelp>Compose the resource identifier using the catalog URL and the metadata identifier (eg. http://www.organization.org/catalogue/5391bf69-44bc-4ea0-8cc0-6cf6c3bc81ae).</add-resource-idHelp>
   <add-extent-from-geokeywords>Compute extent from keyword</add-extent-from-geokeywords>
   <add-extent-from-geokeywordsHelp>Analyze each keyword of type place and add matching extent.</add-extent-from-geokeywordsHelp>
+
+  <!-- String for INSPIRE SDS tab -->
+
+  <inspire_sds_cc1>Conformance class 1: invocable</inspire_sds_cc1>
+  <inspire_sds_cc2>Conformance class 2: interoperable</inspire_sds_cc2>
+  <inspire_sds_cc3>Conformance class 3: harmonized</inspire_sds_cc3>
+
+  <sds-category>Category</sds-category>
+  <inspire_add_pass>Add pass element</inspire_add_pass>
+  <sds-add-dataquality>Add DataQuality element</sds-add-dataquality>
+  <sds-add-dataqualityHelp>TG4: For each spatial data service, there shall be one and only one set of quality information (dataQualityInfo element) scoped to “service”.</sds-add-dataqualityHelp>
+  <sds-add-tech-spec>Add a technical specification</sds-add-tech-spec>
+  <sds-add-tech-specHelp>TG8: The Specification metadata element shall at least refer to or contain one technical specification to which the invocable spatial data service fully conforms, providing all the necessary technical elements, to actually invoke the service and enable its usage.</sds-add-tech-specHelp>
+  <sds-tech-spec>Technical specification</sds-tech-spec>
+  <conformity_desc>Tech spec title</conformity_desc>
+  <conformity_linkage>Tech spec URL </conformity_linkage>
+
+
+  <sds-section-qos>Quality of Service</sds-section-qos>
+  <sds-add-qualityofservice>Add missing Quality of Service criteria</sds-add-qualityofservice>
+  <sds-add-qualityofserviceHelp>INSPIRE SDS requires three quality of service criteria to be reported in the metadata: Availability, Performance and Capacity. This button will add the missing criteria.</sds-add-qualityofserviceHelp>
+  <qos_measure>Measure: </qos_measure>
+  <qos_uom>UOM</qos_uom>
+  <qos_description>Description</qos_description>
+  <qos_value>Value</qos_value>
+  <sds-section-crs>Coordinate reference system</sds-section-crs>
+
+  <sds-fix-category>Fix the Category element</sds-fix-category>
+  <sds-fix-categoryHelp>(Rec1) Replace gco:CharacterString with gmx:Anchor in the description metadata element.</sds-fix-categoryHelp>
+
+  <sds-accesspoint>Access Point URL</sds-accesspoint>
+  <sds-add-accesspoint>Add Access Point</sds-add-accesspoint>
+
+  <sds-endpoint>Endpoint URL</sds-endpoint>
+  <sds-add-endpoint>Add Endpoint</sds-add-endpoint>
+
+  <sds-addNoConstraints>No Limitation</sds-addNoConstraints>
+  <sds-addNoConstraintsHelp>Add an element that documents that there are no limitation for this service.</sds-addNoConstraintsHelp>
+  <sds-addUnknownConstraints>Unknown Limitation</sds-addUnknownConstraints>
+  <sds-addConstraints>Customizable constraints</sds-addConstraints>
+
+  <sds>
+    <noConditionsApply>No conditions apply</noConditionsApply>
+    <conditionsUnknown>Conditions unknown</conditionsUnknown>
+  </sds>
+
+  <sds-limitation>Limitation</sds-limitation>
+
+  <sds-section-custodian>Responsible custodian</sds-section-custodian>
+  <sds-addOperation>Add Operation</sds-addOperation>
+
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/sds-add-dataquality.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/sds-add-dataquality.xsl
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Author: Emanuele Tajariol (etj at geo-solutions dot it)
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exslt="http://exslt.org/common"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                version="2.0"
+                exclude-result-prefixes="#all">
+
+    <xsl:import href="../../iso19139/process/process-utility.xsl"/>
+
+    <xsl:variable name="isService" select="boolean(/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification)"/>
+
+    <!-- CC1 Rec 1 -->
+    <!-- Add a gmd:dataQualityInfo with service scope -->
+
+    <xsl:template match="gmd:MD_Metadata">
+        <xsl:copy>
+
+            <xsl:apply-templates select="node()[not(self::gmd:portrayalCatalogueInfo)
+                                         and not(self::gmd:metadataConstraints)
+                                         and not(self::gmd:applicationSchemaInfo)
+                                         and not(self::gmd:metadataMaintenance)]"/>
+
+            <gmd:dataQualityInfo>     <!-- 0..n -->
+                <gmd:DQ_DataQuality>
+                    <gmd:scope>
+                        <gmd:DQ_Scope>
+                            <gmd:level>
+                                <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="service"/>
+                            </gmd:level>
+                        </gmd:DQ_Scope>
+                    </gmd:scope>
+                    <gmd:report>
+                        <gmd:DQ_DomainConsistency>
+                            <gmd:result>
+                                <gmd:DQ_ConformanceResult>
+                                    <gmd:specification>
+                                        <gmd:CI_Citation>
+                                            <gmd:title>
+                                                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Category/invocable">invocable</gmx:Anchor>
+                                            </gmd:title>
+                                            <gmd:date>
+                                                <gmd:CI_Date>
+                                                    <gmd:date>
+                                                        <gco:Date>2014-12-11</gco:Date>
+                                                    </gmd:date>
+                                                    <gmd:dateType>
+                                                        <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml #CI_DateTypeCode" codeListValue="publication"/>
+                                                    </gmd:dateType>
+                                                </gmd:CI_Date>
+                                            </gmd:date>
+                                        </gmd:CI_Citation>
+                                    </gmd:specification>
+                                    <gmd:explanation>
+                                        <gco:CharacterString>Conformant to the INSPIRE SDS specifications.</gco:CharacterString>
+                                    </gmd:explanation>
+                                    <gmd:pass>
+                                        <gco:Boolean>true</gco:Boolean>
+                                    </gmd:pass>
+                                </gmd:DQ_ConformanceResult>
+                            </gmd:result>
+                        </gmd:DQ_DomainConsistency> 
+                    </gmd:report>
+                </gmd:DQ_DataQuality>
+            </gmd:dataQualityInfo>
+
+            <xsl:apply-templates select="gmd:portrayalCatalogueInfo"/>
+            <xsl:apply-templates select="gmd:metadataConstraints"/>
+            <xsl:apply-templates select="gmd:applicationSchemaInfo"/>
+            <xsl:apply-templates select="gmd:metadataMaintenance"/>
+
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Do a copy of every nodes and attributes -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Remove geonet:* elements. -->
+    <xsl:template match="geonet:*" priority="2"/>
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/sds-add-qualityofservice.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/sds-add-qualityofservice.xsl
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Author: Emanuele Tajariol (etj at geo-solutions dot it)
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exslt="http://exslt.org/common"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                version="2.0"
+                exclude-result-prefixes="#all">
+
+    <xsl:import href="../../iso19139/process/process-utility.xsl"/>
+
+    <xsl:variable name="isService" select="boolean(/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification)"/>
+
+    <!-- CC2 4.5.2 Quality of Service -->
+    <!-- Add gmd:DQ_ConceptualConsistency elements to express Quality of service in term of:
+           * Availability
+           * Performance
+           * Capacity
+    -->
+    <xsl:template match="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']">
+
+        <xsl:copy>
+            <xsl:apply-templates select="gmd:scope"/>
+            <xsl:apply-templates select="gmd:report"/>
+
+            <xsl:if test="count(gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor[@xlink:href='http://inspire.ec.europa.eu/metadata-codelist/Criteria/availability'])=0">
+                <xsl:message>Adding missing availablility QoS</xsl:message>
+                <gmd:report>
+                    <gmd:DQ_ConceptualConsistency>
+                        <gmd:nameOfMeasure>
+                            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Criteria/availability">availability</gmx:Anchor>
+                        </gmd:nameOfMeasure>
+                        <gmd:measureIdentification>
+                            <gmd:MD_Identifier>
+                                <gmd:code>
+                                    <gco:CharacterString>INSPIRE_service_availability</gco:CharacterString>
+                                </gmd:code>
+                            </gmd:MD_Identifier>
+                        </gmd:measureIdentification>
+                        <gmd:result>
+                            <gmd:DQ_QuantitativeResult>
+                                <gmd:valueUnit xlink:href="http://www.opengis.net/def/uom/OGC/1.0/unity"/>
+                                <gmd:value>
+                                    <gco:Record>90</gco:Record>
+                                </gmd:value>
+                            </gmd:DQ_QuantitativeResult>
+                        </gmd:result>
+                    </gmd:DQ_ConceptualConsistency>
+                </gmd:report>
+            </xsl:if>
+
+            <xsl:if test="count(gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor[@xlink:href='http://inspire.ec.europa.eu/metadata-codelist/Criteria/performance'])=0">
+                <xsl:message>Adding missing performance QoS</xsl:message>
+                <gmd:report>
+                    <gmd:DQ_ConceptualConsistency>
+                        <gmd:nameOfMeasure>
+                            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Criteria/performance">performance</gmx:Anchor>
+                        </gmd:nameOfMeasure>
+                        <gmd:measureIdentification>
+                            <gmd:MD_Identifier>
+                                <gmd:code>
+                                    <gco:CharacterString> INSPIRE_service_performance</gco:CharacterString>
+                                </gmd:code>
+                            </gmd:MD_Identifier>
+                        </gmd:measureIdentification>
+                        <gmd:result>
+                            <gmd:DQ_QuantitativeResult>
+                                <gmd:valueUnit xlink:href=" http://www.opengis.net/def/uom/SI/second"/>
+                                <gmd:value>
+                                    <gco:Record>0.5</gco:Record>
+                                </gmd:value>
+                            </gmd:DQ_QuantitativeResult>
+                        </gmd:result>
+                    </gmd:DQ_ConceptualConsistency>
+                </gmd:report>
+            </xsl:if>
+
+            <xsl:if test="count(gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor[@xlink:href='http://inspire.ec.europa.eu/metadata-codelist/Criteria/capacity'])=0">
+                <xsl:message>Adding missing capacity QoS</xsl:message>
+                <gmd:report>
+                    <gmd:DQ_ConceptualConsistency>
+                        <gmd:nameOfMeasure>
+                            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Criteria/capacity">capacity</gmx:Anchor>
+                        </gmd:nameOfMeasure>
+                        <gmd:measureIdentification>
+                            <gmd:MD_Identifier>
+                                <gmd:code>
+                                    <gco:CharacterString>INSPIRE_service_capacity </gco:CharacterString>
+                                </gmd:code>
+                            </gmd:MD_Identifier>
+                        </gmd:measureIdentification>
+                        <gmd:result>
+                            <gmd:DQ_QuantitativeResult>
+                                <gmd:valueUnit gco:nilReason="inapplicable"/>
+                                <gmd:value>
+                                    <gco:Record>50</gco:Record>
+                                </gmd:value>
+                            </gmd:DQ_QuantitativeResult>
+                        </gmd:result>
+                    </gmd:DQ_ConceptualConsistency>
+                </gmd:report>
+            </xsl:if>
+
+            <xsl:apply-templates select="gmd:lineage"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Do a copy of every nodes and attributes -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- Remove geonet:* elements. -->
+    <xsl:template match="geonet:*" priority="2"/>
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/sds-fix-category.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/sds-fix-category.xsl
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Author: Emanuele Tajariol (etj at geo-solutions dot it)
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exslt="http://exslt.org/common"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                version="2.0" exclude-result-prefixes="#all">
+
+    <xsl:import href="../../iso19139/process/process-utility.xsl"/>
+
+    <xsl:variable name="isService" select="boolean(/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification)"/>
+
+    <!-- CC1 Rec 1 -->
+    <xsl:template match="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title[gco:CharacterString]">
+        <xsl:copy>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Category/invocable">invocable</gmx:Anchor>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Do a copy of every nodes and attributes -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Remove geonet:* elements. -->
+    <xsl:template match="geonet:*" priority="2"/>
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-inspire-sds.disabled.sch
+++ b/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-inspire-sds.disabled.sch
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sch:schema
+    xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    queryBinding="xslt2">
+<!--
+
+This Schematron define INSPIRE IR on metadata for Spatial Data Service (SDS)
+
+    @author Emanuele Tajariol - GeoSolutions, 2016
+
+
+This work is licensed under the Creative Commons Attribution 2.5 License. 
+To view a copy of this license, visit 
+    http://creativecommons.org/licenses/by/2.5/ 
+
+or send a letter to:
+
+Creative Commons, 
+543 Howard Street, 5th Floor, 
+San Francisco, California, 94105, 
+USA.
+
+    -->
+
+    <sch:title xmlns="http://www.w3.org/2001/XMLSchema">INSPIRE SDS metadata</sch:title>
+
+    <sch:ns prefix="gml" uri="http://www.opengis.net/gml"/>
+    <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+    <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
+    <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+    <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+    <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+    <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+    <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+
+    <!-- INSPIRE SDS metadata rules / START -->
+
+    <sch:pattern>
+        <sch:title>$loc/strings/precondition</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata">
+
+            <sch:report test="count(gmd:identificationInfo/srv:SV_ServiceIdentification)=0">
+                <sch:value-of select="$loc/strings/precondition.noservice"/>
+            </sch:report>
+
+            <sch:report test="count(gmd:identificationInfo/srv:SV_ServiceIdentification)=1">
+                <sch:value-of select="$loc/strings/precondition.service"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+    <!-- TG Requirement 4
+    For each spatial data service, there shall be one and only one set of quality information (dataQualityInfo element) scoped to “service”. -->
+
+    <sch:pattern>
+        <sch:title>$loc/strings/tg4</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]">
+
+            <sch:assert test="count(gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service'])>0">
+                <sch:value-of select="$loc/strings/tg4.missing"/>
+            </sch:assert>
+            <sch:assert test="count(gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service'])&lt;2">
+                <sch:value-of select="$loc/strings/tg4.toomany"/>
+            </sch:assert>
+
+            <sch:report test="count(gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service'])=1">
+                <sch:value-of select="$loc/strings/tg4.ok"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+
+    <!-- TG Requirement 5
+         Category.
+    -->
+
+    <sch:pattern>
+        <sch:title>$loc/strings/tg5.category</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']">
+
+            <sch:let name="anchorExists" value="count(gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gmx:Anchor)>0"/>
+            <sch:let name="anchorHref"  value="string(gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href)"/>
+            <sch:let name="category"    value="lower-case(substring-after($anchorHref, 'http://inspire.ec.europa.eu/metadata-codelist/Category/' ))"/>
+            <sch:let name="isValid"     value="contains('invocable|interoperable|harmonised', $category)"/>
+
+            <sch:assert test="$anchorExists">
+                <sch:value-of select="$loc/strings/tg5.category.noanchor"/>
+            </sch:assert>
+            <sch:report test="$anchorExists">
+                <sch:value-of select="$loc/strings/tg5.category.anchorfound"/>
+            </sch:report>
+
+            <sch:assert test="not($anchorExists) or ($anchorExists and $isValid)">
+                <sch:value-of select="$loc/strings/tg5.category.invalid"/>: <sch:value-of select="$category"/>
+            </sch:assert>
+            <sch:report test="$isValid">
+                <sch:value-of select="$loc/strings/tg5.category.valid"/>: <sch:value-of select="$category"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+    <!-- TG Requirement 6
+         The value of the pass element shall be set to true.
+    -->
+
+    <sch:pattern>
+        <sch:title>$loc/strings/tg6</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]/gmd:dataQualityInfo/gmd:DQ_DataQuality[gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue='service']">
+
+            <sch:let name="passExists" value="count(gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:pass)>0"/>
+            <sch:let name="boolExists" value="count(gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:pass/gco:Boolean)>0"/>
+            <sch:let name="pass"  value="gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:pass/gco:Boolean/text()='true'"/>
+
+            <sch:assert test="$passExists">
+                <sch:value-of select="$loc/strings/tg6.nopass"/>
+            </sch:assert>
+            <sch:report test="$passExists">
+                <sch:value-of select="$loc/strings/tg6.passfound"/>
+            </sch:report>
+
+            <sch:assert test="not($passExists) or ($passExists and $boolExists)">
+                <sch:value-of select="$loc/strings/tg6.nobool"/>
+            </sch:assert>
+            <sch:report test="$boolExists">
+                <sch:value-of select="$loc/strings/tg6.boolfound"/>
+            </sch:report>
+
+            <sch:assert test="not($boolExists) or ($boolExists and $pass)">
+                <sch:value-of select="$loc/strings/tg6.badbool"/>
+            </sch:assert>
+            <sch:report test="$pass">
+                <sch:value-of select="$loc/strings/tg6.passok"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+
+    <!-- TG Requirement 7
+         Resource locator.
+    -->
+
+    <sch:pattern>
+        <sch:title>$loc/strings/tg7.exists</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]">
+
+            <sch:let name="anchorExists" 
+                     value="count(gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:description/gmx:Anchor)>0"/>
+            <sch:let name="accessPointExists"
+                     value="count(gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:description/gmx:Anchor
+                                [@xlink:href='http://inspire.ec.europa.eu/registry/metadata-codelist/ResourceLocatorDescription/accessPoint'])>0"/>
+
+            <sch:assert test="$anchorExists">
+                <sch:value-of select="$loc/strings/tg7.exists.noanchor"/>
+            </sch:assert>
+            <sch:report test="$anchorExists">
+                <sch:value-of select="$loc/strings/tg7.exists.anchorfound"/>
+            </sch:report>
+
+            <sch:assert test="not($anchorExists) or ($anchorExists and $accessPointExists)">
+                <sch:value-of select="$loc/strings/tg7.exists.noaccesspoint"/>
+            </sch:assert>
+            <sch:report test="$accessPointExists">
+                <sch:value-of select="$loc/strings/tg7.exists.accesspointfound"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+    <sch:pattern>
+        <sch:title>$loc/strings/tg7.check</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:description/gmx:Anchor">
+
+            <sch:let name="anchorHref"  value="string(@xlink:href)"/>
+            <sch:let name="description" value="lower-case(substring-after($anchorHref, 'http://inspire.ec.europa.eu/registry/metadata-codelist/ResourceLocatorDescription/' ))"/>
+            <sch:let name="isValid"     value="contains('accesspoint|endpoint', $description)"/>
+
+            <sch:assert test="$isValid">
+                <sch:value-of select="$loc/strings/tg7.check.invalid"/>: <sch:value-of select="$description"/>
+            </sch:assert>
+            <sch:report test="$isValid">
+                <sch:value-of select="$loc/strings/tg7.check.valid"/>: <sch:value-of select="$description"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+    <!-- TG Requirement 8
+         Technical specification.
+    -->
+    <sch:pattern>
+        <sch:title>$loc/strings/tg8.exists</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]">
+
+            <sch:let name="anchorExists"
+                     value="count(gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_FormatConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gmx:Anchor)>0"/>
+
+            <sch:assert test="$anchorExists">
+                <sch:value-of select="$loc/strings/tg8.exists.noanchor"/>
+            </sch:assert>
+            <sch:report test="$anchorExists">
+                <sch:value-of select="$loc/strings/tg8.exists.anchorfound"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+    <!-- TG Requirement 10
+         Coordinate Reference Systems Identifier
+    -->
+    <sch:pattern>
+        <sch:title>$loc/strings/tg10.exists</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]">
+
+            <sch:let name="anchorExists"
+                     value="count(gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:code/gmx:Anchor)>0"/>
+
+            <sch:assert test="$anchorExists">
+                <sch:value-of select="$loc/strings/tg10.exists.noanchor"/>
+            </sch:assert>
+            <sch:report test="$anchorExists">
+                <sch:value-of select="$loc/strings/tg10.exists.anchorfound"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+    <!-- TG Requirement 12
+         Quality of Service
+    -->
+    <sch:pattern>
+        <sch:title>$loc/strings/tg12</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]">
+
+            <sch:let name="availExists"
+                     value="count(gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor
+                              [@xlink:href='http://inspire.ec.europa.eu/metadata-codelist/Criteria/availability'])>0"/>
+            <sch:let name="perfExists"
+                     value="count(gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor
+                              [@xlink:href='http://inspire.ec.europa.eu/metadata-codelist/Criteria/performance'])>0"/>
+            <sch:let name="capaExists"
+                     value="count(gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure/gmx:Anchor
+                              [@xlink:href='http://inspire.ec.europa.eu/metadata-codelist/Criteria/capacity'])>0"/>
+
+
+            <sch:assert test="$availExists"><sch:value-of select="$loc/strings/tg12.noavail"/></sch:assert>
+            <sch:report test="$availExists"><sch:value-of select="$loc/strings/tg12.availfound"/></sch:report>
+
+            <sch:assert test="$perfExists"><sch:value-of select="$loc/strings/tg12.noperf"/></sch:assert>
+            <sch:report test="$perfExists"><sch:value-of select="$loc/strings/tg12.perffound"/></sch:report>
+
+            <sch:assert test="$capaExists"><sch:value-of select="$loc/strings/tg12.nocapa"/></sch:assert>
+            <sch:report test="$capaExists"><sch:value-of select="$loc/strings/tg12.capafound"/></sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+    <!-- TG Requirement 13
+         Conditions applying to access and use
+    -->
+
+    <sch:pattern>
+        <sch:title>$loc/strings/tg13.exists</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]">
+
+            <sch:let name="exists"
+                     value="count(.//gmd:resourceConstraints/gmd:MD_LegalConstraints)>0"/>
+
+            <sch:assert test="$exists">
+                <sch:value-of select="$loc/strings/tg13.exists.notfound"/>
+            </sch:assert>
+            <sch:report test="$exists">
+                <sch:value-of select="$loc/strings/tg13.exists.found"/>
+            </sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+
+    <sch:pattern>
+        <sch:title>$loc/strings/tg13</sch:title>
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]/gmd:resourceConstraints/gmd:MD_LegalConstraints">
+
+            <sch:let name="access" value="count(gmd:accessConstraints)>0"/>
+            <sch:let name="use"  value="count(gmd:useConstraints)>0"/>
+            <sch:let name="other"  value="count(gmd:otherConstraints)>0"/>
+
+            <sch:let name="onlyone"  value="($access and not($use)) or (not($access) and $use)"/>
+
+            <sch:let name="accesscode" value="count(gmd:accessConstraints/gmd:MD_RestrictionCode[@codeListValue='otherRestrictions'] )>0"/>
+            <sch:let name="usecode" value="count(gmd:useConstraints/gmd:MD_RestrictionCode[@codeListValue='otherRestrictions'] )>0"/>
+
+            <sch:assert test="$other"><sch:value-of select="$loc/strings/tg13.othermissing"/></sch:assert>
+            <sch:assert test="$onlyone"><sch:value-of select="$loc/strings/tg13.both"/></sch:assert>
+
+            <!--<sch:assert test="not($onlyone) or ($onlyone and $access and $accesscode) or ($onlyone and $use and $usecode)"><sch:value-of select="$loc/strings/tg13.badcodelist"/></sch:assert>-->
+            <sch:assert test="not($onlyone) or ($onlyone and ($accesscode or $usecode))"><sch:value-of select="$loc/strings/tg13.badcodelist"/></sch:assert>
+
+            <sch:report test="$onlyone and $access and $other"><sch:value-of select="$loc/strings/tg13.accessfound"/></sch:report>
+            <sch:report test="$onlyone and $use and $other"><sch:value-of select="$loc/strings/tg13.usefound"/></sch:report>
+
+            <sch:report test="$onlyone and $access and $other and $accesscode"><sch:value-of select="$loc/strings/tg13.okaccess"/></sch:report>
+            <sch:report test="$onlyone and $use and $other and $usecode"><sch:value-of select="$loc/strings/tg13.okuse"/></sch:report>
+
+        </sch:rule>
+    </sch:pattern>
+
+
+    <!-- TG Requirement 15
+         Conditions applying to access and use
+    -->
+
+    <sch:pattern>
+        <sch:title>$loc/strings/tg15</sch:title>
+
+        <sch:rule context="//gmd:MD_Metadata[gmd:identificationInfo/srv:SV_ServiceIdentification]">
+
+            <sch:let name="existspoc"       value="count(gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty)>0"/>
+            <sch:let name="existscustodian" value="count(gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='custodian'])>0"/>
+
+            <sch:assert test="$existspoc"><sch:value-of select="$loc/strings/tg15.nopoc"/></sch:assert>
+            <sch:assert test="not($existspoc) or ($existspoc and $existscustodian)"><sch:value-of select="$loc/strings/tg15.nocustodian"/></sch:assert>
+
+            <sch:report test="$existscustodian"><sch:value-of select="$loc/strings/tg15.okcustodian"/></sch:report>
+            
+        </sch:rule>
+    </sch:pattern>
+
+
+    <!-- INSPIRE SDS metadata rules / END -->
+
+</sch:schema>

--- a/schemas/iso19139/src/main/plugin/iso19139/templates/inspire_sds.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/templates/inspire_sds.xml
@@ -1,0 +1,459 @@
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:gml="http://www.opengis.net/gml"
+                 xmlns:srv="http://www.isotc211.org/2005/srv"
+                 xmlns:xlink="http://www.w3.org/1999/xlink">
+   <gmd:fileIdentifier>
+      <gco:CharacterString>0d6a46d6-a01f-4b2d-b19e-36b2b0c934d0</gco:CharacterString>
+   </gmd:fileIdentifier>
+   <gmd:language>
+      <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+   </gmd:language>
+   <gmd:characterSet>
+      <gmd:MD_CharacterSetCode codeListValue="utf8"
+                               codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"/>
+  </gmd:characterSet>
+   <gmd:hierarchyLevel>
+      <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
+                        codeListValue="service"/>
+   </gmd:hierarchyLevel>
+   <gmd:contact>
+      <gmd:CI_ResponsibleParty>
+         <gmd:individualName>
+            <gco:CharacterString>The administrator of the service</gco:CharacterString>
+         </gmd:individualName>
+         <gmd:organisationName gco:nilReason="missing">
+            <gco:CharacterString/>
+         </gmd:organisationName>
+         <gmd:positionName gco:nilReason="missing">
+            <gco:CharacterString/>
+         </gmd:positionName>
+         <gmd:contactInfo>
+            <gmd:CI_Contact>
+               <gmd:phone>
+                  <gmd:CI_Telephone>
+                     <gmd:voice gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:voice>
+                     <gmd:facsimile gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:facsimile>
+                  </gmd:CI_Telephone>
+               </gmd:phone>
+               <gmd:address>
+                  <gmd:CI_Address>
+                     <gmd:deliveryPoint gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:deliveryPoint>
+                     <gmd:city gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:city>
+                     <gmd:administrativeArea gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:administrativeArea>
+                     <gmd:postalCode gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:postalCode>
+                     <gmd:country gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:country>
+                     <gmd:electronicMailAddress gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:electronicMailAddress>
+                  </gmd:CI_Address>
+               </gmd:address>
+               <gmd:onlineResource>
+                  <gmd:CI_OnlineResource>
+                     <gmd:linkage>
+                        <gmd:URL>http://geonetwork-opensource.org/</gmd:URL>
+                     </gmd:linkage>
+                  </gmd:CI_OnlineResource>
+               </gmd:onlineResource>
+            </gmd:CI_Contact>
+         </gmd:contactInfo>
+         <gmd:role>
+            <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode"
+                             codeListValue="pointOfContact"/>
+         </gmd:role>
+      </gmd:CI_ResponsibleParty>
+  </gmd:contact>
+   <gmd:dateStamp>
+      <gco:DateTime>2016-02-29T15:12:24</gco:DateTime>
+   </gmd:dateStamp>
+   <gmd:metadataStandardName>
+      <gco:CharacterString>ISO 19115:2003/19139</gco:CharacterString>
+   </gmd:metadataStandardName>
+   <gmd:metadataStandardVersion>
+      <gco:CharacterString>1.0</gco:CharacterString>
+   </gmd:metadataStandardVersion>
+   <gmd:referenceSystemInfo>
+      <gmd:MD_ReferenceSystem/>
+  </gmd:referenceSystemInfo>
+   <gmd:referenceSystemInfo>
+      <gmd:MD_ReferenceSystem/>
+  </gmd:referenceSystemInfo>
+   <gmd:identificationInfo>
+      <srv:SV_ServiceIdentification>
+         <gmd:citation>
+            <gmd:CI_Citation>
+               <gmd:title>
+                  <gco:CharacterString>Template for INSPIRE SDS metadata</gco:CharacterString>
+               </gmd:title>
+               <gmd:alternateTitle gco:nilReason="missing"/>
+               <gmd:date>
+                  <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:DateTime>2016-02-29T12:00:00</gco:DateTime>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                             codeListValue="revision"/>
+                     </gmd:dateType>
+                  </gmd:CI_Date>
+               </gmd:date>
+            </gmd:CI_Citation>
+         </gmd:citation>
+         <gmd:abstract>
+            <gco:CharacterString>The INSPIRE SDS specification follows mainly ISO19139/119 metadata, and provides specific information about the invocability of a service.</gco:CharacterString>
+         </gmd:abstract>
+         <gmd:status>
+            <gmd:MD_ProgressCode codeListValue="completed"
+                                 codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode"/>
+         </gmd:status>
+         <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+               <gmd:individualName gco:nilReason="missing">
+                  <gco:CharacterString/>
+               </gmd:individualName>
+               <gmd:organisationName gco:nilReason="missing">
+                  <gco:CharacterString/>
+               </gmd:organisationName>
+               <gmd:positionName gco:nilReason="missing">
+                  <gco:CharacterString/>
+               </gmd:positionName>
+               <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                     <gmd:phone>
+                        <gmd:CI_Telephone>
+                           <gmd:voice gco:nilReason="missing">
+                              <gco:CharacterString/>
+                           </gmd:voice>
+                           <gmd:facsimile gco:nilReason="missing">
+                              <gco:CharacterString/>
+                           </gmd:facsimile>
+                        </gmd:CI_Telephone>
+                     </gmd:phone>
+                     <gmd:address>
+                        <gmd:CI_Address>
+                           <gmd:deliveryPoint gco:nilReason="missing">
+                              <gco:CharacterString/>
+                           </gmd:deliveryPoint>
+                           <gmd:city gco:nilReason="missing">
+                              <gco:CharacterString/>
+                           </gmd:city>
+                           <gmd:administrativeArea gco:nilReason="missing">
+                              <gco:CharacterString/>
+                           </gmd:administrativeArea>
+                           <gmd:postalCode gco:nilReason="missing">
+                              <gco:CharacterString/>
+                           </gmd:postalCode>
+                           <gmd:country gco:nilReason="missing">
+                              <gco:CharacterString/>
+                           </gmd:country>
+                        </gmd:CI_Address>
+                     </gmd:address>
+                     <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                           <gmd:linkage>
+                              <gmd:URL>http://geonetwork-opensource.org/</gmd:URL>
+                           </gmd:linkage>
+                        </gmd:CI_OnlineResource>
+                     </gmd:onlineResource>
+                  </gmd:CI_Contact>
+               </gmd:contactInfo>
+               <gmd:role>
+                  <gmd:CI_RoleCode codeListValue="pointOfContact"
+                                   codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode"/>
+               </gmd:role>
+            </gmd:CI_ResponsibleParty>
+         </gmd:pointOfContact>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>GEONETWORK</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>OSGeo</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeListValue="theme"
+                                          codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"/>
+               </gmd:type>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword gco:nilReason="missing">
+                  <gco:CharacterString/>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                          codeListValue="theme"/>
+               </gmd:type>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>INSPIRE Service taxonomy</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date>
+                        <gmd:CI_Date>
+                           <gmd:date>
+                              <gco:Date>2010-04-22</gco:Date>
+                           </gmd:date>
+                           <gmd:dateType>
+                              <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                                   codeListValue="publication"/>
+                           </gmd:dateType>
+                        </gmd:CI_Date>
+                     </gmd:date>
+                     <gmd:identifier>
+                        <gmd:MD_Identifier>
+                           <gmd:code>
+                              <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/eng/thesaurus.download?ref=external.theme.inspire-service-taxonomy">geonetwork.thesaurus.external.theme.inspire-service-taxonomy</gmx:Anchor>
+                           </gmd:code>
+                        </gmd:MD_Identifier>
+                     </gmd:identifier>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:resourceConstraints>
+            <gmd:MD_LegalConstraints>
+               <gmd:accessConstraints>
+                  <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                          codeListValue="otherRestrictions"/>
+               </gmd:accessConstraints>
+               <gmd:otherConstraints>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/registry/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">No Conditions Apply</gmx:Anchor>
+               </gmd:otherConstraints>
+            </gmd:MD_LegalConstraints>
+         </gmd:resourceConstraints>
+         <srv:serviceType>
+            <gco:LocalName codeSpace="www.w3c.org">W3C:HTML:LINK</gco:LocalName>
+         </srv:serviceType>
+         <srv:serviceTypeVersion>
+            <gco:CharacterString>1.1.1</gco:CharacterString>
+         </srv:serviceTypeVersion>
+         <srv:accessProperties>
+            <gmd:MD_StandardOrderProcess>
+               <gmd:fees>
+                  <gco:CharacterString>NONE</gco:CharacterString>
+               </gmd:fees>
+            </gmd:MD_StandardOrderProcess>
+         </srv:accessProperties>
+         <srv:extent>
+            <gmd:EX_Extent>
+               <gmd:geographicElement>
+                  <gmd:EX_GeographicBoundingBox>
+                     <gmd:westBoundLongitude>
+                        <gco:Decimal>-180</gco:Decimal>
+                     </gmd:westBoundLongitude>
+                     <gmd:eastBoundLongitude>
+                        <gco:Decimal>180</gco:Decimal>
+                     </gmd:eastBoundLongitude>
+                     <gmd:southBoundLatitude>
+                        <gco:Decimal>-90</gco:Decimal>
+                     </gmd:southBoundLatitude>
+                     <gmd:northBoundLatitude>
+                        <gco:Decimal>90</gco:Decimal>
+                     </gmd:northBoundLatitude>
+                  </gmd:EX_GeographicBoundingBox>
+               </gmd:geographicElement>
+            </gmd:EX_Extent>
+         </srv:extent>
+         <srv:couplingType>
+            <srv:SV_CouplingType codeListValue="tight"
+                                 codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#SV_CouplingType"/>
+         </srv:couplingType>
+         <srv:containsOperations>
+            <srv:SV_OperationMetadata>
+               <srv:operationName>
+                  <gco:CharacterString>GetCapabilities</gco:CharacterString>
+               </srv:operationName>
+               <srv:DCP>
+                  <srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#DCPList"
+                               codeListValue="XML"/>
+               </srv:DCP>
+               <srv:DCP>
+                  <srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#DCPList"
+                               codeListValue=""/>
+               </srv:DCP>
+            </srv:SV_OperationMetadata>
+         </srv:containsOperations>
+      </srv:SV_ServiceIdentification>
+   </gmd:identificationInfo>
+   <gmd:distributionInfo>
+      <gmd:MD_Distribution>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name gco:nilReason="missing">
+                  <gco:CharacterString/>
+               </gmd:name>
+               <gmd:version gco:nilReason="missing">
+                  <gco:CharacterString/>
+               </gmd:version>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions/>
+         </gmd:transferOptions>
+      </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+   <gmd:dataQualityInfo>
+      <gmd:DQ_DataQuality>
+         <gmd:scope>
+            <gmd:DQ_Scope>
+               <gmd:level>
+                  <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
+                                    codeListValue="service"/>
+               </gmd:level>
+            </gmd:DQ_Scope>
+         </gmd:scope>
+         <gmd:report>
+            <gmd:DQ_DomainConsistency>
+               <gmd:result>
+                  <gmd:DQ_ConformanceResult>
+                     <gmd:specification>
+                        <gmd:CI_Citation>
+                           <gmd:title>
+                              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Category/invocable">invocable</gmx:Anchor>
+                           </gmd:title>
+                           <gmd:date>
+                              <gmd:CI_Date>
+                                 <gmd:date>
+                                    <gco:Date>2014-12-11</gco:Date>
+                                 </gmd:date>
+                                 <gmd:dateType>
+                                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                                         codeListValue="publication"/>
+                                 </gmd:dateType>
+                              </gmd:CI_Date>
+                           </gmd:date>
+                        </gmd:CI_Citation>
+                     </gmd:specification>
+                     <gmd:explanation>
+                        <gco:CharacterString>Conformant to the INSPIRE SDS specifications.</gco:CharacterString>
+                     </gmd:explanation>
+                     <gmd:pass>
+                        <gco:Boolean>true</gco:Boolean>
+                     </gmd:pass>
+                  </gmd:DQ_ConformanceResult>
+               </gmd:result>
+            </gmd:DQ_DomainConsistency>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_ConceptualConsistency>
+               <gmd:nameOfMeasure>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Criteria/availability">availability</gmx:Anchor>
+               </gmd:nameOfMeasure>
+               <gmd:measureIdentification>
+                  <gmd:MD_Identifier>
+                     <gmd:code>
+                        <gco:CharacterString>INSPIRE_service_availability</gco:CharacterString>
+                     </gmd:code>
+                  </gmd:MD_Identifier>
+               </gmd:measureIdentification>
+               <gmd:result>
+                  <gmd:DQ_QuantitativeResult>
+                     <gmd:valueUnit xlink:href="http://www.opengis.net/def/uom/OGC/1.0/unity"/>
+                     <gmd:value>
+                        <gco:Record>90</gco:Record>
+                     </gmd:value>
+                  </gmd:DQ_QuantitativeResult>
+               </gmd:result>
+            </gmd:DQ_ConceptualConsistency>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_ConceptualConsistency>
+               <gmd:nameOfMeasure>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Criteria/performance">performance</gmx:Anchor>
+               </gmd:nameOfMeasure>
+               <gmd:measureIdentification>
+                  <gmd:MD_Identifier>
+                     <gmd:code>
+                        <gco:CharacterString>INSPIRE_service_performance</gco:CharacterString>
+                     </gmd:code>
+                  </gmd:MD_Identifier>
+               </gmd:measureIdentification>
+               <gmd:result>
+                  <gmd:DQ_QuantitativeResult>
+                     <gmd:valueUnit xlink:href=" http://www.opengis.net/def/uom/SI/second"/>
+                     <gmd:value>
+                        <gco:Record>0.5</gco:Record>
+                     </gmd:value>
+                  </gmd:DQ_QuantitativeResult>
+               </gmd:result>
+            </gmd:DQ_ConceptualConsistency>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_ConceptualConsistency>
+               <gmd:nameOfMeasure>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/Criteria/capacity">capacity</gmx:Anchor>
+               </gmd:nameOfMeasure>
+               <gmd:measureIdentification>
+                  <gmd:MD_Identifier>
+                     <gmd:code>
+                        <gco:CharacterString>INSPIRE_service_capacity</gco:CharacterString>
+                     </gmd:code>
+                  </gmd:MD_Identifier>
+               </gmd:measureIdentification>
+               <gmd:result>
+                  <gmd:DQ_QuantitativeResult>
+                     <gmd:valueUnit gco:nilReason="inapplicable"/>
+                     <gmd:value>
+                        <gco:Record>50</gco:Record>
+                     </gmd:value>
+                  </gmd:DQ_QuantitativeResult>
+               </gmd:result>
+            </gmd:DQ_ConceptualConsistency>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_FormatConsistency>
+               <gmd:result>
+                  <gmd:DQ_ConformanceResult>
+                     <gmd:specification>
+                        <gmd:CI_Citation>
+                           <gmd:title>
+                              <gmx:Anchor xlink:href="http://link,to/the.technical.specification">Description of technical specification</gmx:Anchor>
+                           </gmd:title>
+                           <gmd:date>
+                              <gmd:CI_Date>
+                                 <gmd:date>
+                                    <gco:Date>
+                                       <gco:Date>2014-12-11</gco:Date>
+                                    </gco:Date>
+                                 </gmd:date>
+                                 <gmd:dateType>
+                                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                                         codeListValue="publication"/>
+                                 </gmd:dateType>
+                              </gmd:CI_Date>
+                           </gmd:date>
+                        </gmd:CI_Citation>
+                     </gmd:specification>
+                     <gmd:explanation>
+                        <gco:CharacterString>Conformant to the cited specifications.</gco:CharacterString>
+                     </gmd:explanation>
+                     <gmd:pass>
+                        <gco:Boolean>true</gco:Boolean>
+                     </gmd:pass>
+                  </gmd:DQ_ConformanceResult>
+               </gmd:result>
+            </gmd:DQ_FormatConsistency>
+         </gmd:report>
+      </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+</gmd:MD_Metadata>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -10,6 +10,9 @@
 	<xsl:include href="../iso19139/convert/thesaurus-transformation.xsl"/>
 
   <xsl:variable name="serviceUrl" select="/root/env/siteURL" />
+
+  <!-- We use the category check to find out if this is an SDS metadata. Please replace with anything better -->
+  <xsl:variable name="isSDS" select="count(//gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gmx:Anchor[starts-with(@xlink:href, 'http://inspire.ec.europa.eu/metadata-codelist/Category')]) = 1" />
   
 	<!-- ================================================================= -->
 
@@ -497,6 +500,20 @@
 			<xsl:with-param name="prefix" select="'gml'"/>
 		</xsl:call-template>
 	</xsl:template>
+
+<!-- ================================================================= -->
+        <!-- SDS fixes -->
+        
+        <!-- DCP codelist -->
+	<xsl:template match="srv:DCP[$isSDS]/srv:DCPList[@codeListValue]">
+		<xsl:copy>
+			<xsl:apply-templates select="@*"/>
+			<xsl:attribute name="codeList">
+				<xsl:value-of select="'http://inspire.ec.europa.eu/metadata-codelist/DCPList'"/>
+			</xsl:attribute>
+		</xsl:copy>
+	</xsl:template>
+
 
 <!-- ================================================================= -->
 	<!-- copy everything else as is -->

--- a/web-ui/src/main/resources/catalog/components/edit/crsselector/CRSSelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/crsselector/CRSSelector.js
@@ -31,6 +31,12 @@
              scope.snippetRef = gnEditor.
              buildXMLFieldName(scope.elementRef, scope.elementName);
 
+             // Replace the name attribute with id since this textarea is used only to store the template, we don't wanna submit it
+             var textarea = $.find("textarea[name="+scope.snippetRef+"]")[0];
+             var elemValue = $(textarea).attr('name');
+             $(textarea).removeAttr('name');
+             $(textarea).attr('id', elemValue);
+             
              scope.add = function() {
                gnEditor.add(gnCurrentEdit.id,
                scope.elementRef, scope.elementName, scope.domId, 'before');
@@ -52,9 +58,10 @@
              scope.$watch('filter', scope.search);
 
              scope.addCRS = function(crs) {
-               scope.snippet = gnEditorXMLService.buildCRSXML(
-               crs,
-               gnCurrentEdit.schema);
+
+               var textarea = $.find("textarea[id="+scope.snippetRef+"]")[0];
+               var xmlSnippet = textarea ? $(textarea).text() : undefined;
+               scope.snippet = gnEditorXMLService.buildCRSXML(crs, gnCurrentEdit.schema, xmlSnippet);
                scope.crsResults = [];
 
                $timeout(function() {

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorXMLService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorXMLService.js
@@ -44,7 +44,7 @@
           '       <gco:CharacterString>{{description}}</gco:CharacterString>' +
           '     </mcc:description>' +
           '   </mcc:MD_Identifier>' +
-          ' </mrs:referenceSystemIdentifier>'
+          ' </mrs:referenceSystemIdentifier>'  
     }});
 
   module.factory('gnEditorXMLService',
@@ -67,13 +67,12 @@
            * description, codeSpace and version properties of
            * the CRS.
            */
-           buildCRSXML: function(crs, schema) {
+           buildCRSXML: function(crs, schema, xmlSnippet) {
              var replacement = ['description', 'codeSpace',
                'authority', 'code', 'version'];
-             var xml = gnXmlTemplates.CRS[schema] ||
-             gnXmlTemplates.CRS['iso19139'];
+             var xml = xmlSnippet || gnXmlTemplates.CRS[schema] || gnXmlTemplates.CRS['iso19139'];
              angular.forEach(replacement, function(key) {
-               xml = xml.replace('{{' + key + '}}', crs[key]);
+               xml = xml.replace(new RegExp('{{' + key + '}}', 'g'), crs[key]);
              });
              return xml;
            },

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -73,6 +73,7 @@
     element of same kind. eg. do not display label. -->
     <xsl:param name="isFirst" required="no" as="xs:boolean" select="true()"/>
 
+    <xsl:param name="isReadOnly" required="no" as="xs:boolean" select="false()"/>
 
     <xsl:variable name="isMultilingual" select="count($value/values) > 0"/>
 
@@ -150,6 +151,7 @@
                     <xsl:with-param name="type" select="$type"/>
                     <xsl:with-param name="tooltip" select="$tooltip"/>
                     <xsl:with-param name="isRequired" select="$isRequired"/>
+                    <xsl:with-param name="isReadOnly" select="$isReadOnly"/>
                     <xsl:with-param name="isDisabled" select="$isDisabled"/>
                     <xsl:with-param name="editInfo" select="$editInfo"/>
                     <xsl:with-param name="parentEditInfo" select="$parentEditInfo"/>
@@ -190,6 +192,7 @@
                   <xsl:with-param name="tooltip" select="concat($schema, '|', name(.), '|', name(..), '|', $xpath)"/>
                   <xsl:with-param name="isRequired" select="$isRequired"/>
                   <xsl:with-param name="isDisabled" select="$isDisabled"/>
+                  <xsl:with-param name="isReadOnly" select="$isReadOnly"/>
                   <xsl:with-param name="editInfo" select="$editInfo"/>
                   <xsl:with-param name="parentEditInfo" select="$parentEditInfo"/>
                   <xsl:with-param name="listOfValues" select="$listOfValues"/>
@@ -745,6 +748,7 @@
     <xsl:param name="tooltip" required="no"/>
     <xsl:param name="isRequired"/>
     <xsl:param name="isDisabled"/>
+    <xsl:param name="isReadOnly"/>
     <xsl:param name="editInfo"/>
     <xsl:param name="parentEditInfo"/>
     <xsl:param name="checkDirective" select="$isRequired"/>
@@ -774,6 +778,9 @@
           </xsl:if>
           <xsl:if test="$isDisabled">
             <xsl:attribute name="disabled" select="'disabled'"/>
+          </xsl:if>
+          <xsl:if test="$isReadOnly">
+            <xsl:attribute name="readonly" select="'readonly'"/>
           </xsl:if>
           <xsl:if test="$tooltip">
             <xsl:attribute name="data-gn-field-tooltip" select="$tooltip"/>
@@ -908,6 +915,10 @@
             <xsl:if test="$isDisabled">
               <xsl:attribute name="disabled" select="'disabled'"/>
             </xsl:if>
+           <xsl:if test="$isReadOnly">
+              <xsl:attribute name="readonly" select="'readonly'"/>
+           </xsl:if>
+
             <xsl:if test="$lang">
               <xsl:attribute name="lang" select="$lang"/>
             </xsl:if>

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -265,6 +265,7 @@
           <xsl:variable name="name" select="@name"/>
           <xsl:variable name="del" select="@del"/>
           <xsl:variable name="template" select="template"/>
+          <xsl:variable name="forceLabel" select="@forceLabel"/>
           <xsl:for-each select="$nodes/*">
             <!-- Retrieve matching key values 
               Only text values are supported. Separator is #.
@@ -427,7 +428,7 @@
               <xsl:with-param name="template" select="$templateCombinedWithNode"/>
               <xsl:with-param name="keyValues" select="$keyValues"/>
               <xsl:with-param name="refToDelete" select="if ($refToDelete) then $refToDelete/gn:element else ''"/>
-              <xsl:with-param name="isFirst" select="position() = 1"/>
+              <xsl:with-param name="isFirst" select="$forceLabel or position() = 1"/>
             </xsl:call-template>
           </xsl:for-each>
           


### PR DESCRIPTION
As described in #1445, this PR adds a new tab for editing metadata fields related to the INSPIRE Spatial Data Services (SDS).

Furthermore some improvements to the form-configurator and form-builder have been added (check 
#1467).

_This PR comes from a squashed set of commits and replaces #1468_