### PR TITLE
Improve CSW getCapabilities request in harvesters

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -476,7 +476,12 @@
 
         if ($scope.harvesterSelected &&
             $scope.harvesterSelected.site &&
-            $scope.harvesterSelected.site.capabilitiesUrl) {
+            $scope.harvesterSelected.site.capabilitiesUrl &&
+            (
+              $scope.harvesterSelected.site.capabilitiesUrl.indexOf("http://") != -1 ||
+              $scope.harvesterSelected.site.capabilitiesUrl.indexOf("https://") != -1
+            )
+        ) {
 
 
           var url = $scope.harvesterSelected.site.capabilitiesUrl;
@@ -549,9 +554,19 @@
         }
       };
 
-      $scope.$watch('harvesterSelected.site.capabilitiesUrl', function() {
-        $scope.cswGetCapabilities();
+      // Don't launch the getCapabilities request until 750 ms after the last value change.
+      // Instantiate these variables outside the watch
+      var capabilitiesUrlDelay;
+      $scope.$watch('harvesterSelected.site.capabilitiesUrl', function (val) {
+        if (capabilitiesUrlDelay) {
+          $timeout.cancel(capabilitiesUrlDelay);
+        }
+
+        capabilitiesUrlDelay = $timeout(function() {
+          $scope.cswGetCapabilities();
+          }, 750); // delay 750 ms
       });
+      
 
 
 


### PR DESCRIPTION
* Don't make a request when there is no URL in the input box.
* Wait 750 ms after the last url value change to make the capabilities request.

Fix conflicts found in PR #1886.