### PR TITLE
Hide the loading spinner of validate button on error

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -79,6 +79,8 @@
                   scope.ruleTypes = scope.ruleTypes.concat(optional);
                   scope.hasSuccess = scope.ruleTypes.length > 0;
                   scope.loading = false;
+                }).finally(function() {
+                  scope.loading = false;
                 });
               };
 


### PR DESCRIPTION
Remove the loading spinner from the _Validate_ button if there is any error while saving or validating.