### PR TITLE
Processing / Add the capability to preview process results.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiParams.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiParams.java
@@ -42,10 +42,19 @@ public class ApiParams {
     public static final String API_PARAM_SCHEMA_IDENTIFIERS = "Schema identifiers";
     public static final String API_PARAM_PROCESS_TEST_ONLY = "Test only (ie. metadata are not saved). Return the report only.";
     public static final String API_PARAM_PROCESS_ID = "Process identifier";
-    public static final String API_OP_NOTE_PROCESS = "Process a metadata with an XSL transformation declared for " +
+    public static final String API_OP_NOTE_PROCESS =
+        "Process a metadata with an XSL transformation declared in " +
         "the metadata schema (See the process folder). " +
         "Parameters sent to the service are forwarded " +
         "to XSL process.";
+    public static final String API_OP_NOTE_PROCESS_PREVIEW =
+        "Preview result of a process applied to metadata records with an XSL transformation declared in " +
+        "the metadata schema (See the process folder). " +
+        "Parameters sent to the service are forwarded " +
+        "to XSL process. Append mode has 2 limitations. First, it only support a set of records " +
+        "in the same schema. Secondly, it does not propagate URL parameters. This mode is mainly " +
+        "used to create custom reports based on metadata records content." +
+        "If process name ends with '.csv', the XSL process output a text document which is returned.";
     public static final String API_PARAM_METADATA_TITLE = "Metadata title";
     public static final String API_PARAM_MAPSERVER_RESOURCE = "Resource name (could be a file or a db connection)";
     public static final String API_PARAM_METADATA_ABSTRACT = "Metadata abstract";

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
@@ -23,7 +23,14 @@
 
 package org.fao.geonet.api.processing;
 
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import jeeves.services.ReadWriteController;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -31,8 +38,10 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.processing.report.XsltMetadataProcessingReport;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.MetadataIndexerProcessor;
-import org.fao.geonet.services.metadata.XslProcessing;
+import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -44,19 +53,18 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-import jeeves.services.ReadWriteController;
 import springfox.documentation.annotations.ApiIgnore;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.Set;
+
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 /**
  * Process a metadata with an XSL transformation declared for the metadata schema. Parameters sent
@@ -84,6 +92,123 @@ import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
 @Controller("xslprocess")
 @ReadWriteController
 public class XslProcessApi {
+
+
+    @ApiOperation(
+        value = "Preview process result applied to one or more records",
+        nickname = "previewProcessRecordsUsingXslt",
+        notes = ApiParams.API_OP_NOTE_PROCESS_PREVIEW)
+    @RequestMapping(
+        value = "/{process}",
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.ALL_VALUE
+        })
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('Editor')")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Processed records."),
+        @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_EDITOR)
+    })
+    public Object previewProcessRecords(
+        @ApiParam(
+            value = ApiParams.API_PARAM_PROCESS_ID
+        )
+        @PathVariable
+            String process,
+        @ApiParam(value = API_PARAM_RECORD_UUIDS_OR_SELECTION,
+            required = false,
+            example = "")
+        @RequestParam(required = false)
+            String[] uuids,
+        @ApiParam(value = "Append documents before processing",
+            required = false,
+            example = "false")
+        @RequestParam(required = false, defaultValue = "false")
+            boolean appendFirst,
+        @ApiIgnore
+            HttpSession httpSession,
+        @ApiIgnore
+            HttpServletRequest request,
+        @ApiIgnore
+            HttpServletResponse response) throws IllegalArgumentException {
+        UserSession session = ApiUtils.getUserSession(httpSession);
+
+        XsltMetadataProcessingReport xslProcessingReport =
+            new XsltMetadataProcessingReport(process);
+
+        Element preview = new Element("preview");
+        StringBuffer output = new StringBuffer();
+
+        boolean isText = process.endsWith(".csv");
+
+        response.setHeader(CONTENT_TYPE, isText ? MediaType.TEXT_PLAIN_VALUE : MediaType.APPLICATION_XML_VALUE);
+
+        try {
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, session);
+            ApplicationContext context = ApplicationContextHolder.get();
+            DataManager dataMan = context.getBean(DataManager.class);
+            SchemaManager schemaMan = context.getBean(SchemaManager.class);
+
+            final String siteURL = request.getRequestURL().toString() + "?" + request.getQueryString();
+            Element mergedDocuments = new Element("records");
+            String schema = null;
+            for (String uuid : records) {
+                String id = dataMan.getMetadataId(uuid);
+                Log.info("org.fao.geonet.services.metadata",
+                    "Processing metadata for preview with id:" + id);
+
+
+                if (appendFirst) {
+                    // Check that all metadata are in the same schema
+                    String currentSchema = dataMan.getMetadataSchema(id);
+                    if (schema != null && !currentSchema.equals(schema)) {
+                        // We can't append and use a mix of schema.
+                        throw new IllegalArgumentException(String.format(
+                            "When using append mode, process preview cannot process records with different schemas. " +
+                                "Record with uuid '%s' as schema '%s'. Select only records in the same schema (ie. '%s')",
+                            uuid, currentSchema, schema));
+                    } else {
+                        schema = currentSchema;
+                    }
+                    mergedDocuments.addContent(dataMan.getMetadata(id));
+                } else {
+                    // Save processed metadata
+                    if (isText) {
+                        output.append(XslProcessUtils.processAsText(ApiUtils.createServiceContext(request),
+                            id, process, true,
+                            xslProcessingReport, siteURL, request.getParameterMap())
+                        );
+                    } else {
+                        Element record = XslProcessUtils.process(ApiUtils.createServiceContext(request),
+                            id, process, true,
+                            xslProcessingReport, siteURL, request.getParameterMap());
+                        if (record != null) {
+                            preview.addContent(record.detach());
+                        }
+                    }
+                }
+            }
+            if (appendFirst) {
+                Path xslProcessing = schemaMan.getSchemaDir(schema).resolve("process").resolve(process + ".xsl");
+                if (process.endsWith(".csv")) {
+                    StringWriter sw = new StringWriter();
+                    Xml.transform(
+                        mergedDocuments, xslProcessing,  new StreamResult(sw), null);
+                    return sw.toString();
+                } else {
+                    return Xml.transform(mergedDocuments, xslProcessing);
+                }
+            }
+        } catch (Exception exception) {
+            xslProcessingReport.addError(exception);
+        } finally {
+            xslProcessingReport.close();
+        }
+
+        return isText ? output.toString() : preview;
+    }
 
     @ApiOperation(
         value = "Apply a process to one or more records",
@@ -118,7 +243,6 @@ public class XslProcessApi {
             HttpSession httpSession,
         @ApiIgnore
             HttpServletRequest request) throws Exception {
-
         UserSession session = ApiUtils.getUserSession(httpSession);
 
         XsltMetadataProcessingReport xslProcessingReport =

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
@@ -36,12 +36,15 @@ import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 import jeeves.server.context.ServiceContext;
+
+import javax.xml.transform.stream.StreamResult;
 
 /**
  * Created by francois on 23/05/16.
@@ -160,6 +163,103 @@ public class XslProcessUtils {
                 e.printStackTrace();
             }
             return processedMetadata;
+        }
+        return null;
+    }
+
+    public static String processAsText(ServiceContext context, String id, String process, boolean save,
+                                  XsltMetadataProcessingReport report,
+                                  String siteUrl,
+                                  Map<String, String[]> params) throws Exception {
+        SchemaManager schemaMan = context.getBean(SchemaManager.class);
+        AccessManager accessMan = context.getBean(AccessManager.class);
+        DataManager dataMan = context.getBean(DataManager.class);
+        SettingManager settingsMan = context.getBean(SettingManager.class);
+        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+
+        report.incrementProcessedRecords();
+
+        // When a record is deleted the UUID is in the selection manager
+        // and when retrieving id, return null
+        if (id == null) {
+            report.incrementNullRecords();
+            return null;
+        }
+
+        int iId = Integer.valueOf(id);
+        Metadata info = metadataRepository.findOne(id);
+
+
+        if (info == null) {
+            report.addNotFoundMetadataId(iId);
+        } else if (!accessMan.canEdit(context, id)) {
+            report.addNotEditableMetadataId(iId);
+        } else {
+
+            // -----------------------------------------------------------------------
+            // --- check processing exist for current schema
+            String schema = info.getDataInfo().getSchemaId();
+
+            Path xslProcessing = schemaMan.getSchemaDir(schema).resolve("process").resolve(process + ".xsl");
+            if (!Files.exists(xslProcessing)) {
+                Log.info("org.fao.geonet.services.metadata", "  Processing instruction not found for " + schema +
+                    " schema. Looking for " + xslProcessing);
+                report.addNoProcessFoundMetadataId(iId);
+                return null;
+            }
+
+
+            // --- Process metadata
+            StringWriter sw = new StringWriter();
+            try {
+                boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = true;
+                Element md = dataMan.getMetadata(context, id, forEditing, withValidationErrors, keepXlinkAttributes);
+
+                Map<String, Object> xslParameter = new HashMap<>();
+
+                xslParameter.put("guiLang", context.getLanguage());
+                xslParameter.put("baseUrl", context.getBaseUrl());
+                xslParameter.put("nodeUrl", settingsMan.getNodeURL());
+                xslParameter.put("catalogUrl", settingsMan.getSiteURL(context));
+                xslParameter.put("nodeId", context.getNodeId());
+
+                for (Map.Entry<String, String[]> parameter : params.entrySet()) {
+                    String value = parameter.getValue()[0].trim();
+                    String key = parameter.getKey();
+                    // Add extra metadata
+                    if (key.equals("extra_metadata_uuid")
+                        && !value.equals("")) {
+                        String extraMetadataId = dataMan.getMetadataId(value);
+                        if (extraMetadataId != null) {
+                            Element extraMetadata = dataMan.getMetadata(context,
+                                extraMetadataId, forEditing,
+                                withValidationErrors, keepXlinkAttributes);
+                            md.addContent(new Element("extra")
+                                .addContent(extraMetadata));
+                            xslParameter.put(key, value);
+                        }
+                    } else {
+                        // Or add parameter
+                        xslParameter.put(key, value);
+                    }
+                }
+
+
+                xslParameter.put("siteUrl", siteUrl);
+
+                Xml.transform(
+                    md, xslProcessing,  new StreamResult(sw), xslParameter);
+
+                report.addMetadataId(iId);
+                // TODO : it could be relevant to list at least
+                // if there was any change in the record or not.
+                // Using hash on processMd and metadata ?
+            } catch (Exception e) {
+                report.addMetadataError(iId, e);
+                context.error("  Processing failed with error " + e.getMessage());
+                e.printStackTrace();
+            }
+            return sw.toString();
         }
         return null;
     }


### PR DESCRIPTION
API change:
* GET GET /srv/api/0.1/processes/{process}

Return results of the selected records after processing.

Usually process return XML. All processed records are combined under
a ```<preview/>``` root tag.

Process could also return text output if process name ends-with ```.csv```.
In such case, output is return with appropriate headers.

The CSV mode is usefull when having to create some kind of reports based
on the content of the metadata which requires advanced XPath filters
(eg. table of quality measures).


![image](https://cloud.githubusercontent.com/assets/1701393/21217795/53603914-c2ae-11e6-8ac8-1447fe657a0e.png)

