### PR TITLE
Editor / Make table layout configurable

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -70,6 +70,7 @@ a set of views with at least one.
         <xs:element minOccurs="0" maxOccurs="1" ref="fields"/>
         <xs:element minOccurs="0" maxOccurs="1" ref="fieldsWithFieldset"/>
         <xs:element minOccurs="0" maxOccurs="1" ref="multilingualFields"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="tableFields"/>
         <xs:element minOccurs="1" maxOccurs="1" ref="views"/>
         <xs:element minOccurs="0" maxOccurs="1" ref="batchEditing"/>
       </xs:sequence>
@@ -203,6 +204,107 @@ If expanded, then one field per language is displayed with no need to click on t
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+
+  <xs:element name="tableFields">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[
+Defining fields to display as tables
+------------------------------------
+
+Configure here the list of fields to display using a table. This only applies to flat mode views.
+
+.. figure:: ../../user-guide/describing-information/img/table-fields.png
+
+
+.. code-block:: xml
+
+
+    <editor>
+       <fields>...</fields>
+       <fieldsWithFieldset>...</fieldsWithFieldset>
+        <multilingualFields>...</multilingualFields>
+        <tableFields>
+          <table for="gmd:CI_OnlineResource">
+            <header>
+              <hcol label="gmd:protocol"/>
+              <hcol label="gmd:linkage"/>
+              <hcol label="gmd:name"/>
+              <hcol/>
+            </header>
+            <row>
+              <col xpath="gmd:protocol"/>
+              <col xpath="gmd:linkage"/>
+              <col xpath="gmd:name"/>
+              <col del=".."/>
+            </row>
+          </table>
+        ]]></xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="table">
+          <xs:complexType>
+            <xs:attribute name="for" use="required">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[
+Element to match for creating the table.
+                  ]]>
+                </xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:sequence>
+              <xs:element maxOccurs="1" ref="header"/>
+              <xs:element maxOccurs="1" ref="row"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="header">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[
+Table header row.
+        ]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" name="col">
+          <xs:complexType>
+            <xs:attribute name="label" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="row">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[
+Table column.
+        ]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" name="col">
+          <xs:complexType>
+            <xs:attribute name="xpath" type="xs:string" use="optional"/>
+            <xs:attribute name="del" type="xs:string" use="optional"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
 
   <xs:element name="expanded">
     <xs:annotation>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -280,6 +280,77 @@
     </exclude>
   </multilingualFields>
 
+  <tableFields>
+    <table for="gmd:CI_ResponsibleParty">
+      <header>
+        <!-- TODO: Add label from strings.xml / label with context-->
+        <col label="gmd:organisationName"/>
+        <col label="gmd:individualName"/>
+        <col label="gmd:electronicMailAddress"/>
+        <col label="gmd:role"/>
+        <col/>
+      </header>
+      <row>
+        <col xpath="gmd:organisationName"/>
+        <col xpath="gmd:individualName"/>
+        <col xpath="gmd:contactInfo/*/gmd:address/*/gmd:electronicMailAddress"/>
+        <col xpath="gmd:role"/>
+        <col del=".."/>
+      </row>
+    </table>
+    <table for="gmd:CI_OnlineResource">
+      <header>
+        <col label="gmd:protocol"/>
+        <col label="gmd:linkage"/>
+        <col label="gmd:name"/>
+        <col/>
+      </header>
+      <row>
+        <col xpath="gmd:protocol"/>
+        <col xpath="gmd:linkage"/>
+        <col xpath="gmd:name"/>
+        <col del=".."/>
+      </row>
+    </table>
+    <table for="srv:SV_CoupledResource">
+      <header>
+        <col label="srv:operationName"/>
+        <col label="gco:ScopedName"/>
+        <col label="srv:identifier"/>
+        <col/>
+      </header>
+      <row>
+        <col xpath="srv:operationName"/>
+        <col xpath="gco:ScopedName"/>
+        <col xpath="srv:identifier"/>
+        <col del=".."/>
+      </row>
+    </table>
+    <table for="gmd:MD_Format">
+      <header>
+        <col label="gmd:name"/>
+        <col label="gmd:version"/>
+        <col/>
+      </header>
+      <row>
+        <col xpath="gmd:name"/>
+        <col xpath="gmd:version"/>
+        <col del=".."/>
+      </row>
+    </table>
+    <table for="gmd:PT_Locale">
+      <header>
+        <col label="gmd:languageCode"/>
+        <col label="gmd:characterEncoding"/>
+        <col/>
+      </header>
+      <row>
+        <col xpath="gmd:languageCode"/>
+        <col xpath="gmd:characterEncoding"/>
+        <col del=".."/>
+      </row>
+    </table>
+  </tableFields>
 
   <!-- View configuration -->
   <views>
