### PR TITLE
File path checks improvements

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/FilePathChecker.java
+++ b/common/src/main/java/org/fao/geonet/utils/FilePathChecker.java
@@ -1,0 +1,58 @@
+//=============================================================================
+//===	Copyright (C) 2001-2005 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This library is free software; you can redistribute it and/or
+//===	modify it under the terms of the GNU Lesser General Public
+//===	License as published by the Free Software Foundation; either
+//===	version 2.1 of the License, or (at your option) any later version.
+//===
+//===	This library is distributed in the hope that it will be useful,
+//===	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//===	Lesser General Public License for more details.
+//===
+//===	You should have received a copy of the GNU Lesser General Public
+//===	License along with this library; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: GeoNetwork@fao.org
+//==============================================================================
+
+package org.fao.geonet.utils;
+
+import org.fao.geonet.exceptions.BadParameterEx;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Utility class to validate a file path.
+ *
+ * @author josegar
+ */
+public class FilePathChecker {
+
+    /**
+     * Checks that a file path is not absolute path and doesn't have .. characters, throwing an exception
+     * in these cases.
+     *
+     * @param filePath
+     * @throws Exception
+     */
+    public static void verify(String filePath) throws Exception {
+        if (filePath.contains("..")) {
+            throw new BadParameterEx(
+                    "Invalid character found in path.",
+                    filePath);
+        }
+
+        Path path = Paths.get(filePath);
+        if (path.isAbsolute() || filePath.startsWith("/") ||
+                filePath.startsWith("://", 1))  {
+            throw new SecurityException("Wrong filename");
+        }
+    }
+}

--- a/services/src/main/java/org/fao/geonet/services/feedback/AddLimitations.java
+++ b/services/src/main/java/org/fao/geonet/services/feedback/AddLimitations.java
@@ -39,6 +39,7 @@ import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.UserRepository;
 import org.fao.geonet.services.Utils;
 import org.fao.geonet.utils.BinaryFile;
