### PR TITLE
Add .editorconfig for formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.java]
+indent_size = 4
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false


### PR DESCRIPTION
Most of IDE are supporting this .editorconfig file (http://editorconfig.org/). It does not modify existing files (unless we use reformat code action or some autoformat options are enabled) and only applies to new files.