### PR TITLE
Add a new service to get all related from a set of metadatas

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/related/Related.java
+++ b/services/src/main/java/org/fao/geonet/api/related/Related.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.related;
+
+import io.swagger.annotations.*;
+import jeeves.server.context.ServiceContext;
+import jeeves.services.ReadWriteController;
+import org.fao.geonet.api.API;
+import org.fao.geonet.api.ApiParams;
+import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.exception.NotAllowedException;
+import org.fao.geonet.api.records.MetadataUtils;
+import org.fao.geonet.api.records.model.related.RelatedItemType;
+import org.fao.geonet.api.records.model.related.RelatedResponse;
+import org.fao.geonet.api.tools.i18n.LanguageUtils;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+@RequestMapping(value = {
+    "/api/related",
+    "/api/" + API.VERSION_0_1 +
+        "/related"
+})
+@Api(value = "related",
+    tags = "related",
+    description = "Related records")
+@Controller("related")
+@ReadWriteController
+public class Related implements ApplicationContextAware {
+
+    @Autowired
+    LanguageUtils languageUtils;
+
+    private ApplicationContext context;
+
+    public synchronized void setApplicationContext(ApplicationContext context) {
+        this.context = context;
+    }
+
+    @ApiOperation(
+        value = "Get record related resources for all requested metadatas",
+        nickname = "getAssociated",
+        notes = "Retrieve related services, datasets, onlines, thumbnails, sources, ... " +
+            "to all requested records.<br/>" +
+            "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/associating-resources/index.html'>More info</a>")
+    @RequestMapping(value = "",
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.APPLICATION_XML_VALUE,
+            MediaType.APPLICATION_JSON_VALUE
+        })
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Return the associated resources."),
+        @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
+    })
+    @ResponseBody
+    public Map<String, RelatedResponse> getRelated(
+        @ApiParam(value = "Type of related resource. If none, all resources are returned.",
+            required = false
+        )
+        @RequestParam(defaultValue = "", name="type")
+            RelatedItemType[] types,
+        @ApiParam(value = "Uuids of the metadatas you request the relations from.",
+            required = false
+        )
+        @RequestParam(defaultValue = "",name="uuid")
+            String[] uuids,
+        HttpServletRequest request) throws Exception {
+
+        Locale language = languageUtils.parseAcceptLanguage(request.getLocales());
+        final ServiceContext context = ApiUtils.createServiceContext(request);
+        GeonetworkDataDirectory dataDirectory = context.getBean(GeonetworkDataDirectory.class);
+        Path relatedXsl = dataDirectory.getWebappDir().resolve("xslt/services/metadata/relation.xsl");
+
+        Metadata md;
+        Map<String, RelatedResponse> res = new HashMap<String, RelatedResponse>();
+
+        for(String uuid : uuids) {
+            try{
+                md = ApiUtils.canViewRecord(uuid, request);
+                Element raw = new Element("root").addContent(Arrays.asList(
+                    new Element("gui").addContent(Arrays.asList(
+                        new Element("language").setText(language.getISO3Language()),
+                        new Element("url").setText(context.getBaseUrl())
+                    )),
+                    MetadataUtils.getRelated(context, md.getId(), md.getUuid(), types, 1, 1000, true)
+                ));
+                final Element transform = Xml.transform(raw, relatedXsl);
+                RelatedResponse response = (RelatedResponse) Xml.unmarshall(transform, RelatedResponse.class);
+                res.put(uuid, response);
+            } catch (SecurityException e) {
+                Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+                throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
+            }
+
+        }
+        return res;
+    }
+}

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -35,7 +35,7 @@
    * config.js
    */
   module.service('gnRelatedService', ['$http', '$q', function($http, $q) {
-    function get(uuid, types) {
+    this.get = function(uuid, types) {
       var canceller = $q.defer();
       var request = $http({
         method: 'get',
@@ -68,9 +68,16 @@
           }
       );
       return (promise);
-    }
-    return {
-      get: get
+    };
+
+    this.getMdsRelated = function(uuids, types) {
+      var url = '../api/related';
+      return $http.get(url, {
+        params: {
+          type: types,
+          uuid: uuids
+        }
+      });
     };
   }]);
   module

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/gridRelated.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/gridRelated.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+
+  goog.provide('gn_gridrelated_directive');
+
+  var module = angular.module('gn_gridrelated_directive', []);
+
+  module.value('gnGridRelatedList', {
+    list: {},
+    promise: undefined,
+    types: []
+  });
+
+  module.directive('gnGridRelatedQuery', [
+    'gnGlobalSettings', 'gnRelatedService', 'gnGridRelatedList',
+    function(gnGlobalSettings, gnRelatedService, gnGridRelatedList) {
+
+      return {
+        restrict: 'A',
+        scope: {
+          records: '<gnGridRelatedQuery'
+        },
+        link: function(scope, element, attrs) {
+
+          var types = gnGlobalSettings.gnCfg.mods.search.grid.related;
+          gnGridRelatedList.types = types;
+
+          scope.$watch('records', function(mds) {
+            var uuids = mds.map(function(md) {
+              return md.getUuid();
+            });
+            if(uuids.length) {
+              gnGridRelatedList.promise =
+                gnRelatedService.getMdsRelated(uuids, types).then(
+                  function(response) {
+                    gnGridRelatedList.list = response.data;
+                  });
+            }
+          });
+        }
+      };
+    }]);
+
+  module.directive('gnGridRelated', [
+    'gnGlobalSettings', 'gnRelatedService', 'gnGridRelatedList',
+    function(gnGlobalSettings, gnRelatedService, gnGridRelatedList) {
+
+      return {
+        restrict: 'A',
+        scope: {
+          uuid: '<gnGridRelatedUuid'
+        },
+        templateUrl: function(elem, attrs) {
+          return attrs.template ||
+            '../../catalog/components/metadataactions/partials/related.html';
+        },
+        link: function(scope, element, attrs) {
+          gnGridRelatedList.promise.then(function() {
+            var related = gnGridRelatedList.list[scope.uuid];
+            if(related) {
+              scope.types = gnGridRelatedList.types;
+              scope.relations = related;
+            }
+          });
+        }
+      };
+    }]);
+
+})();

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -87,20 +87,14 @@
         </div>
 
         <div class="row gn-md-details">
