### PR TITLE
Update user list on IE11 (admin interface)

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -74,6 +74,13 @@
       $scope.isLoadingUsers = false;
       $scope.isLoadingGroups = false;
 
+      // This is to force IE11 NOT to cache json requests
+      if (!$http.defaults.headers.get) {
+          $http.defaults.headers.get = {};
+      }
+      $http.defaults.headers.get['Cache-Control'] = 'no-cache';
+      $http.defaults.headers.get['Pragma'] = 'no-cache';
+
       $http.get('info?type=categories&_content_type=json').
           success(function(data) {
             $scope.categories = data.metadatacategory;


### PR DESCRIPTION
When creating a new user on Internet Explorer 11, the user list won't be updated, as if the user didn't exist at all. Working fine on any other browser.

Tried to: Log out/in again, close browser, clear browser caché, clear wro4j cache, reboot client & server... and problem persisted. It turns out to be an IE11 "issue" with JSON AJAX queries: http://stackoverflow.com/questions/16098430/angular-ie-caching-issue-for-http

Forcing cache headers solved it.
