### PR TITLE
#1849: Enable INSPIRE view in config-editor.xml according to settings

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -370,8 +370,8 @@
 
   <!-- View configuration -->
   <views>
-    <!--Turn off INSPIRE view by default -->
-    <view name="inspire" upAndDownControlHidden="true" disabled="true">
+    <!--Turn on INSPIRE according to system settings -->
+    <view name="inspire" upAndDownControlHidden="true" displayIfServiceInfo="/settings/system/inspire/enable='true'">
       <tab id="inspire" default="true" mode="flat">
         <section name="resource">
           <field


### PR DESCRIPTION
Instead of creating a new variable on the /root/gui/setting/system subtree as suggested in #1849, let's just use the existing serviceInfo.