### PR TITLE
Remove usage of ServiceContext.get() in api methods

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
@@ -29,6 +29,7 @@ import io.swagger.annotations.*;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
+import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.kernel.DataManager;
@@ -44,6 +45,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import java.nio.file.Path;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 
 import jeeves.server.context.ServiceContext;
 
@@ -110,10 +112,11 @@ public class AttachmentsActionsApi {
         @RequestParam()
             String jsonConfig,
         @ApiParam(value = "The rotation angle of the map")
-        @RequestParam(required = false, defaultValue = "0") int rotationAngle
+        @RequestParam(required = false, defaultValue = "0") int rotationAngle,
+        HttpServletRequest request
     )
         throws Exception {
-        ServiceContext context = ServiceContext.get();
+        ServiceContext context = ApiUtils.createServiceContext(request);
         DataManager dataMan = appContext.getBean(DataManager.class);
 
         String metadataId = dataMan.getMetadataId(metadataUuid);

--- a/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
@@ -28,6 +28,7 @@ import io.swagger.annotations.*;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
+import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.processing.report.IProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.api.records.model.BatchEditParameter;
@@ -61,6 +62,8 @@ import java.util.Set;
 
 import jeeves.server.context.ServiceContext;
 import jeeves.services.ReadWriteController;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RequestMapping(value = {
     "/api/records",
@@ -105,7 +108,8 @@ public class BatchEditsApi implements ApplicationContextAware {
             required = false,
             example = "iso19139")
         @RequestParam(required = false) String[] uuids,
-        @RequestBody BatchEditParameter[] edits)
+        @RequestBody BatchEditParameter[] edits,
+        HttpServletRequest request)
         throws Exception {
 
         List<BatchEditParameter> listOfUpdates = Arrays.asList(edits);
@@ -114,7 +118,7 @@ public class BatchEditsApi implements ApplicationContextAware {
         }
 
 
-        ServiceContext serviceContext = ServiceContext.get();
+        ServiceContext serviceContext = ApiUtils.createServiceContext(request);
         final Set<String> setOfUuidsToEdit;
         if (uuids == null) {
             SelectionManager selectionManager =

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
@@ -60,6 +60,8 @@ import io.swagger.annotations.Authorization;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 
+import javax.servlet.http.HttpServletRequest;
+
 @EnableWebMvc
 @Service
 @RequestMapping(value = {
@@ -135,9 +137,12 @@ public class DirectoryApi {
             required = false,
             example = "@uuid")
         @RequestParam(required = false)
-            String identifierXpath
+            String identifierXpath,
+        HttpServletRequest request
     ) throws Exception {
-        return collectEntries(uuids, bucket, xpath, identifierXpath, false, null);
+        ServiceContext context = ApiUtils.createServiceContext(request);
+
+        return collectEntries(context, uuids, bucket, xpath, identifierXpath, false, null);
     }
 
 
@@ -175,22 +180,26 @@ public class DirectoryApi {
             required = false,
             example = "@uuid")
         @RequestParam(required = false)
-            String identifierXpath
+            String identifierXpath,
+        HttpServletRequest request
         // TODO: Add an option to set categories ?
         // TODO: Add an option to set groupOwner ?
         // TODO: Add an option to set privileges ?
     ) throws Exception {
-        return collectEntries(uuids, bucket, xpath, identifierXpath, true, null);
+        ServiceContext context = ApiUtils.createServiceContext(request);
+
+        return collectEntries(context, uuids, bucket, xpath, identifierXpath, true, null);
     }
 
 
     private ResponseEntity<Object> collectEntries(
+        ServiceContext context,
         String[] uuids,
         String bucket,
         String xpath,
         String identifierXpath,
         boolean save, String directoryFilterQuery) throws Exception {
-        ServiceContext context = ServiceContext.get();
+
         UserSession session = context.getUserSession();
 
         // Check which records to analyse
@@ -217,10 +226,11 @@ public class DirectoryApi {
                 // Processing
                 try {
                     CollectResults collectResults =
-                        DirectoryUtils.collectEntries(
+                        DirectoryUtils.collectEntries(context,
                             record, xpath, identifierXpath);
                     if (save) {
                         DirectoryUtils.saveEntries(
+                            context,
                             collectResults,
                             siteId, user,
                             1, // TODO: Define group or take a default one
@@ -306,9 +316,12 @@ public class DirectoryApi {
             required = false,
             example = "groupPublished:IFREMER")
         @RequestParam(required = false)
-            String fq
+            String fq,
+        HttpServletRequest request
     ) throws Exception {
-        return updateRecordEntries(uuids, bucket, xpath, identifierXpath, propertiesToCopy, substituteAsXLink, false, fq);
+        ServiceContext context = ApiUtils.createServiceContext(request);
+
+        return updateRecordEntries(context, uuids, bucket, xpath, identifierXpath, propertiesToCopy, substituteAsXLink, false, fq);
     }
 
 
@@ -358,13 +371,17 @@ public class DirectoryApi {
             required = false,
             example = "groupPublished:IFREMER")
         @RequestParam(required = false)
-            String fq
+            String fq,
+        HttpServletRequest request
     ) throws Exception {
-        return updateRecordEntries(uuids, bucket, xpath, identifierXpath, propertiesToCopy, substituteAsXLink, true, fq);
+        ServiceContext context = ApiUtils.createServiceContext(request);
+
+        return updateRecordEntries(context, uuids, bucket, xpath, identifierXpath, propertiesToCopy, substituteAsXLink, true, fq);
     }
 
 
     private ResponseEntity<Object> updateRecordEntries(
+        ServiceContext context,
         String[] uuids,
         String bucket,
         String xpath,
@@ -372,7 +389,7 @@ public class DirectoryApi {
         List<String> propertiesToCopy,
         boolean substituteAsXLink,
         boolean save, String directoryFilterQuery) throws Exception {
-        ServiceContext context = ServiceContext.get();
+
         UserSession session = context.getUserSession();
         Profile profile = session.getProfile();
 
@@ -401,6 +418,7 @@ public class DirectoryApi {
                 try {
                     CollectResults collectResults =
                         DirectoryUtils.synchronizeEntries(
+                            context,
                             record, xpath, identifierXpath,
                             propertiesToCopy, substituteAsXLink, directoryFilterQuery);
                     listOfRecordInternalId.add(record.getId());

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
@@ -44,12 +44,12 @@ public class DirectoryUtils {
     /**
      * Save entries and metadata
      */
-    public static void saveEntries(CollectResults collectResults,
+    public static void saveEntries(ServiceContext context,
+                                   CollectResults collectResults,
                                    String sourceIdentifier,
                                    Integer owner,
                                    Integer groupOwner,
                                    boolean saveRecord) {
-        ServiceContext context = ServiceContext.get();
         DataManager dataManager = context.getBean(DataManager.class);
         MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
         Table<String, String, Element> entries = collectResults.getEntries();
@@ -122,10 +122,11 @@ public class DirectoryUtils {
      * Extract all entries matching a specific XPath. If an entry is found multiple times in the
      * record, and the identifier match, only one is reported (the last one).
      */
-    public static CollectResults collectEntries(Metadata record,
+    public static CollectResults collectEntries(ServiceContext context,
+                                                Metadata record,
                                                 String xpath,
                                                 String identifierXpath) throws Exception {
-        return collectEntries(record, xpath, identifierXpath, null, false, false, null);
+        return collectEntries(context, record, xpath, identifierXpath, null, false, false, null);
     }
 
     /**
@@ -133,18 +134,20 @@ public class DirectoryUtils {
      * subtemplate list, the record one is updated. To preserve properties from the record, use the
      * propertiesToCopy
      */
-    public static CollectResults synchronizeEntries(Metadata record,
+    public static CollectResults synchronizeEntries(ServiceContext context,
+                                                    Metadata record,
                                                     String xpath,
                                                     String identifierXpath,
                                                     List<String> propertiesToCopy,
                                                     boolean substituteAsXLink,
                                                     String directoryFilterQuery) throws Exception {
-        return collectEntries(record, xpath, identifierXpath,
+        return collectEntries(context, record, xpath, identifierXpath,
             propertiesToCopy, substituteAsXLink, true, directoryFilterQuery);
     }
 
 
-    private static CollectResults collectEntries(Metadata record,
+    private static CollectResults collectEntries(ServiceContext context,
+                                                 Metadata record,
                                                  String xpath,
                                                  String identifierXpath,
                                                  List<String> propertiesToCopy,
@@ -153,7 +156,7 @@ public class DirectoryUtils {
                                                  String directoryFilterQuery) throws Exception {
         CollectResults collectResults = new CollectResults(record);
         Map<String, List<Namespace>> namespaceList = new HashMap<String, List<Namespace>>();
-        ServiceContext context = ServiceContext.get();
+
         MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
 
         if (Log.isDebugEnabled(LOGGER)) {
@@ -280,7 +283,7 @@ public class DirectoryUtils {
                             }
                         }
                         parameters.put(searchIndexField, identifier);
-                        String id = search(parameters);
+                        String id = search(context, parameters);
                         if (id != null) {
                             Metadata subTemplate = metadataRepository.findOne(id);
                             if (subTemplate != null) {
@@ -398,9 +401,9 @@ public class DirectoryUtils {
      *
      * @return The record identifier
      */
-    private static String search(Map<String, String> searchParameters) {
+    private static String search(ServiceContext context, Map<String, String> searchParameters) {
         ServiceConfig _config = new ServiceConfig();
-        ServiceContext context = ServiceContext.get();
+
         SearchManager searchMan = context.getBean(SearchManager.class);
 
         try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -400,10 +400,9 @@ public class SiteApi {
         @ApiResponse(code = 200, message = "Site information.")
     })
     @ResponseBody
-    public SiteInformation getInformation(
+    public SiteInformation getInformation(HttpServletRequest request
     ) throws Exception {
-        ApplicationContext appContext = ApplicationContextHolder.get();
-        ServiceContext context = ServiceContext.get();
+        ServiceContext context = ApiUtils.createServiceContext(request);
         return new SiteInformation(context, (GeonetContext) context
             .getHandlerContext(Geonet.CONTEXT_NAME));
     }

--- a/services/src/main/java/org/fao/geonet/api/status/StatusApi.java
+++ b/services/src/main/java/org/fao/geonet/api/status/StatusApi.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.api.status;
 
 import org.fao.geonet.api.API;
+import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.domain.StatusValue;
 import org.fao.geonet.repository.StatusValueRepository;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,8 @@ import java.util.List;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import jeeves.server.context.ServiceContext;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RequestMapping(value = {
     "/api/status",
@@ -60,8 +63,8 @@ public class StatusApi {
         method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
     @ResponseBody
-    public List<StatusValue> getStatus() throws Exception {
-        ServiceContext context = ServiceContext.get();
+    public List<StatusValue> getStatus(HttpServletRequest request) throws Exception {
+        ServiceContext context = ApiUtils.createServiceContext(request);
         return context.getBean(StatusValueRepository.class).findAll();
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/users/PasswordApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/PasswordApi.java
@@ -25,6 +25,7 @@ package org.fao.geonet.api.users;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
+import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.kernel.security.ldap.LDAPConstants;
@@ -54,6 +55,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -94,12 +96,12 @@ public class PasswordApi {
             required = true)
         @RequestBody
             PasswordUpdateParameter passwordAndChangeKey,
-        ServletRequest request)
+        HttpServletRequest request)
         throws Exception {
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
 
-        ServiceContext context = ServiceContext.get();
+        ServiceContext context = ApiUtils.createServiceContext(request);
 
         final UserRepository userRepository = context.getBean(UserRepository.class);
         User user = userRepository.findOneByUsername(username);
@@ -179,12 +181,13 @@ public class PasswordApi {
             required = true)
         @PathVariable
             String username,
-        ServletRequest request)
+        HttpServletRequest request)
         throws Exception {
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         String language = locale.getISO3Language();
         ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
 
+        ServiceContext serviceContext = ApiUtils.createServiceContext(request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         final User user = appContext.getBean(UserRepository.class).findOneByUsername(username);
         if (user == null) {
@@ -217,7 +220,7 @@ public class PasswordApi {
         Calendar cal = Calendar.getInstance();
         SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT);
         String todaysDate = sdf.format(cal.getTime());
-        String changeKey = PasswordUtil.encode(ServiceContext.get(),
+        String changeKey = PasswordUtil.encode(serviceContext,
             scrambledPassword + todaysDate);
 
         String subject = String.format(

--- a/services/src/main/java/org/fao/geonet/api/users/RegisterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/RegisterApi.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.api.users;
 
 import org.fao.geonet.api.API;
+import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.Profile;
@@ -53,7 +54,7 @@ import java.sql.SQLException;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -90,14 +91,14 @@ public class RegisterApi {
             required = true)
         @RequestBody
             User user,
-        ServletRequest request)
+        HttpServletRequest request)
         throws Exception {
 
 
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
 
-        ServiceContext context = ServiceContext.get();
+        ServiceContext context = ApiUtils.createServiceContext(request);
         final UserRepository userRepository = context.getBean(UserRepository.class);
         if (userRepository.findOneByEmail(user.getEmail()) != null) {
             return new ResponseEntity<>(String.format(

--- a/services/src/test/java/org/fao/geonet/api/directory/DirectoryApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/directory/DirectoryApiTest.java
@@ -71,7 +71,7 @@ public class DirectoryApiTest extends AbstractServiceIntegrationTest {
 
         final Metadata record = _metadataRepo.findOne(id);
         CollectResults collectResults =
-            DirectoryUtils.collectEntries(record, xpath, null);
+            DirectoryUtils.collectEntries(context, record, xpath, null);
 
         assertEquals("3 contacts extracted",
             3, collectResults.getEntries().size());
@@ -94,7 +94,7 @@ public class DirectoryApiTest extends AbstractServiceIntegrationTest {
         final Metadata record = _metadataRepo.findOne(id);
         final String uuidXpath = ".//gmd:electronicMailAddress/gco:CharacterString/text()";
         CollectResults collectResults =
-            DirectoryUtils.collectEntries(record, xpath, uuidXpath);
+            DirectoryUtils.collectEntries(context, record, xpath, uuidXpath);
 
         assertEquals("2 unique contacts extracted",
             2, collectResults.getEntries().size());
@@ -118,7 +118,7 @@ public class DirectoryApiTest extends AbstractServiceIntegrationTest {
 
         final Metadata record = _metadataRepo.findOne(id);
         CollectResults collectResults =
-            DirectoryUtils.collectEntries(record, xpath, null);
+            DirectoryUtils.collectEntries(context, record, xpath, null);
 
         assertEquals("1 graphic overview extracted",
             1, collectResults.getEntries().size());
@@ -173,7 +173,7 @@ public class DirectoryApiTest extends AbstractServiceIntegrationTest {
 
 
         CollectResults collectResults =
-            DirectoryUtils.synchronizeEntries(record,
+            DirectoryUtils.synchronizeEntries(context, record,
                 xpath, uuidXpath, propertiesToCopy,
                 false, null);
 
@@ -228,7 +228,7 @@ public class DirectoryApiTest extends AbstractServiceIntegrationTest {
 
 
         CollectResults collectResults =
-            DirectoryUtils.synchronizeEntries(record,
+            DirectoryUtils.synchronizeEntries(context, record,
                 xpath, uuidXpath, propertiesToCopy,
                 true, null);
 

--- a/services/src/test/java/org/fao/geonet/api/site/SiteApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/site/SiteApiTest.java
@@ -66,8 +66,12 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
     @Test
     public void getInformation() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockHttpSession = loginAsAdmin();
+
         this.mockMvc.perform(get("/api/site/info")
-            .accept(MediaType.parseMediaType("application/json")))
+            .accept(MediaType.parseMediaType("application/json"))
+            .session(this.mockHttpSession))
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath("$.catalogue['data.dataDir']", is(not(isEmptyOrNullString()))))

--- a/services/src/test/java/org/fao/geonet/api/status/StatusApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/status/StatusApiTest.java
@@ -27,6 +27,7 @@ import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -52,14 +53,19 @@ public class StatusApiTest extends AbstractServiceIntegrationTest {
 
     private MockMvc mockMvc;
 
+    private MockHttpSession mockHttpSession;
 
     @Test
     public void getStatus() throws Exception {
         Long statusValueCount = statusValueRepo.count();
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockHttpSession = loginAsAdmin();
+
         this.mockMvc.perform(get("/api/status")
-            .accept(MediaType.parseMediaType("application/json")))
+            .accept(MediaType.parseMediaType("application/json"))
+            .session(this.mockHttpSession))
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath("$", hasSize(statusValueCount.intValue())));


### PR DESCRIPTION
This pull request removes the usage of problematic `ServiceContext.get()` in controllers from the `org.fao.geonet.api` package. 

Still some usages in `FilesystemStore` and `ResourceLoggerStore` that require some review/refactoring.