### PR TITLE
Local inspire atom feeds

### DIFF
--- a/common/src/main/java/org/fao/geonet/exceptions/AtomFeedNotFoundEx.java
+++ b/common/src/main/java/org/fao/geonet/exceptions/AtomFeedNotFoundEx.java
@@ -1,0 +1,50 @@
+//=============================================================================
+//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This library is free software; you can redistribute it and/or
+//===	modify it under the terms of the GNU Lesser General Public
+//===	License as published by the Free Software Foundation; either
+//===	version 2.1 of the License, or (at your option) any later version.
+//===
+//===	This library is distributed in the hope that it will be useful,
+//===	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//===	Lesser General Public License for more details.
+//===
+//===	You should have received a copy of the GNU Lesser General Public
+//===	License along with this library; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.exceptions;
+
+//=============================================================================
+
+public class AtomFeedNotFoundEx extends NotFoundEx
+{
+	//--------------------------------------------------------------------------
+	//---
+	//--- Constructor
+	//---
+	//--------------------------------------------------------------------------
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -5759127829247984309L;
+
+	public AtomFeedNotFoundEx(String name)
+	{
+		super("Atom feed not found", name);
+
+		id = "atom-feed-not-found";
+	}
+}
+
+//=============================================================================
+

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -638,7 +638,11 @@ public class ServiceManager {
                         req.getOutputStream().write(Xml.getJSON(response).getBytes(Constants.ENCODING));
                         req.endStream();
                     } else {
-                        req.beginStream("application/xml; charset=UTF-8", cache);
+                        if (context.getService().equals("atom.describe")) {
+                        	req.beginStream("application/atom+xml; charset=UTF-8", cache);
+                        } else {
+                        	req.beginStream("application/xml; charset=UTF-8", cache);                        	
+                        }
                         req.write(response);
                     }
                 }

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -638,7 +638,7 @@ public class ServiceManager {
                         req.getOutputStream().write(Xml.getJSON(response).getBytes(Constants.ENCODING));
                         req.endStream();
                     } else {
-                        if (context.getService().equals("atom.describe")) {
+                        if (context.getService().equals("atom.describe") || context.getService().equals("atom.local")) {
                         	req.beginStream("application/atom+xml; charset=UTF-8", cache);
                         } else {
                         	req.beginStream("application/xml; charset=UTF-8", cache);                        	

--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -108,6 +108,7 @@ public final class Geonet {
         public static final String UPDATE_FIXED_INFO = "update-fixed-info.xsl";
         public static final String UPDATE_CHILD_FROM_PARENT_INFO = "update-child-from-parent-info.xsl";
         public static final String EXTRACT_UUID = "extract-uuid.xsl";
+        public static final String EXTRACT_DATASET_CODE_AND_CODESPACE = "extract-dataset-code-and-codespace.xsl";
         public static final String EXTRACT_SKOS_FROM_ISO19135 = "xml_iso19135ToSKOS.xsl";
         public static final String EXTRACT_DATE_MODIFIED = "extract-date-modified.xsl";
         public static final String SET_UUID = "set-uuid.xsl";

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -1162,6 +1162,14 @@ public class DataManager implements ApplicationEventPublisherAware {
         return uuid;
     }
 
+    public Element extractDatasetCodeAndCodeSpace(String schema, Element md) throws Exception {
+        Path styleSheet = getSchemaDir(schema).resolve(Geonet.File.EXTRACT_DATASET_CODE_AND_CODESPACE);
+        Element identifier = Xml.transform(md, styleSheet);
+        //--- needed to detach md from the document
+        md.detach();
+        return identifier;
+    }
+
     /**
      *
      * @param schema

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -23,11 +23,22 @@
 
 package org.fao.geonet.util;
 
-import jeeves.component.ProfileManager;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
-import net.objecthunter.exp4j.Expression;
-import net.objecthunter.exp4j.ExpressionBuilder;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.text.NumberFormat;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
@@ -55,16 +66,11 @@ import org.owasp.esapi.reference.DefaultEncoder;
 import org.springframework.context.ApplicationContext;
 import org.w3c.dom.Node;
 
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import jeeves.component.ProfileManager;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+import net.objecthunter.exp4j.Expression;
+import net.objecthunter.exp4j.ExpressionBuilder;
 
 /**
  * These are all extension methods for calling from xsl docs.  Note:  All params are objects because
@@ -628,4 +634,61 @@ public final class XslUtil {
             return str;
         }
     }
+
+	/**
+	 * @param dateFormat	Date format part supported by the SimpleDateFormat java class
+	 * @return	Formatted current date
+	 */
+    public static String getCurrentDate(String dateFormat) {
+		return new SimpleDateFormat(dateFormat).format(new Date());
+	}
+    
+	/**
+	 * @param dateFormat	Date format part supported by the SimpleDateFormat java class
+	 * @param timeFormat	Time format part supported by the SimpleDateFormat java class
+	 * @return	ISO 8601 date/time string like 1994-11-05T13:15:30Z
+	 */
+	public static String getCurrentDateTime(String dateFormat, String timeFormat) {
+		return new SimpleDateFormat(dateFormat + "'T'" + timeFormat).format(new Date());
+	}
+	
+	/**
+	 * @param sNumber	Number to format
+	 * @param decimals	Number of decimals
+	 * @return	Formatted string with number of decimals or 0.0 in case of parse error
+	 */
+	public static String formatNumber(String sNumber, String decimals) {
+		NumberFormat nf = NumberFormat.getInstance(Locale.US);
+		nf.setGroupingUsed(false);
+		nf.setMinimumFractionDigits(Integer.parseInt(decimals));
+		nf.setMaximumFractionDigits(Integer.parseInt(decimals));
+		double dNumber = 0.0;
+		try {
+			dNumber = Double.parseDouble(sNumber);
+		} catch (Exception e) {
+            Log.error(Geonet.GEONETWORK, "Failed to format number: " + e.getMessage());
+		}
+		return nf.format(dNumber);
+	}
+	
+	/**
+	 * @param sNumber1	First number
+	 * @param sNumber2	Second number
+	 * @return Closest long value of the product of the 2 numbers
+	 */
+	public static String multiply(String sNumber1, String sNumber2) {
+		double dNumber1 = 0.0;
+		double dNumber2 = 0.0;
+		try {
+			dNumber1 = Double.parseDouble(sNumber1);
+		} catch (Exception e) {
+            Log.error(Geonet.GEONETWORK, "Failed to format number: " + e.getMessage());
+		}
+		try {
+			dNumber2 = Double.parseDouble(sNumber2);
+		} catch (Exception e) {
+            Log.error(Geonet.GEONETWORK, "Failed to format number: " + e.getMessage());
+		}
+		return Long.toString(Math.round(dNumber1 * dNumber2));
+	}
 }

--- a/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
+++ b/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
@@ -72,8 +72,11 @@ public class InspireAtomFeed extends GeonetEntity implements Serializable {
         Namespace ns = Namespace.getNamespace("f", "http://www.w3.org/2005/Atom");
         Namespace nsXml = Namespace.getNamespace("xml", "http://www.w3.org/XML/1998/namespace");
 
-        inspireAtomFeed.setTitle(atomDoc.getChildText("title", ns));
-        inspireAtomFeed.setSubtitle(atomDoc.getChildText("subtitle", ns));
+        /* Max length of title and subtitle of atom feed is 255 */
+        String title = atomDoc.getChildText("title", ns);
+        inspireAtomFeed.setTitle(title!=null ? title.substring(0,Math.min(title.length()-1, 255)):"");
+        String subTitle = atomDoc.getChildText("subtitle", ns);
+        inspireAtomFeed.setSubtitle(subTitle!=null ? subTitle.substring(0,Math.min(subTitle.length()-1, 255)):"");
         inspireAtomFeed.setRights(atomDoc.getChildText("rights", ns));
         inspireAtomFeed.setLang(atomDoc.getAttributeValue("lang", ns));
         Element authorEl = atomDoc.getChild("author", ns);

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/InspireAtomService.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/InspireAtomService.java
@@ -57,7 +57,7 @@ public class InspireAtomService {
         String atomUrl = feed!=null ? feed.getAtomUrl():"";
         boolean bLocalUrl = atomUrl.equals(baseAtomUrl) ? true : false;
         if (bLocalUrl || StringUtils.isEmpty(atomUrl)) {
-        	feedValue = InspireAtomUtil.retrieveLocalAtomFeedDocument(context, (context.getBean(SettingManager.class).getSiteURL(context.getLanguage()) + "atom.local?" + AtomDescribe.SERVICE_IDENTIFIER + "=" + fileIdentifier).replaceAll(":80/","/").replaceAll(":443/","/"));
+        	feedValue = InspireAtomUtil.retrieveLocalAtomFeedDocumentAsString(context, (context.getBean(SettingManager.class).getSiteURL(context.getLanguage()) + "atom.local?" + AtomDescribe.SERVICE_IDENTIFIER + "=" + fileIdentifier).replaceAll(":80/","/").replaceAll(":443/","/"));
 	        if (StringUtils.isEmpty(atomUrl)) {
 	            Element atomDoc = Xml.loadString(feedValue, false);
 	            InspireAtomFeed inspireAtomFeed = InspireAtomFeed.build(atomDoc);
@@ -96,12 +96,12 @@ public class InspireAtomService {
         InspireAtomFeed feed = _repository.findByMetadataId(metadataId);
         String feedValue = null;
         String atomUrl = feed!=null ? feed.getAtomUrl():"";
-        NodeInfo nodeInfo = ApplicationContextHolder.get().getBean(NodeInfo.class);
+//        NodeInfo nodeInfo = ApplicationContextHolder.get().getBean(NodeInfo.class);
         String baseAtomUrl = InspireAtomUtil.getBaseDatasetAtomUrl(context);
         boolean bLocalUrl = atomUrl.startsWith(baseAtomUrl) ? true : false;
         if (bLocalUrl || StringUtils.isEmpty(atomUrl)) {
         	
-        	feedValue = InspireAtomUtil.retrieveLocalAtomFeedDocument(context, (context.getBean(SettingManager.class).getSiteURL(context.getLanguage()) + "atom.local?" +
+        	feedValue = InspireAtomUtil.retrieveLocalAtomFeedDocumentAsString(context, (context.getBean(SettingManager.class).getSiteURL(context.getLanguage()) + "atom.local?" +
         			AtomDescribe.DATASET_IDENTIFIER_CODE_PARAM + "=" + datasetIdCode + "&" +
         			AtomDescribe.DATASET_IDENTIFIER_NS_PARAM + "=" + datasetIdNs +
         			(StringUtils.isEmpty(crs) ? "" : "&" + AtomDescribe.DATASET_CRS_PARAM + "=" + crs) +

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/InspireAtomService.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/InspireAtomService.java
@@ -22,19 +22,25 @@
 //==============================================================================
 package org.fao.geonet.inspireatom;
 
-import jeeves.server.context.ServiceContext;
+import java.util.Arrays;
+
+import javax.transaction.Transactional;
 
 import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.NodeInfo;
 import org.fao.geonet.csw.common.util.Xml;
 import org.fao.geonet.domain.InspireAtomFeed;
 import org.fao.geonet.inspireatom.util.InspireAtomUtil;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.repository.InspireAtomFeedRepository;
+import org.fao.geonet.services.inspireatom.AtomDescribe;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import jeeves.server.context.ServiceContext;
 
 @Component
 @Transactional
@@ -43,6 +49,102 @@ public class InspireAtomService {
     @Autowired
     private InspireAtomFeedRepository _repository;
 
+    public Element retrieveServiceFeed(DataManager dm, ServiceContext context, int metadataId, String fileIdentifier) throws Exception {
+        // Check the metadata has an atom document.
+        InspireAtomFeed feed = _repository.findByMetadataId(metadataId);
+        String feedValue = null;
+        String baseAtomUrl = InspireAtomUtil.getBaseServiceAtomUrl(context, fileIdentifier);
+        String atomUrl = feed!=null ? feed.getAtomUrl():"";
+        boolean bLocalUrl = atomUrl.equals(baseAtomUrl) ? true : false;
+        if (bLocalUrl || StringUtils.isEmpty(atomUrl)) {
+        	feedValue = InspireAtomUtil.retrieveLocalAtomFeedDocument(context, (context.getBean(SettingManager.class).getSiteURL(context.getLanguage()) + "atom.local?" + AtomDescribe.SERVICE_IDENTIFIER + "=" + fileIdentifier).replaceAll(":80/","/").replaceAll(":443/","/"));
+	        if (StringUtils.isEmpty(atomUrl)) {
+	            Element atomDoc = Xml.loadString(feedValue, false);
+	            InspireAtomFeed inspireAtomFeed = InspireAtomFeed.build(atomDoc);
+	            inspireAtomFeed.setMetadataId(metadataId);
+	            inspireAtomFeed.setAtomUrl(baseAtomUrl);
+	            inspireAtomFeed.setAtom(feedValue);
+	            inspireAtomFeed.setAtomDatasetid("");
+	            inspireAtomFeed.setAtomDatasetns("");
+	
+	
+	//            _repository.save(inspireAtomFeed);
+	            _repository.saveAndFlush(inspireAtomFeed);
+	
+	            // Index the metadata to store the atom feed information in the index
+	            dm.indexMetadata(Arrays.asList(new String[]{String.valueOf(metadataId)}));
+	            feed = _repository.findByMetadataId(metadataId);
+	            atomUrl = feed.getAtomUrl();
+	        }
+        } else {
+//            if (StringUtils.isEmpty(atomUrl)) throw new Exception("Metadata has no atom feed");
+
+            // Retrieve the remote feed
+            feedValue = InspireAtomUtil.retrieveRemoteAtomFeedDocument(context, atomUrl);
+        }
+
+
+        if (StringUtils.isEmpty(feedValue)) {
+            feedValue = feed.getAtom();
+        }
+
+        return Xml.loadString(feedValue, false);
+    }
+
+    public Element retrieveDatasetFeed(ServiceContext context, int metadataId, String fileIdentifier, String datasetIdCode, String datasetIdNs, String crs, String searchTerms) throws Exception {
+        // Check the metadata has an atom document.
+        InspireAtomFeed feed = _repository.findByMetadataId(metadataId);
+        String feedValue = null;
+        String atomUrl = feed!=null ? feed.getAtomUrl():"";
+        NodeInfo nodeInfo = ApplicationContextHolder.get().getBean(NodeInfo.class);
+        String baseAtomUrl = InspireAtomUtil.getBaseDatasetAtomUrl(context);
+        boolean bLocalUrl = atomUrl.startsWith(baseAtomUrl) ? true : false;
+        if (bLocalUrl || StringUtils.isEmpty(atomUrl)) {
+        	
+        	feedValue = InspireAtomUtil.retrieveLocalAtomFeedDocument(context, (context.getBean(SettingManager.class).getSiteURL(context.getLanguage()) + "atom.local?" +
+        			AtomDescribe.DATASET_IDENTIFIER_CODE_PARAM + "=" + datasetIdCode + "&" +
+        			AtomDescribe.DATASET_IDENTIFIER_NS_PARAM + "=" + datasetIdNs +
+        			(StringUtils.isEmpty(crs) ? "" : "&" + AtomDescribe.DATASET_CRS_PARAM + "=" + crs) +
+        			(StringUtils.isEmpty(searchTerms) ? "" : "&" + AtomDescribe.DATASET_Q_PARAM + "=" + searchTerms)).replaceAll(":80/","/").replaceAll(":443/","/"));
+	        if (StringUtils.isEmpty(atomUrl)) {
+		        DataManager dm = context.getBean(DataManager.class);
+	            Element atomDoc = Xml.loadString(feedValue, false);
+	            InspireAtomFeed inspireAtomFeed = InspireAtomFeed.build(atomDoc);
+	            inspireAtomFeed.setMetadataId(metadataId);
+	            inspireAtomFeed.setAtomUrl(baseAtomUrl + "?" +
+	        			AtomDescribe.DATASET_IDENTIFIER_CODE_PARAM + "=" + datasetIdCode + "&" +
+	        			AtomDescribe.DATASET_IDENTIFIER_NS_PARAM + "=" + datasetIdNs +
+	        			(StringUtils.isEmpty(crs) ? "" : "&" + AtomDescribe.DATASET_CRS_PARAM + "=" + crs) +
+	        			(StringUtils.isEmpty(searchTerms) ? "" : "&" + AtomDescribe.DATASET_Q_PARAM + "=" + searchTerms));
+	            inspireAtomFeed.setAtom(feedValue);
+	            inspireAtomFeed.setAtomDatasetid(datasetIdCode);
+	            inspireAtomFeed.setAtomDatasetns(datasetIdNs);
+	
+	
+	//            _repository.save(inspireAtomFeed);
+	            _repository.saveAndFlush(inspireAtomFeed);
+	
+	            // Index the metadata to store the atom feed information in the index
+	            dm.indexMetadata(Arrays.asList(new String[]{String.valueOf(metadataId)}));
+	            feed = _repository.findByMetadataId(metadataId);
+	            atomUrl = feed.getAtomUrl();
+	        }
+        } else {
+//            if (StringUtils.isEmpty(atomUrl)) throw new Exception("Metadata has no atom feed");
+
+            // Retrieve the remote feed
+            feedValue = InspireAtomUtil.retrieveRemoteAtomFeedDocument(context, atomUrl);
+        }
+
+
+        if (StringUtils.isEmpty(feedValue)) {
+            feedValue = feed.getAtom();
+        }
+
+        return Xml.loadString(feedValue, false);
+    }
+
+/*    
     public Element retrieveFeed(ServiceContext context, int metadataId) throws Exception {
         // Check the metadata has an atom document.
         InspireAtomFeed feed = _repository.findByMetadataId(metadataId);
@@ -64,11 +166,11 @@ public class InspireAtomService {
         // Check the metadata has an atom document.
         return retrieveFeed(context, feed.getMetadataId());
     }
-
+*/
     public String retrieveDatasetUuidFromIdentifierNs(String datasetIdCode, String datasetIdNs) {
         return _repository.retrieveDatasetUuidFromIdentifierNs(datasetIdCode, datasetIdNs);
     }
-
+    
     public InspireAtomFeed findByMetadataId(int metadataId) {
         return _repository.findByMetadataId(metadataId);
     }

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
@@ -393,7 +393,7 @@ public class InspireAtomHarvester {
                 String atomUrl = InspireAtomUtil.getBaseDatasetAtomUrl(context) + "?" +
 	        			AtomDescribe.DATASET_IDENTIFIER_CODE_PARAM + "=" + atomDatasetId + "&" +
 	        			AtomDescribe.DATASET_IDENTIFIER_NS_PARAM + "=" + atomDatasetNs;
-                String atomFeedDocument = InspireAtomUtil.retrieveLocalAtomFeedDocument(context, context.getBean(SettingManager.class).getSiteURL(context) + "atom.local?" +
+                String atomFeedDocument = InspireAtomUtil.retrieveLocalAtomFeedDocumentAsString(context, context.getBean(SettingManager.class).getSiteURL(context) + "atom.local?" +
             			AtomDescribe.DATASET_IDENTIFIER_CODE_PARAM + "=" + atomDatasetId + "&" +
             			AtomDescribe.DATASET_IDENTIFIER_NS_PARAM + "=" + atomDatasetNs);
 */                

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
@@ -101,12 +101,11 @@ public class InspireAtomUtil {
 	/**
      * Issue an http request to retrieve the local Atom feed document.
      *
-     * @param context Service context.
      * @param url Atom document url.
      * @return Atom document content.
      * @throws Exception Exception.
      */
-    public static String retrieveLocalAtomFeedDocument(final ServiceContext context,
+    public static Element retrieveLocalAtomFeedDocument(final ServiceContext context,
                                                         final String url) throws Exception {
     	XmlRequest remoteRequest = context.getBean(GeonetHttpRequestFactory.class).createXmlRequest(new URL(url));
 
@@ -114,9 +113,20 @@ public class InspireAtomUtil {
 
         Lib.net.setupProxy(sm, remoteRequest);
 
-        Element atomFeed = remoteRequest.execute();
+        return remoteRequest.execute();
 
-        return Xml.getString(atomFeed);
+    }
+
+	/**
+     * Issue an http request to retrieve the local Atom feed document.
+     *
+     * @param url Atom document url.
+     * @return Atom document content as a String.
+     * @throws Exception Exception.
+     */
+    public static String retrieveLocalAtomFeedDocumentAsString(final ServiceContext context,
+                                                        final String url) throws Exception {
+        return Xml.getString(retrieveLocalAtomFeedDocument(context, url));
     }
 
     /**

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomGetData.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomGetData.java
@@ -71,7 +71,10 @@ public class AtomGetData implements Service {
      **/
     private final static String DATASET_CRS_PARAM = "crs";
 
-    public void init(Path appPath, ServiceConfig params) throws Exception {
+	/** Query param name **/
+	private static final String DATASET_Q_PARAM = "q";
+
+	public void init(Path appPath, ServiceConfig params) throws Exception {
 
     }
 
@@ -100,7 +103,14 @@ public class AtomGetData implements Service {
         String datasetIdNs = Util.getParam(params, DATASET_IDENTIFIER_NS_PARAM);
         String datasetCrs = Util.getParam(params, DATASET_CRS_PARAM);
 
-        // Get the metadata uuid for the dataset
+		String searchTerms = null;
+		try {
+			searchTerms = Util.getParam(params,
+					DATASET_Q_PARAM);
+		} catch (Exception e) {
+		}
+
+		// Get the metadata uuid for the dataset
         String datasetUuid = service.retrieveDatasetUuidFromIdentifierNs(datasetIdCode, datasetIdNs);
         if (StringUtils.isEmpty(datasetUuid)) throw new MetadataNotFoundEx(datasetUuid);
 
@@ -138,7 +148,8 @@ public class AtomGetData implements Service {
             // Otherwise, return a feed with the downloads for the specified CRS
         } else {
             // Retrieve the dataset feed
-            Element feed = service.retrieveFeed(context, inspireAtomFeed);
+        	Element feed = service.retrieveDatasetFeed(context, Integer.parseInt(id), datasetUuid, datasetIdCode, datasetIdNs, datasetCrs, searchTerms);
+//            Element feed = service.retrieveFeed(context, inspireAtomFeed);
 
             // Filter the dataset feed by CRS code.
             InspireAtomUtil.filterDatasetFeedByCrs(feed, datasetCrs);

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomLocalDescribe.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomLocalDescribe.java
@@ -1,0 +1,95 @@
+package org.fao.geonet.services.inspireatom;
+
+
+import java.nio.file.Path;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.Util;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.exceptions.MetadataNotFoundEx;
+import org.fao.geonet.inspireatom.InspireAtomService;
+import org.fao.geonet.inspireatom.util.InspireAtomUtil;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.utils.Log;
+import org.jdom.Element;
+
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+
+/**
+ * Service to get local Atom feed.
+ *
+ * @author Gustaaf Vandeboel
+ */
+public class AtomLocalDescribe implements Service {
+
+    public void init(Path appPath, ServiceConfig params) throws Exception {
+    }
+
+    //--------------------------------------------------------------------------
+    //---
+    //--- Exec
+    //---
+    //--------------------------------------------------------------------------
+
+    public Element exec(Element params, ServiceContext context) throws Exception
+    {
+        SettingManager sm = context.getBean(SettingManager.class);
+        boolean inspireEnable = sm.getValueAsBool("system/inspire/enable");
+
+        if (!inspireEnable) {
+            Log.info(Geonet.ATOM, "Inspire is disabled");
+            throw new Exception("Inspire is disabled");
+        }
+
+        // Get request parameters: depending on parameters manage as service feed (fileIdentifier)
+        // or a dataset feed (spatial_dataset_identifier_code, spatial_dataset_identifier_namespace)
+        String fileIdentifier = Util.getParam(params, AtomDescribe.SERVICE_IDENTIFIER, "");
+
+        if (StringUtils.isEmpty(fileIdentifier)) {
+            DataManager dm = context.getBean(DataManager.class);
+            InspireAtomService service = context.getBean(InspireAtomService.class);
+
+            // Get request parameters
+            String datasetIdCode = Util.getParam(params, AtomDescribe.DATASET_IDENTIFIER_CODE_PARAM);
+            String datasetIdNs = Util.getParam(params, AtomDescribe.DATASET_IDENTIFIER_NS_PARAM);
+            System.out.println("Searching for atomfeed with id datasetIdCode " + datasetIdCode + " and datasetIdNs " + datasetIdNs);
+    		String datasetCrs = null;
+    		try {
+    			datasetCrs = Util.getParam(params,
+    					AtomDescribe.DATASET_CRS_PARAM);
+    		} catch (Exception e) {
+    		}
+
+    		String searchTerms = null;
+    		try {
+    			searchTerms = Util.getParam(params,
+    					AtomDescribe.DATASET_Q_PARAM);
+    		} catch (Exception e) {
+    		}
+
+    		Log.debug(Geonet.ATOM, "Processing dataset feed  (" + AtomDescribe.DATASET_IDENTIFIER_CODE_PARAM + ": " +
+                datasetIdCode + ", " + AtomDescribe.DATASET_IDENTIFIER_NS_PARAM + ": " + datasetIdNs + " )");
+
+            // Get metadata uuid
+            fileIdentifier = service.retrieveDatasetUuidFromIdentifierNs(datasetIdCode, datasetIdNs);
+            if (StringUtils.isEmpty(fileIdentifier)) {
+            	fileIdentifier = InspireAtomUtil.retrieveDatasetUuidFromIdentifier(context, datasetIdCode, "identifier", null);
+            }
+            if (StringUtils.isEmpty(fileIdentifier)) {
+            	throw new MetadataNotFoundEx("datasetIdCode=" + datasetIdCode);
+            }
+
+            // Retrieve metadata to check existence and permissions.
+            String id = dm.getMetadataId(fileIdentifier);
+            //fileIdentifier = dm.getMetadataUuid(id);
+            return InspireAtomUtil.getDatasetFeed(dm, context, id, fileIdentifier, datasetIdCode, datasetIdNs, datasetCrs, searchTerms);
+        } else {
+            System.out.println("Searching for atomfeed with id fileIdentifier " + fileIdentifier);
+            return InspireAtomUtil.getServiceFeed(fileIdentifier, context, null);
+        }
+    }
+
+}

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-atom-feed.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-atom-feed.xsl
@@ -39,7 +39,7 @@
     <!-- Get first element -->
     <atomfeed>
       <xsl:value-of
-        select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[lower-case(gmd:protocol/gco:CharacterString) = lower-case($atomProtocol)]/gmd:linkage/gmd:URL"/>
+        select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[lower-case(gmd:protocol/gco:CharacterString) = lower-case($atomProtocol) and contains(gmd:linkage/gmd:URL,'describe')]/gmd:linkage/gmd:URL"/>
     </atomfeed>
 
   </xsl:template>

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-dataset-code-and-codespace.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-dataset-code-and-codespace.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	version="1.0" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd">
+
+	<xsl:template match="gmd:MD_Metadata">
+		<identifier>
+			<code><xsl:value-of select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:code/gco:CharacterString" /></code>
+			<codeSpace><xsl:value-of select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:codeSpace/gco:CharacterString|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:codeSpace/gco:CharacterString" /></codeSpace>
+		</identifier>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-dataset-entry-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-dataset-entry-info.xsl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+				xmlns:gco="http://www.isotc211.org/2005/gco">
+	<xsl:variable name="protocol">WWW:DOWNLOAD-1.0-HTTP--DOWNLOAD</xsl:variable>
+	<xsl:variable name="applicationProfile">INSPIRE-Download-Atom</xsl:variable>
+    <xsl:template match="gmd:MD_Metadata">
+        <gmd:MD_Metadata>
+			<xsl:if test="count(gmd:distributionInfo/*/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[upper-case(gmd:protocol/gco:CharacterString) = $protocol and gmd:applicationProfile/gco:CharacterString=$applicationProfile]/gmd:description)>0">
+				<xsl:copy-of select="gmd:fileIdentifier"/>                
+				<xsl:copy-of select="gmd:language"/>                
+				<xsl:copy-of select="gmd:identificationInfo/gmd:MD_DataIdentification"/>                
+				<xsl:copy-of select="gmd:distributionInfo/*/gmd:transferOptions/gmd:MD_DigitalTransferOptions"/>                
+				<xsl:copy-of select="gmd:dateStamp/gco:DateTime"/>
+				<xsl:copy-of select="gmd:locale"/>
+				<xsl:copy-of select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent[1]/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox"/>
+			</xsl:if>
+        </gmd:MD_Metadata>
+    </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-dataset-fileidentifiers.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-dataset-fileidentifiers.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+				xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:srv="http://www.isotc211.org/2005/srv">
+    <xsl:template match="gmd:MD_Metadata">
+        <fileIdentifiers>
+            <xsl:for-each  select="gmd:identificationInfo/srv:SV_ServiceIdentification/srv:operatesOn[@xlink:href!='' and @uuidref!='']">
+				<xsl:variable name="fileIdentifier">
+					<xsl:call-template name="getParamFromUrl">
+				       	<xsl:with-param name="url" select="@xlink:href"/>
+						<xsl:with-param name="paramName" select="'id'"/>
+					</xsl:call-template>
+           		</xsl:variable>
+           		<fileIdentifier><xsl:value-of select="normalize-space($fileIdentifier)"/></fileIdentifier>                    	
+			</xsl:for-each>
+        </fileIdentifiers>
+    </xsl:template>
+
+    <xsl:template name="getParamFromUrl">
+       	<xsl:param name="url" />
+		<xsl:param name="paramName" />
+		<xsl:variable name="paramValue"><xsl:choose><xsl:when test="contains($url,concat('&amp;amp;',$paramName,'='))"><xsl:value-of select="substring-after($url,concat('&amp;amp;',$paramName,'='))"/></xsl:when><xsl:when test="contains($url,concat('&amp;',$paramName,'='))"><xsl:value-of select="substring-after($url,concat('&amp;',$paramName,'='))"/></xsl:when></xsl:choose></xsl:variable>
+		<xsl:choose>
+			<xsl:when test="contains($paramValue,'&amp;')"><xsl:value-of select="substring-before($paramValue,'&amp;')"/></xsl:when>
+			<xsl:when test="contains($paramValue,'&amp;amp;')"><xsl:value-of select="substring-before($paramValue,'&amp;amp;')"/></xsl:when>
+			<xsl:otherwise><xsl:value-of select="$paramValue"/></xsl:otherwise>
+		</xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-datasetid.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-datasetid.xsl
@@ -30,7 +30,7 @@
   <xsl:template match="gmd:MD_Metadata">
     <identifier>
       <xsl:value-of
-        select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString"/>
+        select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:code/gco:CharacterString"/>
     </identifier>
   </xsl:template>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-service-type.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-service-type.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+                  xmlns:gco="http://www.isotc211.org/2005/gco"
+				  xmlns:srv="http://www.isotc211.org/2005/srv"
+                  xmlns:gmd="http://www.isotc211.org/2005/gmd">
+
+    <xsl:template match="gmd:MD_Metadata">
+    	<service>
+	        <serviceType><xsl:value-of select="gmd:identificationInfo/srv:SV_ServiceIdentification/srv:serviceType/gco:LocalName"/></serviceType>
+	        <serviceTypeVersion><xsl:value-of select="gmd:identificationInfo/srv:SV_ServiceIdentification/srv:serviceTypeVersion"/></serviceTypeVersion>
+	    </service>
+    </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -631,6 +631,9 @@
         <Field name="format" string="{string(.)}" store="true" index="true"/>
       </xsl:for-each>
 
+      <xsl:if test="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[normalize-space(gmd:applicationProfile/gco:CharacterString)='INSPIRE-Download-Atom'])>0">
+        <Field name="has_atom" string="true" store="false" index="true"/>
+      </xsl:if>
       <!-- index online protocol -->
       <xsl:for-each select="gmd:transferOptions/gmd:MD_DigitalTransferOptions">
         <xsl:variable name="tPosition" select="position()"></xsl:variable>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -483,6 +483,10 @@
         <Field name="format" string="{string(.)}" store="true" index="true"/>
       </xsl:for-each>
 
+      <xsl:if test="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[normalize-space(gmd:applicationProfile/gco:CharacterString)='INSPIRE-Download-Atom'])>0">
+        <Field name="has_atom" string="true" store="false" index="true"/>
+      </xsl:if>
+
       <xsl:for-each select="gmd:transferOptions/gmd:MD_DigitalTransferOptions">
         <xsl:variable name="tPosition" select="position()"></xsl:variable>
         <xsl:for-each select="gmd:onLine/gmd:CI_OnlineResource[

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -235,6 +235,9 @@
         <xsl:with-param name="fname" select="$fname"/>
       </xsl:call-template>
     </xsl:variable>
+    <xsl:variable name="inspireMimeType">
+    	<xsl:choose><xsl:when test="$mimeType='multipart/x-zip'">application/x-gmz</xsl:when><xsl:otherwise><xsl:value-of select="$mimeType"/></xsl:otherwise></xsl:choose>
+    </xsl:variable>
 
     <xsl:copy>
       <xsl:copy-of select="@*"/>
@@ -246,7 +249,7 @@
       <xsl:copy-of select="gmd:protocol"/>
       <xsl:copy-of select="gmd:applicationProfile"/>
       <gmd:name>
-        <gmx:MimeFileType type="{$mimeType}">
+        <gmx:MimeFileType type="{$inspireMimeType}">
           <xsl:value-of select="$fname"/>
         </gmx:MimeFileType>
       </gmd:name>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -287,32 +287,11 @@
 
   <!-- ================================================================= -->
 
-  <!-- Do not allow to expand operatesOn sub-elements
-        and constrain users to use uuidref attribute to link
-        service metadata to datasets. This will avoid to have
-        error on XSD validation. -->
-
-  <xsl:template match="srv:operatesOn|gmd:featureCatalogueCitation">
-    <xsl:copy>
-      <xsl:copy-of select="@uuidref"/>
-      <xsl:if test="@uuidref">
-        <xsl:choose>
-          <xsl:when test="not(string(@xlink:href)) or starts-with(@xlink:href, $serviceUrl)">
-            <xsl:attribute name="xlink:href">
-              <xsl:value-of
-                select="concat($serviceUrl,'csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=',@uuidref)"/>
-            </xsl:attribute>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:copy-of select="@xlink:href"/>
-          </xsl:otherwise>
-        </xsl:choose>
-
-      </xsl:if>
-    </xsl:copy>
-
-  </xsl:template>
-
+	<xsl:template match="srv:operatesOn|gmd:featureCatalogueCitation">
+		<xsl:copy>
+			<xsl:copy-of select="@*"/>
+		</xsl:copy>
+	</xsl:template>
 
   <!-- ================================================================= -->
   <!-- Set local identifier to the first 3 letters of iso code. Locale ids

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -29,6 +29,7 @@
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:java="java:org.fao.geonet.util.XslUtil"
+                xmlns:util="java:java.util.UUID"
                 version="2.0" exclude-result-prefixes="#all">
 
   <xsl:include href="../iso19139/convert/functions.xsl"/>
@@ -558,6 +559,27 @@
 	  <xsl:if test="not(contains($url, $fileIdentifier))">
 		<xsl:apply-templates select="*"/>
 	  </xsl:if>
+	</xsl:copy>
+  </xsl:template>
+
+  <!-- ================================================================= -->
+  <!-- Initialize dataset RS_Identifier if created from template -->
+  <!-- ================================================================= -->
+  <xsl:template match="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier|gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier">
+  	<xsl:copy>
+		<xsl:copy-of select="@*" />
+		<xsl:variable name="fileIdentifier" select="/root/gmd:MD_Metadata/gmd:fileIdentifier/gco:CharacterString"/>
+		<xsl:if test="/root/env/uuid!=$fileIdentifier">
+			<gmd:code>
+				<gco:CharacterString><xsl:value-of select="util:toString(util:randomUUID())" /></gco:CharacterString>
+			</gmd:code>
+			<gmd:codeSpace gco:nilReason="missing">
+				<gco:CharacterString/>
+			</gmd:codeSpace>
+		</xsl:if>
+		<xsl:if test="/root/env/uuid=$fileIdentifier">
+			<xsl:apply-templates select="*"/>
+		</xsl:if>
 	</xsl:copy>
   </xsl:template>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -541,4 +541,21 @@
     </xsl:copy>
   </xsl:template>
 
+  <xsl:template match="gmd:linkage">
+    <xsl:copy>
+	  <xsl:variable name="url" select="normalize-space(gmd:URL)"/>
+	  <xsl:if test="normalize-space($url)=''">
+		<xsl:attribute name="gco:nilReason">missing</xsl:attribute>
+	  </xsl:if>
+	  <xsl:copy-of select="@*[not(name()='gco:nilReason')]"/>
+	  <xsl:variable name="fileIdentifier" select="/root/gmd:MD_Metadata/gmd:fileIdentifier/gco:CharacterString"/>
+	  <xsl:if test="contains($url, $fileIdentifier)">
+		<gmd:URL><xsl:value-of select="concat(substring-before($url, $fileIdentifier),/root/env/uuid,substring-after($url, $fileIdentifier))"/></gmd:URL>
+	  </xsl:if>
+	  <xsl:if test="not(contains($url, $fileIdentifier))">
+		<xsl:apply-templates select="*"/>
+	  </xsl:if>
+	</xsl:copy>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -120,7 +120,7 @@
   "exportPDF": "Export (PDF)",
   "exportMEF": "Export (ZIP)",
   "welcomeTitle": "{{orgName}} Data Portal",
-  "welcomeText": "Here you will find data, services and maps and more.",
+  "welcomeText": "This portal allows you to search for data that has been published by the Grand-Duchy of Luxembourg in relation with the INSPIRE directive of the European Union. Search for metadata about INSPIRE Services (Discovery Service, View Services) as well as INSPIRE Datasets.",
   "getstarted": "Get started",
   "searchOver": "Search over <strong>{{records}}</strong> data sets, services and maps, ...",
   "browseBy": "Browse by",

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -37,6 +37,7 @@
     <property name="accessDecisionManager" ref="accessDecisionManager"></property>
     <property name="securityMetadataSource">
       <sec:filter-security-metadata-source use-expressions="true" request-matcher="regex">
+        <sec:intercept-url pattern="/dataset/.*" access="permitAll"/>
         <sec:intercept-url pattern="/metadata/.*" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/metadata/.*" access="permitAll"/>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -876,6 +876,8 @@
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atomharvester!?.*"
                            access="hasRole('Administrator')"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.get!?.*" access="permitAll"/>
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.local!?.*"
+                           access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.description!?.*"
                            access="permitAll"/>
         <sec:intercept-url pattern="/opensearch/[a-z]{2,3}/!?.*" access="permitAll"/>

--- a/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
@@ -69,21 +69,7 @@
   <!-- Define the languages in the UI. Seems like these should come from database
     at some point but at the moment they are needed here. -->
   <util:set id="languages" value-type="java.lang.String">
-    <value>ara</value>
-    <value>cat</value>
-    <value>chi</value>
     <value>dut</value>
-    <value>eng</value>
-    <value>fin</value>
-    <value>fre</value>
-    <value>ger</value>
-    <value>ita</value>
-    <value>nor</value>
-    <value>pol</value>
-    <value>por</value>
-    <value>rus</value>
-    <value>spa</value>
-    <value>tur</value>
   </util:set>
 
   <util:map id="jpaPropertyMap">

--- a/web/src/main/webapp/WEB-INF/config/config-service-inspireatom.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-service-inspireatom.xml
@@ -35,9 +35,17 @@
     <!-- OpenDescription document -->
     <service name="atom.description">
       <class name="org.fao.geonet.services.inspireatom.AtomServiceDescription"/>
-
+<!--
       <output sheet="../xslt/services/inspire-atom/opensearch.xsl"
               contentType="text/xml; charset=UTF-8"/>
+-->
+      <output sheet="../xslt/services/inspire-atom/opensearch-local.xsl" contentType="application/opensearchdescription+xml; charset=UTF-8"/>
+    </service>
+
+    <!-- Describe local -->
+    <service name="atom.local">
+        <class name="org.fao.geonet.services.inspireatom.AtomLocalDescribe" />
+        <output sheet="inspire-atom-feed.xsl" contentType="application/atom+xml; charset=UTF-8"/>
     </service>
 
     <!-- Describe -->

--- a/web/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/web/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -304,6 +304,14 @@
     <to type="forward">/srv/$1/atom.download</to>
   </rule>
 
+  <rule>
+    <note>
+      Download dataset when metadata of dataset contains only one online resource with mime-type download 
+    </note>
+    <from>^/dataset/(.*)$</from>
+    <to type="forward">/srv/eng/atom.download?fileIdentifier=$1</to>
+  </rule>
+
   <!-- Rules for direct links (for RDF at least) -->
   <rule>
     <note>

--- a/web/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/web/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -282,7 +282,8 @@
       INSPIRE Atom Describe (service)
     </note>
     <from>^/opensearch/(.*)/(.*)/describe?(.*)$</from>
-    <to type="forward">/srv/$1/atom.describe?fileIdentifier=$2</to>
+    <to type="forward">/srv/$1/atom.local?fileIdentifier=$2</to>
+<!--    <to type="forward">/srv/$1/atom.describe?fileIdentifier=$2</to>-->
   </rule>
 
   <rule>
@@ -290,7 +291,8 @@
       INSPIRE Atom DescribeBy
     </note>
     <from>^/opensearch/(.*)/describe?(.*)$</from>
-    <to type="forward">/srv/$1/atom.describe</to>
+    <to type="forward">/srv/$1/atom.local</to>
+<!--    <to type="forward">/srv/$1/atom.describe</to>-->
   </rule>
 
 

--- a/web/src/main/webapp/xsl/inspire-atom-feed.xsl
+++ b/web/src/main/webapp/xsl/inspire-atom-feed.xsl
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:atom="http://www.w3.org/2005/Atom"
+				xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:java="java:org.fao.geonet.util.XslUtil"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:georss="http://www.georss.org/georss"
+                xmlns:gml="http://www.opengis.net/gml"
+				xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"
+                xmlns:opensearchextensions="http://example.com/opensearchextensions/1.0/"
+                xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
+                exclude-result-prefixes="gmx xsl gmd gco srv java">
+	<xsl:variable name="protocol">WWW:DOWNLOAD-1.0-HTTP--DOWNLOAD</xsl:variable>
+	<xsl:variable name="applicationProfile">INSPIRE-Download-Atom</xsl:variable>
+	<xsl:variable name="guiLang" select="/root/gui/language"/>
+    <xsl:variable name="baseUrl" select="concat(/root/gui/env/server/protocol,'://',/root/gui/env/server/host,/root/gui/url)"/>
+
+	<xsl:template match="/root">
+		<atom:feed xsi:schemaLocation="http://www.w3.org/2005/Atom http://inspire-geoportal.ec.europa.eu/schemas/inspire/atom/1.0/atom.xsd" xml:lang="en">
+			<xsl:apply-templates mode="service" select="service/gmd:MD_Metadata"/>
+			<xsl:apply-templates mode="dataset" select="dataset/gmd:MD_Metadata">
+				<xsl:with-param name="isServiceEntry" select="false()"/>
+			</xsl:apply-templates>
+		</atom:feed>
+	</xsl:template>
+
+    <xsl:template mode="service" match="gmd:MD_Metadata">
+
+        <!-- Get first element. TODO: Check if can be several -->
+		<xsl:variable name="fileIdentifier" select="gmd:fileIdentifier/gco:CharacterString"/>
+		<xsl:variable name="docLang" select="gmd:language/gmd:LanguageCode/@codeListValue"/>
+		<xsl:variable name="titleNode" select="gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:title"/>
+		<xsl:variable name="title"><xsl:apply-templates mode="get-translation" select="$titleNode"><xsl:with-param name="lang" select="$guiLang"/></xsl:apply-templates></xsl:variable>
+		<xsl:variable name="updated" select="gmd:dateStamp/gco:DateTime"/>
+       	<atom:title><xsl:call-template name="translated-description"><xsl:with-param name="lang" select="$guiLang"/><xsl:with-param name="type" select="2"/></xsl:call-template><xsl:text> </xsl:text><xsl:value-of select="$title"/></atom:title>
+       	<atom:subtitle><xsl:call-template name="translated-description"><xsl:with-param name="lang" select="$guiLang"/><xsl:with-param name="type" select="2"/></xsl:call-template><xsl:text> </xsl:text><xsl:apply-templates mode="get-translation" select="gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:abstract"><xsl:with-param name="lang" select="$guiLang"/></xsl:apply-templates></atom:subtitle>
+       	<xsl:call-template name="csw-link">
+			<xsl:with-param name="lang" select="$guiLang"/>
+			<xsl:with-param name="baseUrl" select="$baseUrl"/>
+			<xsl:with-param name="fileIdentifier" select="$fileIdentifier"/>
+      	</xsl:call-template>
+		<xsl:call-template name="atom-link">
+			<xsl:with-param name="title"><xsl:value-of select="$title"/></xsl:with-param>
+			<xsl:with-param name="lang" select="$guiLang"/>
+			<xsl:with-param name="baseUrl" select="$baseUrl"/>
+			<xsl:with-param name="fileIdentifier" select="$fileIdentifier"/>
+			<xsl:with-param name="rel">self</xsl:with-param>
+		</xsl:call-template>
+		<xsl:for-each select="gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata[srv:operationName/gco:CharacterString='GetCapabilities']">
+			<xsl:variable name="capabalitiesURL" select="normalize-space(srv:connectPoint/gmd:CI_OnlineResource/gmd:linkage/gmd:URL)"/>
+			<xsl:if test="$capabalitiesURL!=''">
+				<atom:link href="{$capabalitiesURL}" rel="related" type="application/xml" title="Service implementing Direct Access operations"/>
+			</xsl:if>
+		</xsl:for-each>
+       	<atom:link rel="search" type="application/opensearchdescription+xml">
+       		<xsl:attribute name="title"><xsl:call-template name="translated-description"><xsl:with-param name="lang" select="$guiLang"/><xsl:with-param name="type" select="1"/></xsl:call-template><xsl:text> </xsl:text><xsl:value-of select="$title"/></xsl:attribute>
+       		<xsl:attribute name="href" select="concat($baseUrl,'/opensearch/',$guiLang,'/',$fileIdentifier,'/OpenSearchDescription.xml')"/>
+       	</atom:link>
+       	<xsl:for-each select="gmd:locale/gmd:PT_Locale/gmd:languageCode/gmd:LanguageCode/@codeListValue">
+       		<xsl:if test="$guiLang!=.">
+				<xsl:call-template name="atom-link">
+					<xsl:with-param name="title"><xsl:apply-templates mode="get-translation" select="$titleNode"><xsl:with-param name="lang" select="."/></xsl:apply-templates></xsl:with-param>
+					<xsl:with-param name="lang" select="."/>
+					<xsl:with-param name="baseUrl" select="$baseUrl"/>
+					<xsl:with-param name="fileIdentifier" select="$fileIdentifier"/>
+					<xsl:with-param name="rel"><xsl:if test="$guiLang=.">self</xsl:if><xsl:if test="$guiLang!=.">alternate</xsl:if></xsl:with-param>
+				</xsl:call-template>
+			</xsl:if>
+		</xsl:for-each>
+   		<xsl:if test="$guiLang!=$docLang">
+			<xsl:call-template name="atom-link">
+				<xsl:with-param name="title"><xsl:apply-templates mode="get-translation" select="$titleNode"><xsl:with-param name="lang" select="$docLang"/></xsl:apply-templates></xsl:with-param>
+				<xsl:with-param name="lang" select="$docLang"/>
+				<xsl:with-param name="baseUrl" select="$baseUrl"/>
+				<xsl:with-param name="fileIdentifier" select="$fileIdentifier"/>
+				<xsl:with-param name="rel">alternate</xsl:with-param>
+			</xsl:call-template>
+		</xsl:if>
+		<atom:id>
+			<xsl:call-template name="atom-link-href">
+				<xsl:with-param name="lang"><xsl:value-of select="$guiLang"/></xsl:with-param>
+				<xsl:with-param name="baseUrl"><xsl:value-of select="$baseUrl"/></xsl:with-param>
+				<xsl:with-param name="fileIdentifier"><xsl:value-of select="$fileIdentifier"/></xsl:with-param>
+			</xsl:call-template>
+   		</atom:id>
+   		<atom:rights><xsl:apply-templates mode="translated-rights" select="gmd:identificationInfo/srv:SV_ServiceIdentification"/></atom:rights>
+		<atom:updated><xsl:value-of select="$updated"/>Z</atom:updated>
+		<atom:author>
+			<atom:name><xsl:value-of select="gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact[1]/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString"/></atom:name>
+			<atom:email><xsl:value-of select="gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact[1]/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/*[name(.)='gmd:CI_Address' or @gco:isoType='CI_Address_Type']/gmd:electronicMailAddress/gco:CharacterString"/></atom:email>
+		</atom:author>
+		<xsl:for-each select="datasets/gmd:MD_Metadata">
+			<atom:entry>
+				<inspire_dls:spatial_dataset_identifier_code><xsl:value-of select="gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString|gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:code/gco:CharacterString"/></inspire_dls:spatial_dataset_identifier_code>
+				<inspire_dls:spatial_dataset_identifier_namespace><xsl:value-of select="gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:codeSpace/gco:CharacterString|gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:codeSpace/gco:CharacterString"/></inspire_dls:spatial_dataset_identifier_namespace>
+				<xsl:apply-templates mode="dataset" select=".">
+					<xsl:with-param name="isServiceEntry" select="true()"/>
+				</xsl:apply-templates>
+			</atom:entry>
+		</xsl:for-each>
+    </xsl:template>
+    
+    <xsl:template mode="dataset" match="gmd:MD_Metadata">
+    	<xsl:param name="isServiceEntry"/>
+		<xsl:variable name="fileIdentifier" select="gmd:fileIdentifier/gco:CharacterString"/>
+		<xsl:variable name="docLang" select="gmd:language/gmd:LanguageCode/@codeListValue"/>
+		<xsl:variable name="datasetTitleNode" select="gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title"/>
+		<xsl:variable name="datasetTitle"><xsl:apply-templates mode="get-translation" select="$datasetTitleNode"><xsl:with-param name="lang" select="$guiLang"/></xsl:apply-templates></xsl:variable>
+		<xsl:variable name="identifierCode" select="gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString|gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:code/gco:CharacterString"/>
+		<xsl:variable name="identifierCodeSpace" select="gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:codeSpace/gco:CharacterString|gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:codeSpace/gco:CharacterString"/>
+		<xsl:variable name="updated" select="gco:DateTime"/>
+		<xsl:if test="not($isServiceEntry)">
+	       	<atom:title><xsl:call-template name="translated-description"><xsl:with-param name="lang" select="$guiLang"/><xsl:with-param name="type" select="3"/></xsl:call-template><xsl:text> </xsl:text><xsl:value-of select="$datasetTitle"/></atom:title>
+	       	<atom:subtitle><xsl:call-template name="translated-description"><xsl:with-param name="lang" select="$guiLang"/><xsl:with-param name="type" select="3"/></xsl:call-template><xsl:text> </xsl:text><xsl:apply-templates mode="get-translation" select="gmd:MD_DataIdentification/gmd:abstract"><xsl:with-param name="lang" select="$guiLang"/></xsl:apply-templates></atom:subtitle>
+		</xsl:if>
+		<xsl:if test="$isServiceEntry">
+			<xsl:for-each select="gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[upper-case(gmd:protocol/gco:CharacterString) = $protocol and gmd:applicationProfile/gco:CharacterString=$applicationProfile]/gmd:description">
+				<xsl:variable name="crs" select="normalize-space(.)"/>
+				<xsl:variable name="crsLabel" select="/root/gui/schemas/iso19139/labels/element[@name = 'gmd:description']/helper/option[@value=$crs]"/>
+					<atom:category term="{$crs}" label="{$crsLabel}"/>
+			</xsl:for-each>
+		</xsl:if>
+		<xsl:variable name="authorName" select="gmd:MD_DataIdentification/gmd:pointOfContact[1]/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString"/>
+		<xsl:variable name="authorEmail" select="gmd:MD_DataIdentification/gmd:pointOfContact[1]/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/*[name(.)='gmd:CI_Address' or @gco:isoType='CI_Address_Type']/gmd:electronicMailAddress/gco:CharacterString"/>
+		<xsl:if test="$isServiceEntry">
+			<atom:author>
+				<atom:name><xsl:value-of select="$authorName"/></atom:name>
+				<atom:email><xsl:value-of select="$authorEmail"/></atom:email>
+			</atom:author>
+		</xsl:if>
+   		<atom:id>
+			<xsl:call-template name="atom-link-href">
+				<xsl:with-param name="lang"><xsl:value-of select="$guiLang"/></xsl:with-param>
+				<xsl:with-param name="baseUrl"><xsl:value-of select="$baseUrl"/></xsl:with-param>
+				<xsl:with-param name="identifier"><xsl:value-of select="$identifierCode"/></xsl:with-param>
+				<xsl:with-param name="codeSpace"><xsl:value-of select="$identifierCodeSpace"/></xsl:with-param>
+			</xsl:call-template>
+   		</atom:id>
+       	<xsl:call-template name="csw-link">
+			<xsl:with-param name="lang" select="$guiLang"/>
+			<xsl:with-param name="baseUrl" select="$baseUrl"/>
+			<xsl:with-param name="fileIdentifier" select="$fileIdentifier"/>
+   		</xsl:call-template>
+		<xsl:call-template name="atom-link">
+			<xsl:with-param name="title"><xsl:apply-templates mode="get-translation" select="$datasetTitleNode"><xsl:with-param name="lang" select="$guiLang"/></xsl:apply-templates></xsl:with-param>
+			<xsl:with-param name="lang" select="$guiLang"/>
+			<xsl:with-param name="baseUrl" select="$baseUrl"/>
+			<xsl:with-param name="identifier" select="$identifierCode"/>
+			<xsl:with-param name="codeSpace"><xsl:value-of select="$identifierCodeSpace"/></xsl:with-param>
+			<xsl:with-param name="rel"><xsl:if test="name(../..)='root'">self</xsl:if><xsl:if test="name(..)='datasets'">alternate</xsl:if></xsl:with-param>
+		</xsl:call-template>
+		<xsl:if test="not($isServiceEntry)">
+	       	<xsl:for-each select="gmd:locale/gmd:PT_Locale/gmd:languageCode/gmd:LanguageCode/@codeListValue">
+	       		<xsl:if test="$guiLang!=.">
+					<xsl:call-template name="atom-link">
+						<xsl:with-param name="title"><xsl:apply-templates mode="get-translation" select="$datasetTitleNode"><xsl:with-param name="lang" select="."/></xsl:apply-templates></xsl:with-param>
+						<xsl:with-param name="lang" select="."/>
+						<xsl:with-param name="baseUrl" select="$baseUrl"/>
+						<xsl:with-param name="identifier" select="$identifierCode"/>
+						<xsl:with-param name="codeSpace"><xsl:value-of select="$identifierCodeSpace"/></xsl:with-param>
+						<xsl:with-param name="rel"><xsl:if test="$guiLang=.">self</xsl:if><xsl:if test="$guiLang!=.">alternate</xsl:if></xsl:with-param>
+					</xsl:call-template>
+				</xsl:if>
+			</xsl:for-each>
+	   		<xsl:if test="$guiLang!=$docLang">
+				<xsl:call-template name="atom-link">
+					<xsl:with-param name="title"><xsl:apply-templates mode="get-translation" select="$datasetTitleNode"><xsl:with-param name="lang" select="$docLang"/></xsl:apply-templates></xsl:with-param>
+					<xsl:with-param name="lang" select="$docLang"/>
+					<xsl:with-param name="baseUrl" select="$baseUrl"/>
+					<xsl:with-param name="identifier" select="$identifierCode"/>
+					<xsl:with-param name="codeSpace"><xsl:value-of select="$identifierCodeSpace"/></xsl:with-param>
+					<xsl:with-param name="rel">alternate</xsl:with-param>
+				</xsl:call-template>
+			</xsl:if>
+		</xsl:if>
+		<xsl:variable name="serviceIdentifier" select="normalize-space(../serviceIdentifier)"/>
+		<xsl:if test="$serviceIdentifier">
+			<atom:link title="The parent service feed" rel="up" type="application/atom+xml" hreflang="{$guiLang}">
+				<xsl:attribute name="href">
+					<xsl:call-template name="atom-link-href">
+						<xsl:with-param name="lang"><xsl:value-of select="$guiLang"/></xsl:with-param>
+						<xsl:with-param name="baseUrl"><xsl:value-of select="$baseUrl"/></xsl:with-param>
+						<xsl:with-param name="fileIdentifier"><xsl:value-of select="$serviceIdentifier"/></xsl:with-param>
+					</xsl:call-template>
+				</xsl:attribute>
+			</atom:link>
+		</xsl:if>
+   		<atom:rights><xsl:apply-templates mode="translated-rights" select="gmd:MD_DataIdentification"/></atom:rights>
+		<xsl:if test="$isServiceEntry">
+	       	<atom:summary><xsl:apply-templates mode="get-translation" select="gmd:MD_DataIdentification/gmd:abstract"><xsl:with-param name="lang" select="$guiLang"/></xsl:apply-templates></atom:summary>
+	       	<atom:title><xsl:call-template name="translated-description"><xsl:with-param name="lang" select="$guiLang"/><xsl:with-param name="type" select="3"/></xsl:call-template><xsl:text> </xsl:text><xsl:value-of select="$datasetTitle"/></atom:title>
+		</xsl:if>
+		<atom:updated><xsl:value-of select="$updated"/>Z</atom:updated>
+		<xsl:variable name="w" select="normalize-space(gmd:EX_GeographicBoundingBox/gmd:westBoundLongitude/gco:Decimal/text())"/>
+		<xsl:variable name="e" select="normalize-space(gmd:EX_GeographicBoundingBox/gmd:eastBoundLongitude/gco:Decimal/text())"/>
+		<xsl:variable name="s" select="normalize-space(gmd:EX_GeographicBoundingBox/gmd:southBoundLatitude/gco:Decimal/text())"/>
+		<xsl:variable name="n" select="normalize-space(gmd:EX_GeographicBoundingBox/gmd:northBoundLatitude/gco:Decimal/text())"/>
+		<xsl:variable name="fw" select="java:formatNumber($w,'5')"/>
+		<xsl:variable name="fe" select="java:formatNumber($e,'5')"/>
+		<xsl:variable name="fs" select="java:formatNumber($s,'5')"/>
+		<xsl:variable name="fn" select="java:formatNumber($n,'5')"/>
+		<xsl:if test="$isServiceEntry">
+			<xsl:if test="$w!='' and $e!='' and $s!='' and $n!=''">
+				<georss:polygon><xsl:value-of select="concat($fs,' ',$fw,' ',$fn,' ',$fw,' ',$fn,' ',$fe,' ',$fs,' ',$fe,' ',$fs,' ',$fw)"/></georss:polygon>
+			</xsl:if>
+		</xsl:if>
+		<xsl:if test="not($isServiceEntry)">
+			<xsl:variable name="requestedCRS" select="normalize-space(../crs)"/>
+			<atom:author>
+				<atom:name><xsl:value-of select="$authorName"/></atom:name>
+				<atom:email><xsl:value-of select="$authorEmail"/></atom:email>
+			</atom:author>
+			<xsl:for-each select="gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[upper-case(gmd:protocol/gco:CharacterString) = $protocol and gmd:applicationProfile/gco:CharacterString=$applicationProfile]">
+				<xsl:variable name="crs" select="normalize-space(gmd:description)"/>
+				<xsl:if test="$requestedCRS='' or $requestedCRS=$crs">
+					<atom:entry>				
+						<xsl:variable name="crsLabel" select="/root/gui/schemas/iso19139/labels/element[@name = 'gmd:description']/helper/option[@value=$crs]"/>
+						<xsl:variable name="mimeFileType" select="normalize-space(gmd:name/gmx:MimeFileType/@type)"/>
+						<xsl:variable name="entryTitle" select="concat($datasetTitle,' in ', $crsLabel, ' - ', /root/gui/strings/mimetypeChoice[@value=$mimeFileType])"/>
+						<inspire_dls:spatial_dataset_identifier_code><xsl:value-of select="$identifierCode"/></inspire_dls:spatial_dataset_identifier_code>
+						<inspire_dls:spatial_dataset_identifier_namespace><xsl:value-of select="$identifierCodeSpace"/></inspire_dls:spatial_dataset_identifier_namespace>
+						<xsl:variable name="crs" select="normalize-space(gmd:description)"/>
+						<atom:category term="{$crs}" label="{$crsLabel}"/>
+						<atom:author>
+							<atom:name><xsl:value-of select="$authorName"/></atom:name>
+							<atom:email><xsl:value-of select="$authorEmail"/></atom:email>
+						</atom:author>
+						<atom:id><xsl:value-of select="gmd:linkage/gmd:URL"/></atom:id>
+						<atom:link title="{$entryTitle}" rel="alternate">
+							<xsl:attribute name="type"><xsl:value-of select="normalize-space(gmd:name/gmx:MimeFileType/@type)"/></xsl:attribute>
+							<xsl:attribute name="href"><xsl:value-of select="gmd:linkage/gmd:URL"/></xsl:attribute>
+							<xsl:variable name="length"><xsl:value-of select="java:multiply(../../gmd:transferSize/gco:Real,'1000000')"/></xsl:variable>
+							<xsl:if test="$length > 0"><xsl:attribute name="length"><xsl:value-of select="$length"/></xsl:attribute></xsl:if>
+			   				<xsl:attribute name="hreflang" select="$guiLang"/>
+						</atom:link>
+						<atom:title><xsl:value-of select="$entryTitle"/></atom:title>
+						<atom:updated><xsl:value-of select="$updated"/>Z</atom:updated>
+						<georss:polygon><xsl:value-of select="concat($fs,' ',$fw,' ',$fn,' ',$fw,' ',$fn,' ',$fe,' ',$fs,' ',$fe,' ',$fs,' ',$fw)"/></georss:polygon>
+					</atom:entry>
+				</xsl:if>
+			</xsl:for-each>
+		</xsl:if>
+    </xsl:template>
+
+	<xsl:template name="translated-description">
+		<xsl:param name="lang"/>
+		<xsl:param name="type"/>
+		<xsl:variable name="suffix"><xsl:choose><xsl:when test="$lang='dut'">voor</xsl:when><xsl:when test="$lang='fre'">pour</xsl:when><xsl:otherwise>for</xsl:otherwise></xsl:choose></xsl:variable>
+		<xsl:choose>
+			<xsl:when test="$type=1"><xsl:value-of select="concat('Open Search Description ', $suffix)"/></xsl:when>
+			<xsl:when test="$type=2"><xsl:value-of select="concat('INSPIRE Download Service Atom feed ', $suffix)"/></xsl:when>
+			<xsl:when test="$type=3"><xsl:value-of select="concat('INSPIRE Dataset Atom feed ', $suffix)"/></xsl:when>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template mode="translated-rights" match="srv:SV_ServiceIdentification|gmd:MD_DataIdentification">
+<!--		<xsl:variable name="useLimitation" select="normalize-space(gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation/gco:CharacterString)"/>
+		<xsl:variable name="translated-useLimitation" select="normalize-space(gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',upper-case($guiLang))])"/>
+		<xsl:choose>
+			<xsl:when test="$translated-useLimitation!=''"><xsl:value-of select="$translated-useLimitation"/></xsl:when>
+			<xsl:otherwise><xsl:value-of select="$useLimitation"/></xsl:otherwise>
+		</xsl:choose>
+		<xsl:text> </xsl:text>
+-->
+		<xsl:for-each select="gmd:resourceConstraints/gmd:MD_LegalConstraints">
+			<xsl:variable name="accessConstraints" select="gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue"/>
+			<xsl:variable name="otherConstraints" select="normalize-space(gmd:otherConstraints/gco:CharacterString)"/>
+			<xsl:variable name="translated-otherConstraints" select="normalize-space(gmd:otherConstraints/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',upper-case($guiLang))])"/>
+			<xsl:variable name="resultValue">
+				<xsl:choose>
+					<xsl:when test="$accessConstraints='otherRestrictions' and $otherConstraints!=''"><xsl:if test="$translated-otherConstraints!=''"><xsl:value-of select="$translated-otherConstraints"/></xsl:if><xsl:if test="$translated-otherConstraints=''"><xsl:value-of select="$otherConstraints"/></xsl:if></xsl:when>
+					<xsl:otherwise><xsl:value-of select="/root/gui/schemas/iso19139/codelists/codelist[@name = 'gmd:MD_RestrictionCode']/entry[code = $accessConstraints]/description"/></xsl:otherwise>
+				</xsl:choose>
+			</xsl:variable>
+			<xsl:if test="normalize-space($resultValue)!=''">
+				<xsl:value-of select="normalize-space($resultValue)"/><xsl:if test="not(ends-with(normalize-space($resultValue),'.'))">.</xsl:if><xsl:text> </xsl:text>
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:for-each select="gmd:resourceConstraints/gmd:MD_SecurityConstraints">
+			<xsl:variable name="classificationConstraints" select="gmd:classification/gmd:MD_ClassificationCode/@codeListValue"/>
+			<xsl:variable name="resultValue" select="/root/gui/schemas/iso19139/codelists/codelist[@name = 'gmd:MD_ClassificationCode']/entry[code = $classificationConstraints]/description"/>
+			<xsl:if test="normalize-space($resultValue)!=''">
+				<xsl:value-of select="normalize-space($resultValue)"/><xsl:if test="not(ends-with(normalize-space($resultValue),'.'))">.</xsl:if><xsl:text> </xsl:text>
+			</xsl:if>
+		</xsl:for-each>
+	</xsl:template>
+
+	<xsl:template name="csw-link">
+		<xsl:param name="lang"/>
+		<xsl:param name="baseUrl"/>
+		<xsl:param name="fileIdentifier"/>
+		<atom:link rel="describedby" type="application/xml">
+			<xsl:attribute name="href" select="concat($baseUrl,'/srv/',$lang,'/csw?service=CSW&amp;version=2.0.2&amp;request=GetRecordById&amp;outputschema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=',$fileIdentifier)"/>
+       	</atom:link>
+	</xsl:template>
+
+	<xsl:template name="atom-link">
+		<xsl:param name="lang"/>
+		<xsl:param name="baseUrl"/>
+		<xsl:param name="fileIdentifier"/>
+		<xsl:param name="identifier"/>
+		<xsl:param name="codeSpace"/>
+		<xsl:param name="title"/>
+		<xsl:param name="rel"/>
+		<xsl:variable name="type" select="if ($fileIdentifier!='') then 2 else 3"/>
+       	<atom:link type="application/atom+xml">
+       		<xsl:if test="$lang!=$guiLang">
+   				<xsl:attribute name="hreflang" select="$lang"/>
+			</xsl:if>
+			<xsl:if test="$rel!=''">
+   				<xsl:attribute name="rel" select="$rel"/>
+			</xsl:if>
+       		<xsl:attribute name="title"><xsl:call-template name="translated-description"><xsl:with-param name="lang" select="$lang"/><xsl:with-param name="type" select="$type"/></xsl:call-template><xsl:text> </xsl:text><xsl:value-of select="$title"/></xsl:attribute>
+       		<xsl:attribute name="href">
+				<xsl:call-template name="atom-link-href">
+					<xsl:with-param name="lang" select="$lang"/>
+					<xsl:with-param name="baseUrl" select="$baseUrl"/>
+					<xsl:with-param name="fileIdentifier" select="$fileIdentifier"/>
+					<xsl:with-param name="identifier" select="$identifier"/>
+					<xsl:with-param name="codeSpace" select="$codeSpace"/>
+				</xsl:call-template>
+       		</xsl:attribute>
+       	</atom:link>
+	</xsl:template>
+
+	<xsl:template name="atom-link-href">
+		<xsl:param name="lang"/>
+		<xsl:param name="baseUrl"/>
+		<xsl:param name="fileIdentifier"/>
+		<xsl:param name="identifier"/>
+		<xsl:param name="codeSpace"/>
+		<xsl:if test="$fileIdentifier!=''"><xsl:value-of select="concat($baseUrl,'/opensearch/',$lang,'/',$fileIdentifier,'/describe')"/></xsl:if>
+		<xsl:if test="$identifier!=''"><xsl:value-of select="concat($baseUrl,'/opensearch/',$lang,'/describe?spatial_dataset_identifier_code=',$identifier,'&amp;spatial_dataset_identifier_namespace=',$codeSpace)"/></xsl:if>
+	</xsl:template>
+
+	<xsl:template mode="get-translation" match="*|@*">
+		<xsl:param name="lang"/>
+		<xsl:variable name="translation" select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',upper-case($lang))]"/>
+		<xsl:choose>
+			<xsl:when test="$translation!=''"><xsl:value-of select="$translation"/></xsl:when>
+			<xsl:otherwise><xsl:value-of select="normalize-space(gco:CharacterString)"/></xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+		
+</xsl:stylesheet>

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearch-local.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearch-local.xsl
@@ -82,6 +82,9 @@
             </Url>
 			
 			<xsl:variable name="url" select="concat(//server/protocol,'://',//server/host,/root/gui/url,'/opensearch/', /root/gui/language, '/download?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+			<Url type="application/atom+xml" rel="results">
+			    <xsl:attribute name="template"><xsl:value-of select="$url"/></xsl:attribute>
+			</Url>
 			<Url type="application/x-shapefile" rel="results">
 			    <xsl:attribute name="template"><xsl:value-of select="$url"/></xsl:attribute>
 			</Url>

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearch-local.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearch-local.xsl
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:template match="/">
+    <OpenSearchDescription xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
+                           xmlns="http://a9.com/-/spec/opensearch/1.1/">
+
+
+      <!--URL of this document-->
+      <xsl:choose>
+        <xsl:when test="string(/root/response/fileId)">
+          <ShortName>INSPIRE Download</ShortName>
+          <LongName><xsl:value-of select="substring(/root/response/title,1,48)"/></LongName>
+          <Description><xsl:value-of select="/root/response/title"/>: <xsl:value-of select="/root/response/subtitle"/></Description>
+
+          <Url type="application/opensearchdescription+xml" rel="self">
+            <xsl:attribute name="template">
+              <xsl:value-of
+                select="concat(//server/protocol,'://',//server/host,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/OpenSearchDescription.xml')"/>
+            </xsl:attribute>
+          </Url>
+
+                    <!--Generic URL template for browser integration-->
+<!--
+                    <Url type="application/atom+xml" rel="results">
+                        <xsl:attribute name="template">
+                            <xsl:value-of select="concat(//server/protocol,'://',//server/host,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/describe')"/>
+                        </xsl:attribute>
+                    </Url>
+-->
+
+                    <!--Generic URL template for browser integration-->
+                    <Url type="text/html" rel="results">
+                        <xsl:attribute name="template">
+                            <xsl:value-of select="concat(//server/protocol,'://',//server/host,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/htmlsearch?q={searchTerms?}')"/>
+                        </xsl:attribute>
+                    </Url>
+        </xsl:when>
+        <xsl:otherwise>
+                    <ShortName>INSPIRE Download</ShortName>
+                    <LongName><xsl:value-of select="substring(//site/organization,1,24)"/> | GeoNetwork opensource</LongName>
+                    <Description><xsl:value-of select="/root/gui/strings/opensearch"/></Description>
+
+                    <!--Generic URL template for browser integration-->
+                    <Url type="application/xml" rel="results">
+                        <xsl:attribute name="template">
+                            <xsl:value-of select="concat(//server/protocol,'://',//server/host,/root/gui/url,'/opensearch/', /root/gui/language, '/search?q={searchTerms?}')"/>
+                        </xsl:attribute>
+                    </Url>
+        </xsl:otherwise>
+      </xsl:choose>
+
+			<!--Describe Spatial Data Set Operation request URL template to be used
+			    in order to retrieve the Description of Spatial Object Types in a Spatial
+			    Dataset-->
+			<Url type="application/atom+xml" rel="describedby">
+			    <xsl:attribute name="template">
+					<xsl:value-of select="concat(//server/protocol,'://',//server/host,/root/gui/url,'/opensearch/', /root/gui/language, '/describe?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+				</xsl:attribute>
+            </Url>
+			
+			<xsl:variable name="url" select="concat(//server/protocol,'://',//server/host,/root/gui/url,'/opensearch/', /root/gui/language, '/download?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+			<Url type="application/x-shapefile" rel="results">
+			    <xsl:attribute name="template"><xsl:value-of select="$url"/></xsl:attribute>
+			</Url>
+			<Url type="application/x-gmz" rel="results">
+			    <xsl:attribute name="template"><xsl:value-of select="$url"/></xsl:attribute>
+			</Url>
+
+
+      <!-- Repeat the following for each data set, for each CRS of a dataset query example (regardless of the number of file formats -->
+            <!-- Repeat the following for each data set, for each CRS of a dataset query example (regardless of the number of file formats -->
+            <xsl:for-each select="/root/response/datasets/dataset">
+                <xsl:variable name="codeVal" select="code" />
+                <xsl:variable name="namespaceVal" select="namespace" />
+
+                <xsl:for-each select="file">
+                    <Query role="example"
+                           inspire_dls:spatial_dataset_identifier_namespace="{$namespaceVal}"
+                           inspire_dls:spatial_dataset_identifier_code="{$codeVal}" inspire_dls:crs="{crs}" language="{lang}" title="{title}" count="{crsCount}"/>
+                </xsl:for-each>
+
+            </xsl:for-each>
+
+      <xsl:choose>
+        <xsl:when test="string(/root/response/fileId)">
+          <!-- For each Service Feed the contact -->
+          <Contact><xsl:value-of select="/root/response/authorEmail" /></Contact>
+          <Tags>
+            <xsl:value-of select="/root/response/keywords"/>
+          </Tags>
+          <!-- per Atom Service feed / Service metadata record combinatie: -->
+          <Developer>
+            <xsl:value-of select="/root/response/authorName"/>
+          </Developer>
+          <!--Languages supported by the service. The first language is the default language-->
+          <!-- And for each language of the Service Feed: -->
+          <Language>
+            <xsl:value-of select="/root/response/lang"/>
+          </Language>
+        </xsl:when>
+        <xsl:otherwise>
+          <Contact>
+            <xsl:value-of select="//feedback/email"/>
+          </Contact>
+          <Language>
+            <xsl:value-of select="/root/gui/language"/>
+          </Language>
+        </xsl:otherwise>
+      </xsl:choose>
+
+
+    </OpenSearchDescription>
+  </xsl:template>
+</xsl:stylesheet>

--- a/web/src/main/webapp/xslt/ui/service-not-allowed.xsl
+++ b/web/src/main/webapp/xslt/ui/service-not-allowed.xsl
@@ -37,7 +37,7 @@
                         then '' else /root/request/referer"/>
 
           <xsl:value-of
-            select="replace($i18n/serviceNotAllowed, '\{1\}', concat('&quot;', $referer, '&quot;'))"/>
+            select="replace($i18n/serviceNotAllowed, '\{1\}', concat('&quot; ', $referer, '&quot;'))"/>
           <xsl:copy-of select="$i18n/linkToHome"/>
         </p>
       </div>


### PR DESCRIPTION
**Introduction**
This branch implements the generation of local INSPIRE atom feeds based on the INSPIRE download service metadata record and the coupled dataset metadata records.

To handle http://yourdomainname/geonetwork/opensearch/eng/[fileidentifier]/OpenSearchDescription.xml request the AtomServiceDescription.java produces the xml like a link to itself, a template url and query url for each linked dataset atom feed.

To handle the http://yourdomainname/geonetwork/opensearch/eng/[fileidentifier]/describe request the AtomDescribe.java produces the xml describing the service atom feed (title, subtitle, link to CSW metadatarecord, link to itself, link to opensearchdescription.xml, entry for each dataset atom feed end-point), 

To handle the http://yourdomainname/geonetwork/opensearch/fre/describe?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?} request the AtomDescribe.java produces the xml describing the dataset atom feed (title, subtitle, link to itself, link to CSW metadatarecord, update date, author, the dataset (crs, title, update date, extent, identifier code, identifier namespace)).

To handle the http://yourdomainname/geonetwork/opensearch/fre/download?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&crs={inspire_dls:crs?}&language={language?} request  the AtomGetData.java downloads the dataset itself or a new dataset atom feed if more datasets are available corresponding to requested criterium.

Look at the snippets at the end of this pull request to know what xml parts are mandatory for a download service and dataset metadata records containing download urls so they can to be read by the firefox RSS/Atom extension.

**Here the modified/added files with some extra info:**
Modified urlrewrite.xml to forward to atom.local service and not to atom.describe.
Modified config-security-mapping.xml and config-service-inspireatom.xml to add atom.local service.
Modified update-fixed-info.xsl to update fileidentifiers in service atom feed urls of a download service metadata record.
Modified default.xsl and language-default.xsl by adding has_atom lucene index field.
Modified extract-datasetid.xsl to support also the gmd:RS_Identifier metadata tag.
Modified extract-atom-feed.xsl to extract only the url with describe in the url preventing an transformation error.
Modified AtomServiceDescription.java based on new opensearch-local.xsl (could be better to use a new class AtomLocalServiceDescription class) and added crsCount to resulting xml.
Modified AtomDescribe.java and AtomGetData.java using the new methods retrieveDatasetFeed and retrieveServiceFeed and support for extra request parameters.
Modified InspireAtomUtil.java to support local Inspire atom feeds using existing and new xslt's, by changed retrieveDatasetUuidFromIdentifier method for searching lucene index on a more flexibel way, by checking on service type version INSPIRE ATOM V3.1, by checking on service type download.
Modified InspireAtomFeedHarvester.java by changing filter to get only one metadatarecord, by using saveAndFlush before indexing, by changing parameter counts for methods whose signature is changed, by preparing the harvester to support local atom feeds (in comment).
Modified InspireAtomService.java by preventing null-pointer exception if atom feed isn't already harvested or requested for the first time.
Modified InspireAtomFeed.java by reducing the length of title and subtitle of the atom feed to the maximum of 255 characters.
Modified ServiceManager.java to set the application/atom+xml format in case of atom.describe or atom.local service.
Added inspire-atom-feed.xsl and opensearch-local.xsl to support valid result xml.
Added extract-service-type.xsl to check the service type and service type version for service atom feeds.
Added extract-dataset-fileidentifiers.xsl and extract-dataset-entry-info.xsl to be used for the describe dataset atom feed resulting xml.
Added AtomLocalDescribe.java  to support local Inspire atom feeds.
Added AtomFeedNotFoundEx.java to throw an Atom feed not found exception.
Added some new functions to the XslUtil.java.

In attachement the snippets for download service and linked dataset metadata.
 
[service-snippet.txt](https://github.com/geonetwork/core-geonetwork/files/566897/service-snippet.txt)
[dataset-snippet.txt](https://github.com/geonetwork/core-geonetwork/files/566898/dataset-snippet.txt)
