### PR TITLE
Fix use of string.startsWith for IE

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -44,7 +44,7 @@
           return {
             request: function(config) {
 
-              if (config.url.startsWith('http')) {
+              if (config.url.indexOf('http', 0) === 0) {
                 var url = config.url.split('/');
                 url = url[0] + '/' + url[1] + '/' + url[2] + '/';
 
@@ -66,14 +66,14 @@
               } else if (!config.status || config.status == -1) {
                 var defer = $q.defer();
 
-                if (config.url.startsWith('http')) {
+                if (config.url.indexOf('http', 0) === 0) {
                   var url = config.url.split('/');
                   url = url[0] + '/' + url[1] + '/' + url[2] + '/';
 
                   if ($.inArray(url, gnGlobalSettings.requireProxy) == -1) {
                     gnGlobalSettings.requireProxy.push(url);
                   }
-                  
+
                   $injector.invoke(['$http', function($http) {
                     // This modification prevents interception (infinite
                     // loop):


### PR DESCRIPTION
Internet Explorer's strings doesn't implement the `startsWith` method. In this PR calls to startsWith have been replaced by `.indexOf('textToSearch', 0) === 0`.