### PR TITLE
Allow configure locale files in views

### DIFF
--- a/web-ui/src/main/resources/catalog/js/GnLocale.js
+++ b/web-ui/src/main/resources/catalog/js/GnLocale.js
@@ -40,6 +40,20 @@
         function buildUrl(prefix, lang, value, suffix) {
           if (value.indexOf('/') === 0) {
             return value.substring(1);
+          } else if (value.indexOf('|') > -1) {
+            /* Allows to configure locales for custom views,
+               providing the path and the locale type
+               separated by a |:
+
+             module.config(['$LOCALES', function($LOCALES) {
+              $LOCALES.push('../../catalog/views/sdi/locales/|search');
+             }]);
+
+             */
+            var localPrefix = value.split('|')[0];
+            var localValue = value.split('|')[1];
+            return localPrefix + gnLangs.getIso2Lang(lang)
+              + '-' + localValue + suffix;
           } else {
             return prefix + gnLangs.getIso2Lang(lang) + '-' + value + suffix;
           }


### PR DESCRIPTION
Enhancement of ```GnLocale``` to allow load translations defined in custom views while also loading the default GeoNetwork translations. 

Previously, the only way to add custom translations in a view was to modify the locale files from GeoNetwork, not optimal.

With this change, you can define in your view a snippet like this with the path and name of the locale name to load:

```
module.config(['$LOCALES', function($LOCALES) {
  $LOCALES.push('../../catalog/views/sdi/locales/|search');
}]);
```

Maybe there's a better way to do this, but this works and it's quite simple to setup.

@fxprunayre , @fgravin If you can review and merge it if looks fine would be great. Thanks.