### PR TITLE
CSW / Adding some checks on startPosition and nextRecord

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecords.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecords.java
@@ -204,6 +204,8 @@ public class GetRecords extends AbstractOperation implements CatalogService {
             }
         }
 
+
+        // "Constraint Optional" & "Must be specified with QUERYCONSTRAINT parameter"
         Element constr = query.getChild("Constraint", Csw.NAMESPACE_CSW);
         Element filterExpr = getFilterExpression(constr);
         String filterVersion = getFilterVersion(constr);


### PR DESCRIPTION
## If requesting a page beyond the set of records:

```
<?xml version="1.0"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                xmlns:gmd="http://www.isotc211.org/2005/gmd"
                service="CSW" version="2.0.2" startPosition="199"
                resultType="results">
  <csw:Query typeNames="gmd:MD_Metadata">
    <csw:Constraint version="1.1.0">
      <Filter xmlns="http://www.opengis.net/ogc"/>
    </csw:Constraint>
  </csw:Query>
</csw:GetRecords>
```

Return an exception saying that startPosition <= matching records:
```
<?xml version="1.0" encoding="UTF-8"?>
<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2.0" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd">
  <ows:Exception exceptionCode="InvalidParameterValue" locator="startPosition">
    <ows:ExceptionText>Start position (199) can't be greater than number of matching records (6 for current search).</ows:ExceptionText>
  </ows:Exception>
</ows:ExceptionReport>

```

instead of
```
  <csw:SearchResults numberOfRecordsMatched="6" numberOfRecordsReturned="0" elementSet="summary" nextRecord="199" />
```

## If startPosition = number of match record return nextRecords = 0.

```
<?xml version="1.0"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                xmlns:gmd="http://www.isotc211.org/2005/gmd"
                service="CSW" version="2.0.2" startPosition="6"
                resultType="results">
  <csw:Query typeNames="gmd:MD_Metadata">
    <csw:Constraint version="1.1.0">
      <Filter xmlns="http://www.opengis.net/ogc"/>
    </csw:Constraint>
  </csw:Query>
</csw:GetRecords>

```
Now it returns:
```
  <csw:SearchResults numberOfRecordsMatched="6" numberOfRecordsReturned="1" elementSet="summary" nextRecord="0">
```
instead of
```
  <csw:SearchResults numberOfRecordsMatched="6" numberOfRecordsReturned="1" elementSet="summary" nextRecord="7">
```

## If outputSchema requested is not supported by matching records


return a comment informing about that in the response.
```
<?xml version="1.0"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                service="CSW" version="2.0.2"
                resultType="results"
                outputSchema="http://www.isotc211.org/2005/gfc">
  <csw:Query typeNames="gfc:FC_FeatureCatalogue">
  </csw:Query>
</csw:GetRecords>
```

Returns
```
<?xml version="1.0" encoding="UTF-8"?>
<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
  <csw:SearchStatus timestamp="2017-01-26T19:28:30" />
  <csw:SearchResults numberOfRecordsMatched="6" numberOfRecordsReturned="6" elementSet="summary" nextRecord="0">
    <!--OutputSchema 'gfc' not supported for metadata with '141' (dublin-core).
Corresponding XSL transformation 'gfc-summary.xsl' does not exist for this schema.
The record will not be returned in response.-->
    <!--OutputSchema 'gfc' not supported for metadata with '131' (iso19139).
Corresponding XSL transformation 'gfc-summary.xsl' does not exist for this schema.
The record will not be returned in response.-->
```
instead of:

```
<?xml version="1.0" encoding="UTF-8"?>
<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
  <csw:SearchStatus timestamp="2017-01-27T13:22:21" />
  <csw:SearchResults numberOfRecordsMatched="6" numberOfRecordsReturned="0" elementSet="summary" nextRecord="1" />
</csw:GetRecordsResponse>

```
where nextRecord is wrong. Currently nextRecord depends on the schema of records in the page. In this case 1 because there is one ISO19110 record.

If records not transformed by outputSchema, take it into account
into counter in order to return proper nextRecord info:

```
<?xml version="1.0"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                service="CSW" version="2.0.2"
                resultType="results"
startPosition="4"
maxRecords="1"
                outputSchema="http://www.isotc211.org/2005/gfc">
  <csw:Query typeNames="gfc:FC_FeatureCatalogue">
  </csw:Query>
</csw:GetRecords>
```
used to return
```
  <csw:SearchResults numberOfRecordsMatched="6" numberOfRecordsReturned="0" elementSet="summary" nextRecord="4" />
```

and now returns
```
  <csw:SearchResults numberOfRecordsMatched="6" numberOfRecordsReturned="1" elementSet="summary" nextRecord="5">
```

An harvester using nextRecord in such situation will currently loop forever.