### PR TITLE
Set thumbnails and onlines to null in JSON get related API response 

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
@@ -80,57 +80,61 @@
                 match="metadata[gmd:MD_Metadata or *[contains(@gco:isoType, 'MD_Metadata')]]"
                 priority="99">
 
-    <thumbnails>
-      <xsl:for-each select="*/descendant::*[name(.) = 'gmd:graphicOverview']/*">
-        <item>
-          <id>
-            <xsl:value-of select="gmd:fileName/gco:CharacterString"/>
-          </id>
-          <url>
-            <xsl:value-of select="gmd:fileName/gco:CharacterString"/>
-          </url>
-          <title>
-            <xsl:apply-templates mode="get-iso19139-localized-string"
-                                 select="gmd:fileDescription"/>
-          </title>
-          <type>thumbnail</type>
-        </item>
-      </xsl:for-each>
-    </thumbnails>
+    <xsl:if test="count(*/descendant::*[name(.) = 'gmd:graphicOverview']/*) > 0">
+      <thumbnails>
+        <xsl:for-each select="*/descendant::*[name(.) = 'gmd:graphicOverview']/*">
+          <item>
+            <id>
+              <xsl:value-of select="gmd:fileName/gco:CharacterString"/>
+            </id>
+            <url>
+              <xsl:value-of select="gmd:fileName/gco:CharacterString"/>
+            </url>
+            <title>
+              <xsl:apply-templates mode="get-iso19139-localized-string"
+                                   select="gmd:fileDescription"/>
+            </title>
+            <type>thumbnail</type>
+          </item>
+        </xsl:for-each>
+      </thumbnails>
+    </xsl:if>
 
-    <onlines>
-      <xsl:for-each select="*/descendant::*[name(.) = 'gmd:onLine']/*[gmd:linkage/gmd:URL!='']">
-        <item>
-          <xsl:variable name="langCode">
-            <xsl:value-of select="concat('#', upper-case(util:twoCharLangCode($lang, 'EN')))"/>
-          </xsl:variable>
-          <xsl:variable name="url" select="gmd:linkage/gmd:URL"/>
-          <id>
-            <xsl:value-of select="$url"/>
-          </id>
-          <title>
-            <xsl:apply-templates mode="get-iso19139-localized-string"
-                                 select="gmd:name"/>
-          </title>
-          <url>
-            <xsl:value-of select="$url"/>
-          </url>
-          <function>
-            <xsl:value-of select="gmd:function/*/@codeListValue"/>
-          </function>
-          <applicationProfile>
-            <xsl:value-of select="gmd:applicationProfile/gco:CharacterString"/>
-          </applicationProfile>
-          <description>
-            <xsl:apply-templates mode="get-iso19139-localized-string"
-                                 select="gmd:description"/>
-          </description>
-          <protocol>
-            <xsl:value-of select="gn-fn-rel:translate(gmd:protocol, $langCode)"/>
-          </protocol>
-          <type>onlinesrc</type>
-        </item>
-      </xsl:for-each>
-    </onlines>
+    <xsl:if test="count(*/descendant::*[name(.) = 'gmd:onLine']/*[gmd:linkage/gmd:URL!='']) > 0">
+      <onlines>
+        <xsl:for-each select="*/descendant::*[name(.) = 'gmd:onLine']/*[gmd:linkage/gmd:URL!='']">
+          <item>
+            <xsl:variable name="langCode">
+              <xsl:value-of select="concat('#', upper-case(util:twoCharLangCode($lang, 'EN')))"/>
+            </xsl:variable>
+            <xsl:variable name="url" select="gmd:linkage/gmd:URL"/>
+            <id>
+              <xsl:value-of select="$url"/>
+            </id>
+            <title>
+              <xsl:apply-templates mode="get-iso19139-localized-string"
+                                   select="gmd:name"/>
+            </title>
+            <url>
+              <xsl:value-of select="$url"/>
+            </url>
+            <function>
+              <xsl:value-of select="gmd:function/*/@codeListValue"/>
+            </function>
+            <applicationProfile>
+              <xsl:value-of select="gmd:applicationProfile/gco:CharacterString"/>
+            </applicationProfile>
+            <description>
+              <xsl:apply-templates mode="get-iso19139-localized-string"
+                                   select="gmd:description"/>
+            </description>
+            <protocol>
+              <xsl:value-of select="gn-fn-rel:translate(gmd:protocol, $langCode)"/>
+            </protocol>
+            <type>onlinesrc</type>
+          </item>
+        </xsl:for-each>
+      </onlines>
+    </xsl:if>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
In the API /records/{uuid}/related, when requested in JSON, and no thumbnails or onlines are found set these properties to null instead of an empty array to remain consistents with the other fields in the related response.