### PR TITLE
Adding CSRF support

### DIFF
--- a/core/src/main/java/org/fao/geonet/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/core/src/main/java/org/fao/geonet/security/web/csrf/CookieCsrfTokenRepository.java
@@ -1,0 +1,199 @@
+/*
+ * Taken from https://raw.githubusercontent.com/spring-projects/spring-security/master/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+ */
+
+package org.fao.geonet.security.web.csrf;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.WebUtils;
+
+/**
+ * A {@link CsrfTokenRepository} that persists the CSRF token in a cookie named
+ * "XSRF-TOKEN" and reads from the header "X-XSRF-TOKEN" following the
+ * conventions of AngularJS. When using with AngularJS be sure to use
+ * {@link #withHttpOnlyFalse()}.
+ *
+ * @author Rob Winch
+ * @since 4.1
+ */
+public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
+  static final String DEFAULT_CSRF_COOKIE_NAME = "XSRF-TOKEN";
+
+  static final String DEFAULT_CSRF_PARAMETER_NAME = "_csrf";
+
+  static final String DEFAULT_CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+
+  private String parameterName = DEFAULT_CSRF_PARAMETER_NAME;
+
+  private String headerName = DEFAULT_CSRF_HEADER_NAME;
+
+  private String cookieName = DEFAULT_CSRF_COOKIE_NAME;
+
+  private final Method setHttpOnlyMethod;
+
+  private boolean cookieHttpOnly;
+
+  private String cookiePath;
+
+  public CookieCsrfTokenRepository() {
+    this.setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
+    if (this.setHttpOnlyMethod != null) {
+      this.cookieHttpOnly = true;
+    }
+  }
+
+  @Override
+  public CsrfToken generateToken(HttpServletRequest request) {
+    return new DefaultCsrfToken(this.headerName, this.parameterName, createNewToken());
+  }
+
+  @Override
+  public void saveToken(CsrfToken token, HttpServletRequest request, HttpServletResponse response) {
+    String tokenValue = token == null ? "" : token.getToken();
+    Cookie cookie = new Cookie(this.cookieName, tokenValue);
+    cookie.setSecure(request.isSecure());
+    if (this.cookiePath != null && !this.cookiePath.isEmpty()) {
+      cookie.setPath(this.cookiePath);
+    } else {
+      cookie.setPath(this.getRequestContext(request));
+    }
+    if (token == null) {
+      cookie.setMaxAge(0);
+    } else {
+      cookie.setMaxAge(-1);
+    }
+    if (cookieHttpOnly && setHttpOnlyMethod != null) {
+      ReflectionUtils.invokeMethod(setHttpOnlyMethod, cookie, Boolean.TRUE);
+    }
+
+    response.addCookie(cookie);
+  }
+
+  @Override
+  public CsrfToken loadToken(HttpServletRequest request) {
+    Cookie cookie = WebUtils.getCookie(request, this.cookieName);
+    if (cookie == null) {
+      return null;
+    }
+    String token = cookie.getValue();
+    if (!StringUtils.hasLength(token)) {
+      return null;
+    }
+    return new DefaultCsrfToken(this.headerName, this.parameterName, token);
+  }
+
+  /**
+   * Sets the name of the HTTP request parameter that should be used to provide
+   * a token.
+   *
+   * @param parameterName
+   *          the name of the HTTP request parameter that should be used to
+   *          provide a token
+   */
+  public void setParameterName(String parameterName) {
+    Assert.notNull(parameterName, "parameterName is not null");
+    this.parameterName = parameterName;
+  }
+
+  /**
+   * Sets the name of the HTTP header that should be used to provide the token.
+   *
+   * @param headerName
+   *          the name of the HTTP header that should be used to provide the
+   *          token
+   */
+  public void setHeaderName(String headerName) {
+    Assert.notNull(headerName, "headerName is not null");
+    this.headerName = headerName;
+  }
+
+  /**
+   * Sets the name of the cookie that the expected CSRF token is saved to and
+   * read from.
+   *
+   * @param cookieName
+   *          the name of the cookie that the expected CSRF token is saved to
+   *          and read from
+   */
+  public void setCookieName(String cookieName) {
+    Assert.notNull(cookieName, "cookieName is not null");
+    this.cookieName = cookieName;
+  }
+
+  /**
+   * Sets the HttpOnly attribute on the cookie containing the CSRF token. The
+   * cookie will only be marked as HttpOnly if both <code>cookieHttpOnly</code>
+   * is <code>true</code> and the underlying version of Servlet is 3.0 or
+   * greater. Defaults to <code>true</code> if the underlying version of Servlet
+   * is 3.0 or greater. NOTE: The {@link Cookie#setHttpOnly(boolean)} was
+   * introduced in Servlet 3.0.
+   *
+   * @param cookieHttpOnly
+   *          <code>true</code> sets the HttpOnly attribute, <code>false</code>
+   *          does not set it (depending on Servlet version)
+   * @throws IllegalArgumentException
+   *           if <code>cookieHttpOnly</code> is <code>true</code> and the
+   *           underlying version of Servlet is less than 3.0
+   */
+  public void setCookieHttpOnly(boolean cookieHttpOnly) {
+    if (cookieHttpOnly && setHttpOnlyMethod == null) {
+      throw new IllegalArgumentException(
+          "Cookie will not be marked as HttpOnly because you are using a version of Servlet less than 3.0. NOTE: The Cookie#setHttpOnly(boolean) was introduced in Servlet 3.0.");
+    }
+    this.cookieHttpOnly = cookieHttpOnly;
+  }
+
+  private String getRequestContext(HttpServletRequest request) {
+    String contextPath = request.getContextPath();
+    return contextPath.length() > 0 ? contextPath : "/";
+  }
+
+  /**
+   * Factory method to conveniently create an instance that has
+   * {@link #setCookieHttpOnly(boolean)} set to false.
+   *
+   * @return an instance of CookieCsrfTokenRepository with
+   *         {@link #setCookieHttpOnly(boolean)} set to false
+   */
+  public static CookieCsrfTokenRepository withHttpOnlyFalse() {
+    CookieCsrfTokenRepository result = new CookieCsrfTokenRepository();
+    result.setCookieHttpOnly(false);
+    return result;
+  }
+
+  private String createNewToken() {
+    return UUID.randomUUID().toString();
+  }
+
+  /**
+   * Set the path that the Cookie will be created with. This will override the
+   * default functionality which uses the request context as the path.
+   *
+   * @param path
+   *          the path to use
+   */
+  public void setCookiePath(String path) {
+    this.cookiePath = path;
+  }
+
+  /**
+   * Get the path that the CSRF cookie will be set to.
+   *
+   * @return the path to be used.
+   */
+  public String getCookiePath() {
+    return this.cookiePath;
+  }
+}