@@ -1926,6 +1997,7 @@
         <for name="gmd:spatialResolution"/>
         <for name="gmd:pointOfContact"/>
         <for name="gmd:distributor"/>
+        <for name="gmd:distributionFormat"/>
         <for name="gmd:contact"/>
         <for name="gmd:processor"/>
         <for name="gmd:topicCategory"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
@@ -5,96 +5,122 @@
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:saxon="http://saxon.sf.net/"
                 xmlns:gn="http://www.fao.org/geonetwork"
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
                 xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
                 version="2.0"
+                extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
   <!--
     Display contact as table when mode is flat (eg. simple view) or if using xsl mode
-
     Match first node (or added one)
   -->
   <xsl:template mode="mode-iso19139"
-                match="gmd:pointOfContact[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]|
-                       gmd:contact[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]|
-                       gmd:distributorContact[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]|
-                       gmd:processor[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]|
-                       gmd:citedResponsibleParty[gmd:CI_ResponsibleParty and (1 or @gn:addedObj = 'true') and $isFlatMode]"
+                match="*[
+                        *[1]/name() = $editorConfig/editor/tableFields/table/@for and
+                        (1 or @gn:addedObj = 'true') and
+                        $isFlatMode]"
                 priority="2000">
-    <xsl:call-template name="iso19139-table-contact"/>
+    <xsl:call-template name="iso19139-table"/>
   </xsl:template>
-
 
   <!-- Ignore the following -->
   <xsl:template mode="mode-iso19139"
-                match="gmd:pointOfContact[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]|
-                       gmd:contact[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]|
-                       gmd:distributorContact[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]|
-                       gmd:processor[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]|
-                       gmd:citedResponsibleParty[gmd:CI_ResponsibleParty and position() > 1 and not(@gn:addedObj) and $isFlatMode]"
-                priority="2000">
-  </xsl:template>
+                match="*[
+                        *[1]/name() = $editorConfig/editor/tableFields/table/@for and
+                        preceding-sibling::*[1]/name() = name() and
+                        not(@gn:addedObj) and
+                        $isFlatMode]"
+                priority="2000"/>
 
 
   <!-- Define table layout -->
-  <xsl:template name="iso19139-table-contact">
+  <xsl:template name="iso19139-table">
     <xsl:variable name="name" select="name()"/>
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
 
+    <xsl:variable name="childName"
+                  select="*[1]/name()"/>
+
+    <xsl:variable name="isEmbeddedMode"
+                  select="@gn:addedObj = 'true'"/>
+    <xsl:variable name="isFirstOfItsKind"
+                  select="preceding-sibling::*[1]/name() != $name"/>
+
+    <xsl:variable name="tableConfig"
+                  select="$editorConfig/editor/tableFields/table[@for = $childName]"/>
+
     <xsl:variable name="values">
