### PR TITLE
Stop some threads when the webapp is stopped

### DIFF
--- a/core/src/main/java/jeeves/monitor/MonitorManager.java
+++ b/core/src/main/java/jeeves/monitor/MonitorManager.java
@@ -36,6 +36,7 @@ import org.fao.geonet.utils.Log;
 import org.jdom.Element;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PreDestroy;
 import javax.servlet.ServletContext;
 
 import java.util.HashMap;
@@ -297,7 +298,9 @@ public class MonitorManager {
         return resourceTracker;
     }
 
+    @PreDestroy
     public void shutdown() {
+        Log.info(Log.ENGINE, "MonitorManager#shutdown");
         if (resourceTracker != null) {
             resourceTracker.clean();
         }

--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -526,18 +526,8 @@ public class JeevesEngine {
         try {
             info("=== Stopping system ========================================");
 
-            info("Shutting down monitor manager...");
-            ApplicationContext app = ApplicationContextHolder.get();
-            if (app != null) {
-                MonitorManager m = app.getBean(MonitorManager.class);
-                if (m != null) {
-                    m.shutdown();
-                } else {
-                    error("Unable to get MonitorManager bean (already destroyed ?)");
-                }
-            } else {
-                error("Unable to get a hook on the ApplicationContext.");
-            }
+            // The monitor manager will be stopped by the ApplicationContextHolder when it is closed
+
             info("Stopping handlers...");
             stopHandlers();
 

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/OaiPmhDispatcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/OaiPmhDispatcher.java
@@ -37,6 +37,7 @@ import org.fao.geonet.kernel.oaipmh.services.ListRecords;
 import org.fao.geonet.kernel.oaipmh.services.ListSets;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.fao.oaipmh.exceptions.BadArgumentException;
 import org.fao.oaipmh.exceptions.OaiPmhException;
@@ -46,6 +47,7 @@ import org.fao.oaipmh.server.OaiPmhFactory;
 import org.fao.oaipmh.util.Lib;
 import org.jdom.Element;
 
+import javax.annotation.PreDestroy;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,6 +58,7 @@ public class OaiPmhDispatcher {
 
     public static final int MODE_MODIFIDATE = 2;
     public static final int MODE_TEMPEXTEND = 1;
+    private ResumptionTokenCache cache;
 
     //---------------------------------------------------------------------------
     //---
@@ -67,7 +70,7 @@ public class OaiPmhDispatcher {
     //---------------------------------------------------------------------------
 
     public OaiPmhDispatcher(SettingManager sm, SchemaManager scm) {
-        ResumptionTokenCache cache = new ResumptionTokenCache(sm);
+        cache = new ResumptionTokenCache(sm);
 
         register(new GetRecord());
         register(new Identify());
@@ -151,6 +154,13 @@ public class OaiPmhDispatcher {
         } catch (Exception e) {
             context.warning("OAI-PMH response does not validate : " + e.getMessage());
         }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        Log.info(Log.ENGINE, "OaiPmhDispatcher#shutdown");
+        cache.stopRunning();
+        cache = null;
     }
 }
 

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/ResumptionTokenCache.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/ResumptionTokenCache.java
@@ -41,7 +41,8 @@ public class ResumptionTokenCache extends Thread {
     public final static int CACHE_EXPUNGE_DELAY = 10 * 1000; // 10 seconds
 
     private Map<String, GeonetworkResumptionToken> map;
-    private boolean running = true;
+    private static Object stopper = new Object();
+    private volatile boolean running = true;
     private SettingManager settingMan;
 
     /**
@@ -93,15 +94,19 @@ public class ResumptionTokenCache extends Thread {
     }
 
     public void run() {
-
-        while (running && !isInterrupted()) {
-            try {
-                Thread.sleep(CACHE_EXPUNGE_DELAY);
-                expunge();
-            } catch (java.lang.InterruptedException ie) {
-                ie.printStackTrace();
+        synchronized (stopper) {
+            while (running && !isInterrupted()) {
+                try {
+                    stopper.wait(CACHE_EXPUNGE_DELAY);
+                    if (running) {
+                        expunge();
+                    }
+                } catch (java.lang.InterruptedException ie) {
+                    ie.printStackTrace();
+                }
             }
         }
+        Log.info(Geonet.OAI_HARVESTER, "ResumptionTokenCache thread end");
     }
 
     private synchronized void expunge() {
@@ -158,7 +163,15 @@ public class ResumptionTokenCache extends Thread {
     }
 
     public void stopRunning() {
-        this.running = false;
+        synchronized (stopper) {
+            this.running = false;
+            stopper.notify();
+        }
+        try {
+            this.join();
+            Log.info(Geonet.OAI_HARVESTER, "ResumptionTokenCache thread stopped");
+        } catch (InterruptedException ignored) {
+        }
     }
 
 }

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneOptimizerManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneOptimizerManager.java
@@ -94,6 +94,14 @@ public class LuceneOptimizerManager {
 
     }
 
+    public void shutdown() {
+        try {
+            scheduler.shutdown(true);
+        } catch (SchedulerException e) {
+            Log.warning(Geonet.INDEX_ENGINE, "Error stopping the scheduler", e);
+        }
+    }
+
     public void reschedule(Calendar beginAt, int interval) throws SchedulerException {
         if (_dateFormat.format(beginAt.getTime()).equals(_dateFormat.format(_beginAt.getTime())) &&
             (interval == _intervalInMinutes)) {

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -558,19 +558,10 @@ public class SearchManager {
 
     @PreDestroy
     public void end() throws Exception {
-        ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
-        if (applicationContext != null) {
-            LuceneIndexLanguageTracker tracker = applicationContext.getBean(LuceneIndexLanguageTracker.class);
-            if (tracker != null) {
-                tracker.close(TimeUnit.MINUTES.toMillis(1), true);
-            } else {
-                Log.error(Geonet.SEARCH_ENGINE, "Unable to get a hook on the LuceneIndexLanguageTracker bean (already destroyed ?");
-            }
-        } else {
-            Log.error(Geonet.SEARCH_ENGINE, "Unable to get a hook on the application context (already destroyed ?).");
-        }
+        // the tracker is closed when the ApplicationContext is closed.
+
         _spatial.end();
-        _luceneOptimizerManager.cancel();
+        _luceneOptimizerManager.shutdown();
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialIndexWriter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialIndexWriter.java
@@ -289,7 +289,7 @@ public class SpatialIndexWriter implements FeatureListener {
             _transaction.close();
             _index = null;
             _featureStore.setTransaction(Transaction.AUTO_COMMIT);
-            SpatialFilter.getJCSCache().clear();
+            // Done by JCSServletContextListener: SpatialFilter.getJCSCache().clear();
         } catch (Exception e) {
             e.printStackTrace();
         } finally {

--- a/core/src/main/java/org/fao/geonet/util/ThreadPool.java
+++ b/core/src/main/java/org/fao/geonet/util/ThreadPool.java
@@ -83,7 +83,20 @@ public class ThreadPool {
 
     @PreDestroy
     public void shutDown() {
+        Log.info(Geonet.THREADPOOL, "Stopping the ThreadPool");
         threadPool.shutdown();
+        try {
+            threadPool.awaitTermination(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Log.warning(Geonet.THREADPOOL, "Error while stopping threadPool", e);
+        }
+        timer.shutdown();
+        try {
+            timer.awaitTermination(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Log.warning(Geonet.THREADPOOL, "Error while stopping threadPool", e);
+        }
+        Log.info(Geonet.THREADPOOL, "Stopped the ThreadPool");
     }
 
     public String toString() {

--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -25,10 +25,12 @@
 <beans
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.springframework.org/schema/beans"
+  xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
     ">
-
+  <context:annotation-config/>
   <bean id="ProfileManager" class="jeeves.component.ProfileManager" lazy-init="true"/>
   <bean id="MonitorManager" class="jeeves.monitor.MonitorManager" lazy-init="true"/>
   <bean id="JeevesEngine" class="jeeves.server.JeevesEngine" lazy-init="true"/>

--- a/domain/src/main/java/org/fao/geonet/domain/SpringScheduledThreadPoolExecutor.java
+++ b/domain/src/main/java/org/fao/geonet/domain/SpringScheduledThreadPoolExecutor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.domain;
+
+import org.fao.geonet.utils.Log;
+
+import javax.annotation.PreDestroy;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Just add a blocking stop method to be able to bloc until the threads are stopped.
+ */
+public class SpringScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
+    public SpringScheduledThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory) {
+        super(corePoolSize, threadFactory);
+    }
+
+    @PreDestroy
+    public void stop() {
+        Log.info(Log.RESOURCES, "Stopping the ScheduledThreadPoolExecutor");
+        shutdown();
+        try {
+            awaitTermination(60, TimeUnit.SECONDS);
+            Log.info(Log.RESOURCES, "Stopped the ScheduledThreadPoolExecutor");
+        } catch (InterruptedException e) {
+            Log.warning(Log.RESOURCES, "Error stopping the ScheduledThreadPoolExecutor", e);
+        }
+    }
+}

--- a/domain/src/main/resources/config-spring-geonetwork-parent.xml
+++ b/domain/src/main/resources/config-spring-geonetwork-parent.xml
@@ -28,11 +28,13 @@
   xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
     ">
-  <bean id="timerThreadPool" class="java.util.concurrent.ScheduledThreadPoolExecutor">
+  <bean id="timerThreadPool" class="org.fao.geonet.domain.SpringScheduledThreadPoolExecutor">
     <constructor-arg value="2"/>
     <constructor-arg>
       <bean class="org.fao.geonet.utils.TimerThreadFactory"/>
     </constructor-arg>
+    <property name="executeExistingDelayedTasksAfterShutdownPolicy" value="false"/>
+    <property name="continueExistingPeriodicTasksAfterShutdownPolicy" value="false"/>
   </bean>
 
 </beans>

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -174,7 +174,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
      * TODO Javadoc.
      */
     public static void shutdownScheduler() throws SchedulerException {
-        getScheduler().shutdown(false);
+        getScheduler().shutdown(true);
     }
 
     /**

--- a/healthmonitor/src/main/java/org/fao/geonet/monitor/webapp/MetricsRegistryInitializerFilter.java
+++ b/healthmonitor/src/main/java/org/fao/geonet/monitor/webapp/MetricsRegistryInitializerFilter.java
@@ -27,6 +27,7 @@ import com.yammer.metrics.core.HealthCheckRegistry;
 import com.yammer.metrics.core.MetricsRegistry;
 
 import jeeves.monitor.MonitorManager;
+import org.fao.geonet.utils.Log;
 
 import javax.servlet.*;
 
@@ -39,6 +40,8 @@ import java.io.IOException;
  * User: jeichar Date: 4/17/12 Time: 5:32 PM
  */
 public class MetricsRegistryInitializerFilter implements Filter {
+    private MetricsRegistry metricsRegistry;
+
     public void init(FilterConfig filterConfig) throws ServletException {
         ServletContext context = filterConfig.getServletContext();
         context.setAttribute(MonitorManager.HEALTH_CHECK_REGISTRY, new HealthCheckRegistry());
@@ -46,7 +49,7 @@ public class MetricsRegistryInitializerFilter implements Filter {
         context.setAttribute(MonitorManager.WARNING_HEALTH_CHECK_REGISTRY, new HealthCheckRegistry());
         context.setAttribute(MonitorManager.EXPENSIVE_HEALTH_CHECK_REGISTRY, new HealthCheckRegistry());
 
-        MetricsRegistry metricsRegistry = new MetricsRegistry();
+        metricsRegistry = new MetricsRegistry();
         context.setAttribute(MonitorManager.METRICS_REGISTRY, metricsRegistry);
         context.setAttribute(DefaultWebappMetricsFilter.REGISTRY_ATTRIBUTE, metricsRegistry);
     }
@@ -56,5 +59,7 @@ public class MetricsRegistryInitializerFilter implements Filter {
     }
 
     public void destroy() {
+        Log.info(Log.WEBAPP, "Shutdown metricsRegistry");
+        metricsRegistry.shutdown();
     }
 }

--- a/healthmonitor/src/main/java/org/fao/geonet/monitor/webapp/WebappMetricsFilter.java
+++ b/healthmonitor/src/main/java/org/fao/geonet/monitor/webapp/WebappMetricsFilter.java
@@ -107,7 +107,7 @@ public abstract class WebappMetricsFilter implements Filter {
     }
 
     public void destroy() {
-
+        Metrics.defaultRegistry().shutdown();
     }
 
     public void doFilter(ServletRequest request,

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvesterScheduler.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvesterScheduler.java
@@ -124,4 +124,11 @@ public class InspireAtomHarvesterScheduler {
         return QuartzSchedulerUtils.getScheduler(SCHEDULER_ID, true);
     }
 
+    public static void shutdown() {
+        try {
+            getScheduler().shutdown(true);
+        } catch (SchedulerException e) {
+            Log.warning(Geonet.ATOM, "Error stopping the scheduler", e);
+        }
+    }
 }

--- a/messaging/src/main/java/org/geonetwork/messaging/JMSMessager.java
+++ b/messaging/src/main/java/org/geonetwork/messaging/JMSMessager.java
@@ -27,26 +27,29 @@ public class JMSMessager {
             // Create a Connection
             Connection connection = connectionFactory.createConnection();
             connection.start();
+            try {
+                // Create a Session
+                Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
 
-            // Create a Session
-            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                try {
+                    // Create the destination (Topic or Queue)
+                    Destination destination = session.createQueue(queue);
 
-            // Create the destination (Topic or Queue)
-            Destination destination = session.createQueue(queue);
+                    // Create a MessageProducer from the Session to the Topic or Queue
+                    MessageProducer producer = session.createProducer(destination);
+                    producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
 
-            // Create a MessageProducer from the Session to the Topic or Queue
-            MessageProducer producer = session.createProducer(destination);
-            producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+                    // Create a messages
+                    ObjectMessage message = session.createObjectMessage(event);
 
-            // Create a messages
-            ObjectMessage message = session.createObjectMessage(event);
-
-            // Tell the producer to send the message
-            producer.send(message);
-
-            // Clean up
-            session.close();
-            connection.close();
+                    // Tell the producer to send the message
+                    producer.send(message);
+                } finally {
+                    session.close();
+                }
+            } finally {
+                connection.close();
+            }
         } catch (Exception e) {
             // TODO : dedicated logger needed
             System.out.println("Caught: " + e);

--- a/messaging/src/main/resources/config-spring-geonetwork-parent.xml
+++ b/messaging/src/main/resources/config-spring-geonetwork-parent.xml
@@ -3,13 +3,16 @@
         xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:amq="http://activemq.apache.org/schema/core"
+        xmlns:context="http://www.springframework.org/schema/context"
         xsi:schemaLocation="
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://activemq.apache.org/schema/core
-        http://activemq.apache.org/schema/core/activemq-core.xsd">
-
-  <amq:broker useJmx="false" persistent="false">
+        http://activemq.apache.org/schema/core/activemq-core.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd">
+  <context:annotation-config/>
+  <amq:broker useJmx="false" persistent="false" useShutdownHook="false">
     <amq:transportConnectors>
       <amq:transportConnector uri="${jms.url}" />
     </amq:transportConnectors>
@@ -45,7 +48,7 @@
   -->
 
   <bean id="activemq"
-        class="org.apache.activemq.camel.component.ActiveMQComponent">
+        class="org.apache.activemq.camel.component.ActiveMQComponent" destroy-method="shutdown">
     <property name="connectionFactory">
       <bean class="org.apache.activemq.ActiveMQConnectionFactory">
         <property name="brokerURL" value="${jms.url}"/>

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/cache/FilesystemStore.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/cache/FilesystemStore.java
@@ -137,6 +137,7 @@ public class FilesystemStore implements PersistentStore {
 
     @PreDestroy
     synchronized void close() throws ClassNotFoundException, SQLException {
+        Log.info(Geonet.FORMATTER, "Stopping the FileSystemStore");
         if (metadataDb != null) {
             metadataDb.close();
         }

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -111,6 +111,7 @@ public class Geonetwork implements ApplicationHandler {
     private SearchManager searchMan;
     private MetadataNotifierControl metadataNotifierControl;
     private ConfigurableApplicationContext _applicationContext;
+    private OaiPmhDispatcher oaipmhDis;
 
     //---------------------------------------------------------------------------
     //---
@@ -208,6 +209,7 @@ public class Geonetwork implements ApplicationHandler {
         }
 
         //------------------------------------------------------------------------
+        //--- initialize SRU
 
         logger.info("  - SRU...");
 
@@ -328,7 +330,7 @@ public class Geonetwork implements ApplicationHandler {
 
         logger.info("  - Open Archive Initiative (OAI-PMH) server...");
 
-        OaiPmhDispatcher oaipmhDis = new OaiPmhDispatcher(settingMan, schemaMan);
+        oaipmhDis = new OaiPmhDispatcher(settingMan, schemaMan);
 
 
         GeonetContext gnContext = new GeonetContext(_applicationContext, false);
@@ -609,18 +611,7 @@ public class Geonetwork implements ApplicationHandler {
         logger.info("shutting down CSW HarvestResponse executionService");
         CswHarvesterResponseExecutionService.getExecutionService().shutdownNow();
 
-        //------------------------------------------------------------------------
-        //--- end search
-        logger.info("  - search...");
-
-        try {
-            searchMan.end();
-        } catch (Exception e) {
-            logger.error("Raised exception while stopping search");
-            logger.error("  Exception : " + e);
-            logger.error("  Message   : " + e.getMessage());
-            logger.error("  Stack     : " + Util.getStackTrace(e));
-        }
+        InspireAtomHarvesterScheduler.shutdown();
 
         logger.info("  - MetadataNotifier ...");
         try {
@@ -635,6 +626,10 @@ public class Geonetwork implements ApplicationHandler {
 
         logger.info("  - Harvest Manager...");
         _applicationContext.getBean(HarvestManager.class).shutdown();
+
+        // Beans registered using SingletonBeanRegistry#registerSingleton don't have their
+        // @PreDestroy called. So do it manually.
+        oaipmhDis.shutdown();
     }
 
     //---------------------------------------------------------------------------

--- a/web/src/main/webapp/WEB-INF/classes/log4j.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j.xml
@@ -219,7 +219,6 @@
     <appender-ref ref="fileAppender"/>
   </logger>
 
-
   <!-- Turn off logging except when explicitly declared below -->
   <root>
     <level value="OFF"></level>

--- a/web/src/main/webapp/WEB-INF/config-spring-geonetwork-parent.xml
+++ b/web/src/main/webapp/WEB-INF/config-spring-geonetwork-parent.xml
@@ -25,9 +25,11 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        default-lazy-init="true"
        xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
-
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+  <context:annotation-config/>
   <import resource="classpath*:/config-spring-geonetwork-parent.xml"/>
 
 </beans>

--- a/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
@@ -26,11 +26,13 @@
        xmlns:util="http://www.springframework.org/schema/util"
        default-lazy-init="true"
        xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 ">
-
+  <context:annotation-config/>
   <import resource="config-spring-env.xml"/>
   <import resource="config-security/config-security.xml"/>
   <import resource="config-summary.xml"/>

--- a/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork-jms.xml
+++ b/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork-jms.xml
@@ -26,23 +26,26 @@
         xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:amq="http://activemq.apache.org/schema/core"
+        xmlns:context="http://www.springframework.org/schema/context"
         xsi:schemaLocation="
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://activemq.apache.org/schema/core
-        http://activemq.apache.org/schema/core/activemq-core.xsd">
-
+        http://activemq.apache.org/schema/core/activemq-core.xsd
+        http://www.springframework.org/schema/context
+         http://www.springframework.org/schema/context/spring-context.xsd">
+  <context:annotation-config/>
   <import resource="config-spring-geonetwork.xml"/>
 
   <!--  Embedded ActiveMQ Broker -->
-  <amq:broker useJmx="false" persistent="false">
+  <amq:broker useJmx="false" persistent="false" useShutdownHook="false">
     <amq:transportConnectors>
       <amq:transportConnector uri="${jms.url}" />
     </amq:transportConnectors>
   </amq:broker>
 
   <bean id="activemq"
-        class="org.apache.activemq.camel.component.ActiveMQComponent">
+        class="org.apache.activemq.camel.component.ActiveMQComponent"><!-- destroy-method="shutdown">-->
     <property name="connectionFactory">
       <bean class="org.apache.activemq.ActiveMQConnectionFactory">
         <property name="brokerURL" value="${jms.url}"/>

--- a/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
@@ -24,15 +24,12 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:amq="http://activemq.apache.org/schema/core"
        xmlns:cm="http://camel.apache.org/schema/spring"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://camel.apache.org/schema/spring
-        http://camel.apache.org/schema/spring/camel-spring.xsd
-        http://activemq.apache.org/schema/core
-        http://activemq.apache.org/schema/core/activemq-core.xsd">
+        http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="wfsfeaturesHarvesterRouteBuilder"
         class="org.fao.geonet.harvester.wfsfeatures.worker.WFSHarvesterRouteBuilder">

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/DiskbackedCache.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/DiskbackedCache.java
@@ -80,7 +80,7 @@ public class DiskbackedCache implements CacheStrategy<CacheKey, CacheValue>, Clo
             "CREATE TABLE IF NOT EXISTS " + TABLE + "(" + GROUPNAME + "  VARCHAR(128) NOT NULL, " + TYPE + " VARCHAR(3) NOT NULL, " +
                 HASH + " VARCHAR(256) NOT NULL, " + RAW_DATA + " CLOB NOT NULL, PRIMARY KEY (" + GROUPNAME + ", " + TYPE + "))"
         };
-        String init = ";INIT=" + Joiner.on("\\;").join(initSql) + ";";
+        String init = ";INIT=" + Joiner.on("\\;").join(initSql) + ";DB_CLOSE_ON_EXIT=FALSE;";
 
         try {
             this.dbConnection = DriverManager.getConnection("jdbc:h2:" + path + init, "wro4jcache", "");


### PR DESCRIPTION
A lot of threads are not stopped when the webapp is stopped. This can
cause trouble if you use the tomcat manager to install and uninstall the
application. Leaving threads behind and running.

To test, I've used:
```
mvn package -Dmaven.test.skip=true && \
  docker run -ti --rm -p 8080:8080 \
    -v $PWD/web/target/geonetwork.war:/usr/local/tomcat/webapps/geonetwork.war \
    tomcat:8.5-jre8
```
You let it start and you hit CTRL+C