### PR TITLE
Add optional inflate mechanism to apply when the metadata is edited

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -125,6 +125,7 @@ public final class Geonet {
         public static final String SCHEMA_PLUGINS_CATALOG = "schemaplugin-uri-catalog.xml";
         public static final String SORT_HARVESTERS = "sort-harvesters.xsl";
         public static final String JZKITAPPLICATIONCONTEXT = "JZkitApplicationContext.xml";
+        public static final String INFLATE_METADATA = "inflate-metadata.xsl";
 
         /**
          * Stylesheet to convert a CQL parameter to a filter.

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -1655,7 +1655,8 @@ public class DataManager implements ApplicationEventPublisherAware {
      * @param keepXlinkAttributes When XLinks are resolved in non edit mode, do not remove XLink
      *                            attributes.
      */
-    public Element getMetadata(ServiceContext srvContext, String id, boolean forEditing, boolean withEditorValidationErrors, boolean keepXlinkAttributes) throws Exception {
+    public Element getMetadata(ServiceContext srvContext, String id, boolean forEditing,
+                               boolean withEditorValidationErrors, boolean keepXlinkAttributes) throws Exception {
         boolean doXLinks = getXmlSerializer().resolveXLinks();
         Element metadataXml = getXmlSerializer().selectNoXLinkResolver(id, false);
         if (metadataXml == null) return null;
@@ -1665,6 +1666,21 @@ public class DataManager implements ApplicationEventPublisherAware {
         if (forEditing) { // copy in xlink'd fragments but leave xlink atts to editor
             if (doXLinks) Processor.processXLink(metadataXml, srvContext);
             String schema = getMetadataSchema(id);
+
+            // Inflate metadata
+            Path inflateStyleSheet = getSchemaDir(schema).resolve(Geonet.File.INFLATE_METADATA);
+            if (Files.exists(inflateStyleSheet)) {
+                //--- setup environment
+                Element env = new Element("env");
+                env.addContent(new Element("lang").setText(srvContext.getLanguage()));
+
+                // add original metadata to result
+                Element result = new Element("root");
+                result.addContent(metadataXml);
+                result.addContent(env);
+
+                metadataXml = Xml.transform(result, inflateStyleSheet);
+            }
 
             if (withEditorValidationErrors) {
                 version = doValidate(srvContext.getUserSession(), schema, id, metadataXml, srvContext.getLanguage(), forEditing).two();


### PR DESCRIPTION
This pull request allows to define a xslt process in the metadata schemas in a file `inflate-metadata.xsl` to add elements to the metadata before it's edited.

Note that in most cases, a similar stuff can be accomplished with the proper configuration of the editor fields, the inflate option is only required in some advanced cases where the editor configuration is not suitable. 

Usually the inflate process, will require a deflate process to remove the added elements for example if are left empty by the user and can cause validation issues in that case. This deflate can be done in the  `update-fixed-info.xsl`.

**An example use case**

The metadata requires these elements:

* 2 gmd:spatialResolution with an inner element gmd:equivalentScale
* 2 gmd:spatialResolution with an inner element gmd:distance
* The first tuple (`gmd:equivalentScale`, `gmd:distance`) is mandatory and 2on is optional. 

If you leave the optional elements with empty values, xsd validation complaints due to empty `gco:Integer`. For this case:

- `inflate-metadata.xsl`: adds the elements to make sure in the editor the correct number of elements are available for editing.
- when saving the metadata, the `update-fixed-info.xsl` should remove the elements with empty values to avoid xsd validation issues.