+import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
@@ -105,7 +106,9 @@ public class AddLimitations implements Service {
 
             String fname = elem.getText();
 
-            if (fname.contains("..")) {
+            try {
+                FilePathChecker.verify(fname);
+            } catch (Exception ex) {
                 continue;    // Avoid unsecured file name
             }
 

--- a/services/src/main/java/org/fao/geonet/services/logo/Add.java
+++ b/services/src/main/java/org/fao/geonet/services/logo/Add.java
@@ -23,9 +23,11 @@
 
 package org.fao.geonet.services.logo;
 
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.domain.responses.StatusResponse;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.resources.Resources;
+import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.IO;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -75,13 +77,9 @@ public class Add implements ApplicationContextAware {
                 logoDir = this.logoDirectory;
             }
 
-			if (fname.getName().contains("..")) {
-				throw new BadParameterEx(
-						"Invalid character found in resource name.",
-						fname.getName());
-			}
+            FilePathChecker.verify(fname.getName());
 
-			if ("".equals(fname.getName())) {
+			if (StringUtils.isEmpty(fname.getName())) {
 				throw new Exception("Logo name is not defined.");
 			}
 

--- a/services/src/main/java/org/fao/geonet/services/logo/Delete.java
+++ b/services/src/main/java/org/fao/geonet/services/logo/Delete.java
@@ -26,10 +26,12 @@ package org.fao.geonet.services.logo;
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.resources.Resources;
+import org.fao.geonet.utils.FilePathChecker;
 import org.jdom.Element;
 
 import java.nio.file.Files;
@@ -54,11 +56,9 @@ public class Delete implements Service {
 
         String file = Util.getParam(params, Params.FNAME);
 
-        if (file.contains("..")) {
-            throw new BadParameterEx("Invalid character found in resource name.", file);
-        }
+        FilePathChecker.verify(file);
 
-        if ("".equals(file)) {
+        if (StringUtils.isEmpty(file)) {
             throw new Exception("Logo name is not defined.");
         }
 

--- a/services/src/main/java/org/fao/geonet/services/logo/Set.java
+++ b/services/src/main/java/org/fao/geonet/services/logo/Set.java
@@ -26,11 +26,13 @@ package org.fao.geonet.services.logo;
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.resources.Resources;
+import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.IO;
 import org.jdom.Element;
 
@@ -62,12 +64,9 @@ public class Set implements Service {
         String file = Util.getParam(params, Params.FNAME);
         String asFavicon = Util.getParam(params, Params.FAVICON, "0");
 
-        if (file.contains("..")) {
-            throw new BadParameterEx(
-                    "Invalid character found in resource name.", file);
-        }
+        FilePathChecker.verify(file);
 
-        if ("".equals(file)) {
+        if (StringUtils.isEmpty(file)) {
             throw new Exception("Logo name is not defined.");
         }
 

--- a/services/src/main/java/org/fao/geonet/services/mef/ImportWebMap.java
+++ b/services/src/main/java/org/fao/geonet/services/mef/ImportWebMap.java
@@ -28,6 +28,7 @@ import org.fao.geonet.kernel.mef.Importer;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.services.NotInReadOnlyModeService;
+import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
@@ -57,11 +58,9 @@ public class ImportWebMap extends NotInReadOnlyModeService {
         String mapAbstract = Util.getParam(params, "map_abstract", "");
         String title = Util.getParam(params, "map_title", "");
         String mapFileName = Util.getParam(params, "map_filename", "map-context.ows");
-        if (mapFileName.contains("..")) {
-            throw new BadParameterEx(
-                    "Invalid character '..' found in resource name.",
-                    mapFileName);
-        }
+
+        FilePathChecker.verify(mapFileName);
+
         String topic = Util.getParam(params, "topic", "");
 
         

--- a/services/src/main/java/org/fao/geonet/services/resources/Download.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/Download.java
@@ -40,6 +40,7 @@ import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.services.resources.handlers.IResourceDownloadHandler;
 import org.fao.geonet.util.MailSender;
+import org.fao.geonet.utils.FilePathChecker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Controller;
@@ -86,10 +87,8 @@ public class Download {
         final ServiceContext context = serviceManager.createServiceContext("resources.get", lang, httpServletRequest);
         boolean doNotify = false;
 
-		if (fname.contains("..")) {
-			throw new BadParameterEx("Invalid character found in resource name.", fname);
-		}
-		
+        FilePathChecker.verify(fname);
+
 		if (access.equals(Params.Access.PRIVATE))
 		{
 			Lib.resource.checkPrivilege(context, id, ReservedOperation.download);
@@ -99,10 +98,6 @@ public class Download {
 		// Build the response
 		Path dir = Lib.resource.getDir(context, access, id);
 		Path file= dir.resolve(fname);
-		
-		if(fname.startsWith("/") || fname.startsWith("://", 1)) {
-		    throw new SecurityException("Wrong filename");
-		}
 
 		context.info("File is : " +file);
 

--- a/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
@@ -37,6 +37,7 @@ import org.fao.geonet.repository.UserRepository;
 import org.fao.geonet.services.resources.handlers.IResourceDownloadHandler;
 import org.fao.geonet.utils.BinaryFile;
 import org.fao.geonet.Util;
+import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Xml;
 import org.fao.geonet.GeonetContext;
@@ -102,10 +103,8 @@ public class DownloadArchive implements Service
 			Path dir = Lib.resource.getDir(context, access, id);
 			String fname = Util.getParam(params, Params.FNAME);
 
-			if (fname.contains("..")) {
-				throw new BadParameterEx("Invalid character found in resource name.", fname);
-			}
-			
+			FilePathChecker.verify(fname);
+
 			Path file = dir.resolve(fname);
 			return BinaryFile.encode(200, file, false).getElement();
 		}
@@ -164,7 +163,9 @@ public class DownloadArchive implements Service
             for (Element elem : files) {
                 String fname = elem.getText();
 
-                if (fname.contains("..")) {
+                try {
+                    FilePathChecker.verify(fname);
+                } catch (Exception ex) {
                     continue;
                 }
 

--- a/services/src/main/java/org/fao/geonet/services/resources/Get.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/Get.java
@@ -32,6 +32,7 @@ import org.fao.geonet.constants.Params;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.services.NotInReadOnlyModeService;
 import org.fao.geonet.services.Utils;
+import org.fao.geonet.utils.FilePathChecker;
 import org.jdom.Element;
 
 import java.nio.file.Files;
@@ -56,12 +57,8 @@ public class Get extends NotInReadOnlyModeService {
 
         // delete the file
         Path file = Lib.resource.getDir(context, access, id).resolve(filename);
-        
-        if(filename.contains("..")
-                || filename.startsWith("://", 1) 
-                || filename.startsWith("/")) {
-            throw new SecurityException("Wrong filename");
-        }
+
+        FilePathChecker.verify(filename);
 
         Files.deleteIfExists(file);
 

--- a/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceRemoveHandler.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceRemoveHandler.java
@@ -29,6 +29,7 @@ import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.MetadataFileUpload;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.MetadataFileUploadRepository;
+import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
 
@@ -51,6 +52,8 @@ public class DefaultResourceRemoveHandler implements IResourceRemoveHandler {
                          String fileName, String access) throws ResourceHandlerException {
 
         try {
+            FilePathChecker.verify(fileName);
+
             // delete online resource
             Path dir  = Lib.resource.getDir(context, access, metadataId);
             Path file = dir.resolve(fileName);
@@ -93,6 +96,8 @@ public class DefaultResourceRemoveHandler implements IResourceRemoveHandler {
 			throws ResourceHandlerException {
 
         try {
+            FilePathChecker.verify(fileName);
+
             // delete online resource
             Path dir  = Lib.resource.getDir(context, access, metadataId);
             Path file = dir.resolve(fileName);

--- a/services/src/main/java/org/fao/geonet/services/thesaurus/Upload.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/Upload.java
@@ -37,6 +37,7 @@ import org.fao.geonet.kernel.ThesaurusManager;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
@@ -143,11 +144,10 @@ public class Upload implements Service {
                 }
 			}
 		} else {
-	                fname = param.getTextTrim();
-			if (fname.contains("..")) {
-				throw new BadParameterEx("Invalid character found in thesaurus name.", fname);
-			}
-			
+			fname = param.getTextTrim();
+
+			FilePathChecker.verify(fname);
+
 			rdfFile = uploadDir.resolve(fname);
             fname = fname.replaceAll("\\s+", "");
 		}


### PR DESCRIPTION
Unify file path checks done in several services to avoid absolute or relative paths using `..` characters.

There's room for further improvements like review of the exceptions throws, additional checks if required. But I guess is a starting point.

The PR is for 3.0.x, will be added to 3.2.x when merging 3.0.x into 3.2.x