### PR TITLE
Improve UX of topconcept for hierarchical thesaursus (#278)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-concept.html
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-concept.html
@@ -58,21 +58,19 @@
         <li ng-repeat="c in broader"
             data-ng-mouseover="initConceptNavigationHelp(c)">
           <a class="skos-btn-icons btn-small btn-link"
-             ng-click="navigateConcept(c)">
-            <i class="fa fa-circle-o "
-               title="{{'makeConceptCurrent' | translate}}"></i>
+             ng-click="addConcept(c)">
+            <i class="fa fa-plus-circle"
+               title="{{'addConcept' | translate}}"></i>
           </a>&nbsp;
           <a class="btn-small btn-link"
-             ng-click="addConcept(c)"
+             ng-click="navigateConcept(c)"
              ng-mouseenter="c.over = true"
              ng-mouseleave="c.over = false">
 
             <i title="{{c.help.broader}}"></i>
                     <span skos-label="c"
                           lang="{{mainLanguage}}"
-                          title="{{'addConcept' | translate}}"></span>
-            <i class="fa fa-plus-circle"
-               data-ng-class="{'invisible': !c.over}"></i>
+                          title="{{'makeConceptCurrent' | translate}}"></span>
           </a>
         </li>
       </ul>
@@ -84,20 +82,18 @@
         <li ng-repeat="c in narrower"
             data-ng-mouseover="initConceptNavigationHelp(c)">
           <a class="skos-btn-icons btn-small btn-link "
-             ng-click="navigateConcept(c)">
-            <i class="fa fa-circle-o "
-               title="{{'makeConceptCurrent' | translate}}"></i>
+             ng-click="addConcept(c)">
+            <i class="fa fa-plus-circle"
+               title="{{'addConcept' | translate}}"></i>
           </a>&nbsp;
           <a class="btn-small btn-link"
-             ng-click="addConcept(c)"
+             ng-click="navigateConcept(c)"
              ng-mouseenter="c.over = true"
              ng-mouseleave="c.over = false">
 
             <i title="{{c.help.narrower}}"></i>
                     <span skos-label="c" lang="{{mainLanguage}}"
-                          title="{{'addConcept' | translate}}"></span>
-            <i class="fa fa-plus-circle"
-               data-ng-class="{'invisible': !c.over}"></i>
+                          title="{{'makeConceptCurrent' | translate}}"></span>
           </a>
         </li>
       </ul>
@@ -109,19 +105,17 @@
         <li ng-repeat="c in related"
             data-ng-mouseover="initConceptNavigationHelp(c)">
           <a class="skos-btn-icons btn-small btn-link"
-             ng-click="navigateConcept(c)">
-            <i class="fa fa-circle-o "
-               title="{{'makeConceptCurrent' | translate}}"></i>
+             ng-click="addConcept(c)">
+            <i class="fa fa-plus-circle"
+               title="{{'addConcept' | translate}}"></i>
           </a>&nbsp;
           <a class="btn-small btn-link"
-             ng-click="addConcept(c)"
+             ng-click="navigateConcept(c)"
              ng-mouseenter="c.over = true"
              ng-mouseleave="c.over = false">
             <i title="{{c.help.related}}"></i>
                     <span skos-label="c" lang="{{mainLanguage}}"
-                          title="{{'addConcept' | translate}}"></span>
-            <i class="fa fa-plus-circle"
-               data-ng-class="{'invisible': !c.over}"></i>
+                          title="{{'makeConceptCurrent' | translate}}"></span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
To add the concept to the keywords, the user hits on the "plus" icon.
To make the concept the current concept, the user hits on the concept's name

![capture1](https://cloud.githubusercontent.com/assets/576292/16684787/38314dc4-4507-11e6-8317-4dae3dc15b81.PNG)