-          <p data-ng-repeat="c in md.getAllContacts().resource">
-            <img data-ng-if="c.logo"
+          <p ng-if="::!md.getAllContacts().resource">&nbsp;</p>
+          <p data-ng-repeat="c in ::md.getAllContacts().resource">
+            <img data-ng-if="::c.logo"
                  data-ng-src="{{::c.logo}}"
                  class="gn-source-logo"
                  title="{{::c.name}} ({{::c.role}})"/>
             {{::c.name}}
           </p>
-          <!--<p data-ng-if="md.Constraints">
-            <h5 data-translate="">license</h5>
-            <span data-ng-repeat="c in ::md.Constraints">{{c}}, </span>
-          </p>-->
-          <!--<p data-ng-if="md.keyword">
-            <span class="badge" data-ng-repeat="k in ::md.keyword">{{k}}</span>
-          </p>-->
         </div>
       </div>
 
@@ -109,8 +103,11 @@
 
     <!--start bottom row-->
     <div>
+      <div gn-grid-related gn-grid-related-uuid="::md.getUuid()"
+           template="../../catalog/views/default/templates/gridRelated.html"></div>
       <gn-links-btn></gn-links-btn>
     </div>
+
     </div>
     <!--end bottom row-->
     <div style="clear: both;"></div>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -130,6 +130,9 @@
                   'formatters/xsl-view?root=div&view=advanced'
             }]
           },
+          'grid': {
+            'related': ['parent', 'children', 'services', 'datasets']
+          },
           'linkTypes': {
             'links': ['LINK', 'kml'],
             'downloads': ['DOWNLOAD'],
@@ -203,7 +206,7 @@
       current: null,
       init: function(config, gnUrl, gnViewerSettings, gnSearchSettings) {
         // Remap some old settings with new one
-        angular.extend(this.gnCfg, config || {});
+        angular.extend(this.gnCfg, config, {});
         this.gnUrl = gnUrl || '../';
         this.proxyUrl = this.gnUrl + '../proxy?url=';
         gnViewerSettings.mapConfig = this.gnCfg.mods.map;
@@ -215,7 +218,7 @@
         gnViewerSettings.layerName = this.gnCfg.mods.map.layer.name;
       },
       getDefaultConfig: function() {
-        return angulaWr.copy(defaultConfig);
+        return angular.copy(defaultConfig);
       }
     };
   }());

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -606,3 +606,31 @@ button.active [role=tooltip] {
   color: #a94442;
   font-weight: normal;
 }
