### PR TITLE
Add schema.org tags in xsl formatter.

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
@@ -52,6 +52,10 @@
     <xsl:value-of select="dc:title"/>
   </xsl:template>
 
+  <xsl:template mode="getMetadataHierarchyLevel" match="simpledc">
+    <xsl:value-of select="'dataset'"/>
+  </xsl:template>
+
   <xsl:template mode="getMetadataAbstract" match="simpledc">
     <xsl:value-of select="dc:description"/>
   </xsl:template>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -78,6 +78,10 @@
     <xsl:value-of select="$value/gco:CharacterString"/>
   </xsl:template>
 
+  <xsl:template mode="getMetadataHierarchyLevel" match="gmd:MD_Metadata">
+    <xsl:value-of select="gmd:hierarchyLevel/gmd:MD_ScopeCode/@codeListValue"/>
+  </xsl:template>
+
   <xsl:template mode="getMetadataHeader" match="gmd:MD_Metadata">
   </xsl:template>
 
@@ -193,7 +197,9 @@
       </h3>
       <div class="row">
         <div class="col-md-6">
-          <address>
+          <address itemprop="author"
+                   itemscope="itemscope"
+                   itemtype="http://schema.org/Organization">
             <strong>
               <xsl:choose>
                 <xsl:when test="$email">
@@ -208,10 +214,36 @@
             </strong>
             <br/>
             <xsl:for-each select="*/gmd:contactInfo/*">
-              <xsl:for-each select="gmd:address/*/(
-                                          gmd:deliveryPoint|gmd:city|
-                                          gmd:administrativeArea|gmd:postalCode|gmd:country)">
-                <xsl:apply-templates mode="render-value" select="."/>
+              <xsl:for-each select="gmd:address/*">
+                <div itemprop="address"
+                      itemscope="itemscope"
+                      itemtype="http://schema.org/PostalAddress">
+                  <xsl:for-each select="gmd:deliveryPoint">
+                    <span itemprop="streetAddress">
+                      <xsl:apply-templates mode="render-value" select="."/>
+                    </span>
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:city">
+                    <span itemprop="addressLocality">
+                      <xsl:apply-templates mode="render-value" select="."/>
+                    </span>
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:administrativeArea">
+                    <span itemprop="addressRegion">
+                      <xsl:apply-templates mode="render-value" select="."/>
+                    </span>
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:postalCode">
+                    <span itemprop="postalCode">
+                      <xsl:apply-templates mode="render-value" select="."/>
+                    </span>
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:country">
+                    <span itemprop="addressCountry">
+                      <xsl:apply-templates mode="render-value" select="."/>
+                    </span>
+                  </xsl:for-each>
+                </div>
                 <br/>
               </xsl:for-each>
             </xsl:for-each>
@@ -221,13 +253,20 @@
           <address>
             <xsl:for-each select="*/gmd:contactInfo/*">
               <xsl:for-each select="gmd:phone/*/gmd:voice[normalize-space(.) != '']">
-                <xsl:variable name="phoneNumber">
-                  <xsl:apply-templates mode="render-value" select="."/>
-                </xsl:variable>
-                <i class="fa fa-phone"></i>
-                <a href="tel:{$phoneNumber}">
-                  <xsl:value-of select="$phoneNumber"/>
-                </a>
+                <div itemprop="contactPoint"
+                      itemscope="itemscope"
+                      itemtype="http://schema.org/ContactPoint">
+                  <meta itemprop="contactType"
+                        content="{ancestor::gmd:CI_ResponsibleParty/*/gmd:role/*/@codeListValue}"/>
+
+                  <xsl:variable name="phoneNumber">
+                    <xsl:apply-templates mode="render-value" select="."/>
+                  </xsl:variable>
+                  <i class="fa fa-phone"></i>
+                  <a href="tel:{$phoneNumber}">
+                    <xsl:value-of select="$phoneNumber"/>
+                  </a>
+                </div>
               </xsl:for-each>
               <xsl:for-each select="gmd:phone/*/gmd:facsimile[normalize-space(.) != '']">
                 <xsl:variable name="phoneNumber">
