### PR TITLE
Indexing / Add the capability to index the catalogue content in Elasticsearch.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -498,6 +498,11 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-hibernate4</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.geonetwork-opensource</groupId>
+      <artifactId>es-core</artifactId>
+      <version>3.3.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -88,6 +88,7 @@ import org.fao.geonet.exceptions.SchematronValidationErrorEx;
 import org.fao.geonet.exceptions.ServiceNotAllowedEx;
 import org.fao.geonet.exceptions.XSDValidationErrorEx;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.search.ISearchManager;
 import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.kernel.search.index.IndexingList;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -415,7 +416,7 @@ public class DataManager implements ApplicationEventPublisherAware {
 
         // remove from index metadata not in DBMS
         for (String id : docs.keySet()) {
-            getSearchManager().delete("_id", id);
+            getSearchManager().delete(id);
 
             if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
                 Log.debug(Geonet.DATA_MANAGER, "- removed record (" + id + ") from index");
@@ -451,6 +452,7 @@ public class DataManager implements ApplicationEventPublisherAware {
      * Reindex all records in current selection.
      */
     public synchronized void rebuildIndexForSelection(final ServiceContext context,
+                                                      String bucket,
                                                       boolean clearXlink)
         throws Exception {
 
@@ -459,8 +461,8 @@ public class DataManager implements ApplicationEventPublisherAware {
         UserSession session = context.getUserSession();
         SelectionManager sm = SelectionManager.getManager(session);
 
-        synchronized (sm.getSelection("metadata")) {
-            for (Iterator<String> iter = sm.getSelection("metadata").iterator();
+        synchronized (sm.getSelection(bucket)) {
+            for (Iterator<String> iter = sm.getSelection(bucket).iterator();
                  iter.hasNext(); ) {
                 String uuid = (String) iter.next();
                 String id = getMetadataId(uuid);
@@ -557,7 +559,7 @@ public class DataManager implements ApplicationEventPublisherAware {
 
     public void indexMetadata(final List<String> metadataIds) throws Exception {
         for (String metadataId : metadataIds) {
-            indexMetadata(metadataId, false);
+            indexMetadata(metadataId, false, null);
         }
 
         getSearchManager().forceIndexChanges();
@@ -566,7 +568,7 @@ public class DataManager implements ApplicationEventPublisherAware {
     /**
      * TODO javadoc.
      */
-    public void indexMetadata(final String metadataId, boolean forceRefreshReaders) throws Exception {
+    public void indexMetadata(final String metadataId, boolean forceRefreshReaders, ISearchManager searchManager) throws Exception {
         indexLock.lock();
         try {
             if (waitForIndexing.contains(metadataId)) {
@@ -762,7 +764,12 @@ public class DataManager implements ApplicationEventPublisherAware {
                 }
                 moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.VALID, isValid, true, true));
             }
-            getSearchManager().index(getSchemaManager().getSchemaDir(schema), md, metadataId, moreFields, metadataType, root, forceRefreshReaders);
+
+            if (searchManager == null) {
+                getSearchManager().index(getSchemaManager().getSchemaDir(schema), md, metadataId, moreFields, metadataType, root, forceRefreshReaders);
+            } else {
+                searchManager.index(getSchemaManager().getSchemaDir(schema), md, metadataId, moreFields, metadataType, root, forceRefreshReaders);
+            }
         } catch (Exception x) {
             Log.error(Geonet.DATA_MANAGER, "The metadata document index with id=" + metadataId + " is corrupt/invalid - ignoring it. Error: " + x.getMessage(), x);
             fullMd = null;
@@ -1283,7 +1290,7 @@ public class DataManager implements ApplicationEventPublisherAware {
      */
     public void setTemplate(final int id, final MetadataType type, final String title) throws Exception {
         setTemplateExt(id, type);
-        indexMetadata(Integer.toString(id), true);
+        indexMetadata(Integer.toString(id), true, null);
     }
 
     /**
@@ -1304,7 +1311,7 @@ public class DataManager implements ApplicationEventPublisherAware {
      */
     public void setHarvested(int id, String harvestUuid) throws Exception {
         setHarvestedExt(id, harvestUuid);
-        indexMetadata(Integer.toString(id), true);
+        indexMetadata(Integer.toString(id), true, null);
     }
 
     /**
@@ -1436,7 +1443,7 @@ public class DataManager implements ApplicationEventPublisherAware {
             }
         });
 
-        indexMetadata(Integer.toString(metadataId), true);
+        indexMetadata(Integer.toString(metadataId), true, null);
 
         return rating;
     }
@@ -1614,7 +1621,7 @@ public class DataManager implements ApplicationEventPublisherAware {
         copyDefaultPrivForGroup(context, stringId, groupId, fullRightsForGroup);
 
         if (index) {
-            indexMetadata(stringId, forceRefreshReaders);
+            indexMetadata(stringId, forceRefreshReaders, null);
         }
 
         if (notifyChange) {
@@ -1745,12 +1752,13 @@ public class DataManager implements ApplicationEventPublisherAware {
      * Returns all the keywords in the system.
      */
     public Element getKeywords() throws Exception {
-        Collection<String> keywords = getSearchManager().getTerms("keyword");
+        // TODO ES
+//        Collection<String> keywords = getSearchManager().getTerms("keyword");
         Element el = new Element("keywords");
 
-        for (Object keyword : keywords) {
-            el.addContent(new Element("keyword").setText((String) keyword));
-        }
+//        for (Object keyword : keywords) {
+//            el.addContent(new Element("keyword").setText((String) keyword));
+//        }
         return el;
     }
 
@@ -1828,7 +1836,7 @@ public class DataManager implements ApplicationEventPublisherAware {
         } finally {
             if (index) {
                 //--- update search criteria
-                indexMetadata(metadataId, true);
+                indexMetadata(metadataId, true, null);
             }
         }
         // Return an up to date metadata record
@@ -2138,7 +2146,7 @@ public class DataManager implements ApplicationEventPublisherAware {
         }
 
         //--- update search criteria
-        getSearchManager().delete("_id", metadataId + "");
+        getSearchManager().delete(metadataId + "");
 //        _entityManager.flush();
 //        _entityManager.clear();
     }
@@ -2152,7 +2160,7 @@ public class DataManager implements ApplicationEventPublisherAware {
     public synchronized void deleteMetadataGroup(ServiceContext context, String metadataId) throws Exception {
         deleteMetadataFromDB(context, metadataId);
         //--- update search criteria
-        getSearchManager().deleteGroup("_id", metadataId + "");
+        getSearchManager().delete(metadataId + "");
     }
 
     /**
@@ -2314,7 +2322,7 @@ public class DataManager implements ApplicationEventPublisherAware {
             notifyMetadataChange(md, metadataId);
 
             //--- update search criteria
-            indexMetadata(metadataId, true);
+            indexMetadata(metadataId, true, null);
         }
     }
 
@@ -2630,7 +2638,7 @@ public class DataManager implements ApplicationEventPublisherAware {
      */
     public MetadataStatus setStatus(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception {
         MetadataStatus statusObject = setStatusExt(context, id, status, changeDate, changeMessage);
-        indexMetadata(Integer.toString(id), true);
+        indexMetadata(Integer.toString(id), true, null);
         return statusObject;
     }
 
@@ -3221,7 +3229,7 @@ public class DataManager implements ApplicationEventPublisherAware {
         }
 
         // Remove records from the index
-        getSearchManager().delete("_id", Lists.transform(idsOfMetadataToDelete, new Function<Integer, String>() {
+        getSearchManager().delete(Lists.transform(idsOfMetadataToDelete, new Function<Integer, String>() {
             @Nullable
             @Override
             public String apply(@Nonnull Integer input) {
@@ -3247,7 +3255,7 @@ public class DataManager implements ApplicationEventPublisherAware {
         return getApplicationContext().getBean(requiredType);
     }
 
-    private SearchManager getSearchManager() {
+    private ISearchManager getSearchManager() {
         return getBean(SearchManager.class);
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -111,7 +111,7 @@ final class IndexMetadataTask implements Runnable {
                 }
 
                 try {
-                    dataManager.indexMetadata(metadataId.toString(), false);
+                    dataManager.indexMetadata(metadataId.toString(), false, null);
                 } catch (Exception e) {
                     Log.error(Geonet.INDEX_ENGINE, "Error indexing metadata '" + metadataId + "': " + e.getMessage()
                         + "\n" + Util.getStackTrace(e));

--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -474,7 +474,7 @@ public class Importer {
                 Files.createDirectories(priDir);
 
 
-                dm.indexMetadata(metadataIdMap.get(index), true);
+                dm.indexMetadata(metadataIdMap.get(index), true, null);
             }
 
             // --------------------------------------------------------------------

--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -1,0 +1,532 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.kernel.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.JsonElement;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Get;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.es.EsClient;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class EsSearchManager implements ISearchManager {
+    public static final String ID = "id";
+    public static final String DOC_TYPE = "docType";
+    public static final String SCHEMA_INDEX_XSLT_FOLDER = "index-fields";
+    public static final String SCHEMA_INDEX_XSTL_FILENAME = "index.xsl";
+    public static final String FIELDNAME = "name";
+    public static final String FIELDSTRING = "string";
+
+    @Value("${es.index.records}")
+    private String index = "records";
+
+    @Autowired
+    private EsClient client;
+
+    public static Path getXSLTForIndexing(Path schemaDir) {
+        Path xsltForIndexing = schemaDir
+            .resolve(SCHEMA_INDEX_XSLT_FOLDER).resolve(SCHEMA_INDEX_XSTL_FILENAME);
+        if (!Files.exists(xsltForIndexing)) {
+            throw new RuntimeException(String.format(
+                "XSLT for schema indexing does not exist. Create file '%s'.",
+                xsltForIndexing.toString()));
+        }
+        return xsltForIndexing;
+    }
+
+    private static void addMDFields(Element doc, Path schemaDir, Element metadata, String root) {
+        final Path styleSheet = getXSLTForIndexing(schemaDir);
+        try {
+            Element fields = Xml.transform(metadata, styleSheet);
+            /* Generates something like that:
+            <doc>
+              <field name="toto">Contenu</field>
+            </doc>*/
+            for (Element field : (List<Element>) fields.getChildren()) {
+                doc.addContent((Element) field.clone());
+            }
+        } catch (Exception e) {
+            Log.error(Geonet.INDEX_ENGINE,
+                String.format("Indexing stylesheet contains errors: %s \n\t Marking the metadata as _indexingError=1 in index",
+                    e.getMessage()));
+            doc.addContent(new Element(IndexFields.INDEXING_ERROR_FIELD).setText("1"));
+            doc.addContent(new Element(IndexFields.INDEXING_ERROR_MSG).setText("GNIDX-XSL||" + e.getMessage()));
+            StringBuilder sb = new StringBuilder();
+            allText(metadata, sb);
+            doc.addContent(new Element("_text_").setText(sb.toString()));
+        }
+    }
+
+    private static void allText(Element metadata, StringBuilder sb) {
+        String text = metadata.getText().trim();
+        if (text.length() > 0) {
+            if (sb.length() > 0)
+                sb.append(" ");
+            sb.append(text);
+        }
+        @SuppressWarnings("unchecked")
+        List<Element> children = metadata.getChildren();
+        for (Element aChildren : children) {
+            allText(aChildren, sb);
+        }
+    }
+
+    private static void addMoreFields(Element doc, List<Element> fields) {
+        for (Element field : fields) {
+            doc.addContent(new Element(field.getAttributeValue(FIELDNAME))
+                .setText(field.getAttributeValue(FIELDSTRING)));
+        }
+    }
+
+//    public static String convertDate(Object date) {
+//        if (date != null) {
+//            return new ISODate((Date) date).toString();
+//        } else {
+//            return null;
+//        }
+//    }
+
+    public static Integer convertInteger(Object value) {
+        if (value == null) {
+            return null;
+        } else if (value instanceof Number) {
+            return ((Number) value).intValue();
+        } else {
+            return Integer.valueOf(value.toString());
+        }
+    }
+
+    public static Element makeField(String name, String value) {
+        Element field = new Element("Field");
+        field.setAttribute(EsSearchManager.FIELDNAME, name);
+        field.setAttribute(EsSearchManager.FIELDSTRING, value == null ? "" : value);
+        return field;
+    }
+
+    /**
+     * Creates a new XML field for the Lucene index and add it to the document.
+     */
+    public static void addField(Element xmlDoc, String name, String value, boolean store, boolean index) {
+        Element field = makeField(name, value);
+        xmlDoc.addContent(field);
+    }
+
+    @Override
+    public void init(ServiceConfig handlerConfig) throws Exception {
+    }
+
+    @Override
+    public void end() throws Exception {
+    }
+
+    @Override
+    public MetaSearcher newSearcher(String stylesheetName) throws Exception {
+        //TODO
+        return null;
+    }
+
+    @Override
+    public void index(Path schemaDir, Element metadata, String id, List<Element> moreFields,
+                      MetadataType metadataType, String root, boolean forceRefreshReaders) throws Exception {
+
+        Element docs = new Element("docs");
+        Element allFields = new Element("doc");
+        allFields.addContent(new Element(ID).setText(id));
+        allFields.addContent(new Element(DOC_TYPE).setText("metadata"));
+        addMDFields(allFields, schemaDir, metadata, root);
+        addMoreFields(allFields, moreFields);
+
+
+        docs.addContent(allFields);
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode doc = documentToJson(docs).get(id);
+
+        // ES does not allow a _source field
+        String catalog = doc.get("source").asText();
+        doc.remove("source");
+        doc.put("sourceCatalogue", catalog);
+        Map<String, String> docListToIndex = new HashMap<>();
+        docListToIndex.put(id, mapper.writeValueAsString(doc));
+        client.bulkRequest(index, docListToIndex);
+        if (forceRefreshReaders) {
+//            client.commit();
+        }
+    }
+
+    /**
+     * Convert document to JSON.
+     */
+    public Map<String, ObjectNode> documentToJson(Element xml) {
+        ObjectMapper mapper = new ObjectMapper();
+
+        List<Element> records = xml.getChildren("doc");
+        Map<String, ObjectNode> listOfXcb = new HashMap<>();
+
+        // Loop on docs
+        for (int i = 0; i < records.size(); i++) {
+            Element record = records.get(i);
+            if (record != null && record instanceof Element) {
+                ObjectNode doc = mapper.createObjectNode();
+                String id = null;
+                List<String> elementNames = new ArrayList();
+                List<Element> fields = record.getChildren();
+
+                // Loop on doc fields
+                for (int j = 0; j < fields.size(); j++) {
+                    Element currentField = fields.get(j);
+                    String name = currentField.getName();
+
+                    if (!elementNames.contains(name)) {
+                        // Register list of already processed names
+                        elementNames.add(name);
+
+                        List<Element> nodeElements = record.getChildren(name);
+                        boolean isArray = nodeElements.size() > 1;
+
+                        // Field starting with _ not supported in Kibana
+                        // Those are usually GN internal fields
+                        String propertyName = name.startsWith("_") ?
+                            name.substring(1) : name;
+
+                        ArrayNode arrayNode = null;
+                        if (isArray) {
+                            arrayNode = doc.putArray(propertyName);
+                        }
+
+                        // Group fields in array if needed
+                        for (int k = 0; k < nodeElements.size(); k++) {
+                            Element node = nodeElements.get(k);
+
+                            if (name.equals("id")) {
+                                id = node.getTextNormalize();
+                            }
+
+                            if (name.equals("geom")) {
+                                continue;
+                            }
+
+                            if (isArray) {
+                                arrayNode.add(node.getTextNormalize());
+                            } else if (name.equals("geojson")) {
+                                doc.put("geom", node.getTextNormalize());
+                            } else if (
+                                // Skip some fields causing errors / TODO
+                                !name.startsWith("conformTo_")) {
+                                doc.put(
+                                    propertyName,
+                                    node.getTextNormalize());
+                            }
+                        }
+                    }
+                }
+                listOfXcb.put(id, doc);
+            }
+        }
+        return listOfXcb;
+    }
+    @Override
+    public void forceIndexChanges() throws IOException {
+//        try {
+//            client.commit();
+//        } catch (SolrServerException e) {
+//            throw new IOException(e);
+//        }
+    }
+
+    @Override
+    public boolean rebuildIndex(ServiceContext context, boolean xlinks,
+                                boolean reset, String bucket) throws Exception {
+        DataManager dataMan = context.getBean(DataManager.class);
+        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+
+        if (reset) {
+            clearIndex();
+        }
+
+        if (StringUtils.isNotBlank(bucket)) {
+            dataMan.rebuildIndexForSelection(context, bucket, xlinks);
+        } else {
+
+        }
+
+//        final List<Metadata> metadataList = new ArrayList();
+//        metadataList.add(metadataRepository.findOneByUuid("419534c7-060b-4448-8e96-813a70e31c17"));
+        final List<Metadata> metadataList = metadataRepository.findAll();
+        for(Metadata metadata : metadataList) {
+            if (metadata != null) {
+                dataMan.indexMetadata(metadata.getId() + "", false, this);
+            }
+        }
+        return true;
+    }
+
+    public void clearIndex() throws Exception {
+        client.deleteByQuery(index, DOC_TYPE + ":metadata");
+    }
+
+//    public void iterateQuery(SolrQuery params, final Consumer<SolrDocument> callback) throws IOException, SolrServerException {
+//        final MutableLong pos = new MutableLong(0);
+//        final MutableLong last = new MutableLong(1);
+//        while (pos.longValue() < last.longValue()) {
+//            params.setStart(pos.intValue());
+//            client.queryAndStreamResponse(params, new StreamingResponseCallback() {
+//                @Override
+//                public void streamSolrDocument(SolrDocument doc) {
+//                    pos.add(1);
+//                    callback.accept(doc);
+//                }
+//
+//                @Override
+//                public void streamDocListInfo(long numFound, long start, Float maxScore) {
+//                    last.setValue(numFound);
+//                }
+//            });
+//        }
+//    }
+
+    @Override
+    public Map<String, String> getDocsChangeDate() throws Exception {
+        String query = "{\"query\": {\"filtered\": {\"query_string\": \"*:*\"}}}";
+        Search search = new Search.Builder(query).addIndex(index).addType(index).build();
+        // TODO: limit to needed field
+//        params.setFields(ID, Geonet.IndexFieldNames.DATABASE_CHANGE_DATE);
+        SearchResult searchResult = client.getClient().execute(search);
+
+//        final Map<String, String> result = new HashMap<>();
+//        iterateQuery(searchResult.getHits(), doc ->
+//            result.put(doc.getFieldValue(ID).toString(),
+//                convertDate(doc.getFieldValue(Geonet.IndexFieldNames.DATABASE_CHANGE_DATE))));
+        return null;
+    }
+
+    @Override
+    public ISODate getDocChangeDate(String mdId) throws Exception {
+        // TODO: limit to needed field
+        Get get = new Get.Builder(index, mdId).type(index).build();
+        JestResult result = client.getClient().execute(get);
+        if (result != null) {
+            JsonElement date =
+                result.getJsonObject().get(Geonet.IndexFieldNames.DATABASE_CHANGE_DATE);
+            return date != null ? new ISODate(date.getAsString()) : null;
+        } else {
+            return null;
+        }
+    }
+
+//    public SolrDocument getDocFieldValue(String query, String... field) throws IOException, SolrServerException {
+//        final SolrQuery params = new SolrQuery(query);
+//        params.setFilterQueries(DOC_TYPE + ":metadata");
+//        params.setFields(field);
+//        QueryResponse response = client.query(params);
+//        final SolrDocumentList results = response.getResults();
+//        if (results.size() == 0) {
+//            return null;
+//        } else {
+//            return results.get(0);
+//        }
+//    }
+//
+//    public SolrDocumentList getDocsFieldValue(String query, String... field) throws IOException, SolrServerException {
+//        final SolrQuery params = new SolrQuery(query);
+//        params.setFilterQueries(DOC_TYPE + ":metadata");
+//        params.setFields(field);
+//        QueryResponse response = client.query(params);
+//        return response.getResults();
+//    }
+//
+//    public List<String> getDocsUuids(String query, Integer rows) throws IOException, SolrServerException {
+//        final SolrQuery solrQuery = new SolrQuery(query == null ? "*:*" : query);
+//        solrQuery.setFilterQueries(DOC_TYPE + ":metadata");
+//        solrQuery.setFields(IndexFields.UUID);
+//        if (rows != null) {
+//            solrQuery.setRows(rows);
+//        }
+//        final List<String> result = new ArrayList<>();
+//        iterateQuery(solrQuery, doc ->
+//            result.add(doc.getFieldValue(IndexFields.UUID).toString()));
+//        return result;
+//    }
+
+    @Override
+    public Set<Integer> getDocsWithXLinks() throws Exception {
+//        final SolrQuery params = new SolrQuery("*:*");
+//        params.setFilterQueries(DOC_TYPE + ":metadata");
+//        params.setFilterQueries(Geonet.IndexFieldNames.HASXLINKS + ":1");
+//        params.setFields(ID);
+//        Set<Integer> result = new HashSet<>();
+//        iterateQuery(params,
+//            doc -> result.add(convertInteger(doc.getFieldValue(ID))));
+        return null;
+    }
+
+    @Override
+    public void delete(String txt) throws Exception {
+        client.deleteByQuery(index, txt);
+//        client.commit();
+    }
+
+    @Override
+    public void delete(List<String> txts) throws Exception {
+//        client.deleteById(txts);
+//        client.commit();
+    }
+
+    @Override
+    public void rescheduleOptimizer(Calendar beginAt, int interval) {
+
+    }
+
+    @Override
+    public void disableOptimizer() {
+
+    }
+
+    public int getNumDocs(String query) throws Exception {
+        if (StringUtils.isBlank(query)) {
+            query = "*:*";
+        }
+        String searchQuery = "{\"query\": {\"filtered\": {\"query_string\": \"" + query + "\"}}}";
+        Search search = new Search.Builder(searchQuery).addIndex(index).addType(index).build();
+        SearchResult searchResult = client.getClient().execute(search);
+        return searchResult.getTotal();
+    }
+
+//    public List<FacetField.Count> getDocFieldValues(String indexField,
+//                                                    String query,
+//                                                    boolean missing,
+//                                                    Integer limit,
+//                                                    String sort) throws IOException {
+//        final SolrQuery solrQuery = new SolrQuery(query == null ? "*:*" : query)
+//            .setFilterQueries(DOC_TYPE + ":metadata")
+//            .setRows(0)
+//            .setFacet(true)
+//            .setFacetMissing(missing)
+//            .setFacetLimit(limit != null ? limit : 1000)
+//            .setFacetSort(sort != null ? sort : "count") // or index
+//            .addFacetField(indexField);
+//        QueryResponse response = client.query(solrQuery);
+//        return response.getFacetField(indexField).getValues();
+//    }
+//
+//    public void updateRating(int metadataId, int newValue) throws IOException, SolrServerException {
+//        updateField(metadataId, Geonet.IndexFieldNames.RATING, newValue, "set");
+//    }
+//
+//    public void incrementPopularity(int metadataId) throws IOException, SolrServerException {
+//        //TODO: check that works
+//        updateField(metadataId, Geonet.IndexFieldNames.POPULARITY, 1, "inc");
+//    }
+//
+//    private void updateField(int metadataId, String fieldName, int newValue, String operator) throws IOException, SolrServerException {
+//        SolrInputDocument doc = new SolrInputDocument();
+//        doc.addField(ID, metadataId);
+//        Map<String, Object> fieldModifier = new HashMap<>(1);
+//        fieldModifier.put(operator, newValue);
+//        doc.addField(fieldName, fieldModifier);
+//        client.add(doc);
+//        client.commit();
+//    }
+
+    public EsClient getClient() {
+        return client;
+    }
+
+    /**
+     * Only for UTs
+     */
+    void setClient(EsClient client) {
+        this.client = client;
+    }
+
+    public List<Element> getDocs(String query, Integer start, Integer rows) throws IOException, JDOMException {
+        final List<String> result = getDocIds(query, start, rows);
+        List<Element> xmlDocs = new ArrayList<>(result.size());
+        MetadataRepository metadataRepository = ApplicationContextHolder.get().getBean(MetadataRepository.class);
+        for (String id : result) {
+            Metadata metadata = metadataRepository.findOne(id);
+            xmlDocs.add(metadata.getXmlData(false));
+        }
+        return xmlDocs;
+    }
+
+    public List<String> getDocIds(String query, Integer start, Integer rows) throws IOException, JDOMException {
+//        final SolrQuery solrQuery = new SolrQuery(query == null ? "*:*" : query);
+//        solrQuery.setFilterQueries(DOC_TYPE + ":metadata");
+//        solrQuery.setFields(SolrSearchManager.ID);
+//        if (start != null) {
+//            solrQuery.setStart(start);
+//        }
+//        if (rows != null) {
+//            solrQuery.setRows(rows);
+//        }
+//        QueryResponse response = client.query(solrQuery);
+//        SolrDocumentList results = response.getResults();
+//        List<String> idList = new ArrayList<>(results.size());
+//        for (SolrDocument document : results) {
+//            idList.add(document.getFieldValue(SolrSearchManager.ID).toString());
+//        }
+//        return idList;
+        return null;
+    }
+
+    public List<Element> getAllDocs(String query) throws Exception {
+        int hitsNumber = getNumDocs(query);
+        return getDocs(query, 0, hitsNumber);
+    }
+
+    public List<String> getAllDocIds(String query) throws Exception {
+        int hitsNumber = getNumDocs(query);
+        return getDocIds(query, 0, hitsNumber);
+    }
+
+}

--- a/core/src/main/java/org/fao/geonet/kernel/search/ISearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/ISearchManager.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.kernel.search;
+
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataType;
+import org.jdom.Element;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+
+/**
+ * Base interface for the search (Lucene or Solr).
+ */
+public interface ISearchManager {
+    void init(ServiceConfig handlerConfig) throws Exception;
+
+    void end() throws Exception;
+
+    MetaSearcher newSearcher(String stylesheetName) throws Exception;
+
+    /**
+     * Indexes a metadata record.
+     *
+     * @param forceRefreshReaders if true then block all searches until they can obtain a up-to-date
+     *                            reader
+     */
+    void index(Path schemaDir, Element metadata, String id, List<Element> moreFields,
+               MetadataType metadataType, String root, boolean forceRefreshReaders)
+        throws Exception;
+
+    /**
+     * Force the index to wait until all changes are processed and the next reader obtained will get
+     * the latest data.
+     */
+    void forceIndexChanges() throws IOException;
+
+
+    /**
+     * Rebuilds the Lucene index. If xlink or from selection parameters are defined, reindex a
+     * subset of record. Otherwise reindex all records.
+     *
+     * @param xlinks        Search all docs with XLinks, clear the XLinks cache and index all
+     *                      records found.
+     * @param bucket Reindex all records from selection bucket.
+     */
+    boolean rebuildIndex(ServiceContext context,
+                         boolean xlinks,
+                         boolean reset,
+                         String bucket) throws Exception;
+
+    Map<String, String> getDocsChangeDate() throws Exception;
+
+    ISODate getDocChangeDate(String mdId) throws Exception;
+
+    Set<Integer> getDocsWithXLinks() throws Exception;
+
+    /**
+     * deletes a document.
+     */
+    void delete(String txt) throws Exception;
+
+    /**
+     * deletes a list of documents.
+     */
+    void delete(List<String> txts) throws Exception;
+
+    void rescheduleOptimizer(Calendar beginAt, int interval) throws Exception;
+
+    void disableOptimizer() throws Exception;
+}

--- a/core/src/main/java/org/fao/geonet/kernel/search/IndexFields.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/IndexFields.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.kernel.search;
+
+/**
+ * Names of fields in the Lucene index.
+ *
+ * @author heikki doeleman
+ */
+public class IndexFields {
+
+    /**
+     * Groups allowed to view.
+     */
+    public static final String _OP0 = "_op0";
+    /**
+     * Groups allowed to download.
+     */
+    public static final String _OP1 = "_op1";
+    /**
+     * Groups allowed to edit.
+     */
+    public static final String _OP2 = "_op2";
+    /**
+     * Groups allowed to be notified.
+     */
+    public static final String _OP3 = "_op3";
+    /**
+     * Groups allowed "dynamic".
+     */
+    public static final String _OP5 = "_op5";
+    /**
+     * Groups allowed to feature.
+     */
+    public static final String _OP6 = "_op6";
+
+    public static final String ABSTRACT = "abstract";
+    public static final String ANY = "any";
+    public static final String CAT = "_cat";
+    public static final String CHANGE_DATE = "changeDate";
+    public static final String CREATE_DATE = "createDate";
+    public static final String CREDIT = "credit";
+    public static final String DATAPARAM = "dataparam";
+    public static final String DENOMINATOR_FROM = "denominatorFrom";
+    public static final String DENOMINATOR_TO = "denominatorTo";
+    public static final String DENOMINATOR = "denominator";
+    public static final String DIGITAL = "digital";
+    public static final String DOWNLOAD = "download";
+    public static final String DUMMY = "_dummy";
+    public static final String EAST = "eastBL";
+    public static final String GROUP_OWNER = "_groupOwner";
+    public static final String ID = "_id";
+    public static final String INSPIRE_ANNEX = "inspireannex";
+    public static final String INSPIRE_CAT = "inspirecat";
+    public static final String INSPIRE_THEME = "inspiretheme";
+    public static final String IS_TEMPLATE = "_isTemplate";
+    public static final String KEYWORD = "keyword";
+    public static final String METADATA_STANDARD_NAME = "metadataStandardName";
+    public static final String NORTH = "northBL";
+    public static final String OPERATESON = "operatesOn";
+    public static final String ORG_NAME = "orgName";
+    public static final String OWNER = "_owner";
+    public static final String PAPER = "paper";
+    public static final String PARENTUUID = "parentUuid";
+    public static final String PROTOCOL = "protocol";
+    public static final String PUBLICATION_DATE = "publicationDate";
+    public static final String REVISION_DATE = "revisionDate";
+    public static final String SCHEMA = "_schema";
+    public static final String SERVICE_TYPE = "serviceType";
+    public static final String SOURCE = "_source";
+    public static final String SOUTH = "southBL";
+    public static final String SPATIALREPRESENTATIONTYPE = "spatialRepresentationType";
+    public static final String SUBJECT = "subject";
+    public static final String TAXON = "taxon:name";
+    public static final String TEMPORALEXTENT_BEGIN = "tempExtentBegin";
+    public static final String TEMPORALEXTENT_END = "tempExtentEnd";
+    public static final String TITLE = "title";
+    public static final String ALT_TITLE = "altTitle";
+    public static final String TOPIC_CATEGORY = "topicCat";
+    public static final String TYPE = "type";
+    public static final String UUID = "_uuid";
+    public static final String VALID = "_valid";
+    public static final String WEST = "westBL";
+    public static final String RECORD_IDENTIFIER = "metadataIdentifier";
+    public static final String RESOURCE_IDENTIFIER = "resourceIdentifier";
+    public static final String HAS_ATOM = "has_atom";
+    public static final String PARENT_RECORD_UUID = "parent";
+    public static final String RECORD_OPERATE_ON = "recordOperateOn";
+    public static final String RESOURCE_TITLE = "resourceTitle";
+    public static final String RESOURCE_ABSTRACT = "resourceAbstract";
+    public static final String RESOURCE_TYPE = "resourceType";
+    public static final String ROOT = "_root";
+    public static final String INDEXING_ERROR_MSG = "_indexingErrorMsg";
+    public static final String INDEXING_ERROR_FIELD = "_indexingError";
+}

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -933,12 +933,12 @@ public class SearchManager implements ISearchManager {
 
     @Override
     public void delete(String txt) throws Exception {
-
+        delete("_id", txt);
     }
 
     @Override
     public void delete(List<String> txts) throws Exception {
-
+        delete("_id", txts);
     }
 
     public ISODate getDocChangeDate(String mdId) throws Exception {

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
@@ -25,8 +25,6 @@ package org.fao.geonet.kernel.search.index;
 
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.ServiceManager;
-import jeeves.transaction.TransactionManager;
-import jeeves.transaction.TransactionTask;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
@@ -75,7 +73,7 @@ public class IndexingTask extends QuartzJobBean {
 
             for (Integer metadataIdentifier : metadataIdentifiers) {
                 try {
-                    _dataManager.indexMetadata(String.valueOf(metadataIdentifier), false);
+                    _dataManager.indexMetadata(String.valueOf(metadataIdentifier), false, null);
                 } catch (Exception e) {
                     Log.error(Geonet.INDEX_ENGINE, "Indexing task / An error happens indexing the metadata "
                         + metadataIdentifier + ". Error: " + e.getMessage(), e);

--- a/core/src/main/java/org/fao/geonet/services/thumbnail/Set.java
+++ b/core/src/main/java/org/fao/geonet/services/thumbnail/Set.java
@@ -153,7 +153,7 @@ public class Set {
             dataMan.setThumbnail(context, id, type.equals("small"), file.getOriginalFilename(), false);
         }
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         return new Response(id, dataMan.getNewVersion(id));
     }
@@ -209,7 +209,7 @@ public class Set {
         saveThumbnail(scaling, file, type, dataDir, scalingDir, scalingFactor, dataMan, id, context);
 
         //-----------------------------------------------------------------------
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
         Element response = new Element("Response");
         response.addContent(new Element("id").setText(id));
 

--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -58,6 +58,7 @@
   <bean id="translatorFactory" class="org.fao.geonet.kernel.search.TranslatorFactory"/>
 
   <bean id="SearchManager" class="org.fao.geonet.kernel.search.SearchManager" lazy-init="true"/>
+  <bean id="EsSearchManager" class="org.fao.geonet.kernel.search.EsSearchManager" lazy-init="true"/>
   <bean id="LuceneIndexLanguageTracker"
         class="org.fao.geonet.kernel.search.index.LuceneIndexLanguageTracker" lazy-init="true"/>
   <bean id="HarvesterSettingsManager" class="org.fao.geonet.kernel.setting.HarvesterSettingsManager"

--- a/core/src/test/java/org/fao/geonet/AbstractCoreIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/AbstractCoreIntegrationTest.java
@@ -77,7 +77,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.servlet.http.HttpSession;
 
 import jeeves.constants.ConfigFile;
 import jeeves.server.UserSession;
@@ -320,7 +319,7 @@ public abstract class AbstractCoreIntegrationTest extends AbstractSpringDataTest
             id, createDate, createDate,
             "" + groupId, metadataType);
 
-        dataManager.indexMetadata(id.get(0), true);
+        dataManager.indexMetadata(id.get(0), true, null);
         return Integer.parseInt(id.get(0));
     }
 

--- a/core/src/test/java/org/fao/geonet/kernel/search/LuceneSearcherPresentTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/LuceneSearcherPresentTest.java
@@ -43,7 +43,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -87,7 +86,7 @@ public class LuceneSearcherPresentTest extends AbstractCoreIntegrationTest {
 
         final String mdId = importMetadata.getMetadataIds().get(0);
         dataManager.unsetOperation(serviceContext, mdId, "" + ReservedGroup.all.getId(), ReservedOperation.editing);
-        dataManager.indexMetadata(mdId, true);
+        dataManager.indexMetadata(mdId, true, null);
 
         indexAndTaxonomy = searchManager.getNewIndexReader("eng");
         try {

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/Transaction.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/Transaction.java
@@ -262,7 +262,7 @@ public class Transaction extends AbstractOperation implements CatalogService {
             dataMan.setOperation(context, id, "" + ReservedGroup.all.getId(), ReservedOperation.view);
         }
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         fileIds.add(uuid);
 

--- a/es/README.md
+++ b/es/README.md
@@ -26,6 +26,7 @@ cd es
 mvn install -Pes-download
 mvn exec:exec -Des-start
 curl -X PUT http://localhost:9200/features -d @config/features.json
+curl -X PUT http://localhost:9200/records -d @config/records.json
 ```
 
 To delete your index:

--- a/es/config/features.json
+++ b/es/config/features.json
@@ -81,7 +81,16 @@
               "search_analyzer": "keyword"
             }
           }
-        }
+        },
+        {
+          "stringType": {
+            "match": "_op*",
+            "mapping": {
+              "type": "keyword",
+              "fielddata": true
+            }
+          }
+        },
       ],
       "properties": {
         "id": {

--- a/es/config/records.json
+++ b/es/config/records.json
@@ -6,7 +6,9 @@
           "synInspireAnnexes": {
             "tokenizer": "keyword",
             "filter": [
-              "synInspireAnnexes"
+              "synInspireThemes",
+              "synInspireAnnexes",
+              "keepInspireAnnexes"
             ]
           },
           "synInspireThemes": {
@@ -994,6 +996,39 @@
               "type": "keyword"
             }
           }
+        },
+        {
+          "synInspireAnnexesType": {
+            "match": "inspireAnnex*",
+            "mapping": {
+              "type":     "string",
+              "fielddata": true,
+              "analyzer": "synInspireAnnexes",
+              "search_analyzer": "keyword"
+            }
+          }
+        },
+        {
+          "synInspireThemeType": {
+            "match": "inspireTheme*",
+            "mapping": {
+              "type":     "string",
+              "fielddata": true,
+              "analyzer": "synInspireThemes",
+              "search_analyzer": "keyword"
+            }
+          }
+        },
+        {
+          "inspireServiceType": {
+            "match": "inspireServiceType",
+            "mapping": {
+              "type":     "string",
+              "fielddata": true,
+              "analyzer": "keepInspireServiceTypes",
+              "search_analyzer": "keyword"
+            }
+          }
         }
       ]
     },
@@ -1055,21 +1090,6 @@
         },
         "isAboveThreshold": {
           "type": "boolean"
-        },
-        "inspireAnnex": {
-          "type": "keyword"
-        },
-        "inspireAnnexForFirstTheme": {
-          "type": "keyword"
-        },
-        "inspireServiceType": {
-          "type": "keyword"
-        },
-        "inspireTheme": {
-          "type": "keyword"
-        },
-        "inspireThemeFirst": {
-          "type": "keyword"
         },
         "inspireThemeFirst_syn": {
           "type": "keyword"

--- a/es/config/records.json
+++ b/es/config/records.json
@@ -1,0 +1,1247 @@
+{
+  "settings": {
+    "index": {
+      "analysis": {
+        "analyzer": {
+          "synInspireAnnexes": {
+            "tokenizer": "keyword",
+            "filter": [
+              "synInspireAnnexes"
+            ]
+          },
+          "synInspireThemes": {
+            "tokenizer": "keyword",
+            "filter": [
+              "synInspireThemes"
+            ]
+          },
+          "keepInspireServiceTypes": {
+            "tokenizer": "keyword",
+            "filter": [
+              "lowercase", "keepInspireServiceTypes"
+            ]
+          },
+          "keepInspireAnnexes": {
+            "tokenizer": "keyword",
+            "filter": [
+              "lowercase", "keepInspireAnnexes"
+            ]
+          },
+          "keepInspireThemes": {
+            "tokenizer": "keyword",
+            "filter": [
+              "lowercase", "keepInspireThemes"
+            ]
+          },
+          "synCheckpoint": {
+            "tokenizer": "keyword",
+            "filter": [
+              "synCheckpoint"
+            ]
+          }
+        },
+        "filter": {
+          "keepInspireServiceTypes": {
+            "type": "keep",
+            "keep_words": [
+              "discovery",
+              "view",
+              "download",
+              "invoke",
+              "transformation",
+              "other"
+            ]
+          },
+          "keepInspireAnnexes": {
+            "type": "keep",
+            "keep_words": [
+              "i",
+              "ii",
+              "iii"
+            ]
+          },
+          "keepInspireThemes": {
+            "type": "keep",
+            "keep_words": [
+              "Coordinate reference systems",
+              "Elevation",
+              "Land cover",
+              "Orthoimagery",
+              "Geology",
+              "Statistical units",
+              "Buildings",
+              "Soil",
+              "Land use",
+              "Human health and safety",
+              "Utility and governmental services",
+              "Geographical grid systems",
+              "Environmental monitoring facilities",
+              "Production and industrial facilities",
+              "Agricultural and aquaculture facilities",
+              "Population distribution — demography",
+              "Area management/restriction/regulation zones and reporting units",
+              "Natural risk zones",
+              "Atmospheric conditions",
+              "Meteorological geographical features",
+              "Oceanographic geographical features",
+              "Sea regions",
+              "Geographical names",
+              "Bio-geographical regions",
+              "Habitats and biotopes",
+              "Species distribution",
+              "Energy resources",
+              "Mineral resources",
+              "Administrative units",
+              "Addresses",
+              "Cadastral parcels",
+              "Transport networks",
+              "Hydrography",
+              "Protected sites"
+            ]
+          },
+          "synInspireAnnexes": {
+            "type": "synonym",
+            "tokenizer": "keyword",
+            "ignore_case": true,
+            "synonyms": [
+              "Coordinate reference systems => I",
+              "Elevation => II",
+              "Land cover => II",
+              "Orthoimagery => II",
+              "Geology => II",
+              "Statistical units => III",
+              "Buildings => III",
+              "Soil => III",
+              "Land use => III",
+              "Human health and safety => III",
+              "Utility and governmental services => III",
+              "Geographical grid systems => I",
+              "Environmental monitoring facilities => III",
+              "Production and industrial facilities => III",
+              "Agricultural and aquaculture facilities => III",
+              "Population distribution — demography => III",
+              "Area management/restriction/regulation zones and reporting units => III",
+              "Natural risk zones => III",
+              "Atmospheric conditions => III",
+              "Meteorological geographical features => III",
+              "Oceanographic geographical features => III",
+              "Sea regions => III",
+              "Geographical names => I",
+              "Bio-geographical regions => III",
+              "Habitats and biotopes => III",
+              "Species distribution => III",
+              "Energy resources => III",
+              "Mineral resources => III",
+              "Administrative units => I",
+              "Addresses => I",
+              "Cadastral parcels => I",
+              "Transport networks => I",
+              "Hydrography => I",
+              "Protected sites => I"
+            ]
+          },
+          "synInspireThemes": {
+            "type": "synonym",
+            "tokenizer": "keyword",
+            "ignore_case": true,
+            "synonyms": [
+              "Referenskoordinatsystem => Coordinate reference systems",
+              "Referenčni koordinatni sistemi => Coordinate reference systems",
+              "Súradnicové referenčné systémy => Coordinate reference systems",
+              "Sisteme de coordonate de referință => Coordinate reference systems",
+              "Sisteme de coordonate de referinţă => Coordinate reference systems",
+              "Systemy odniesienia za pomocą współrzędnych => Coordinate reference systems",
+              "Sistemas de referencia => Coordinate reference systems",
+              "Systemen voor verwijzing door middel van coördinaten => Coordinate reference systems",
+              "Sistemi ta' referenza ta' koordinati => Coordinate reference systems",
+              "Koordinātu atskaites sistēmas => Coordinate reference systems",
+              "Koordinačių atskaitos sistemos => Coordinate reference systems",
+              "Sistemi di coordinate => Coordinate reference systems",
+              "Koordinátarendszerek => Coordinate reference systems",
+              "Référentiels de coordonnées => Coordinate reference systems",
+              "Koordinaattijärjestelmät => Coordinate reference systems",
+              "Sistemas de coordenadas de referencia => Coordinate reference systems",
+              "Koordinaatsüsteemid => Coordinate reference systems",
+              "Συστήματα συντεταγμένων => Coordinate reference systems",
+              "Koordinatenreferenzsysteme => Coordinate reference systems",
+              "Координатни справочни системи => Coordinate reference systems",
+              "Koordinatsystemer => Coordinate reference systems",
+              "Souřadnicové referenční systémy => Coordinate reference systems",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/1 => Coordinate reference systems",
+              "Höjd => Elevation",
+              "Altitude => Elevation",
+              "Elevaţie => Elevation",
+              "Elevație => Elevation",
+              "Digitalni model višin => Elevation",
+              "Výška => Elevation",
+              "Ukształtowanie terenu => Elevation",
+              "Hoogte => Elevation",
+              "Elevazzjoni => Elevation",
+              "Augstums => Elevation",
+              "Aukštis => Elevation",
+              "Elevazione => Elevation",
+              "Korkeus => Elevation",
+              "Domborzat => Elevation",
+              "Υψομετρία => Elevation",
+              "Elevaciones => Elevation",
+              "Kõrgused => Elevation",
+              "Höhe => Elevation",
+              "Højde => Elevation",
+              "Nadmořská výška => Elevation",
+              "Релеф => Elevation",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/10 => Elevation",
+              "Landtäcke => Land cover",
+              "Pokrovnost tal => Land cover",
+              "Ocupação do solo => Land cover",
+              "Krajinná pokrývka (land cover) => Land cover",
+              "Acoperire terestră => Land cover",
+              "Bodemgebruik => Land cover",
+              "Użytkowanie terenu => Land cover",
+              "Zemes virsma => Land cover",
+              "Kopertura ta' l-art => Land cover",
+              "Žemės danga => Land cover",
+              "A felszín borítása => Land cover",
+              "Occupation des terres => Land cover",
+              "Copertura del suolo => Land cover",
+              "Cubierta terrestre => Land cover",
+              "Maakate => Land cover",
+              "Maanpeite => Land cover",
+              "Κάλυψη γης => Land cover",
+              "Bodenbedeckung => Land cover",
+              "Krajinný pokryv => Land cover",
+              "Arealdække => Land cover",
+              "Земна покривка => Land cover",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/11 => Land cover",
+              "Ortofoto => Orthoimagery",
+              "Ortoimagini => Orthoimagery",
+              "Ortometria => Orthoimagery",
+              "Sporządzanie ortoobrazów => Orthoimagery",
+              "Ortoimagens => Orthoimagery",
+              "Orthobeeldvorming => Orthoimagery",
+              "Orthoimagery => Orthoimagery",
+              "Ortofotogrāfija => Orthoimagery",
+              "Ortofotografinis vaizdavimas => Orthoimagery",
+              "Orto immagini => Orthoimagery",
+              "Ortofotók => Orthoimagery",
+              "Ortho-imagerie => Orthoimagery",
+              "Ortoimágenes => Orthoimagery",
+              "Ortoilmakuvat => Orthoimagery",
+              "Ortokujutised => Orthoimagery",
+              "Ορθοφωτογραφία => Orthoimagery",
+              "Orthofotografie => Orthoimagery",
+              "Ortofotosnímky => Orthoimagery",
+              "Ортоизображение => Orthoimagery",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/12 => Orthoimagery",
+              "Geologia => Geology",
+              "Geologie => Geology",
+              "Geológia => Geology",
+              "Geologija => Geology",
+              "Geologi => Geology",
+              "Ġeologija => Geology",
+              "Ģeoloģija => Geology",
+              "Földtan => Geology",
+              "Géologie => Geology",
+              "Geología => Geology",
+              "Geoloogia => Geology",
+              "Γεωλογία => Geology",
+              "Геология => Geology",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/13 => Geology",
+              "Unidades estatísticas => Statistical units",
+              "Unităţi statistice => Statistical units",
+              "Štatistické jednotky => Statistical units",
+              "Statistični okoliši => Statistical units",
+              "Statistiska enheter => Statistical units",
+              "Statistische eenheden => Statistical units",
+              "Jednostki statystyczne => Statistical units",
+              "Statistiniai vienetai => Statistical units",
+              "Unitajiet statistiċi => Statistical units",
+              "Unități statistice => Statistical units",
+              "Statistikas vienības => Statistical units",
+              "Unità statistiche => Statistical units",
+              "Tilastoyksiköt => Statistical units",
+              "Unités statistiques => Statistical units",
+              "Statisztikai egységek => Statistical units",
+              "Unidades estadísticas => Statistical units",
+              "Statistilised üksused => Statistical units",
+              "Statistische Einheiten => Statistical units",
+              "Στατιστικές μονάδες => Statistical units",
+              "Statistické jednotky => Statistical units",
+              "Statistiske enheder => Statistical units",
+              "Статистически единици => Statistical units",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/14 => Statistical units",
+              "Stavbe => Buildings",
+              "Byggnader => Buildings",
+              "Clădiri => Buildings",
+              "Stavby => Buildings",
+              "Edifícios => Buildings",
+              "Budynki => Buildings",
+              "Ēkas => Buildings",
+              "Bini => Buildings",
+              "Gebouwen => Buildings",
+              "Κτίρια => Buildings",
+              "Edificios => Buildings",
+              "Ehitised => Buildings",
+              "Rakennukset => Buildings",
+              "Pastatai => Buildings",
+              "Edifici => Buildings",
+              "Épületek => Buildings",
+              "Bâtiments => Buildings",
+              "Сгради => Buildings",
+              "Budovy => Buildings",
+              "Bygninger => Buildings",
+              "Gebäude => Buildings",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/15 => Buildings",
+              "Tla => Soil",
+              "Mark => Soil",
+              "Soluri => Soil",
+              "Gleba => Soil",
+              "Pôda => Soil",
+              "Solo => Soil",
+              "Augsne => Soil",
+              "Bodem => Soil",
+              "Ħamrija => Soil",
+              "Suolo => Soil",
+              "Dirvožemis => Soil",
+              "Talaj => Soil",
+              "Sols => Soil",
+              "Maaperä => Soil",
+              "Pinnas => Soil",
+              "Suelo => Soil",
+              "Έδαφος => Soil",
+              "Boden => Soil",
+              "Jord => Soil",
+              "Půda => Soil",
+              "Почва => Soil",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/16 => Soil",
+              "Markanvändning => Land use",
+              "Namenska raba tal => Land use",
+              "Zagospodarowanie przestrzenne => Land use",
+              "Uso do solo => Land use",
+              "Utilizarea terenului => Land use",
+              "Využitie územia => Land use",
+              "Zemes izmantošana => Land use",
+              "Użu ta' l-art => Land use",
+              "Landgebruik => Land use",
+              "Földhasználat => Land use",
+              "Žemės naudojimas => Land use",
+              "Utilizzo del territorio => Land use",
+              "Maakasutus => Land use",
+              "Maankäyttö => Land use",
+              "Usage des sols => Land use",
+              "Χρήσεις γης => Land use",
+              "Uso del suelo => Land use",
+              "Ползване на земята => Land use",
+              "Využití území => Land use",
+              "Arealanvendelse => Land use",
+              "Bodennutzung => Land use",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/17 => Land use",
+              "Människors hälsa och säkerhet => Human health and safety",
+              "Zdravje in varnost prebivalstva => Human health and safety",
+              "Ľudské zdravie a bezpečnosť => Human health and safety",
+              "Zdrowie i bezpieczeństwo ludzi => Human health and safety",
+              "Sănătate şi siguranţă umană => Human health and safety",
+              "Sănătate și siguranță umană => Human health and safety",
+              "Saúde humana e segurança => Human health and safety",
+              "Žmonių sveikata ir sauga => Human health and safety",
+              "Cilvēku veselība un drošība => Human health and safety",
+              "Is-saħħa u s-siġurtà tal-bniedem => Human health and safety",
+              "Menselijke gezondheid en veiligheid => Human health and safety",
+              "Salute umana e sicurezza => Human health and safety",
+              "Emberi egészség és biztonság => Human health and safety",
+              "Santé et sécurité des personnes => Human health and safety",
+              "Väestön terveys ja turvallisuus => Human health and safety",
+              "Salud y seguridad humanas => Human health and safety",
+              "Inimeste tervis ja ohutus => Human health and safety",
+              "Sikkerhed => Human health and safety",
+              "Gesundheit und Sicherheit => Human health and safety",
+              "Ανθρώπινη υγεία και ασφάλεια => Human health and safety",
+              "Здраве и безопасност на човека => Human health and safety",
+              "Lidské zdraví a bezpečnost => Human health and safety",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/18 => Human health and safety",
+              "Allmännyttiga och offentliga tjänster => Utility and governmental services",
+              "Komunalne in javne storitve => Utility and governmental services",
+              "Servicii de utilitate publică şi servicii publice => Utility and governmental services",
+              "Servicii de utilitate publică și servicii publice => Utility and governmental services",
+              "Verejné a štátne služby => Utility and governmental services",
+              "Usługi użyteczności publicznej i służby państwowe => Utility and governmental services",
+              "Serviços de utilidade pública e do Estado => Utility and governmental services",
+              "Nutsdiensten en overheidsdiensten => Utility and governmental services",
+              "Komunalinės įmonės ir valstybės tarnybos => Utility and governmental services",
+              "Servizzi ta' utilità u tal-gvern => Utility and governmental services",
+              "Komunālie un valsts dienesti => Utility and governmental services",
+              "Servizi di pubblica utilità e servizi amministrativi => Utility and governmental services",
+              "Services d'utilité publique et services publics => Utility and governmental services",
+              "Közüzemi és közszolgáltatások => Utility and governmental services",
+              "Yleishyödylliset ja muut julkiset palvelut => Utility and governmental services",
+              "Servicios de utilidad pública y estatales => Utility and governmental services",
+              "Kommunaal- ja riiklikud teenused => Utility and governmental services",
+              "Offentlig forsyningsvirksomhed og offentlige tjenesteydelser => Utility and governmental services",
+              "Versorgungswirtschaft und staatliche Dienste => Utility and governmental services",
+              "Комунално-битови и обществени услуги => Utility and governmental services",
+              "Επιχειρήσεις κοινής ωφελείας και κρατικές υπηρεσίες => Utility and governmental services",
+              "Veřejné služby a služby veřejné správy => Utility and governmental services",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/19 => Utility and governmental services",
+              "Geografska koordinatna mreža => Geographical grid systems",
+              "Geografiska rutnätssystem => Geographical grid systems",
+              "Sisteme de caroiaj geografic => Geographical grid systems",
+              "Geografické systémy sietí => Geographical grid systems",
+              "Systemy siatek geograficznych => Geographical grid systems",
+              "Sistemas de quadrículas geográficas => Geographical grid systems",
+              "Sistemi ta' grilji ġeografiċi => Geographical grid systems",
+              "Geografisch rastersysteem => Geographical grid systems",
+              "Ģeogrāfisko koordinātu tīklu sistēmas => Geographical grid systems",
+              "Geografinio tinklelio sistemos => Geographical grid systems",
+              "Sistemi di griglie geografiche => Geographical grid systems",
+              "Systèmes de maillage géographique => Geographical grid systems",
+              "Földrajzi rácsrendszerek => Geographical grid systems",
+              "Paikannusruudustot => Geographical grid systems",
+              "Sistema de cuadrículas geográficas => Geographical grid systems",
+              "Geograafilised ruutvõrgud => Geographical grid systems",
+              "Συστήματα γεωγραφικού καννάβου => Geographical grid systems",
+              "Geografiske kvadratnetsystemer => Geographical grid systems",
+              "Geografische Gittersysteme => Geographical grid systems",
+              "Географски координатни системи => Geographical grid systems",
+              "Zeměpisné soustavy souřadnicových sítí => Geographical grid systems",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/2 => Geographical grid systems",
+              "Anläggningar för miljöövervakning => Environmental monitoring facilities",
+              "Naprave in objekti za monitoring okolja => Environmental monitoring facilities",
+              "Zariadenia na monitorovanie životného prostredia => Environmental monitoring facilities",
+              "Instalações de monitorização do ambiente => Environmental monitoring facilities",
+              "Milieubewakingsvoorzieningen => Environmental monitoring facilities",
+              "Urządzenia do monitorowania środowiska => Environmental monitoring facilities",
+              "Instalaţii de supraveghere a mediului => Environmental monitoring facilities",
+              "Instalații de supraveghere a mediului => Environmental monitoring facilities",
+              "Faċilitajiet ta' monitoraġġ ambjentali => Environmental monitoring facilities",
+              "Aplinkos stebėsenos priemonės => Environmental monitoring facilities",
+              "Vides monitoringa iekārtas => Environmental monitoring facilities",
+              "Környezetvédelmi monitoringlétesítmények => Environmental monitoring facilities",
+              "Impianti di monitoraggio ambientale => Environmental monitoring facilities",
+              "Installations de suivi environnemental => Environmental monitoring facilities",
+              "Keskkonnaseirerajatised => Environmental monitoring facilities",
+              "Ympäristön tilan seurantalaitteet => Environmental monitoring facilities",
+              "Instalaciones de observación del medio ambiente => Environmental monitoring facilities",
+              "Εγκαταστάσεις παρακολούθησης του περιβάλλοντος => Environmental monitoring facilities",
+              "Miljøovervågningsfaciliteter => Environmental monitoring facilities",
+              "Umweltüberwachung => Environmental monitoring facilities",
+              "Zařízení pro sledování životního prostředí => Environmental monitoring facilities",
+              "Съоръжения за управление на околната среда => Environmental monitoring facilities",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/20 => Environmental monitoring facilities",
+              "Produktions- och industrianläggningar => Production and industrial facilities",
+              "Instalaţii de producţie şi industriale => Production and industrial facilities",
+              "Instalații de producție și industriale => Production and industrial facilities",
+              "Proizvodni in industrijski objekti in naprave => Production and industrial facilities",
+              "Výrobné a priemyselné zariadenia => Production and industrial facilities",
+              "Faciliteiten voor productie en industrie => Production and industrial facilities",
+              "Instalações industriais e de produção => Production and industrial facilities",
+              "Obiekty produkcyjne i przemysłowe => Production and industrial facilities",
+              "Ražošanas un rūpniecības iekārtas => Production and industrial facilities",
+              "Faċilitajiet ta' produzzjoni u industrijali => Production and industrial facilities",
+              "Produzione e impianti industriali => Production and industrial facilities",
+              "Gamybos ir pramonės įrenginiai => Production and industrial facilities",
+              "Tuotanto- ja teollisuuslaitokset => Production and industrial facilities",
+              "Lieux de production et sites industriels => Production and industrial facilities",
+              "Termelő és ipari létesítmények => Production and industrial facilities",
+              "Tootmis- ja tööstusrajatised => Production and industrial facilities",
+              "Instalaciones de producción e industriales => Production and industrial facilities",
+              "Εγκαταστάσεις παραγωγής και βιομηχανικές εγκαταστάσεις => Production and industrial facilities",
+              "Produktions- und Industrieanlagen => Production and industrial facilities",
+              "Výrobní a průmyslová zařízení => Production and industrial facilities",
+              "Produktions- og industrifaciliteter => Production and industrial facilities",
+              "Производствени и промишлени съоръжения => Production and industrial facilities",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/21 => Production and industrial facilities",
+              "Jordbruks- och vattenbruksanläggningar => Agricultural and aquaculture facilities",
+              "Objekti in naprave za kmetijstvo in ribogojstvo => Agricultural and aquaculture facilities",
+              "Poľnohospodárske zariadenia a zariadenia akvakultúry => Agricultural and aquaculture facilities",
+              "Instalações agrícolas e aquícolas => Agricultural and aquaculture facilities",
+              "Instalaţii agricole şi pentru acvacultură => Agricultural and aquaculture facilities",
+              "Instalații agricole și pentru acvacultură => Agricultural and aquaculture facilities",
+              "Obiekty rolnicze oraz akwakultury => Agricultural and aquaculture facilities",
+              "Faċilitajiet agrikoli u ta' l-akwakultura => Agricultural and aquaculture facilities",
+              "Faciliteiten voor landbouw en aquacultuur => Agricultural and aquaculture facilities",
+              "Lauksaimniecības un akvakultūras iekārtas => Agricultural and aquaculture facilities",
+              "Žemės ūkio ir akvakultūros infrastruktūra => Agricultural and aquaculture facilities",
+              "Impianti agricoli e di acquacoltura => Agricultural and aquaculture facilities",
+              "Γεωργικές εγκαταστάσεις και εγκαταστάσεις υδατοκαλλιέργειας => Agricultural and aquaculture facilities",
+              "Mezőgazdasági és akvakultúra-ágazati létesítmények => Agricultural and aquaculture facilities",
+              "Installations agricoles et aquacoles => Agricultural and aquaculture facilities",
+              "Maatalous- ja vesiviljelylaitokset => Agricultural and aquaculture facilities",
+              "Põllumajandus- ja vesiviljelusrajatised => Agricultural and aquaculture facilities",
+              "Instalaciones agrícolas y de acuicultura => Agricultural and aquaculture facilities",
+              "Селскостопански и водностопански съоръжения => Agricultural and aquaculture facilities",
+              "Zemědělská a akvakulturní zařízení => Agricultural and aquaculture facilities",
+              "Landwirtschaftliche Anlagen und Aquakulturanlagen => Agricultural and aquaculture facilities",
+              "Landbrugs- og akvakulturanlæg => Agricultural and aquaculture facilities",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/22 => Agricultural and aquaculture facilities",
+              "Befolkningsfördelning – demografi => Population distribution — demography",
+              "Porazdelitev prebivalstva – demografski podatki => Population distribution — demography",
+              "Repartizarea populaţiei – demografie => Population distribution — demography",
+              "Repartizarea populației – demografie => Population distribution — demography",
+              "Rozmiestnenie obyvateľstva – demografia => Population distribution — demography",
+              "Distribuição da população — demografia => Population distribution — demography",
+              "Spreiding van de bevolking — demografie => Population distribution — demography",
+              "Rozmieszczenie ludności – demografia => Population distribution — demography",
+              "Iedzīvotāju sadalījums – demogrāfija => Population distribution — demography",
+              "Distribuzzjoni tal-popolazzjoni – demografija => Population distribution — demography",
+              "Distribuzione della popolazione — demografia => Population distribution — demography",
+              "Gyventojų pasiskirstymas – demografija => Population distribution — demography",
+              "Répartition de la population — démographie => Population distribution — demography",
+              "A népesség eloszlása – demográfia => Population distribution — demography",
+              "Elanikkonna jaotumine – demograafia => Population distribution — demography",
+              "Väestöjakauma – demografia => Population distribution — demography",
+              "Distribución de la población — demografía => Population distribution — demography",
+              "Κατανομή πληθυσμού — δημογραφία => Population distribution — demography",
+              "Rozložení obyvatelstva – demografie => Population distribution — demography",
+              "Verteilung der Bevölkerung — Demografie => Population distribution — demography",
+              "Befolkningsfordeling — demografi => Population distribution — demography",
+              "Разпределение на населението — демография => Population distribution — demography",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/23 => Population distribution — demography",
+              "Spravované/obmedzené/regulované zóny a jednotky podávajúce správy => Area management/restriction/regulation zones and reporting units",
+              "Områden med särskild förvaltning/begränsningar/reglering samt enheter för rapportering => Area management/restriction/regulation zones and reporting units",
+              "Območja upravljanja/zaprta območja/regulirana območja in poročevalske enote => Area management/restriction/regulation zones and reporting units",
+              "Zone de administrare/restricţie/reglementare şi unităţi de raportare => Area management/restriction/regulation zones and reporting units",
+              "Zone de administrare/restricție/reglementare și unități de raportare => Area management/restriction/regulation zones and reporting units",
+              "Gebiedsbeheer, gebieden waar beperkingen gelden, gereguleerde gebieden en rapportage-eenheden => Area management/restriction/regulation zones and reporting units",
+              "Zonas de gestão/restrição/regulamentação e unidades de referência => Area management/restriction/regulation zones and reporting units",
+              "Gospodarowanie obszarem/strefy ograniczone/regulacyjne oraz jednostki sprawozdawcze => Area management/restriction/regulation zones and reporting units",
+              "Apgabala pārvaldības/ierobežojumu/reglamentētas zonas un ziņošanas vienības => Area management/restriction/regulation zones and reporting units",
+              "Zone sottoposte a gestione/limitazioni/regolamentazione e unità con obbligo di comunicare dati => Area management/restriction/regulation zones and reporting units",
+              "Amministrazzjoni ta' żoni/restrizzjoni/żoni regolati u unitajiet ta' rapportar => Area management/restriction/regulation zones and reporting units",
+              "Tvarkomos teritorijos, ribojamos ir reglamentuojamos zonos bei vienetai, už kuriuos atsiskaitoma => Area management/restriction/regulation zones and reporting units",
+              "Területgazdálkodási/-korlátozási/-szabályozási övezetek és adatszolgáltató egységek => Area management/restriction/regulation zones and reporting units",
+              "Zones de gestion, de restriction ou de réglementation et unités de déclaration => Area management/restriction/regulation zones and reporting units",
+              "Aluesuunnittelun, rajoitusten ja sääntelyn piiriin kuuluvat alueet ja raportointiyksiköt => Area management/restriction/regulation zones and reporting units",
+              "Üldplaneering/piirangu-/reguleeritud tsoonid ja aruandlusüksused => Area management/restriction/regulation zones and reporting units",
+              "Zonas sujetas a ordenación, a restricciones o reglamentaciones y unidades de notificación => Area management/restriction/regulation zones and reporting units",
+              "Bewirtschaftungsgebiete/Schutzgebiete/geregelte Gebiete und Berichterstattungseinheiten => Area management/restriction/regulation zones and reporting units",
+              "Ζώνες διαχείρισης/περιορισμού/ρύθμισης εκτάσεων και μονάδες αναφοράς => Area management/restriction/regulation zones and reporting units",
+              "Forvaltede og regulerede områder samt områder med brugsbegrænsning og indberetningsenheder => Area management/restriction/regulation zones and reporting units",
+              "Správní oblasti/chráněná pásma/regulovaná území a jednotky podávající hlášení => Area management/restriction/regulation zones and reporting units",
+              "Управление на територията/ограничени/регулирани зони и отчетни единици => Area management/restriction/regulation zones and reporting units",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/24 => Area management/restriction/regulation zones and reporting units",
+              "Območja nevarnosti naravnih nesreč => Natural risk zones",
+              "Naturliga riskområden => Natural risk zones",
+              "Zóny prírodného rizika => Natural risk zones",
+              "Zone de risc natural => Natural risk zones",
+              "Zonas de risco natural => Natural risk zones",
+              "Strefy zagrożenia naturalnego => Natural risk zones",
+              "Żoni ta' riskju naturali => Natural risk zones",
+              "Gebieden met natuurrisico'es => Natural risk zones",
+              "Gebieden met natuurrisico's => Natural risk zones",
+              "Dabas apdraudējuma zonas => Natural risk zones",
+              "Gamtinių pavojų zonos => Natural risk zones",
+              "Természeti kockázati zónák => Natural risk zones",
+              "Zone a rischio naturale => Natural risk zones",
+              "Zones à risque naturel => Natural risk zones",
+              "Luonnonriskialueet => Natural risk zones",
+              "Looduslikud ohutsoonid => Natural risk zones",
+              "Zonas de riesgos naturales => Natural risk zones",
+              "Ζώνες φυσικών κινδύνων => Natural risk zones",
+              "Природни рискови зони => Natural risk zones",
+              "Områder med naturlige risici => Natural risk zones",
+              "Gebiete mit naturbedingten Risiken => Natural risk zones",
+              "Oblasti ohrožené přírodními riziky => Natural risk zones",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/25 => Natural risk zones",
+              "Ozračje => Atmospheric conditions",
+              "Atmosfäriska förhållanden => Atmospheric conditions",
+              "Condiţii atmosferice => Atmospheric conditions",
+              "Condiții atmosferice => Atmospheric conditions",
+              "Atmosférické podmienky => Atmospheric conditions",
+              "Warunki atmosferyczne => Atmospheric conditions",
+              "Condições atmosféricas => Atmospheric conditions",
+              "Atmosferische omstandigheden => Atmospheric conditions",
+              "Kondizzjonijiet atmosferiċi => Atmospheric conditions",
+              "Atmosfēras apstākļi => Atmospheric conditions",
+              "Condizioni atmosferiche => Atmospheric conditions",
+              "Atmosferos sąlygos => Atmospheric conditions",
+              "Conditions atmosphériques => Atmospheric conditions",
+              "Légköri viszonyok => Atmospheric conditions",
+              "Atmosfääritingimused => Atmospheric conditions",
+              "Ilmakehän tila => Atmospheric conditions",
+              "Condiciones atmosféricas => Atmospheric conditions",
+              "Atmosphärische Bedingungen => Atmospheric conditions",
+              "Ατμοσφαιρικές συνθήκες => Atmospheric conditions",
+              "Stav ovzduší => Atmospheric conditions",
+              "Atmosfæriske forhold => Atmospheric conditions",
+              "Атмосферни условия => Atmospheric conditions",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/26 => Atmospheric conditions",
+              "Meteorološke značilnosti => Meteorological geographical features",
+              "Geografiska meteorologiska förhållanden => Meteorological geographical features",
+              "Meteorologické geografické prvky => Meteorological geographical features",
+              "Características geometeorológicas => Meteorological geographical features",
+              "Caracteristici geografice meteorologice => Meteorological geographical features",
+              "Warunki meteorologiczno-geograficzne => Meteorological geographical features",
+              "Meteorologische geografische kenmerken => Meteorological geographical features",
+              "Karatteristiċi ġeografiċi meteoroloġiċi => Meteorological geographical features",
+              "Meteoroloģiski ģeogrāfiskie raksturlielumi => Meteorological geographical features",
+              "Meteorologinės geografinės sąlygos => Meteorological geographical features",
+              "Elementi geografici meteorologici => Meteorological geographical features",
+              "Meteorológiai földrajzi jellemzők => Meteorological geographical features",
+              "Ilmaston maantieteelliset ominaispiirteet => Meteorological geographical features",
+              "Caractéristiques géographiques météorologiques => Meteorological geographical features",
+              "Meteoroloogilis-geograafilised tunnusjooned => Meteorological geographical features",
+              "Μετεωρολογικά γεωγραφικά χαρακτηριστικά => Meteorological geographical features",
+              "Aspectos geográficos de carácter meteorológico => Meteorological geographical features",
+              "Meteorologisch-geografische Kennwerte => Meteorological geographical features",
+              "Meteorologisk-geografiske forhold => Meteorological geographical features",
+              "Метеорологични географски характеристики => Meteorological geographical features",
+              "Zeměpisné meteorologické prvky => Meteorological geographical features",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/27 => Meteorological geographical features",
+              "Geografiska oceanografiska förhållanden => Oceanographic geographical features",
+              "Oceanogeografske značilnosti => Oceanographic geographical features",
+              "Características oceanográficas => Oceanographic geographical features",
+              "Caracteristici geografice oceanografice => Oceanographic geographical features",
+              "Oceánografické geografické prvky => Oceanographic geographical features",
+              "Warunki oceanograficzno-geograficzne => Oceanographic geographical features",
+              "Karatteristiċi ġeografiċi oċeanografiċi => Oceanographic geographical features",
+              "Oceanografische geografische kenmerken => Oceanographic geographical features",
+              "Okeanogrāfiski ģeogrāfiskie raksturlielumi => Oceanographic geographical features",
+              "Elementi geografici oceanografici => Oceanographic geographical features",
+              "Okeanografinės geografinės sąlygos => Oceanographic geographical features",
+              "Oceanográfiai földrajzi jellemzők => Oceanographic geographical features",
+              "Caractéristiques géographiques océanographiques => Oceanographic geographical features",
+              "Merentutkimuksen maantieteelliset ominaispiirteet => Oceanographic geographical features",
+              "Okeanograafilis-geograafilised tunnusjooned => Oceanographic geographical features",
+              "Rasgos geográficos oceanográficos => Oceanographic geographical features",
+              "Oceanografiske/geografiske forhold => Oceanographic geographical features",
+              "Ozeanografisch-geografische Kennwerte => Oceanographic geographical features",
+              "Ωκεανογραφικά γεωγραφικά χαρακτηριστικά => Oceanographic geographical features",
+              "Zeměpisné oceánografické prvky => Oceanographic geographical features",
+              "Океанографски географски характеристики => Oceanographic geographical features",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/28 => Oceanographic geographical features",
+              "Havsområden => Sea regions",
+              "Morske regije => Sea regions",
+              "Morské regióny => Sea regions",
+              "Regiuni maritime => Sea regions",
+              "Zeegebieden => Sea regions",
+              "Regiony morskie => Sea regions",
+              "Regiões marinhas => Sea regions",
+              "Reġjuni tal-baħar => Sea regions",
+              "Jūru reģioni => Sea regions",
+              "Jūrų regionai => Sea regions",
+              "Regioni marine => Sea regions",
+              "Tengeri régiók => Sea regions",
+              "Régions maritimes => Sea regions",
+              "Merepiirkonnad => Sea regions",
+              "Merialueet => Sea regions",
+              "Regiones marinas => Sea regions",
+              "Θαλάσσιες περιοχές => Sea regions",
+              "Mořské oblasti => Sea regions",
+              "Havområder => Sea regions",
+              "Meeresregionen => Sea regions",
+              "Морски региони => Sea regions",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/29 => Sea regions",
+              "Zemljepisna imena => Geographical names",
+              "Geografiska namn => Geographical names",
+              "Zemepisné názvy => Geographical names",
+              "Denumiri geografice => Geographical names",
+              "Nazwy geograficzne => Geographical names",
+              "Toponímia => Geographical names",
+              "Toponīmi => Geographical names",
+              "Ismijiet ġeografiċi => Geographical names",
+              "Geografische namen => Geographical names",
+              "Dénominations géographiques => Geographical names",
+              "Földrajzi nevek => Geographical names",
+              "Nomi geografici => Geographical names",
+              "Geografiniai pavadinimai => Geographical names",
+              "Paikannimet => Geographical names",
+              "Geograafilised nimed => Geographical names",
+              "Nombres geográficos => Geographical names",
+              "Τοπωνύμια => Geographical names",
+              "Geografische Bezeichnungen => Geographical names",
+              "Географски наименования => Geographical names",
+              "Zeměpisné názvy => Geographical names",
+              "Stednavne => Geographical names",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/3 => Geographical names",
+              "Biogeografiska regioner => Bio-geographical regions",
+              "Biogeografske regije => Bio-geographical regions",
+              "Biogeografické regióny => Bio-geographical regions",
+              "Regiuni biogeografice => Bio-geographical regions",
+              "Regiony biogeograficzne => Bio-geographical regions",
+              "Regiões biogeográficas => Bio-geographical regions",
+              "Biogeografische gebieden => Bio-geographical regions",
+              "Biogeografiniai regionai => Bio-geographical regions",
+              "Bioģeogrāfiskie reģioni => Bio-geographical regions",
+              "Reġjuni bijo-ġeografiċi => Bio-geographical regions",
+              "Regioni biogeografiche => Bio-geographical regions",
+              "Biogeográfiai régiók => Bio-geographical regions",
+              "Régions biogéographiques => Bio-geographical regions",
+              "Biomaantieteelliset alueet => Bio-geographical regions",
+              "Bio-geograafilised piirkonnad => Bio-geographical regions",
+              "Regiones biogeográficas => Bio-geographical regions",
+              "Βιογεωγραφικές περιοχές => Bio-geographical regions",
+              "Biogeografische Regionen => Bio-geographical regions",
+              "Biogeografiske regioner => Bio-geographical regions",
+              "Bioregiony => Bio-geographical regions",
+              "Биогеографски региони => Bio-geographical regions",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/30 => Bio-geographical regions",
+              "Naturtyper och biotoper => Habitats and biotopes",
+              "Habitati in biotopi => Habitats and biotopes",
+              "Habitaty a biotopy => Habitats and biotopes",
+              "Habitate şi biotopuri => Habitats and biotopes",
+              "Habitate și biotopuri => Habitats and biotopes",
+              "Habitats e biótopos => Habitats and biotopes",
+              "Siedliska i obszary przyrodniczo jednorodne => Habitats and biotopes",
+              "Habitats en biotopen => Habitats and biotopes",
+              "L-abitati naturali u l-bijotopi => Habitats and biotopes",
+              "Dzīvotnes un biotopi => Habitats and biotopes",
+              "Buveinės ir biotopai => Habitats and biotopes",
+              "Habitat e biotopi => Habitats and biotopes",
+              "Élőhelyek és biotópok => Habitats and biotopes",
+              "Habitats et biotopes => Habitats and biotopes",
+              "Elinympäristöt ja biotoopit => Habitats and biotopes",
+              "Elupaigad ja biotoobid => Habitats and biotopes",
+              "Hábitats y biotopos => Habitats and biotopes",
+              "Ενδιαιτήματα και βιότοποι => Habitats and biotopes",
+              "Lebensräume und Biotope => Habitats and biotopes",
+              "Levesteder og biotoper => Habitats and biotopes",
+              "Местообитания и биотопи => Habitats and biotopes",
+              "Stanoviště a biotopy => Habitats and biotopes",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/31 => Habitats and biotopes",
+              "Arters utbredning => Species distribution",
+              "Porazdelitev vrst => Species distribution",
+              "Výskyt druhov => Species distribution",
+              "Repartizarea speciilor => Species distribution",
+              "Distribuição das espécies => Species distribution",
+              "Rozmieszczenie gatunków => Species distribution",
+              "Spreiding van soorten => Species distribution",
+              "Distribuzzjoni ta' l-ispeċi => Species distribution",
+              "Sugu izplatība => Species distribution",
+              "Rūšių pasiskirstymas => Species distribution",
+              "Distribuzione delle specie => Species distribution",
+              "A fajok megoszlása => Species distribution",
+              "Répartition des espèces => Species distribution",
+              "Lajien levinneisyys => Species distribution",
+              "Liikide jaotumine => Species distribution",
+              "Distribución de las especies => Species distribution",
+              "Κατανομή ειδών => Species distribution",
+              "Verteilung der Arten => Species distribution",
+              "Rozložení druhů => Species distribution",
+              "Artsfordeling => Species distribution",
+              "Разпределение на видовете => Species distribution",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/32 => Species distribution",
+              "Zdroje energie => Energy resources",
+              "Energetski viri => Energy resources",
+              "Energiresurser => Energy resources",
+              "Recursos energéticos => Energy resources",
+              "Resurse energetice => Energy resources",
+              "Zasoby energetyczne => Energy resources",
+              "Energiebronnen => Energy resources",
+              "Enerģijas resursi => Energy resources",
+              "Riżorsi ta' enerġija => Energy resources",
+              "Energijos ištekliai => Energy resources",
+              "Risorse energetiche => Energy resources",
+              "Energiaforrások => Energy resources",
+              "Sources d'énergie => Energy resources",
+              "Energiavarat => Energy resources",
+              "Energiaressursid => Energy resources",
+              "Ενεργειακοί πόροι => Energy resources",
+              "Energiequellen => Energy resources",
+              "Energiressourcer => Energy resources",
+              "Energetické zdroje => Energy resources",
+              "Енергийни източници => Energy resources",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/33 => Energy resources",
+              "Mineralni viri => Mineral resources",
+              "Mineralfyndigheter => Mineral resources",
+              "Zdroje nerastných surovín => Mineral resources",
+              "Resurse minerale => Mineral resources",
+              "Recursos minerais => Mineral resources",
+              "Zasoby mineralne => Mineral resources",
+              "Minerale bronnen => Mineral resources",
+              "Riżorsi minerali => Mineral resources",
+              "Derīgo izrakteņu resursi => Mineral resources",
+              "Naudingosios iškasenos => Mineral resources",
+              "Risorse minerarie => Mineral resources",
+              "Ásványi nyersanyagok => Mineral resources",
+              "Ressources minérales => Mineral resources",
+              "Mineraalivarat => Mineral resources",
+              "Maavarad => Mineral resources",
+              "Recursos minerales => Mineral resources",
+              "Ορυκτοί πόροι => Mineral resources",
+              "Mineralische Bodenschätze => Mineral resources",
+              "Mineralressourcer => Mineral resources",
+              "Nerostné suroviny => Mineral resources",
+              "Минерални ресурси => Mineral resources",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/34 => Mineral resources",
+              "Upravne enote => Administrative units",
+              "Administrativa enheter => Administrative units",
+              "Správne jednotky => Administrative units",
+              "Unităţi administrative => Administrative units",
+              "Unități administrative => Administrative units",
+              "Jednostki administracyjne => Administrative units",
+              "Unidades administrativas => Administrative units",
+              "Administratieve eenheden => Administrative units",
+              "Unitajiet amministrattivi => Administrative units",
+              "Administratīvas vienības => Administrative units",
+              "Közigazgatási egységek => Administrative units",
+              "Unità amministrative => Administrative units",
+              "Administraciniai vienetai => Administrative units",
+              "Unités administratives => Administrative units",
+              "Hallinnolliset yksiköt => Administrative units",
+              "Haldusüksused => Administrative units",
+              "Διοικητικές ενότητες => Administrative units",
+              "Verwaltungseinheiten => Administrative units",
+              "Administrative enheder => Administrative units",
+              "Административни единици => Administrative units",
+              "Správní jednotky => Administrative units",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/4 => Administrative units",
+              "Adrese => Addresses",
+              "Adresy => Addresses",
+              "Naslovi => Addresses",
+              "Adresser => Addresses",
+              "Endereços => Addresses",
+              "Indirizzi => Addresses",
+              "Adressen => Addresses",
+              "Adresai => Addresses",
+              "Adreses => Addresses",
+              "Címek => Addresses",
+              "Adresses => Addresses",
+              "Osoitteet => Addresses",
+              "Direcciones => Addresses",
+              "Aadressid => Addresses",
+              "Διευθύνσεις => Addresses",
+              "Адреси => Addresses",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/5 => Addresses",
+              "Fastighetsområden => Cadastral parcels",
+              "Katastrske parcele => Cadastral parcels",
+              "Katastrálne parcely => Cadastral parcels",
+              "Parcele cadastrale => Cadastral parcels",
+              "Pakketti katastali => Cadastral parcels",
+              "Kadastrale percelen => Cadastral parcels",
+              "Działki katastralne => Cadastral parcels",
+              "Parcelas cadastrais => Cadastral parcels",
+              "Kadastrāli zemes gabali => Cadastral parcels",
+              "Kadastro sklypai => Cadastral parcels",
+              "Parcelle catastali => Cadastral parcels",
+              "Parcelles cadastrales => Cadastral parcels",
+              "Kataszteri parcellák => Cadastral parcels",
+              "Γεωτεμάχια κτηματολογίου => Cadastral parcels",
+              "Parcelas catastrales => Cadastral parcels",
+              "Katastriüksused => Cadastral parcels",
+              "Kiinteistöt => Cadastral parcels",
+              "Кадастрални парцели => Cadastral parcels",
+              "Katastrální parcely => Cadastral parcels",
+              "Matrikulære parceller => Cadastral parcels",
+              "Flurstücke/Grundstücke (Katasterparzellen) => Cadastral parcels",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/6 => Cadastral parcels",
+              "Transportnät => Transport networks",
+              "Prometna omrežja => Transport networks",
+              "Dopravné siete => Transport networks",
+              "Reţele de transport => Transport networks",
+              "Rețele de transport => Transport networks",
+              "Redes de transporte => Transport networks",
+              "Sieci transportowe => Transport networks",
+              "Transporta tīkli => Transport networks",
+              "Networks tat-trasport => Transport networks",
+              "Vervoersnetwerken => Transport networks",
+              "Transporto tinklai => Transport networks",
+              "Közlekedési hálózatok => Transport networks",
+              "Reti di trasporto => Transport networks",
+              "Liikenneverkot => Transport networks",
+              "Réseaux de transport => Transport networks",
+              "Transpordivõrgud => Transport networks",
+              "Δίκτυα μεταφορών => Transport networks",
+              "Verkehrsnetze => Transport networks",
+              "Transportnet => Transport networks",
+              "Транспортни мрежи => Transport networks",
+              "Dopravní sítě => Transport networks",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/7 => Transport networks",
+              "Hidrografija => Hydrography",
+              "Hydrografi => Hydrography",
+              "Hydrografia => Hydrography",
+              "Hidrografia => Hydrography",
+              "Hidrografie => Hydrography",
+              "Hydrografie => Hydrography",
+              "Idrografija => Hydrography",
+              "Hidrogrāfija => Hydrography",
+              "Hydrographie => Hydrography",
+              "Idrografia => Hydrography",
+              "Vízrajz => Hydrography",
+              "Hüdrograafia => Hydrography",
+              "Hidrografía => Hydrography",
+              "Υδρογραφία => Hydrography",
+              "Gewässernetz => Hydrography",
+              "Hydrograf => Hydrography",
+              "Vodopis => Hydrography",
+              "Хидрография => Hydrography",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/8 => Hydrography",
+              "Zavarovana območja => Protected sites",
+              "Skyddade områden => Protected sites",
+              "Zone protejate => Protected sites",
+              "Chránené územia => Protected sites",
+              "Obszary chronione => Protected sites",
+              "Sítios protegidos => Protected sites",
+              "Beschermde gebieden => Protected sites",
+              "Siti protetti => Protected sites",
+              "Saugomos teritorijos => Protected sites",
+              "Aizsargājamas teritorijas => Protected sites",
+              "Suojellut alueet => Protected sites",
+              "Sites protégés => Protected sites",
+              "Védett helyek => Protected sites",
+              "Kaitsealused kohad => Protected sites",
+              "Lugares protegidos => Protected sites",
+              "Προστατευόμενες τοποθεσίες => Protected sites",
+              "Beskyttede lokaliteter => Protected sites",
+              "Schutzgebiete => Protected sites",
+              "Chráněná území => Protected sites",
+              "Защитени обекти => Protected sites",
+              "http://rdfdata.eionet.europa.eu/inspirethemes/themes/9 => Protected sites"
+            ]
+          },
+          "synCheckpoint": {
+            "type": "synonym",
+            "tokenizer": "keyword",
+            "ignore_case": true,
+            "synonyms": [
+              "No charge => Free",
+              "Distribution cost charge => Cost charge",
+              "Collection cost charge => Cost charge",
+              "Commercial cost charge => Commercial cost",
+              "Cost charge depends on intented use and category of users => Cost charge",
+              "Cost charge depends on intended use and category of users => Cost charge",
+              "Restricted => Restricted",
+              "Accessible under moratorium => Partially restricted",
+              "Unrestricted => Unrestricted",
+              "&lt;15mn (on-line download) => High response",
+              "Less than 3 hours => Medium response",
+              "Less than 24 hours => Medium response",
+              "Less than 1 week => Medium response",
+              "More than 1 week => Low response",
+              "Not documented => Unknown",
+              "Unknown => Unknown",
+              "Order form/envoice => Manual",
+              "Order form/invoice => Manual",
+              "On-line downloading services => Partial INSPIRE function",
+              "On-line discovery+viewing + downloading services => Full INSPIRE function",
+              "On-line discovery + viewing + downloading services => Full INSPIRE function",
+              "On-line discovery + viewing + downloading + advanced services (High resolution viewing,3D viewing services, Processing/Mapping services...) => Full INSPIRE function"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "mappings": {
+    "_default_": {
+      "dynamic_templates": [
+        {
+          "codelist": {
+            "match": "codelist_*",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "org": {
+            "match": "*Org*",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "contact": {
+            "match": "*contact*",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "date": {
+            "match": "*Date*",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "dateMonth": {
+            "match": "*Month*",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "dateYear": {
+            "match": "*Year*",
+            "mapping": {
+              "type": "short"
+            }
+          }
+        },
+        {
+          "measure": {
+            "match": "measure_*",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "operationAllowed": {
+            "match": "op*",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "validationStatus": {
+            "match": "valid*",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        }
+      ]
+    },
+    "records": {
+      "properties": {
+        "accessConstraints": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "coordinateSystem": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "dateStamp": {
+          "type": "date"
+        },
+        "document": {
+          "type": "text"
+        },
+        "documentStandard": {
+          "type": "keyword"
+        },
+        "documentType": {
+          "type": "keyword"
+        },
+        "geom": {
+          "type": "text"
+        },
+        "harvesterId": {
+          "type": "keyword"
+        },
+        "harvesterUuid": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "hasInspireTheme": {
+          "type": "boolean"
+        },
+        "hasOverview": {
+          "type": "boolean"
+        },
+        "isValid": {
+          "type": "boolean"
+        },
+        "isSchemaValid": {
+          "type": "boolean"
+        },
+        "isAboveThreshold": {
+          "type": "boolean"
+        },
+        "inspireAnnex": {
+          "type": "keyword"
+        },
+        "inspireAnnexForFirstTheme": {
+          "type": "keyword"
+        },
+        "inspireServiceType": {
+          "type": "keyword"
+        },
+        "inspireTheme": {
+          "type": "keyword"
+        },
+        "inspireThemeFirst": {
+          "type": "keyword"
+        },
+        "inspireThemeFirst_syn": {
+          "type": "keyword"
+        },
+        "inspireTheme_syn": {
+          "type": "keyword"
+        },
+        "isOpenData": {
+          "type": "keyword"
+        },
+        "lineage": {
+          "type": "text"
+        },
+        "link": {
+          "type": "text"
+        },
+        "linkProtocol": {
+          "type": "keyword"
+        },
+        "linkUrl": {
+          "type": "text"
+        },
+        "mainLanguage": {
+          "type": "keyword"
+        },
+        "metadataIdentifier": {
+          "type": "keyword"
+        },
+        "numberOfInspireTheme": {
+          "type": "short"
+        },
+        "otherConstraints": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "overviewUrl": {
+          "type": "text"
+        },
+        "pointOfTruthURL": {
+          "type": "text"
+        },
+        "recordOperateOn": {
+          "type": "keyword"
+        },
+        "resolutionDistance": {
+          "type": "keyword"
+        },
+        "resolutionScaleDenominator": {
+          "type": "keyword"
+        },
+        "resourceAbstract": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "resourceAltTitle": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "resourceCredit": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "resourceLanguage": {
+          "type": "keyword"
+        },
+        "resourceTitle": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "resourceType": {
+          "type": "keyword"
+        },
+        "serviceType": {
+          "type": "keyword"
+        },
+        "spatialRepresentationType": {
+          "type": "keyword"
+        },
+        "standardName": {
+          "type": "keyword"
+        },
+        "tag": {
+          "type": "keyword"
+        },
+        "territory": {
+          "type": "keyword"
+        },
+        "topic": {
+          "type": "keyword"
+        },
+        "validDate": {
+          "type": "date",
+          "format": "date_hour_minute_second"
+        },
+        "schemaValidDate": {
+          "type": "date",
+          "format": "date_hour_minute_second"
+        },
+        "useLimitation": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "groupPublished": {
+          "type": "keyword"
+        },
+        "changeDate": {
+          "type": "keyword"
+        },
+        "createDate": {
+          "type": "keyword"
+        },
+        "groupOwner": {
+          "type": "keyword"
+        },
+        "hasxlinks": {
+          "type": "boolean"
+        },
+        "isTemplate": {
+          "type": "keyword"
+        },
+        "isHarvested": {
+          "type": "boolean"
+        },
+        "popularity": {
+          "type": "short"
+        },
+        "rating": {
+          "type": "short"
+        },
+        "status": {
+          "type": "short"
+        },
+        "owner": {
+          "type": "keyword"
+        },
+        "xlink": {
+          "type": "keyword"
+        },
+        "root": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/es/es-core/pom.xml
+++ b/es/es-core/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>es</artifactId>
+    <groupId>org.geonetwork-opensource</groupId>
+    <version>3.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>es-core</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!--<dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+    </dependency>-->
+    <!--Require Lucene 5 <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>transport</artifactId>
+    </dependency>-->
+    <dependency>
+      <groupId>io.searchbox</groupId>
+      <artifactId>jest</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/es/es-core/src/main/java/org/fao/geonet/es/DeleteByQuery.java
+++ b/es/es-core/src/main/java/org/fao/geonet/es/DeleteByQuery.java
@@ -1,4 +1,4 @@
-package org.fao.geonet.harvester.wfsfeatures;
+package org.fao.geonet.es;
 
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;

--- a/es/es-core/src/main/java/org/fao/geonet/es/EsClient.java
+++ b/es/es-core/src/main/java/org/fao/geonet/es/EsClient.java
@@ -1,4 +1,27 @@
-package org.fao.geonet.harvester.wfsfeatures.worker;
+/*
+ * Copyright (C) 2001-2015 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.es;
 
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestClientFactory;
@@ -7,13 +30,12 @@ import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.core.Bulk;
 import io.searchbox.core.BulkResult;
 import io.searchbox.core.Index;
-import org.fao.geonet.harvester.wfsfeatures.DeleteByQuery;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.logging.Logger;
 
 
 /**
@@ -21,13 +43,12 @@ import java.util.logging.Logger;
  */
 public class EsClient implements InitializingBean {
 
-    Logger logger = Logger.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
-
     private static EsClient instance;
 
     private JestClient client;
+
+    @Value("${es.url}")
     private String serverUrl;
-    private String collection;
     private String username;
     private String password;
 
@@ -59,7 +80,8 @@ public class EsClient implements InitializingBean {
                 instance = this;
             }
         } else {
-            throw new Exception(String.format("No ES client URL defined in %s. "
+            throw new Exception(String.format(
+                "No ES client URL defined in %s. "
                 + "Check bean configuration.", this.serverUrl));
         }
     }
@@ -89,14 +111,6 @@ public class EsClient implements InitializingBean {
     public EsClient setPassword(String password) {
         this.password = password;
         return this;
-    }
-
-    public String getCollection() {
-        return collection;
-    }
-
-    public void setCollection(String collection) {
-        this.collection = collection;
     }
 
     public boolean bulkRequest(String index, Map<String, String> docs) throws IOException {
@@ -189,7 +203,9 @@ public class EsClient implements InitializingBean {
         if (result.isSucceeded()) {
             return String.format("Record removed. %s.", result.getJsonString());
         } else {
-            return String.format("Error during removal. Errors is '%s'.", result.getErrorMessage());
+            throw new IOException(String.format(
+                "Error during removal. Errors is '%s'.", result.getErrorMessage()
+            ));
         }
 //
 //        Search search = new Search.TemplateBuilder(searchQuery)

--- a/es/pom.xml
+++ b/es/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>es</artifactId>
+  <packaging>pom</packaging>
 
   <profiles>
     <profile>
@@ -77,6 +78,9 @@
       </properties>
     </profile>
   </profiles>
+  <modules>
+    <module>es-core</module>
+  </modules>
 
   <properties>
     <es.executable>elasticsearch</es.executable>

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
@@ -22,17 +22,13 @@
 //==============================================================================
 package org.fao.geonet.kernel.harvest.harvester.arcsde;
 
-import com.google.common.base.Function;
 import jeeves.server.context.ServiceContext;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.fao.geonet.Logger;
 import org.fao.geonet.arcgis.ArcSDEConnection;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -373,7 +369,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 
         dataMan.flush();
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
     }
 
     /**
@@ -417,7 +413,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 
         aligner.addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, log);
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         return id;
     }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -303,7 +303,7 @@ public class Aligner extends BaseAligner {
 
         addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, log);
 
-        dataMan.indexMetadata(id, Math.random() < 0.01);
+        dataMan.indexMetadata(id, Math.random() < 0.01, null);
         result.addedMetadata++;
     }
 
@@ -359,7 +359,7 @@ public class Aligner extends BaseAligner {
 
                 dataMan.flush();
 
-                dataMan.indexMetadata(id, Math.random() < 0.01);
+                dataMan.indexMetadata(id, Math.random() < 0.01, null);
                 result.updatedMetadata++;
             }
         }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
@@ -412,7 +412,7 @@ public class FragmentHarvester extends BaseAligner {
 
         addPrivileges(id, params.privileges, localGroups, dataMan, context, log);
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         dataMan.flush();
 
@@ -586,7 +586,7 @@ public class FragmentHarvester extends BaseAligner {
             dataMan.setHarvestedExt(iId, params.uuid, Optional.of(harvestUri));
         }
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         dataMan.flush();
     }
@@ -634,7 +634,7 @@ public class FragmentHarvester extends BaseAligner {
         }
         addPrivileges(id, params.privileges, localGroups, dataMan, context, log);
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         if (log.isDebugEnabled()) {
             log.debug("	- Commit " + id);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
@@ -227,7 +227,7 @@ public class Aligner extends BaseAligner {
 
         addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, log);
 
-        dataMan.indexMetadata(id, Math.random() < 0.01);
+        dataMan.indexMetadata(id, Math.random() < 0.01, null);
         result.addedMetadata++;
     }
 
@@ -272,7 +272,7 @@ public class Aligner extends BaseAligner {
                 addCategories(metadata, params.getCategories(), localCateg, context, log, null, true);
                 dataMan.flush();
 
-                dataMan.indexMetadata(id, Math.random() < 0.01);
+                dataMan.indexMetadata(id, Math.random() < 0.01, null);
                 result.updatedMetadata++;
             }
         }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -571,7 +571,7 @@ public class Aligner extends BaseAligner {
         }
         context.getBean(MetadataRepository.class).save(metadata);
 
-        dataMan.indexMetadata(id, Math.random() < 0.01);
+        dataMan.indexMetadata(id, Math.random() < 0.01, null);
         result.addedMetadata++;
 
         return id;
@@ -834,7 +834,7 @@ public class Aligner extends BaseAligner {
         metadataRepository.save(metadata);
 //        dataMan.flush();
 
-        dataMan.indexMetadata(id, Math.random() < 0.01);
+        dataMan.indexMetadata(id, Math.random() < 0.01, null);
     }
 
     private void updateFile(String id, String file, String dir, String changeDate,

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
@@ -195,7 +195,7 @@ public class Aligner {
                 //--- maybe the metadata was unretrievable
 
                 if (id != null) {
-                    dataMan.indexMetadata(id, true);
+                    dataMan.indexMetadata(id, true, null);
                 }
             }
         }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -194,7 +194,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
         dataMan.flush();
 
         if (indexAfterUpdate == true) {
-            dataMan.indexMetadata(id, true);
+            dataMan.indexMetadata(id, true, null);
         }
     }
 
@@ -244,7 +244,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
         dataMan.flush();
 
         if (index) {
-            dataMan.indexMetadata(id, true);
+            dataMan.indexMetadata(id, true, null);
         }
         return id;
     }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -389,7 +389,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
 
         dataMan.flush();
 
-        dataMan.indexMetadata(id, Math.random() < 0.01);
+        dataMan.indexMetadata(id, Math.random() < 0.01, null);
         result.addedMetadata++;
     }
 
@@ -522,7 +522,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
             addCategories(metadata, params.getCategories(), localCateg, context, log, null, true);
 
             dataMan.flush();
-            dataMan.indexMetadata(id, Math.random() < 0.01);
+            dataMan.indexMetadata(id, Math.random() < 0.01, null);
             result.updatedMetadata++;
         }
     }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
@@ -554,7 +554,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
 
         addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, log);
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         dataMan.flush();
     }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -328,7 +328,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
 
         dataMan.flush();
 
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
         result.addedMetadata++;
     }
 
@@ -482,7 +482,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
 
             dataMan.flush();
 
-            dataMan.indexMetadata(record.id, true);
+            dataMan.indexMetadata(record.id, true, null);
             result.updatedMetadata++;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1267,6 +1267,7 @@
     <es.host>localhost</es.host>
     <es.url>http://${es.host}:${es.port}</es.url>
     <es.index.features>features</es.index.features>
+    <es.index.records>records</es.index.records>
     <es.username></es.username>
     <es.password></es.password>
 

--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:daobs="http://daobs.org"
+                xmlns:saxon="http://saxon.sf.net/"
+                extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all"
+                version="2.0">
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:output name="default-serialize-mode"
+              indent="no"
+              omit-xml-declaration="yes"
+              encoding="utf-8"
+              escape-uri-attributes="yes"/>
+
+  <!-- List of keywords to search for to flag a record as opendata.
+   Do not put accents or upper case letters here as comparison will not
+   take them in account. -->
+  <xsl:variable name="openDataKeywords"
+                select="'opendata|open data|donnees ouvertes'"/>
+
+  <xsl:variable name="dateFormat" as="xs:string"
+                select="'[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01]'"/>
+
+  <xsl:variable name="separator" as="xs:string"
+                select="'|'"/>
+
+  <!-- To avoid Document contains at least one immense term
+  in field="resourceAbstract" (whose UTF8 encoding is longer
+  than the max length 32766. -->
+  <xsl:variable name="maxFieldLength" select="32000" as="xs:integer"/>
+
+  <xsl:template match="/">
+    <xsl:apply-templates mode="index"/>
+  </xsl:template>
+
+
+  <xsl:template match="simpledc"
+                mode="index">
+    <!-- Main variables for the document -->
+    <xsl:variable name="identifier" as="xs:string"
+                  select="dc:identifier"/>
+
+
+    <xsl:message><xsl:value-of select="concat(
+      '#', count(preceding-sibling::simpledc), $identifier)"/>
+    </xsl:message>
+
+    <!-- Create a first document representing the main record. -->
+    <doc>
+      <documentType>metadata</documentType>
+      <documentStandard>dublin-core</documentStandard>
+
+      <!-- Index the metadata document as XML -->
+      <document>
+        <!--<xsl:value-of select="saxon:serialize(., 'default-serialize-mode')"/>-->
+      </document>
+      <uuid>
+        <xsl:value-of select="$identifier"/>
+      </uuid>
+      <metadataIdentifier>
+        <xsl:value-of select="$identifier"/>
+      </metadataIdentifier>
+
+      <harvestedDate>
+        <xsl:value-of select="format-dateTime(current-dateTime(), $dateFormat)"/>
+      </harvestedDate>
+
+
+      <!-- For multilingual docs it is good to have a title in the default locale.  In this type of metadata we don't have one but in the general case we do so we need to add it to all -->
+      <resourceTitle><xsl:value-of select="string(dc:title)"/></resourceTitle>
+
+      <xsl:for-each select="dc:language">
+        <mainLanguage><xsl:value-of select="string(.)"/></mainLanguage>
+      </xsl:for-each>
+
+      <xsl:for-each select="dct:abstract|dc:description">
+        <resourceAbstract><xsl:value-of select="string(.)"/></resourceAbstract>
+      </xsl:for-each>
+
+      <xsl:for-each select="dc:date">
+        <creationDateForResource><xsl:value-of select="string(.)"/></creationDateForResource>
+      </xsl:for-each>
+
+      <xsl:for-each select="dct:modified">
+        <revisionDateForResource><xsl:value-of select="string(.)"/></revisionDateForResource>
+      </xsl:for-each>
+
+      <xsl:for-each select="dc:format">
+        <format><xsl:value-of select="string(.)"/></format>
+      </xsl:for-each>
+
+      <xsl:for-each select="dc:type">
+        <resourceType><xsl:value-of select="string(.)"/></resourceType>
+      </xsl:for-each>
+
+      <xsl:for-each select="dc:source">
+        <lineage><xsl:value-of select="string(.)"/></lineage>
+      </xsl:for-each>
+
+      <xsl:for-each select="dc:relation">
+        <related><xsl:value-of select="string(.)"/></related>
+      </xsl:for-each>
+
+      <xsl:for-each select="dct:accessRights">
+        <useLimitation><xsl:value-of select="string(.)"/></useLimitation>
+      </xsl:for-each>
+
+      <xsl:for-each select="dct:rights">
+        <useLimitation><xsl:value-of select="string(.)"/></useLimitation>
+      </xsl:for-each>
+
+      <xsl:for-each select="dct:spatial">
+        <geoTag><xsl:value-of select="string(.)"/></geoTag>
+      </xsl:for-each>
+      <xsl:for-each select="dc:subject">
+        <tag><xsl:value-of select="string(.)"/></tag>
+      </xsl:for-each>
+
+
+
+      <xsl:for-each select="(dct:references|dc:relation)[normalize-space(.) != '']">
+        <xsl:variable name="name" select="tokenize(., '/')[last()]"/>
+        <!-- Index link where last token after the last / is the link name. -->
+        <link><xsl:value-of select="concat($name, '||', ., '|WWW-LINK|WWW:LINK|0')"/></link>
+      </xsl:for-each>
+      <xsl:for-each select="(dct:references|dc:relation)[normalize-space(.) != ''
+                              and matches(., '.*(.gif|.png.|.jpeg|.jpg)$', 'i')]">
+        <xsl:variable name="thumbnailType"
+                      select="if (position() = 1) then 'thumbnail' else 'overview'"/>
+        <!-- First thumbnail is flagged as thumbnail and could be considered the main one -->
+        <overviewUrl><xsl:value-of select="concat($thumbnailType, '|', ., '|')"/></overviewUrl>
+      </xsl:for-each>
+
+
+      <!-- This index for "coverage" requires significant expansion to
+         work well for spatial searches. It now only works for very
+         strictly formatted content
+         North 46.3, South 42.51, East 3.88, West -1.84
+      <xsl:for-each select="/simpledc/dc:coverage">
+        <xsl:variable name="coverage" select="."/>
+
+        <xsl:choose>
+          <xsl:when test="starts-with(., 'North')">
+            <xsl:variable name="n" select="substring-after($coverage,'North ')"/>
+            <xsl:variable name="north" select="substring-before($n, ',')"/>
+            <xsl:variable name="s" select="substring-after($coverage,'South ')"/>
+            <xsl:variable name="south" select="substring-before($s, ',')"/>
+            <xsl:variable name="e" select="substring-after($coverage,'East ')"/>
+            <xsl:variable name="east" select="substring-before($e, ',')"/>
+            <xsl:variable name="w" select="substring-after($coverage,'West ')"/>
+            <xsl:variable name="west"
+                          select="if (contains($w, '. ')) then substring-before($w, '. ') else $w"/>
+            <xsl:variable name="p" select="substring-after($coverage,'(')"/>
+            <xsl:variable name="place" select="substring-before($p,')')"/>
+
+            <Field name="westBL" string="{$west}" store="false" index="true"/>
+            <Field name="eastBL" string="{$east}" store="false" index="true"/>
+            <Field name="southBL" string="{$south}" store="false" index="true"/>
+            <Field name="northBL" string="{$north}" store="false" index="true"/>
+            <Field name="geoBox" string="{concat($west, '|',
+                                                  $south, '|',
+                                                  $east, '|',
+                                                  $north
+                                                  )}" store="true" index="false"/>
+
+            <Field name="keyword" string="{$place}" store="true" index="true"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <Field name="keyword" string="{.}" store="true" index="true"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:for-each>-->
+    </doc>
+  </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/fn.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/fn.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2014-2016 European Environment Agency
+  ~
+  ~ Licensed under the EUPL, Version 1.1 or – as soon
+  ~ they will be approved by the European Commission -
+  ~ subsequent versions of the EUPL (the "Licence");
+  ~ You may not use this work except in compliance
+  ~ with the Licence.
+  ~ You may obtain a copy of the Licence at:
+  ~
+  ~ https://joinup.ec.europa.eu/community/eupl/og_page/eupl
+  ~
+  ~ Unless required by applicable law or agreed to in
+  ~ writing, software distributed under the Licence is
+  ~ distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  ~ either express or implied.
+  ~ See the Licence for the specific language governing
+  ~ permissions and limitations under the Licence.
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:daobs="http://daobs.org"
+                exclude-result-prefixes="#all"
+                version="2.0">
+
+  <xsl:function name="daobs:search-in" as="node()*">
+    <xsl:param name="list" as="node()*"/>
+    <xsl:param name="value" as="xs:string"/>
+
+    <!-- Convert accent, lower case -->
+    <xsl:copy-of select="$list[
+                    normalize-unicode(replace(normalize-unicode(
+                      lower-case(normalize-space(.)),'NFKD'),'\p{Mn}',''),'NFKC') =
+                    normalize-unicode(replace(normalize-unicode(
+                      lower-case(normalize-space($value)),'NFKD'),'\p{Mn}',''),'NFKC')]"/>
+  </xsl:function>
+
+  <xsl:function name="daobs:search-in-contains" as="node()*">
+    <xsl:param name="list" as="node()*"/>
+    <xsl:param name="value" as="xs:string"/>
+
+    <!-- Convert accent, lower case -->
+    <xsl:copy-of select="$list[contains(
+                    normalize-unicode(replace(normalize-unicode(
+                      lower-case(normalize-space($value)),'NFKD'),'\p{Mn}',''),'NFKC'),
+                    normalize-unicode(replace(normalize-unicode(
+                      lower-case(normalize-space(.)),'NFKD'),'\p{Mn}',''),'NFKC')
+                      )]"/>
+  </xsl:function>
+
+  <!-- Compare ignoring case, accents -->
+  <xsl:function name="daobs:compare" as="xs:boolean">
+    <xsl:param name="this" as="xs:string"/>
+    <xsl:param name="that" as="xs:string"/>
+
+    <xsl:value-of select="normalize-unicode(replace(normalize-unicode(
+                      lower-case(normalize-space($this)),'NFKD'),'\p{Mn}',''),'NFKC') =
+                    normalize-unicode(replace(normalize-unicode(
+                      lower-case(normalize-space($that)),'NFKD'),'\p{Mn}',''),'NFKC')"/>
+  </xsl:function>
+
+  <xsl:function name="daobs:contains" as="xs:boolean">
+    <xsl:param name="this" as="xs:string"/>
+    <xsl:param name="that" as="xs:string"/>
+
+    <xsl:value-of select="contains(
+                    normalize-unicode(replace(normalize-unicode(
+                      lower-case(normalize-space($this)),'NFKD'),'\p{Mn}',''),'NFKC'),
+                    normalize-unicode(replace(normalize-unicode(
+                      lower-case(normalize-space($that)),'NFKD'),'\p{Mn}',''),'NFKC'))"/>
+  </xsl:function>
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -1,0 +1,920 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:gmi="http://www.isotc211.org/2005/gmi"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:daobs="http://daobs.org"
+                xmlns:saxon="http://saxon.sf.net/"
+                extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all"
+                version="2.0">
+
+  <xsl:import href="fn.xsl"/>
+  <xsl:import href="inspire-constant.xsl"/>
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:output name="default-serialize-mode"
+              indent="no"
+              omit-xml-declaration="yes"
+              encoding="utf-8"
+              escape-uri-attributes="yes"/>
+
+  <!-- Define if operatesOn type should be defined
+  by analysis of protocol in all transfers options.
+  -->
+  <xsl:variable name="operatesOnSetByProtocol" select="false()"/>
+
+  <!-- Define if search for regulation title should be strict or light. -->
+  <xsl:variable name="inspireRegulationLaxCheck" select="false()"/>
+
+  <!-- List of keywords to search for to flag a record as opendata.
+   Do not put accents or upper case letters here as comparison will not
+   take them in account. -->
+  <xsl:variable name="openDataKeywords"
+                select="'opendata|open data|donnees ouvertes'"/>
+
+  <xsl:variable name="dateFormat" as="xs:string"
+                select="'[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01]'"/>
+
+  <xsl:variable name="separator" as="xs:string"
+                select="'|'"/>
+
+  <!-- To avoid Document contains at least one immense term
+  in field="resourceAbstract" (whose UTF8 encoding is longer
+  than the max length 32766. -->
+  <xsl:variable name="maxFieldLength" select="32000" as="xs:integer"/>
+
+  <xsl:template match="/">
+    <xsl:apply-templates mode="index"/>
+  </xsl:template>
+
+  <xsl:template match="gmi:MI_Metadata|gmd:MD_Metadata"
+                mode="extract-uuid">
+    <xsl:value-of select="gmd:fileIdentifier/gco:CharacterString"/>
+  </xsl:template>
+
+
+  <xsl:template mode="index-extra-fields" match="*"/>
+
+  <xsl:template mode="index-extra-documents" match="*"/>
+
+  <xsl:template match="gmi:MI_Metadata|gmd:MD_Metadata"
+                mode="index">
+    <!-- Main variables for the document -->
+    <xsl:variable name="identifier" as="xs:string"
+                  select="gmd:fileIdentifier/gco:CharacterString[. != '']"/>
+
+
+    <xsl:variable name="mainLanguageCode" as="xs:string?"
+                  select="gmd:language[1]/gmd:LanguageCode/
+                        @codeListValue[normalize-space(.) != '']"/>
+    <xsl:variable name="mainLanguage" as="xs:string?"
+                  select="if ($mainLanguageCode) then $mainLanguageCode else
+                    gmd:language[1]/gco:CharacterString[normalize-space(.) != '']"/>
+
+    <xsl:variable name="otherLanguages" as="attribute()*"
+                  select="gmd:locale/gmd:PT_Locale/
+                        gmd:languageCode/gmd:LanguageCode/
+                          @codeListValue[normalize-space(.) != '']"/>
+
+    <!-- Record is dataset if no hierarchyLevel -->
+    <xsl:variable name="isDataset" as="xs:boolean"
+                  select="
+                      count(gmd:hierarchyLevel[gmd:MD_ScopeCode/@codeListValue='dataset']) > 0 or
+                      count(gmd:hierarchyLevel) = 0"/>
+    <xsl:variable name="isService" as="xs:boolean"
+                  select="
+                      count(gmd:hierarchyLevel[gmd:MD_ScopeCode/@codeListValue='service']) > 0"/>
+
+    <xsl:message><xsl:value-of select="concat(
+      '#', count(preceding-sibling::gmd:MD_Metadata), $identifier)"/>
+    </xsl:message>
+
+    <!-- Create a first document representing the main record. -->
+    <doc>
+      <documentType>metadata</documentType>
+      <documentStandard>iso19139</documentStandard>
+
+      <!-- Index the metadata document as XML -->
+      <document>
+        <!--<xsl:value-of select="saxon:serialize(., 'default-serialize-mode')"/>-->
+      </document>
+      <uuid>
+        <xsl:value-of select="$identifier"/>
+      </uuid>
+      <metadataIdentifier>
+        <xsl:value-of select="$identifier"/>
+      </metadataIdentifier>
+
+      <xsl:for-each select="gmd:metadataStandardName/gco:CharacterString">
+        <standardName>
+          <xsl:value-of select="normalize-space(.)"/>
+        </standardName>
+      </xsl:for-each>
+
+      <!-- Harvester details
+      <territory>
+        <xsl:value-of select="util:getSettingValue('system/site/name')"/>
+      </territory>
+      <harvesterId>
+        <xsl:value-of select="util:getSettingValue('nodeUrl')"/>
+      </harvesterId>
+      <harvesterUuid>
+        <xsl:value-of select="util:getSettingValue('system/site/siteId')"/>
+      </harvesterUuid> -->
+      <harvestedDate>
+        <xsl:value-of select="format-dateTime(current-dateTime(), $dateFormat)"/>
+      </harvestedDate>
+
+
+      <!-- Indexing record information -->
+      <!-- # Date -->
+      <!-- TODO improve date formatting maybe using Joda parser
+      Select first one because some records have 2 dates !
+      eg. fr-784237539-bdref20100101-0105
+
+      Remove millisec and timezone until not supported
+      eg. 2017-02-08T13:18:03.138+00:02
+      -->
+      <xsl:for-each select="gmd:dateStamp/*[text() != '' and position() = 1]">
+        <dateStamp>
+          <xsl:variable name="date"
+                        select="if (name() = 'gco:Date' and string-length(.) = 4)
+                                then concat(., '-01-01T00:00:00')
+                                else if (name() = 'gco:Date' and string-length(.) = 7)
+                                then concat(., '-01T00:00:00')
+                                else if (name() = 'gco:Date' or string-length(.) = 10)
+                                then concat(., 'T00:00:00')
+                                else if (contains(., '.'))
+                                then tokenize(., '\.')[1]
+                                else ."/>
+
+          <xsl:value-of select="translate(string(
+                                   adjust-dateTime-to-timezone(
+                                      xs:dateTime($date),
+                                      xs:dayTimeDuration('PT0H'))
+                                     ), 'Z', '')"/>
+        </dateStamp>
+      </xsl:for-each>
+
+
+      <!-- # Languages -->
+      <mainLanguage>
+        <xsl:value-of select="$mainLanguage"/>
+      </mainLanguage>
+
+      <xsl:for-each select="$otherLanguages">
+        <otherLanguage>
+          <xsl:value-of select="."/>
+        </otherLanguage>
+      </xsl:for-each>
+
+
+      <!-- # Resource type -->
+      <xsl:choose>
+        <xsl:when test="$isDataset">
+          <resourceType>dataset</resourceType>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:for-each select="gmd:hierarchyLevel/gmd:MD_ScopeCode/
+                              @codeListValue[normalize-space(.) != '']">
+            <resourceType>
+              <xsl:value-of select="."/>
+            </resourceType>
+          </xsl:for-each>
+        </xsl:otherwise>
+      </xsl:choose>
+
+
+      <!-- Indexing metadata contact -->
+      <xsl:apply-templates mode="index-contact" select="gmd:contact">
+        <xsl:with-param name="fieldSuffix" select="''"/>
+      </xsl:apply-templates>
+
+      <!-- Indexing all codelist
+
+      Indexing method is:
+      <gmd:accessConstraints>
+        <gmd:MD_RestrictionCode codeListValue="otherRestrictions"
+        is indexed as
+        codelist_accessConstraints:otherRestrictions
+
+        Exclude some useless codelist like
+        Contact role, Date type.
+      -->
+      <xsl:for-each select=".//*[@codeListValue != '' and
+                            name() != 'gmd:CI_RoleCode' and
+                            name() != 'gmd:CI_DateTypeCode' and
+                            name() != 'gmd:LanguageCode'
+                            ]">
+        <xsl:element name="codelist_{local-name(..)}">
+          <xsl:value-of select="@codeListValue"/>
+        </xsl:element>
+      </xsl:for-each>
+
+
+      <!-- Indexing resource information
+      TODO: Should we support multiple identification in the same record
+      eg. nl db60a314-5583-437d-a2ff-1e59cc57704e
+      Also avoid error when records contains multiple MD_IdentificationInfo
+      or SRV_ServiceIdentification or a mix
+      eg. de 8bb5334f-558b-982b-7b12-86ea486540d7
+      -->
+      <xsl:for-each select="gmd:identificationInfo[1]/*[1]">
+        <xsl:for-each select="gmd:citation/gmd:CI_Citation">
+          <resourceTitle>
+            <xsl:value-of select="gmd:title/gco:CharacterString/text()"/>
+          </resourceTitle>
+          <resourceAltTitle>
+            <xsl:value-of
+              select="gmd:alternateTitle/gco:CharacterString/text()"/>
+          </resourceAltTitle>
+
+          <xsl:for-each select="gmd:date/gmd:CI_Date[gmd:date/*/text() != '']">
+            <xsl:variable name="dateType"
+                          select="gmd:dateType[1]/gmd:CI_DateTypeCode/@codeListValue"
+                          as="xs:string?"/>
+            <xsl:variable name="date"
+                          select="string(gmd:date[1]/gco:Date|gmd:date[1]/gco:DateTime)"/>
+            <xsl:element name="{$dateType}DateForResource">
+              <xsl:value-of select="$date"/>
+            </xsl:element>
+            <xsl:element name="{$dateType}YearForResource">
+              <xsl:value-of select="substring($date, 0, 5)"/>
+            </xsl:element>
+            <xsl:element name="{$dateType}MonthForResource">
+              <xsl:value-of select="substring($date, 0, 8)"/>
+            </xsl:element>
+          </xsl:for-each>
+
+          <xsl:for-each
+            select="gmd:presentationForm/gmd:CI_PresentationFormCode/@codeListValue[. != '']">
+            <presentationForm>
+              <xsl:value-of select="."/>
+            </presentationForm>
+          </xsl:for-each>
+        </xsl:for-each>
+
+        <resourceAbstract>
+          <xsl:value-of select="substring(
+                gmd:abstract/gco:CharacterString,
+                0, $maxFieldLength)"/>
+        </resourceAbstract>
+
+
+        <!-- Indexing resource contact -->
+        <xsl:apply-templates mode="index-contact"
+                             select="gmd:pointOfContact">
+          <xsl:with-param name="fieldSuffix" select="'ForResource'"/>
+        </xsl:apply-templates>
+
+        <xsl:for-each select="gmd:credit/*[. != '']">
+          <resourceCredit>
+            <xsl:value-of select="."/>
+          </resourceCredit>
+        </xsl:for-each>
+
+
+        <xsl:variable name="overviews"
+                      select="gmd:graphicOverview/gmd:MD_BrowseGraphic/
+                              gmd:fileName/gco:CharacterString[. != '']"/>
+        <hasOverview>
+          <xsl:value-of select="if (count($overviews) > 0) then 'true' else 'false'"/>
+        </hasOverview>
+
+        <xsl:for-each select="$overviews">
+          <overviewUrl>
+            <xsl:value-of select="."/>
+          </overviewUrl>
+        </xsl:for-each>
+
+        <xsl:for-each
+          select="gmd:language/gco:CharacterString|gmd:language/gmd:LanguageCode/@codeListValue">
+          <resourceLanguage>
+            <xsl:value-of select="."/>
+          </resourceLanguage>
+        </xsl:for-each>
+
+
+        <!-- TODO: create specific INSPIRE template or mode -->
+        <!-- INSPIRE themes
+
+        Select the first thesaurus title because some records
+        may contains many even if invalid.
+
+        Also get the first title at it may happen that a record
+        have more than one.
+
+        Select any thesaurus having the title containing "INSPIRE themes".
+        Some records have "GEMET-INSPIRE themes" eg. sk:ee041534-b8f3-4683-b9dd-9544111a0712
+        Some other "GEMET - INSPIRE themes"
+
+        Take in account gmd:descriptiveKeywords or srv:keywords
+        -->
+        <!-- TODO: Some MS may be using a translated version of the thesaurus title -->
+        <xsl:variable name="inspireKeywords"
+                      select="*/gmd:MD_Keywords[
+                      contains(lower-case(
+                       gmd:thesaurusName[1]/*/gmd:title[1]/*[1]/text()
+                       ), 'gemet') and
+                       contains(lower-case(
+                       gmd:thesaurusName[1]/*/gmd:title[1]/*[1]/text()
+                       ), 'inspire')]
+                  /gmd:keyword"/>
+        <xsl:for-each
+          select="$inspireKeywords">
+          <xsl:variable name="position" select="position()"/>
+          <xsl:for-each select="gco:CharacterString[. != '']|
+                                gmx:Anchor[. != '']">
+            <xsl:variable name="inspireTheme" as="xs:string"
+                          select="text()"/>
+            <!--select="solr:analyzeField('synInspireThemes', text())"/>-->
+
+            <inspireTheme_syn>
+              <xsl:value-of select="text()"/>
+            </inspireTheme_syn>
+            <inspireTheme>
+              <xsl:value-of select="$inspireTheme"/>
+            </inspireTheme>
+
+            <!--
+            WARNING: Here we only index the first keyword in order
+            to properly compute one INSPIRE annex.
+            -->
+            <xsl:if test="$position = 1">
+              <inspireThemeFirst_syn>
+                <xsl:value-of select="text()"/>
+              </inspireThemeFirst_syn>
+              <inspireThemeFirst>
+                <xsl:value-of select="$inspireTheme"/>
+              </inspireThemeFirst>
+              <inspireAnnexForFirstTheme>
+                <xsl:value-of
+                  select="'TODO'"/>
+                <!--select="solr:analyzeField('synInspireAnnexes', $inspireTheme)"/>-->
+              </inspireAnnexForFirstTheme>
+            </xsl:if>
+            <inspireAnnex>
+              <xsl:value-of
+                select="'TODO'"/>
+            </inspireAnnex>
+          </xsl:for-each>
+        </xsl:for-each>
+
+        <!-- For services, the count does not take into account
+        dataset's INSPIRE themes which are transfered to the service
+        by service-dataset-task. -->
+        <numberOfInspireTheme>
+          <xsl:value-of
+            select="count($inspireKeywords)"/>
+        </numberOfInspireTheme>
+
+        <hasInspireTheme>
+          <xsl:value-of
+            select="if (count($inspireKeywords) > 0) then 'true' else 'false'"/>
+        </hasInspireTheme>
+
+        <!-- Index all keywords -->
+        <xsl:variable name="keywords"
+                      select="*/gmd:MD_Keywords/
+                                gmd:keyword/gco:CharacterString|
+                              */gmd:MD_Keywords/
+                                gmd:keyword/gmd:PT_FreeText/gmd:textGroup/
+                                  gmd:LocalisedCharacterString"/>
+        <xsl:for-each select="$keywords">
+          <tag>
+            <xsl:value-of select="text()"/>
+          </tag>
+        </xsl:for-each>
+
+        <xsl:variable name="isOpenData">
+          <xsl:for-each select="$keywords">
+            <xsl:if test="matches(
+                            normalize-unicode(replace(normalize-unicode(
+                              lower-case(normalize-space(text())), 'NFKD'), '\p{Mn}', ''), 'NFKC'),
+                            $openDataKeywords)">
+              <xsl:value-of select="'true'"/>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:choose>
+          <xsl:when test="normalize-space($isOpenData) != ''">
+            <isOpenData>true</isOpenData>
+          </xsl:when>
+          <xsl:otherwise>
+            <isOpenData>false</isOpenData>
+          </xsl:otherwise>
+        </xsl:choose>
+
+        <!-- Index keywords which are of type place -->
+        <xsl:for-each
+          select="*/gmd:MD_Keywords/
+                          gmd:keyword[gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'place']/
+                            gco:CharacterString|
+                        */gmd:MD_Keywords/
+                          gmd:keyword[gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'place']/
+                            gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString">
+          <geotag>
+            <xsl:value-of select="text()"/>
+          </geotag>
+        </xsl:for-each>
+
+
+        <!-- Index all keywords having a specific thesaurus -->
+        <xsl:for-each
+          select="*/gmd:MD_Keywords[gmd:thesaurusName]/
+                            gmd:keyword">
+
+          <xsl:variable name="thesaurusName"
+                        select="../gmd:thesaurusName[1]/gmd:CI_Citation/
+                                  gmd:title[1]/gco:CharacterString"/>
+
+          <xsl:variable name="thesaurusId"
+                        select="normalize-space(../gmd:thesaurusName/gmd:CI_Citation/
+                                  gmd:identifier[position() = 1]/gmd:MD_Identifier/
+                                    gmd:code/(gco:CharacterString|gmx:Anchor)/text())"/>
+
+          <xsl:variable name="key">
+            <xsl:choose>
+              <xsl:when test="$thesaurusId != ''">
+                <xsl:value-of select="$thesaurusId"/>
+              </xsl:when>
+              <!-- Try to build a thesaurus key based on the name
+              by removing space - to be improved. -->
+              <xsl:when test="normalize-space($thesaurusName) != ''">
+                <!--TODO handle special character to build a valid key usable for field
+                <xsl:value-of select="replace($thesaurusName, ' ', '-')"/>-->
+              </xsl:when>
+            </xsl:choose>
+          </xsl:variable>
+
+          <xsl:if test="normalize-space($key) != ''">
+            <!-- Index keyword characterString including multilingual ones
+             and element like gmx:Anchor including the href attribute
+             which may contains keyword identifier. -->
+            <xsl:for-each select="*[normalize-space() != '']|
+                                  */@xlink:href[normalize-space() != '']|
+                                  gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[normalize-space() != '']">
+              <xsl:element name="thesaurus_{replace($key, '[^a-zA-Z0-9]', '')}">
+                <xsl:value-of select="normalize-space(.)"/>
+              </xsl:element>
+            </xsl:for-each>
+          </xsl:if>
+        </xsl:for-each>
+
+
+        <xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode">
+          <topic>
+            <xsl:value-of select="."/>
+          </topic>
+          <!-- TODO: Get translation ? -->
+        </xsl:for-each>
+
+
+        <xsl:for-each select="gmd:spatialResolution/gmd:MD_Resolution">
+          <xsl:for-each
+            select="gmd:equivalentScale/gmd:MD_RepresentativeFraction/gmd:denominator/gco:Integer[. != '']">
+            <resolutionScaleDenominator>
+              <xsl:value-of select="."/>
+            </resolutionScaleDenominator>
+          </xsl:for-each>
+
+          <xsl:for-each select="gmd:distance/gco:Distance[. != '']">
+            <resolutionDistance>
+              <xsl:value-of select="concat(., ' ', @uom)"/>
+            </resolutionDistance>
+          </xsl:for-each>
+        </xsl:for-each>
+
+        <xsl:for-each
+          select="gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode/@codeListValue[. != '']">
+          <spatialRepresentationType>
+            <xsl:value-of select="."/>
+          </spatialRepresentationType>
+        </xsl:for-each>
+
+
+        <xsl:for-each select="gmd:resourceConstraints">
+          <xsl:for-each
+            select="*/gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue[. != '']">
+            <accessConstraints>
+              <xsl:value-of select="."/>
+            </accessConstraints>
+          </xsl:for-each>
+          <xsl:for-each
+            select="*/gmd:otherConstraints/gco:CharacterString[. != '']">
+            <otherConstraints>
+              <xsl:value-of select="."/>
+            </otherConstraints>
+          </xsl:for-each>
+          <xsl:for-each
+            select="*/gmd:classification/gmd:MD_ClassificationCode/@codeListValue[. != '']">
+            <constraintClassification>
+              <xsl:value-of select="."/>
+            </constraintClassification>
+          </xsl:for-each>
+          <xsl:for-each
+            select="*/gmd:useLimitation/gco:CharacterString[. != '']">
+            <useLimitation>
+              <xsl:value-of select="."/>
+            </useLimitation>
+          </xsl:for-each>
+        </xsl:for-each>
+
+
+        <xsl:for-each select="*/gmd:EX_Extent">
+
+          <xsl:for-each select="gmd:geographicElement/gmd:EX_GeographicDescription/
+            gmd:geographicIdentifier/gmd:MD_Identifier/
+            gmd:code/gco:CharacterString[normalize-space(.) != '']">
+            <geoTag>
+              <xsl:value-of select="."/>
+            </geoTag>
+          </xsl:for-each>
+
+          <!-- TODO: index bounding polygon -->
+          <xsl:for-each select=".//gmd:EX_GeographicBoundingBox[
+                                ./gmd:westBoundLongitude/gco:Decimal castable as xs:decimal and
+                                ./gmd:eastBoundLongitude/gco:Decimal castable as xs:decimal and
+                                ./gmd:northBoundLatitude/gco:Decimal castable as xs:decimal and
+                                ./gmd:southBoundLatitude/gco:Decimal castable as xs:decimal
+                                ]">
+            <xsl:variable name="format" select="'#0.000000'"></xsl:variable>
+
+            <xsl:variable name="w"
+                          select="format-number(./gmd:westBoundLongitude/gco:Decimal/text(), $format)"/>
+            <xsl:variable name="e"
+                          select="format-number(./gmd:eastBoundLongitude/gco:Decimal/text(), $format)"/>
+            <xsl:variable name="n"
+                          select="format-number(./gmd:northBoundLatitude/gco:Decimal/text(), $format)"/>
+            <xsl:variable name="s"
+                          select="format-number(./gmd:southBoundLatitude/gco:Decimal/text(), $format)"/>
+
+            <!-- Example: ENVELOPE(-10, 20, 15, 10) which is minX, maxX, maxY, minY order
+            http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
+            https://cwiki.apache.org/confluence/display/solr/Spatial+Search
+
+            bbox field type limited to one. TODO
+            <xsl:if test="position() = 1">
+              <bbox>
+                <xsl:text>ENVELOPE(</xsl:text>
+                <xsl:value-of select="$w"/>
+                <xsl:text>,</xsl:text>
+                <xsl:value-of select="$e"/>
+                <xsl:text>,</xsl:text>
+                <xsl:value-of select="$n"/>
+                <xsl:text>,</xsl:text>
+                <xsl:value-of select="$s"/>
+                <xsl:text>)</xsl:text>
+              </field>
+            </xsl:if>
+            -->
+            <xsl:choose>
+              <xsl:when test="-180 &lt;= number($e) and number($e) &lt;= 180 and
+                              -180 &lt;= number($w) and number($w) &lt;= 180 and
+                              -90 &lt;= number($s) and number($s) &lt;= 90 and
+                              -90 &lt;= number($n) and number($n) &lt;= 90">
+                <xsl:choose>
+                  <xsl:when test="$e = $w and $s = $n">
+                    <geom>
+                      <xsl:text>POINT(</xsl:text>
+                      <xsl:value-of select="concat($w, ' ', $s)"/>
+                      <xsl:text>)</xsl:text>
+                    </geom>
+
+                    <geojson>
+                      <xsl:text>{"type": "point",</xsl:text>
+                      <xsl:text>"coordinates": "</xsl:text><xsl:value-of select="concat($w, ' ', $s)"/>"
+                      <xsl:text>}</xsl:text>
+                    </geojson>
+                  </xsl:when>
+                  <xsl:when
+                    test="($e = $w and $s != $n) or ($e != $w and $s = $n)">
+                    <!-- Probably an invalid bbox indexing a point only -->
+                    <geom>
+                      <xsl:text>POINT(</xsl:text>
+                      <xsl:value-of select="concat($w, ' ', $s)"/>
+                      <xsl:text>)</xsl:text>
+                    </geom>
+
+                    <geojson>
+                      <xsl:text>{"type": "point",</xsl:text>
+                      <xsl:text>"coordinates": "</xsl:text><xsl:value-of select="concat($w, ' ', $s)"/>"
+                      <xsl:text>}</xsl:text>
+                    </geojson>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <geom>
+                      <xsl:text>POLYGON((</xsl:text>
+                      <xsl:value-of select="concat($w, ' ', $s)"/>
+                      <xsl:text>,</xsl:text>
+                      <xsl:value-of select="concat($e, ' ', $s)"/>
+                      <xsl:text>,</xsl:text>
+                      <xsl:value-of select="concat($e, ' ', $n)"/>
+                      <xsl:text>,</xsl:text>
+                      <xsl:value-of select="concat($w, ' ', $n)"/>
+                      <xsl:text>,</xsl:text>
+                      <xsl:value-of select="concat($w, ' ', $s)"/>
+                      <xsl:text>))</xsl:text>
+                    </geom>
+
+
+                    <geojson>
+                      <xsl:text>{"type": "polygon",</xsl:text>
+                      <xsl:text>"coordinates": [</xsl:text>
+                      <xsl:value-of select="concat('[', $w, ' ', $s, ']')"/>
+                      <xsl:text>,</xsl:text>
+                      <xsl:value-of select="concat('[', $e, ' ', $s, ']')"/>
+                      <xsl:text>,</xsl:text>
+                      <xsl:value-of select="concat('[', $e, ' ', $n, ']')"/>
+                      <xsl:text>,</xsl:text>
+                      <xsl:value-of select="concat('[', $w, ' ', $n, ']')"/>
+                      <xsl:text>,</xsl:text>
+                      <xsl:value-of select="concat('[', $w, ' ', $s, ']')"/>
+                      <xsl:text>]}</xsl:text>
+                    </geojson>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:when>
+              <xsl:otherwise></xsl:otherwise>
+            </xsl:choose>
+
+            <!--<xsl:value-of select="($e + $w) div 2"/>,<xsl:value-of select="($n + $s) div 2"/></field>-->
+          </xsl:for-each>
+        </xsl:for-each>
+
+
+        <!-- Service information -->
+        <xsl:for-each select="srv:serviceType/gco:LocalName">
+          <serviceType>
+            <xsl:value-of select="text()"/>
+          </serviceType>
+          <xsl:variable name="inspireServiceType" as="xs:string"
+                        select="text()"/>
+          <!--select="solr:analyzeField(
+            'keepInspireServiceTypes', text())"/>-->
+          <xsl:if test="$inspireServiceType != ''">
+            <inspireServiceType>
+              <xsl:value-of select="lower-case($inspireServiceType)"/>
+            </inspireServiceType>
+          </xsl:if>
+          <xsl:if test="following-sibling::srv:serviceTypeVersion">
+            <serviceTypeAndVersion>
+              <xsl:value-of select="concat(
+                        text(),
+                        $separator,
+                        following-sibling::srv:serviceTypeVersion/gco:CharacterString/text())"/>
+            </serviceTypeAndVersion>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:for-each>
+
+
+      <xsl:for-each select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
+        <xsl:for-each select="gmd:referenceSystemIdentifier/gmd:RS_Identifier">
+          <xsl:variable name="crs" select="gmd:code/gco:CharacterString"/>
+
+          <xsl:if test="$crs != ''">
+            <coordinateSystem>
+              <xsl:value-of select="$crs"/>
+            </coordinateSystem>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:for-each>
+
+
+      <!-- INSPIRE Conformity -->
+
+      <!-- Conformity for services -->
+      <xsl:choose>
+        <xsl:when test="$isService">
+          <xsl:for-each-group select="gmd:dataQualityInfo/*/gmd:report"
+                              group-by="*/gmd:result/*/gmd:specification/gmd:CI_Citation/
+        gmd:title/gco:CharacterString">
+            <xsl:variable name="title" select="current-grouping-key()"/>
+            <xsl:variable name="matchingEUText"
+                          select="if ($inspireRegulationLaxCheck)
+                                  then daobs:search-in-contains($eu9762009/*, $title)
+                                  else daobs:search-in($eu9762009/*, $title)"/>
+            <xsl:if test="count($matchingEUText) = 1">
+              <xsl:variable name="pass"
+                            select="*/gmd:result/*/gmd:pass/gco:Boolean"/>
+              <inspireConformResource>
+                <xsl:value-of select="$pass"/>
+              </inspireConformResource>
+            </xsl:if>
+          </xsl:for-each-group>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- Conformity for dataset -->
+          <xsl:for-each-group select="gmd:dataQualityInfo/*/gmd:report"
+                              group-by="*/gmd:result/*/gmd:specification/gmd:CI_Citation/
+        gmd:title/gco:CharacterString">
+
+            <xsl:variable name="title" select="current-grouping-key()"/>
+            <xsl:variable name="matchingEUText"
+                          select="if ($inspireRegulationLaxCheck)
+                                  then daobs:search-in-contains($eu10892010/*, $title)
+                                  else daobs:search-in($eu10892010/*, $title)"/>
+
+            <xsl:if test="count($matchingEUText) = 1">
+              <xsl:variable name="pass"
+                            select="*/gmd:result/*/gmd:pass/gco:Boolean"/>
+              <inspireConformResource>
+                <xsl:value-of select="$pass"/>
+              </inspireConformResource>
+            </xsl:if>
+          </xsl:for-each-group>
+        </xsl:otherwise>
+      </xsl:choose>
+
+      <xsl:for-each-group select="gmd:dataQualityInfo/*/gmd:report"
+                          group-by="*/gmd:result/*/gmd:specification/
+                                      */gmd:title/gco:CharacterString">
+        <xsl:variable name="title" select="current-grouping-key()"/>
+        <xsl:variable name="pass" select="*/gmd:result/*/gmd:pass/gco:Boolean"/>
+        <xsl:if test="$pass">
+          <xsl:element name="conformTo_{replace(normalize-space($title), '[^a-zA-Z0-9]', '')}">
+            <xsl:value-of select="$pass"/>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each-group>
+
+
+      <xsl:for-each select="gmd:dataQualityInfo/*">
+
+        <xsl:for-each select="gmd:lineage/gmd:LI_Lineage/
+                                gmd:statement/gco:CharacterString[. != '']">
+          <lineage>
+            <xsl:value-of select="."/>
+          </lineage>
+        </xsl:for-each>
+
+
+        <!-- Indexing measure value -->
+        <xsl:for-each select="gmd:report/*[
+                normalize-space(gmd:nameOfMeasure[0]/gco:CharacterString) != '']">
+          <xsl:variable name="measureName"
+                        select="replace(
+                                normalize-space(
+                                  gmd:nameOfMeasure[0]/gco:CharacterString), ' ', '-')"/>
+          <xsl:for-each select="gmd:result/gmd:DQ_QuantitativeResult/gmd:value">
+            <xsl:if test=". != ''">
+              <xsl:element name="measure_{replace($measureName, '[^a-zA-Z0-9]', '')}">
+                <xsl:value-of select="."/>
+              </xsl:element>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:for-each>
+      </xsl:for-each>
+
+
+      <xsl:for-each select="gmd:distributionInfo/*">
+        <xsl:for-each
+          select="gmd:distributionFormat/*/gmd:name/gco:CharacterString">
+          <format>
+            <xsl:value-of select="."/>
+          </format>
+        </xsl:for-each>
+
+        <xsl:for-each select="gmd:transferOptions/*/
+                                gmd:onLine/*[gmd:linkage/gmd:URL != '']">
+
+          <xsl:variable name="protocol" select="gmd:protocol/gco:CharacterString/text()"/>
+
+          <linkUrl>
+            <xsl:value-of select="gmd:linkage/gmd:URL"/>
+          </linkUrl>
+          <linkProtocol>
+            <xsl:value-of select="$protocol"/>
+          </linkProtocol>
+          <link>
+            <xsl:value-of select="gmd:protocol/*/text()"/>
+            <xsl:text>|</xsl:text>
+            <xsl:value-of select="gmd:linkage/gmd:URL"/>
+            <xsl:text>|</xsl:text>
+            <xsl:value-of select="gmd:name/*/text()"/>
+            <xsl:text>|</xsl:text>
+            <xsl:value-of select="gmd:description/*/text()"/>
+          </link>
+
+          <xsl:if test="$operatesOnSetByProtocol and normalize-space($protocol) != ''">
+            <xsl:if test="daobs:contains($protocol, 'wms')">
+              <recordOperatedByType>view</recordOperatedByType>
+            </xsl:if>
+            <xsl:if test="daobs:contains($protocol, 'wfs') or
+                          daobs:contains($protocol, 'wcs') or
+                          daobs:contains($protocol, 'download')">
+              <recordOperatedByType>download</recordOperatedByType>
+            </xsl:if>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:for-each>
+
+      <!-- Service/dataset relation. Create document for the association.
+      Note: not used for indicators anymore
+       This could be used to retrieve :
+      {!child of=documentType:metadata}+documentType:metadata +id:9940c446-6fd4-4ab3-a4de-7d0ee028a8d1
+      {!child of=documentType:metadata}+documentType:metadata +resourceType:service +serviceType:view
+      {!child of=documentType:metadata}+documentType:metadata +resourceType:service +serviceType:download
+       -->
+      <xsl:for-each
+        select="gmd:identificationInfo/srv:SV_ServiceIdentification/srv:operatesOn">
+        <xsl:variable name="associationType" select="'operatesOn'"/>
+        <xsl:variable name="serviceType"
+                      select="../srv:serviceType/gco:LocalName"/>
+        <!--<xsl:variable name="relatedTo" select="@uuidref"/>-->
+        <xsl:variable name="getRecordByIdId">
+          <xsl:if test="@xlink:href != ''">
+            <xsl:analyze-string select="@xlink:href"
+                                regex=".*[i|I][d|D]=([\w\-\.\{{\}}]*).*">
+              <xsl:matching-substring>
+                <xsl:value-of select="regex-group(1)"/>
+              </xsl:matching-substring>
+            </xsl:analyze-string>
+          </xsl:if>
+        </xsl:variable>
+
+        <xsl:variable name="datasetId">
+          <xsl:choose>
+            <xsl:when test="$getRecordByIdId != ''">
+              <xsl:value-of select="$getRecordByIdId"/>
+            </xsl:when>
+            <xsl:when test="@uuidref != ''">
+              <xsl:value-of select="@uuidref"/>
+            </xsl:when>
+          </xsl:choose>
+        </xsl:variable>
+
+        <xsl:if test="$datasetId != ''">
+          <recordOperateOn>
+            <xsl:value-of select="$datasetId"/>
+          </recordOperateOn>
+        </xsl:if>
+      </xsl:for-each>
+
+      <!-- Index more fields in this element -->
+      <xsl:apply-templates mode="index-extra-fields" select="."/>
+    </doc>
+
+    <!-- Index more documents for this element -->
+    <xsl:apply-templates mode="index-extra-documents" select="."/>
+  </xsl:template>
+
+  <xsl:template mode="index-contact" match="*[gmd:CI_ResponsibleParty]">
+    <xsl:param name="fieldSuffix" select="''" as="xs:string"/>
+
+    <!-- Select the first child which should be a CI_ResponsibleParty.
+    Some records contains more than one CI_ResponsibleParty which is
+    not valid and they will be ignored.
+     Same for organisationName eg. de:b86a8604-bf78-480f-a5a8-8edff5586679 -->
+    <xsl:variable name="organisationName"
+                  select="*[1]/gmd:organisationName[1]/(gco:CharacterString|gmx:Anchor)"
+                  as="xs:string*"/>
+
+    <xsl:variable name="role"
+                  select="*[1]/gmd:role/*/@codeListValue"
+                  as="xs:string?"/>
+    <xsl:if test="normalize-space($organisationName) != ''">
+      <xsl:element name="Org{$fieldSuffix}">
+        <xsl:value-of select="$organisationName"/>
+      </xsl:element>
+      <xsl:element name="{$role}Org{$fieldSuffix}">
+        <xsl:value-of select="$organisationName"/>
+      </xsl:element>
+    </xsl:if>
+    <xsl:element name="contact{$fieldSuffix}">{
+      org:"<xsl:value-of
+        select="replace($organisationName, '&quot;', '\\&quot;')"/>",
+      role:"<xsl:value-of select="$role"/>"
+      }
+    </xsl:element>
+  </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -140,6 +140,7 @@
       </xsl:for-each>
 
       <!-- Harvester details
+      <territory>GN</territory>
       <territory>
         <xsl:value-of select="util:getSettingValue('system/site/name')"/>
       </territory>
@@ -376,14 +377,12 @@
                 <xsl:value-of select="$inspireTheme"/>
               </inspireThemeFirst>
               <inspireAnnexForFirstTheme>
-                <xsl:value-of
-                  select="'TODO'"/>
+                <xsl:value-of select="$inspireTheme"/>
                 <!--select="solr:analyzeField('synInspireAnnexes', $inspireTheme)"/>-->
               </inspireAnnexForFirstTheme>
             </xsl:if>
             <inspireAnnex>
-              <xsl:value-of
-                select="'TODO'"/>
+              <xsl:value-of select="text()"/>
             </inspireAnnex>
           </xsl:for-each>
         </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/inspire-constant.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/inspire-constant.xsl
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2014-2016 European Environment Agency
+
+    Licensed under the EUPL, Version 1.1 or – as soon
+    they will be approved by the European Commission -
+    subsequent versions of the EUPL (the "Licence");
+    You may not use this work except in compliance
+    with the Licence.
+    You may obtain a copy of the Licence at:
+
+    https://joinup.ec.europa.eu/community/eupl/og_page/eupl
+
+    Unless required by applicable law or agreed to in
+    writing, software distributed under the Licence is
+    distributed on an "AS IS" basis,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied.
+    See the Licence for the specific language governing
+    permissions and limitations under the Licence.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="2.0">
+
+  <xsl:variable name="inspireThemesMap">
+    <map theme="Coordinate reference systems"
+         monitoring="coordinateReferenceSystems" annex="I"/>
+    <map theme="Elevation"
+         monitoring="elevation" annex="II"/>
+    <map theme="Land cover"
+         monitoring="landCover" annex="II"/>
+    <map theme="Orthoimagery"
+         monitoring="orthoimagery" annex="II"/>
+    <map theme="Geology"
+         monitoring="geology" annex="II"/>
+    <map theme="Statistical units"
+         monitoring="statisticalUnits" annex="III"/>
+    <map theme="Buildings"
+         monitoring="buildings" annex="III"/>
+    <map theme="Soil"
+         monitoring="soil" annex="III"/>
+    <map theme="Land use"
+         monitoring="landUse" annex="III"/>
+    <map theme="Human health and safety"
+         monitoring="humanHealthAndSafety" annex="III"/>
+    <map theme="Utility and governmental services"
+         monitoring="utilityAndGovernmentalServices" annex="III"/>
+    <map theme="Geographical grid systems"
+         monitoring="geographicalGridSystems" annex="I"/>
+    <map theme="Environmental monitoring facilities"
+         monitoring="environmentalMonitoringFacilities" annex="III"/>
+    <map theme="Production and industrial facilities"
+         monitoring="productionAndIndustrialFacilities" annex="III"/>
+    <map theme="Agricultural and aquaculture facilities"
+         monitoring="agriculturalAndAquacultureFacilities" annex="III"/>
+    <!--<map theme="Population distribution — demography"-->
+    <map theme="Population distribution.*"
+         monitoring="populationDistributionDemography" annex="III"/>
+    <map theme="Area management/restriction/regulation zones and reporting units"
+         monitoring="areaManagementRestrictionRegulationZonesAndReportingUnits" annex="III"/>
+    <map theme="Natural risk zones"
+         monitoring="naturalRiskZones" annex="III"/>
+    <map theme="Atmospheric conditions"
+         monitoring="atmosphericConditions" annex="III"/>
+    <map theme="Meteorological geographical features"
+         monitoring="meteorologicalGeographicalFeatures" annex="III"/>
+    <map theme="Oceanographic geographical features"
+         monitoring="oceanographicGeographicalFeatures" annex="III"/>
+    <map theme="Sea regions"
+         monitoring="seaRegions" annex="III"/>
+    <map theme="Geographical names"
+         monitoring="geographicalNames" annex="I"/>
+    <map theme="Bio-geographical regions"
+         monitoring="bioGeographicalRegions" annex="III"/>
+    <map theme="Habitats and biotopes"
+         monitoring="habitatsAndBiotopes" annex="III"/>
+    <map theme="Species distribution"
+         monitoring="speciesDistribution" annex="III"/>
+    <map theme="Energy resources"
+         monitoring="energyResources" annex="III"/>
+    <map theme="Mineral resources"
+         monitoring="mineralResources" annex="III"/>
+    <map theme="Administrative units"
+         monitoring="administrativeUnits" annex="I"/>
+    <map theme="Addresses"
+         monitoring="addresses" annex="I"/>
+    <map theme="Cadastral parcels"
+         monitoring="cadastralParcels" annex="I"/>
+    <map theme="Transport networks"
+         monitoring="transportNetworks" annex="I"/>
+    <map theme="Hydrography"
+         monitoring="hydrography" annex="I"/>
+    <map theme="Protected sites"
+         monitoring="protectedSites" annex="I"/>
+  </xsl:variable>
+
+  <xsl:variable name="eu10892010">
+    <xsl:choose>
+      <xsl:when test="$inspireRegulationLaxCheck">
+        <cr>commission regulation (eu)</cr>
+        <re>reglement (ue)</re>
+        <in>inspire</in>
+      </xsl:when>
+      <xsl:otherwise>
+        <en>Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</en>
+        <bg>Регламент (ЕС) № 1089/2010 на Комисията от 23 ноември 2010 година за прилагане на Директива 2007/2/ЕО на Европейския парламент и на Съвета по отношение на оперативната съвместимост на масиви от пространствени данни и услуги за пространствени данни</bg>
+        <es>Reglamento (UE) n ° 1089/2010 de la Comisión, de 23 de noviembre de 2010 , por el que se aplica la Directiva 2007/2/CE del Parlamento Europeo y del Consejo en lo que se refiere a la interoperabilidad de los conjuntos y los servicios de datos espaciales</es>
+        <cs>Nařízení Komise (EU) č. 1089/2010 ze dne 23. listopadu 2010 , kterým se provádí směrnice Evropského parlamentu a Rady 2007/2/ES, pokud jde o interoperabilitu sad prostorových dat a služeb prostorových dat</cs>
+        <da>Kommissionens forordning (EU) nr. 1089/2010 af 23. november 2010 om gennemførelse af Europa-Parlamentets og Rådets direktiv 2007/2/EF for så vidt angår interoperabilitet for geodatasæt og -tjenester</da>
+        <de>Verordnung (EG) Nr. 1089/2010 der Kommission vom 23. November 2010 zur Durchführung der Richtlinie 2007/2/EG des Europäischen Parlaments und des Rates hinsichtlich der Interoperabilität von Geodatensätzen und -diensten</de>
+        <et>Komisjoni määrus (EL) nr 1089/2010, 23. november 2010 , millega rakendatakse Euroopa Parlamendi ja nõukogu direktiivi 2007/2/EÜ seoses ruumiandmekogumite ja -teenuste ristkasutatavusega</et>
+        <el>Κανονισμός (ΕΕ) αριθ. 1089/2010 της Επιτροπής, της 23ης Νοεμβρίου 2010 , σχετικά με την εφαρμογή της οδηγίας 2007/2/ΕΚ του Ευρωπαϊκού Κοινοβουλίου και του Συμβουλίου όσον αφορά τη διαλειτουργικότητα των συνόλων και των υπηρεσιών χωρικών δεδομένων</el>
+        <fr>Règlement (UE) n ° 1089/2010 de la Commission du 23 novembre 2010 portant modalités d'application de la directive 2007/2/CE du Parlement européen et du Conseil en ce qui concerne l'interopérabilité des séries et des services de données géographiques</fr>
+        <hr>Uredba Komisije (EU) br. 1089/2010 od 23. studenoga 2010. o provedbi Direktive 2007/2/EZ Europskog parlamenta i Vijeća o međuoperativnosti skupova prostornih podataka i usluga u vezi s prostornim podacima</hr>
+        <it>Regolamento (UE) n. 1089/2010 della Commissione, del 23 novembre 2010 , recante attuazione della direttiva 2007/2/CE del Parlamento europeo e del Consiglio per quanto riguarda l'interoperabilità dei set di dati territoriali e dei servizi di dati territoriali</it>
+        <lv>Komisijas Regula (ES) Nr. 1089/2010 ( 2010. gada 23. novembris ), ar kuru īsteno Eiropas Parlamenta un Padomes Direktīvu 2007/2/EK attiecībā uz telpisko datu kopu un telpisko datu pakalpojumu savstarpējo izmantojamību</lv>
+        <lt>2010 m. lapkričio 23 d. Komisijos reglamentas (ES) Nr. 1089/2010, kuriuo įgyvendinamos Europos Parlamento ir Tarybos direktyvos 2007/2/EB nuostatos dėl erdvinių duomenų rinkinių ir paslaugų sąveikumo</lt>
+        <hu>A Bizottság 1089/2010/EU rendelete ( 2010. november 23. ) a 2007/2/EK európai parlamenti és tanácsi irányelv téradatkészletek és -szolgáltatások interoperabilitására vonatkozó rendelkezéseinek végrehajtásáról</hu>
+        <mt>Regolament tal-Kummissjoni (UE) Nru 1089/2010 tat- 23 ta' Novembru 2010 li jimplimenta d-Direttiva 2007/2/KE tal-Parlament Ewropew u tal-Kunsill fir-rigward tal-interoperabbiltà tas-settijiet ta’ dejta u servizzi ġeografiċi</mt>
+        <nl>Verordening (EU) nr. 1089/2010 van de Commissie van 23 november 2010 ter uitvoering van Richtlijn 2007/2/EG van het Europees Parlement en de Raad betreffende de interoperabiliteit van verzamelingen ruimtelijke gegevens en van diensten met betrekking tot ruimtelijke gegevens</nl>
+        <pl>Rozporządzenie Komisji (UE) nr 1089/2010 z dnia 23 listopada 2010 r. w sprawie wykonania dyrektywy 2007/2/WE Parlamentu Europejskiego i Rady w zakresie interoperacyjności zbiorów i usług danych przestrzennych</pl>
+        <pt>Regulamento (UE) n. ° 1089/2010 da Comissão, de 23 de Novembro de 2010 , que estabelece as disposições de execução da Directiva 2007/2/CE do Parlamento Europeu e do Conselho relativamente à interoperabilidade dos conjuntos e serviços de dados geográficos</pt>
+        <ro>Regulamentul (UE) nr. 1089/2010 al Comisiei din 23 noiembrie 2010 de punere în aplicare a Directivei 2007/2/CE a Parlamentului European și a Consiliului în ceea ce privește interoperabilitatea seturilor și serviciilor de date spațiale</ro>
+        <sk>Nariadenie Komisie (EÚ) č. 1089/2010 z  23. novembra 2010 , ktorým sa vykonáva smernica Európskeho parlamentu a Rady 2007/2/ES, pokiaľ ide o interoperabilitu súborov a služieb priestorových údajov</sk>
+        <sl>Uredba Komisije (EU) št. 1089/2010 z dne 23. novembra 2010 o izvajanju Direktive 2007/2/ES Evropskega parlamenta in Sveta glede medopravilnosti zbirk prostorskih podatkov in storitev v zvezi s prostorskimi podatki</sl>
+        <fi>Komission asetus (EU) N:o 1089/2010, annettu 23 päivänä marraskuuta 2010 , Euroopan parlamentin ja neuvoston direktiivin 2007/2/EY täytäntöönpanosta paikkatietoaineistojen ja -palvelujen yhteentoimivuuden osalta</fi>
+        <sv>Kommissionens förordning (EU) nr 1089/2010 av den 23 november 2010 om genomförande av Europaparlamentets och rådets direktiv 2007/2/EG vad gäller interoperabilitet för rumsliga datamängder och datatjänster</sv>
+        <!-- Translation http://eur-lex.europa.eu/legal-content/SV/TXT/?uri=CELEX:32010R1089&qid=1418298723943  -->
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
+  <xsl:variable name="eu9762009">
+    <xsl:choose>
+      <xsl:when test="$inspireRegulationLaxCheck">
+        <cr>commission regulation (eu)</cr>
+        <re>reglement (ue)</re>
+        <in>inspire</in>
+      </xsl:when>
+      <xsl:otherwise>
+        <en>Commission Regulation (EC) No 976/2009 of 19 October 2009 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards the Network Services</en>
+        <bg>Регламент (ЕО) № 976/2009 на Комисията от 19 октомври 2009 година за прилагане на Директива 2007/2/ЕО на Европейския парламент и на Съвета по отношение на мрежовите услуги</bg>
+        <cs>Nařízení Komise (ES) č. 976/2009 ze dne 19. října 2009 , kterým se provádí směrnice Evropského parlamentu a Rady 2007/2/ES, pokud jde o síťové služby</cs>
+        <da>Kommissionens forordning (EF) nr. 976/2009 af 19. oktober 2009 om gennemførelse af Europa-Parlamentets og Rådets direktiv 2007/2/EF for så vidt angår nettjenesterne</da>
+        <de>Verordnung (EG) Nr. 976/2009 der Kommission vom 19. Oktober 2009 zur Durchführung der Richtlinie 2007/2/EG des Europäischen Parlaments und des Rates hinsichtlich der Netzdienste</de>
+        <et>Komisjoni määrus (EÜ) nr 976/2009, 19. oktoober 2009 , millega rakendatakse Euroopa Parlamendi ja nõukogu direktiivi 2007/2/EÜ seoses võrguteenustega</et>
+        <el>Κανονισμός (ΕΚ) αριθ. 976/2009 της Επιτροπής, της 19ης Οκτωβρίου 2009 , για την υλοποίηση της οδηγίας 2007/2/ΕΚ του Ευρωπαϊκού Κοινοβουλίου και του Συμβουλίου όσον αφορά τις δικτυακές υπηρεσίες</el>
+        <fr>Règlement (CE) n o  976/2009 de la Commission du 19 octobre 2009 portant modalités d’application de la directive 2007/2/CE du Parlement européen et du Conseil en ce qui concerne les services en réseau</fr>
+        <hr>Uredba Komisije (EZ) br. 976/2009 od 19. listopada 2009. o provedbi Direktive 2007/2/EZ Europskog parlamenta i Vijeća u vezi s mrežnim uslugama</hr>
+        <it>Regolamento (CE) n. 976/2009 della Commissione, del 19 ottobre 2009 , recante attuazione della direttiva 2007/2/CE del Parlamento europeo e del Consiglio per quanto riguarda i servizi di rete</it>
+        <lv>Komisijas Regula (EK) Nr. 976/2009 ( 2009. gada 19. oktobris ), ar kuru īsteno Eiropas Parlamenta un Padomes Direktīvu 2007/2/EK attiecībā uz tīkla pakalpojumiem</lv>
+        <lt>2009 m. spalio 19 d. Komisijos reglamentas (EB) Nr. 976/2009, kuriuo įgyvendinamos Europos Parlamento ir Tarybos direktyvos 2007/2/EB nuostatos dėl tinklo paslaugų</lt>
+        <hu>A Bizottság 976/2009/EK rendelete ( 2009. október 19. ) a 2007/2/EK európai parlamenti és tanácsi irányelv hálózati szolgáltatásokra vonatkozó rendelkezéseinek végrehajtásáról</hu>
+        <mt>Regolament tal-Kummissjoni (KE) Nru 976/2009 tad- 19 ta’ Ottubru 2009 li jimplimenta d-Direttiva 2007/2/KE tal-Parlament Ewropew u tal-Kunsill fir-rigward tas-Servizzi ta’ Netwerk</mt>
+        <nl>Verordening (EG) nr. 976/2009 van de Commissie van 19 oktober 2009 tot uitvoering van Richtlijn 2007/2/EG van het Europees Parlement en de Raad wat betreft de netwerkdiensten</nl>
+        <pl>Rozporządzenie Komisji (WE) nr 976/2009 z dnia 19 października 2009 r. w sprawie wykonania dyrektywy 2007/2/WE Parlamentu Europejskiego i Rady w zakresie usług sieciowych</pl>
+        <pt>Regulamento (CE) n. o  976/2009 da Comissão, de 19 de Outubro de 2009 , que estabelece as disposições de execução da Directiva 2007/2/CE do Parlamento Europeu e do Conselho no que respeita aos serviços de rede</pt>
+        <ro>Regulamentul (CE) nr. 976/2009 al Comisiei din 19 octombrie 2009 de aplicare a Directivei 2007/2/CE a Parlamentului European și a Consiliului în ceea ce privește serviciile de rețea</ro>
+        <sk>Nariadenie Komisie (ES) č. 976/2009 z  19. októbra 2009 , ktorým sa vykonáva smernica Európskeho parlamentu a Rady 2007/2/ES, pokiaľ ide o sieťové služby</sk>
+        <sl>Uredba Komisije (ES) št. 976/2009 z dne 19. oktobra 2009 o izvajanju Direktive 2007/2/ES Evropskega parlamenta in Sveta glede omrežnih storitev</sl>
+        <fi>Komission asetus (EY) N:o 976/2009, annettu 19 päivänä lokakuuta 2009 , Euroopan parlamentin ja neuvoston direktiivin 2007/2/EY täytäntöönpanosta verkkopalvelujen osalta</fi>
+        <sv>Kommissionens förordning (EG) nr 976/2009 av den 19 oktober 2009 om genomförande av Europaparlamentets och rådets direktiv 2007/2/EG med avseende på nättjänster</sv>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+</xsl:stylesheet>

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
@@ -153,7 +153,7 @@ public class XslProcessUtils {
                     // Always udpate metadata date stamp on metadata processing (minor edit has no effect).
                     boolean updateDateStamp = true;
                     dataMan.updateMetadata(context, id, processedMetadata, validate, ufo, index, language, new ISODate().toString(), updateDateStamp);
-                    dataMan.indexMetadata(id, true);
+                    dataMan.indexMetadata(id, true, null);
                 }
 
                 report.addMetadataId(iId);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -974,7 +974,7 @@ public class MetadataInsertDeleteApi {
             });
         }
 
-        dataMan.indexMetadata(id.get(0), true);
+        dataMan.indexMetadata(id.get(0), true, null);
         return Pair.read(Integer.valueOf(id.get(0)), uuid);
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -159,7 +159,7 @@ public class MetadataSharingApi {
 
         List<GroupOperations> privileges = sharing.getPrivileges();
         setOperations(sharing, dataManager, context, metadata, operationMap, privileges);
-        dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
+        dataManager.indexMetadata(String.valueOf(metadata.getId()), true, null);
     }
 
 
@@ -321,7 +321,7 @@ public class MetadataSharingApi {
         if (!hasValidation) {
             dm.doValidate(metadata.getDataInfo().getSchemaId(), metadata.getId() + "",
                 new Document(metadata.getXmlData(false)), context.getLanguage());
-            dm.indexMetadata(metadata.getId() + "", true);
+            dm.indexMetadata(metadata.getId() + "", true, null);
         }
 
         boolean isInvalid =
@@ -481,7 +481,7 @@ public class MetadataSharingApi {
 
         metadata.getSourceInfo().setGroupOwner(groupIdentifier);
         metadataRepository.save(metadata);
-        dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
+        dataManager.indexMetadata(String.valueOf(metadata.getId()), true, null);
     }
 
 
@@ -690,7 +690,7 @@ public class MetadataSharingApi {
                 report, dataManager, accessMan, metadataRepository,
                 serviceContext, listOfUpdatedRecords, metadataUuid);
             dataManager.flush();
-            dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
+            dataManager.indexMetadata(String.valueOf(metadata.getId()), true, null);
 
         } catch (Exception exception) {
             report.addError(exception);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -168,7 +168,7 @@ public class MetadataTagApi {
             }
         }
 
-        dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
+        dataManager.indexMetadata(String.valueOf(metadata.getId()), true, null);
     }
 
     @ApiOperation(
@@ -216,7 +216,7 @@ public class MetadataTagApi {
             }
         }
 
-        dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
+        dataManager.indexMetadata(String.valueOf(metadata.getId()), true, null);
     }
 
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -38,14 +38,12 @@ import org.fao.geonet.kernel.metadata.StatusActionsFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.HashSet;
 import java.util.Locale;
@@ -145,6 +143,6 @@ public class MetadataWorkflowApi {
 
         //--- reindex metadata
         DataManager dataManager = appContext.getBean(DataManager.class);
-        dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
+        dataManager.indexMetadata(String.valueOf(metadata.getId()), true, null);
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
@@ -594,7 +594,7 @@ public class AjaxEditUtils extends EditUtils {
         dataManager.notifyMetadataChange(md, id);
 
         //--- update search criteria
-        dataManager.indexMetadata(id, true);
+        dataManager.indexMetadata(id, true, null);
 
         return true;
     }
@@ -643,7 +643,7 @@ public class AjaxEditUtils extends EditUtils {
         dataManager.notifyMetadataChange(md, id);
 
         //--- update search criteria
-        dataManager.indexMetadata(id, true);
+        dataManager.indexMetadata(id, true, null);
 
         return true;
     }

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -44,7 +44,6 @@ import org.fao.geonet.kernel.*;
 import org.fao.geonet.kernel.metadata.StatusActions;
 import org.fao.geonet.kernel.metadata.StatusActionsFactory;
 import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.MetadataValidationRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.MetadataValidationSpecs;
@@ -343,7 +342,7 @@ public class MetadataEditingApi {
             }
 
             if (reindex) {
-                dataMan.indexMetadata(id, true);
+                dataMan.indexMetadata(id, true, null);
             }
 
             ajaxEditUtils.removeMetadataEmbedded(session, id);

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -34,6 +34,7 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.SystemInfo;
+import org.fao.geonet.Util;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
@@ -44,6 +45,8 @@ import org.fao.geonet.domain.*;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.search.EsSearchManager;
+import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
@@ -59,6 +62,7 @@ import org.fao.geonet.utils.ProxyInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -81,6 +85,7 @@ import java.util.*;
 
 import static org.apache.commons.fileupload.util.Streams.checkFileName;
 import static org.fao.geonet.api.ApiParams.API_CLASS_CATALOG_TAG;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
 
 /**
  *
@@ -482,6 +487,104 @@ public class SiteApi {
     ) throws Exception {
         ApiUtils.createServiceContext(request);
         return ApplicationContextHolder.get().getBean(DataManager.class).isIndexing();
+    }
+
+    @ApiOperation(
+        value = "Index",
+        notes = "",
+        nickname = "index")
+    @RequestMapping(
+        path = "/index",
+        produces = MediaType.APPLICATION_JSON_VALUE,
+        method = RequestMethod.PUT)
+    @PreAuthorize("hasRole('Editor')")
+    @ResponseBody
+    public HttpEntity index(
+        @ApiParam(value = "Drop and recreate index",
+            required = false)
+        @RequestParam(required = false, defaultValue = "true")
+        boolean reset,
+        @ApiParam(value = "Records having only XLinks",
+            required = false)
+        @RequestParam(required = false, defaultValue = "false")
+            boolean havingXlinkOnly,
+//        @ApiParam(value = API_PARAM_RECORD_UUIDS_OR_SELECTION,
+//            required = false,
+//            example = "")
+//        @RequestParam(required = false)
+//        String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+        String bucket,
+        HttpServletRequest request
+    ) throws Exception {
+        ServiceContext context = ApiUtils.createServiceContext(request);
+        SearchManager searchMan = ApplicationContextHolder.get().getBean(SearchManager.class);
+
+        searchMan.rebuildIndex(context, havingXlinkOnly, reset, bucket);
+
+        return new HttpEntity<>(HttpStatus.CREATED);
+    }
+
+    @ApiOperation(
+        value = "Index in Elastic",
+        notes = "",
+        nickname = "indexes")
+    @RequestMapping(
+        path = "/index/es",
+        produces = MediaType.APPLICATION_JSON_VALUE,
+        method = RequestMethod.PUT)
+    @PreAuthorize("hasRole('Editor')")
+    @ResponseBody
+    public HttpEntity indexEs(
+        @ApiParam(value = "Drop and recreate index",
+            required = false)
+        @RequestParam(required = false, defaultValue = "true")
+            boolean reset,
+        @ApiParam(value = "Records having only XLinks",
+            required = false)
+        @RequestParam(required = false, defaultValue = "false")
+            boolean havingXlinkOnly,
+//        @ApiParam(value = API_PARAM_RECORD_UUIDS_OR_SELECTION,
+//            required = false,
+//            example = "")
+//        @RequestParam(required = false)
+//        String[] uuids,
+        @ApiParam(
+            value = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
+        HttpServletRequest request
+    ) throws Exception {
+        ServiceContext context = ApiUtils.createServiceContext(request);
+        EsSearchManager searchMan = ApplicationContextHolder.get().getBean(EsSearchManager.class);
+
+        searchMan.rebuildIndex(context, havingXlinkOnly, reset, bucket);
+
+        return new HttpEntity<>(HttpStatus.CREATED);
+    }
+
+    @ApiOperation(
+        value = "Delete index in Elastic",
+        notes = "",
+        nickname = "deleteIndexes")
+    @RequestMapping(
+        path = "/index/es",
+        produces = MediaType.APPLICATION_JSON_VALUE,
+        method = RequestMethod.DELETE)
+    @PreAuthorize("hasRole('Editor')")
+    @ResponseBody
+    public HttpEntity deleteIndexEs() throws Exception {
+        EsSearchManager searchMan = ApplicationContextHolder.get().getBean(EsSearchManager.class);
+        searchMan.clearIndex();
+        return new HttpEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @ApiOperation(

--- a/services/src/main/java/org/fao/geonet/services/metadata/BatchOpsMetadataReindexer.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/BatchOpsMetadataReindexer.java
@@ -142,7 +142,7 @@ public class BatchOpsMetadataReindexer extends MetadataIndexerProcessor {
         public Void call() throws Exception {
             for (int i = beginIndex; i < beginIndex + count; i++) {
                 boolean doIndex = beginIndex + count - 1 == i;
-                dm.indexMetadata(ids[i] + "", doIndex);
+                dm.indexMetadata(ids[i] + "", doIndex, null);
             }
 
             return null;

--- a/services/src/main/java/org/fao/geonet/services/metadata/IndexRebuild.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/IndexRebuild.java
@@ -74,7 +74,7 @@ public class IndexRebuild implements Service {
 
         SearchManager searchMan = gc.getBean(SearchManager.class);
 
-        boolean info = searchMan.rebuildIndex(context, xlinks, reset, fromSelection);
+        boolean info = searchMan.rebuildIndex(context, xlinks, reset, fromSelection ? "metadata" : null);
 
         Element elResp = new Element(Jeeves.Elem.RESPONSE);
         elResp.addContent(new Element("status").setText((info ? "true" : "false")));

--- a/services/src/main/java/org/fao/geonet/services/metadata/Insert.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Insert.java
@@ -181,7 +181,7 @@ public class Insert extends NotInReadOnlyModeService {
         }
 
         // Index
-        dm.indexMetadata(id.get(0), true);
+        dm.indexMetadata(id.get(0), true, null);
 
         // Return response
         Element response = new Element(Jeeves.Elem.RESPONSE);

--- a/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
@@ -175,7 +175,7 @@ public class Publish {
 
                         dataManager.doValidate(metadata.getDataInfo().getSchemaId(), metadata.getId() + "",
                                 new Document(metadata.getXmlData(false)), serviceContext.getLanguage());
-                        dataManager.indexMetadata(nextId, true);
+                        dataManager.indexMetadata(nextId, true, null);
                     }
 
                     boolean isInvalid =

--- a/services/src/main/java/org/fao/geonet/services/metadata/Update.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Update.java
@@ -190,7 +190,7 @@ public class Update extends NotInReadOnlyModeService {
 			}
 
 			if (reindex) {
-				dataMan.indexMetadata(id, true);
+				dataMan.indexMetadata(id, true, null);
 			}
 
 

--- a/services/src/main/java/org/fao/geonet/services/metadata/UpdateAdminOper.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/UpdateAdminOper.java
@@ -49,7 +49,6 @@ import org.jdom.Element;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -172,7 +171,7 @@ public class UpdateAdminOper extends NotInReadOnlyModeService {
 		}
 
         //--- index metadata
-        dm.indexMetadata(id, true);
+        dm.indexMetadata(id, true, null);
 
         //--- return id for showing
 		return new Element(Jeeves.Elem.RESPONSE).addContent(new Element(Geonet.Elem.ID).setText(id));
@@ -199,7 +198,7 @@ public class UpdateAdminOper extends NotInReadOnlyModeService {
 
 			dm.doValidate(metadata.getDataInfo().getSchemaId(), mdId + "",
 					new Document(metadata.getXmlData(false)), context.getLanguage());
-			dm.indexMetadata(mdId + "", true);
+			dm.indexMetadata(mdId + "", true, null);
 		}
 
 		boolean isInvalid =

--- a/services/src/main/java/org/fao/geonet/services/metadata/UpdateCategories.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/UpdateCategories.java
@@ -96,7 +96,7 @@ public class UpdateCategories extends NotInReadOnlyModeService {
         }
 
         //--- index metadata
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         //--- return id for showing
         return new Element(Jeeves.Elem.RESPONSE).addContent(new Element(Geonet.Elem.ID).setText(id));

--- a/services/src/main/java/org/fao/geonet/services/metadata/UpdateGroupOwner.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/UpdateGroupOwner.java
@@ -96,7 +96,7 @@ public class UpdateGroupOwner extends NotInReadOnlyModeService {
         metadataRepository.save(metadata);
 
         //--- index metadata
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         //--- return id for showing
         return new Element(Jeeves.Elem.RESPONSE).

--- a/services/src/main/java/org/fao/geonet/services/metadata/UpdateStatus.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/UpdateStatus.java
@@ -102,7 +102,7 @@ public class UpdateStatus extends NotInReadOnlyModeService {
         sa.statusChange(status, metadataIds, changeDate, changeMessage);
 
         //--- reindex metadata
-        dataMan.indexMetadata(id, true);
+        dataMan.indexMetadata(id, true, null);
 
         //--- return id for showing
         return new Element(Jeeves.Elem.RESPONSE).addContent(new Element(Geonet.Elem.ID).setText(id));

--- a/services/src/test/java/org/fao/geonet/services/metadata/PublishTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/PublishTest.java
@@ -104,7 +104,7 @@ public class PublishTest extends AbstractServiceIntegrationTest {
         final String metadataId = metadataIds.get(0);
 
         allowedRepository.deleteAll();
-        dataManager.indexMetadata(metadataId, true);
+        dataManager.indexMetadata(metadataId, true, null);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.getSession();
@@ -117,7 +117,7 @@ public class PublishTest extends AbstractServiceIntegrationTest {
         assertPublishedInIndex(true, metadataId);
 
         allowedRepository.deleteAll();
-        dataManager.indexMetadata(metadataId, true);
+        dataManager.indexMetadata(metadataId, true, null);
         assertPublishedInIndex(false, metadataId);
 
         SecurityContextHolder.clearContext();

--- a/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
@@ -444,6 +444,22 @@
                 type: 'danger'});
             });
       };
+      $scope.indexInEs = function() {
+        return $http.put('../api/site/index/es')
+          .success(function(data) {
+            $rootScope.$broadcast('StatusUpdated', {
+              msg: $translate.instant('indexInEsDone'),
+              timeout: 2,
+              type: 'success'});
+          })
+          .error(function(data) {
+            $rootScope.$broadcast('StatusUpdated', {
+              title: $translate.instant('indexInEsDoneError'),
+              error: data,
+              timeout: 0,
+              type: 'danger'});
+          });
+      };
 
       $scope.optimizeIndex = function() {
         return $http.get('admin.index.optimize')

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -459,6 +459,8 @@
     "indexOptimizationInProgress": "Index optimization in progress ...",
     "indexingRecordsRelatedToTheThesaurus": "Records related to this thesaurus are being indexed ...",
     "information": "Information",
+    "indexInEs": "(beta) Index in remote index",
+    "indexInEsHelp": "Index the catalogue content in a remote Elasticsearch instance.",
     "inspireatom-errors": "Errors:",
     "inspireatom-harvestedfeeds": "Harvested feeds:",
     "inspireatom-loadAtomHarvesterReport": "Atom harvester report",

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/index.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/index.html
@@ -28,18 +28,6 @@
         <div class="row">
           <div class="col-lg-4">
             <button type="button" class="btn btn-warning btn-lg btn-block"
-                    data-gn-click-and-spin="indexInEs()"
-                    data-translate=""
-            >indexInEs
-            </button>
-
-          </div>
-          <div class="col-lg-8" data-translate="">indexInEsHelp</div>
-        </div>
-        <br/>
-        <div class="row">
-          <div class="col-lg-4">
-            <button type="button" class="btn btn-warning btn-lg btn-block"
                     data-gn-click-and-spin="optimizeIndex()" data-ng-disabled="isIndexing"
                     data-translate=""
             >optimizeIndex
@@ -62,6 +50,21 @@
           </div>
           <div class="col-lg-8" data-translate="">reloadLuceneConfigHelp</div>
         </div>
+        <hr/>
+
+        <br/>
+        <div class="row">
+          <div class="col-lg-4">
+            <button type="button" class="btn btn-warning btn-lg btn-block"
+                    data-gn-click-and-spin="indexInEs()"
+                    data-translate=""
+            >indexInEs
+            </button>
+
+          </div>
+          <div class="col-lg-8" data-translate="">indexInEsHelp</div>
+        </div>
+        <hr/>
 
         <br/>
         <div class="row">

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/index.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/index.html
@@ -28,6 +28,18 @@
         <div class="row">
           <div class="col-lg-4">
             <button type="button" class="btn btn-warning btn-lg btn-block"
+                    data-gn-click-and-spin="indexInEs()"
+                    data-translate=""
+            >indexInEs
+            </button>
+
+          </div>
+          <div class="col-lg-8" data-translate="">indexInEsHelp</div>
+        </div>
+        <br/>
+        <div class="row">
+          <div class="col-lg-4">
+            <button type="button" class="btn btn-warning btn-lg btn-block"
                     data-gn-click-and-spin="optimizeIndex()" data-ng-disabled="isIndexing"
                     data-translate=""
             >optimizeIndex

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -13,5 +13,6 @@ usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}
 
 es.url=${es.url}
 es.index.features=${es.index.features}
+es.index.records=${es.index.records}
 
 jms.url=${jms.url}

--- a/workers/wfsfeature-harvester/pom.xml
+++ b/workers/wfsfeature-harvester/pom.xml
@@ -91,6 +91,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.geonetwork-opensource</groupId>
+      <artifactId>es-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>messaging</artifactId>
       <version>${project.version}</version>
@@ -107,22 +113,9 @@
       <artifactId>spring-web</artifactId>
     </dependency>
 
-
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-geojson</artifactId>
-    </dependency>
-    <!--<dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch</artifactId>
-    </dependency>-->
-    <!--Require Lucene 5 <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>transport</artifactId>
-    </dependency>-->
-    <dependency>
-      <groupId>io.searchbox</groupId>
-      <artifactId>jest</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/WFSHarvesterApi.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/WFSHarvesterApi.java
@@ -29,9 +29,10 @@ import net.sf.json.JSONObject;
 import org.apache.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
+import org.fao.geonet.es.EsClient;
 import org.fao.geonet.harvester.wfsfeatures.event.WFSHarvesterEvent;
 import org.fao.geonet.harvester.wfsfeatures.model.WFSHarvesterParameter;
-import org.fao.geonet.harvester.wfsfeatures.worker.EsClient;
+import org.fao.geonet.harvester.wfsfeatures.worker.EsWFSFeatureIndexer;
 import org.fao.geonet.harvester.wfsfeatures.worker.WFSHarvesterRouteBuilder;
 import org.geonetwork.messaging.JMSMessager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +44,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 
-import static org.fao.geonet.harvester.wfsfeatures.worker.EsWFSFeatureIndexer.deleteFeatures;
 
 /**
  * Created by fgravin on 10/29/15.
@@ -98,8 +98,10 @@ public class WFSHarvesterApi {
         @RequestParam
         String typeName) throws Exception {
 
-
-        deleteFeatures(serviceUrl, typeName, Logger.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME), client);
+        EsWFSFeatureIndexer indexer = ApplicationContextHolder.get().getBean(EsWFSFeatureIndexer.class);
+        indexer.deleteFeatures(serviceUrl, typeName,
+            Logger.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME),
+            client);
 
         // TODO: Check user is authenticated ?
         JSONObject result = new JSONObject();

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
@@ -37,6 +37,7 @@ import io.searchbox.core.Index;
 import org.apache.camel.Exchange;
 import org.apache.jcs.access.exception.InvalidArgumentException;
 import org.apache.log4j.Logger;
+import org.fao.geonet.es.EsClient;
 import org.fao.geonet.harvester.wfsfeatures.model.WFSHarvesterParameter;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
@@ -56,6 +57,7 @@ import org.opengis.metadata.extent.GeographicBoundingBox;
 import org.opengis.metadata.extent.GeographicExtent;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -64,7 +66,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.StringTokenizer;
 
 //import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -74,6 +75,9 @@ public class EsWFSFeatureIndexer {
     public static final String MULTIVALUED_SUFFIX = "s";
     public static final String TREE_FIELD_SUFFIX = "_tree";
     public static final String FEATURE_FIELD_PREFIX = "ft_";
+
+    @Value("es.index.features")
+    private String index = "features";
 
     @Autowired
     private EsClient client;
@@ -172,16 +176,16 @@ public class EsWFSFeatureIndexer {
         deleteFeatures(url, typeName, logger, client);
     }
 
-    public static void deleteFeatures(String url, String typeName, Logger logger,
+    public void deleteFeatures(String url, String typeName, Logger logger,
                                       EsClient client) {
         logger.info(String.format(
                 "Deleting features previously index from service '%s' and feature type '%s' in '%s'",
-                url, typeName, client.getCollection()));
+                url, typeName, index));
 
         try {
             ZonedDateTime startTime = ZonedDateTime.now();
             String msg = client.deleteByQuery(
-                client.getCollection(),
+                index,
                 String.format(
                     "+featureTypeId:\\\"%s#%s\\\"", url, typeName)
             );
@@ -191,7 +195,7 @@ public class EsWFSFeatureIndexer {
 
             startTime = ZonedDateTime.now();
             msg = client.deleteByQuery(
-                client.getCollection(),
+                index,
                 String.format(
                     "+id:\\\"%s#%s\\\"", url, typeName)
             );
@@ -202,18 +206,18 @@ public class EsWFSFeatureIndexer {
             e.printStackTrace();
             logger.error(String.format(
                     "Error connecting to ES at '%s'. Error is %s.",
-                    client.getCollection(), e.getMessage()));
+                    index, e.getMessage()));
         }
     }
 
     private void saveHarvesterReport(WFSHarvesterExchangeState state) {
         Map<String, Object> report = state.getHarvesterReport();
-        Index index = new Index.Builder(report)
-            .index(client.getCollection())
-            .type(client.getCollection())
+        Index search = new Index.Builder(report)
+            .index(index)
+            .type(index)
             .id(report.get("id").toString()).build();
         try {
-            DocumentResult response = client.getClient().execute(index);
+            DocumentResult response = client.getClient().execute(search);
             logger.info(String.format(
                     "Report saved for %s. Error is '%s'.",
                     state.getParameters().getTypeName(),
@@ -445,7 +449,7 @@ public class EsWFSFeatureIndexer {
                                 typeName, nbOfFeatures));
                     }
                     try {
-                        client.bulkRequest(client.getCollection(),
+                        client.bulkRequest(index,
                             docCollection);
                     } catch (Exception ex) {
                         state.getHarvesterReport().put("error_ss", String.format(
@@ -472,7 +476,7 @@ public class EsWFSFeatureIndexer {
                         typeName, nbOfFeatures));
                 }
                 try {
-                    client.bulkRequest(client.getCollection(),
+                    client.bulkRequest(index,
                         docCollection);
                 } catch (Exception ex) {
                     state.getHarvesterReport().put("error_ss", String.format(
@@ -506,5 +510,9 @@ public class EsWFSFeatureIndexer {
         } finally {
             saveHarvesterReport(state);
         }
+    }
+
+    public void setIndex(String index) {
+        this.index = index;
     }
 }

--- a/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
@@ -48,10 +48,7 @@
   </bean>
 
   <bean id="esClient"
-        class="org.fao.geonet.harvester.wfsfeatures.worker.EsClient">
-    <property name="serverUrl" value="\${es.url}"/>
-    <property name="collection" value="\${es.index.features}"/>
-  </bean>
+        class="org.fao.geonet.es.EsClient"/>
 
 
   <cm:camelContext id="harvest-wfs"


### PR DESCRIPTION
# Overview

Main goal of this proposal is to be able to push GeoNetwork content in a remote index in order to build dashboards on the content of the catalogue. This work will also help on the future migration from Lucene to Elasticsearch.

# Proposal

Add the capability to index the catalogue content in a remote elasticsearch index. Indexing is similar to actual indexing process ie.:
* collect information in database about the record
* extract record fields using XSLT
* send document to the index

This will expose all metadata records in the Elasticsearch index (you've to take care of restricting access to not public record if needed).


From the admin trigger the indexation process:

![image](https://cloud.githubusercontent.com/assets/1701393/26145584/3e11cde0-3aed-11e7-885b-c7a618cb5e83.png)


API allows to remove index content and index the full catalogue or a selection:

![image](https://cloud.githubusercontent.com/assets/1701393/26145355/78aae8e8-3aec-11e7-90bf-a07cf80f81c4.png)


# Usages

## Creating dashboards using Kibana

Dahsboard can be created on metadata content and on "internal" fields like validation status, publication groups, ... (which is a limitation of user of DAOBS project which only harvest records from CSW)

![image](https://cloud.githubusercontent.com/assets/1701393/26145955/c19b199a-3aee-11e7-92f5-b8d12942f2b6.png)

Dashboards can then be added to the admin console:

![image](https://user-images.githubusercontent.com/1701393/27036910-ab1f1480-4f86-11e7-9c84-c1eea01d54b5.png)


# Reference document

* Learn more about Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
* Kibana documentation https://www.elastic.co/guide/en/kibana/current/getting-started.html
