### PR TITLE
Map extent fix when loaded from another view + minor UI fixes

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
@@ -141,14 +141,12 @@
                 }
               });
               if (!ol.extent.isEmpty(extent)) {
-                // if the map has no valid size, save this extent for later use
-                if(!angular.isArray(
-                  scope.map.getSize()) || scope.map.getSize()[0] <= 0) {
-                    scope.map.set('initExtent', extent);
-                }
-                else {
-                  scope.map.getView().fit(extent, scope.map.getSize());
-                }
+                // fit extent in map
+                scope.map.getView().fit(extent, scope.map.getSize());
+
+                // save this extent for later use (for example if the map
+                // is not currently visible)
+                scope.map.set('lastExtent', extent);
               }
             }
           });

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
@@ -141,7 +141,14 @@
                 }
               });
               if (!ol.extent.isEmpty(extent)) {
-                scope.map.getView().fit(extent, scope.map.getSize());
+                // if the map has no valid size, save this extent for later use
+                if(!angular.isArray(
+                  scope.map.getSize()) || scope.map.getSize()[0] <= 0) {
+                    scope.map.set('initExtent', extent);
+                }
+                else {
+                  scope.map.getView().fit(extent, scope.map.getSize());
+                }
               }
             }
           });

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -97,14 +97,13 @@
               };
 
               scope.doSync = function() {
-                var layers = gnSearchSettings.searchMap.getLayers();
-                layers.clear();
-                scope.map.getLayers().forEach(function(l) {
-                  if (scope.synAllLayers == true || (
-                      scope.synAllLayers === false &&
-                      l.get('group') === 'Background layers'))
+                if (scope.synAllLayer) {
+                  var layers = gnSearchSettings.searchMap.getLayers();
+                  layers.clear();
+                  scope.map.getLayers().forEach(function(l) {
                     layers.push(l);
-                });
+                  });
+                }
               };
 
               scope.init3dMode = function(map) {

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -130,15 +130,16 @@
         gnViewerSettings.initialExtent = extent;
 
         // $timeout used to avoid map no rendered (eg: null size)
+        // if the map has no valid size, save this extent for later use
         if(!angular.isArray(
-            map.getSize()) || map.getSize()[0] <= 0) {
-              map.set('initExtent', extent);
-          }
-          else {
-            $timeout(function() {
-              map.getView().fit(extent, map.getSize(), { nearest: true });
-            }, 0, false);
-          }
+          map.getSize()) || map.getSize()[0] <= 0) {
+            map.set('initExtent', extent);
+        }
+        else {
+          $timeout(function() {
+            map.getView().fit(extent, map.getSize(), { nearest: true });
+          }, 0, false);
+        }
 
         // load the resources
         var layers = context.resourceList.layer;

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -130,16 +130,13 @@
         gnViewerSettings.initialExtent = extent;
 
         // $timeout used to avoid map no rendered (eg: null size)
-        // if the map has no valid size, save this extent for later use
-        if(!angular.isArray(
-          map.getSize()) || map.getSize()[0] <= 0) {
-            map.set('initExtent', extent);
-        }
-        else {
-          $timeout(function() {
-            map.getView().fit(extent, map.getSize(), { nearest: true });
-          }, 0, false);
-        }
+        $timeout(function() {
+          map.getView().fit(extent, map.getSize(), { nearest: true });
+        }, 0, false);
+
+        // save this extent for later use (for example if the map
+        // is not currently visible)
+        map.set('lastExtent', extent);
 
         // load the resources
         var layers = context.resourceList.layer;

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -130,9 +130,15 @@
         gnViewerSettings.initialExtent = extent;
 
         // $timeout used to avoid map no rendered (eg: null size)
-        $timeout(function() {
-          map.getView().fit(extent, map.getSize(), { nearest: true });
-        }, 0, false);
+        if(!angular.isArray(
+            map.getSize()) || map.getSize()[0] <= 0) {
+              map.set('initExtent', extent);
+          }
+          else {
+            $timeout(function() {
+              map.getView().fit(extent, map.getSize(), { nearest: true });
+            }, 0, false);
+          }
 
         // load the resources
         var layers = context.resourceList.layer;

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -393,7 +393,7 @@ img.thumb-small {
 
 .tt-suggestion {
   padding: 3px 20px;
-  font-size: 18px;
+  font-size: 1em;
   line-height: 24px;
 }
 

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -175,21 +175,21 @@ span.gn-facet-label:first-letter {
 }
 
 .tt-dropdown-menu {
-  margin-top: 4px;
-  margin-left: -8px;
+  margin-top: 7px;
+  margin-left: -7px;
   padding: 8px 0;
   background-color: #fff;
   border: 1px solid #ccc;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
   -webkit-box-shadow: 0 5px 10px rgba(0,0,0,.2);
   -moz-box-shadow: 0 5px 10px rgba(0,0,0,.2);
   box-shadow: 0 5px 10px rgba(0,0,0,.2);
   max-height: 350px;
   overflow-y: auto;
-  width: inherit;
+  width: calc(~"100% + 14px");
 }
 
 .tt-suggestion {

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
@@ -19,7 +19,7 @@
     <ul class="dropdown-menu" role="menu">
       <li ng-repeat="link in ::links">
         <a href="{{::link.url}}"
-           target="_blank">{{::link.desc}}</a>
+           target="_blank">{{::link.desc || link.name}}</a>
       </li>
     </ul>
   </div>

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -276,11 +276,16 @@
             viewerMap.getSize()) || viewerMap.getSize().indexOf(0) >= 0)) {
           setTimeout(function() {
             viewerMap.updateSize();
+            if(viewerMap.get('initExtent')) {
+              viewerMap.getView().fit(
+                viewerMap.get('initExtent'),
+                viewerMap.getSize(), { nearest: true });
+            }
           }, 0);
         }
