### PR TITLE
if server supports CORS, then no use of proxy

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -30,8 +30,8 @@
 
   module.provider('gnOwsCapabilities', function() {
     this.$get = ['$http', '$q',
-      'gnUrlUtils', 'gnGlobalSettings',
-      function($http, $q, gnUrlUtils, gnGlobalSettings) {
+      'gnUrlUtils', 'gnGlobalSettings', 'gnViewerSettings',
+      function($http, $q, gnUrlUtils, gnGlobalSettings, viewerSettings) {
 
         var displayFileContent = function(data) {
           var parser = new ol.format.WMSCapabilities();
@@ -116,7 +116,7 @@
 
               //send request and decode result
               if (gnUrlUtils.isValid(url)) {
-                var proxyUrl = gnGlobalSettings.proxyUrl +
+                var proxyUrl = viewerSettings.hasCORS(url)?url:gnGlobalSettings.proxyUrl +
                     encodeURIComponent(url);
                 $http.get(proxyUrl, {
                   cache: true
@@ -146,7 +146,7 @@
 
               if (gnUrlUtils.isValid(url)) {
 
-                var proxyUrl = gnGlobalSettings.proxyUrl +
+                var proxyUrl = viewerSettings.hasCORS(url)?url:gnGlobalSettings.proxyUrl +
                     encodeURIComponent(url);
                 $http.get(proxyUrl, {
                   cache: true

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -50,6 +50,7 @@
     this.$injector = $injector;
     this.$http = this.$injector.get('$http');
     this.gnProxyUrl =  this.$injector.get('gnGlobalSettings').proxyUrl;
+    this.hasCORS =  this.$injector.get('gnViewerSettings').hasCORS;
 
     this.layer = config.layer;
     this.map = config.map;
@@ -65,7 +66,7 @@
   };
 
   geonetwork.GnFeaturesLoader.prototype.proxyfyUrl = function(url){
-    return this.gnProxyUrl + encodeURIComponent(url);
+    return this.hasCORS(url)?url:this.gnProxyUrl + encodeURIComponent(url);
   };
 
   /**

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsService.js
@@ -43,8 +43,9 @@
     'gnMap',
     'gnUrlUtils',
     'gnOwsCapabilities',
+    'gnViewerSettings',
     '$http',
-    function(gnMap, gnUrlUtils, gnOwsCapabilities, $http) {
+    function(gnMap, gnUrlUtils, gnOwsCapabilities, viewerSettings, $http) {
 
       /**
        * @ngdoc method
@@ -87,7 +88,7 @@
        */
       this.feedOlLayer = function(layer) {
         var url = this.getMetadataUrl(layer);
-        var proxyUrl = '../../proxy?url=' + encodeURIComponent(url);
+        var proxyUrl = viewerSettings.hasCORS?url:'../../proxy?url=' + encodeURIComponent(url);
 
         $http.get(proxyUrl)
             .success(function(json) {
@@ -255,7 +256,7 @@
         var url = gnUrlUtils.append(layer.getSource().getUrls(),
                   gnUrlUtils.toKeyValue(p));
 
-        var proxyUrl = '../../proxy?url=' + encodeURIComponent(url);
+        var proxyUrl = viewerSettings.hasCORS?url:'../../proxy?url=' + encodeURIComponent(url);
         return $http.get(proxyUrl);
       };
     }

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -236,7 +236,7 @@
       this.loadContextFromUrl = function(url, map) {
         var self = this;
         if (/^(f|ht)tps?:\/\//i.test(url)) {
-          url = gnGlobalSettings.proxyUrl + encodeURIComponent(url);
+          url = viewerSettings.hasCORS(url)?url:gnGlobalSettings.proxyUrl + encodeURIComponent(url);
         }
         $http.get(url).success(function(data) {
           self.loadContext(data, map);

--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/WfsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/WfsService.js
@@ -77,8 +77,9 @@
     'gnOwsCapabilities',
     'gnUrlUtils',
     'gnGlobalSettings',
+    'gnViewerSettings',
     '$q',
-    function($http, gnOwsCapabilities, gnUrlUtils, gnGlobalSettings, $q) {
+    function($http, gnOwsCapabilities, gnUrlUtils, gnGlobalSettings, viewerSettings, $q) {
 
       /**
        * Do a getCapabilies request to the url (service) given in parameter.
@@ -97,7 +98,7 @@
           });
 
           if (gnUrlUtils.isValid(url)) {
-            var proxyUrl = gnGlobalSettings.proxyUrl +
+            var proxyUrl = viewerSettings.hasCORS(url)?url:gnGlobalSettings.proxyUrl +
                 encodeURIComponent(url);
             $http.get(proxyUrl, {
               cache: true

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -203,7 +203,7 @@
                 return;
               }
 
-              var proxyUrl = '../../proxy?url=' + encodeURIComponent(url);
+              var proxyUrl = viewerSettings.hasCORS(url)?url:'../../proxy?url=' + encodeURIComponent(url);
               $http.get(proxyUrl).then(function(response) {
                 var kmlSource = new ol.source.Vector();
                 kmlSource.addFeatures(


### PR DESCRIPTION
Don't use geonetwork proxy when calling getcapabilities, getfeatureinfo etc...

In config.js a list of servers is defined that are known to support CORS. At each external ajax request the server is checked against this list to verify if use of a proxy is required

The code in this pull request works but is not fully tested, let's first discuss if this is a valid approach
A better approach would be to create a service which manages all $http.get, and while doing so checks if CORS is available or a proxy is required.
Also is it a good practice to introduce viewerSettings in all these services, or could this better be configured elsewhere