### PR TITLE
Add context to the label search for custom fields and templates

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout-custom-fields.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout-custom-fields.xsl
@@ -33,13 +33,17 @@
 
   <!-- Readonly elements -->
   <xsl:template mode="mode-iso19110" priority="200" match="gmx:versionDate|gfc:versionDate">
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+    <xsl:variable name="labelConfig"
+                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
 
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
-                      select="gn-fn-metadata:getLabel($schema, name(), $labels)/label"/>
+                      select="$labelConfig/label"/>
       <xsl:with-param name="value" select="*"/>
       <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
       <xsl:with-param name="type" select="gn-fn-iso19110:getFieldType(name(), '')"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
@@ -80,9 +80,10 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig"
-                  select="gn-fn-metadata:getLabel($schema, name(), $labels)"/>
-
+                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
     <xsl:variable name="dateTypeElementRef"
                   select="../gn:element/@ref"/>
 
@@ -157,9 +158,10 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig"
-                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), '', '')"/>
-
+                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
     <xsl:variable name="dateTypeElementRef"
                   select="../gn:element/@ref"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -41,12 +41,17 @@
   <!-- Readonly elements -->
   <xsl:template mode="mode-iso19139" priority="2000" match="gmd:fileIdentifier|gmd:dateStamp">
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+    <xsl:variable name="labelConfig"
+                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
+
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
-                      select="gn-fn-metadata:getLabel($schema, name(), $labels)/label"/>
+                      select="$labelConfig/label"/>
       <xsl:with-param name="value" select="*"/>
       <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
       <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
@@ -63,8 +68,11 @@
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="refToDelete" select="gn:element" required="no"/>
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig"
-                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), '', '')"/>
+                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
+
     <xsl:variable name="labelMeasureType"
                   select="gn-fn-metadata:getLabel($schema, name(gco:*), $labels, name(), '', '')"/>
 
@@ -138,10 +146,11 @@
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+    <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
 
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
-                      select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)/label"/>
+                      select="$labelConfig/label"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
@@ -162,6 +171,8 @@
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="value" select="normalize-space(text())"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+    <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
 
 
     <xsl:variable name="attributes">
@@ -179,7 +190,7 @@
 
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
-                      select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), '', $xpath)/label"/>
+                      select="$labelConfig/label"/>
       <xsl:with-param name="name" select="gn:element/@ref"/>
       <xsl:with-param name="value" select="text()"/>
       <xsl:with-param name="cls" select="local-name()"/>
@@ -208,10 +219,11 @@
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+    <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
 
     <xsl:call-template name="render-boxed-element">
       <xsl:with-param name="label"
-                      select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)/label"/>
+                      select="$labelConfig/label"/>
       <xsl:with-param name="editInfo" select="gn:element"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="subTreeSnippet">

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
@@ -41,22 +41,24 @@
   <!-- Define table layout -->
   <xsl:template name="iso19139-table-contact">
     <xsl:variable name="name" select="name()"/>
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
 
     <xsl:variable name="values">
       <header>
         <col>
-          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'gmd:organisationName', $labels,'', '', '')/label"/>
+          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'gmd:organisationName', $labels, '', $isoType, $xpath)/label"/>
         </col>
         <col>
-          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'gmd:individualName', $labels,'', '', '')/label"/>
-        </col>
-        <col>
-          <xsl:value-of
-            select="gn-fn-metadata:getLabel($schema, 'gmd:electronicMailAddress', $labels,'', '', '')/label"/>
+          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'gmd:individualName', $labels, '', $isoType, $xpath)/label"/>
         </col>
         <col>
           <xsl:value-of
-            select="gn-fn-metadata:getLabel($schema, 'gmd:role', $labels,'', '', '')/label"/>
+            select="gn-fn-metadata:getLabel($schema, 'gmd:electronicMailAddress', $labels, '', $isoType, $xpath)/label"/>
+        </col>
+        <col>
+          <xsl:value-of
+            select="gn-fn-metadata:getLabel($schema, 'gmd:role', $labels, '', $isoType, $xpath)/label"/>
         </col>
       </header>
       <xsl:for-each select="(.|following-sibling::*[name() = $name])/gmd:CI_ResponsibleParty">
@@ -79,9 +81,6 @@
         </row>
       </xsl:for-each>
     </xsl:variable>
-
-    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
 
     <xsl:call-template name="render-boxed-element">
       <xsl:with-param name="label"


### PR DESCRIPTION
Now use the `isoType` and `xpath` to retireve the right label for fields defined in custom fields xsl. This should use the context defined in the `<element>`  in labels.xml to determine the right label to choose.