### PR TITLE
Display links in gmx:Anchor (used for gmd:useLimitation) with hyperlinks in metadata views

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Functions.groovy
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Functions.groovy
@@ -26,6 +26,15 @@ public class Functions {
     def isoUrlText = { el ->
         el.'gmd:URL'.text()
     }
+
+    def isoAnchorUrlLink = { el ->
+        el.'gmx:Anchor'['@xlink:href'].text()
+    }
+
+    def isoAnchorUrlText = { el ->
+        el.'gmx:Anchor'.text()
+    }
+
     def isoText = { el ->
         def uiCode2 = '#'+env.lang2.toUpperCase()
         def uiCode3 = '#'+env.lang3.toUpperCase()

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
@@ -30,6 +30,7 @@ public class Handlers {
         handlers.add name: 'Text Elements', select: matchers.isTextEl, isoTextEl
         handlers.add name: 'Simple Text Elements', select: matchers.isSimpleTextEl, isoSimpleTextEl
         handlers.add name: 'URL Elements', select: matchers.isUrlEl, isoUrlEl
+        handlers.add name: 'Anchor URL Elements', select: matchers.isAnchorUrlEl, isoAnchorUrlEl
         handlers.add name: 'Simple Elements', select: matchers.isBasicType, isoBasicType
         handlers.add name: 'Boolean Elements', select: matchers.isBooleanEl, isoBooleanEl
         handlers.add name: 'CodeList Elements', select: matchers.isCodeListEl, isoCodeListEl
@@ -83,6 +84,7 @@ public class Handlers {
 
     def isoTextEl = { isofunc.isoTextEl(it, isofunc.isoText(it))}
     def isoUrlEl = { isofunc.isoUrlEl(it, isofunc.isoUrlText(it), isofunc.isoUrlText(it))}
+    def isoAnchorUrlEl = { isofunc.isoUrlEl(it, isofunc.isoAnchorUrlLink(it), isofunc.isoAnchorUrlText(it))}
     def isoDatasetUriEl = { isofunc.isoUrlEl(it, isofunc.isoText(it), isofunc.isoText(it))}
     def isoCodeListEl = {isofunc.isoTextEl(it, f.codelistValueLabel(it))}
     def isoBasicType = {isofunc.isoTextEl(it, it.'*'.text())}

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Matchers.groovy
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Matchers.groovy
@@ -6,6 +6,7 @@ public class Matchers {
     def env
 
     def isUrlEl = {!it.'gmd:URL'.text().isEmpty()}
+    def isAnchorUrlEl = {!it.'gmx:Anchor'['@xlink:href'].text().isEmpty()}
     def simpleElements = ['gco:Decimal', 'gco:Integer', 'gco:Scale', 'gco:Angle', 'gco:Measure', 'gco:Distance',
                           'gmd:MD_PixelOrientationCode', 'gts:TM_PeriodDuration']
 
@@ -37,7 +38,7 @@ public class Matchers {
 
     def isContainerEl = {el ->
         !isBasicType(el) && !isSimpleTextEl(el) &&
-                !isTextEl(el) && !isUrlEl(el) &&
+                !isTextEl(el) && !isUrlEl(el) && !isAnchorUrlEl(el) &&
                 !isCodeListEl(el) && !hasCodeListChild(el) &&
                 !isDateEl(el) && !hasDateChild(el) &&
                 !el.children().isEmpty()

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -456,6 +456,16 @@
                     <Field name="{$fieldPrefix}UseLimitation"
                            string="{string(.)}" store="true" index="true"/>
                 </xsl:for-each>
+
+                <xsl:for-each select="gmd:useLimitation/gmx:Anchor[not(string(@xlink:href))]">
+                    <Field name="{$fieldPrefix}UseLimitation"
+                           string="{string(.)}" store="true" index="true"/>
+                </xsl:for-each>
+
+                <xsl:for-each select="gmd:useLimitation/gmx:Anchor[string(@xlink:href)]">
+                    <Field name="{$fieldPrefix}UseLimitation"
+                           string="{concat('link|',string(@xlink:href), '|', string(.))}" store="true" index="true"/>
+                </xsl:for-each>
             </xsl:for-each>
 
             <!-- Index aggregation info and provides option to query by type of association

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -903,4 +903,40 @@
       }
     };
   });
+
+  /**
+   * @ngdoc directive
+   * @name gn_utility.directive:gnLynky
+   *
+   * @description
+   * If the text provided contains the following format:
+   * link|URL|Text, it's converted to an hyperlink, otherwise
+   * the text is displayed without any formatting.
+   *
+   */
+  module.directive('gnLynky', ['$compile',
+    function($compile) {
+      return {
+        restrict: 'A',
+        scope: {
+          text: '@gnLynky'
+        },
+        link: function(scope, element, attrs) {
+          if (scope.text.startsWith('link') &&
+              scope.text.split('|').length == 3) {
+            scope.link = scope.text.split('|')[1];
+            scope.value = scope.text.split('|')[2];
+
+            element.replaceWith($compile('<a data-ng-href="{{link}}" ' +
+                'data-ng-bind-html="value"></a>')(scope));
+          } else {
+
+            element.replaceWith($compile('<span ' +
+                'data-ng-bind-html="text"></span>')(scope));
+          }
+        }
+
+      };
+    }
+  ]);
 })();

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -195,7 +195,7 @@
             <tr data-ng-if="mdView.current.record.resourceConstraints">
               <th data-translate="">resourceConstraints</th>
               <td>
-                <p data-ng-repeat="c in mdView.current.record.resourceConstraints track by $index">{{c}}</p>
+                <p data-ng-repeat="c in mdView.current.record.resourceConstraints track by $index"><span data-gn-lynky="{{c}}" /></p>
               </td>
             </tr>
 


### PR DESCRIPTION
This feature adds a new directive ```gnLynky``` that can be used to display metadata indexed fields (or any other text) with the following format: ```link|URL|Text``` as an HTML hyperlink:


![use-limitations-hyperlink](https://cloud.githubusercontent.com/assets/1695003/18197497/bcac74c2-70f7-11e6-87b2-3f25cc743051.png)

It contains changes in the indexing of ```gmd:useLimitation``` with ```gmx:Anchor``` that contains ```xlink:href``` attributes with previous format to be displayed with the ```gnLynky``` directive. An example xml snippet with this use case:

```
<gmd:useLimitation>
    <gmx:Anchor 
        xlink:href="http://www.nationalarchives.gov.uk/doc/open-government-licence/">
     Open Government Licence</gmx:Anchor>
</gmd:useLimitation>
```
Similar indexing can be applied to other elements with similar stuff.

Also the groovy formatter has been updated to manage these cases:

![groovy-formatter-use-limitations-hyperlink](https://cloud.githubusercontent.com/assets/1695003/18197547/01d60b3a-70f8-11e6-8de0-60d7bcc2bf08.png)