@@ -239,8 +278,17 @@
                 </a>
               </xsl:for-each>
 
+              <xsl:for-each select="gmd:hoursOfService">
+                <span itemprop="hoursAvailable"
+                      itemscope="itemscope"
+                      itemtype="http://schema.org/OpeningHoursSpecification">
+                  <xsl:apply-templates mode="render-field"
+                                       select="."/>
+                </span>
+              </xsl:for-each>
+
               <xsl:apply-templates mode="render-field"
-                                   select="gmd:hoursOfService|gmd:contactInstructions"/>
+                                   select="gmd:contactInstructions"/>
               <xsl:apply-templates mode="render-field"
                                    select="gmd:onlineResource"/>
 
@@ -275,7 +323,10 @@
   <xsl:template mode="render-field"
                 match="*[gmd:CI_OnlineResource and */gmd:linkage/gmd:URL != '']"
                 priority="100">
-    <dl class="gn-link">
+    <dl class="gn-link"
+        itemprop="distribution"
+        itemscope="itemscope"
+        itemtype="http://schema.org/DataDownload">
       <dt>
         <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
       </dt>

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
@@ -66,6 +66,13 @@ public class XsltFormatter implements FormatterImpl {
 
         root.addContent(new Element("lang").setText(fparams.context.getLanguage()));
         root.addContent(new Element("url").setText(fparams.url));
+        // FIXME: This is a hack to mimic what Jeeves service are doing.
+        // Some XSLT are used by both formatters and Jeeves and Spring MVC services
+        Element gui = new Element("gui");
+        gui.addContent(new Element("url").setText(fparams.url + "../.."));
+        gui.addContent(new Element("reqService").setText("md.format.html"));
+        root.addContent(gui);
+
         root.addContent(new Element("locUrl").setText(fparams.getLocUrl()));
 
         root.addContent(new Element("resourceUrl").setText(fparams.getResourceUrl()));

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -187,17 +187,9 @@
             // defaultUrl: 'md.format.xml?xsl=xsl-view&uuid=',
             // defaultPdfUrl: 'md.format.pdf?xsl=full_view&uuid=',
             list: [{
-            //  label: 'inspire',
-            //  url: 'md.format.xml?xsl=xsl-view' + '&view=inspire&id='
-            //}, {
-            //  label: 'full',
-            //  url: 'md.format.xml?xsl=xsl-view&view=advanced&id='
-            //}, {
               label: 'full',
-              // url: 'md.format.xml?xsl=full_view&uuid='
-              // You can use a function to choose formatter
               url : function(md) {
-                return '../api/records/' + md.getUuid();
+                return '../api/records/' + md.getUuid() + '/formatters/xsl-view?root=div&view=advanced';
               }
             }]
           };

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -6,6 +6,35 @@
                 version="2.0"
                 exclude-result-prefixes="#all">
 
+  <!-- Convert a hierarchy level into corresponding
+  schema.org class. If no match, return http://schema.org/Thing
+   -->
+  <xsl:function name="gn-fn-render:get-schema-org-class" as="xs:string">
+    <xsl:param name="type" as="xs:string"/>
+
+    <xsl:variable name="map">
+      <entry key="dataset" value="http://schema.org/Dataset"/>
+      <entry key="series" value="http://schema.org/DataCatalog"/>
+      <entry key="service" value="http://schema.org/DataCatalog"/>
+      <entry key="application" value="http://schema.org/SoftwareApplication"/>
+      <entry key="collectionHardware" value="http://schema.org/Thing"/>
+      <entry key="nonGeographicDataset" value="http://schema.org/Dataset"/>
+      <entry key="dimensionGroup" value="http://schema.org/Dataset"/>
+      <entry key="featureType" value="http://schema.org/Dataset"/>
+      <entry key="model" value="http://schema.org/APIReference"/>
+      <entry key="tile" value="http://schema.org/Dataset"/>
+      <entry key="fieldSession" value="http://schema.org/Thing"/>
+      <entry key="collectionSession" value="http://schema.org/Thing"/>
+    </xsl:variable>
+
+    <xsl:message>aa<xsl:value-of select="$type"/> </xsl:message>
+    <xsl:message>aa<xsl:value-of select="$map/entry"/> </xsl:message>
+    <xsl:variable name="match"
+                  select="$map/entry[@key = $type]/@value"/>
+    <xsl:value-of select="if ($match != '')
+                          then $match
+                          else 'http://schema.org/Thing'"/>
+  </xsl:function>
 
   <xsl:function name="gn-fn-render:get-schema-strings" as="xs:string">
     <xsl:param name="strings" as="node()"/>