--- a/web-ui/src/main/resources/catalog/components/admin/schematron/partials/criteria-viewer.html
+++ b/web-ui/src/main/resources/catalog/components/admin/schematron/partials/criteria-viewer.html
@@ -19,6 +19,7 @@
   <div class="row" data-ng-show="editing">
         <form class="" role="form"
           data-ng-keyup="handleKeyUp($event.keyCode)">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
                 <div class="form-group col-sm-4">
         <select
           class="form-control"

--- a/web-ui/src/main/resources/catalog/components/common/map/print/partials/print.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/partials/print.html
@@ -1,4 +1,5 @@
 <form class="">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
   <div class="form-group">
     <label class="control-label"
            data-translate="">print_layout</label>

--- a/web-ui/src/main/resources/catalog/components/common/map/print/partials/printmap.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/partials/printmap.html
@@ -1,4 +1,5 @@
 <form>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
   <div class="form-group">
     <label class="control-label"
            data-translate="">mapTitle</label>

--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -20,6 +20,7 @@
 
   <form name="opsForm" id="opsForm"
         data-ng-class="{'gn-sharing-batch': batch}">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <table class="table table-striped" data-ng-show="privileges.length > 0">
       <thead>
       <tr>

--- a/web-ui/src/main/resources/catalog/components/contactus/partials/contactusform.html
+++ b/web-ui/src/main/resources/catalog/components/contactus/partials/contactusform.html
@@ -1,4 +1,5 @@
 <form class="form-horizontal" role="form" id="gn-contact-us-form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
   <div class="form-group">
     <label class="col-sm-3 control-label" data-translate="">name</label>
     <div class="col-sm-9">

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/partials/geopublisher.html
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/partials/geopublisher.html
@@ -28,6 +28,7 @@
     <div class="panel-body">
       <!-- Header with projection selection, draw button and area list -->
       <form class="form" data-role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <div class="form-group" class="col-sm-12 inline">
           <div class="btn-toolbar">
             <button class="btn btn-lin btn-xs"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -6,6 +6,7 @@
             class="form-horizontal"
             role="form"
             method="POST">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <div class="onlinesrc-container">
 
           <div data-ng-show="config.types.length > 1 && config.display == 'radio'">
