### PR TITLE
Fix CRS labels starts with :: on metadata view

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -821,9 +821,14 @@
 
         <xsl:for-each select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
             <xsl:for-each select="gmd:referenceSystemIdentifier/gmd:RS_Identifier">
-                <xsl:variable name="crs" select="concat(string(gmd:codeSpace/gco:CharacterString),'::',string(gmd:code/gco:CharacterString))"/>
+                <xsl:variable name="crs">
+                    <xsl:for-each select="gmd:codeSpace/gco:CharacterString/text() | gmd:code/gco:CharacterString/text()">
+                        <xsl:value-of select="."/>
+                        <xsl:if test="not(position() = last())">::</xsl:if>
+                    </xsl:for-each>
+                </xsl:variable>
 
-                <xsl:if test="$crs != '::'">
+                <xsl:if test="$crs != ''">
                     <Field name="crs" string="{$crs}" store="true" index="true"/>
                 </xsl:if>
             </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -637,9 +637,14 @@
 
         <xsl:for-each select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
             <xsl:for-each select="gmd:referenceSystemIdentifier/gmd:RS_Identifier">
-                <xsl:variable name="crs" select="concat(string(gmd:codeSpace/gco:CharacterString),'::',string(gmd:code/gco:CharacterString))"/>
+                <xsl:variable name="crs">
+                    <xsl:for-each select="gmd:codeSpace/gco:CharacterString/text() | gmd:code/gco:CharacterString/text()">
+                        <xsl:value-of select="."/>
+                        <xsl:if test="not(position() = last())">::</xsl:if>
+                    </xsl:for-each>
+                </xsl:variable>
 
-                <xsl:if test="$crs != '::'">
+                <xsl:if test="$crs != ''">
                     <Field name="crs" string="{$crs}" store="true" index="true"/>
                 </xsl:if>
             </xsl:for-each>


### PR DESCRIPTION
Don't concatenate "::" when no codeSpace is present:

![7512c54c-9c2d-11e6-8b25-439d452c2327](https://cloud.githubusercontent.com/assets/485651/20306172/444e1090-ab39-11e6-8503-c80daa4296f7.png)
