### PR TITLE
Encode passwords stored in the database

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -501,6 +501,15 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-hibernate4</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt-spring31</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java
@@ -24,12 +24,15 @@
 package org.fao.geonet.kernel.setting;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.HarvesterSetting;
 import org.fao.geonet.repository.HarvesterSettingRepository;
 import org.fao.geonet.utils.Log;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jdom.Element;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -67,6 +70,10 @@ public class HarvesterSettingsManager {
 
     @PersistenceContext
     private EntityManager _entityManager;
+
+    @Autowired
+    private StandardPBEStringEncryptor encryptor;
+
 
     // ---------------------------------------------------------------------------
     // ---
@@ -139,7 +146,11 @@ public class HarvesterSettingsManager {
         HarvesterSettingRepository settingsRepo = ApplicationContextHolder.get().getBean(HarvesterSettingRepository.class);
         HarvesterSetting s = settingsRepo.findOneByPath(path);
 
-        return (s == null) ? null : s.getValue();
+        if (s == null) {
+            return null;
+        } else {
+            return getSettingValue(s);
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -199,7 +210,7 @@ public class HarvesterSettingsManager {
                 success = false;
                 Log.warning(Geonet.SETTINGS, "Unable to find Settings row for: " + path + ". Check settings table.");
             } else {
-                s.setValue(value);
+                setSettingValue(s, value);
                 if (Log.isDebugEnabled(Geonet.SETTINGS)) {
                     Log.debug(Geonet.SETTINGS, "Set path: " + path + ", value: " + value);
                 }
@@ -214,8 +225,17 @@ public class HarvesterSettingsManager {
 
     /**
      * When adding to a newly created node, path must be 'id:...'.
+     *
+     * @param path
+     * @param name
+     * @param value
+     * @return
      */
     public String add(String path, Object name, Object value) {
+        return add(path, name, value, false);
+    }
+
+    public String add(String path, Object name, Object value, boolean encrypted) {
         if (name == null)
             throw new IllegalArgumentException("Name cannot be null");
 
@@ -231,7 +251,8 @@ public class HarvesterSettingsManager {
         if (parent == null)
             return null;
 
-        HarvesterSetting child = new HarvesterSetting().setParent(parent).setName(sName).setValue(sValue);
+        HarvesterSetting child = new HarvesterSetting().setParent(parent).setName(sName).setEncrypted(encrypted);
+        setSettingValue(child, sValue);
 
         settingsRepo.save(child);
         return Integer.toString(child.getId());
@@ -337,7 +358,7 @@ public class HarvesterSettingsManager {
         el.setAttribute("id", Integer.toString(s.getId()));
         if (s.getValue() != null) {
             Element value = new Element("value");
-            value.setText(s.getValue());
+            value.setText(getSettingValue(s));
             el.addContent(value);
         }
 
@@ -367,7 +388,7 @@ public class HarvesterSettingsManager {
 
         if (s.getValue() != null) {
             Element value = new Element("value");
-            value.setText(s.getValue());
+            value.setText(getSettingValue(s));
 
             el.addContent(value);
         }
@@ -400,5 +421,35 @@ public class HarvesterSettingsManager {
 
     public void refresh() {
         _entityManager.getEntityManagerFactory().getCache().evict(HarvesterSetting.class);
+    }
+
+
+
+    /**
+     * Sets a setting value, encrypting the value if required.
+     *
+     * @param s
+     * @param value
+     */
+    private void setSettingValue(HarvesterSetting s, String value) {
+        if (s.isEncrypted() && StringUtils.isNotEmpty(value)) {
+            s.setValue(this.encryptor.encrypt(value));
+        } else {
+            s.setValue(value);
+        }
+    }
+
+    /**
+     * Retrieves a setting value, decrypting the value if required.
+     *
+     * @param s
+     * @return
+     */
+    private String getSettingValue(HarvesterSetting s) {
+        if (s.isEncrypted() && StringUtils.isNotEmpty(s.getValue())) {
+            return this.encryptor.decrypt(s.getValue());
+        } else {
+            return s.getValue();
+        }
     }
 }

--- a/core/src/test/resources/web-test-context.xml
+++ b/core/src/test/resources/web-test-context.xml
@@ -77,4 +77,13 @@ http://www.fao.org/geonetwork/spring http://www.fao.org/geonetwork/spring/gn-spr
     </gns:summaryType>
   </gns:summaryTypes>
 
+  <bean id="strongEncryptor"
+        class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor">
+    <property name="algorithm">
+      <value>PBEWithMD5AndDES</value>
+    </property>
+    <property name="password">
+      <value>jasypt</value>
+    </property>
+  </bean>
 </beans>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -120,6 +120,18 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt-spring31</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt-hibernate4</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/domain/src/main/java/org/fao/geonet/domain/HarvesterSetting.java
+++ b/domain/src/main/java/org/fao/geonet/domain/HarvesterSetting.java
@@ -58,6 +58,8 @@ public class HarvesterSetting extends GeonetEntity {
     private HarvesterSetting _parent;
     private String _name;
     private String _value;
+    private char _encrypted  = Constants.YN_FALSE;
+
 
     /**
      * Get the setting id. This is a generated value and as such new instances should not have this
@@ -184,6 +186,47 @@ public class HarvesterSetting extends GeonetEntity {
     public HarvesterSetting setValue(int value) {
         return setValue(String.valueOf(value));
     }
+
+    /**
+     * For backwards compatibility we need the activated column to be either 'n' or 'y'.
+     * This is a workaround to allow this until future
+     * versions of JPA that allow different ways of controlling how types are mapped to the database.
+     */
+    @Column(name = "encrypted", nullable = false, length = 1, columnDefinition="char default 'y'")
+    protected char getEncrypted_JpaWorkaround() {
+        return _encrypted;
+    }
+
+    /**
+     * Set the column value. Constants.YN_ENABLED for true Constants.YN_DISABLED for false.
+     *
+     * @param encryptedValue the column value. Constants.YN_ENABLED for true Constants.YN_DISABLED for false.
+     * @return
+     */
+    protected void setEncrypted_JpaWorkaround(char encryptedValue) {
+        _encrypted = encryptedValue;
+    }
+
+    /**
+     * Return true if the setting is public.
+     *
+     * @return true if the setting is public.
+     */
+    @Transient
+    public boolean isEncrypted() {
+        return Constants.toBoolean_fromYNChar(getEncrypted_JpaWorkaround());
+    }
+
+    /**
+     * Set true if the setting is private.
+     *
+     * @param encrypted true if the setting is private.
+     */
+    public HarvesterSetting setEncrypted(boolean encrypted) {
+        setEncrypted_JpaWorkaround(Constants.toYN_EnabledChar(encrypted));
+        return this;
+    }
+
 
     /**
      * Get the values as a boolean. Returns false if the values is not a boolean.

--- a/domain/src/main/java/org/fao/geonet/domain/MapServer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MapServer.java
@@ -24,6 +24,10 @@
 package org.fao.geonet.domain;
 
 import org.fao.geonet.entitylistener.MapServerEntityListenerManager;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.jasypt.hibernate4.type.EncryptedStringType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,6 +42,14 @@ import java.util.Map;
  *
  * @author Francois
  */
+@TypeDef(
+        name="encryptedString",
+        typeClass=EncryptedStringType.class,
+        parameters= {
+                // value will be used later to register encryptor
+                @Parameter(name="encryptorRegisteredName", value="STRING_ENCRYPTOR")
+        }
+)
 @Entity
 @Table(name = "Mapservers")
 @Cacheable
@@ -232,6 +244,7 @@ public class MapServer extends GeonetEntity {
      * @return the password.
      */
     @Column(length = 128)
+    @Type(type="encryptedString")
     public String getPassword() {
         return _password;
     }

--- a/domain/src/main/java/org/fao/geonet/domain/Setting.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Setting.java
@@ -51,6 +51,8 @@ public class Setting extends GeonetEntity {
     private SettingDataType dataType = SettingDataType.STRING;
     private int position = 0;
     private char internal = Constants.YN_TRUE;
+    private char encrypted  = Constants.YN_FALSE;
+
 
     @Id
     @Column(name = "name", nullable = false, length = 255/* mysql cannot accept it any bigger if it is to be the id */)
@@ -133,6 +135,46 @@ public class Setting extends GeonetEntity {
      */
     public Setting setInternal(boolean internal) {
         setInternal_JpaWorkaround(Constants.toYN_EnabledChar(internal));
+        return this;
+    }
+
+    /**
+     * For backwards compatibility we need the activated column to be either 'n' or 'y'.
+     * This is a workaround to allow this until future
+     * versions of JPA that allow different ways of controlling how types are mapped to the database.
+     */
+    @Column(name = "encrypted", nullable = false, length = 1, columnDefinition="char default 'y'")
+    protected char getEncrypted_JpaWorkaround() {
+        return encrypted;
+    }
+
+    /**
+     * Set the column value. Constants.YN_ENABLED for true Constants.YN_DISABLED for false.
+     *
+     * @param encryptedValue the column value. Constants.YN_ENABLED for true Constants.YN_DISABLED for false.
+     * @return
+     */
+    protected void setEncrypted_JpaWorkaround(char encryptedValue) {
+        encrypted = encryptedValue;
+    }
+
+    /**
+     * Return true if the setting is public.
+     *
+     * @return true if the setting is public.
+     */
+    @Transient
+    public boolean isEncrypted() {
+        return Constants.toBoolean_fromYNChar(getEncrypted_JpaWorkaround());
+    }
+
+    /**
+     * Set true if the setting is private.
+     *
+     * @param encrypted true if the setting is private.
+     */
+    public Setting setEncrypted(boolean encrypted) {
+        setEncrypted_JpaWorkaround(Constants.toYN_EnabledChar(encrypted));
         return this;
     }
 

--- a/domain/src/test/java/org/fao/geonet/repository/MapServerTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/MapServerTest.java
@@ -25,6 +25,9 @@ package org.fao.geonet.repository;
 
 
 import org.fao.geonet.domain.MapServer;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.hibernate4.encryptor.HibernatePBEEncryptorRegistry;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +49,17 @@ public class MapServerTest extends AbstractSpringDataTest {
     EntityManager _entityManager;
 
     private AtomicInteger _nextId = new AtomicInteger();
+
+    @BeforeClass
+    public static void init() {
+        StandardPBEStringEncryptor strongEncryptor = new StandardPBEStringEncryptor();
+        strongEncryptor.setPassword("testpassword");
+
+        HibernatePBEEncryptorRegistry registry =
+                HibernatePBEEncryptorRegistry.getInstance();
+        registry.registerPBEStringEncryptor("STRING_ENCRYPTOR", strongEncryptor);
+    }
+
 
     public static MapServer newMapServer(AtomicInteger nextId) {
         int id = nextId.incrementAndGet();

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -769,7 +769,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
         String useAccId = settingMan.add(ID_PREFIX + siteId, "useAccount", params.isUseAccount());
 
         settingMan.add(ID_PREFIX + useAccId, "username", params.getUsername());
-        settingMan.add(ID_PREFIX + useAccId, "password", params.getPassword());
+        settingMan.add(ID_PREFIX + useAccId, "password", params.getPassword(), true);
 
         //--- setup options node ---------------------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -1012,6 +1012,21 @@
         <artifactId>jaxb-impl</artifactId>
         <version>2.2.7</version>
       </dependency>
+      <dependency>
+        <groupId>org.jasypt</groupId>
+        <artifactId>jasypt</artifactId>
+        <version>1.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jasypt</groupId>
+        <artifactId>jasypt-spring31</artifactId>
+        <version>1.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jasypt</groupId>
+        <artifactId>jasypt-hibernate4</artifactId>
+        <version>1.9.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/services/src/test/java/org/fao/geonet/api/mapservers/MapServersApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/mapservers/MapServersApiTest.java
@@ -29,8 +29,11 @@ import org.fao.geonet.api.JsonFieldNamingStrategy;
 import org.fao.geonet.domain.MapServer;
 import org.fao.geonet.repository.MapServerRepository;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.hibernate4.encryptor.HibernatePBEEncryptorRegistry;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -64,6 +67,17 @@ public class MapServersApiTest extends AbstractServiceIntegrationTest {
     @Before
     public void setUp() {
         createTestData();
+    }
+
+
+    @BeforeClass
+    public static void init() {
+        StandardPBEStringEncryptor strongEncryptor = new StandardPBEStringEncryptor();
+        strongEncryptor.setPassword("testpassword");
+
+        HibernatePBEEncryptorRegistry registry =
+                HibernatePBEEncryptorRegistry.getInstance();
+        registry.registerPBEStringEncryptor("STRING_ENCRYPTOR", strongEncryptor);
     }
 
     @Test

--- a/services/src/test/resources/services-repository-test-context.xml
+++ b/services/src/test/resources/services-repository-test-context.xml
@@ -62,4 +62,13 @@
         class="org.fao.geonet.api.records.formatters.cache.NoCachingStore">
   </bean>
 
+  <bean id="strongEncryptor"
+        class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor">
+    <property name="algorithm">
+      <value>PBEWithMD5AndDES</value>
+    </property>
+    <property name="password">
+      <value>jasypt</value>
+    </property>
+  </bean>
 </beans>

--- a/web/src/main/java/org/fao/geonet/DatabaseMigration.java
+++ b/web/src/main/java/org/fao/geonet/DatabaseMigration.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -274,6 +275,11 @@ public class DatabaseMigration implements BeanPostProcessor {
             _logger.info("         - Java migration class:" + className);
 
             DatabaseMigrationTask task = (DatabaseMigrationTask) Class.forName(className).newInstance();
+
+            if (task instanceof ApplicationContextAware) {
+                ((ApplicationContextAware) task).setApplicationContext(_applicationContext);
+            }
+
             task.update(conn);
             return false;
         } catch (SQLException e) {

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -550,124 +550,124 @@ INSERT INTO Operations (id, name) VALUES  (6,'featured');
 -- === Table: Settings
 -- ======================================================================
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/site/name', 'My GeoNetwork catalogue', 0, 110, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/site/siteId', '', 0, 120, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/site/organization', 'My organization', 0, 130, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/platform/version', '3.2.1', 0, 150, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/platform/subVersion', 'SNAPSHOT', 0, 160, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/site/svnUuid', '', 0, 170, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/host', 'localhost', 0, 210, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/protocol', 'http', 0, 220, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/port', '8080', 1, 230, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/securePort', '8443', 1, 240, 'y');
-INSERT INTO settings (name, value, datatype, position, internal) VALUES ('system/server/log','log4j.xml',0,250,'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/network', '127.0.0.1', 0, 310, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/netmask', '255.0.0.0', 0, 320, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/use', 'false', 2, 510, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/host', NULL, 0, 520, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/port', NULL, 1, 530, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/username', NULL, 0, 540, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/password', NULL, 0, 550, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/ignorehostlist', NULL, 0, 560, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/email', 'root@localhost', 0, 610, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/host', '', 0, 630, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/port', '25', 1, 640, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/username', '', 0, 642, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/password', '', 0, 643, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/ssl', 'false', 2, 641, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/tls', 'false', 2, 644, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/ignoreSslCertificateErrors', 'false', 2, 645, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/selectionmanager/maxrecords', '1000', 1, 910, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/csw/enable', 'true', 2, 1210, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/csw/contactId', NULL, 0, 1220, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/csw/metadataPublic', 'false', 2, 1310, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/csw/transactionUpdateCreateXPath', 'true', 2, 1320, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userSelfRegistration/enable', 'false', 2, 1910, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userFeedback/enable', 'false', 2, 1911, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/clickablehyperlinks/enable', 'true', 2, 2010, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/localrating/enable', 'false', 2, 2110, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/downloadservice/leave', 'false', 0, 2210, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/downloadservice/simple', 'true', 0, 2220, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/downloadservice/withdisclaimer', 'false', 0, 2230, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/xlinkResolver/enable', 'false', 2, 2310, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/xlinkResolver/localXlinkEnable', 'true', 2, 2311, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/xlinkResolver/ignore', 'operatesOn,featureCatalogueCitation,Anchor,source', 0, 2312, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/hidewithheldelements/enableLogging', 'false', 2, 2320, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/autofixing/enable', 'true', 2, 2410, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/searchStats/enable', 'true', 2, 2510, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/indexoptimizer/enable', 'true', 2, 6010, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/indexoptimizer/at/hour', '0', 1, 6030, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/indexoptimizer/at/min', '0', 1, 6040, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/indexoptimizer/at/sec', '0', 1, 6050, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/indexoptimizer/interval', NULL, 0, 6060, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/indexoptimizer/interval/day', '0', 1, 6070, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/indexoptimizer/interval/hour', '24', 1, 6080, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/indexoptimizer/interval/min', '0', 1, 6090, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/oai/mdmode', '1', 0, 7010, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/oai/tokentimeout', '3600', 1, 7020, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/oai/cachesize', '60', 1, 7030, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/oai/maxrecords', '10', 1, 7040, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/enable', 'false', 2, 7210, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/enableSearchPanel', 'false', 2, 7220, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atom', 'disabled', 0, 7230, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atomSchedule', '0 0 0/24 ? * *', 0, 7240, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atomProtocol', 'INSPIRE-ATOM', 0, 7250, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvester/enableEditing', 'false', 2, 9010, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/recipient', NULL, 0, 9020, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/template', '', 0, 9021, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/templateError', 'There was an error on the harvesting: $$errorMsg$$', 0, 9022, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/templateWarning', '', 0, 9023, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/subject', '[$$harvesterType$$] $$harvesterName$$ finished harvesting', 0, 9024, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/enabled', 'false', 2, 9025, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/level1', 'false', 2, 9026, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/level2', 'false', 2, 9027, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/level3', 'false', 2, 9028, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/prefergrouplogo', 'true', 2, 9111, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/allThesaurus', 'false', 2, 9160, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadatacreate/generateUuid', 'true', 2, 9100, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/usergrouponly', 'false', 2, 9180, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/threadedindexing/maxthreads', '1', 1, 9210, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/autodetect/enable', 'false', 2, 9510, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/requestedLanguage/only', 'prefer_locale', 0, 9530, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/requestedLanguage/sorted', 'false', 2, 9540, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/requestedLanguage/ignorechars', '', 0, 9590, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/requestedLanguage/preferUiLanguage', 'true', 2, 9595, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/site/name', 'My GeoNetwork catalogue', 0, 110, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/site/siteId', '', 0, 120, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/site/organization', 'My organization', 0, 130, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/platform/version', '3.2.1', 0, 150, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/platform/subVersion', 'SNAPSHOT', 0, 160, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/site/svnUuid', '', 0, 170, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/server/host', 'localhost', 0, 210, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/server/protocol', 'http', 0, 220, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/server/port', '8080', 1, 230, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/server/securePort', '8443', 1, 240, 'y', 'n');
+INSERT INTO settings (name, value, datatype, position, internal, encrypted) VALUES ('system/server/log','log4j.xml',0,250,'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/intranet/network', '127.0.0.1', 0, 310, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/intranet/netmask', '255.0.0.0', 0, 320, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/proxy/use', 'false', 2, 510, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/proxy/host', NULL, 0, 520, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/proxy/port', NULL, 1, 530, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/proxy/username', NULL, 0, 540, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/proxy/password', NULL, 0, 550, 'y', 'y');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/proxy/ignorehostlist', NULL, 0, 560, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/email', 'root@localhost', 0, 610, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/mailServer/host', '', 0, 630, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/mailServer/port', '25', 1, 640, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/mailServer/username', '', 0, 642, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/mailServer/password', '', 0, 643, 'y', 'y');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/mailServer/ssl', 'false', 2, 641, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/mailServer/tls', 'false', 2, 644, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/mailServer/ignoreSslCertificateErrors', 'false', 2, 645, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/selectionmanager/maxrecords', '1000', 1, 910, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/csw/enable', 'true', 2, 1210, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/csw/contactId', NULL, 0, 1220, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/csw/metadataPublic', 'false', 2, 1310, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/csw/transactionUpdateCreateXPath', 'true', 2, 1320, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/userSelfRegistration/enable', 'false', 2, 1910, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/userFeedback/enable', 'false', 2, 1911, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/clickablehyperlinks/enable', 'true', 2, 2010, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/localrating/enable', 'false', 2, 2110, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/downloadservice/leave', 'false', 0, 2210, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/downloadservice/simple', 'true', 0, 2220, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/downloadservice/withdisclaimer', 'false', 0, 2230, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/xlinkResolver/enable', 'false', 2, 2310, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/xlinkResolver/localXlinkEnable', 'true', 2, 2311, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/xlinkResolver/ignore', 'operatesOn,featureCatalogueCitation,Anchor,source', 0, 2312, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/hidewithheldelements/enableLogging', 'false', 2, 2320, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/autofixing/enable', 'true', 2, 2410, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/searchStats/enable', 'true', 2, 2510, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/indexoptimizer/enable', 'true', 2, 6010, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/indexoptimizer/at/hour', '0', 1, 6030, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/indexoptimizer/at/min', '0', 1, 6040, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/indexoptimizer/at/sec', '0', 1, 6050, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/indexoptimizer/interval', NULL, 0, 6060, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/indexoptimizer/interval/day', '0', 1, 6070, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/indexoptimizer/interval/hour', '24', 1, 6080, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/indexoptimizer/interval/min', '0', 1, 6090, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/oai/mdmode', '1', 0, 7010, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/oai/tokentimeout', '3600', 1, 7020, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/oai/cachesize', '60', 1, 7030, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/oai/maxrecords', '10', 1, 7040, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/inspire/enable', 'false', 2, 7210, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/inspire/enableSearchPanel', 'false', 2, 7220, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/inspire/atom', 'disabled', 0, 7230, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/inspire/atomSchedule', '0 0 0/24 ? * *', 0, 7240, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/inspire/atomProtocol', 'INSPIRE-ATOM', 0, 7250, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvester/enableEditing', 'false', 2, 9010, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/recipient', NULL, 0, 9020, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/template', '', 0, 9021, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/templateError', 'There was an error on the harvesting: $$errorMsg$$', 0, 9022, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/templateWarning', '', 0, 9023, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/subject', '[$$harvesterType$$] $$harvesterName$$ finished harvesting', 0, 9024, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/enabled', 'false', 2, 9025, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/level1', 'false', 2, 9026, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/level2', 'false', 2, 9027, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/harvesting/mail/level3', 'false', 2, 9028, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/metadata/prefergrouplogo', 'true', 2, 9111, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/metadata/allThesaurus', 'false', 2, 9160, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/metadatacreate/generateUuid', 'true', 2, 9100, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/metadataprivs/usergrouponly', 'false', 2, 9180, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/threadedindexing/maxthreads', '1', 1, 9210, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/autodetect/enable', 'false', 2, 9510, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/requestedLanguage/only', 'prefer_locale', 0, 9530, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/requestedLanguage/sorted', 'false', 2, 9540, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/requestedLanguage/ignorechars', '', 0, 9590, 'y', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/requestedLanguage/preferUiLanguage', 'true', 2, 9595, 'y', 'n');
 
 
 -- INSERT INTO Settings (name, value, datatype, position, internal) VALUES
 --  ('map/backgroundChoices', '{"contextList": []}', 0, 9590, false);
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES
-  ('map/config', '{"viewerMap": "../../map/config-viewer.xml", "listOfServices": {"wms": [], "wmts": []}, "useOSM":true,"context":"","layer":{"url":"http://www2.demis.nl/mapserver/wms.asp?","layers":"Countries","version":"1.1.1"},"projection":"EPSG:3857","projectionList":[{"code":"EPSG:4326","label":"WGS84 (EPSG:4326)"},{"code":"EPSG:3857","label":"Google mercator (EPSG:3857)"}]}', 3, 9590, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES
+  ('map/config', '{"viewerMap": "../../map/config-viewer.xml", "listOfServices": {"wms": [], "wmts": []}, "useOSM":true,"context":"","layer":{"url":"http://www2.demis.nl/mapserver/wms.asp?","layers":"Countries","version":"1.1.1"},"projection":"EPSG:3857","projectionList":[{"code":"EPSG:4326","label":"WGS84 (EPSG:4326)"},{"code":"EPSG:3857","label":"Google mercator (EPSG:3857)"}]}', 3, 9590, 'n', 'n');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/background', 'osm', 0, 9590, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/width', '500', 0, 9590, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/summaryWidth', '500', 0, 9590, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/mapproj', 'EPSG:3857', 0, 9590, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('region/getmap/background', 'osm', 0, 9590, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('region/getmap/width', '500', 0, 9590, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('region/getmap/summaryWidth', '500', 0, 9590, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('region/getmap/mapproj', 'EPSG:3857', 0, 9590, 'n', 'n');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES
-  ('map/proj4js', '[{"code":"EPSG:2154","value":"+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"}]', 3, 9591, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES
+  ('map/proj4js', '[{"code":"EPSG:2154","value":"+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"}]', 3, 9591, 'n', 'n');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES
-  ('map/isMapViewerEnabled', 'true', 2, 9592, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES
-  ('map/is3DModeAllowed', 'false', 2, 9593, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES
-  ('map/isSaveMapInCatalogAllowed', 'true', 2, 9594, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES
+  ('map/isMapViewerEnabled', 'true', 2, 9592, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES
+  ('map/is3DModeAllowed', 'false', 2, 9593, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES
+  ('map/isSaveMapInCatalogAllowed', 'true', 2, 9594, 'n', 'n');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES
-  ('metadata/editor/schemaConfig', '{"iso19110":{"defaultTab":"default","displayToolTip":false,"related":{"display":true,"readonly":true,"categories":["dataset"]},"validation":{"display":true}},"iso19139":{"defaultTab":"default","displayToolTip":false,"related":{"display":true,"categories":[]},"suggestion":{"display":true},"validation":{"display":true}},"dublin-core":{"defaultTab":"default","related":{"display":true,"readonly":false,"categories":["parent","onlinesrc"]}}}', 3, 10000, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES
+  ('metadata/editor/schemaConfig', '{"iso19110":{"defaultTab":"default","displayToolTip":false,"related":{"display":true,"readonly":true,"categories":["dataset"]},"validation":{"display":true}},"iso19139":{"defaultTab":"default","displayToolTip":false,"related":{"display":true,"categories":[]},"suggestion":{"display":true},"validation":{"display":true}},"dublin-core":{"defaultTab":"default","related":{"display":true,"readonly":false,"categories":["parent","onlinesrc"]}}}', 3, 10000, 'n', 'n');
 
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/resourceIdentifierPrefix', 'http://localhost:8080/geonetwork/srv/metadata/', 0, 10001, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('metadata/resourceIdentifierPrefix', 'http://localhost:8080/geonetwork/srv/metadata/', 0, 10001, 'n', 'n');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/workflow/draftWhenInGroup', '', 0, 100002, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/workflow/allowPublishInvalidMd', 'true', 2, 100003, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/workflow/automaticUnpublishInvalidMd', 'false', 2, 100004, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/workflow/forceValidationOnMdSave', 'false', 2, 100005, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('metadata/workflow/draftWhenInGroup', '', 0, 100002, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('metadata/workflow/allowPublishInvalidMd', 'true', 2, 100003, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('metadata/workflow/automaticUnpublishInvalidMd', 'false', 2, 100004, 'n', 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('metadata/workflow/forceValidationOnMdSave', 'false', 2, 100005, 'n', 'n');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/ui/defaultView', 'default', 0, 10100, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/ui/defaultView', 'default', 0, 10100, 'n', 'n');
 
-INSERT INTO HarvesterSettings (id, parentid, name, value) VALUES  (1,NULL,'harvesting',NULL);
+INSERT INTO HarvesterSettings (id, parentid, name, value, encrypted) VALUES  (1,NULL,'harvesting',NULL, 'n');
 
 -- ======================================================================
 -- === Table: Users

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v321/UpdateEncryptedSettings.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v321/UpdateEncryptedSettings.java
@@ -1,0 +1,140 @@
+package v321;
+
+import jeeves.config.springutil.JeevesApplicationContext;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.DatabaseMigrationTask;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.Log;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import java.io.FileReader;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ *
+ */
+public class UpdateEncryptedSettings implements DatabaseMigrationTask, ApplicationContextAware {
+    private static ApplicationContext applicationContext = null;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void update(Connection connection) throws SQLException {
+        // Take the StandardPBEStringEncryptor configuration from the properties file
+        StandardPBEStringEncryptor standardPBEStringEncryptor = new StandardPBEStringEncryptor();
+
+        String path = ((JeevesApplicationContext) applicationContext).getServletContext()
+                .getRealPath("WEB-INF/config-security/config-security.properties");
+        Properties properties = new Properties();
+
+        FileReader fileReader = null;
+        try {
+            fileReader = new FileReader(path);
+            properties.load(fileReader);
+
+            standardPBEStringEncryptor.setAlgorithm(properties.getProperty("encrypter.algorithm"));
+            standardPBEStringEncryptor.setPassword(properties.getProperty("encrypter.password"));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        } finally {
+            IOUtils.closeQuietly(fileReader);
+        }
+
+        try (Statement statement = connection.createStatement()) {
+            final String encryptedSettings = "SELECT name, value FROM Settings WHERE encrypted = 'y'";
+
+            ResultSet settingsResultSet = statement.executeQuery(encryptedSettings);
+            int numberOfSettings = 0;
+            Map<String, String> updates = new HashMap<String, String>();
+
+            try {
+                while (settingsResultSet.next()) {
+                    String name = settingsResultSet.getString(1);
+                    String value = settingsResultSet.getString(2);
+                    if (StringUtils.isNotEmpty(value)) {
+                        value = standardPBEStringEncryptor.encrypt(value);
+                        updates.put(name, value);
+                        numberOfSettings++;
+                    }
+                }
+                Log.debug(Geonet.DB, "  Number of settings of type password to update: " + numberOfSettings);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            } finally {
+                settingsResultSet.close();
+            }
+
+            for(String key : updates.keySet()) {
+                statement.execute("UPDATE Settings SET value='" + updates.get(key) + "' WHERE name='" + key + "'");
+            }
+
+            final String encryptedHarvesterSettings = "SELECT name, value FROM HarvesterSettings WHERE name = 'password'";
+            ResultSet harvesterSettingsResultSet = statement.executeQuery(encryptedHarvesterSettings);
+            int numberOfHarvesterSettings = 0;
+            updates = new HashMap<String, String>();
+            try {
+                while (harvesterSettingsResultSet.next()) {
+                    String name = harvesterSettingsResultSet.getString(1);
+                    String value = harvesterSettingsResultSet.getString(2);
+                    if (StringUtils.isNotEmpty(value)) {
+                        value = standardPBEStringEncryptor.encrypt(value);
+                        updates.put(name, value);
+
+                        numberOfHarvesterSettings++;
+                    }
+                }
+
+                Log.debug(Geonet.DB, "  Number of harvester settings of type password to update: " + numberOfHarvesterSettings);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            } finally {
+                harvesterSettingsResultSet.close();
+            }
+
+            for(String key : updates.keySet()) {
+                statement.execute("UPDATE HarvesterSettings SET value='" + updates.get(key) + "' WHERE name='" + key + "'");
+            }
+
+
+            final String encryptedMapServerPasswords = "SELECT id, password FROM Mapservers";
+            ResultSet mapServerResultSet = statement.executeQuery(encryptedMapServerPasswords);
+            int numberOfMapServers = 0;
+            Map<Integer, String> updatesMapServers = new HashMap<Integer, String>();
+            try {
+                while (mapServerResultSet.next()) {
+                    Integer id = mapServerResultSet.getInt(1);
+                    String password = mapServerResultSet.getString(2);
+                    if (StringUtils.isNotEmpty(password)) {
+                        password = standardPBEStringEncryptor.encrypt(password);
+                        updatesMapServers.put(id, password);
+                        numberOfMapServers++;
+                    }
+                }
+
+                Log.debug(Geonet.DB, "  Number of map server passwords to update: " + numberOfMapServers);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            } finally {
+                harvesterSettingsResultSet.close();
+            }
+
+            for(Integer key : updatesMapServers.keySet()) {
+                statement.execute("UPDATE Mapservers SET password='" + updates.get(key) + "' WHERE id='" + key + "'");
+            }
+
+        }
+    }
+}

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v321/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v321/migrate-default.sql
@@ -1,2 +1,7 @@
 UPDATE Settings SET value='3.2.1' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
+
+ALTER TABLE Settings ADD COLUMN encrypted VARCHAR(1) DEFAULT 'n';
+
+UPDATE Settings SET encrypted='y' WHERE name='system/proxy/password';
+UPDATE Settings SET encrypted='y' WHERE name='system/feedback/mailServer/password';

--- a/web/src/main/webapp/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webapp/WEB-INF/config-db/database_migration.xml
@@ -169,6 +169,7 @@
     <entry key="3.2.1">
       <list>
         <value>WEB-INF/classes/setup/sql/migrate/v321/migrate-</value>
+        <value>java:v321.UpdateEncryptedSettings</value>
       </list>
     </entry>
   </util:map>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security.properties
@@ -23,33 +23,33 @@
 
 #Core security properties
 
-logout.success.url = /home?node=@@nodeId@@
-loginForm = /signin?node=@@nodeId@@
-loginErrorForm = /login.jsp?node=@@nodeId@@&failure=true
-passwordSalt = secret-hash-salt=
+logout.success.url=/home?node=@@nodeId@@
+loginForm=/signin?node=@@nodeId@@
+loginErrorForm=/login.jsp?node=@@nodeId@@&failure=true
+passwordSalt=secret-hash-salt=
 
 # LDAP Connection Settings
-ldap.base.provider.url = ldap://localhost:389
-ldap.base.dn = dc=fao,dc=org
-ldap.security.principal = cn=admin,dc=fao,dc=org
-ldap.security.credentials = ldap
+ldap.base.provider.url=ldap://localhost:389
+ldap.base.dn=dc=fao,dc=org
+ldap.security.principal=cn=admin,dc=fao,dc=org
+ldap.security.credentials=ldap
 
-ldap.base.search.base = ou=people
-ldap.base.dn.pattern = uid={0},${ldap.base.search.base}
+ldap.base.search.base=ou=people
+ldap.base.dn.pattern=uid={0},${ldap.base.search.base}
 #ldap.base.dn.pattern=mail={0},${ldap.base.search.base}
 
 
 # Define if groups and profile information are imported from LDAP. If not, local database is used.
 # When a new user connect first, the default profile is assigned. A user administrator can update
 # privilege information.
-ldap.privilege.import = false
+ldap.privilege.import=false
 
 # Define if LDAP groups should be create in catalog
 # database if they do not exist.
-ldap.privilege.create.nonexisting.groups = true
+ldap.privilege.create.nonexisting.groups=true
 
 # Define if users should be saved in the LDAP
-ldap.privilege.create.nonexisting.users = false
+ldap.privilege.create.nonexisting.users=false
 
 
 
@@ -57,54 +57,54 @@ ldap.privilege.create.nonexisting.users = false
 # 1. Define one attribute for the profile and one for groups in config-security-overrides.properties
 
 # 2. Define one attribute for the privilege and define a custom pattern (use LDAPUserDetailsContextMapperWithPattern in config-security.xml).
-ldap.privilege.pattern = 
+ldap.privilege.pattern=
 #ldap.privilege.pattern=CAT_(.*)_(.*)
-ldap.privilege.pattern.idx.group = 1
-ldap.privilege.pattern.idx.profil = 2
+ldap.privilege.pattern.idx.group=1
+ldap.privilege.pattern.idx.profil=2
 
 
 # 3. Define custom location for extracting group and role (no support for group/role combination) (use LDAPUserDetailsContextMapperWithProfileSearch in config-security.xml).
-ldap.privilege.search.group.attribute = cn
-ldap.privilege.search.group.object = ou=groups
+ldap.privilege.search.group.attribute=cn
+ldap.privilege.search.group.object=ou=groups
 #ldap.privilege.search.group.query=(&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=EL_*))
-ldap.privilege.search.group.queryprop = memberuid
-ldap.privilege.search.group.query = (&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(|(cn=SP_*)(cn=EL_*)))
-ldap.privilege.search.group.pattern = EL_(.*)
-ldap.privilege.search.privilege.attribute = cn
-ldap.privilege.search.privilege.object = ou=groups
-ldap.privilege.search.privilege.query = (&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=SV_*))
-ldap.privilege.search.privilege.pattern = SV_(.*)
+ldap.privilege.search.group.queryprop=memberuid
+ldap.privilege.search.group.query=(&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(|(cn=SP_*)(cn=EL_*)))
+ldap.privilege.search.group.pattern=EL_(.*)
+ldap.privilege.search.privilege.attribute=cn
+ldap.privilege.search.privilege.object=ou=groups
+ldap.privilege.search.privilege.query=(&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=SV_*))
+ldap.privilege.search.privilege.pattern=SV_(.*)
 
 
 
 # Run LDAP sync every day at 23:30
-ldap.sync.cron = 0 30 23 * * ?
+ldap.sync.cron=0 30 23 * * ?
 #ldap.sync.cron=0 * * * * ?
 #ldap.sync.cron=0 0/1 * 1/1 * ? *
-ldap.sync.startDelay = 60000
-ldap.sync.user.search.base = ${ldap.base.search.base}
-ldap.sync.user.search.filter = (&(objectClass=*)(mail=*@*)(givenName=*))
-ldap.sync.user.search.attribute = uid
-ldap.sync.group.search.base = ou=groups
-ldap.sync.group.search.filter = (&(objectClass=posixGroup)(cn=EL_*))
-ldap.sync.group.search.attribute = cn
-ldap.sync.group.search.pattern = EL_(.*)
+ldap.sync.startDelay=60000
+ldap.sync.user.search.base=${ldap.base.search.base}
+ldap.sync.user.search.filter=(&(objectClass=*)(mail=*@*)(givenName=*))
+ldap.sync.user.search.attribute=uid
+ldap.sync.group.search.base=ou=groups
+ldap.sync.group.search.filter=(&(objectClass=posixGroup)(cn=EL_*))
+ldap.sync.group.search.attribute=cn
+ldap.sync.group.search.pattern=EL_(.*)
 
 
 # CAS properties
-cas.baseURL = https://localhost:8443/cas
-cas.ticket.validator.url = ${cas.baseURL}
-cas.login.url = ${cas.baseURL}/login
-cas.logout.url = ${cas.baseURL}/logout?url=${geonetwork.https.url}/
+cas.baseURL=https://localhost:8443/cas
+cas.ticket.validator.url=${cas.baseURL}
+cas.login.url=${cas.baseURL}/login
+cas.logout.url=${cas.baseURL}/logout?url=${geonetwork.https.url}/
 
 # either the hardcoded url to the server
 # or if has the form @blah@ it will be replaced with
 # the server details from the server configuration
-geonetwork.https.url = @to_be_replaced_at_runtime@
+geonetwork.https.url=@to_be_replaced_at_runtime@
 
 # The url to redirect to if a user logs in to one node then logs into another.
-wrongNodeRedirectURL = /@@nodeId@@/@@lang@@/node-change-warning?oldUserName=@@oldUserName@@&redirectedFrom=@@redirectedFrom@@&oldNodeId=@@oldNodeId@@
+wrongNodeRedirectURL=/@@nodeId@@/@@lang@@/node-change-warning?oldUserName=@@oldUserName@@&redirectedFrom=@@redirectedFrom@@&oldNodeId=@@oldNodeId@@
 
 # Password encrypter for passwords stored in database
-encrypter.algorithm = PBEWithMD5AndDES
-encrypter.password = v5PeSqW94K
+encrypter.algorithm=PBEWithMD5AndDES
+encrypter.password=default

--- a/web/src/main/webapp/WEB-INF/config-security/config-security.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security.properties
@@ -23,33 +23,33 @@
 
 #Core security properties
 
-logout.success.url=/home?node=@@nodeId@@
-loginForm=/signin?node=@@nodeId@@
-loginErrorForm=/login.jsp?node=@@nodeId@@&failure=true
-passwordSalt=secret-hash-salt=
+logout.success.url = /home?node=@@nodeId@@
+loginForm = /signin?node=@@nodeId@@
+loginErrorForm = /login.jsp?node=@@nodeId@@&failure=true
+passwordSalt = secret-hash-salt=
 
 # LDAP Connection Settings
-ldap.base.provider.url=ldap://localhost:389
-ldap.base.dn=dc=fao,dc=org
-ldap.security.principal=cn=admin,dc=fao,dc=org
-ldap.security.credentials=ldap
+ldap.base.provider.url = ldap://localhost:389
+ldap.base.dn = dc=fao,dc=org
+ldap.security.principal = cn=admin,dc=fao,dc=org
+ldap.security.credentials = ldap
 
-ldap.base.search.base=ou=people
-ldap.base.dn.pattern=uid={0},${ldap.base.search.base}
+ldap.base.search.base = ou=people
+ldap.base.dn.pattern = uid={0},${ldap.base.search.base}
 #ldap.base.dn.pattern=mail={0},${ldap.base.search.base}
 
 
 # Define if groups and profile information are imported from LDAP. If not, local database is used.
 # When a new user connect first, the default profile is assigned. A user administrator can update
 # privilege information.
-ldap.privilege.import=false
+ldap.privilege.import = false
 
 # Define if LDAP groups should be create in catalog
 # database if they do not exist.
-ldap.privilege.create.nonexisting.groups=true
+ldap.privilege.create.nonexisting.groups = true
 
 # Define if users should be saved in the LDAP
-ldap.privilege.create.nonexisting.users=false
+ldap.privilege.create.nonexisting.users = false
 
 
 
@@ -57,50 +57,54 @@ ldap.privilege.create.nonexisting.users=false
 # 1. Define one attribute for the profile and one for groups in config-security-overrides.properties
 
 # 2. Define one attribute for the privilege and define a custom pattern (use LDAPUserDetailsContextMapperWithPattern in config-security.xml).
-ldap.privilege.pattern=
+ldap.privilege.pattern = 
 #ldap.privilege.pattern=CAT_(.*)_(.*)
-ldap.privilege.pattern.idx.group=1
-ldap.privilege.pattern.idx.profil=2
+ldap.privilege.pattern.idx.group = 1
+ldap.privilege.pattern.idx.profil = 2
 
 
 # 3. Define custom location for extracting group and role (no support for group/role combination) (use LDAPUserDetailsContextMapperWithProfileSearch in config-security.xml).
-ldap.privilege.search.group.attribute=cn
-ldap.privilege.search.group.object=ou=groups
+ldap.privilege.search.group.attribute = cn
+ldap.privilege.search.group.object = ou=groups
 #ldap.privilege.search.group.query=(&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=EL_*))
-ldap.privilege.search.group.queryprop=memberuid
-ldap.privilege.search.group.query=(&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(|(cn=SP_*)(cn=EL_*)))
-ldap.privilege.search.group.pattern=EL_(.*)
-ldap.privilege.search.privilege.attribute=cn
-ldap.privilege.search.privilege.object=ou=groups
-ldap.privilege.search.privilege.query=(&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=SV_*))
-ldap.privilege.search.privilege.pattern=SV_(.*)
+ldap.privilege.search.group.queryprop = memberuid
+ldap.privilege.search.group.query = (&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(|(cn=SP_*)(cn=EL_*)))
+ldap.privilege.search.group.pattern = EL_(.*)
+ldap.privilege.search.privilege.attribute = cn
+ldap.privilege.search.privilege.object = ou=groups
+ldap.privilege.search.privilege.query = (&(objectClass=*)(memberUid=uid={0},${ldap.base.search.base},${ldap.base.dn})(cn=SV_*))
+ldap.privilege.search.privilege.pattern = SV_(.*)
 
 
 
 # Run LDAP sync every day at 23:30
-ldap.sync.cron=0 30 23 * * ?
+ldap.sync.cron = 0 30 23 * * ?
 #ldap.sync.cron=0 * * * * ?
 #ldap.sync.cron=0 0/1 * 1/1 * ? *
-ldap.sync.startDelay=60000
-ldap.sync.user.search.base=${ldap.base.search.base}
-ldap.sync.user.search.filter=(&(objectClass=*)(mail=*@*)(givenName=*))
-ldap.sync.user.search.attribute=uid
-ldap.sync.group.search.base=ou=groups
-ldap.sync.group.search.filter=(&(objectClass=posixGroup)(cn=EL_*))
-ldap.sync.group.search.attribute=cn
-ldap.sync.group.search.pattern=EL_(.*)
+ldap.sync.startDelay = 60000
+ldap.sync.user.search.base = ${ldap.base.search.base}
+ldap.sync.user.search.filter = (&(objectClass=*)(mail=*@*)(givenName=*))
+ldap.sync.user.search.attribute = uid
+ldap.sync.group.search.base = ou=groups
+ldap.sync.group.search.filter = (&(objectClass=posixGroup)(cn=EL_*))
+ldap.sync.group.search.attribute = cn
+ldap.sync.group.search.pattern = EL_(.*)
 
 
 # CAS properties
-cas.baseURL=https://localhost:8443/cas
-cas.ticket.validator.url=${cas.baseURL}
-cas.login.url=${cas.baseURL}/login
-cas.logout.url=${cas.baseURL}/logout?url=${geonetwork.https.url}/
+cas.baseURL = https://localhost:8443/cas
+cas.ticket.validator.url = ${cas.baseURL}
+cas.login.url = ${cas.baseURL}/login
+cas.logout.url = ${cas.baseURL}/logout?url=${geonetwork.https.url}/
 
 # either the hardcoded url to the server
 # or if has the form @blah@ it will be replaced with
 # the server details from the server configuration
-geonetwork.https.url=@to_be_replaced_at_runtime@
+geonetwork.https.url = @to_be_replaced_at_runtime@
 
 # The url to redirect to if a user logs in to one node then logs into another.
-wrongNodeRedirectURL=/@@nodeId@@/@@lang@@/node-change-warning?oldUserName=@@oldUserName@@&redirectedFrom=@@redirectedFrom@@&oldNodeId=@@oldNodeId@@
+wrongNodeRedirectURL = /@@nodeId@@/@@lang@@/node-change-warning?oldUserName=@@oldUserName@@&redirectedFrom=@@redirectedFrom@@&oldNodeId=@@oldNodeId@@
+
+# Password encrypter for passwords stored in database
+encrypter.algorithm = PBEWithMD5AndDES
+encrypter.password = v5PeSqW94K

--- a/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
@@ -66,6 +66,7 @@
   <bean id="defaultLanguage" class="java.lang.String">
     <constructor-arg index="0" value="eng"/>
   </bean>
+
   <!-- Define the languages in the UI. Seems like these should come from database
     at some point but at the moment they are needed here. -->
   <util:set id="languages" value-type="java.lang.String">
@@ -176,4 +177,14 @@
     <constructor-arg name="langCode" value="eng"/>
   </bean>
   -->
+
+  <bean id="strongEncryptor"
+        class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor">
+    <property name="algorithm">
+      <value>${encrypter.algorithm}</value>
+    </property>
+    <property name="password">
+      <value>${encrypter.password}</value>
+    </property>
+  </bean>
 </beans>


### PR DESCRIPTION
This pull request allows to encrypt the passwords used for mail, proxy, harvesters and map servers that are stored in the database.

When the passwords are retrieved from the database are unencrypted, the code using them requires no changes.

For the encryption/decryption of the passwords is used the library [jasypt](http://www.jasypt.org/). 

The configuration for the encrypter is stored in the file
`WEB-INF/config-security/config-security.properties`:

```
# Password encrypter for passwords stored in database
encrypter.algorithm=PBEWithMD5AndDES
encrypter.password=default
```

When GeoNetwork starts up, if `encrypter.password` has the value `default` it's generated a random key that replaces the value `default`.

It's important to indicate that if GeoNetwork is migrated to a newer version, the encrypter password should be copied to the new installation, otherwise will not be possible to decrypt the existing passwords.