### PR TITLE
Fix#1907 - Update style of the container editor (margin-top)

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -4,8 +4,8 @@
 @import (less) "../lib/style/datetimepicker.css";
 @import (less) "../lib/jquery.ext/jquery.fileupload-ui.css";
 @import "gn.less";
-body {
 
+body {
 }
 
 .gn-line-height {
@@ -92,7 +92,18 @@ input[type=text], input[type=number], select {
 
 .gn-editor-container {
   padding: 20px 5px;
-  margin-top: 45px;
+  margin-top: 60px;
+}
+
+@media only screen and (max-width: 815px) {
+  .gn-editor-container {
+    margin-top: 120px;
+  }
+}
+@media only screen and (max-width: 425px) {
+  .gn-editor-container {
+    margin-top: 160px;
+  }
 }
 
 


### PR DESCRIPTION
Avoid overlapping (#1907)
![overlapping-sol2](https://cloud.githubusercontent.com/assets/576292/23301509/8f4a9082-fa8a-11e6-87cc-598d4c5fa2ae.jpg)
![ovelapping_sol1](https://cloud.githubusercontent.com/assets/576292/23301532/a7a23a18-fa8a-11e6-99c9-8eb92904feef.jpg)

