### PR TITLE
Retry the request as POST when HEAD fails in getUrlStatus

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -457,7 +457,8 @@ public final class XslUtil {
             });
             //response = requestFactory.execute(head);
             if (response.getRawStatusCode() == HttpStatus.SC_BAD_REQUEST
-                || response.getRawStatusCode() == HttpStatus.SC_METHOD_NOT_ALLOWED) {
+                || response.getRawStatusCode() == HttpStatus.SC_METHOD_NOT_ALLOWED
+                || response.getRawStatusCode() == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
                 // the website doesn't support HEAD requests. Need to do a GET...
                 response.close();
                 HttpGet get = new HttpGet(url);


### PR DESCRIPTION
Some servers return a 500 error (incorrectly) when they don't support the HEAD method used to test if a metadata linked resource exists so this commit add this error code to the ones that launch a new GET
request if HEAD is not supported.

This change can be applied to 3.0.x branch too.