### PR TITLE
Bug/inspire indexing windows

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -1077,7 +1077,7 @@ public class SearchManager {
         try {
             Map<String, Object> params = new HashMap<String, Object>();
             params.put("inspire", Boolean.toString(isInspireEnabled()));
-            params.put("thesauriDir", geonetworkDataDirectory.getThesauriDir().toAbsolutePath());
+            params.put("thesauriDir", geonetworkDataDirectory.getThesauriDir().toAbsolutePath().toString());
 
             Element defaultLang = Xml.transform(xml, defaultLangStyleSheet, params);
             if (Files.exists(otherLocalesStyleSheet)) {

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -58,7 +58,7 @@
   <xsl:param name="inspire">false</xsl:param>
 
   <xsl:variable name="inspire-thesaurus"
-                select="if ($inspire!='false') then document(concat('file:///', $thesauriDir, '/external/thesauri/theme/inspire-theme.rdf')) else ''"/>
+                select="if ($inspire!='false') then document(concat('file:///', replace($thesauriDir, '\\', '/'), '/external/thesauri/theme/inspire-theme.rdf')) else ''"/>
   <xsl:variable name="inspire-theme"
                 select="if ($inspire!='false') then $inspire-thesaurus//skos:Concept else ''"/>
 


### PR DESCRIPTION
This is a bug fix for #1402
The windows path contained '\' instead of '/', so I added a replace. I also checked the other xsl files, and they were already handling this correctly.