@@ -35,8 +64,13 @@
                   $east, ' ', $south, '))')"/>
     <xsl:variable name="numberFormat" select="'0.00'"/>
 
-    <div class="thumbnail extent">
-      <span>
+    <div class="thumbnail extent"
+         itemprop="spatial"
+         itemscope="itemscope"
+         itemtype="http://schema.org/Place">
+      <span itemprop="geo"
+            itemscope="itemscope"
+            itemtype="http://schema.org/geoShape">
         <div class="input-group coord coord-north">
           <input type="text" class="form-control"
                  value="{format-number($north, $numberFormat)}" readonly=""/>
@@ -57,6 +91,9 @@
                  value="{format-number($west, $numberFormat)}" readonly=""/>
           <span class="input-group-addon">W</span>
         </div>
+        <meta itemprop="box"
+              content="{$south},{$east} {$north},{$west}"/>
+
       </span>
       <xsl:copy-of select="gn-fn-render:geometry($boxGeometry)"/>
     </div>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -27,8 +27,6 @@
       <entry key="collectionSession" value="http://schema.org/Thing"/>
     </xsl:variable>
 
-    <xsl:message>aa<xsl:value-of select="$type"/> </xsl:message>
-    <xsl:message>aa<xsl:value-of select="$map/entry"/> </xsl:message>
     <xsl:variable name="match"
                   select="$map/entry[@key = $type]/@value"/>
     <xsl:value-of select="if ($match != '')

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -6,6 +6,7 @@
                 exclude-result-prefixes="#all"
                 version="2.0">
 
+  <xsl:import href="common/render-html.xsl"/>
   <xsl:import href="render-variables.xsl"/>
   <xsl:import href="render-functions.xsl"/>
   <xsl:import href="render-layout-fields.xsl"/>
@@ -13,14 +14,43 @@
   <!-- Those templates should be overriden in the schema plugin - start -->
   <xsl:template mode="getMetadataTitle" match="undefined"/>
   <xsl:template mode="getMetadataAbstract" match="undefined"/>
+  <xsl:template mode="getMetadataHierarchyLevel" match="undefined"/>
   <xsl:template mode="getMetadataHeader" match="undefined"/>
   <!-- Those templates should be overriden in the schema plugin - end -->
 
   <!-- Starting point -->
   <xsl:template match="/">
+    <xsl:choose>
+      <xsl:when test="$root = 'div'">
+        <!-- Render only a DIV with the record details -->
+        <xsl:call-template name="render-record"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- Render complete HTML page -->
+        <xsl:call-template name="render-html">
+          <xsl:with-param name="content">
+            <xsl:call-template name="render-record"/>
+          </xsl:with-param>
+          <xsl:with-param name="title">
+            <xsl:apply-templates mode="getMetadataTitle" select="$metadata"/>
+          </xsl:with-param>
+          <xsl:with-param name="description">
+            <xsl:apply-templates mode="getMetadataAbstract" select="$metadata"/>
+          </xsl:with-param>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="render-record">
     <div class="container gn-metadata-view">
 
-      <article id="gn-metadata-view-{$metadataId}">
+      <xsl:variable name="type">
+        <xsl:apply-templates mode="getMetadataHierarchyLevel" select="$metadata"/>
+      </xsl:variable>
+      <article id="gn-metadata-view-{$metadataId}"
+               itemscope="itemscope"
+               itemtype="{gn-fn-render:get-schema-org-class($type)}">
         <header>
           <h1>
             <xsl:apply-templates mode="getMetadataTitle" select="$metadata"/>
