### PR TITLE
ISO19139 / Add table view mode for contact 

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -898,7 +898,7 @@ eg. The gmd:MD_Identifier may contain a gmd:authority node which needs to be pre
       </gmd:identifier>
     </snippet>
 
-Warning: Template based field does not support multilingual editing for ISO standards (ie. only the main language is edited - therefore, multilingual elements will be preserved). 
+Warning: Template based field does not support multilingual editing for ISO standards (ie. only the main language is edited - therefore, multilingual elements will be preserved).
 
         ]]></xs:documentation>
     </xs:annotation>
@@ -1572,6 +1572,13 @@ the layout:
       <xsl:template name="iso19115-3-qm">
         <h1><xsl:value-of select="$strings/qualityMeasures"/></h1>
 
+
+For example, create a table of contact:
+
+.. code-block:: xml
+
+      <xsl xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact"
+           mode="iso19139-table-contact"/>
 
 ]]>
       </xs:documentation>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:gn="http://www.fao.org/geonetwork"
+                xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
+                xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
+                version="2.0"
+                exclude-result-prefixes="#all">
+
+  <!--
+    Display contact as table when mode is flat (eg. simple view) or if using xsl mode
+
+    Match first node (or added one)
+  -->
+  <xsl:template mode="mode-iso19139"
+                match="gmd:pointOfContact[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]|
+                       gmd:contact[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]|
+                       gmd:distributorContact[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]|
+                       gmd:processor[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]|
+                       gmd:citedResponsibleParty[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]"
+                priority="2000">
+    <xsl:call-template name="iso19139-table-contact"/>
+  </xsl:template>
+
+
+  <!-- Ignore the following -->
+  <xsl:template mode="mode-iso19139"
+                match="gmd:pointOfContact[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]|
+                       gmd:contact[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]|
+                       gmd:distributorContact[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]|
+                       gmd:processor[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]|
+                       gmd:citedResponsibleParty[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]"
+                priority="2000">
+  </xsl:template>
+
+
+  <!-- Define table layout -->
+  <xsl:template name="iso19139-table-contact">
+    <xsl:variable name="name" select="name()"/>
+
+    <xsl:variable name="values">
+      <header>
+        <col>
+          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'gmd:organisationName', $labels,'', '', '')/label"/>
+        </col>
+        <col>
+          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'gmd:individualName', $labels,'', '', '')/label"/>
+        </col>
+        <col>
+          <xsl:value-of
+            select="gn-fn-metadata:getLabel($schema, 'gmd:electronicMailAddress', $labels,'', '', '')/label"/>
+        </col>
+        <col>
+          <xsl:value-of
+            select="gn-fn-metadata:getLabel($schema, 'gmd:role', $labels,'', '', '')/label"/>
+        </col>
+      </header>
+      <xsl:for-each select="(.|following-sibling::*[name() = $name])/gmd:CI_ResponsibleParty">
+        <row>
+          <col>
+            <xsl:copy-of select="gmd:organisationName"/>
+          </col>
+          <col>
+            <xsl:copy-of select="gmd:individualName"/>
+          </col>
+          <col>
+            <xsl:copy-of select="gmd:contactInfo/*/gmd:address/*/gmd:electronicMailAddress"/>
+          </col>
+          <col>
+            <xsl:copy-of select="gmd:role"/>
+          </col>
+          <col remove="">
+            <xsl:copy-of select="ancestor::*[name() = $name]/gn:element"/>
+          </col>
+        </row>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+
+    <xsl:call-template name="render-boxed-element">
+      <xsl:with-param name="label"
+                      select="gn-fn-metadata:getLabel($schema, $name, $labels, name(..), $isoType, $xpath)/label"/>
+      <xsl:with-param name="editInfo" select="gn:element"/>
+      <xsl:with-param name="cls" select="local-name()"/>
+      <xsl:with-param name="subTreeSnippet">
+
+        <xsl:call-template name="render-table">
+          <xsl:with-param name="values" select="$values"/>
+        </xsl:call-template>
+
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -38,6 +38,7 @@
   <xsl:include href="utility-tpl.xsl"/>
   <xsl:include href="layout-custom-fields.xsl"/>
   <xsl:include href="layout-custom-fields-date.xsl"/>
+  <xsl:include href="layout-custom-tpl.xsl"/>
 
   <!-- Ignore all gn element -->
   <xsl:template mode="mode-iso19139"

--- a/schemas/iso19139/src/main/plugin/iso19139/schema-suggestions.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema-suggestions.xml
@@ -130,6 +130,7 @@
         ie. less fields than in GeoNetwork default behaviour.-->
   <field name="gmd:CI_ResponsibleParty">
     <suggest name="gmd:organisationName"/>
