### PR TITLE
Leak

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/index/LuceneIndexLanguageTracker.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/LuceneIndexLanguageTracker.java
@@ -149,12 +149,12 @@ public class LuceneIndexLanguageTracker {
         LuceneConfig luceneConfig = context.getBean(LuceneConfig.class);
         DirectoryFactory directoryFactory = context.getBean(DirectoryFactory.class);
 
-        Directory cachedFSDir = null;
+        Directory cachedFSDir = directoryFactory.createIndexDirectory(indexId, luceneConfig);
         IndexWriter writer = null;
         GeonetworkNRTManager nrtManager = null;
         TrackingIndexWriter trackingIndexWriter;
+        boolean done = false;
         try {
-            cachedFSDir = directoryFactory.createIndexDirectory(indexId, luceneConfig);
             IndexWriterConfig conf = new IndexWriterConfig(Geonet.LUCENE_VERSION, SearchManager.getAnalyzer(indexId, false));
             ConcurrentMergeScheduler mergeScheduler = new ConcurrentMergeScheduler();
             conf.setMergeScheduler(mergeScheduler);
@@ -162,21 +162,13 @@ public class LuceneIndexLanguageTracker {
             trackingIndexWriter = new TrackingIndexWriter(writer);
             nrtManager = new GeonetworkNRTManager(luceneConfig, indexId,
                 trackingIndexWriter, writer, null, true, taxonomyIndexTracker);
-        } catch (CorruptIndexException e) {
-            IOUtils.closeQuietly(nrtManager);
-            IOUtils.closeQuietly(writer);
-            IOUtils.closeQuietly(cachedFSDir);
-            throw e;
-        } catch (LockObtainFailedException e) {
-            IOUtils.closeQuietly(nrtManager);
-            IOUtils.closeQuietly(writer);
-            IOUtils.closeQuietly(cachedFSDir);
-            throw e;
-        } catch (IOException e) {
-            IOUtils.closeQuietly(nrtManager);
-            IOUtils.closeQuietly(writer);
-            IOUtils.closeQuietly(cachedFSDir);
-            throw e;
+            done = true;
+        } finally {
+            if (!done) {
+                IOUtils.closeQuietly(nrtManager);
+                IOUtils.closeQuietly(writer);
+                IOUtils.closeQuietly(cachedFSDir);
+            }
         }
         dirs.put(indexId, cachedFSDir);
         trackingWriters.put(indexId, trackingIndexWriter);
@@ -477,6 +469,25 @@ public class LuceneIndexLanguageTracker {
                     reset(TimeUnit.MINUTES.toMillis(1));
                     throw new RuntimeException(e);
                 }
+            }
+        } finally {
+            lock.unlock();
+        }
+
+        // wait for the merges to be done outside of the lock to avoid locking writes to the indexes
+        for (TrackingIndexWriter writer: trackingWriters.values()) {
+            writer.getIndexWriter().waitForMerges();
+        }
+
+        // need to re-open the indexes for the files' size to actually reduce
+        lock.lock();
+        try{
+            ArrayList<String> ids = new ArrayList<>(trackingWriters.keySet());
+            for (String id : ids) {
+                trackingWriters.get(id).getIndexWriter().close();
+                searchManagers.get(id).close();
+                dirs.get(id).close();
+                openIndex(id);
             }
         } finally {
             lock.unlock();

--- a/domain/src/main/java/org/fao/geonet/repository/OperationAllowedRepositoryImpl.java
+++ b/domain/src/main/java/org/fao/geonet/repository/OperationAllowedRepositoryImpl.java
@@ -35,6 +35,7 @@ import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.ParameterExpression;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.metamodel.SingularAttribute;
@@ -60,8 +61,9 @@ public class OperationAllowedRepositoryImpl implements OperationAllowedRepositor
         int iMdId = Integer.parseInt(metadataId);
         Root<OperationAllowed> root = query.from(OperationAllowed.class);
 
-        query.where(builder.equal(builder.literal(iMdId), root.get(OperationAllowed_.id).get(OperationAllowedId_.metadataId)));
-        return _entityManager.createQuery(query).getResultList();
+        ParameterExpression<Integer> idParameter = builder.parameter(Integer.class, "id");
+        query.where(builder.equal(idParameter, root.get(OperationAllowed_.id).get(OperationAllowedId_.metadataId)));
+        return _entityManager.createQuery(query).setParameter("id", iMdId).getResultList();
     }
 
     @Override

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -86,7 +86,7 @@
   <bean id="formatterCache" lazy-init="true"
         class="org.fao.geonet.api.records.formatters.cache.FormatterCache">
     <constructor-arg index="0" ref="fsStore"/>
-    <constructor-arg index="1" value="500000"/>
+    <constructor-arg index="1" value="500"/>
     <constructor-arg index="2" value="5000"/>
   </bean>
   <bean id="fsStore" class="org.fao.geonet.api.records.formatters.cache.FilesystemStore"


### PR DESCRIPTION
Caching 500000 formatted MDs in RAM is not a good idea
This functionnality doesn't seem to be used... so not very useful,
but reducing this value anyway.

Use query parameters

Lucene optimisation now shrinks the files
Have to re-open the writers for that to happen.
