### PR TITLE
fixed annoying null pointer issue

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -132,7 +132,9 @@
                   if (promise && angular.isFunction(promise.abort)) {
                     promise.abort();
                   }
-                  scope.uuid = scope.md.getUuid();
+                  if(scope.md != null){
+                	  scope.uuid = scope.md.getUuid();
+                  }
                   scope.updateRelations();
                 }
               });


### PR DESCRIPTION
Sometimes scope.md is null and the code in RelatedDirective.js throws an exception 