+
+.gn-related-list {
+  padding: 0;
+  list-style: none;
+  > li {
+    padding-left: 25px;
+    &:hover {
+      text-decoration: none;
+      color: #262626;
+      background-color: #f5f5f5;
+    }
+    &.gn-related-type {
+      padding-left: 15px;
+      padding-bottom: 1px;
+      min-width: 250px;
+      &:hover {
+        background-color: transparent;
+        cursor: default !important;
+      }
+      &:first-letter {
+        text-transform: uppercase;
+      }
+    }
+    &:not(.gn-related-type) {
+      font-size: 12px;
+    }
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -32,13 +32,14 @@
   goog.require('gn_mdactions_directive');
   goog.require('gn_related_directive');
   goog.require('gn_search');
+  goog.require('gn_gridrelated_directive');
   goog.require('gn_search_default_config');
   goog.require('gn_search_default_directive');
 
   var module = angular.module('gn_search_default',
       ['gn_search', 'gn_search_default_config',
        'gn_search_default_directive', 'gn_related_directive',
-       'cookie_warning', 'gn_mdactions_directive']);
+       'cookie_warning', 'gn_mdactions_directive', 'gn_gridrelated_directive']);
 
 
   module.controller('gnsSearchPopularController', [

--- a/web-ui/src/main/resources/catalog/views/default/templates/gridRelated.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/gridRelated.html
@@ -1,0 +1,20 @@
+<div class="btn-group" ng-if="::relations"  placement="bottom" container="{{container}}">
+  <button type="button"
+          class="btn dropdown-toggle btn-default"
+          data-toggle="dropdown"
+          title="Relations">
+    <span class="fa fa-code-fork"></span>
+    <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu small-dropdown" role="menu">
+    <ul ng-repeat="type in ::types" ng-if="::relations[type]" class="gn-related-list">
+      <li class="gn-related-type">{{type | translate}}</li>
+      <li ng-repeat="r in ::relations[type]" >
+        <a href="#/metadata/{{r.id}}"
+           title="{{r.title | gnLocalized: lang}}">
+          {{r.title | gnLocalized: lang}}
+        </a>
+      </li>
+    </ul>
+  </ul>
+</div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -3,6 +3,7 @@
      data-runSearch="true">
   <div data-ng-include="'../../catalog/views/default/templates/searchForm.html'"></div>
 
+  <div gn-grid-related-query="searchResults.records"></div>
   <div class="row">
     <div class="col-md-3 gn-search-facet">
 


### PR DESCRIPTION
- A new service is created to get all related from a set of metadatas instead of getting them one metadata by one: `api/related`

Reduce the number of requests and processes to get all relations in metadatas search result grid.

Exemple: 
http://localhost:8080/geonetwork/srv/api/related?type=parent&type=children&type=services&type=datasets&uuid=e21e09f13a47ae498cf9c891cf4ac6b58f8cf873&uuid=f232e24f9c219d67c6fda40976062cb14b659e7d&uuid=0cab0c4c632c8e220f1a66c9150c6a55c4990fcc

- Add a directive`gnGridRelated`  in the grid result to display relations of all metadatas. The metadatas relations are fetched from an angular value that contains all relations of the metadata list, returned by the new service (done in `gnGridRelatedQuery`).

![image](https://cloud.githubusercontent.com/assets/1491924/26098113/fb7f08f6-3a26-11e7-98c0-2fa998e6d9e5.png)

New settings in angular api for the ui :
```js
mods: {
  search: {
    grid: {
      related: ['parent', 'children', 'services', 'datasets']
    }
  }
}
```
If nothing is defined, no request is send.
Choose the kind of relations you wanted to appear in grid result.
