### PR TITLE
FIxed defunct Default Category in Admin->Groups page

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/Group.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Group.java
@@ -300,7 +300,7 @@ public class Group extends Localized implements Serializable {
     /**
      * Get a list of allowed categories for metadata defined on this group.
      */
-    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.DETACH, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.REMOVE})
     @JoinTable(name = "group_category",
         joinColumns = {
             @JoinColumn(name = "GROUP_ID", nullable = false, updatable = false)},

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
@@ -84,14 +84,10 @@
             <p class="help-block" data-translate="">groupDescriptionHelp</p>
 
             <label data-translate="">category</label>
-            <select name="category"
-                    data-ng-model="groupSelected.defaultCategory"
+            <select name="category" data-ng-model="groupSelected.defaultCategory" 
+             		ng-options="category.label[lang] for category in categories track by category.id"
                     class="form-control">
-              <option value="{{category.id}}"
-                      data-ng-selected="category.id == groupSelected.defaultCategory"
-                      data-ng-repeat="category in categories track by $index">
-                {{category.label[lang]}}
-              </option>
+                <option value="none">&nbsp;</option>
             </select>
             <p class="help-block" data-translate="">categoryDescriptionHelp</p>
 


### PR DESCRIPTION
The HTML modification will now send a json object for Default Category and not an ID as was previously sent.
The entity modification fixes an issue created after the Default Category is successfully received in the server-side, which marks a MetadataCategory as detached.