### PR TITLE
Default language improvement.

### DIFF
--- a/core/src/main/java/jeeves/config/springutil/MultiNodeAuthenticationFilter.java
+++ b/core/src/main/java/jeeves/config/springutil/MultiNodeAuthenticationFilter.java
@@ -32,7 +32,10 @@ import jeeves.server.sources.http.JeevesServlet;
 
 import org.fao.geonet.Constants;
 import org.fao.geonet.NodeInfo;
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.User;
+import org.fao.geonet.web.DefaultLanguage;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -122,6 +125,9 @@ public class MultiNodeAuthenticationFilter extends GenericFilterBean {
         chain.doFilter(request, response);
     }
 
+    @Autowired
+    DefaultLanguage defaultLanguage;
+
     private String getRequestLanguage(ConfigurableApplicationContext appContext, HttpServletRequest request) {
         String language = request.getParameter("hl");
         if (language == null) {
@@ -140,10 +146,11 @@ public class MultiNodeAuthenticationFilter extends GenericFilterBean {
         }
 
         if (language == null) {
-            language = appContext.getBean("defaultLanguage", String.class);
+            language = defaultLanguage.getLanguage();
         }
+
         if (language == null) {
-            language = "eng";
+            language = Geonet.DEFAULT_LANGUAGE;
         }
         return language;
     }

--- a/core/src/main/java/org/fao/geonet/web/DefaultLanguage.java
+++ b/core/src/main/java/org/fao/geonet/web/DefaultLanguage.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.web;
+
+import org.fao.geonet.constants.Geonet;
+
+/**
+ * Default catalog language and characteristics.
+ */
+public class DefaultLanguage {
+
+    public DefaultLanguage() {
+        language = Geonet.DEFAULT_LANGUAGE;
+        forceDefault = false;
+    }
+
+
+    private String language;
+
+    /**
+     * @return The default language.
+     */
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+
+    private boolean forceDefault;
+
+    /**
+     * @return true if the default language is forced even if
+     * there is custom HTTP headers or URL parameters.
+     */
+    public boolean isForceDefault() {
+        return forceDefault;
+    }
+
+    public void setForceDefault(boolean forceDefault) {
+        this.forceDefault = forceDefault;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/web/LocaleRedirects.java
+++ b/core/src/main/java/org/fao/geonet/web/LocaleRedirects.java
@@ -24,15 +24,9 @@
 package org.fao.geonet.web;
 
 import jeeves.constants.Jeeves;
-import jeeves.server.overrides.ConfigurationOverrides;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.NodeInfo;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Element;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -51,7 +45,6 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
@@ -85,7 +78,8 @@ public class LocaleRedirects {
 
     private String _homeRedirectUrl = "catalog.search";
 
-    private String _defaultLanguage = Geonet.DEFAULT_LANGUAGE;
+    @Autowired
+    DefaultLanguage defaultLanguage;
 
     @RequestMapping(value = "/home")
     public ModelAndView home(final HttpServletRequest request,
@@ -166,6 +160,9 @@ public class LocaleRedirects {
     }
 
     private String lang(String langParam, String langCookie, String langHeader) {
+        if (defaultLanguage.isForceDefault()) {
+            return defaultLanguage.getLanguage();
+        }
 
         if (langParam != null) {
             return langParam;
@@ -174,7 +171,7 @@ public class LocaleRedirects {
             return langCookie;
         }
         if (langHeader == null) {
-            return _defaultLanguage;
+            return defaultLanguage.getLanguage();
         }
 
         String userLang = langHeader.split("-|,", 2)[0].toLowerCase();
@@ -210,7 +207,7 @@ public class LocaleRedirects {
         } else if (userLang.matches("^tr")) {
             userLang = "tur";
         } else {
-            userLang = _defaultLanguage;
+            userLang = defaultLanguage.getLanguage();
         }
 
         return userLang;

--- a/pom.xml
+++ b/pom.xml
@@ -1189,6 +1189,16 @@
   </distributionManagement>
 
   <properties>
+
+    <!-- Default catalog language when accessing the home page
+    ie. http://localhost:8080/geonetwork. -->
+    <language.default>eng</language.default>
+    <!-- Define if redirection should ignore HTTP headers,
+    Cookie or URL parameters. Set it to true to always redirect
+    to the default language. -->
+    <language.forceDefault>false</language.forceDefault>
+
+
     <jetty.version>9.3.9.v20160517</jetty.version>
     <geotools.version>16.0</geotools.version>
 

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -1,0 +1,2 @@
+language.default=${language.default}
+language.forceDefault=${language.forceDefault}

--- a/web/src/main/webResources/WEB-INF/spring-servlet.xml
+++ b/web/src/main/webResources/WEB-INF/spring-servlet.xml
@@ -52,12 +52,12 @@
 
   <bean id="localeResolver"
         class="org.springframework.web.servlet.i18n.SessionLocaleResolver">
-    <property name="defaultLocale" value="eng"/>
+    <property name="defaultLocale" value="${language.default}"/>
   </bean>
 
   <bean id="localeChangeInterceptor"
         class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor">
-    <property name="paramName" value="language"/>
+    <property name="paramName" value="${language.default}"/>
   </bean>
   <bean id="urlLocaleChangeInterceptor" class="org.fao.geonet.i18n.UrlLocaleChangeInterceptor">
     <property name="urlPosition" value="0"/>

--- a/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
@@ -33,6 +33,11 @@
         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 ">
   <context:annotation-config/>
+
+  <context:property-placeholder location="WEB-INF/config.properties"
+                                file-encoding="UTF-8"
+                                ignore-unresolvable="true" />
+
   <import resource="config-spring-env.xml"/>
   <import resource="config-security/config-security.xml"/>
   <import resource="config-summary.xml"/>
@@ -63,9 +68,11 @@
     <property name="numberOfConcurrentRequests" value="30"/>
   </bean>
 
-  <bean id="defaultLanguage" class="java.lang.String">
-    <constructor-arg index="0" value="eng"/>
+  <bean id="language" class="org.fao.geonet.web.DefaultLanguage">
+    <property name="language" value="${language.default}"/>
+    <property name="forceDefault" value="${language.forceDefault}"/>
   </bean>
+
   <!-- Define the languages in the UI. Seems like these should come from database
     at some point but at the moment they are needed here. -->
   <util:set id="languages" value-type="java.lang.String">


### PR DESCRIPTION
* Add compile time option to set default language (default is eng).
* Add an option to force redirection to the default language.
  Define if redirection should ignore HTTP headers,
  Cookie or URL parameters. Set it to true to always redirect
  to the default language. This is useful when you only have one language supported.

Related to #1579 (@josegar74 could you have a look ? Thanks)