### PR TITLE
Add beforeScript in the local harvester

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemParams.java
@@ -41,6 +41,7 @@ public class LocalFilesystemParams extends AbstractParams {
     public boolean checkFileLastModifiedForUpdate;
     public boolean nodelete;
     public String recordType;
+    public String beforeScript;
 
     public LocalFilesystemParams(DataManager dm) {
         super(dm);
@@ -82,6 +83,7 @@ public class LocalFilesystemParams extends AbstractParams {
         String checkFileLastModifiedForUpdateString = Util.getParam(site, "checkFileLastModifiedForUpdate", "true");
         checkFileLastModifiedForUpdate = (checkFileLastModifiedForUpdateString.equals("on") || checkFileLastModifiedForUpdateString.equals("true"));
         recordType = Util.getParam(site, "recordType", "n");
+        beforeScript = Util.getParam(site, "beforeScript", "");
     }
 
     public LocalFilesystemParams copy() {
@@ -93,6 +95,7 @@ public class LocalFilesystemParams extends AbstractParams {
         copy.nodelete = nodelete;
         copy.checkFileLastModifiedForUpdate = checkFileLastModifiedForUpdate;
         copy.recordType = recordType;
+        copy.beforeScript = beforeScript;
         return copy;
     }
 }

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
@@ -2547,8 +2547,6 @@
     <label>Sluttdato</label>
     <description>Formattert som 2007-09-12T15:00:00 (ÅÅÅÅ-MM-DDTtt:mm:ss)</description>
   </element>
-  >>>>>>> cd2dec4... Change all protocolChoice value to helper value (each language) and remove all
-  protocolChoice reference in xsl files
 
   <element name="gml:relatedTime">
     <label>Related time</label>

--- a/web-ui/src/main/resources/catalog/locales/ca-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Exportar (ZIP)",
     "facetIndicatorHelp": "Les estadístiques de les entrades es defineixen en base a la configuració de facets i poden representar només els valors més freqüents.",
     "fees": "Quotes",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Actualitzar entrada al catàleg només si el fitxer s'ha actualitzat",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Actualitzar entrada al catàleg només si el fitxer s'ha actualitzat",
     "filesystem-directory": "Directori",

--- a/web-ui/src/main/resources/catalog/locales/cz-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/cz-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Exportovat (ZIP)",
     "facetIndicatorHelp": "Statistiky podle záznamů jsou definovány na základě konfigurace ploch a mohou představovat jen nejčastější hodnoty.",
     "fees": "Poplatky",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Aktualizovat katalogový záznam až po aktualizaci souboru",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Aktualizovat katalogový záznam pouze po aktualizaci souboru",
     "filesystem-directory": "Adresář",

--- a/web-ui/src/main/resources/catalog/locales/du-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/du-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Exporteer (ZIP)",
     "facetIndicatorHelp": "Statistieken van metadata bestanden worden gedefinieerd op basis van de facetten configuratie en kunnen daardoor alleen de meest voorkomende waarden vertegenwoordigen.",
     "fees": "Vergoedingen",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Werk item bij, alleen als het externe bestand is bijgewerkt",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Werk catalogusbestand bij, alleen als het bestand is bijgewerkt",
     "filesystem-directory": "Adressenboek",

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Export (ZIP)",
     "facetIndicatorHelp": "Statistics by records are defined based on facets configuration and may represent only the most frequent values.",
     "fees": "Fees",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Update catalog record only if file was updated",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Update catalog record only if file was updated",
     "filesystem-directory": "Directory",

--- a/web-ui/src/main/resources/catalog/locales/es-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/es-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Exportar (ZIP)",
     "facetIndicatorHelp": "Las estadísticas de las entradas se definen basándose en la configuración de facets y pueden representar sólo los valores más frecuentes.",
     "fees": "Cuotas",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Actualizar entrada en el catálogo sólo si el fichero se ha actualizado",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Actualizar entrada en el catálogo sólo si el fichero se ha actualizado",
     "filesystem-directory": "Directorio",

--- a/web-ui/src/main/resources/catalog/locales/fi-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Vie (ZIP)",
     "facetIndicatorHelp": "Tietuetilastot rakentuvat fasettien perusteella ja ne saattavat edustaa ainoastaan yleisimpiä arvoja.",
     "fees": "Maksut",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Päivitä luettelon tietue vain, jos tiedosto oli päivitetty.",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Päivät luettelon tietua vain, jos tiedosto oli päivitetty.",
     "filesystem-directory": "Hakemisto",

--- a/web-ui/src/main/resources/catalog/locales/fr-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Export (ZIP)",
     "facetIndicatorHelp": "Les statistiques sur les fiches reposent sur la configuration des facettes et peuvent ne représenter qu'un sous-ensemble du catalogue.",
     "fees": "Honnoraires",
+    "filesystem-beforeScript": "Script à exécuter avant moissonage",
+    "filesystem-beforeScriptHelp": "Peut être utiliser pour exécuter un rsync ou quelque chose d'équivalent. N'exécute rien si vide.",
     "filesystem-checkFileLastModifiedForUpdate": "Mettre à jour les fiches dans le catalogue uniquement si la date du fichier a été modifiée",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Mettre à jour les fiches dans le catalogue uniquement si la date du fichier a été modifiée",
     "filesystem-directory": "Répertoire",

--- a/web-ui/src/main/resources/catalog/locales/ge-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/ge-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Als ZIP-Datei exportieren",
     "facetIndicatorHelp": "Statistiken zu Datensätzen werden definiert auf der Basis der Facetten-Konfiguration and bilden nur die häufigsten Werte ab.",
     "fees": "Gebühren",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Aktualisierte Datensätze",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Datensätze im Katalog nur dann aktualisieren, wenn Datei aktualisiert wurde.",
     "filesystem-directory": "Verzeichnis",

--- a/web-ui/src/main/resources/catalog/locales/it-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/it-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "Esporta (ZIP)",
     "facetIndicatorHelp": "Statistics by records are defined based on facets configuration and may represent only the most frequent values.",
     "fees": "Fees",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Update catalog record only if file was updated",
     "filesystem-checkFileLastModifiedForUpdateHelp": "Update catalog record only if file was updated",
     "filesystem-directory": "Directory",

--- a/web-ui/src/main/resources/catalog/locales/ko-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-admin.json
@@ -332,6 +332,8 @@
     "exportLogAsZIP": "내보내기 (ZIP)",
     "facetIndicatorHelp": "기록에 의한 통계는 구성측면과 자주 사용되는 값을 기반으로 정의됩니다.",
     "fees": "수수료",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "파일이 업데이트된 경우에만 카탈로그 레코드 갱신",
     "filesystem-checkFileLastModifiedForUpdateHelp": "파일이 업데이트된 경우에만 카탈로그 레코드 갱신",
     "filesystem-directory": "디렉토리",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
@@ -75,8 +75,13 @@
 
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
     </div>
-  </fieldset>
 
+    <div>
+      <label class="control-label" data-translate="">filesystem-beforeScript</label>
+      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.beforeScript"/>
+      <p class="help-block" data-translate="">filesystem-beforeScriptHelp</p>
+    </div>
+  </fieldset>
 
   <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.js
@@ -15,7 +15,8 @@ var gnHarvesterfilesystem = {
                 "nodelete" : true,
                 "checkFileLastModifiedForUpdate" : true,
                 "recordType" : 'n',
-                "icon" : "blank.png"
+                "icon" : "blank.png",
+                "beforeScript": ""
             },
             "content" : {
                 "validate" : "NOVALIDATION",
@@ -53,6 +54,7 @@ var gnHarvesterfilesystem = {
                 + '    <directory>' + h.site.directory + '</directory>'
                 + '    <recordType>' + h.site.recordType + '</recordType>'
                 + '    <icon>' + h.site.icon + '</icon>'
+                + '    <beforeScript>' + h.site.beforeScript + '</beforeScript>'
                 + '  </site>'
                 + '  <options>'
                 + '    <oneRunOnly>' + h.options.oneRunOnly + '</oneRunOnly>'

--- a/web/src/main/webapp/xsl/xml/harvesting/filesystem.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/filesystem.xsl
@@ -29,6 +29,9 @@
     <icon>
       <xsl:value-of select="icon/value"/>
     </icon>
+    <beforeScript>
+      <xsl:value-of select="beforeScript/value"/>
+    </beforeScript>
   </xsl:template>
 
   <!-- ============================================================================================= -->


### PR DESCRIPTION
Now, the user can configure a local harvester to run a script before the
files are harvested. For example, this can be used to do a rsync of a remote
directory.

Fix bad merge resolution in ISO19139 Norvegian labels