@@ -221,6 +222,7 @@
         <div class="panel-body">
           <form class="form-horizontal" role="form"
                 data-ng-search-form="">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div class="input-group">
               <span class="input-group-addon">
                 <i class="fa fa-search"/>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
@@ -1,6 +1,7 @@
 <div>
   <form class="form-horizontal" role="form"
         data-ng-search-form="">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="onlinesrc-container">
       <div class="form-group">
         <div class="col-sm-10">

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
@@ -1,6 +1,7 @@
 <div>
   <form class="form-horizontal" role="form"
         data-ng-search-form="">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="onlinesrc-container">
       <div class="form-group">
         <div class="col-sm-10">

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
@@ -1,6 +1,7 @@
 <div>
   <form class="form-horizontal" role="form"
         data-ng-search-form="">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="onlinesrc-container">
 
       <div class="form-group">

--- a/web-ui/src/main/resources/catalog/components/edit/suggestion/partials/runprocess.html
+++ b/web-ui/src/main/resources/catalog/components/edit/suggestion/partials/runprocess.html
@@ -1,6 +1,7 @@
 <div>
   <div class="alert alert-info">{{currentSuggestion.name}}</div>
   <form class="form-horizontal" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="form-group" data-ng-repeat="(key,param) in processParams">
       <label
         data-ng-if="param.type == 'string' || param.type == 'expression' || param.type == 'codelist'"

--- a/web-ui/src/main/resources/catalog/components/mdFeedback/partials/mdFeedback.html
+++ b/web-ui/src/main/resources/catalog/components/mdFeedback/partials/mdFeedback.html
@@ -21,6 +21,7 @@
               name="gnFeedbackForm"
               data-ng-submit="send(gnFeedbackForm, '#gn-contact-md-form')"
               id="gn-contact-md-form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <div class="modal-body">
             <div data-ng-if="!success">
               <div class="">

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/statusupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/statusupdater.html
@@ -1,4 +1,5 @@
 <form name="myForm">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
   <div class="row">
     <div class="col-md-4">
       <!-- TODO: Status are disabled based on profiles and

--- a/web-ui/src/main/resources/catalog/components/viewer/draw/partials/styleform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/draw/partials/styleform.html
@@ -1,4 +1,5 @@
 <form role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <!--Point-->
   <div data-ng-if="getType() == 'point'">

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/partials/ncwmstools.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/partials/ncwmstools.html
@@ -1,5 +1,6 @@
 <div class="panel-body panel-ncwms">
   <form class="form-horizontal" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
     <!--Scales-->
     <div class="form-group">

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
@@ -24,6 +24,7 @@
   <fieldset data-ng-if="isSaveMapInCatalogAllowed && user.isEditorOrMore()">
     <legend data-translate="">saveMapInCatalog</legend>
     <form>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
       <div class="form-group">
         <label for="mapTitle"
                data-translate="">mapTitle</label>

--- a/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
@@ -1,5 +1,6 @@
 <div>
   <form role="form" data-ng-search-form="">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="form-group">
       <div class="input-group">
         <span class="input-group-addon"><i

--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/processform.html
@@ -9,6 +9,7 @@
 
     <div ng-switch-when="loaded">
       <form>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <h5>{{::title}}</h5>
         <div ng-repeat="input in inputs" class="form-group"
              ng-class="{'gn-required': input.required}">

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -1,4 +1,5 @@
 <form name="wfsFilterForm">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <!--WFS not available alert-->
   <div data-ng-show="isWfsAvailable == false" class="alert alert-warning">

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/kmlimport.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/kmlimport.html
@@ -1,5 +1,6 @@
 <div>
   <form class="ng-pristine ng-valid" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="form-group" data-ng-class="{'has-error' : !validUrl}">
 
       <!--File URL-->

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/wmsimport.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/wmsimport.html
@@ -1,5 +1,6 @@
 <div class="layerTree">
   <form role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="form-group">
       <div data-ng-show="catServicesList.length > 0">
         <div class="dropdown">

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -91,11 +91,11 @@
     '$scope', '$http', '$q', '$rootScope', '$translate',
     'gnSearchManagerService', 'gnConfigService', 'gnConfig',
     'gnGlobalSettings', '$location', 'gnUtilityService', 'gnSessionService',
