### PR TITLE
Display a link to the XML editor if an error occurs

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -255,6 +255,7 @@
     solrproxy: '../api/0.1/search'
   });
 
+
   /**
    * @ngdoc service
    * @kind function

--- a/web-ui/src/main/resources/catalog/components/edit/crsselector/CRSSelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/crsselector/CRSSelector.js
@@ -24,7 +24,7 @@
 (function() {
   goog.provide('gn_crs_selector');
 
-  var module = angular.module('gn_crs_selector', []);
+  var module = angular.module('gn_crs_selector', ['pascalprecht.translate']);
 
   /**
    *
@@ -32,9 +32,9 @@
    */
   module.directive('gnCrsSelector',
       ['$rootScope', '$timeout', '$http',
-       'gnEditor', 'gnEditorXMLService', 'gnCurrentEdit',
+       'gnEditor', 'gnEditorXMLService', 'gnCurrentEdit', '$translate',
        function($rootScope, $timeout, $http,
-               gnEditor, gnEditorXMLService, gnCurrentEdit) {
+               gnEditor, gnEditorXMLService, gnCurrentEdit, $translate) {
 
          return {
            restrict: 'A',
@@ -94,7 +94,16 @@
 
                $timeout(function() {
                  // Save the metadata and refresh the form
-                 gnEditor.save(gnCurrentEdit.id, true);
+                 gnEditor.save(gnCurrentEdit.id, true).then(function() {
+                   // Success. Do nothing.
+                 }, function(rejectedValue) {
+                   $rootScope.$broadcast('StatusUpdated', {
+                     title: $translate.instant('runServiceError'),
+                     error: rejectedValue,
+                     timeout: 0,
+                     type: 'danger'
+                   });
+                 });
                });
 
                return false;

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -32,7 +32,7 @@
 
   var module = angular.module('gn_directory_entry_selector',
       ['gn_metadata_manager_service', 'gn_schema_manager_service',
-        'gn_editor_xml_service']);
+        'gn_editor_xml_service', 'pascalprecht.translate']);
 
   /**
    *
@@ -149,7 +149,16 @@
                         scope.elementRef, scope.elementName,
                         scope.domId, 'before').then(function() {
                       if (scope.templateAddAction) {
-                        gnEditor.save(gnCurrentEdit.id, true);
+                        gnEditor.save(gnCurrentEdit.id, true).then(function() {
+                          // success. Nothing to do.
+                        }, function(rejectedValue) {
+                          $rootScope.$broadcast('StatusUpdated', {
+                            title: $translate.instant('saveMetadataError'),
+                            error: rejectedValue,
+                            timeout: 0,
+                            type: 'danger'
+                          });
+                        });
                       }
                     });
                   };
@@ -180,7 +189,14 @@
                             // Save the metadata and refresh the form
                             gnEditor.save(gnCurrentEdit.id, true).then(
                            function(r) {
-                             defer.resolve();
+                             defer.resolve(r);
+                           }, function(rejectedValue) {
+                                $rootScope.$broadcast('StatusUpdated', {
+                                  title: $translate.instant('runServiceError'),
+                                  error: rejectedValue,
+                                  timeout: 0,
+                                  type: 'danger'
+                                });
                            });
                           });
                         }

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
@@ -29,7 +29,7 @@
   /**
    */
   angular.module('gn_geopublisher_directive',
-      ['gn_owscontext_service'])
+      ['gn_owscontext_service', 'pascalprecht.translate'])
       .directive('gnGeoPublisher', [
         'gnMap',
         'gnOwsContextService',
@@ -39,9 +39,10 @@
         'gnCurrentEdit',
         '$timeout',
         '$translate',
+        '$rootScope',
         function(gnMap, gnOwsContextService, gnOnlinesrc,
             gnGeoPublisher, gnEditor, gnCurrentEdit,
-            $timeout, $translate) {
+            $timeout, $translate, $rootScope) {
           return {
             restrict: 'A',
             replace: true,
@@ -150,7 +151,16 @@
                 }
 
                 $timeout(function() {
-                  gnEditor.save(true);
+                  gnEditor.save(true).then(function () {
+                    // success. Nothing to do.
+                  }, function(rejectedValue) {
+                    $rootScope.$broadcast('StatusUpdated', {
+                      title: $translate.instant('runServiceError'),
+                      error: rejectedValue,
+                      timeout: 0,
+                      type: 'danger'
+                    });
+                  });
                 });
               };
               scope.openStyler = function() {

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -159,6 +159,7 @@
 
       /**
        * Run a service (not a batch) to add or remove
+       *
        * an onlinesrc.
        * Save the form, launch the service, then refresh
        * the form and reload the onlinesrc list.

--- a/web-ui/src/main/resources/catalog/components/edit/organisationentryselector/OrganisationEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/organisationentryselector/OrganisationEntrySelector.js
@@ -32,7 +32,7 @@
 
   var module = angular.module('gn_organisation_entry_selector',
       ['gn_metadata_manager_service', 'gn_schema_manager_service',
-       'gn_editor_xml_service']);
+       'gn_editor_xml_service', 'pascalprecht.translate']);
 
   /**
    *
@@ -42,11 +42,11 @@
       ['$rootScope', '$timeout', '$q', '$http',
         'gnEditor', 'gnSchemaManagerService',
         'gnEditorXMLService', 'gnHttp', 'gnConfig',
-        'gnCurrentEdit', 'gnConfigService',
-        function($rootScope, $timeout, $q, $http, 
-            gnEditor, gnSchemaManagerService, 
-            gnEditorXMLService, gnHttp, gnConfig, 
-            gnCurrentEdit, gnConfigService) {
+        'gnCurrentEdit', 'gnConfigService', '$translate',
+        function($rootScope, $timeout, $q, $http,
+            gnEditor, gnSchemaManagerService,
+            gnEditorXMLService, gnHttp, gnConfig,
+            gnCurrentEdit, gnConfigService, $translate) {
 
          return {
            restrict: 'A',
@@ -109,7 +109,16 @@
                    scope.elementRef, scope.elementName,
                    scope.domId, 'before').then(function() {
                  if (scope.templateAddAction) {
-                   gnEditor.save(gnCurrentEdit.id, true);
+                   gnEditor.save(gnCurrentEdit.id, true).then(function() {
+                     // success. Nothing to do.
+                   }, function(rejectedValue) {
+                     $rootScope.$broadcast('StatusUpdated', {
+                       title: $translate.instant('runServiceError'),
+                       error: rejectedValue,
+                       timeout: 0,
+                       type: 'danger'
+                     });
+                   });
                  }
                });
                return false;
@@ -134,7 +143,16 @@
 
                     $timeout(function() {
                       // Save the metadata and refresh the form
-                      gnEditor.save(gnCurrentEdit.id, true);
+                      gnEditor.save(gnCurrentEdit.id, true).then(function() {
+                        // success. Nothing to do
+                      }, function(rejectedValue) {
+                        $rootScope.$broadcast('StatusUpdated', {
+                          title: $translate.instant('runServiceError'),
+                          error: rejectedValue,
+                          timeout: 0,
+                          type: 'danger'
+                        });
+                      });
                     });
                  }
                };

--- a/web-ui/src/main/resources/catalog/components/edit/templatefield/TemplateFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/templatefield/TemplateFieldDirective.js
@@ -21,12 +21,12 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-(function() {
+(function () {
   goog.provide('gn_template_field_directive');
 
-  var module = angular.module('gn_template_field_directive', []);
-  module.directive('gnTemplateFieldAddButton', ['gnEditor', 'gnCurrentEdit',
-    function(gnEditor, gnCurrentEdit) {
+  var module = angular.module('gn_template_field_directive', ['pascalprecht.translate']);
+  module.directive('gnTemplateFieldAddButton', ['gnEditor', 'gnCurrentEdit', '$rootScope', '$translate',
+    function (gnEditor, gnCurrentEdit, $rootScope, $translate) {
 
       return {
         restrict: 'A',
@@ -34,36 +34,46 @@
         scope: {
           id: '@gnTemplateFieldAddButton'
         },
-        link: function(scope, element, attrs) {
+        link: function (scope, element, attrs) {
           var textarea = $(element).parent()
-              .find('textarea[name=' + scope.id + ']');
+            .find('textarea[name=' + scope.id + ']');
           // Unregister this textarea to the form
           // It will be only submitted if user click the add button
           textarea.removeAttr('name');
 
-          scope.addFromTemplate = function() {
+          scope.addFromTemplate = function () {
             textarea.attr('name', scope.id);
 
             // Save and refreshform
-            gnEditor.save(gnCurrentEdit.id, true);
+            gnEditor.save(gnCurrentEdit.id, true).then(function () {
+              // success. Do nothing
+            }, function (rejectedValue) {
+              $rootScope.$broadcast('StatusUpdated', {
+                title: $translate.instant('runServiceError'),
+                error: rejectedValue,
+                timeout: 0,
+                type: 'danger'
+              });
+            });
           };
 
           $(element).click(scope.addFromTemplate);
         }
       };
-    }]),
+    }]);
+
   /**
-     * The template field directive managed a custom field which
-     * is based on an XML snippet to be sent in the form with some
-     * string to be replace from related inputs.
-     *
-     * This allows to edit a complex XML structure with simple
-     * form fields. eg. a date of creation where only the date field
-     * is displayed to the end user and the creation codelist value
-     * is in the XML template for the field.
-     */
+   * The template field directive managed a custom field which
+   * is based on an XML snippet to be sent in the form with some
+   * string to be replace from related inputs.
+   *
+   * This allows to edit a complex XML structure with simple
+   * form fields. eg. a date of creation where only the date field
+   * is displayed to the end user and the creation codelist value
+   * is in the XML template for the field.
+   */
   module.directive('gnTemplateField', ['$http', '$rootScope', '$timeout',
-    function($http, $rootScope, $timeout) {
+    function ($http, $rootScope, $timeout) {
 
       return {
         restrict: 'A',
@@ -75,17 +85,17 @@
           values: '@',
           notSetCheck: '@'
         },
-        link: function(scope, element, attrs) {
+        link: function (scope, element, attrs) {
           var xmlSnippetTemplate = element[0].innerHTML;
           var separator = '$$$';
           var fields = scope.keys && scope.keys.split(separator);
           var values = scope.values && scope.values.split(separator);
 
           // Replace all occurence of {{fieldname}} by its value
-          var generateSnippet = function() {
+          var generateSnippet = function () {
             var xmlSnippet = xmlSnippetTemplate, isOneFieldDefined = false;
 
-            angular.forEach(fields, function(fieldName) {
+            angular.forEach(fields, function (fieldName) {
               var field = $('#' + scope.id + '_' + fieldName);
               var value = '';
               if (field.attr('type') === 'checkbox') {
@@ -96,8 +106,8 @@
 
               if (value !== '') {
                 xmlSnippet = xmlSnippet.replace(
-                    '{{' + fieldName + '}}',
-                    value.replace(/\&/g, '&amp;amp;')
+                  '{{' + fieldName + '}}',
+                  value.replace(/\&/g, '&amp;amp;')
                     .replace(/\"/g, '&quot;'));
 
                 // If one value is defined the field
@@ -105,8 +115,8 @@
                 isOneFieldDefined = true;
               } else {
                 xmlSnippet = xmlSnippet.replace(
-                    '{{' + fieldName + '}}',
-                    '');
+                  '{{' + fieldName + '}}',
+                  '');
               }
             });
 
@@ -125,9 +135,9 @@
               element[0].innerHTML = '';
             }
           };
-          var init = function() {
+          var init = function () {
             // Initialize all values
-            angular.forEach(values, function(value, key) {
+            angular.forEach(values, function (value, key) {
               var selector = '#' + scope.id + '_' + fields[key];
               if ($(selector).attr('type') === 'checkbox') {
                 $(selector).attr('checked', value === 'true');
@@ -138,8 +148,8 @@
 
             // Register change event on each fields to be
             // replaced in the XML snippet.
-            angular.forEach(fields, function(value) {
-              $('#' + scope.id + '_' + value).change(function() {
+            angular.forEach(fields, function (value) {
+              $('#' + scope.id + '_' + value).change(function () {
                 generateSnippet();
               });
             });
@@ -152,7 +162,7 @@
               element[0].innerHTML = '';
               // When checkbox is checked generate default
               // snippet.
-              unsetCheckbox.change(function() {
+              unsetCheckbox.change(function () {
                 $('#' + scope.notSetCheck).toggleClass('hidden');
                 if (unsetCheckbox[0].checked) {
                   element[0].innerHTML = '';
@@ -164,7 +174,7 @@
               generateSnippet();
             }
           };
-          $timeout(function() {
+          $timeout(function () {
             init();
           });
         }

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -24,7 +24,7 @@
 (function() {
   goog.provide('gn_thesaurus_directive');
 
-  var module = angular.module('gn_thesaurus_directive', []);
+  var module = angular.module('gn_thesaurus_directive', ['pascalprecht.translate']);
 
   /**
    * @ngdoc directive
@@ -46,12 +46,12 @@
    *
    */
   module.directive('gnThesaurusSelector',
-      ['$timeout',
-       'gnThesaurusService', 'gnEditor',
-       'gnEditorXMLService', 'gnCurrentEdit',
-       function($timeout,
-               gnThesaurusService, gnEditor,
-               gnEditorXMLService, gnCurrentEdit) {
+    ['$timeout',
+      'gnThesaurusService', 'gnEditor',
+      'gnEditorXMLService', 'gnCurrentEdit',
+      function ($timeout,
+                gnThesaurusService, gnEditor,
+                gnEditorXMLService, gnCurrentEdit) {
 
          return {
            restrict: 'A',
@@ -123,7 +123,7 @@
                } else {
                  gnCurrentEdit.working = true;
                  return gnThesaurusService
-                 .getXML(thesaurusIdentifier,  null,
+                 .getXML(thesaurusIdentifier, null,
                  attrs.transformation).then(
                          function(data) {
                    // Add the fragment to the form
@@ -134,17 +134,26 @@
                                    scope.elementName);
 
 
-                   $timeout(function() {
-                     // Save the metadata and refresh the form
-                     gnEditor.save(gnCurrentEdit.id, true);
-                   });
-                 });
-               }
-               return false;
-             };
-           }
-         };
-       }]);
+                      $timeout(function () {
+                        // Save the metadata and refresh the form
+                        gnEditor.save(gnCurrentEdit.id, true).then(function() {
+                          // success. Nothing to do.
+                        }, function(rejectedValue) {
+                          $rootScope.$broadcast('StatusUpdated', {
+                            title: $translate.instant('runServiceError'),
+                            error: rejectedValue,
+                            timeout: 0,
+                            type: 'danger'
+                          });
+                        });
+                      });
+                    });
+              }
+              return false;
+            };
+          }
+        };
+      }]);
 
 
   /**

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -28,7 +28,7 @@
   goog.require('gn_facets');
 
   var module = angular.module('gn_directory_controller',
-      ['gn_catalog_service', 'gn_facets']);
+      ['gn_catalog_service', 'gn_facets', 'pascalprecht.translate']);
 
   /**
    * Controller to create new metadata record.
@@ -182,7 +182,16 @@
               .then(function() {
                 gnEditor.add(gnCurrentEdit.id, ref, name,
                     insertRef, position, attribute);
-              });
+              }).then(function () {
+                // success. Nothing to do.
+              }, function(rejectedValue) {
+                $rootScope.$broadcast('StatusUpdated', {
+                  title: $translate.instant('runServiceError'),
+                  error: rejectedValue,
+                  timeout: 0,
+                  type: 'danger'
+                });
+          });
         } else {
           gnEditor.add(gnCurrentEdit.id, ref, name,
               insertRef, position, attribute);

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -53,7 +53,7 @@
        'gn_editorboard_controller', 'gn_share',
        'gn_directory_controller', 'gn_utility_directive',
        'gn_scroll_spy', 'gn_thesaurus', 'ui.bootstrap.datetimepicker',
-       'ngRoute', 'gn_mdactions_service']);
+       'ngRoute', 'gn_mdactions_service', 'pascalprecht.translate']);
 
   var tplFolder = '../../catalog/templates/editor/';
 
@@ -395,6 +395,13 @@
               .then(function() {
                 gnEditor.add(gnCurrentEdit.id, ref, name,
                     insertRef, position, attribute);
+              }, function (rejectedValue) {
+                $rootScope.$broadcast('StatusUpdated', {
+                  title: $translate.instant('runServiceError'),
+                  error: rejectedValue,
+                  timeout: 0,
+                  type: 'danger'
+                });
               });
         } else {
           return gnEditor.add(gnCurrentEdit.id, ref, name,

--- a/web-ui/src/main/resources/catalog/locales/du-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/du-editor.json
@@ -321,5 +321,7 @@
     "parentConcept": "Parent concept",
     "moreSpecificConcept": "Meer specifieke concepten",
     "associatedConcept": "Geassocieerde concepten",
-    "xsd": "Schema validatie"
+    "xsd": "Schema validatie",
+    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>."
+
 }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -324,5 +324,6 @@
     "parentConcept":"Parent concept",
     "moreSpecificConcept":"More specific concepts",
     "associatedConcept":"Associated concepts",
-    "xsd": "Schema validation"
+    "xsd": "Schema validation",
+    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>."
 }

--- a/web-ui/src/main/resources/catalog/templates/info.html
+++ b/web-ui/src/main/resources/catalog/templates/info.html
@@ -6,6 +6,8 @@
   </button>
   <h4 data-ng-hide="!status.title">{{status.title}}</h4>
   <p data-ng-hide="!status.msg">{{status.msg}}</p>
+  <p data-ng-hide="!gnCurrentEdit" data-translate="linkToXmlTab"
+         data-translate-values="{metadataId: gnCurrentEdit.id}"></p>
 
   <div data-ng-hide="!status.error">
     {{status.error['class'] | translate}}


### PR DESCRIPTION
Display a link to the XML editor if a error occurs while saving the editor form contents. See attached screenshot.

![image](https://cloud.githubusercontent.com/assets/826920/21323391/7eefad4a-c61d-11e6-8f76-c7eb5b4854b5.png)


Duplicates #1804 for branch 3.2.x.