### PR TITLE
harvesters - plugging the harvester error counter

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvestError.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvestError.java
@@ -1,0 +1,24 @@
+package org.fao.geonet.kernel.harvest.harvester;
+
+import org.fao.geonet.monitor.harvest.AbstractHarvesterErrorCounter;
+
+import com.yammer.metrics.core.Counter;
+
+import jeeves.monitor.MonitorManager;
+import jeeves.server.context.ServiceContext;
+
+public class AbstractHarvestError {
+	
+	public AbstractHarvestError(ServiceContext context) {
+		super();
+		// we don't catch anything because this is not critical
+		// if the following code is not executed, we just want to
+		// avoid to raise an exception.
+		try {
+			MonitorManager mm = context.getBean(MonitorManager.class);
+			Counter harvestError = mm.getCounter(AbstractHarvesterErrorCounter.class);
+			harvestError.inc();
+		} finally {}
+		
+	}
+}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -553,7 +553,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                     + this.getType()
                     + "] didn't accept some of the parameters sent.");
 
-                errors.add(new HarvestError(e, logger));
+                errors.add(new HarvestError(context, e, logger));
                 error = e;
                 operResult = OperResult.ERROR;
             } catch (Throwable t) {
@@ -562,8 +562,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                 logger.warning(" (C) Class   : " + t.getClass().getSimpleName());
                 logger.warning(" (C) Message : " + t.getMessage());
                 error = t;
-                t.printStackTrace();
-                errors.add(new HarvestError(t, logger));
+                errors.add(new HarvestError(context, t, logger));
             } finally {
                 List<HarvestError> harvesterErrors = getErrors();
                 if (harvesterErrors != null) {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvestError.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvestError.java
@@ -35,6 +35,8 @@ import org.fao.geonet.csw.common.exceptions.InvalidParameterValueEx;
 import org.fao.geonet.exceptions.*;
 import org.jdom.JDOMException;
 
+import jeeves.server.context.ServiceContext;
+
 /**
  * <p> Master class for harvesting errors. </p> <p> Example of usage: </p> <code> SQLException e =
  * ...; HarvestError harvestError = new HarvestError(e, log); harvestError.setDescription("Error
@@ -44,7 +46,7 @@ import org.jdom.JDOMException;
  *
  * @author delawen
  */
-public class HarvestError {
+public class HarvestError extends AbstractHarvestError {
 
     /**
      * Exception that caused the harvest error.
@@ -63,8 +65,8 @@ public class HarvestError {
      */
     private String hint = "Check with your administrator the error.";
 
-    public HarvestError(InvalidParameterValueEx ex, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, InvalidParameterValueEx ex, Logger log) {
+    	super(context);
 
         this.origin = ex;
         this.description = "The server didn't accept one of the parameters"
@@ -76,8 +78,8 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(Throwable ex, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, Throwable ex, Logger log) {
+        super(context);
 
         this.origin = ex;
         this.description = ex.getMessage();
@@ -87,25 +89,24 @@ public class HarvestError {
         // Do not print log, as it is a very generic exception
         // leave it to main caller
     }
-
-    public HarvestError(CacheException ex, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, CacheException ex, Logger log) {
+        super(context);
 
         this.origin = ex;
         this.description = "Failed to update Jeeves cache: " + ex.getMessage();
         printLog(log);
     }
 
-    public HarvestError(JDOMException ex, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, JDOMException ex, Logger log) {
+        super(context);
 
         this.origin = ex;
         this.description = "There was an error processing the response. " + ex.getMessage();
         printLog(log);
     }
 
-    public HarvestError(BadServerResponseEx e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, BadServerResponseEx e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "The server returned an answer that could not be processed: "
@@ -114,8 +115,8 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(BadSoapResponseEx e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, BadSoapResponseEx e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "The server returned an answer that could not be processed.";
@@ -123,24 +124,24 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(HttpException e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, HttpException e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "There was an error trying to reach some URL. " + e.getMessage();
         printLog(log);
     }
 
-    public HarvestError(IOException e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, IOException e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "There was an error trying to reach an URI. " + e.getMessage();
         printLog(log);
     }
 
-    public HarvestError(MalformedURLException e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, MalformedURLException e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "There was an error trying to reach an URL. ";
@@ -148,8 +149,8 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(UnsupportedEncodingException e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, UnsupportedEncodingException e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "The metadata is defined on an unsupported encoding: "
@@ -158,8 +159,8 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(java.text.ParseException e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, java.text.ParseException e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "Unable to parse the metadata.";
@@ -168,8 +169,8 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(SQLException e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, SQLException e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "There was an error while updating the database: "
@@ -178,8 +179,8 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(UserNotFoundEx e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, UserNotFoundEx e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "Couldn't log in to harvest using " + e.getObject();
@@ -187,17 +188,16 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(SchemaMatchConflictException e, Logger log, String name) {
-        super();
+    public HarvestError(ServiceContext context, SchemaMatchConflictException e, Logger log, String name) {
+        super(context);
 
         this.origin = e;
         this.description = "Couldn't match the schema for " + name;
         this.hint = "Check that the schemas used are defined on geonetwork.";
         printLog(log);
     }
-
-    public HarvestError(SchemaMatchConflictException e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, SchemaMatchConflictException e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "Couldn't match the schema.";
@@ -205,8 +205,8 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(NoSchemaMatchesException e, Logger log, String name) {
-        super();
+    public HarvestError(ServiceContext context, NoSchemaMatchesException e, Logger log, String name) {
+        super(context);
 
         this.origin = e;
         this.description = "Couldn't recognize the schema for " + name;
@@ -214,8 +214,8 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(NoSchemaMatchesException e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, NoSchemaMatchesException e, Logger log) {
+        super(context);
 
         this.origin = e;
         this.description = "Couldn't recognize the schema.";
@@ -223,16 +223,16 @@ public class HarvestError {
         printLog(log);
     }
 
-    public HarvestError(BadXmlResponseEx e, Logger log, String capabUrl) {
-        super();
+    public HarvestError(ServiceContext context, BadXmlResponseEx e, Logger log, String capabUrl) {
+        super(context);
         this.origin = e;
         this.description = "The response returned from the server doesn't look like XML";
         this.hint = "Check the URL is ok: " + capabUrl;
         printLog(log);
     }
 
-    public HarvestError(BadXmlResponseEx e, Logger log) {
-        super();
+    public HarvestError(ServiceContext context, BadXmlResponseEx e, Logger log) {
+        super(context);
         this.origin = e;
         this.description = "The response returned from the server doesn't look like XML. " + e.getMessage();
         this.hint = "Check the URL is ok.";

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -221,8 +221,8 @@ public class Aligner extends BaseAligner {
                 if (id == null) addMetadata(ri);
                 else updateMetadata(ri, id);
                 result.totalMetadata++;
-            } catch (Throwable t) {
-                errors.add(new HarvestError(t, log));
+            }catch(Throwable t) {
+                errors.add(new HarvestError(context, t, log));
                 log.error("Unable to process record from csw (" + this.params.getName() + ")");
                 log.error("   Record failed: " + ri.uuid + ". Error is: " + t.getMessage());
             } finally {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -144,11 +144,11 @@ class Harvester implements IHarvester<HarvestResult> {
             log.error("Unknown error trying to harvest");
             log.error(t.getMessage());
             log.error(t);
-            errors.add(new HarvestError(t, log));
+            errors.add(new HarvestError(context, t, log));
         } catch (Throwable t) {
             log.fatal("Something unknown and terrible happened while harvesting");
             log.fatal(t.getMessage());
-            errors.add(new HarvestError(t, log));
+            errors.add(new HarvestError(context, t, log));
         }
 
         log.info("Total records processed in all searches :" + records.size());
@@ -175,7 +175,7 @@ class Harvester implements IHarvester<HarvestResult> {
         if (params.capabUrl.contains("GetCapabilities")) {
             req = requestFactory.createXmlRequest(new URL(params.capabUrl));
         } else {
-            req = requestFactory.createXmlRequest(new URL(params.capabUrl + (params.capabUrl.contains("?") ? "&" : "?") + GETCAPABILITIES_PARAMETERS));
+          req = requestFactory.createXmlRequest(new URL(params.capabUrl + (params.capabUrl.contains("?") ? "&" : "?") + GETCAPABILITIES_PARAMETERS));
         }
 
         Lib.net.setupProxy(context, req);
@@ -183,11 +183,11 @@ class Harvester implements IHarvester<HarvestResult> {
         if (params.isUseAccount())
             req.setCredentials(params.getUsername(), params.getPassword());
         CswServer server = null;
-        try {
+        try{
             Element capabil = req.execute();
 
-            if (log.isDebugEnabled())
-                log.debug("Capabilities:\n" + Xml.getString(capabil));
+            if(log.isDebugEnabled())
+                log.debug("Capabilities:\n"+Xml.getString(capabil));
 
             if (capabil.getName().equals("ExceptionReport"))
                 CatalogException.unmarshal(capabil);
@@ -200,8 +200,8 @@ class Harvester implements IHarvester<HarvestResult> {
             if (!checkOperation(log, server, "GetRecordById"))
                 throw new OperationAbortedEx("GetRecordById operation not found");
 
-        } catch (BadXmlResponseEx e) {
-            errors.add(new HarvestError(e, log, params.capabUrl));
+        } catch(BadXmlResponseEx e) {
+            errors.add(new HarvestError(context, e, log, params.capabUrl));
             throw e;
         }
 
@@ -260,7 +260,7 @@ class Harvester implements IHarvester<HarvestResult> {
                 log.debug(ex.getMessage());
                 log.debug(String.format("Due to errors, changing CSW harvester method to HTTP %s method.", PREFERRED_HTTP_METHOD.equals("GET") ? "POST" : "GET"));
             }
-            errors.add(new HarvestError(ex, log));
+            errors.add(new HarvestError(context, ex, log));
 
             configRequest(request, oper, server, s, PREFERRED_HTTP_METHOD.equals("GET") ? "POST" : "GET");
         }
@@ -301,7 +301,7 @@ class Harvester implements IHarvester<HarvestResult> {
                     }
 
                 } catch (Exception ex) {
-                    errors.add(new HarvestError(ex, log));
+                    errors.add(new HarvestError(context, ex, log));
                     log.error("Unable to process record from csw (" + this.params.getName() + ")");
                     log.error("   Record failed: " + foundCnt);
                     log.debug("   Record: " + ((Element) record).getName());
@@ -593,13 +593,15 @@ class Harvester implements IHarvester<HarvestResult> {
             }
 
             return response;
-        } catch (Exception e) {
-            errors.add(new HarvestError(e, log));
-            log.warning("Raised exception when searching : " + e);
-            log.warning("Url: " + request.getHost());
-            log.warning("Method: " + request.getMethod());
-            log.warning("Sent request " + request.getSentData());
-            throw new OperationAbortedEx("Raised exception when searching: " + e.getMessage(), e);
+        }
+        catch(Exception e)
+        {
+          errors.add(new HarvestError(context, e, log));
+          log.warning("Raised exception when searching : "+ e);
+          log.warning("Url: " + request.getHost());
+          log.warning("Method: " + request.getMethod());
+          log.warning("Sent request " + request.getSentData());
+          throw new OperationAbortedEx("Raised exception when searching: " + e.getMessage(), e);
         }
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
@@ -169,8 +169,8 @@ public class Aligner extends BaseAligner {
                 else updateMetadata(ri, id);
                 result.totalMetadata++;
 
-            } catch (Throwable t) {
-                errors.add(new HarvestError(t, log));
+            }catch (Throwable t) {
+                errors.add(new HarvestError(context, t, log));
                 log.error("Unable to process record from csw (" + this.params.getName() + ")");
                 log.error("   Record failed: " + ri.uuid);
             }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Harvester.java
@@ -120,12 +120,12 @@ class Harvester implements IHarvester<HarvestResult> {
                 log.error("Unknown error trying to harvest");
                 log.error(t.getMessage());
                 t.printStackTrace();
-                errors.add(new HarvestError(t, log));
+                errors.add(new HarvestError(context, t, log));
             } catch (Throwable t) {
                 log.fatal("Something unknown and terrible happened while harvesting");
                 log.fatal(t.getMessage());
                 t.printStackTrace();
-                errors.add(new HarvestError(t, log));
+                errors.add(new HarvestError(context, t, log));
             }
         }
 
@@ -137,12 +137,12 @@ class Harvester implements IHarvester<HarvestResult> {
                 log.error("Unknown error trying to harvest");
                 log.error(t.getMessage());
                 t.printStackTrace();
-                errors.add(new HarvestError(t, log));
-            } catch (Throwable t) {
+                errors.add(new HarvestError(context, t, log));
+            } catch(Throwable t) {
                 log.fatal("Something unknown and terrible happened while harvesting");
                 log.fatal(t.getMessage());
                 t.printStackTrace();
-                errors.add(new HarvestError(t, log));
+                errors.add(new HarvestError(context, t, log));
             }
         }
 
@@ -208,15 +208,15 @@ class Harvester implements IHarvester<HarvestResult> {
             }
             return response;
         } catch (BadSoapResponseEx e) {
-            errors.add(new HarvestError(e, log));
+            errors.add(new HarvestError(context, e, log));
             throw new OperationAbortedEx("Raised exception when searching: "
                 + e.getMessage(), e);
         } catch (BadXmlResponseEx e) {
-            errors.add(new HarvestError(e, log));
+            errors.add(new HarvestError(context, e, log));
             throw new OperationAbortedEx("Raised exception when searching: "
                 + e.getMessage(), e);
         } catch (IOException e) {
-            errors.add(new HarvestError(e, log));
+            errors.add(new HarvestError(context, e, log));
             throw new OperationAbortedEx("Raised exception when searching: "
                 + e.getMessage(), e);
         }
@@ -252,13 +252,13 @@ class Harvester implements IHarvester<HarvestResult> {
                 log.debug("getRecordInfo: adding " + identif + " with modification date " + modified);
             return new RecordInfo(identif, modified);
         } catch (UnsupportedEncodingException e) {
-            HarvestError harvestError = new HarvestError(e, log);
+            HarvestError harvestError = new HarvestError(context, e, log);
             harvestError.setDescription(harvestError.getDescription() + "\n record: " + Xml.getString(record));
             errors.add(harvestError);
         } catch (ParseException e) {
-            HarvestError harvestError = new HarvestError(e, log);
+            HarvestError harvestError = new HarvestError(context, e, log);
             harvestError.setDescription(harvestError.getDescription() + "\n record: " + Xml.getString(record));
-            errors.add(new HarvestError(e, log));
+            errors.add(new HarvestError(context, e, log));
         }
 
         // we get here if we couldn't get the UUID or date modified

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
@@ -167,12 +167,12 @@ class Harvester implements IHarvester<HarvestResult> {
                 log.error("Unknown error trying to harvest");
                 log.error(t.getMessage());
                 log.error(t);
-                errors.add(new HarvestError(t, log));
+                errors.add(new HarvestError(context, t, log));
             } catch (Throwable t) {
                 log.fatal("Something unknown and terrible happened while harvesting");
                 log.fatal(t.getMessage());
                 t.printStackTrace();
-                errors.add(new HarvestError(t, log));
+                errors.add(new HarvestError(context, t, log));
             }
         }
 
@@ -184,12 +184,12 @@ class Harvester implements IHarvester<HarvestResult> {
                 log.error("Unknown error trying to harvest");
                 log.error(t.getMessage());
                 log.error(t);
-                errors.add(new HarvestError(t, log));
+                errors.add(new HarvestError(context, t, log));
             } catch (Throwable t) {
                 log.fatal("Something unknown and terrible happened while harvesting");
                 log.fatal(t.getMessage());
                 t.printStackTrace();
-                errors.add(new HarvestError(t, log));
+                errors.add(new HarvestError(context, t, log));
             }
         }
 
@@ -246,7 +246,7 @@ class Harvester implements IHarvester<HarvestResult> {
                     records.add(new RecordInfo(uuid, changeDate, schema, source));
                 }
             } catch (Exception e) {
-                HarvestError harvestError = new HarvestError(e, log);
+                HarvestError harvestError = new HarvestError(context, e, log);
                 harvestError.setDescription("Malformed element '"
                     + o.toString() + "'");
                 harvestError
@@ -273,10 +273,10 @@ class Harvester implements IHarvester<HarvestResult> {
             return response;
         } catch (BadSoapResponseEx e) {
             log.warning("Raised exception when searching : " + e.getMessage());
-            this.errors.add(new HarvestError(e, log));
+            this.errors.add(new HarvestError(context, e, log));
             throw new OperationAbortedEx("Raised exception when searching", e);
         } catch (BadXmlResponseEx e) {
-            HarvestError harvestError = new HarvestError(e, log);
+            HarvestError harvestError = new HarvestError(context, e, log);
             harvestError.setDescription("Error while searching on "
                 + params.getName() + ". Excepted XML, returned: "
                 + e.getMessage());
@@ -284,14 +284,14 @@ class Harvester implements IHarvester<HarvestResult> {
             this.errors.add(harvestError);
             throw new OperationAbortedEx("Raised exception when searching", e);
         } catch (IOException e) {
-            HarvestError harvestError = new HarvestError(e, log);
+            HarvestError harvestError = new HarvestError(context, e, log);
             harvestError.setDescription("Error while searching on "
                 + params.getName() + ". ");
             harvestError.setHint("Check with your administrator.");
             this.errors.add(harvestError);
             throw new OperationAbortedEx("Raised exception when searching", e);
-        } catch (Exception e) {
-            HarvestError harvestError = new HarvestError(e, log);
+        } catch(Exception e) {
+            HarvestError harvestError = new HarvestError(context, e, log);
             harvestError.setDescription("Error while searching on "
                 + params.getName() + ". ");
             harvestError.setHint("Check with your administrator.");

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -148,7 +148,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
         try {
             t.setUrl(new URL(params.url));
         } catch (MalformedURLException e1) {
-            HarvestError harvestError = new HarvestError(e1, log);
+            HarvestError harvestError = new HarvestError(context, e1, log);
             harvestError.setDescription(harvestError.getDescription() + " " + params.url);
             errors.add(harvestError);
             throw new AbortExecutionException(e1);
@@ -177,12 +177,12 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
                 log.error("Unknown error trying to harvest");
                 log.error(e.getMessage());
                 e.printStackTrace();
-                errors.add(new HarvestError(e, log));
+                errors.add(new HarvestError(context, e, log));
             } catch (Throwable e) {
                 log.fatal("Something unknown and terrible happened while harvesting");
                 log.fatal(e.getMessage());
                 e.printStackTrace();
-                errors.add(new HarvestError(e, log));
+                errors.add(new HarvestError(context, e, log));
             }
         }
 
@@ -194,12 +194,12 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
                 log.error("Unknown error trying to harvest");
                 log.error(e.getMessage());
                 e.printStackTrace();
-                errors.add(new HarvestError(e, log));
-            } catch (Throwable e) {
+                errors.add(new HarvestError(context, e, log));
+            } catch(Throwable e) {
                 log.fatal("Something unknown and terrible happened while harvesting");
                 log.fatal(e.getMessage());
                 e.printStackTrace();
-                errors.add(new HarvestError(e, log));
+                errors.add(new HarvestError(context, e, log));
             }
         }
 
@@ -252,12 +252,12 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
             return records;
         } catch (NoRecordsMatchException e) {
             log.warning("No records were matched: " + e.getMessage());
-            this.errors.add(new HarvestError(e, log));
+            this.errors.add(new HarvestError(context, e, log));
             return records;
         } catch (Exception e) {
             log.warning("Raised exception when searching : " + e);
             log.warning(Util.getStackTrace(e));
-            this.errors.add(new HarvestError(e, log));
+            this.errors.add(new HarvestError(context, e, log));
             throw new OperationAbortedEx("Raised exception when searching", e);
         }
     }
@@ -420,20 +420,25 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
                     log.info("Skipping metadata that does not validate. Remote id : " + ri.id);
                     result.doesNotValidate++;
                 }
-            }
-        } catch (JDOMException e) {
-            HarvestError harvestError = new HarvestError(e, log);
-            harvestError.setDescription("Skipping metadata with bad XML format. Remote id : " + ri.id);
+        }
+    }
+
+    catch(JDOMException e) {
+            HarvestError harvestError = new HarvestError(context, e, log);
+            harvestError.setDescription("Skipping metadata with bad XML format. Remote id : "+ ri.id);
             harvestError.printLog(log);
             this.errors.add(harvestError);
             result.badFormat++;
-        } catch (Exception e) {
-            HarvestError harvestError = new HarvestError(e, log);
-            harvestError.setDescription("Raised exception while getting metadata file : " + e);
+    }
+
+    catch(Exception e)
+    {
+            HarvestError harvestError = new HarvestError(context, e, log);
+            harvestError.setDescription("Raised exception while getting metadata file : "+ e);
             this.errors.add(harvestError);
             harvestError.printLog(log);
             result.unretrievable++;
-        }
+    }
 
         //--- we don't raise any exception here. Just try to go on
         return null;
@@ -446,11 +451,14 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
     private Element toDublinCore(Element md) {
         Path styleSheet = context.getAppPath().resolve("conversion/oai_dc-to-dublin-core/main.xsl");
 
-        try {
+        try
+        {
             return Xml.transform(md, styleSheet);
-        } catch (Exception e) {
-            HarvestError harvestError = new HarvestError(e, log);
-            harvestError.setDescription("Cannot convert oai_dc to dublin core : " + e);
+        }
+        catch (Exception e)
+        {
+            HarvestError harvestError = new HarvestError(context, e, log);
+            harvestError.setDescription("Cannot convert oai_dc to dublin core : "+ e);
             this.errors.add(harvestError);
             harvestError.printLog(log);
             return null;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -276,7 +276,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
             } catch (Exception e) {
                 log.error("  - Failed to set uuid for metadata with remote path : "
                     + rf.getPath());
-                errors.add(new HarvestError(e, this.log));
+                errors.add(new HarvestError(context, e, this.log));
                 return;
             }
         }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
@@ -216,7 +216,7 @@ class Harvester implements IHarvester<HarvestResult> {
         try {
             wfsQuery = Xml.loadString(params.query, false);
         } catch (JDOMException e) {
-            errors.add(new HarvestError(e, log));
+            errors.add(new HarvestError(context, e, log));
             throw new BadParameterEx("GetFeature Query failed to parse\n", params.query);
         }
 
@@ -357,10 +357,10 @@ class Harvester implements IHarvester<HarvestResult> {
                     }
                 }
             } catch (CacheException e) {
-                HarvestError error = new HarvestError(e, log);
+                HarvestError error = new HarvestError(context, e, log);
                 this.errors.add(error);
             } catch (Exception e) {
-                HarvestError error = new HarvestError(e, log);
+                HarvestError error = new HarvestError(context, e, log);
                 this.errors.add(error);
             }
         }


### PR DESCRIPTION
In the `config/config-service-monitoring.xml` file, a `AbstractHarvesterErrorCounter` is defined, but is never used / incremented. This PR aims to increment the counter whenever it is appropriate.

Note: this metric can give some basic hints on when an issue is encountered at runtime, but it might be interesting to dig in further, maybe defining a counter like this for each defined harvesters ? Also, it is never reset.

Compilation: I was not able to compile it from the `harvesters/` subdirectory, and I needed to compile the whole project.

Tests: runtime tested on geOrchestra (based on 3.0.x branch, but the touched code did not evolve that much between develop and the one)