### PR TITLE
prevent xss on jeeves-errors

### DIFF
--- a/common/src/main/java/org/fao/geonet/exceptions/JeevesException.java
+++ b/common/src/main/java/org/fao/geonet/exceptions/JeevesException.java
@@ -74,7 +74,7 @@ public abstract class JeevesException extends RuntimeException {
         }
 
         Element error = new Element(Constants.ERROR)
-            .addContent(new Element("message").setText(msg))
+            .addContent(new Element("message").setText(msg).replaceAll("\\<.*?\\>", ""))
             .addContent(new Element("class").setText(cls))
             .addContent(getStackTrace(t, 10));
 


### PR DESCRIPTION
for example this url presents a thread

http://localhost:8080/geonetwork/srv/kor/q?_content_type=json&fast=index&from=%27%22%3E%3C%2Ftextarea%3E--%3E%3C%3Fxml+version%3D%221.0%22+encoding%3D%22ISO-8859-1%22%3F%3E%3Cscript%3Enew+dd4f47e67c209667613c1d7d5cc9a1d2%3B%3C%2Fscript%3E&serviceType=OGC:WMS&to=100

same for xml.metadata.get, suggest and info service