### PR TITLE
Selection / Add multiple selections support.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiParams.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiParams.java
@@ -69,4 +69,5 @@ public class ApiParams {
     public static final String API_RESPONSE_NOT_ALLOWED_CAN_VIEW = "Operation not allowed. User needs to be able to view the resource.";
     public static final String API_RESPONSE_NOT_ALLOWED_ONLY_AUTHENTICATED = "Operation not allowed. Only authenticated user can access it.";
     public static final String API_RESPONSE_RESOURCE_NOT_FOUND = "Resource not found.";
+    public static final String API_PARAM_BUCKET_NAME = "Selection bucket name";
 }

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -53,7 +53,6 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
-import java.util.Locale;
 import java.util.Set;
 
 import javax.imageio.ImageIO;
@@ -78,15 +77,17 @@ public class ApiUtils {
     /**
      * Return a set of UUIDs based on the input UUIDs array or based on the current selection.
      */
-    static public Set<String> getUuidsParameterOrSelection(String[] uuids, UserSession session) {
+    static public Set<String> getUuidsParameterOrSelection(String[] uuids, String bucket, UserSession session) {
         final Set<String> setOfUuidsToEdit;
         if (uuids == null) {
+            if (bucket == null) {
+                bucket = SelectionManager.SELECTION_METADATA;
+            }
             SelectionManager selectionManager =
                 SelectionManager.getManager(session);
             synchronized (
-                selectionManager.getSelection(
-                    SelectionManager.SELECTION_METADATA)) {
-                final Set<String> selection = selectionManager.getSelection(SelectionManager.SELECTION_METADATA);
+                selectionManager.getSelection(bucket)) {
+                final Set<String> selection = selectionManager.getSelection(bucket);
                 setOfUuidsToEdit = Sets.newHashSet(selection);
             }
         } else {

--- a/services/src/main/java/org/fao/geonet/api/processing/ProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ProcessApi.java
@@ -150,6 +150,13 @@ public class ProcessApi {
         @RequestParam(required = false)
             String[] uuids,
         @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
+        @ApiParam(
             value = ApiParams.API_PARAM_PROCESS_TEST_ONLY,
             required = false)
         @RequestParam(defaultValue = "false")
@@ -180,7 +187,7 @@ public class ProcessApi {
             ApplicationContext applicationContext = ApplicationContextHolder.get();
             DataManager dataMan = applicationContext.getBean(DataManager.class);
 
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, userSession);
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, userSession);
 
             report.setTotalRecords(records.size());
             MetadataSearchAndReplace m = new MetadataSearchAndReplace(

--- a/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
@@ -28,9 +28,6 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
-import org.fao.geonet.api.processing.report.MetadataProcessingReport;
-import org.fao.geonet.api.processing.report.MetadataReplacementProcessingReport;
-import org.fao.geonet.api.processing.report.ProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.api.processing.report.registry.IProcessingReportRegistry;
 import org.fao.geonet.domain.Metadata;
@@ -51,8 +48,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
@@ -105,6 +100,13 @@ public class ValidateApi {
             example = "")
         @RequestParam(required = false)
             String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
         @ApiIgnore
             HttpSession session,
         @ApiIgnore
@@ -120,7 +122,7 @@ public class ValidateApi {
             AccessManager accessMan = applicationContext.getBean(AccessManager.class);
             ServiceContext serviceContext = ApiUtils.createServiceContext(request);
 
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, userSession);
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, userSession);
 
             final MetadataRepository metadataRepository = applicationContext.getBean(MetadataRepository.class);
             for (String uuid : records) {

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
@@ -122,6 +122,13 @@ public class XslProcessApi {
             example = "")
         @RequestParam(required = false)
             String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
         @ApiParam(value = "Append documents before processing",
             required = false,
             example = "false")
@@ -146,7 +153,7 @@ public class XslProcessApi {
         response.setHeader(CONTENT_TYPE, isText ? MediaType.TEXT_PLAIN_VALUE : MediaType.APPLICATION_XML_VALUE);
 
         try {
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, session);
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, session);
             ApplicationContext context = ApplicationContextHolder.get();
             DataManager dataMan = context.getBean(DataManager.class);
             SchemaManager schemaMan = context.getBean(SchemaManager.class);
@@ -239,6 +246,13 @@ public class XslProcessApi {
             example = "")
         @RequestParam(required = false)
             String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
         @ApiIgnore
             HttpSession httpSession,
         @ApiIgnore
@@ -249,7 +263,7 @@ public class XslProcessApi {
             new XsltMetadataProcessingReport(process);
 
         try {
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, session);
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, session);
             ApplicationContext context = ApplicationContextHolder.get();
             DataManager dataMan = context.getBean(DataManager.class);
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -63,7 +63,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -193,6 +192,13 @@ public class MetadataInsertDeleteApi {
         @RequestParam(required = false)
             String[] uuids,
         @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
+        @ApiParam(
             value = API_PARAM_BACKUP_FIRST,
             required = false)
         @RequestParam(
@@ -210,7 +216,7 @@ public class MetadataInsertDeleteApi {
         AccessManager accessMan = appContext.getBean(AccessManager.class);
         SearchManager searchManager = appContext.getBean(SearchManager.class);
 
-        Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, ApiUtils.getUserSession(session));
+        Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, ApiUtils.getUserSession(session));
 
         final MetadataRepository metadataRepository = appContext.getBean(MetadataRepository.class);
         SimpleMetadataProcessingReport report = new SimpleMetadataProcessingReport();

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -182,6 +182,9 @@ public class MetadataSharingApi {
         @ApiParam(value = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION,
             required = false)
         @RequestParam(required = false) String[] uuids,
+        @ApiParam(value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(required = false) String bucket,
         @ApiParam(
             value = "Privileges",
             required = true
@@ -199,7 +202,7 @@ public class MetadataSharingApi {
         MetadataProcessingReport report = new SimpleMetadataProcessingReport();
 
         try {
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, ApiUtils.getUserSession(session));
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, ApiUtils.getUserSession(session));
             report.setTotalRecords(records.size());
 
             final ApplicationContext appContext = ApplicationContextHolder.get();
@@ -329,7 +332,7 @@ public class MetadataSharingApi {
 
     @ApiOperation(
         value = "Get record sharing settings",
-        notes = "Return currnt sharing options for a record.",
+        notes = "Return current sharing options for a record.",
         nickname = "getRecordSharingSettings")
     @RequestMapping(
         value = "/{metadataUuid}/sharing",
@@ -573,6 +576,13 @@ public class MetadataSharingApi {
         )
             Integer groupIdentifier,
         @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+        String bucket,
+        @ApiParam(
             value = "User identifier",
             required = true
         )
@@ -589,7 +599,7 @@ public class MetadataSharingApi {
         MetadataProcessingReport report = new SimpleMetadataProcessingReport();
 
         try {
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, ApiUtils.getUserSession(session));
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, ApiUtils.getUserSession(session));
             report.setTotalRecords(records.size());
 
             final ApplicationContext context = ApplicationContextHolder.get();

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -40,7 +40,6 @@ import org.fao.geonet.repository.MetadataRepository;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -244,6 +243,13 @@ public class MetadataTagApi {
             required = false)
         @RequestParam(required = false) String[] uuids,
         @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
+        @ApiParam(
             value = API_PARAM_TAG_IDENTIFIER,
             required = true
         )
@@ -265,7 +271,7 @@ public class MetadataTagApi {
         MetadataProcessingReport report = new SimpleMetadataProcessingReport();
 
         try {
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, ApiUtils.getUserSession(session));
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, ApiUtils.getUserSession(session));
             report.setTotalRecords(records.size());
 
             final ApplicationContext context = ApplicationContextHolder.get();
@@ -339,6 +345,13 @@ public class MetadataTagApi {
             required = false)
         @RequestParam(required = false) String[] uuids,
         @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
+        @ApiParam(
             value = API_PARAM_TAG_IDENTIFIER
         )
         @RequestParam
@@ -350,7 +363,7 @@ public class MetadataTagApi {
         MetadataProcessingReport report = new SimpleMetadataProcessingReport();
 
         try {
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, ApiUtils.getUserSession(session));
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, ApiUtils.getUserSession(session));
             report.setTotalRecords(records.size());
 
             final ApplicationContext context = ApplicationContextHolder.get();

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataVersionningApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataVersionningApi.java
@@ -26,26 +26,18 @@ package org.fao.geonet.api.records;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import jeeves.constants.Jeeves;
 import jeeves.services.ReadWriteController;
 import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.GeonetContext;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
-import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.processing.report.MetadataProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
-import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.repository.MetadataCategoryRepository;
 import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.services.Utils;
-import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
@@ -59,8 +51,6 @@ import springfox.documentation.annotations.ApiIgnore;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
@@ -133,6 +123,13 @@ public class MetadataVersionningApi {
             value = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION,
             required = false)
         @RequestParam(required = false) String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
         HttpServletRequest request,
         @ApiIgnore
             HttpSession session
@@ -140,7 +137,7 @@ public class MetadataVersionningApi {
         MetadataProcessingReport report = new SimpleMetadataProcessingReport();
 
         try {
-            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, ApiUtils.getUserSession(session));
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, ApiUtils.getUserSession(session));
             report.setTotalRecords(records.size());
 
             final ApplicationContext context = ApplicationContextHolder.get();

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
@@ -57,7 +57,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
-import io.swagger.annotations.AuthorizationScope;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 
@@ -120,6 +119,13 @@ public class DirectoryApi {
             example = "")
         @RequestParam(required = false)
             String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
         @ApiParam(value = APIPARAM_XPATH,
             required = true,
             example = ".//gmd:CI_ResponsibleParty")
@@ -131,7 +137,7 @@ public class DirectoryApi {
         @RequestParam(required = false)
             String identifierXpath
     ) throws Exception {
-        return collectEntries(uuids, xpath, identifierXpath, false, null);
+        return collectEntries(uuids, bucket, xpath, identifierXpath, false, null);
     }
 
 
@@ -153,6 +159,13 @@ public class DirectoryApi {
             example = "")
         @RequestParam(required = false)
             String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
         @ApiParam(value = APIPARAM_XPATH,
             required = true,
             example = ".//gmd:CI_ResponsibleParty")
@@ -167,12 +180,13 @@ public class DirectoryApi {
         // TODO: Add an option to set groupOwner ?
         // TODO: Add an option to set privileges ?
     ) throws Exception {
-        return collectEntries(uuids, xpath, identifierXpath, true, null);
+        return collectEntries(uuids, bucket, xpath, identifierXpath, true, null);
     }
 
 
     private ResponseEntity<Object> collectEntries(
         String[] uuids,
+        String bucket,
         String xpath,
         String identifierXpath,
         boolean save, String directoryFilterQuery) throws Exception {
@@ -180,7 +194,7 @@ public class DirectoryApi {
         UserSession session = context.getUserSession();
 
         // Check which records to analyse
-        final Set<String> setOfUuidsToEdit = ApiUtils.getUuidsParameterOrSelection(uuids, session);
+        final Set<String> setOfUuidsToEdit = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, session);
 
         DataManager dataMan = context.getBean(DataManager.class);
         AccessManager accessMan = context.getBean(AccessManager.class);
@@ -261,6 +275,13 @@ public class DirectoryApi {
             example = "")
         @RequestParam(required = false)
             String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
         @ApiParam(value = APIPARAM_XPATH,
             required = true,
             example = ".//gmd:CI_ResponsibleParty")
@@ -287,7 +308,7 @@ public class DirectoryApi {
         @RequestParam(required = false)
             String fq
     ) throws Exception {
-        return updateRecordEntries(uuids, xpath, identifierXpath, propertiesToCopy, substituteAsXLink, false, fq);
+        return updateRecordEntries(uuids, bucket, xpath, identifierXpath, propertiesToCopy, substituteAsXLink, false, fq);
     }
 
 
@@ -307,6 +328,13 @@ public class DirectoryApi {
             example = "")
         @RequestParam(required = false)
             String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
         @ApiParam(value = APIPARAM_XPATH,
             required = true,
             example = ".//gmd:CI_ResponsibleParty")
@@ -332,12 +360,13 @@ public class DirectoryApi {
         @RequestParam(required = false)
             String fq
     ) throws Exception {
-        return updateRecordEntries(uuids, xpath, identifierXpath, propertiesToCopy, substituteAsXLink, true, fq);
+        return updateRecordEntries(uuids, bucket, xpath, identifierXpath, propertiesToCopy, substituteAsXLink, true, fq);
     }
 
 
     private ResponseEntity<Object> updateRecordEntries(
         String[] uuids,
+        String bucket,
         String xpath,
         String identifierXpath,
         List<String> propertiesToCopy,
@@ -348,7 +377,7 @@ public class DirectoryApi {
         Profile profile = session.getProfile();
 
         // Check which records to analyse
-        final Set<String> setOfUuidsToEdit = ApiUtils.getUuidsParameterOrSelection(uuids, session);
+        final Set<String> setOfUuidsToEdit = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, session);
 
         DataManager dataMan = context.getBean(DataManager.class);
         AccessManager accessMan = context.getBean(AccessManager.class);

--- a/services/src/main/java/org/fao/geonet/api/selections/SelectionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/selections/SelectionsApi.java
@@ -23,6 +23,7 @@
 package org.fao.geonet.api.selections;
 
 import org.fao.geonet.api.API;
+import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.kernel.SelectionManager;
 import org.springframework.http.HttpStatus;
@@ -145,7 +146,7 @@ public class SelectionsApi {
     public
     @ResponseBody
     ResponseEntity<Integer> clear(
-        @ApiParam(value = "Bucket name",
+        @ApiParam(value = ApiParams.API_PARAM_BUCKET_NAME,
             required = true,
             example = "metadata")
         @PathVariable

--- a/services/src/main/java/org/fao/geonet/services/main/Result.java
+++ b/services/src/main/java/org/fao/geonet/services/main/Result.java
@@ -27,17 +27,18 @@ import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
-
 import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.SelectionManager;
-import org.fao.geonet.kernel.search.LuceneSearcher;
 import org.fao.geonet.kernel.search.MetaSearcher;
 import org.jdom.Element;
 
 import java.nio.file.Path;
 
-//=============================================================================
+import static org.fao.geonet.kernel.SelectionManager.SELECTION_BUCKET;
+import static org.fao.geonet.kernel.SelectionManager.SELECTION_METADATA;
+
 
 /**
  * main.result service. shows search results
@@ -46,27 +47,18 @@ import java.nio.file.Path;
 public class Result implements Service {
     private ServiceConfig _config;
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Init
-    //---
-    //--------------------------------------------------------------------------
 
     public void init(Path appPath, ServiceConfig config) throws Exception {
         _config = config;
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Service
-    //---
-    //--------------------------------------------------------------------------
-
     public Element exec(Element params, ServiceContext context) throws Exception {
         // build result data
         UserSession session = context.getUserSession();
+        String bucket = Util.getParam(params, SELECTION_BUCKET, SELECTION_METADATA);
+        params.removeChild(SELECTION_BUCKET);
 
-        MetaSearcher searcher = (MetaSearcher) session.getProperty(Geonet.Session.SEARCH_RESULT);
+        MetaSearcher searcher = (MetaSearcher) session.getProperty(Geonet.Session.SEARCH_RESULT + bucket);
 
         String fast = _config.getValue("fast", "");
 
@@ -90,21 +82,6 @@ public class Result implements Service {
 
         // Update result elements to present
         SelectionManager.updateMDResult(context.getUserSession(), result);
-
-        // Restore last search if set
-        String restoreLastSearch = params.getChildText(Geonet.SearchResult.RESTORELASTSEARCH);
-        if (restoreLastSearch != null && restoreLastSearch.equals("yes")) {
-            Object oldSearcher = session.getProperty(Geonet.Session.LAST_SEARCH_RESULT);
-            if (oldSearcher != null) {
-                context.info("Restoring last search");
-                if (oldSearcher instanceof LuceneSearcher) ((LuceneSearcher) searcher).close();
-                session.setProperty(Geonet.Session.SEARCH_RESULT, oldSearcher);
-            }
-        }
-
         return result;
     }
 }
-
-//=============================================================================
-

--- a/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
+++ b/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
@@ -41,6 +41,9 @@ import org.jdom.Element;
 
 import java.nio.file.Path;
 
+import static org.fao.geonet.kernel.SelectionManager.SELECTION_BUCKET;
+import static org.fao.geonet.kernel.SelectionManager.SELECTION_METADATA;
+
 //=============================================================================
 
 public class XmlSearch implements Service {
@@ -70,6 +73,9 @@ public class XmlSearch implements Service {
 
         SearchManager searchMan = gc.getBean(SearchManager.class);
 
+        String bucket = Util.getParam(params, SELECTION_BUCKET, SELECTION_METADATA);
+        params.removeChild(SELECTION_BUCKET);
+
         Element elData = SearchDefaults.getDefaultSearch(context, params);
 
         // possibly close old searcher
@@ -86,7 +92,7 @@ public class XmlSearch implements Service {
                 elData.getChild(Geonet.SearchResult.BUILD_SUMMARY).setText("true");
             }
 
-            session.setProperty(Geonet.Session.SEARCH_REQUEST, elData.clone());
+            session.setProperty(Geonet.Session.SEARCH_REQUEST + bucket, elData.clone());
             searcher.search(context, elData, _config);
 
             if (!"0".equals(summaryOnly)) {
@@ -103,7 +109,7 @@ public class XmlSearch implements Service {
                 Element result = searcher.present(context, elData, _config);
 
                 // Update result elements to present
-                SelectionManager.updateMDResult(context.getUserSession(), result);
+                SelectionManager.updateMDResult(context.getUserSession(), result, bucket);
 
                 return result;
             }

--- a/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
@@ -80,6 +80,7 @@ import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasM
  *
  * @author Jesse on 1/16/2015.
  */
+@Deprecated
 @Controller("md.publish")
 public class Publish {
 

--- a/web-ui/src/main/resources/catalog/components/category/CategoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/category/CategoryDirective.js
@@ -77,8 +77,9 @@
             var defer = $q.defer();
             var params = [];
             var url = '../api/records/tags?' +
-                      (replace ? 'clear=true&id=' : 'id=');
-
+                        '&bucket=' +
+                (attrs.selectionBucket || 'metadata') + '&' +
+                        (replace ? 'clear=true&id=' : 'id=');
             angular.forEach(scope.categories, function(c) {
               if (c.checked === true) {
                 params.push(c.id);

--- a/web-ui/src/main/resources/catalog/components/common/share/ShareDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/share/ShareDirective.js
@@ -56,10 +56,11 @@
             'panel.html',
         scope: {
           id: '=gnShare',
-          batch: '@gnShareBatch'
+          batch: '@gnShareBatch',
+          selectionBucket: '@'
         },
         link: function(scope) {
-          var translations = null;
+          var translations = null, isBatch = scope.batch === 'true';
           $translate(['privilegesUpdated',
             'privilegesUpdatedError']).then(function(t) {
             translations = t;
@@ -72,7 +73,7 @@
           scope.icons = gnShareConstants.icons;
 
           angular.extend(scope, {
-            batch: scope.batch === 'true',
+            batch: isBatch,
             lang: scope.$parent.lang,
             user: scope.$parent.user,
             internalOperations: gnShareConstants.internalOperations,
@@ -147,10 +148,12 @@
                 });
               });
             }
-            return gnShareService.savePrivileges(scope.id,
-                                                 scope.privileges,
-                                                 scope.user,
-                                                 replace).then(
+            return gnShareService.savePrivileges(
+                isBatch ? undefined : scope.id,
+                isBatch ? scope.selectionBucket : undefined,
+                scope.privileges,
+                scope.user,
+                replace).then(
                 function(data) {
                   scope.$emit('PrivilegesUpdated', true);
                   scope.$emit('StatusUpdated', {

--- a/web-ui/src/main/resources/catalog/components/common/share/ShareService.js
+++ b/web-ui/src/main/resources/catalog/components/common/share/ShareService.js
@@ -169,6 +169,19 @@
           return defer.promise;
         },
 
+        publish: function(metadataId, bucket, onOrOff, user) {
+          var privileges = [{
+            group: 1,
+            operations: {
+              view: onOrOff,
+              download: onOrOff,
+              dynamic: onOrOff
+            }
+          }];
+          return this.savePrivileges(
+              metadataId, bucket, privileges, user, !onOrOff);
+        },
+
         /**
          * @ngdoc method
          * @methodOf gn_share.service:gnShareService
@@ -183,12 +196,16 @@
          *
          * @return {HttpPromise} Future object.
          */
-        savePrivileges: function(metadataId, privileges, user, replace) {
+        savePrivileges: function(
+            metadataId, bucket, privileges, user, replace) {
           var defer = $q.defer();
           var url = '../api/records' + (
               angular.isDefined(metadataId) ? '/' + metadataId : '') +
               '/sharing';
 
+          if (angular.isDefined(bucket)) {
+            url += '?bucket=' + bucket;
+          }
           var ops = [];
           angular.forEach(privileges, function(g) {
             // Do not submit internal groups info

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -41,6 +41,7 @@
     'gnAlertService',
     'gnSearchSettings',
     'gnUtilityService',
+    'gnShareService',
     'gnPopup',
     'gnMdFormatter',
     '$translate',
@@ -48,12 +49,16 @@
     '$http',
     function($rootScope, $timeout, $location, gnHttp,
              gnMetadataManager, gnAlertService, gnSearchSettings,
-             gnUtilityService, gnPopup, gnMdFormatter,
+             gnUtilityService, gnShareService, gnPopup, gnMdFormatter,
              $translate, $q, $http) {
 
       var windowName = 'geonetwork';
       var windowOption = '';
-
+      var translations = null;
+      $translate(['privilegesUpdated',
+        'privilegesUpdatedError']).then(function(t) {
+        translations = t;
+      });
       var alertResult = function(msg) {
         gnAlertService.addAlert({
           msg: msg,
@@ -108,7 +113,7 @@
        * (uuid), we print only one metadata.
        * @param {Object|string} params
        */
-      this.metadataPrint = function(params) {
+      this.metadataPrint = function(params, bucket) {
         var url;
         if (angular.isObject(params) && params.sortBy) {
           url = gnHttp.getService('mdGetPDFSelection');
@@ -116,6 +121,7 @@
           if (params.sortOrder) {
             url += '&sortOrder=' + params.sortOrder;
           }
+          url += '&bucket=' + bucket;
           location.replace(url);
         }
         else if (angular.isString(params)) {
@@ -143,29 +149,31 @@
        * one metadata, else export the whole selection.
        * @param {string} uuid
        */
-      this.metadataMEF = function(uuid) {
+      this.metadataMEF = function(uuid, bucket) {
         var url = gnHttp.getService('mdGetMEF') + '?version=2';
         url += angular.isDefined(uuid) ?
             '&uuid=' + uuid : '&format=full';
+        url += angular.isDefined(bucket) ?
+            '&bucket=' + bucket : '';
 
         location.replace(url);
       };
 
-      this.exportCSV = function() {
-        window.open(gnHttp.getService('csv'), windowName, windowOption);
+      this.exportCSV = function(bucket) {
+        window.open(gnHttp.getService('csv') +
+            '?bucket=' + bucket, windowName, windowOption);
       };
-      this.validateMd = function(md) {
+      this.validateMd = function(md, bucket) {
         if (md) {
           return gnMetadataManager.validate(md.getId()).then(function() {
             $rootScope.$broadcast('mdSelectNone');
             $rootScope.$broadcast('search');
           });
-        }
-        else {
-          return gnHttp.callService('../api/records/validate', null,
-                                    {
-                                      method: 'PUT'
-                                    }).then(function(data) {
+        } else {
+          return gnHttp.callService('../api/records/validate?' +
+              'bucket=' + bucket, null, {
+                    method: 'PUT'
+                  }).then(function(data) {
             alertResult(data.data);
             $rootScope.$broadcast('mdSelectNone');
             $rootScope.$broadcast('search');
@@ -173,7 +181,7 @@
         }
       };
 
-      this.deleteMd = function(md) {
+      this.deleteMd = function(md, bucket) {
         if (md) {
           return gnMetadataManager.remove(md.getId()).then(function() {
             $rootScope.$broadcast('mdSelectNone');
@@ -184,12 +192,14 @@
           });
         }
         else {
-          return $http.delete('../api/records').then(function() {
+          return $http.delete('../api/records?' +
+              'bucket=' + bucket).then(function() {
             $rootScope.$broadcast('mdSelectNone');
             $rootScope.$broadcast('search');
           });
         }
       };
+
 
       this.openPrivilegesPanel = function(md, scope) {
         openModal({
@@ -226,23 +236,26 @@
             });
       };
 
-      this.openPrivilegesBatchPanel = function(scope) {
+      this.openPrivilegesBatchPanel = function(scope, bucket) {
         openModal({
           title: 'privileges',
-          content: '<div gn-share="" gn-share-batch="true"></div>'
+          content: '<div gn-share="" ' +
+              'gn-share-batch="true" ' +
+              'selection-bucket="' + bucket + '"></div>'
         }, scope, 'PrivilegesUpdated');
       };
       this.openBatchEditing = function(scope) {
         $location.path('/batchediting');
       };
-      this.openCategoriesBatchPanel = function(scope) {
+      this.openCategoriesBatchPanel = function(bucket, scope) {
         openModal({
           title: 'categories',
-          content: '<div gn-batch-categories=""></div>'
+          content: '<div gn-batch-categories="" ' +
+              'selection-bucket="' + bucket + '"></div>'
         }, scope, 'CategoriesUpdated');
       };
 
-      this.openTransferOwnership = function(md, scope) {
+      this.openTransferOwnership = function(md, bucket, scope) {
         var uuid = md ? md.getUuid() : '';
         var ownerId = md ? md.getOwnerId() : '';
         var groupOwner = md ? md.getGroupOwner() : '';
@@ -250,7 +263,8 @@
           title: 'transferOwnership',
           content: '<div gn-transfer-ownership="' + uuid +
               '" gn-transfer-md-owner="' + ownerId + '" ' +
-              '" gn-transfer-md-group-owner="' + groupOwner + '"></div>'
+              '" gn-transfer-md-group-owner="' + groupOwner + '" ' +
+              'selection-bucket="' + bucket + '"></div>'
         }, scope, 'TransferOwnership');
       };
       /**
@@ -278,56 +292,36 @@
        * @param {string} flag
        * @return {*}
        */
-      this.publish = function(md, flag) {
+      this.publish = function(md, bucket, flag, scope) {
 
         if (md) {
           flag = md.isPublished() ? 'off' : 'on';
         }
-        var service = flag === 'on' ? 'publish' : 'unpublish';
+        var onOrOff = flag === 'on';
 
-        var publishNotification = function(data) {
-          var message = '<h4>' + $translate.instant(service + 'Completed') +
-              '</h4><dl class="dl-horizontal"><dt>' +
-              $translate.instant('mdPublished') + '</dt><dd>' +
-              data.data.published + '</dd><dt>' +
-              $translate.instant('mdUnpublished') + '</dt><dd>' +
-              data.data.unpublished + '</dd><dt>' +
-              $translate.instant('mdUnmodified') + '</dt><dd>' +
-              data.data.unmodified + '</dd><dt>' +
-              $translate.instant('mdDisallowed') + '</dt><dd>' +
-              data.data.disallowed + '</dd><dt>' +
-              $translate.instant('mdNovalid') + '<dd>' +
-              data.data.novalid + '</dd>' +
-              '</dt></dl>';
-
-          var success = 'success';
-          if (md) {
-            if ((flag === 'on' && data.data.published === 0) ||
-                (flag !== 'on' && data.data.unpublished === 0)) {
-              if (data.data.unmodified > 0) {
-                message = $translate.instant('metadataUnchanged');
-              } else if (data.data.disallowed > 0) {
-                message = $translate.instant('accessRestricted');
+        return gnShareService.publish(
+            angular.isDefined(md) ? md.getId() : undefined,
+            angular.isDefined(md) ? undefined : bucket,
+            onOrOff, $rootScope.user)
+            .then(
+            function(data) {
+              scope.$emit('PrivilegesUpdated', true);
+              scope.$emit('StatusUpdated', {
+                msg: translations.privilegesUpdated,
+                timeout: 0,
+                type: 'success'});
+              if (md) {
+                md.publish();
               }
-              success = 'danger';
-            }
-          }
-          gnAlertService.addAlert({
-            msg: message,
-            type: success
-          });
+            }, function(data) {
+              scope.$emit('PrivilegesUpdated', false);
+              scope.$emit('StatusUpdated', {
+                title: translations.privilegesUpdatedError,
+                error: data,
+                timeout: 0,
+                type: 'danger'});
+            });
 
-          if (md && success === 'success') {
-            md.publish();
-          }
-        };
-        if (angular.isDefined(md)) {
-          return gnHttp.callService(service, {
-            ids: md.getId()
-          }).then(publishNotification);
-        } else {
-          return gnHttp.callService(service, {}).then(publishNotification);
-        }
       };
 
       this.assignGroup = function(metadataId, groupId) {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -296,7 +296,8 @@
         link: function(scope, element, attrs) {
           var ownerId = parseInt(attrs['gnTransferMdOwner']);
           var groupOwner = parseInt(attrs['gnTransferMdGroupOwner']);
-          var mdUuid = attrs['gnTransferOwnership'];
+          var bucket = attrs['gnTransferMdGroupOwner'];
+          var mdUuid = attrs['selectionBucket'];
           scope.selectedUserGroup = null;
 
           scope.selectUser = function(user) {

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -30,38 +30,40 @@
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">
-      <li><a href="" ng-click="mdService.metadataMEF()">
+      <li><a href="" ng-click="mdService.metadataMEF(undefined, searchResults.selectionBucket)">
         <i class="fa fa-file-zip-o"></i>&nbsp;<span translate>exportMEF</span></a></li>
-      <li><a href="" ng-click="mdService.metadataPrint(searchObj.params)">
+      <li><a href="" ng-click="mdService.metadataPrint(searchObj.params, searchResults.selectionBucket)">
         <i class="fa fa-file-pdf-o"></i>&nbsp;<span translate>exportPDF</span></a></li>
-      <li><a href="" ng-click="mdService.exportCSV()">
+      <li><a href="" ng-click="mdService.exportCSV(searchResults.selectionBucket)">
         <i class="fa fa-file-excel-o"></i>&nbsp;<span translate>exportCSV</span></a></li>
+      <li><a href="" ng-click="viewSelectionOnly()">
+        <i class="fa fa-check"></i>&nbsp;<span translate>viewSelectionOnly</span></a></li>
       <li class="divider" data-ng-if="user.isConnected()"></li>
       <li ng-if="user.isEditorOrMore()">
-        <a href="" ng-click="mdService.openPrivilegesBatchPanel(getCatScope())">
+        <a href="" ng-click="mdService.openPrivilegesBatchPanel(getCatScope(), searchResults.selectionBucket)">
         <i class="fa fa-key"></i>&nbsp;<span translate>updatePrivileges</span></a></li>
       <li ng-if="v.service === 'catalog.edit' && user.isEditorOrMore()">
         <a href="" ng-click="mdService.openBatchEditing(getCatScope())">
           <i class="fa fa-pencil"></i>&nbsp;<span translate>editRecords</span></a></li>
       <li ng-if="user.isReviewerOrMore()" class="disabgit led">
-        <a ng-click="mdService.publish(undefined, 'on')">
+        <a ng-click="mdService.publish(undefined, searchResults.selectionBucket, 'on', getCatScope())">
           <i class="fa fa-unlock"></i>&nbsp;<span translate>publish</span></a></li>
       <li ng-if="user.isReviewerOrMore()" class="disabgit led">
-        <a ng-click="mdService.publish(undefined, 'off')">
+        <a ng-click="mdService.publish(undefined, searchResults.selectionBucket, 'off', getCatScope())">
           <i class="fa fa-lock"></i>&nbsp;<span translate>unpublish</span></a></li>
       <li ng-if="user.isUserAdminOrMore()">
-        <a href="" data-ng-click="mdService.openTransferOwnership(md, getCatScope())">
+        <a href="" data-ng-click="mdService.openTransferOwnership(undefined, searchResults.selectionBucket, getCatScope())">
           <i class="fa fa-user"></i>&nbsp;<span translate>transferOwnership</span></a></li>
       <li class="divider" data-ng-if="user.isConnected()"></li>
       <li ng-if="user.isEditorOrMore()">
-        <a href="" ng-click="mdService.openCategoriesBatchPanel(getCatScope())">
+        <a href="" ng-click="mdService.openCategoriesBatchPanel(searchResults.selectionBucket, getCatScope())">
           <i class="fa fa-tags"></i>&nbsp;<span translate>updateCategories</span></a></li>
       <li ng-if="user.isEditorOrMore()">
-        <a href="" ng-click="mdService.validateMd()"
+        <a href="" ng-click="mdService.validateMd(undefined, searchResults.selectionBucket)"
            data-gn-confirm-click="{{'validateSelectedRecordConfirm' | translate:searchResults}}">
           <i class="fa fa-check"></i>&nbsp;<span translate>validate</span></a></li>
       <li ng-if="user.isEditorOrMore()">
-        <a href="" ng-click="mdService.deleteMd()"
+        <a href="" ng-click="mdService.deleteMd(undefined, searchResults.selectionBucket)"
            data-gn-confirm-click="{{'deleteSelectedRecordConfirm' | translate:searchResults}}">
           <i class="fa fa-times"></i>&nbsp;<span translate>delete</span></a></li>
 

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -62,10 +62,13 @@
     /** State of the facets of the current search */
     $scope.currentFacets = [];
 
-    /** Object were are stored result search information */
+    /** Object where are stored result search information */
     $scope.searchResults = {
       records: [],
-      count: -1
+      count: -1,
+      selectionBucket:
+          $scope.searchObj.selectionBucket ||
+          (Math.random() + '').replace('.', '')
     };
 
     $scope.searching = 0;
@@ -145,6 +148,8 @@
         angular.extend(params,
             gnFacetService.getParamsFromFacets($scope.currentFacets));
       }
+
+      params.bucket = $scope.searchResults.selectionBucket || 'metadata';
 
       var finalParams = angular.extend(params, hiddenParams);
       gnSearchManagerService.gnSearch(finalParams).then(

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
@@ -155,6 +155,7 @@
                 filter += '&' + key + '=' + value;
               });
           search('q?_content_type=json&fast=index' +
+              '&bucket=' + scope.searchResults.selectionBucket +
               filter +
               '&from=' + (pageOptions.currentPage *
               pageOptions.hitsPerPage + 1) +
@@ -237,28 +238,29 @@
             });
         return defer.promise;
       };
-      var selected = function() {
-        return $http.get('../api/selections/metadata');
+      var selected = function(bucket) {
+        return $http.get('../api/selections/' + (bucket || 'metadata'));
       };
-      var select = function(uuid) {
-        return $http.put('../api/selections/metadata', null, {
+      var select = function(uuid, bucket) {
+        return $http.put('../api/selections/' + (bucket || 'metadata'), null, {
           params: {
             uuid: uuid
           }
         });
       };
-      var unselect = function(uuid) {
-        return $http.delete('../api/selections/metadata', {
-          params: {
-            uuid: uuid
-          }
-        });
+      var unselect = function(uuid, bucket) {
+        return $http.delete('../api/selections/' + (bucket || 'metadata'),
+            {
+              params: {
+                uuid: uuid
+              }
+            });
       };
-      var selectAll = function() {
-        return $http.put('../api/selections/metadata');
+      var selectAll = function(bucket) {
+        return $http.put('../api/selections/' + (bucket || 'metadata'));
       };
-      var selectNone = function() {
-        return $http.delete('../api/selections/metadata');
+      var selectNone = function(bucket) {
+        return $http.delete('../api/selections/' + (bucket || 'metadata'));
       };
 
       return {

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchResultsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchResultsDirective.js
@@ -41,9 +41,14 @@
           searchResults: '=',
           paginationInfo: '=paginationInfo',
           selection: '=selectRecords',
+          selectionBucket: '@',
           onMdClick: '='
         },
         link: function(scope, element, attrs) {
+
+          if (angular.isUndefined(scope.selectionBucket)) {
+            scope.selectionBucket = (Math.random() + '').replace('.', '');
+          }
 
           // get init options
           scope.options = {};
@@ -97,11 +102,13 @@
                 if (scope.options.selection.mode.indexOf('multiple') >= 0) {
                   if (md['geonet:info'].selected === false) {
                     md['geonet:info'].selected = true;
-                    gnSearchManagerService.select(md['geonet:info'].uuid)
+                    gnSearchManagerService.select(
+                        md['geonet:info'].uuid, scope.selectionBucket)
                         .then(updateSelectionNumber);
                   } else {
                     md['geonet:info'].selected = false;
-                    gnSearchManagerService.unselect(md['geonet:info'].uuid)
+                    gnSearchManagerService.unselect(
+                        md['geonet:info'].uuid, scope.selectionBucket)
                         .then(updateSelectionNumber);
                   }
                 }
@@ -128,9 +135,11 @@
               md['geonet:info'].selected = all;
             });
             if (all) {
-              gnSearchManagerService.selectAll().then(updateSelectionNumber);
+              gnSearchManagerService.selectAll(
+                  scope.selectionBucket).then(updateSelectionNumber);
             } else {
-              gnSearchManagerService.selectNone().then(updateSelectionNumber);
+              gnSearchManagerService.selectNone(
+                  scope.selectionBucket).then(updateSelectionNumber);
             }
           };
 

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -123,7 +123,8 @@
       // Lang names to be displayed in language selector
       $scope.langLabels = {'eng': 'English', 'dut': 'Nederlands',
         'fre': 'Français', 'ger': 'Deutsch', 'kor': '한국의',
-        'spa': 'Español', 'cat': 'Català', 'cze': 'Czech', 'fin': 'Suomeksi', 'fin': 'Suomeksi', 'ice': 'Íslenska'};
+        'spa': 'Español', 'cat': 'Català', 'cze': 'Czech',
+        'fin': 'Suomeksi', 'fin': 'Suomeksi', 'ice': 'Íslenska'};
       $scope.url = '';
       $scope.base = '../../catalog/';
       $scope.proxyUrl = gnGlobalSettings.proxyUrl;

--- a/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
@@ -40,6 +40,7 @@
         permalink: false,
         sortbyValues: gnSearchSettings.sortbyValues,
         hitsperpageValues: gnSearchSettings.hitsperpageValues,
+        selectionBucket: 'b101',
         params: {
           sortBy: 'changeDate',
           _isTemplate: 'y or n',

--- a/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
@@ -36,6 +36,7 @@
         permalink: false,
         sortbyValues: gnSearchSettings.sortbyValues,
         hitsperpageValues: gnSearchSettings.hitsperpageValues,
+        selectionBucket: 'be101',
         params: {
           sortBy: 'changeDate',
           _isTemplate: 'y or n',

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -59,14 +59,16 @@
       $scope.activeType = null;
       $scope.activeEntry = null;
       $scope.ownerGroup = null;
-      $scope.searchObj = {params: {
-        _isTemplate: 's',
-        any: '*',
-        _root: '',
-        sortBy: 'title',
-        sortOrder: 'reverse',
-        resultType: 'subtemplates'
-      }};
+      $scope.searchObj = {
+        selectionBucket: 'd101',
+        params: {
+          _isTemplate: 's',
+          any: '*',
+          _root: '',
+          sortBy: 'title',
+          sortOrder: 'reverse',
+          resultType: 'subtemplates'
+        }};
       $scope.paginationInfo = {
         pages: -1,
         currentPage: 1,

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -51,6 +51,7 @@
         permalink: false,
         sortbyValues: gnSearchSettings.sortbyValues,
         hitsperpageValues: gnSearchSettings.hitsperpageValues,
+        selectionBucket: 'e101',
         params: {
           sortBy: 'changeDate',
           _isTemplate: 'y or n or s',

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -34,6 +34,7 @@
     "previousPage": "Previous page",
     "nextPage": "Next page",
     "topConcepts": "Top Concept(s)",
+    "viewSelectionOnly": "Selection only",
     "add": "Add",
     "address": "Address",
     "gnToggle": "Show/hide sections",

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -31,7 +31,7 @@
                     (!md.hasValidation() ? 'mdnovalidation':
                       (allowPublishInvalidMd() === false ? 'mdinvalidcantpublish' : 'mdinvalid'))) : '') | translate }}"
       >
-        <a data-ng-click="mdService.publish(md)">
+        <a data-ng-click="mdService.publish(md, undefined, undefined, getCatScope())">
           <i class="fa"
              data-ng-class="md.isPublished() ? 'fa-lock' : 'fa-unlock'"></i>&nbsp;
           <span data-ng-if="md.isPublished()"

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -286,6 +286,7 @@
         advancedMode: false,
         from: 1,
         to: 30,
+        selectionBucket: 's101',
         viewerMap: viewerMap,
         searchMap: searchMap,
         mapfieldOption: {


### PR DESCRIPTION
Selection used to be using one session property Geonet.Session.SEARCH_RESULT
used by all services. This change introduces an extra parameter ```bucket```
which can be used to create multiple selections in the same app. eg. the
selection made in the main search page does not interact with the batch process
selection.

On the client side, all JS apps using selection defines a unique bucket name
to not interact with each others. If not set, a unique bucket identifier is set.


This PR also add search "selection only" option

![image](https://cloud.githubusercontent.com/assets/1701393/21483995/b26cbd98-cb8b-11e6-9192-068eb8ef9a8f.png)