@@ -44,6 +74,8 @@
       </article>
     </div>
   </xsl:template>
+
+
 
 
   <!-- Render list of tabs in the current view -->

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
@@ -5,6 +5,10 @@
   <!-- All URL parameters could be available as params -->
   <xsl:param name="view" select="'default'"/>
 
+  <!-- Formatter will render a full HTML page. If not set,
+  then it will render an HTML DIV only. -->
+  <xsl:param name="root" select="'html'"/>
+
   <!-- TODO: schema is not part of the XML -->
   <xsl:variable name="schema"
                 select="/root/info/record/datainfo/schemaid"/>

--- a/web/src/main/webapp/WEB-INF/oasis-catalog.xml
+++ b/web/src/main/webapp/WEB-INF/oasis-catalog.xml
@@ -57,6 +57,9 @@
   <uri name="../../../xsl/utils-fn.xsl"
        uri="../xsl/utils-fn.xsl"/>
 
+  <uri name="common/render-html.xsl"
+       uri="../xslt/common/render-html.xsl"/>
+
   <uri name="common/functions-core.xsl"
        uri="../xslt/common/functions-core.xsl"/>
 

--- a/web/src/main/webapp/xslt/base-layout-nojs.xsl
+++ b/web/src/main/webapp/xslt/base-layout-nojs.xsl
@@ -34,48 +34,16 @@
               encoding="UTF-8"/>
 
   <xsl:include href="common/base-variables.xsl"/>
-  <xsl:include href="skin/default/skin.xsl"/>
-  <xsl:include href="base-layout-cssjs-loader.xsl"/>
+  <xsl:include href="common/render-html.xsl"/>
 
   <xsl:template match="/">
-    <html>
-      <head>
-        <title><!-- todo: md title / md desc / md keywords -->
-          <xsl:value-of select="concat($env/system/site/name, ' - ', $env/system/site/organization)"
-          />
-        </title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
-        <meta name="apple-mobile-web-app-capable" content="yes"/>
-
-        <meta name="description" content=""/>
-        <meta name="keywords" content=""/>
-
-
-        <link rel="icon" sizes="16x16 32x32 48x48" type="image/png"
-              href="../../images/logos/favicon.png"/>
-        <link href="rss.search?sortBy=changeDate" rel="alternate" type="application/rss+xml"
-              title="{concat($env/system/site/name, ' - ', $env/system/site/organization)}"/>
-        <link href="portal.opensearch" rel="search" type="application/opensearchdescription+xml"
-              title="{concat($env/system/site/name, ' - ', $env/system/site/organization)}"/>
-
-        <xsl:call-template name="css-load"/>
-      </head>
-
-
-      <!-- The GnCatController takes care of
-      loading site information, check user login state
-      and a facet search to get main site information.
-      -->
-      <body>
-        <div class="gn-full">
-          <xsl:call-template name="header"/>
-          <xsl:apply-templates mode="content" select="."/>
-          <xsl:call-template name="footer"/>
-        </div>
-      </body>
-    </html>
+    <xsl:call-template name="render-html">
+      <xsl:with-param name="title"
+                      select="concat($env/system/site/name, ' - ', $env/system/site/organization)"/>
+      <xsl:with-param name="content">
+        <xsl:apply-templates mode="content" select="."/>
+      </xsl:with-param>
+    </xsl:call-template>
   </xsl:template>