+    <suggest name="gmd:individualName"/>
     <suggest name="gmd:contactInfo"/>
   </field>
 

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -488,6 +488,22 @@ form.gn-tab-xml {
     display:none;
   }
 }
+
+.gn-table {
+  /* Compact gn-fields displayed in table mode.
+  Label and remove control are hidden. */
+  div.gn-field {
+    padding: 0px !important;
+    label,
+    .col-sm-1.gn-control {
+      display: none;
+    }
+    .col-sm-9 {
+      width: 100%;
+    }
+  }
+}
+
 .skos-btn-icons {
   text-decoration: none !important;
   color: @gray;

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -681,6 +681,10 @@
     <xsl:param name="label" as="xs:string?"/>
     <xsl:param name="directive" as="node()?"/>
     <xsl:param name="childEditInfo"/>
+    <!-- If not provided, add element can't define where to add element.
+    In such case, the add action is not rendered. eg. in table mode
+    elements can't be added in the same col and the parentEditInfo is
+    not provided to not render that part of the form. -->
     <xsl:param name="parentEditInfo"/>
     <!-- Hide add element if child of an XLink section. -->
     <xsl:param name="isDisabled" select="ancestor::node()[@xlink:href]"/>
@@ -690,7 +694,7 @@
     <xsl:param name="btnLabel" required="no" as="xs:string?" select="''"/>
     <xsl:param name="btnClass" required="no" as="xs:string?" select="''"/>
 
-    <xsl:if test="not($isDisabled)">
+    <xsl:if test="not($isDisabled) and $parentEditInfo/@ref != ''">
       <xsl:variable name="id" select="generate-id()"/>
       <xsl:variable name="qualifiedName"
                     select="concat($childEditInfo/@prefix, ':', $childEditInfo/@name)"/>
@@ -1401,7 +1405,7 @@
     <xsl:param name="values" as="node()"/>
     <xsl:param name="addControl" as="node()?"/>
 
-    <table class="table table-striped">
+    <table class="table table-striped gn-table">
       <xsl:for-each select="$values/header">
         <thead>
           <tr>
@@ -1445,31 +1449,35 @@
                   </xsl:when>
                   <xsl:otherwise>
                     <xsl:choose>
-                      <xsl:when test="@type = 'textarea'">
-                        <!-- TODO: Multilingual, codelist, date ... -->
-                        <textarea class="form-control"
-                                  name="_{*/gn:element/@ref}">
-                          <xsl:value-of select="*/text()"/>
-                        </textarea>
-                      </xsl:when>
-                      <xsl:otherwise>
-                        <input class="form-control"
-                               type="{if (@type = 'Real' or @type = 'Integer' or @type = 'Percentage')
+                      <xsl:when test="@type">
+                        <xsl:choose>
+                          <xsl:when test="@type = 'textarea'">
+                            <!-- TODO: Multilingual, codelist, date ... -->
+                            <textarea class="form-control"
+                                      name="_{*/gn:element/@ref}">
+                              <xsl:value-of select="*/text()"/>
+                            </textarea>
+                          </xsl:when>
+                          <xsl:otherwise>
+                            <input class="form-control"
+                                   type="{if (@type = 'Real' or @type = 'Integer' or @type = 'Percentage')
                                   then 'number'
                                   else 'text'}"
-                               name="_{*/gn:element/@ref}"
-                               value="{*/normalize-space()}"/>
+                                   name="_{*/gn:element/@ref}"
+                                   value="{*/normalize-space()}"/>
+                          </xsl:otherwise>
+                        </xsl:choose>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <!-- Call schema render mode of the field without label and controls.-->
+                        <saxon:call-template name="{concat('dispatch-', $schema)}">
+                          <xsl:with-param name="base" select="."/>
+                          <xsl:with-param name="overrideLabel"
+                                          select="''"/>
+                        </saxon:call-template>
                       </xsl:otherwise>
                     </xsl:choose>
 
-                    <!-- TODO call schema render mode of the field without
-                    label and controls.
-
-                    <saxon:call-template name="{concat('dispatch-', $schema)}">
-                      <xsl:with-param name="base" select="."/>
-                      <xsl:with-param name="overrideLabel"
-                                      select="''"/>
-                    </saxon:call-template> -->
                   </xsl:otherwise>
                 </xsl:choose>
               </td>


### PR DESCRIPTION
This mode is applied in flat mode (ie. simple view) or when using an editor configuration with:

```
 <xsl xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact"
         mode="iso19139-table-contact"/>
```

![image](https://cloud.githubusercontent.com/assets/1701393/17691059/c2ab17ec-6392-11e6-9217-cbe8a49c9e52.png)

Advantages with template mode used in INSPIRE view is that it also support multilingual elements.


@josegar74 Could you review that and see if that also cover your needs on the swedish project ? thanks.

One future improvement would be to be able to configure a table from the config-editor section directly.