-      <header>
-        <col>
-          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'gmd:organisationName', $labels, '', $isoType, $xpath)/label"/>
-        </col>
-        <col>
-          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'gmd:individualName', $labels, '', $isoType, $xpath)/label"/>
-        </col>
-        <col>
-          <xsl:value-of
-            select="gn-fn-metadata:getLabel($schema, 'gmd:electronicMailAddress', $labels, '', $isoType, $xpath)/label"/>
-        </col>
-        <col>
-          <xsl:value-of
-            select="gn-fn-metadata:getLabel($schema, 'gmd:role', $labels, '', $isoType, $xpath)/label"/>
-        </col>
-      </header>
-      <xsl:for-each select="(.|following-sibling::*[name() = $name])/gmd:CI_ResponsibleParty">
+      <xsl:if test="not($isEmbeddedMode) or ($isEmbeddedMode and $isFirstOfItsKind)">
+        <header>
+          <xsl:for-each select="$tableConfig/header/col">
+            <col>
+              <xsl:if test="@label">
+                <!-- TODO: column names may comes from strings.xml -->
+                <xsl:value-of select="gn-fn-metadata:getLabel($schema, @label, $labels, '', $isoType, $xpath)/label"/>
+              </xsl:if>
+            </col>
+          </xsl:for-each>
+        </header>
+      </xsl:if>
+      <xsl:for-each select="(.|following-sibling::*[name() = $name])/*[name() = $childName]">
+
+        <xsl:variable name="base"
+                      select="."/>
         <row>
-          <col>
-            <xsl:copy-of select="gmd:organisationName"/>
-          </col>
-          <col>
-            <xsl:copy-of select="gmd:individualName"/>
-          </col>
-          <col>
-            <xsl:copy-of select="gmd:contactInfo/*/gmd:address/*/gmd:electronicMailAddress"/>
-          </col>
-          <col>
-            <xsl:copy-of select="gmd:role"/>
-          </col>
-          <col remove="">
-            <xsl:copy-of select="ancestor::*[name() = $name]/gn:element"/>
-          </col>
+          <xsl:for-each select="$tableConfig/row/col">
+            <col>
+              <xsl:if test="@del != ''">
+                <xsl:attribute name="remove" select="'true'"/>
+
+                <saxon:call-template name="{concat('evaluate-', $schema)}">
+                  <xsl:with-param name="base" select="$base"/>
+                  <xsl:with-param name="in"
+                                  select="concat('/', @del, '/gn:element')"/>
+                </saxon:call-template>
+              </xsl:if>
+
+              <xsl:if test="@xpath != ''">
+                <saxon:call-template name="{concat('evaluate-', $schema)}">
+                  <xsl:with-param name="base" select="$base"/>
+                  <xsl:with-param name="in"
+                                  select="concat('/', @xpath)"/>
+                </saxon:call-template>
+              </xsl:if>
+            </col>
+          </xsl:for-each>
         </row>
       </xsl:for-each>
     </xsl:variable>
 
-    <xsl:call-template name="render-boxed-element">
-      <xsl:with-param name="label"
-                      select="gn-fn-metadata:getLabel($schema, $name, $labels, name(..), $isoType, $xpath)/label"/>
-      <xsl:with-param name="editInfo" select="gn:element"/>
-      <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="subTreeSnippet">
 
+    <!-- Return only the new row in embed mode. -->
+    <xsl:choose>
+      <xsl:when test="$isEmbeddedMode and not($isFirstOfItsKind)">
         <xsl:call-template name="render-table">
           <xsl:with-param name="values" select="$values"/>
         </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="render-boxed-element">
+          <xsl:with-param name="label"
+                          select="gn-fn-metadata:getLabel($schema, $name, $labels, $name, $isoType, $xpath)/label"/>
+          <xsl:with-param name="editInfo"><null/></xsl:with-param>
+          <xsl:with-param name="cls" select="local-name()"/>
+          <xsl:with-param name="subTreeSnippet">
 
-      </xsl:with-param>
-    </xsl:call-template>
+            <xsl:call-template name="render-table">
+              <xsl:with-param name="values" select="$values"/>
+            </xsl:call-template>
+
+          </xsl:with-param>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
In config-editor.xml, define which elements should be displayed using table
in flat mode views (ie. this does not apply to advanced view).

Related work: https://github.com/geonetwork/core-geonetwork/pull/1635

In ISO19139, table is used for contact, online source, coupled resource, format, other locale.