-
 
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="2.0"
+                exclude-result-prefixes="#all">
+
+  <xsl:output omit-xml-declaration="yes" method="html" doctype-system="html" indent="yes"
+              encoding="UTF-8"/>
+
+  <xsl:include href="../base-layout-cssjs-loader.xsl"/>
+  <xsl:include href="../skin/default/skin.xsl"/>
+
+  <xsl:template name="render-html">
+    <xsl:param name="content"/>
+    <xsl:param name="title"
+               select="''"/>
+    <xsl:param name="description"
+               select="''"/>
+
+    <html>
+      <head>
+        <title><xsl:value-of select="$title"/></title>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
+        <meta name="apple-mobile-web-app-capable" content="yes"/>
+
+        <meta name="description" content="{normalize-space($description)}"/>
+        <meta name="keywords" content=""/>
+
+
+        <link rel="icon" sizes="16x16 32x32 48x48" type="image/png"
+              href="../../images/logos/favicon.png"/>
+        <link href="rss.search?sortBy=changeDate"
+              rel="alternate"
+              type="application/rss+xml"
+              title="{$title}"/>
+        <link href="portal.opensearch"
+              rel="search"
+              type="application/opensearchdescription+xml"
+              title="{$title}"/>
+
+        <xsl:call-template name="css-load"/>
+      </head>
+
+      <body>
+        <div class="gn-full">
+          <xsl:call-template name="header"/>
+          <xsl:copy-of select="$content"/>
+          <xsl:call-template name="footer"/>
+        </div>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/web/src/main/webapp/xslt/skin/default/skin.xsl
+++ b/web/src/main/webapp/xslt/skin/default/skin.xsl
@@ -7,14 +7,13 @@
                 version="2.0"
                 exclude-result-prefixes="#all">
 
-
   <xsl:template name="header">
-
     <div class="navbar navbar-default gn-top-bar ng-scope" role="navigation">
       <div class="container-fluid ng-scope">
         <div class="navbar-header">
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
                   data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+            <!-- FIXME: i18n -->
             <span class="sr-only">Toggle navigation</span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
@@ -25,14 +24,16 @@
           <ul class="nav navbar-nav">
             <li class="active">
               <a href=".">
+                <!-- FIXME: Should point to catalog logo -->
                 <img class="gn-logo"
-                     src="../../images/harvesting/GN3.png"/>
+                     src="{/root/gui/url}/images/harvesting/GN3.png"/>&#160;
+                <!-- FIXME: Replace by node name -->
                 <span class="visible-lg ng-binding">GeoNetwork</span>
               </a>
             </li>
             <li>
               <a title="Search" href=".">
-                <i class="fa fa-search"></i>
+                <i class="fa fa-search"></i>&#160;
                 <span class="visible-lg ng-scope">Search</span>
               </a>
             </li>

--- a/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
+++ b/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
@@ -33,8 +33,12 @@
       <div class="col-md-push-3 col-md-6">
         <form action="catalog.search.nojs" class="form-inline">
           <div class="form-group">
-            <input type="text" name="any" id="fldAny"
-                   class="form-control input-large gn-search-text" autofocus=""/>
+            <input type="text"
+                   name="any"
+                   id="fldAny"
+                   value="{/root/request/any}"
+                   class="form-control input-large gn-search-text"
+                   autofocus=""/>
           </div>
           <div class="form-group">
             <input type="submit" class="btn btn-primary" value="Search"/>


### PR DESCRIPTION
This is a replacer for https://github.com/geonetwork/core-geonetwork/pull/1511

It does not create a new formatter but instead improve the existing XSL formatter based on editor-config.xsl for rendering a record. The formatter now provide schema.org tags.

eg.
* get record as full HTML page
http://localhost:8080/geonetwork/srv/api/records/da165110-88fd-11da-a88f-000d939bc5d8/formatters/xsl-view
* get record as a DIV snippet to be emebedded in a page (eg. Angular app)
http://localhost:8080/geonetwork/srv/api/records/da165110-88fd-11da-a88f-000d939bc5d8/formatters/xsl-view?root=div&view=advanced

The formatter is also bind to the nojs XSL template for header and footer to make layout more similar in all HTML pages.

@pvgenuchten , if you could have a look before merging that would be good, I tried to pick up all the changes made in #1511 but would be good to have a double check ? I also added some FIXME to be addressed later. It would be good if someone can improve the CSS of the XSL formatter so we provide a good default - like the one you show me in Bolsena with a map on top (@MichelGabriel maybe ?)