### PR TITLE
Option to sync All layers in the Map Viewer and the Mini Map

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -76,36 +76,23 @@
               scope.is3DModeAllowed = gnConfig['map.is3DModeAllowed'] || false;
               scope.is3dEnabled = gnConfig['is3dEnabled'] || false;
 
-              // Synch only background layer between main map and search map
+              // By default, synch only background layer between main map and search map
               scope.synAllLayers = false;
 
               scope.map.getLayers().on('add', function() {
-                if (angular.isDefined(gnSearchSettings.searchMap)) {
-
-                  var layers = gnSearchSettings.searchMap.getLayers();
-
-                  scope.map.getLayers().forEach(function(l) {
-                    if (scope.synAllLayers === false &&
-                        l.get('group') === 'Background layers') {
-                      layers.removeAt(0);
-                      layers.insertAt(0, l);
-                    }
-                    // TODO: Synchronize all layers
-
-                  });
-
-                }
+                if (angular.isDefined(gnSearchSettings.searchMap))
+                  scope.doSync(map);
               });
 
               scope.syncMod = function(map) {
-
                 scope.synAllLayers=!scope.synAllLayers;
+                scope.doSync(map);
+              }
 
+              scope.doSync = function(map) {
                 var layers = gnSearchSettings.searchMap.getLayers();
                 layers.clear();
-
                 scope.map.getLayers().forEach(function(l) {
-
                 if ( scope.synAllLayers==true || (scope.synAllLayers === false &&
                     l.get('group') === 'Background layers') )
                       layers.push(l);

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -71,16 +71,19 @@
               };
               scope.ol3d = null;
 
+
               // 3D mode is allowed and disabled by default
               scope.is3DModeAllowed = gnConfig['map.is3DModeAllowed'] || false;
               scope.is3dEnabled = gnConfig['is3dEnabled'] || false;
 
-
               // Synch only background layer between main map and search map
               scope.synAllLayers = false;
+
               scope.map.getLayers().on('add', function() {
                 if (angular.isDefined(gnSearchSettings.searchMap)) {
+
                   var layers = gnSearchSettings.searchMap.getLayers();
+
                   scope.map.getLayers().forEach(function(l) {
                     if (scope.synAllLayers === false &&
                         l.get('group') === 'Background layers') {
@@ -88,9 +91,27 @@
                       layers.insertAt(0, l);
                     }
                     // TODO: Synchronize all layers
+
                   });
+
                 }
               });
+
+              scope.syncMod = function(map) {
+
+                scope.synAllLayers=!scope.synAllLayers;
+
+                var layers = gnSearchSettings.searchMap.getLayers();
+                layers.clear();
+
+                scope.map.getLayers().forEach(function(l) {
+
+                if ( scope.synAllLayers==true || (scope.synAllLayers === false &&
+                    l.get('group') === 'Background layers') )
+                      layers.push(l);
+                });
+              }
+
               scope.init3dMode = function(map) {
                 if (map) {
                   scope.ol3d = new olcs.OLCesium({map: map});

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -84,6 +84,11 @@
                   scope.doSync(map);
               });
 
+              scope.map.getLayers().on('change:length', function() {
+                if (angular.isDefined(gnSearchSettings.searchMap))
+                  scope.doSync(map);
+              });
+
               scope.syncMod = function(map) {
                 scope.synAllLayers=!scope.synAllLayers;
                 scope.doSync(map);

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -45,7 +45,7 @@
             data-ng-click="syncMod(map)">
       <span class="fa fa-sync"
             data-ng-class="synAllLayers ? 'fa-lock' : 'fa-unlock'"/>
-      <span role="tooltip" data-translate="">syncAllLayers</span>
+      <span role="tooltip" data-translate="">Sync All Layers</span>
     </button>
 
     <button gi-btn class="btn btn-default" type="submit" ng-model="mInteraction.active"

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -40,6 +40,14 @@
       <span class="fa fa-print"></span>
       <span role="tooltip" data-translate="">Print</span>
     </button>
+
+    <button class="btn btn-default" type="submit"
+            data-ng-click="syncMod(map)">
+      <span class="fa fa-sync"
+            data-ng-class="synAllLayers ? 'fa-lock' : 'fa-unlock'"/>
+      <span role="tooltip" data-translate="">Sync All Layers</span>
+    </button>
+
     <button gi-btn class="btn btn-default" type="submit" ng-model="mInteraction.active"
             data-ng-hide="is3dEnabled"
             rel="#measures" gnv-tools-btn>

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -45,7 +45,7 @@
             data-ng-click="syncMod(map)">
       <span class="fa fa-sync"
             data-ng-class="synAllLayers ? 'fa-lock' : 'fa-unlock'"/>
-      <span role="tooltip" data-translate="">Sync All Layers</span>
+      <span role="tooltip" data-translate="">syncAllLayers</span>
     </button>
 
     <button gi-btn class="btn btn-default" type="submit" ng-model="mInteraction.active"

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -348,7 +348,7 @@
   "fbQuestion": "Question",
   "fbError": "Error",
   "fbCatMetadataContents": "Metadata Contents",
-  "fbCatDataContents": "Data Contents", 
+  "fbCatDataContents": "Data Contents",
   "fbCatServiceContents": "Service Contents",
   "fbCatSupport": "Support",
   "fbCatMapViewer": "Map Viewer",
@@ -359,5 +359,6 @@
   "fbCatMetadataEditing": "Metadata Editing",
   "fbCatHarvesting": "Harvesting",
   "fbCatValidator": "Validator",
-  "fbCatOthers": "Others"
+  "fbCatOthers": "Others",
+  "syncAllLayers": "Synchronize all layers (or only background layers) between map viewer and search overview map"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -348,7 +348,7 @@
   "fbQuestion": "Question",
   "fbError": "Error",
   "fbCatMetadataContents": "Metadata Contents",
-  "fbCatDataContents": "Data Contents",
+  "fbCatDataContents": "Data Contents", 
   "fbCatServiceContents": "Service Contents",
   "fbCatSupport": "Support",
   "fbCatMapViewer": "Map Viewer",
@@ -359,6 +359,5 @@
   "fbCatMetadataEditing": "Metadata Editing",
   "fbCatHarvesting": "Harvesting",
   "fbCatValidator": "Validator",
-  "fbCatOthers": "Others",
-  "syncAllLayers": "Synchronize all layers (or only background layers) between map viewer and search overview map"
+  "fbCatOthers": "Others"
 }


### PR DESCRIPTION
- Implemented sycn mode between map viewer and mini map: sync all layers, or sync only background layers (default).
- Added button on the map viewer, to switch between sync modes

![sync1](https://cloud.githubusercontent.com/assets/1038897/17372564/a91ec9d8-59a4-11e6-92cb-fcd73234e8d5.png)

![sync2](https://cloud.githubusercontent.com/assets/1038897/17372569/b224a976-59a4-11e6-8ce4-d04c0c5485a8.png)

.