### PR TITLE
Fix scrollbar issue

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -560,7 +560,7 @@
   module.directive('gnAutogrow', function() {
     // add helper for measurement to body
     var testObj = angular.element('<textarea ' +
-        ' style="height: 0px; position: absolute; visibility: hidden;"/>');
+        ' style="height: 0px; position: absolute; top: 0; visibility: hidden;"/>');
     angular.element(window.document.body).append(testObj);
 
     return {


### PR DESCRIPTION
Align hidden textarea to top of page
Without "top" attribute textarea started after the 100% height div
Specifying position makes sense of absoulte positioning

Closes #1923