+
+        viewerMap.resized;
       });
-
-
 
       angular.extend($scope.searchObj, {
         advancedMode: false,

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -295,8 +295,6 @@
             }
           }, 0);
         }
-
-        viewerMap.resized;
       });
 
       angular.extend($scope.searchObj, {

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -267,9 +267,9 @@
             searchMap.updateSize();
 
             // if an extent was obtained from a loaded context, apply it
-            if(searchMap.get('initExtent')) {
+            if(searchMap.get('lastExtent')) {
               searchMap.getView().fit(
-                searchMap.get('initExtent'),
+                searchMap.get('lastExtent'),
                 searchMap.getSize(), { nearest: true });
             }
 
@@ -288,9 +288,9 @@
             viewerMap.updateSize();
 
             // if an extent was obtained from a loaded context, apply it
-            if(viewerMap.get('initExtent')) {
+            if(viewerMap.get('lastExtent')) {
               viewerMap.getView().fit(
-                viewerMap.get('initExtent'),
+                viewerMap.get('lastExtent'),
                 viewerMap.getSize(), { nearest: true });
             }
           }, 0);

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -260,10 +260,18 @@
         $scope.activeTab = $location.path().
             match(/^(\/[a-zA-Z0-9]*)($|\/.*)/)[1];
 
-        if (gnSearchLocation.isSearch() && (!angular.isArray(
+        // resize search map for any views exluding viewer
+        if (!gnSearchLocation.isMap() && (!angular.isArray(
             searchMap.getSize()) || searchMap.getSize()[0] < 0)) {
           setTimeout(function() {
             searchMap.updateSize();
+
+            // if an extent was obtained from a loaded context, apply it
+            if(searchMap.get('initExtent')) {
+              searchMap.getView().fit(
+                searchMap.get('initExtent'),
+                searchMap.getSize(), { nearest: true });
+            }
 
             // TODO: load custom context to the search map
             //gnOwsContextService.loadContextFromUrl(
@@ -272,10 +280,14 @@
 
           }, 0);
         }
+
+        // resize viewer map for corresponding view
         if (gnSearchLocation.isMap() && (!angular.isArray(
             viewerMap.getSize()) || viewerMap.getSize().indexOf(0) >= 0)) {
           setTimeout(function() {
             viewerMap.updateSize();
+
+            // if an extent was obtained from a loaded context, apply it
             if(viewerMap.get('initExtent')) {
               viewerMap.getView().fit(
                 viewerMap.get('initExtent'),

--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -1,0 +1,48 @@
+<ul class="nav navbar-nav">
+  <li class="gn-footer-text">
+    <span data-translate=""
+          data-translate-values="{platform: '{{info['system/platform/name']}}', version: '{{info['system/platform/version']}}', subversion: '{{info['system/platform/subVersion']}}'}">
+      versionDetails</span>
+  </li>
+  <li><a href="http://geonetwork-opensource.org/">
+    <i class="fa fa-fw"></i>
+    <span data-translate="">about</span></a>
+  </li>
+  <li class="hidden-sm"><a href="https://github.com/geonetwork/core-geonetwork">
+    <i class="fa fa-github"></i>
+    <span data-translate="">github</span></a></li>
+  <li>
+    <a href="../../doc/api" title="{{'learnTheApi' | translate}}">API</a>
+  </li>
+  <li class="gn-footer-text" ng-hide="showSocialMediaLink">
+    <span data-translate="">shareOn</span>
+  </li>
+  <li class="socialmedia" ng-hide="showSocialMediaLink">
+    <a href="https://twitter.com/share?url={{socialMediaLink | encodeURIComponent}}"
+       target="_blank" title="{{'shareOnTwitter' | translate}}"><i class="fa fa-twitter"></i>
+    </a>
+    <a href="https://plus.google.com/share?url={{socialMediaLink | encodeURIComponent}}"
+       target="_blank" title="{{'shareOnGooglePlus' | translate}}"><i class="fa fa-google-plus"></i>
+    </a>
+    <a href="https://www.facebook.com/sharer.php?u={{socialMediaLink | encodeURIComponent}}"
+       target="_blank" title="{{'shareOnFacebook' | translate}}"><i class="fa fa-facebook"></i>
+    </a>
+    <a
+      href="http://www.linkedin.com/shareArticle?mini=true&amp;url={{socialMediaLink | encodeURIComponent}}"
+      target="_blank" title="{{'shareOnLinkedIn' | translate}}"><i class="fa fa-linkedin"></i>
+    </a>
+    <a href="mailto:?subject={{info.site.name}}&amp;body={{socialMediaLink | encodeURIComponent}}"
+       target="_blank" title="{{'shareByEmail' | translate}}"><i class="fa fa-envelope-o"></i>
+    </a>
+    <a
+      href=""
+      data-ng-click="getPermalink('', socialMediaLink)"
+      title="{{'permalink' | translate}}"><i class="fa fa-fw fa-link"></i></a>
+  </li>
+  <li>
+    <a href="rss.search?sortBy=changeDate&georss=simplepoint"
+       title="{{'lastRecords' | translate}}">
+      <i class="fa fa-rss"/>
+    </a>
+  </li>
+</ul>

--- a/web-ui/src/main/resources/catalog/views/default/templates/index.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/index.html
@@ -25,53 +25,6 @@
 </div>
 
 
-<div class="navbar navbar-default gn-bottom-bar">
-  <ul class="nav navbar-nav">
-    <li class="gn-footer-text">
-      <span data-translate=""
-            data-translate-values="{platform: '{{info['system/platform/name']}}', version: '{{info['system/platform/version']}}', subversion: '{{info['system/platform/subVersion']}}'}">
-        versionDetails</span>
-    </li>
-    <li><a href="http://geonetwork-opensource.org/">
-      <i class="fa fa-fw"></i>
-      <span data-translate="">about</span></a>
-    </li>
-    <li class="hidden-sm"><a href="https://github.com/geonetwork/core-geonetwork">
-      <i class="fa fa-github"></i>
-      <span data-translate="">github</span></a></li>
-    <li>
-      <a href="../../doc/api" title="{{'learnTheApi' | translate}}">API</a>
-    </li>
-    <li class="gn-footer-text" ng-hide="showSocialMediaLink">
-      <span data-translate="">shareOn</span>
-    </li>
-    <li class="socialmedia" ng-hide="showSocialMediaLink">
-      <a href="https://twitter.com/share?url={{socialMediaLink | encodeURIComponent}}"
-         target="_blank" title="{{'shareOnTwitter' | translate}}"><i class="fa fa-twitter"></i>
-      </a>
-      <a href="https://plus.google.com/share?url={{socialMediaLink | encodeURIComponent}}"
-         target="_blank" title="{{'shareOnGooglePlus' | translate}}"><i class="fa fa-google-plus"></i>
-      </a>
-      <a href="https://www.facebook.com/sharer.php?u={{socialMediaLink | encodeURIComponent}}"
-         target="_blank" title="{{'shareOnFacebook' | translate}}"><i class="fa fa-facebook"></i>
-      </a>
-      <a
-        href="http://www.linkedin.com/shareArticle?mini=true&amp;url={{socialMediaLink | encodeURIComponent}}"
-        target="_blank" title="{{'shareOnLinkedIn' | translate}}"><i class="fa fa-linkedin"></i>
-      </a>
-      <a href="mailto:?subject={{info.site.name}}&amp;body={{socialMediaLink | encodeURIComponent}}"
-         target="_blank" title="{{'shareByEmail' | translate}}"><i class="fa fa-envelope-o"></i>
-      </a>
-      <a
-        href=""
-        data-ng-click="getPermalink('', socialMediaLink)"
-        title="{{'permalink' | translate}}"><i class="fa fa-fw fa-link"></i></a>
-    </li>
-    <li>
-      <a href="rss.search?sortBy=changeDate&georss=simplepoint"
-         title="{{'lastRecords' | translate}}">
-        <i class="fa fa-rss"/>
-      </a>
-    </li>
-  </ul>
+<div class="navbar navbar-default gn-bottom-bar" role="navigation"
+     data-ng-include="'../../catalog/views/default/templates/footer.html'">
 </div>


### PR DESCRIPTION
This PR fixes a bug that occurs when a map is asked to fit an extent while not being displayed (ie. the map is in another tab).
This happens on two occasions: 
* Viewer map: when the OWS context is loaded (first arrival on the website)
* Search map: when search results are fetched

In order to fix this, the computed extent is now systematically saved in a `lastExtent` property on the respective map object. This is then used to display maps properly when switching tabs.

Other UI fixes are:
* the footer for the default view is now factorized in a separate template (same as top toolbar)
* the layers synchronization feature between the two maps was causing a bug and has been fixed
* links list in the search results view now use the name of the link when a description is not available
* typeahead suggestions in the advanced search form now display more nicely