### PR TITLE
Fixes some JS errors in the thesaurus directive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-(function() {
+(function () {
   goog.provide('gn_thesaurus_directive');
 
   var module = angular.module('gn_thesaurus_directive', ['pascalprecht.translate']);
@@ -48,90 +48,89 @@
   module.directive('gnThesaurusSelector',
     ['$timeout',
       'gnThesaurusService', 'gnEditor',
-      'gnEditorXMLService', 'gnCurrentEdit',
+      'gnEditorXMLService', 'gnCurrentEdit', '$rootScope', '$translate',
       function ($timeout,
                 gnThesaurusService, gnEditor,
-                gnEditorXMLService, gnCurrentEdit) {
+                gnEditorXMLService, gnCurrentEdit, $rootScope, $translate) {
 
-         return {
-           restrict: 'A',
-           replace: true,
-           transclude: true,
-           scope: {
-             mode: '@gnThesaurusSelector',
-             elementName: '@',
-             elementRef: '@',
-             domId: '@',
-             selectorOnly: '@',
-             transformation: '@',
-             // Comma separated values of thesaurus keys
-             include: '@'
-           },
-           templateUrl: '../../catalog/components/thesaurus/' +
-           'partials/thesaurusselector.html',
-           link: function(scope, element, attrs) {
-             scope.thesaurus = null;
-             scope.thesaurusKey = null;
-             scope.snippet = null;
-             scope.snippetRef = null;
-             var restrictionList = scope.include ? (
-             scope.include.indexOf(',') !== -1 ?
-                 scope.include.split(',') : [scope.include]) : [];
+        return {
+          restrict: 'A',
+          replace: true,
+          transclude: true,
+          scope: {
+            mode: '@gnThesaurusSelector',
+            elementName: '@',
+            elementRef: '@',
+            domId: '@',
+            selectorOnly: '@',
+            transformation: '@',
+            // Comma separated values of thesaurus keys
+            include: '@'
+          },
+          templateUrl: '../../catalog/components/thesaurus/' +
+          'partials/thesaurusselector.html',
+          link: function (scope, element, attrs) {
+            scope.thesaurus = null;
+            scope.thesaurusKey = null;
+            scope.snippet = null;
+            scope.snippetRef = null;
+            var restrictionList = scope.include ? (
+              scope.include.indexOf(',') !== -1 ?
+                scope.include.split(',') : [scope.include]) : [];
 
-             var includeThesaurus = [];
-             var excludeThesaurus = [];
-             for (var i = 0; i < restrictionList.length; i++) {
-               var t = restrictionList[i];
-               if (t.indexOf('-') === 0) {
-                 excludeThesaurus.push(t.substring(1));
-               } else {
-                 includeThesaurus.push(t);
-               }
-             }
+            var includeThesaurus = [];
+            var excludeThesaurus = [];
+            for (var i = 0; i < restrictionList.length; i++) {
+              var t = restrictionList[i];
+              if (t.indexOf('-') === 0) {
+                excludeThesaurus.push(t.substring(1));
+              } else {
+                includeThesaurus.push(t);
+              }
+            }
 
 
-             scope.allowFreeTextKeywords =
-             (attrs.allowFreeTextKeywords === undefined) ||
-             (attrs.allowFreeTextKeywords == 'true');
+            scope.allowFreeTextKeywords =
+              (attrs.allowFreeTextKeywords === undefined) ||
+              (attrs.allowFreeTextKeywords == 'true');
 
-             // TODO: Remove from list existing thesaurus
-             // in the record ?
-             gnThesaurusService.getAll().then(
-             function(listOfThesaurus) {
-               scope.thesaurus = [];
-               angular.forEach(listOfThesaurus, function(thesaurus) {
-                 if (excludeThesaurus.length > 0 &&
-                 $.inArray(thesaurus.getKey(), excludeThesaurus) !== -1) {
+            // TODO: Remove from list existing thesaurus
+            // in the record ?
+            gnThesaurusService.getAll().then(
+              function (listOfThesaurus) {
+                scope.thesaurus = [];
+                angular.forEach(listOfThesaurus, function (thesaurus) {
+                  if (excludeThesaurus.length > 0 &&
+                    $.inArray(thesaurus.getKey(), excludeThesaurus) !== -1) {
 
-                 } else if (includeThesaurus.length == 0 || (
-                 includeThesaurus.length > 0 &&
-                 $.inArray(thesaurus.getKey(), includeThesaurus) !== -1)) {
-                   scope.thesaurus.push(thesaurus);
-                 }
-               });
-             });
+                  } else if (includeThesaurus.length == 0 || (
+                    includeThesaurus.length > 0 &&
+                    $.inArray(thesaurus.getKey(), includeThesaurus) !== -1)) {
+                    scope.thesaurus.push(thesaurus);
+                  }
+                });
+              });
 
-             scope.add = function() {
-               return gnEditor.add(gnCurrentEdit.id,
-               scope.elementRef, scope.elementName, scope.domId, 'before');
-             };
+            scope.add = function () {
+              return gnEditor.add(gnCurrentEdit.id,
+                scope.elementRef, scope.elementName, scope.domId, 'before');
+            };
 
-             scope.addThesaurus = function(thesaurusIdentifier) {
-               if (scope.selectorOnly) {
-                 scope.$parent.thesaurusKey = scope.thesaurusKey =
-                         thesaurusIdentifier;
-               } else {
-                 gnCurrentEdit.working = true;
-                 return gnThesaurusService
-                 .getXML(thesaurusIdentifier, null,
-                 attrs.transformation).then(
-                         function(data) {
-                   // Add the fragment to the form
-                   scope.snippet = data;
-                   scope.snippetRef = gnEditor.
-                                 buildXMLFieldName(
-                                   scope.elementRef,
-                                   scope.elementName);
+            scope.addThesaurus = function (thesaurusIdentifier) {
+              if (scope.selectorOnly) {
+                scope.$parent.thesaurusKey = scope.thesaurusKey =
+                  thesaurusIdentifier;
+              } else {
+                gnCurrentEdit.working = true;
+                return gnThesaurusService
+                  .getXML(thesaurusIdentifier, null,
+                    attrs.transformation).then(
+                    function (data) {
+                      // Add the fragment to the form
+                      scope.snippet = data;
+                      scope.snippetRef = gnEditor.buildXMLFieldName(
+                        scope.elementRef,
+                        scope.elementName);
 
 
                       $timeout(function () {
@@ -176,353 +175,354 @@
    * TODO: explain transformation
    */
   module.directive('gnKeywordSelector',
-      ['$compile', '$timeout', '$translate',
-       'gnThesaurusService', 'gnEditor',
-       'Keyword', 'gnLangs',
-       function($compile, $timeout, $translate,
-               gnThesaurusService, gnEditor, Keyword, gnLangs) {
+    ['$compile', '$timeout', '$translate',
+      'gnThesaurusService', 'gnEditor',
+      'Keyword', 'gnLangs',
+      function ($compile, $timeout, $translate,
+                gnThesaurusService, gnEditor, Keyword, gnLangs) {
 
-         return {
-           restrict: 'A',
-           replace: true,
-           transclude: true,
-           scope: {
-             mode: '@gnKeywordSelector',
-             elementRef: '@',
-             thesaurusKey: '@',
-             keywords: '@',
-             transformations: '@',
-             currentTransformation: '@',
-             lang: '@',
-             textgroupOnly: '@',
+        return {
+          restrict: 'A',
+          replace: true,
+          transclude: true,
+          scope: {
+            mode: '@gnKeywordSelector',
+            elementRef: '@',
+            thesaurusKey: '@',
+            keywords: '@',
+            transformations: '@',
+            currentTransformation: '@',
+            lang: '@',
+            textgroupOnly: '@',
 
-             // Max number of tags allowed. Use 1 to restrict to only
-             // on keyword.
-             maxTags: '@'
-           },
-           templateUrl: '../../catalog/components/thesaurus/' +
-           'partials/keywordselector.html',
-           link: function(scope, element, attrs) {
-             $compile(element.contents())(scope);
-             // pick up skos browser directive with compiler
+            // Max number of tags allowed. Use 1 to restrict to only
+            // on keyword.
+            maxTags: '@'
+          },
+          templateUrl: '../../catalog/components/thesaurus/' +
+          'partials/keywordselector.html',
+          link: function (scope, element, attrs) {
+            $compile(element.contents())(scope);
+            // pick up skos browser directive with compiler
 
-             scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
-             scope.filter = null;
-             scope.results = null;
-             scope.snippet = null;
-             scope.isInitialized = false;
-             scope.elementRefBackup = scope.elementRef;
-             scope.invalidKeywordMatch = false;
-             scope.selected = [];
-             scope.initialKeywords = [];
-             if (scope.keywords) {
-               var buffer = '';
-               for (var i = 0; i < scope.keywords.length; i++) {
-                 var next = scope.keywords.charAt(i);
-                 if (next !== ',') {
-                   buffer += next;
-                 } else if (i === scope.keywords.length - 1 ||
-                 scope.keywords.charAt(i + 1) === ',') {
-                   buffer += next;
-                   i++;
-                 } else {
-                   scope.initialKeywords.push(buffer);
-                   buffer = '';
-                 }
-               }
-               if (buffer.length > 0) {
-                 scope.initialKeywords.push(buffer);
-               }
-             }
-             scope.transformationLists =
-             scope.transformations.indexOf(',') !== -1 ?
-             scope.transformations.split(',') : [scope.transformations];
-             scope.maxTagsLabel = scope.maxTags || '∞';
+            scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
+            scope.filter = null;
+            scope.results = null;
+            scope.snippet = null;
+            scope.isInitialized = false;
+            scope.elementRefBackup = scope.elementRef;
+            scope.invalidKeywordMatch = false;
+            scope.selected = [];
+            scope.initialKeywords = [];
+            if (scope.keywords) {
+              var buffer = '';
+              for (var i = 0; i < scope.keywords.length; i++) {
+                var next = scope.keywords.charAt(i);
+                if (next !== ',') {
+                  buffer += next;
+                } else if (i === scope.keywords.length - 1 ||
+                  scope.keywords.charAt(i + 1) === ',') {
+                  buffer += next;
+                  i++;
+                } else {
+                  scope.initialKeywords.push(buffer);
+                  buffer = '';
+                }
+              }
+              if (buffer.length > 0) {
+                scope.initialKeywords.push(buffer);
+              }
+            }
+            scope.transformationLists =
+              scope.transformations.indexOf(',') !== -1 ?
+                scope.transformations.split(',') : [scope.transformations];
+            scope.maxTagsLabel = scope.maxTags || '∞';
 
-             //Get langs of metadata
-             var langs = [];
-             for (var p in JSON.parse(scope.lang)) {
-               langs.push(p);
-             }
-             scope.mainLang = langs[0];
-             scope.langs = langs.join(',');
+            //Get langs of metadata
+            var langs = [];
+            for (var p in JSON.parse(scope.lang)) {
+              langs.push(p);
+            }
+            scope.mainLang = langs[0];
+            scope.langs = langs.join(',');
 
-             // Check initial keywords are available in the thesaurus
-             scope.sortKeyword = function(a, b) {
-               if (a.getLabel().toLowerCase() <
-               b.getLabel().toLowerCase()) {
-                 return -1;
-               }
-               if (a.getLabel().toLowerCase() >
-               b.getLabel().toLowerCase()) {
-                 return 1;
-               }
-               return 0;
-             };
-             scope.resetKeywords = function() {
-               scope.selected = [];
-               scope.elementRef = scope.elementRefBackup;
-               scope.invalidKeywordMatch = false;
-               checkState();
-             };
-
-
-             var init = function() {
-
-               // Nothing to load - init done
-               scope.isInitialized = scope.initialKeywords.length === 0;
-
-               // If no keyword, set the default transformation
-               if (
-               $.inArray(scope.currentTransformation,
-                   scope.transformationLists) === -1 &&
-               scope.initialKeywords.length === 0) {
-
-                 scope.setTransformation(scope.transformationLists[0]);
-               }
-               if (scope.isInitialized) {
-                 checkState();
-               } else {
-
-                 // Check that all initial keywords are in the thesaurus
-                 var counter = 0;
-                 angular.forEach(scope.initialKeywords, function(keyword) {
-                   // One keyword only and exact match search
-                   // in current editor language.
-                   gnThesaurusService.getKeywords(keyword,
-                   scope.thesaurusKey, gnLangs.current, 1, 'MATCH')
-                     .then(function(listOfKeywords) {
-                     counter++;
-
-                     listOfKeywords[0] &&
-                     scope.selected.push(listOfKeywords[0]);
-                     // Init done when all keywords are selected
-                     if (counter === scope.initialKeywords.length) {
-                       scope.isInitialized = true;
-                       scope.invalidKeywordMatch =
-                       scope.selected.length !== scope.initialKeywords.length;
-
-                       // Get the matching XML snippet for
-                       // the initial set of keywords
-                       // once the loaded keywords are all selected.
-                       checkState();
-                     }
-                   });
-                 });
-               }
-
-               // Then register search filter change
-               // Only applies to multiselect mode
-               scope.$watch('filter', search);
-             };
-
-             // Used by skos-browser to add keywords from the
-             // skos hierarchy to the current list of tags
-             scope.addThesaurusConcept = function(uri, text) {
-                var textArr = [];
-                textArr['#text'] = text;
-                var k = {
-                  uri: uri,
-                  value: textArr
-                };
-                var keyword = new Keyword(k);
-
-                var thisId = '#tagsinput_' + scope.elementRef;
-                // Add to tags
-                $(thisId).tagsinput('add', keyword);
-
-                // Update selection and snippet
-                scope.selected = $(thisId).tagsinput('items');
-                getSnippet(); // FIXME: should not be necessary
-               // as there is a watch on it ?
-
-                // Clear typeahead
-                $(thisId).tagsinput('input').typeahead('setQuery', '');
-             };
-
-             // Init typeahead and tag input
-             var initTagsInput = function() {
-               var id = '#tagsinput_' + scope.elementRef;
-               $timeout(function() {
-                 $(id).tagsinput({
-                   itemValue: 'label',
-                   itemText: 'label',
-                   maxTags: scope.maxTags
-                 });
-
-                 // Add selection to the list of tags
-                 angular.forEach(scope.selected, function(keyword) {
-                   $(id).tagsinput('add', keyword);
-                 });
-
-                 // Load all keywords from thesaurus on startup
-                 gnThesaurusService.getKeywords('',
-                 scope.thesaurusKey, scope.mainLang, scope.max)
-                  .then(function(listOfKeywords) {
-
-                   var field = $(id).tagsinput('input');
-                   field.attr('placeholder',
-                   $translate.instant('searchKeyword'));
-
-                   var keywordsAutocompleter =
-                   gnThesaurusService.getKeywordAutocompleter({
-                     thesaurusKey: scope.thesaurusKey,
-                     dataToExclude: scope.selected,
-                     lang: gnLangs.current
-                   });
-
-                   // Init typeahead
-                   field.typeahead({
-                     minLength: 0,
-                     highlight: true
-                     // template: '<p>{{label}}</p>'
-                     // TODO: could be nice to have definition
-                   }, {
-                     name: 'keyword',
-                     displayKey: 'label',
-                     source: keywordsAutocompleter.ttAdapter()
-                   }).bind('typeahead:selected',
-                   $.proxy(function(obj, keyword) {
-                     // Add to tags
-                     this.tagsinput('add', keyword);
-
-                     // Update selection and snippet
-                     angular.copy(this.tagsinput('items'), scope.selected);
-                     getSnippet(); // FIXME: should not be necessary
-                     // as there is a watch on it ?
-
-                     // Clear typeahead
-                     this.tagsinput('input').typeahead('val', '');
-                   }, $(id))
-                   );
-
-                   $(id).on('itemRemoved', function() {
-                     angular.copy($(this).tagsinput('items'), scope.selected);
-                     getSnippet();
-                   });
-
-                   // When clicking the element trigger input
-                   // to show autocompletion list.
-                   // https://github.com/twitter/typeahead.js/issues/798
-                   field.on('typeahead:opened', function() {
-                     var initial = field.val(),
-                     ev = $.Event('keydown');
-                     ev.keyCode = ev.which = 40;
-                     field.trigger(ev);
-                     if (field.val() != initial) {
-                       field.val('');
-                     }
-                     return true;
-                   });
-                 });
-               });
-             };
-
-             var checkState = function() {
-               if (scope.isInitialized && !scope.invalidKeywordMatch) {
-                 getSnippet();
-
-                 scope.$watch('results', getSnippet);
-                 scope.$watch('selected', getSnippet);
-
-                 if (scope.mode === 'tagsinput') {
-                   initTagsInput();
-                 }
-               } else if (scope.invalidKeywordMatch) {
-                 // invalidate element ref to not trigger
-                 // an update of the record with an invalid
-                 // state ie. keywords not loaded properly
-                 scope.elementRef = '';
-               }
-             };
+            // Check initial keywords are available in the thesaurus
+            scope.sortKeyword = function (a, b) {
+              if (a.getLabel().toLowerCase() <
+                b.getLabel().toLowerCase()) {
+                return -1;
+              }
+              if (a.getLabel().toLowerCase() >
+                b.getLabel().toLowerCase()) {
+                return 1;
+              }
+              return 0;
+            };
+            scope.resetKeywords = function () {
+              scope.selected = [];
+              scope.elementRef = scope.elementRefBackup;
+              scope.invalidKeywordMatch = false;
+              checkState();
+            };
 
 
-             var search = function() {
-               gnThesaurusService.getKeywords(scope.filter,
-               scope.thesaurusKey, gnLangs.current, scope.max)
-                .then(function(listOfKeywords) {
-                 // Remove from search already selected keywords
-                 scope.results = $.grep(listOfKeywords, function(n) {
-                   var alreadySelected = true;
-                   if (scope.selected.length !== 0) {
-                     alreadySelected = $.grep(scope.selected, function(s) {
-                       return s.getLabel() === n.getLabel();
-                     }).length === 0;
-                   }
-                   return alreadySelected;
-                 });
-               });
-             };
-             scope.setTransformation = function(t) {
-               $timeout(function() {
-                 scope.currentTransformation = t;
-                 getSnippet();
-               });
-               return false;
-             };
-             scope.isCurrent = function(t) {
-               return t === scope.currentTransformation;
-             };
-             var getKeywordIds = function() {
-               var ids = [];
-               angular.forEach(scope.selected, function(k) {
-                 ids.push(k.getId());
-               });
-               return ids;
-             };
+            var init = function () {
 
-             var getSnippet = function() {
-               gnThesaurusService
+              // Nothing to load - init done
+              scope.isInitialized = scope.initialKeywords.length === 0;
+
+              // If no keyword, set the default transformation
+              if (
+                $.inArray(scope.currentTransformation,
+                  scope.transformationLists) === -1 &&
+                scope.initialKeywords.length === 0) {
+
+                scope.setTransformation(scope.transformationLists[0]);
+              }
+              if (scope.isInitialized) {
+                checkState();
+              } else {
+
+                // Check that all initial keywords are in the thesaurus
+                var counter = 0;
+                angular.forEach(scope.initialKeywords, function (keyword) {
+                  // One keyword only and exact match search
+                  // in current editor language.
+                  gnThesaurusService.getKeywords(keyword,
+                  scope.thesaurusKey, gnLangs.current, 1, 'MATCH')
+                      .then(function(listOfKeywords) {
+                    counter++;
+
+                    listOfKeywords[0] &&
+                    scope.selected.push(listOfKeywords[0]);
+                    // Init done when all keywords are selected
+                    if (counter === scope.initialKeywords.length) {
+                      scope.isInitialized = true;
+                      scope.invalidKeywordMatch =
+                        scope.selected.length !== scope.initialKeywords.length;
+
+                      // Get the matching XML snippet for
+                      // the initial set of keywords
+                      // once the loaded keywords are all selected.
+                      checkState();
+                    }
+                  });
+                });
+              }
+
+              // Then register search filter change
+              // Only applies to multiselect mode
+              scope.$watch('filter', search);
+            };
+
+            // Used by skos-browser to add keywords from the
+            // skos hierarchy to the current list of tags
+            scope.addThesaurusConcept = function (uri, text) {
+              var textArr = [];
+              textArr['#text'] = text;
+              var k = {
+                uri: uri,
+                value: textArr
+              };
+              var keyword = new Keyword(k);
+
+              var thisId = '#tagsinput_' + scope.elementRef;
+              // Add to tags
+              $(thisId).tagsinput('add', keyword);
+
+              // Update selection and snippet
+              angular.copy($(thisId).tagsinput('items'), scope.selected);
+              getSnippet(); // FIXME: should not be necessary
+              // as there is a watch on it ?
+
+              // Clear typeahead
+              $(thisId).tagsinput('input').typeahead('val', '');
+            };
+
+            // Init typeahead and tag input
+            var initTagsInput = function () {
+              var id = '#tagsinput_' + scope.elementRef;
+              $timeout(function () {
+                try {
+                  $(id).tagsinput({
+                    itemValue: 'label',
+                    itemText: 'label',
+                    maxTags: scope.maxTags
+                  });
+
+                  // Add selection to the list of tags
+                  angular.forEach(scope.selected, function (keyword) {
+                    $(id).tagsinput('add', keyword);
+                  });
+
+                  // Load all keywords from thesaurus on startup
+                  gnThesaurusService.getKeywords('',
+                    scope.thesaurusKey, scope.max)
+                    .then(function (listOfKeywords) {
+
+                      var field = $(id).tagsinput('input');
+                      field.attr('placeholder', $translate.instant('searchKeyword'));
+
+                      var keywordsAutocompleter =
+                        gnThesaurusService.getKeywordAutocompleter({
+                          thesaurusKey: scope.thesaurusKey,
+                          dataToExclude: scope.selected,
+                          lang: gnLangs.current
+                        });
+
+                      // Init typeahead
+                      field.typeahead({
+                        minLength: 0,
+                        highlight: true
+                        // template: '<p>{{label}}</p>'
+                        // TODO: could be nice to have definition
+                      }, {
+                        name: 'keyword',
+                        displayKey: 'label',
+                        source: keywordsAutocompleter.ttAdapter()
+                      }).bind('typeahead:selected',
+                        $.proxy(function (obj, keyword) {
+                          // Add to tags
+                          this.tagsinput('add', keyword);
+
+                          // Update selection and snippet
+                          angular.copy(this.tagsinput('items'), scope.selected);
+                          getSnippet(); // FIXME: should not be necessary
+                          // as there is a watch on it ?
+
+                          // Clear typeahead
+                          this.tagsinput('input').typeahead('val', '');
+                        }, $(id))
+                      );
+
+                      $(id).on('itemRemoved', function () {
+                        angular.copy($(this).tagsinput('items'), scope.selected);
+                        getSnippet();
+                      });
+
+                      // When clicking the element trigger input
+                      // to show autocompletion list.
+                      // https://github.com/twitter/typeahead.js/issues/798
+                      field.on('typeahead:opened', function () {
+                        var initial = field.val(),
+                          ev = $.Event('keydown');
+                        ev.keyCode = ev.which = 40;
+                        field.trigger(ev);
+                        if (field.val() != initial) {
+                          field.val('');
+                        }
+                        return true;
+                      });
+                    });
+                } catch (e) {
+                  console.warn('No tagsinput for ' + id + ', error: ' + e.message);
+                }
+              });
+            };
+
+            var checkState = function () {
+              if (scope.isInitialized && !scope.invalidKeywordMatch) {
+                getSnippet();
+
+                scope.$watch('results', getSnippet);
+                scope.$watch('selected', getSnippet);
+
+                if (scope.mode === 'tagsinput') {
+                  initTagsInput();
+                }
+              } else if (scope.invalidKeywordMatch) {
+                // invalidate element ref to not trigger
+                // an update of the record with an invalid
+                // state ie. keywords not loaded properly
+                scope.elementRef = '';
+              }
+            };
+
+
+            var search = function () {
+              gnThesaurusService.getKeywords(scope.filter,
+                scope.thesaurusKey, gnLangs.current, scope.max)
+                .then(function (listOfKeywords) {
+                  // Remove from search already selected keywords
+                  scope.results = $.grep(listOfKeywords, function (n) {
+                    var alreadySelected = true;
+                    if (scope.selected.length !== 0) {
+                      alreadySelected = $.grep(scope.selected, function (s) {
+                          return s.getLabel() === n.getLabel();
+                        }).length === 0;
+                    }
+                    return alreadySelected;
+                  });
+                });
+            };
+            scope.setTransformation = function (t) {
+              $timeout(function () {
+                scope.currentTransformation = t;
+                getSnippet();
+              });
+              return false;
+            };
+            scope.isCurrent = function (t) {
+              return t === scope.currentTransformation;
+            };
+            var getKeywordIds = function () {
+              var ids = [];
+              angular.forEach(scope.selected, function (k) {
+                ids.push(k.getId());
+              });
+              return ids;
+            };
+
+            var getSnippet = function () {
+              gnThesaurusService
                 .getXML(scope.thesaurusKey,
-               getKeywordIds(), scope.currentTransformation, scope.langs,
-                   scope.textgroupOnly).then(
-               function(data) {
-                 scope.snippet = data;
-               });
-             };
+                  getKeywordIds(), scope.currentTransformation, scope.langs,
+                  scope.textgroupOnly).then(
+                function (data) {
+                  scope.snippet = data;
+                });
+            };
 
-             if (scope.thesaurusKey) {
-               init();
-               gnThesaurusService.getTopConcept(scope.thesaurusKey).then(
-               function(c) {
-                 scope.concept = c;
-               });
-             }
-           }
-         };
-       }]);
+            if (scope.thesaurusKey) {
+              init();
+              gnThesaurusService.getTopConcept(scope.thesaurusKey).then(
+                function (c) {
+                  scope.concept = c;
+                });
+            }
+          }
+        };
+      }]);
 
 
   /**
-     * @ngdoc directive
-     * @name gn_thesaurus.directive:gnKeywordPicker
-     * @function
-     *
-     * @description
-     * Provide simple keyword search.
-     *
-     * We can't transclude input (http://plnkr.co/edit/R2O2ixWA1QJUsVcUHl0N)
-     */
+   * @ngdoc directive
+   * @name gn_thesaurus.directive:gnKeywordPicker
+   * @function
+   *
+   * @description
+   * Provide simple keyword search.
+   *
+   * We can't transclude input (http://plnkr.co/edit/R2O2ixWA1QJUsVcUHl0N)
+   */
   module.directive('gnKeywordPicker', [
     'gnThesaurusService', '$compile', '$translate',
-    function(gnThesaurusService, $compile, $translate) {
+    function (gnThesaurusService, $compile, $translate) {
       return {
         restrict: 'A',
-        link: function(scope, element, attrs) {
-          scope.thesaurusKey = attrs.thesaurusKey ||  '';
+        link: function (scope, element, attrs) {
+          scope.thesaurusKey = attrs.thesaurusKey || '';
           scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
           var initialized = false;
 
           // Create an input group around the element
           // with a thesaurus selector on the right.
-          var addThesaurusSelectorOnElement = function() {
-            var inputGroup = angular.
-                element('<div class="input-group"></div>');
-            var dropDown = angular.
-                element('<div class="input-group-btn"></div>');
+          var addThesaurusSelectorOnElement = function () {
+            var inputGroup = angular.element('<div class="input-group"></div>');
+            var dropDown = angular.element('<div class="input-group-btn"></div>');
             // Thesaurus selector is a directive
             var thesaurusSel = '<span data-gn-thesaurus-selector="" ' +
-                'data-selector-only="true"></span>';
+              'data-selector-only="true"></span>';
 
             var input = element.replaceWith(inputGroup);
             inputGroup.append(input);
@@ -532,12 +532,11 @@
           };
 
 
-          var init = function() {
+          var init = function () {
             // Get list of available thesaurus (if not defined
             // by scope)
             element.typeahead('destroy');
-            element.attr('placeholder',
-                $translate.instant('searchOrTypeKeyword'));
+            element.attr('placeholder', $translate.instant('searchOrTypeKeyword'));
 
             // Thesaurus selector is not added if the key is defined
             // by configuration
@@ -545,10 +544,10 @@
               addThesaurusSelectorOnElement(element);
             }
             var keywordsAutocompleter =
-                gnThesaurusService.getKeywordAutocompleter({
-                  thesaurusKey: scope.thesaurusKey,
-                  lang: scope.lang
-                });
+              gnThesaurusService.getKeywordAutocompleter({
+                thesaurusKey: scope.thesaurusKey,
+                lang: scope.lang
+              });
 
             // Init typeahead
             element.typeahead({
@@ -568,9 +567,9 @@
             // When clicking the element trigger input
             // to show autocompletion list.
             // https://github.com/twitter/typeahead.js/issues/798
-            element.on('typeahead:opened', function() {
+            element.on('typeahead:opened', function () {
               var initial = element.val(),
-                  ev = $.Event('keydown');
+                ev = $.Event('keydown');
               ev.keyCode = ev.which = 40;
               element.trigger(ev);
               if (element.val() != initial) {
@@ -583,7 +582,7 @@
 
           init();
 
-          scope.$watch('thesaurusKey', function(newValue) {
+          scope.$watch('thesaurusKey', function (newValue) {
             init();
           });
         }

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -21,10 +21,11 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-(function () {
+(function() {
   goog.provide('gn_thesaurus_directive');
 
-  var module = angular.module('gn_thesaurus_directive', ['pascalprecht.translate']);
+  var module = angular.module('gn_thesaurus_directive',
+      ['pascalprecht.translate']);
 
   /**
    * @ngdoc directive
@@ -46,113 +47,113 @@
    *
    */
   module.directive('gnThesaurusSelector',
-    ['$timeout',
-      'gnThesaurusService', 'gnEditor',
-      'gnEditorXMLService', 'gnCurrentEdit', '$rootScope', '$translate',
-      function ($timeout,
+      ['$timeout',
+       'gnThesaurusService', 'gnEditor',
+       'gnEditorXMLService', 'gnCurrentEdit', '$rootScope', '$translate',
+       function($timeout,
                 gnThesaurusService, gnEditor,
                 gnEditorXMLService, gnCurrentEdit, $rootScope, $translate) {
 
-        return {
-          restrict: 'A',
-          replace: true,
-          transclude: true,
-          scope: {
-            mode: '@gnThesaurusSelector',
-            elementName: '@',
-            elementRef: '@',
-            domId: '@',
-            selectorOnly: '@',
-            transformation: '@',
-            // Comma separated values of thesaurus keys
-            include: '@'
-          },
-          templateUrl: '../../catalog/components/thesaurus/' +
-          'partials/thesaurusselector.html',
-          link: function (scope, element, attrs) {
-            scope.thesaurus = null;
-            scope.thesaurusKey = null;
-            scope.snippet = null;
-            scope.snippetRef = null;
-            var restrictionList = scope.include ? (
+         return {
+           restrict: 'A',
+           replace: true,
+           transclude: true,
+           scope: {
+             mode: '@gnThesaurusSelector',
+             elementName: '@',
+             elementRef: '@',
+             domId: '@',
+             selectorOnly: '@',
+             transformation: '@',
+             // Comma separated values of thesaurus keys
+             include: '@'
+           },
+           templateUrl: '../../catalog/components/thesaurus/' +
+           'partials/thesaurusselector.html',
+           link: function(scope, element, attrs) {
+             scope.thesaurus = null;
+             scope.thesaurusKey = null;
+             scope.snippet = null;
+             scope.snippetRef = null;
+             var restrictionList = scope.include ? (
               scope.include.indexOf(',') !== -1 ?
-                scope.include.split(',') : [scope.include]) : [];
+             scope.include.split(',') : [scope.include]) : [];
 
-            var includeThesaurus = [];
-            var excludeThesaurus = [];
-            for (var i = 0; i < restrictionList.length; i++) {
-              var t = restrictionList[i];
-              if (t.indexOf('-') === 0) {
-                excludeThesaurus.push(t.substring(1));
-              } else {
-                includeThesaurus.push(t);
-              }
-            }
+             var includeThesaurus = [];
+             var excludeThesaurus = [];
+             for (var i = 0; i < restrictionList.length; i++) {
+               var t = restrictionList[i];
+               if (t.indexOf('-') === 0) {
+                 excludeThesaurus.push(t.substring(1));
+               } else {
+                 includeThesaurus.push(t);
+               }
+             }
 
 
-            scope.allowFreeTextKeywords =
+             scope.allowFreeTextKeywords =
               (attrs.allowFreeTextKeywords === undefined) ||
               (attrs.allowFreeTextKeywords == 'true');
 
-            // TODO: Remove from list existing thesaurus
-            // in the record ?
-            gnThesaurusService.getAll().then(
-              function (listOfThesaurus) {
+             // TODO: Remove from list existing thesaurus
+             // in the record ?
+             gnThesaurusService.getAll().then(
+              function(listOfThesaurus) {
                 scope.thesaurus = [];
-                angular.forEach(listOfThesaurus, function (thesaurus) {
+                angular.forEach(listOfThesaurus, function(thesaurus) {
                   if (excludeThesaurus.length > 0 &&
-                    $.inArray(thesaurus.getKey(), excludeThesaurus) !== -1) {
+                 $.inArray(thesaurus.getKey(), excludeThesaurus) !== -1) {
 
                   } else if (includeThesaurus.length == 0 || (
-                    includeThesaurus.length > 0 &&
-                    $.inArray(thesaurus.getKey(), includeThesaurus) !== -1)) {
+                 includeThesaurus.length > 0 &&
+                 $.inArray(thesaurus.getKey(), includeThesaurus) !== -1)) {
                     scope.thesaurus.push(thesaurus);
                   }
                 });
               });
 
-            scope.add = function () {
-              return gnEditor.add(gnCurrentEdit.id,
+             scope.add = function() {
+               return gnEditor.add(gnCurrentEdit.id,
                 scope.elementRef, scope.elementName, scope.domId, 'before');
-            };
+             };
 
-            scope.addThesaurus = function (thesaurusIdentifier) {
-              if (scope.selectorOnly) {
-                scope.$parent.thesaurusKey = scope.thesaurusKey =
+             scope.addThesaurus = function(thesaurusIdentifier) {
+               if (scope.selectorOnly) {
+                 scope.$parent.thesaurusKey = scope.thesaurusKey =
                   thesaurusIdentifier;
-              } else {
-                gnCurrentEdit.working = true;
-                return gnThesaurusService
+               } else {
+                 gnCurrentEdit.working = true;
+                 return gnThesaurusService
                   .getXML(thesaurusIdentifier, null,
-                    attrs.transformation).then(
-                    function (data) {
-                      // Add the fragment to the form
-                      scope.snippet = data;
-                      scope.snippetRef = gnEditor.buildXMLFieldName(
+                 attrs.transformation).then(
+                 function(data) {
+                   // Add the fragment to the form
+                   scope.snippet = data;
+                   scope.snippetRef = gnEditor.buildXMLFieldName(
                         scope.elementRef,
                         scope.elementName);
 
 
-                      $timeout(function () {
-                        // Save the metadata and refresh the form
-                        gnEditor.save(gnCurrentEdit.id, true).then(function() {
-                          // success. Nothing to do.
-                        }, function(rejectedValue) {
-                          $rootScope.$broadcast('StatusUpdated', {
-                            title: $translate.instant('runServiceError'),
-                            error: rejectedValue,
-                            timeout: 0,
-                            type: 'danger'
-                          });
-                        });
-                      });
-                    });
-              }
-              return false;
-            };
-          }
-        };
-      }]);
+                   $timeout(function() {
+                     // Save the metadata and refresh the form
+                     gnEditor.save(gnCurrentEdit.id, true).then(function() {
+                       // success. Nothing to do.
+                     }, function(rejectedValue) {
+                       $rootScope.$broadcast('StatusUpdated', {
+                         title: $translate.instant('runServiceError'),
+                         error: rejectedValue,
+                         timeout: 0,
+                         type: 'danger'
+                       });
+                     });
+                   });
+                 });
+               }
+               return false;
+             };
+           }
+         };
+       }]);
 
 
   /**
@@ -175,200 +176,201 @@
    * TODO: explain transformation
    */
   module.directive('gnKeywordSelector',
-    ['$compile', '$timeout', '$translate',
-      'gnThesaurusService', 'gnEditor',
-      'Keyword', 'gnLangs',
-      function ($compile, $timeout, $translate,
+      ['$compile', '$timeout', '$translate',
+       'gnThesaurusService', 'gnEditor',
+       'Keyword', 'gnLangs',
+       function($compile, $timeout, $translate,
                 gnThesaurusService, gnEditor, Keyword, gnLangs) {
 
-        return {
-          restrict: 'A',
-          replace: true,
-          transclude: true,
-          scope: {
-            mode: '@gnKeywordSelector',
-            elementRef: '@',
-            thesaurusKey: '@',
-            keywords: '@',
-            transformations: '@',
-            currentTransformation: '@',
-            lang: '@',
-            textgroupOnly: '@',
+         return {
+           restrict: 'A',
+           replace: true,
+           transclude: true,
+           scope: {
+             mode: '@gnKeywordSelector',
+             elementRef: '@',
+             thesaurusKey: '@',
+             keywords: '@',
+             transformations: '@',
+             currentTransformation: '@',
+             lang: '@',
+             textgroupOnly: '@',
 
-            // Max number of tags allowed. Use 1 to restrict to only
-            // on keyword.
-            maxTags: '@'
-          },
-          templateUrl: '../../catalog/components/thesaurus/' +
-          'partials/keywordselector.html',
-          link: function (scope, element, attrs) {
-            $compile(element.contents())(scope);
-            // pick up skos browser directive with compiler
+             // Max number of tags allowed. Use 1 to restrict to only
+             // on keyword.
+             maxTags: '@'
+           },
+           templateUrl: '../../catalog/components/thesaurus/' +
+           'partials/keywordselector.html',
+           link: function(scope, element, attrs) {
+             $compile(element.contents())(scope);
+             // pick up skos browser directive with compiler
 
-            scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
-            scope.filter = null;
-            scope.results = null;
-            scope.snippet = null;
-            scope.isInitialized = false;
-            scope.elementRefBackup = scope.elementRef;
-            scope.invalidKeywordMatch = false;
-            scope.selected = [];
-            scope.initialKeywords = [];
-            if (scope.keywords) {
-              var buffer = '';
-              for (var i = 0; i < scope.keywords.length; i++) {
-                var next = scope.keywords.charAt(i);
-                if (next !== ',') {
-                  buffer += next;
-                } else if (i === scope.keywords.length - 1 ||
+             scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
+             scope.filter = null;
+             scope.results = null;
+             scope.snippet = null;
+             scope.isInitialized = false;
+             scope.elementRefBackup = scope.elementRef;
+             scope.invalidKeywordMatch = false;
+             scope.selected = [];
+             scope.initialKeywords = [];
+             if (scope.keywords) {
+               var buffer = '';
+               for (var i = 0; i < scope.keywords.length; i++) {
+                 var next = scope.keywords.charAt(i);
+                 if (next !== ',') {
+                   buffer += next;
+                 } else if (i === scope.keywords.length - 1 ||
                   scope.keywords.charAt(i + 1) === ',') {
-                  buffer += next;
-                  i++;
-                } else {
-                  scope.initialKeywords.push(buffer);
-                  buffer = '';
-                }
-              }
-              if (buffer.length > 0) {
-                scope.initialKeywords.push(buffer);
-              }
-            }
-            scope.transformationLists =
+                   buffer += next;
+                   i++;
+                 } else {
+                   scope.initialKeywords.push(buffer);
+                   buffer = '';
+                 }
+               }
+               if (buffer.length > 0) {
+                 scope.initialKeywords.push(buffer);
+               }
+             }
+             scope.transformationLists =
               scope.transformations.indexOf(',') !== -1 ?
-                scope.transformations.split(',') : [scope.transformations];
-            scope.maxTagsLabel = scope.maxTags || '∞';
+             scope.transformations.split(',') : [scope.transformations];
+             scope.maxTagsLabel = scope.maxTags || '∞';
 
-            //Get langs of metadata
-            var langs = [];
-            for (var p in JSON.parse(scope.lang)) {
-              langs.push(p);
-            }
-            scope.mainLang = langs[0];
-            scope.langs = langs.join(',');
+             //Get langs of metadata
+             var langs = [];
+             for (var p in JSON.parse(scope.lang)) {
+               langs.push(p);
+             }
+             scope.mainLang = langs[0];
+             scope.langs = langs.join(',');
 
-            // Check initial keywords are available in the thesaurus
-            scope.sortKeyword = function (a, b) {
-              if (a.getLabel().toLowerCase() <
+             // Check initial keywords are available in the thesaurus
+             scope.sortKeyword = function(a, b) {
+               if (a.getLabel().toLowerCase() <
                 b.getLabel().toLowerCase()) {
-                return -1;
-              }
-              if (a.getLabel().toLowerCase() >
+                 return -1;
+               }
+               if (a.getLabel().toLowerCase() >
                 b.getLabel().toLowerCase()) {
-                return 1;
-              }
-              return 0;
-            };
-            scope.resetKeywords = function () {
-              scope.selected = [];
-              scope.elementRef = scope.elementRefBackup;
-              scope.invalidKeywordMatch = false;
-              checkState();
-            };
+                 return 1;
+               }
+               return 0;
+             };
+             scope.resetKeywords = function() {
+               scope.selected = [];
+               scope.elementRef = scope.elementRefBackup;
+               scope.invalidKeywordMatch = false;
+               checkState();
+             };
 
 
-            var init = function () {
+             var init = function() {
 
-              // Nothing to load - init done
-              scope.isInitialized = scope.initialKeywords.length === 0;
+               // Nothing to load - init done
+               scope.isInitialized = scope.initialKeywords.length === 0;
 
-              // If no keyword, set the default transformation
-              if (
+               // If no keyword, set the default transformation
+               if (
                 $.inArray(scope.currentTransformation,
-                  scope.transformationLists) === -1 &&
+               scope.transformationLists) === -1 &&
                 scope.initialKeywords.length === 0) {
 
-                scope.setTransformation(scope.transformationLists[0]);
-              }
-              if (scope.isInitialized) {
-                checkState();
-              } else {
+                 scope.setTransformation(scope.transformationLists[0]);
+               }
+               if (scope.isInitialized) {
+                 checkState();
+               } else {
 
-                // Check that all initial keywords are in the thesaurus
-                var counter = 0;
-                angular.forEach(scope.initialKeywords, function (keyword) {
-                  // One keyword only and exact match search
-                  // in current editor language.
-                  gnThesaurusService.getKeywords(keyword,
-                  scope.thesaurusKey, gnLangs.current, 1, 'MATCH')
-                      .then(function(listOfKeywords) {
-                    counter++;
+                 // Check that all initial keywords are in the thesaurus
+                 var counter = 0;
+                 angular.forEach(scope.initialKeywords, function(keyword) {
+                   // One keyword only and exact match search
+                   // in current editor language.
+                   gnThesaurusService.getKeywords(keyword,
+                   scope.thesaurusKey, gnLangs.current, 1, 'MATCH')
+                   .then(function(listOfKeywords) {
+                     counter++;
 
-                    listOfKeywords[0] &&
-                    scope.selected.push(listOfKeywords[0]);
-                    // Init done when all keywords are selected
-                    if (counter === scope.initialKeywords.length) {
-                      scope.isInitialized = true;
-                      scope.invalidKeywordMatch =
+                     listOfKeywords[0] &&
+                     scope.selected.push(listOfKeywords[0]);
+                     // Init done when all keywords are selected
+                     if (counter === scope.initialKeywords.length) {
+                       scope.isInitialized = true;
+                       scope.invalidKeywordMatch =
                         scope.selected.length !== scope.initialKeywords.length;
 
-                      // Get the matching XML snippet for
-                      // the initial set of keywords
-                      // once the loaded keywords are all selected.
-                      checkState();
-                    }
-                  });
-                });
-              }
+                       // Get the matching XML snippet for
+                       // the initial set of keywords
+                       // once the loaded keywords are all selected.
+                       checkState();
+                     }
+                   });
+                 });
+               }
 
-              // Then register search filter change
-              // Only applies to multiselect mode
-              scope.$watch('filter', search);
-            };
+               // Then register search filter change
+               // Only applies to multiselect mode
+               scope.$watch('filter', search);
+             };
 
-            // Used by skos-browser to add keywords from the
-            // skos hierarchy to the current list of tags
-            scope.addThesaurusConcept = function (uri, text) {
-              var textArr = [];
-              textArr['#text'] = text;
-              var k = {
-                uri: uri,
-                value: textArr
-              };
-              var keyword = new Keyword(k);
+             // Used by skos-browser to add keywords from the
+             // skos hierarchy to the current list of tags
+             scope.addThesaurusConcept = function(uri, text) {
+               var textArr = [];
+               textArr['#text'] = text;
+               var k = {
+                 uri: uri,
+                 value: textArr
+               };
+               var keyword = new Keyword(k);
 
-              var thisId = '#tagsinput_' + scope.elementRef;
-              // Add to tags
-              $(thisId).tagsinput('add', keyword);
+               var thisId = '#tagsinput_' + scope.elementRef;
+               // Add to tags
+               $(thisId).tagsinput('add', keyword);
 
-              // Update selection and snippet
-              angular.copy($(thisId).tagsinput('items'), scope.selected);
-              getSnippet(); // FIXME: should not be necessary
-              // as there is a watch on it ?
+               // Update selection and snippet
+               angular.copy($(thisId).tagsinput('items'), scope.selected);
+               getSnippet(); // FIXME: should not be necessary
+               // as there is a watch on it ?
 
-              // Clear typeahead
-              $(thisId).tagsinput('input').typeahead('val', '');
-            };
+               // Clear typeahead
+               $(thisId).tagsinput('input').typeahead('val', '');
+             };
 
-            // Init typeahead and tag input
-            var initTagsInput = function () {
-              var id = '#tagsinput_' + scope.elementRef;
-              $timeout(function () {
-                try {
-                  $(id).tagsinput({
-                    itemValue: 'label',
-                    itemText: 'label',
-                    maxTags: scope.maxTags
-                  });
+             // Init typeahead and tag input
+             var initTagsInput = function() {
+               var id = '#tagsinput_' + scope.elementRef;
+               $timeout(function() {
+                 try {
+                   $(id).tagsinput({
+                     itemValue: 'label',
+                     itemText: 'label',
+                     maxTags: scope.maxTags
+                   });
 
-                  // Add selection to the list of tags
-                  angular.forEach(scope.selected, function (keyword) {
-                    $(id).tagsinput('add', keyword);
-                  });
+                   // Add selection to the list of tags
+                   angular.forEach(scope.selected, function(keyword) {
+                     $(id).tagsinput('add', keyword);
+                   });
 
-                  // Load all keywords from thesaurus on startup
-                  gnThesaurusService.getKeywords('',
+                   // Load all keywords from thesaurus on startup
+                   gnThesaurusService.getKeywords('',
                     scope.thesaurusKey, scope.max)
-                    .then(function (listOfKeywords) {
+                    .then(function(listOfKeywords) {
 
                       var field = $(id).tagsinput('input');
-                      field.attr('placeholder', $translate.instant('searchKeyword'));
+                      field.attr('placeholder',
+                     $translate.instant('searchKeyword'));
 
                       var keywordsAutocompleter =
-                        gnThesaurusService.getKeywordAutocompleter({
-                          thesaurusKey: scope.thesaurusKey,
-                          dataToExclude: scope.selected,
-                          lang: gnLangs.current
-                        });
+                     gnThesaurusService.getKeywordAutocompleter({
+                       thesaurusKey: scope.thesaurusKey,
+                       dataToExclude: scope.selected,
+                       lang: gnLangs.current
+                     });
 
                       // Init typeahead
                       field.typeahead({
@@ -381,31 +383,32 @@
                         displayKey: 'label',
                         source: keywordsAutocompleter.ttAdapter()
                       }).bind('typeahead:selected',
-                        $.proxy(function (obj, keyword) {
-                          // Add to tags
-                          this.tagsinput('add', keyword);
+                     $.proxy(function(obj, keyword) {
+                       // Add to tags
+                       this.tagsinput('add', keyword);
 
-                          // Update selection and snippet
-                          angular.copy(this.tagsinput('items'), scope.selected);
-                          getSnippet(); // FIXME: should not be necessary
-                          // as there is a watch on it ?
+                       // Update selection and snippet
+                       angular.copy(this.tagsinput('items'), scope.selected);
+                       getSnippet(); // FIXME: should not be necessary
+                       // as there is a watch on it ?
 
-                          // Clear typeahead
-                          this.tagsinput('input').typeahead('val', '');
-                        }, $(id))
+                       // Clear typeahead
+                       this.tagsinput('input').typeahead('val', '');
+                     }, $(id))
                       );
 
-                      $(id).on('itemRemoved', function () {
-                        angular.copy($(this).tagsinput('items'), scope.selected);
+                      $(id).on('itemRemoved', function() {
+                        angular.copy($(this)
+                       .tagsinput('items'), scope.selected);
                         getSnippet();
                       });
 
                       // When clicking the element trigger input
                       // to show autocompletion list.
                       // https://github.com/twitter/typeahead.js/issues/798
-                      field.on('typeahead:opened', function () {
+                      field.on('typeahead:opened', function() {
                         var initial = field.val(),
-                          ev = $.Event('keydown');
+                       ev = $.Event('keydown');
                         ev.keyCode = ev.which = 40;
                         field.trigger(ev);
                         if (field.val() != initial) {
@@ -414,85 +417,86 @@
                         return true;
                       });
                     });
-                } catch (e) {
-                  console.warn('No tagsinput for ' + id + ', error: ' + e.message);
-                }
-              });
-            };
+                 } catch (e) {
+                   console.warn('No tagsinput for ' + id +
+                   ', error: ' + e.message);
+                 }
+               });
+             };
 
-            var checkState = function () {
-              if (scope.isInitialized && !scope.invalidKeywordMatch) {
-                getSnippet();
+             var checkState = function() {
+               if (scope.isInitialized && !scope.invalidKeywordMatch) {
+                 getSnippet();
 
-                scope.$watch('results', getSnippet);
-                scope.$watch('selected', getSnippet);
+                 scope.$watch('results', getSnippet);
+                 scope.$watch('selected', getSnippet);
 
-                if (scope.mode === 'tagsinput') {
-                  initTagsInput();
-                }
-              } else if (scope.invalidKeywordMatch) {
-                // invalidate element ref to not trigger
-                // an update of the record with an invalid
-                // state ie. keywords not loaded properly
-                scope.elementRef = '';
-              }
-            };
+                 if (scope.mode === 'tagsinput') {
+                   initTagsInput();
+                 }
+               } else if (scope.invalidKeywordMatch) {
+                 // invalidate element ref to not trigger
+                 // an update of the record with an invalid
+                 // state ie. keywords not loaded properly
+                 scope.elementRef = '';
+               }
+             };
 
 
-            var search = function () {
-              gnThesaurusService.getKeywords(scope.filter,
+             var search = function() {
+               gnThesaurusService.getKeywords(scope.filter,
                 scope.thesaurusKey, gnLangs.current, scope.max)
-                .then(function (listOfKeywords) {
+                .then(function(listOfKeywords) {
                   // Remove from search already selected keywords
-                  scope.results = $.grep(listOfKeywords, function (n) {
+                  scope.results = $.grep(listOfKeywords, function(n) {
                     var alreadySelected = true;
                     if (scope.selected.length !== 0) {
-                      alreadySelected = $.grep(scope.selected, function (s) {
-                          return s.getLabel() === n.getLabel();
-                        }).length === 0;
+                      alreadySelected = $.grep(scope.selected, function(s) {
+                       return s.getLabel() === n.getLabel();
+                     }).length === 0;
                     }
                     return alreadySelected;
                   });
                 });
-            };
-            scope.setTransformation = function (t) {
-              $timeout(function () {
-                scope.currentTransformation = t;
-                getSnippet();
-              });
-              return false;
-            };
-            scope.isCurrent = function (t) {
-              return t === scope.currentTransformation;
-            };
-            var getKeywordIds = function () {
-              var ids = [];
-              angular.forEach(scope.selected, function (k) {
-                ids.push(k.getId());
-              });
-              return ids;
-            };
+             };
+             scope.setTransformation = function(t) {
+               $timeout(function() {
+                 scope.currentTransformation = t;
+                 getSnippet();
+               });
+               return false;
+             };
+             scope.isCurrent = function(t) {
+               return t === scope.currentTransformation;
+             };
+             var getKeywordIds = function() {
+               var ids = [];
+               angular.forEach(scope.selected, function(k) {
+                 ids.push(k.getId());
+               });
+               return ids;
+             };
 
-            var getSnippet = function () {
-              gnThesaurusService
+             var getSnippet = function() {
+               gnThesaurusService
                 .getXML(scope.thesaurusKey,
-                  getKeywordIds(), scope.currentTransformation, scope.langs,
-                  scope.textgroupOnly).then(
-                function (data) {
+               getKeywordIds(), scope.currentTransformation, scope.langs,
+               scope.textgroupOnly).then(
+                function(data) {
                   scope.snippet = data;
                 });
-            };
+             };
 
-            if (scope.thesaurusKey) {
-              init();
-              gnThesaurusService.getTopConcept(scope.thesaurusKey).then(
-                function (c) {
+             if (scope.thesaurusKey) {
+               init();
+               gnThesaurusService.getTopConcept(scope.thesaurusKey).then(
+                function(c) {
                   scope.concept = c;
                 });
-            }
-          }
-        };
-      }]);
+             }
+           }
+         };
+       }]);
 
 
   /**
@@ -507,22 +511,24 @@
    */
   module.directive('gnKeywordPicker', [
     'gnThesaurusService', '$compile', '$translate',
-    function (gnThesaurusService, $compile, $translate) {
+    function(gnThesaurusService, $compile, $translate) {
       return {
         restrict: 'A',
-        link: function (scope, element, attrs) {
+        link: function(scope, element, attrs) {
           scope.thesaurusKey = attrs.thesaurusKey || '';
           scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
           var initialized = false;
 
           // Create an input group around the element
           // with a thesaurus selector on the right.
-          var addThesaurusSelectorOnElement = function () {
-            var inputGroup = angular.element('<div class="input-group"></div>');
-            var dropDown = angular.element('<div class="input-group-btn"></div>');
+          var addThesaurusSelectorOnElement = function() {
+            var inputGroup = angular.element(
+                '<div class="input-group"></div>');
+            var dropDown = angular.element(
+                '<div class="input-group-btn"></div>');
             // Thesaurus selector is a directive
             var thesaurusSel = '<span data-gn-thesaurus-selector="" ' +
-              'data-selector-only="true"></span>';
+                'data-selector-only="true"></span>';
 
             var input = element.replaceWith(inputGroup);
             inputGroup.append(input);
@@ -532,11 +538,12 @@
           };
 
 
-          var init = function () {
+          var init = function() {
             // Get list of available thesaurus (if not defined
             // by scope)
             element.typeahead('destroy');
-            element.attr('placeholder', $translate.instant('searchOrTypeKeyword'));
+            element.attr('placeholder',
+                $translate.instant('searchOrTypeKeyword'));
 
             // Thesaurus selector is not added if the key is defined
             // by configuration
@@ -544,10 +551,10 @@
               addThesaurusSelectorOnElement(element);
             }
             var keywordsAutocompleter =
-              gnThesaurusService.getKeywordAutocompleter({
-                thesaurusKey: scope.thesaurusKey,
-                lang: scope.lang
-              });
+                gnThesaurusService.getKeywordAutocompleter({
+                  thesaurusKey: scope.thesaurusKey,
+                  lang: scope.lang
+                });
 
             // Init typeahead
             element.typeahead({
@@ -567,9 +574,9 @@
             // When clicking the element trigger input
             // to show autocompletion list.
             // https://github.com/twitter/typeahead.js/issues/798
-            element.on('typeahead:opened', function () {
+            element.on('typeahead:opened', function() {
               var initial = element.val(),
-                ev = $.Event('keydown');
+                  ev = $.Event('keydown');
               ev.keyCode = ev.which = 40;
               element.trigger(ev);
               if (element.val() != initial) {
@@ -582,7 +589,7 @@
 
           init();
 
-          scope.$watch('thesaurusKey', function (newValue) {
+          scope.$watch('thesaurusKey', function(newValue) {
             init();
           });
         }


### PR DESCRIPTION
Fix a JS error when clearing the typeahead content and other when synchronizing the typeadhead contents with the Angular JS model.

```
Uncaught Error: [ng:cpi] Can't copy! Source and destination are identical.
http://errors.angularjs.org/1.5.2/ng/cpi
    at angular.js:68
    at Object.copy (angular.js:868)
    at HTMLInputElement.<anonymous> (ThesaurusDirective.js:391)
    at HTMLInputElement.dispatch (jquery-2.0.3.js:4676)
    at HTMLInputElement.elemData.handle (jquery-2.0.3.js:4360)
    at Object.trigger (jquery-2.0.3.js:4594)
    at HTMLInputElement.<anonymous> (jquery-2.0.3.js:5119)
    at Function.each (jquery-2.0.3.js:590)
    at init.each (jquery-2.0.3.js:237)
    at init.trigger (jquery-2.0.3.js:5118)
```

```
TypeError: Cannot create property 'highlight' on string ''
    at typeahead.bundle.js:1729
    at String.reverseArgs (typeahead.bundle.js:39)
    at Function.each (jquery-2.0.3.js:590)
    at Object.each (typeahead.bundle.js:37)
    at HTMLInputElement.attach (typeahead.bundle.js:1728)
    at Function.each (jquery-2.0.3.js:590)
    at init.each (jquery-2.0.3.js:237)
    at initialize (typeahead.bundle.js:1725)
    at init.$.fn.typeahead (typeahead.bundle.js:1797)
    at Scope.scope.addThesaurusConcept [as addConceptToList] (ThesaurusDirective.js:331)
```