### PR TITLE
Wrong selected count in badge in the editor dashboard

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/SelectionDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/SelectionDirective.js
@@ -51,7 +51,9 @@
 
           // initial state
           gnSearchManagerService.selected().success(function(res) {
-            scope.searchResults.selectedCount = parseInt(res, 10);
+            if (angular.isArray(res)) {
+              scope.searchResults.selectedCount = res.length;
+            }
           });
 
           var updateCkb = function(records) {


### PR DESCRIPTION
The selected count badge in editor dashboard show random values after a reload if there are selected records.  

Fix:
The value returned by `gnSearchManagerService.selected()` is an array. Changed `parseInt(res, 10)` by `res.length`