### PR TITLE
Fix vertical extent on editor's default view

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -134,6 +134,7 @@
     <name>gmd:attributes</name>
     <name>gmd:geographicBox</name>
     <name>gmd:EX_TemporalExtent</name>
+    <name>gmd:EX_VerticalExtent</name>
     <name>gmd:MD_Distributor</name>
     <name>srv:containsOperations</name>
     <name>srv:SV_Parameter</name>
@@ -213,6 +214,8 @@
       <name>gmd:condition</name>
       <name>gmd:maximumOccurence</name>
       <name>gmd:domainValue</name>
+      <name>gmd:minimumValue</name>
+      <name>gmd:maximumValue</name>
       <name>gmd:densityUnits</name>
       <name>gmd:descriptor</name>
       <name>gmd:denominator</name>


### PR DESCRIPTION
Fixes Vertical Extent form elements, which were lacking a section title and were showing integer values as multilingual fields:

![d2e5e798-9201-11e6-8ec7-5eb4d3960556](https://cloud.githubusercontent.com/assets/485651/20305634/ca86b7aa-ab36-11e6-8f89-1330b71dd8be.png)
