### PR TITLE
Fix capabilities URL for OGC WxS harvesters

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -579,7 +579,23 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 			reg.name 	= layer.getChild ("name", wcs).getValue ();
 		} else if (params.ogctype.substring(0,3).equals("SOS")) {
 			Namespace gml = Namespace.getNamespace("http://www.opengis.net/gml");
-			reg.name 	= layer.getChild ("name", gml).getValue ();
+                        /*
+                         * SOS does not always provide a gml:name
+                         */
+                        if (layer.getChild ("name", gml) != null) {
+                            reg.name = layer.getChild ("name", gml).getValue ();
+                        }
+                        else if (layer.getAttribute("id", gml) != null) {
+                            reg.name = layer.getAttribute("id", gml).getValue();
+                        }
+                        else {
+                            /*
+                             * use the layers hash code to create a unique but reproducible name
+                             */
+                            log.warning("Could not derive layer name from " + layer);
+                            String generatedName = layer.getName() + "_" + layer.hashCode();
+                            reg.name = Sha1Encoder.encodeString(generatedName);
+                        }
 		}
 		
 		log.info ("  - Loading layer: " + reg.name);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -108,7 +108,7 @@ import javax.annotation.Nullable;
  * </ul>
  * 
  *  Note : Layer stands for "Layer" for WMS, "FeatureType" for WFS
- *  and "Coverage" for WCS.
+ *  and "Coverage" for WCS, and "ObservationOffering" for SOS.
  *  
  * <pre>  
  * <nodes>
@@ -580,7 +580,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 		} else if (params.ogctype.substring(0,3).equals("SOS")) {
 			Namespace gml = Namespace.getNamespace("http://www.opengis.net/gml");
                         /*
-                         * SOS does not always provide a gml:name
+                         * SOS does not always provide a gml:name in ObservationOffering
                          */
                         if (layer.getChild ("name", gml) != null) {
                             reg.name = layer.getChild ("name", gml).getValue ();

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -590,10 +590,11 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
                         }
                         else {
                             /*
-                             * use the layers hash code to create a unique but reproducible name
+                             * use the layers hash code to create a unique but reproducible name.
+                             * this is a fallback for services that do not provide a gml:id
                              */
                             log.warning("Could not derive layer name from " + layer);
-                            String generatedName = layer.getName() + "_" + layer.hashCode();
+                            String generatedName = layer.getName() + "_" + resolveLayerPosition(layer);
                             reg.name = Sha1Encoder.encodeString(generatedName);
                         }
 		}
@@ -809,6 +810,18 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 		return reg;
 	}
 	
+        
+        private String resolveLayerPosition(Element layer) {
+                Element parent = layer.getParentElement();
+                if (parent != null) {
+                    List<?> children = parent.getChildren();
+                    if (children != null) {
+                        return Integer.toString(children.indexOf(layer));
+                    }
+                }
+
+                return Integer.toString(layer.hashCode());
+        }
 
 	/** 
      * Call GeoNetwork service to load thumbnails and create small and 
@@ -1001,7 +1014,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
 	private static final String GETMAP = "GetMap";
     private static final String IMAGE_FORMAT = "image/png";
     private List<WxSLayerRegistry> layersRegistry = new ArrayList<WxSLayerRegistry>();
-	
+
 	private static class WxSLayerRegistry {
 		public String uuid;
 		public String id;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -816,7 +816,10 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
                 if (parent != null) {
                     List<?> children = parent.getChildren();
                     if (children != null) {
-                        return Integer.toString(children.indexOf(layer));
+                        int index = children.indexOf(layer);
+                        if (index >= 0) {
+                            return Integer.toString(index);
+                        }
                     }
                 }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -207,7 +207,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult>
         // Try to load capabilities document
 		this.capabilitiesUrl = getBaseUrl(params.url) +
         		"SERVICE=" + params.ogctype.substring(0,3) +
-        		"&VERSION=" + params.ogctype.substring(3) +
+        		"&ACCEPTVERSIONS=" + params.ogctype.substring(3) +
         		"&REQUEST=" + GETCAPABILITIES
         		;
 

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCSOSGetCapabilitiesLayer-to-19139.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCSOSGetCapabilitiesLayer-to-19139.xsl
@@ -58,7 +58,7 @@
 
 	<!-- ============================================================================= -->
 	
-	<xsl:template match="sos:Capabilities[//sos:ObservationOffering/gml:name=$Name]">
+	<xsl:template match="sos:Capabilities[//sos:ObservationOffering/gml:name=$Name | //sos:ObservationOffering/@gml:id=$Name]">
 
 		<MD_Metadata>
 


### PR DESCRIPTION
Hi,

@fxprunayre: I have migrated the fixes @nuest has created (https://github.com/geonetwork/core-geonetwork/pull/1351) to the develop branch. The layer name resolution fallback is now reproducible. I tried to write a unit test, but failed due to the high amount of depending references to contexts and schemas. Maybe you could consider splitting the `addLayerMetadata` method to allow fine-grained testing.

Find below the original description:

Simple fix to make GetCapabilities-URLs valid according to Common XML specification.

As discussed in this email thread [here](http://sourceforge.net/p/geonetwork/mailman/message/34461085/), the harvesting of strict OGC web services is broken in 2.10.x.

The GetCapabilities URL creation uses version, which is not a valid parameter in GetCapabilities. Service implementations (more concretely: the 52°North SOS) that throw an exception on invalid parameters cannot be harvested (try for example http://sosmet.nerc-bas.ac.uk:8080/sosmet/sos, example request: http://sosmet.nerc-bas.ac.uk:8080/sosmet/sos?service=SOS&request=GetCapabilities&version=1.0.0).