-    'gnLangs', 'gnAdminMenu',
+    'gnLangs', 'gnAdminMenu', '$cookies',
     function($scope, $http, $q, $rootScope, $translate,
             gnSearchManagerService, gnConfigService, gnConfig,
             gnGlobalSettings, $location, gnUtilityService, gnSessionService,
-            gnLangs, gnAdminMenu) {
+            gnLangs, gnAdminMenu, $cookies) {
       $scope.version = '0.0.1';
       //Display or not the admin menu
       if ($location.absUrl().indexOf('/admin.console') != -1) {
@@ -140,6 +140,18 @@
       $scope.layout = {
         hideTopToolBar: false
       };
+      
+      /**
+       * CSRF support
+       */
+      
+      //Comment the following lines if you want to remove csrf support
+      $http.defaults.xsrfHeaderName = 'X-XSRF-TOKEN';
+      $http.defaults.xsrfCookieName = 'XSRF-TOKEN';
+      $scope.$watch(function() { return $cookies.get('XSRF-TOKEN'); }, function(value){
+        $rootScope.csrf=value;
+      }) ;
+      //Comment the upper lines if you want to remove csrf support
 
       /**
        * Number of selected metadata records.

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -57,6 +57,11 @@
           $scope.signinFailure = gnUtilityService.getUrlParameter('failure');
           $scope.gnConfig = gnConfig;
 
+          //If no csrf, ask for one:
+          if(!$rootScope.csrf) {
+            $http.post('info?type=me');
+          }
+          
           function initForm() {
            if ($window.location.pathname.indexOf('new.password') !== -1) {
              // Retrieve username from URL parameter

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/categories.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/categories.html
@@ -33,6 +33,7 @@
 
   <div class="col-lg-7" data-ng-hide="categorySelected.id==null">
     <form name="gnCategoryFrom" class="form-horizontal">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
       <div class="panel panel-default">
         <div class="panel-heading">
           <span data-ng-hide="categorySelected.id == ''" data-translate="">updateCategory</span>

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -73,6 +73,7 @@
       </ul>-->
         <form id="gn-edit-thesaurus" name="gn-edit-thesaurus">
           <fieldset>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div>
               <label class="control-label" data-translate="">thesaurusTitle</label>
               <input type="text" name="title" class="form-control" data-ng-disabled="!isNew()"
@@ -129,6 +130,7 @@
 
       <div class="panel-body">
         <form class="form-horizontal" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <div class="form-group">
             <label for="keywordFilter" class="col-lg-4 control-label" data-translate=""
             >keywordFilter</label>
@@ -188,7 +190,7 @@
           <!-- File import form -->
           <form id="gn-upload-thesaurus" name="gn-upload-thesaurus"
                 data-ng-show="importAs == 'file' || importAs == 'url'"
-                action="thesaurus.upload?_content_type=json"
+                action="{{'thesaurus.upload?_content_type=json&_csrf=' + csrf}}"
                 method="POST" enctype="multipart/form-data"
                 data-file-upload="thesaurusUploadOptions">
             <span data-ng-show="importAs == 'file'"
@@ -235,6 +237,7 @@
           <!-- User entry form -->
           <form id="gn-create-thesaurus" name="gn-create-thesaurus"
                 data-ng-show="importAs == 'new'">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div>
               <label class="control-label" data-translate="">thesaurusTitle</label>
               <input type="text" name="title" class="form-control" data-ng-disabled="!isNew()"
@@ -300,6 +303,7 @@
         </div>
         <div class="modal-body">
           <form id="gn-edit-keyword" name="gn-edit-keyword">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div>
               <label class="control-label" data-translate="">keywordLabel</label>
               <input type="text" name="name" class="form-control" data-ng-disabled="isExternal()"

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/statistics-content.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/statistics-content.html
@@ -26,6 +26,7 @@
           <h2 data-translate="">mostPopular</h2>
           <form class="form-horizontal" role="form"
                 data-ng-search-form="" runSearch="true">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <table class="table table-striped">
               <tr data-ng-repeat="md in searchResults.records">
                 <td>{{md.title || md.defaultTitle}}</td>
@@ -44,6 +45,7 @@
           <h2 data-translate="">bestRated</h2>
           <form class="form-horizontal" role="form"
                 data-ng-search-form="" runSearch="true">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <table class="table table-striped">
               <tr data-ng-repeat="md in searchResults.records">
                 <td>{{md.title || md.defaultTitle}}</td>

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/statistics-search.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/statistics-search.html
@@ -38,6 +38,7 @@
       <div class="panel-body">
         <!-- TODO : Draw a time line ? -->
         <form class="form-horizontal" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <div class="form-group">
             <label class="col-lg-1" data-translate="">from</label>
             <div class="col-lg-3">

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/status.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/status.html
@@ -75,6 +75,7 @@
             data-ng-search-form=""
             data-runSearch="true"
             data-ng-show="searchResults.records.length > 0">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <div class="panel panel-default panel-danger">
           <div class="panel-heading" data-translate="">metadataWithIndexingErrors</div>
           <div class="panel-body">
@@ -188,6 +189,7 @@
         </h4>
         <div class="btn-toolbar">
           <form class="form-inline pull-right">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div class="checkbox" data-ng-show="threadStatus.threadContentionMonitoringSupported">
               <label>
                 <input type="checkbox"

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/arcsde.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/arcsde.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
     <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
 
   <div class="row">

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
 
   <div class="row">

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geoPREST.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geoPREST.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
     <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
     <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork20.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork20.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
     <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/oaipmh.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/oaipmh.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
     <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/ogcwxs.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/ogcwxs.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
 
   <div class="row">

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/thredds.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/thredds.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
 
   <div class="row">

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/webdav.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/webdav.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
 
   <div class="row">

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/wfsfeatures.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/wfsfeatures.html
@@ -1,4 +1,5 @@
 <form data-ng-keypress="updatingHarvester()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
 
   <div class="row">

--- a/web-ui/src/main/resources/catalog/templates/admin/metadata/formatter.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/metadata/formatter.html
@@ -23,7 +23,7 @@
         <span data-translate="">addAFormatter</span>
       </div>
       <div class="panel-body">
-        <form id="fileupload" action="md.formatter.register" method="POST"
+        <form id="fileupload" action="{{'md.formatter.register?_csrf=' + csrf}}" method="POST"
               enctype="multipart/form-data" data-file-upload="formatterUploadOptions">
           <span class="btn btn-success btn-block fileinput-button" ng-class="{disabled: disabled}">
             <i class="fa fa-plus fa-white"/>
@@ -59,6 +59,7 @@
       </div>
       <div class="panel-body">
         <form class="form-horizontal" id="gn-formatter-file-edit">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <div class="form-group">
             <label class="control-label col-sm-3" data-translate="">chooseAFile</label>
             <div class="col-sm-9">
@@ -92,6 +93,7 @@
       </div>
       <div class="panel-body">
         <form class="form-horizontal">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <div class="form-group">
             <label class="control-label col-sm-3" data-translate="">metadataInternalId</label>
             <div class="col-sm-9">

--- a/web-ui/src/main/resources/catalog/templates/admin/metadata/metadata-identifier-templates.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/metadata/metadata-identifier-templates.html
@@ -48,6 +48,7 @@
       <div class="panel-body">
         <form id="gn-metadata-identifier-template-edit" name="gnMetadataIdentifierTemplateEdit"
               class="form-horizontal">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <input type="hidden" name="id" data-ng-model="mdIdentifierTemplateSelected.id"
                  value="{{mdIdentifierTemplateSelected.id}}"/>
 

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-filedownload-metadata.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-filedownload-metadata.html
@@ -20,6 +20,7 @@
         <form id="gn-metadata-filedownloads-report" name="gnMetadataFileDownloadsReport"
               class="form-horizontal">
           <fieldset>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div
               class="form-group">
 

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-fileupload-metadata.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-fileupload-metadata.html
@@ -20,6 +20,7 @@
         <form id="gn-metadata-fileuploads-report" name="gnMetadataFileUploadsReport"
               class="form-horizontal">
           <fieldset>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div
               class="form-group">
 

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-internal-metadata.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-internal-metadata.html
@@ -20,6 +20,7 @@
         <form id="gn-metadata-internal-report" name="gnMetadataInternalReport"
               class="form-horizontal">
           <fieldset>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div
               class="form-group">
 

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-updated-metadata.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-updated-metadata.html
@@ -20,6 +20,7 @@
         <form id="gn-metadata-updated-report" name="gnMetadataUpdatedReport"
               class="form-horizontal">
           <fieldset>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div
               class="form-group">
 

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-users.html
@@ -20,6 +20,7 @@
 
         <form id="gn-users-report" name="gnUsersReport" class="form-horizontal">
           <fieldset>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
             <div
               class="form-group">

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/csw-virtual.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/csw-virtual.html
@@ -52,6 +52,7 @@
       <div class="panel-body">
         <form id="gn-virtualcsw-edit" name="gnVirtualCSWEdit" class="form-horizontal"
               data-ng-keypress="updatingVirtualCSW()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <fieldset>
             <legend data-translate="">serviceDescription</legend>
             <input type="hidden" name="id" data-ng-model="virtualCSWSelected.id"

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/csw.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/csw.html
@@ -67,6 +67,7 @@
     </div>
     <div class="panel-body">
       <form id="gn-csw-capabilities-properties">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <table class="table table-striped">
           <tr>
             <th>
@@ -117,6 +118,7 @@
     </div>
     <div class="panel-body">
       <form id="gn-csw-elementsetname" class="form-horizontal">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <fieldset>
           <p class="help-block" data-translate="">customizeElementSetHelp</p>
           <div class="form-group" data-ng-repeat="e in cswElementSetName track by $index">

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/logo.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/logo.html
@@ -16,7 +16,7 @@
           <span data-translate="">addNewLogo</span>
         </div>
         <div class="panel-body">
-          <form id="fileupload" action="../api/logos" method="POST"
+          <form id="fileupload" action="{{'../api/logos?_csrf=' + csrf}}" method="POST"
                 enctype="multipart/form-data" data-file-upload="logoUploadOptions">
             <span class="btn btn-success btn-block fileinput-button"
                   ng-class="{disabled: disabled}">

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
@@ -54,6 +54,7 @@
         <form id="gn-mapserver-edit" name="gnMapServerEdit"
               class="form-horizontal"
               data-ng-keypress="updatingMapServer()">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <fieldset>
             <legend data-translate="">mapserverDescription</legend>
             <input type="hidden" name="id"
@@ -208,6 +209,7 @@
         <div class="modal-body">
           <form id="gn-password-reset" class="form-horizontal" name="gnPasswordReset">
             <div class="form-group">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
               <label class="control-label col-sm-3" data-translate="">username</label>
 
               <div class="col-sm-9">

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -5,6 +5,7 @@
     <span data-translate="">settings</span>
     <div class="btn-toolbar">
       <form class="form-inline pull-right">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <select ng-change="updateProfile()" class="form-control"
                 data-ng-model="systemInfo.stagingProfile">
           <option data-ng-repeat="p in stagingProfiles" value="{{p}}"

--- a/web-ui/src/main/resources/catalog/templates/admin/standards/standards.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/standards/standards.html
@@ -37,6 +37,7 @@
       <div class="panel-heading" data-translate="">addOrUpdateStandards</div>
       <div class="panel-body">
         <form id="gn-standard-add" action="admin.standards.add@json">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <div class="form-group">
             <label class="control-label" data-translate="">standardName</label>
             <input type="text" name="schema" class="form-control"/>

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/batch.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/batch.html
@@ -9,6 +9,7 @@
 
         <form data-ng-search-form=""
               data-runSearch="false">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
           <div class="row">
             <div class="col-md-6">
@@ -148,6 +149,7 @@
       <div class="panel-heading" data-translate="">configureProcess</div>
       <div class="panel-body">
         <form class="form-horizontal" id="gn-batch-process">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <select class="form-control"
                   data-ng-disabled="selection.length == 0"
                   data-ng-model="data.selectedProcess"

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
@@ -68,6 +68,7 @@
         <form id="gn-group-edit" name="gnGroupEdit"
               data-ng-keypress="updatingGroup()" method="POST"
               data-file-upload="mdImportUploadOptions" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <fieldset>
             <input type="hidden" name="id" data-ng-model="groupSelected.id"
                    value="{{groupSelected.id}}"/>

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -74,6 +74,7 @@
       <div class="panel-body">
         <form id="gn-user-edit" name="gnUserEdit" data-ng-keypress="updatingUser()"
               class="form-horizontal" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <fieldset>
             <input type="hidden" name="id" data-ng-model="userSelected.id"
                    value="{{userSelected.id}}"/>
@@ -341,6 +342,7 @@
         </div>
         <div class="modal-body">
           <form id="gn-password-reset" class="form-horizontal" name="gnPasswordReset">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div class="form-group"
                  data-ng-class="gnPasswordReset.password.$error.required || gnPasswordReset.password.$error.minlength ? 'has-error' : ''">
               <label class="control-label col-sm-3" data-translate="">password</label>

--- a/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
@@ -33,6 +33,7 @@
           <div class="col-sm-12">
             <form class="form-horizontal"
                   role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
               <div class="row gn-top-search">
                 <div class="col-md-12">
                   <div class="input-group gn-form-any">
@@ -151,6 +152,7 @@
         <div class="row">
           <div class="col-md-12">
             <form class="form-horizontal" id="gn-batch-changes">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
               <fieldset data-ng-repeat="(key, standard) in fieldConfig"
                         data-ng-if="standard.section && hasRecordsInStandard(key)">
                 <legend data-gn-slide-toggle="">{{key | translate}}</legend>
@@ -263,6 +265,7 @@
                 <form class="form-horizontal"
                       name="xpathConfigForm"
                       novalidate="">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
                   <div class="well">
                     <p class="help-block">

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -23,6 +23,7 @@
         </div>
         <div class="panel-body">
           <form data-ng-search-form="">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div class="input-group">
               <input class="form-control" type="text"
                      data-ng-change="triggerSearch()"
@@ -94,6 +95,7 @@
         </div>
         <div class="panel-body">
           <form>
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div class="form-group">
               <label for="data" data-translate="">xmlSnippet</label>
               <textarea class="form-control"

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -7,6 +7,7 @@
 
       <form class="form-horizontal"
             role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <div class="row gn-top-search">
           <div class="col-md-12">
             <div class="input-group gn-form-any">

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -40,6 +40,7 @@
           <form id="gn-import" class="form-horizontal" role="form"
                 method="POST" enctype="{{enctype}}" action="{{action}}"
                 data-file-upload="mdImportUploadOptions">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
             <!-- Folder Path and subfolder options -->
             <div class="form-group" data-ng-if="importMode === 'importFromDir'">

--- a/web-ui/src/main/resources/catalog/templates/new-account.html
+++ b/web-ui/src/main/resources/catalog/templates/new-account.html
@@ -4,6 +4,7 @@
       <div class="panel-heading" data-translate="">needAnAccount</div>
       <div class="panel-body">
         <form class="form-horizontal" id="userinfo">
+         <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <div class="form-group">
             <label class="control-label col-lg-4" data-translate="">email</label>
             <div class="col-lg-8">

--- a/web-ui/src/main/resources/catalog/templates/new-password.html
+++ b/web-ui/src/main/resources/catalog/templates/new-password.html
@@ -4,6 +4,7 @@
       <div class="panel-heading" data-translate="">updatePassword</div>
       <div class="panel-body">
         <form class="form-horizontal" id="userinfo" name="gnUserEdit">
+         <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <input type="hidden"
                  data-ng-model="changeKey"
                  name="changeKey" value="{{changeKey}}"/>

--- a/web-ui/src/main/resources/catalog/templates/signin.html
+++ b/web-ui/src/main/resources/catalog/templates/signin.html
@@ -2,6 +2,7 @@
   <div class="col-lg-6">
     <form class="form-horizontal" name="gnSigninForm" action="{{formAction}}"
           method="post" role="form" data-ng-if="::user">
+      <input type="hidden" name="_csrf" value="{{csrf}}"/>
       <div class="form-group">
         <label class="col-sm-3 control-label"
                for="inputUsername" data-translate="">username</label>
@@ -72,7 +73,8 @@
         </div>
         <div data-ng-show="sendPassword === true">
           <div>
-            <form class="form-horizontal" id="userinfo" name="gnUserinfo">
+            <form class="form-horizontal" id="userinfo" name="gnUserinfo">user">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
               <div class="form-group">
                 <label class="control-label col-lg-3" data-translate="">username</label>
                 <div class="col-lg-8">

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -129,6 +129,7 @@
                 data-ng-search-form=""
                 data-runSearch="true"
                 data-ng-show="searchResults.records.length > 0">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
             <div data-gn-info-list=""></div>
           </form>
@@ -141,6 +142,7 @@
                 data-ng-search-form=""
                 data-runSearch="true"
                 data-ng-show="searchResults.records.length > 0">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div data-gn-info-list=""></div>
           </form>
         </tab>

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -1,5 +1,6 @@
 <form class="form-horizontal"
       role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
   <!--ANY full text search input-->
   <div class="row gn-top-search">
     <div class="col-md-12">

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -89,6 +89,9 @@
     <constructor-arg>
       <list>
         <ref bean="securityContextPersistenceFilter"/>
+        <!-- To disable csrf security (not recommended) comment the following line -->
+        <ref bean="csrfFilter" />
+        <!-- To disable csrf security (not recommended) comment the upper line -->
         <ref bean="logoutFilter"/>
         <!-- A filter that check if an external service already authenticated user
                      (default implementation does nothing but can be overridden) -->
@@ -337,5 +340,17 @@
         id="updateTimestampListener">
   </bean>
 
+
+  <bean id="csrfFilter" class="org.springframework.security.web.csrf.CsrfFilter">
+    <constructor-arg>
+      <ref bean="csrfTokenRepository"/>
+    </constructor-arg>
+  </bean>
+  
+  <bean class="org.fao.geonet.security.web.csrf.CookieCsrfTokenRepository"
+        id="csrfTokenRepository">
+    <property name="cookieHttpOnly" value="false"/>
+  </bean>
+      
 
 </beans>

--- a/web/src/main/webapp/doc/api/index.html
+++ b/web/src/main/webapp/doc/api/index.html
@@ -64,9 +64,29 @@
       if (window.SwaggerTranslator) {
         window.SwaggerTranslator.translate();
       }
+      var csrf = null;
+      var cookiearray = document.cookie.split(';');
+      for(var i =0 ; i < cookiearray.length ; ++i){ 
+          if(cookiearray[i].trim().match('^XSRF-TOKEN=')){ 
+            csrf = cookiearray[i].replace(`XSRF-TOKEN=`,'').trim();
+          }
+      }
+
+      var interceptor = {
+          requestInterceptor: {
+            apply: function (requestObj) {
+              var headers = requestObj.headers || {};
+              headers["X-XSRF-TOKEN"] = csrf;
+              return requestObj;
+            }
+          }
+        };
+
+      
       window.swaggerUi = new SwaggerUi({
         url: url,
         dom_id: "swagger-ui-container",
+        requestInterceptor: interceptor.requestInterceptor,
         supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function (swaggerApi, swaggerUi) {
           if (typeof initOAuth == "function") {
@@ -79,7 +99,7 @@
                         additionalQueryStringParams: {}
                       });
           }
-
+          
           if (window.SwaggerTranslator) {
             window.SwaggerTranslator.translate();
           }


### PR DESCRIPTION
This fixes a security bug on https://en.wikipedia.org/wiki/Cross-site_request_forgery

So now, if you are logged in on GeoNetwork and an external third party tries to ajax call or redirect you to any endpoint in GeoNetwork, GeoNetwork will reject the call because it won't contain this extra security token. This token is generated on the server by session and stored on a cookie called XSRF-TOKEN on the client.

By default, all Angular calls will add the csrf as header X-XSRF-TOKEN and/or parameter _csrf containing the security token. All current forms that don't use Angular have also been modified so we don't have problems. The multi-part forms for uploading files added this parameter inside the "action" element of the form.

![captura de pantalla de 2017-04-27 13-19-15](https://cloud.githubusercontent.com/assets/726590/25481167/411df9d8-2b4c-11e7-9d68-e3c80266d8c5.png)

Changes on future developments: 
 * All requests (POST, PUT, DELETE) should contain this header or parameter. If it is Angular, Angular will take care of it. If it is a direct redirect, call or form submission, make sure you add it.
 * All third party software will have to store the cookie called XSRF-TOKEN after login, so it can add the header or parameter to all calls.

If not, GeoNetwork will return an error asking for this token:
![captura de pantalla de 2017-04-27 12-49-57](https://cloud.githubusercontent.com/assets/726590/25480867/ff87e91c-2b4a-11e7-88b2-57518542fbb7.png)

As a good practice, even GET requests should contain this csrf token, but right now GeoNetwork will skip the check on those calls (default Spring configuration, based on the idea that all GET calls don't modify the platform).

Extra: As Spring -Security 3.2 (security library we are using) does not contain the Cookie filter for Csrf, I just ported it from Spring 4. It is a simple code that works. When (if?) we upgrade, we can remove this file and use the native Spring cookie filter.