### PR TITLE
App & db config properties file location set by maven build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -514,6 +514,33 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.5</version>
+        <executions>
+          <execution>
+            <id>copy-filter-resource</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <escapeString>\</escapeString>
+              <includeEmptyDirs>false</includeEmptyDirs>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/src/main/resources</directory>
+                  <filtering>true</filtering>
+                  <targetPath>${project.build.directory}/classes</targetPath>
+                </resource>
+              </resources>
+              <overwrite>true</overwrite>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -31,7 +31,7 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
     ">
 
-  <context:property-placeholder location="classpath*:WEB-INF/config.properties"
+  <context:property-placeholder location="${app.properties}"
                                 file-encoding="UTF-8"
                                 ignore-unresolvable="true" />
 

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -23,4 +23,37 @@
       <version>${activemq.version}</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.5</version>
+        <executions>
+          <execution>
+            <id>copy-filter-resource</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <escapeString>\</escapeString>
+              <includeEmptyDirs>false</includeEmptyDirs>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/src/main/resources</directory>
+                  <filtering>true</filtering>
+                  <targetPath>${project.build.directory}/classes</targetPath>
+                </resource>
+              </resources>
+              <overwrite>true</overwrite>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/messaging/src/main/resources/config-spring-geonetwork-parent.xml
+++ b/messaging/src/main/resources/config-spring-geonetwork-parent.xml
@@ -14,13 +14,13 @@
 
   <context:annotation-config/>
 
-  <context:property-placeholder location="WEB-INF/config.properties"
+  <context:property-placeholder location="${app.properties}"
                                 file-encoding="UTF-8"
                                 ignore-unresolvable="true" />
 
   <amq:broker useJmx="false" persistent="false" useShutdownHook="false">
     <amq:transportConnectors>
-      <amq:transportConnector uri="${jms.url}" />
+      <amq:transportConnector uri="\${jms.url}" />
     </amq:transportConnectors>
   </amq:broker>
   <!--  Embedded ActiveMQ Broker
@@ -57,13 +57,13 @@
         class="org.apache.activemq.camel.component.ActiveMQComponent" destroy-method="shutdown">
     <property name="connectionFactory">
       <bean class="org.apache.activemq.ActiveMQConnectionFactory">
-        <property name="brokerURL" value="${jms.url}"/>
+        <property name="brokerURL" value="\${jms.url}"/>
       </bean>
     </property>
   </bean>
 
   <bean id="jmsMessager"
         class="org.geonetwork.messaging.JMSMessager">
-    <property name="jmsUrl" value="${jms.url}"/>
+    <property name="jmsUrl" value="\${jms.url}"/>
   </bean>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -1217,6 +1217,12 @@
   </distributionManagement>
 
   <properties>
+    <db.properties>WEB-INF/config-db/jdbc.properties</db.properties>
+    <!--<db.properties>file:/${geonetwork.dir}/jdbc.properties</db.properties>-->
+
+    <app.properties>WEB-INF/config.properties</app.properties>
+    <!--<app.properties>file:/${geonetwork.dir}/config.properties</app.properties>-->
+
     <!-- Configure database config file to use. Could be
      h2, postgres, sqlserver, mysql, oracle, db2, postgres-postgis, jndi-postgres-postgis
      -->

--- a/schemas-test/src/main/webapp/WEB-INF/config.properties
+++ b/schemas-test/src/main/webapp/WEB-INF/config.properties
@@ -1,0 +1,8 @@
+# Define using CRON expression when watchlist notifier is triggered (Default 4AM)
+usersavedselection.watchlist.frequency=0 0 4 * * ?
+
+# Define the link to the list of updated records sent by email by the watchlist notifier
+usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
+
+# Define the link to each record sent by email by the watchlist notifier
+usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}

--- a/services/src/main/webapp/WEB-INF/config.properties
+++ b/services/src/main/webapp/WEB-INF/config.properties
@@ -1,0 +1,8 @@
+# Define using CRON expression when watchlist notifier is triggered (Default 4AM)
+usersavedselection.watchlist.frequency=0 0 4 * * ?
+
+# Define the link to the list of updated records sent by email by the watchlist notifier
+usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
+
+# Define the link to each record sent by email by the watchlist notifier
+usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -550,6 +550,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
+              <escapeString>\</escapeString>
               <includeEmptyDirs>false</includeEmptyDirs>
               <outputDirectory>${build.webapp.resources}</outputDirectory>
               <resources>

--- a/web/src/main/webResources/WEB-INF/config-db/defaultJdbcDataSource.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/defaultJdbcDataSource.xml
@@ -30,7 +30,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 	">
-  <context:property-placeholder location="WEB-INF/config-db/jdbc.properties" file-encoding="UTF-8"
+  <context:property-placeholder location="${db.properties}" file-encoding="UTF-8"
                                 ignore-unresolvable="true" order="1"/>
 
   <bean id="jdbcDataSource" class="org.apache.commons.dbcp.BasicDataSource"

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -171,6 +171,13 @@
 
   Do not forget to add facet configuration on config-summary.xml
 
+  <bean id="regionKeywordClassifier"
+        class="org.fao.geonet.kernel.search.classifier.TermLabel" lazy-init="true">
+    <constructor-arg name="finder" ref="ThesaurusManager"/>
+    <constructor-arg name="conceptScheme" value="http://geonetwork-opensource.org/thesaurus/naturalearth-and-seavox"/>
+    <constructor-arg name="langCode" value="eng"/>
+  </bean>
+
   <bean id="gemetKeywordClassifier"
         class="org.fao.geonet.kernel.search.classifier.TermLabel" lazy-init="true">
     <constructor-arg name="finder" ref="ThesaurusManager"/>

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -34,7 +34,7 @@
 ">
   <context:annotation-config/>
 
-  <context:property-placeholder location="WEB-INF/config.properties"
+  <context:property-placeholder location="${app.properties}"
                                 file-encoding="UTF-8"
                                 ignore-unresolvable="true" />
 
@@ -69,8 +69,8 @@
   </bean>
 
   <bean id="language" class="org.fao.geonet.web.DefaultLanguage">
-    <property name="language" value="${language.default}"/>
-    <property name="forceDefault" value="${language.forceDefault}"/>
+    <property name="language" value="\${language.default}"/>
+    <property name="forceDefault" value="\${language.forceDefault}"/>
   </bean>
 
   <!-- Define the languages in the UI. Seems like these should come from database
@@ -164,18 +164,13 @@
         class="org.fao.geonet.kernel.search.classifier.Split" lazy-init="true">
     <constructor-arg name="regex" value="\s*?/\s*?"/>
   </bean>
+
   <!--
   Example configuration for hierarchical facet based on
   the GeoNetwork region thesaurus or GEMET.
 
   Do not forget to add facet configuration on config-summary.xml
 
-  <bean id="regionKeywordClassifier"
-        class="org.fao.geonet.kernel.search.classifier.TermLabel" lazy-init="true">
-    <constructor-arg name="finder" ref="ThesaurusManager"/>
-    <constructor-arg name="conceptScheme" value="http://geonetwork-opensource.org/thesaurus/naturalearth-and-seavox"/>
-    <constructor-arg name="langCode" value="eng"/>
-  </bean>
   <bean id="gemetKeywordClassifier"
         class="org.fao.geonet.kernel.search.classifier.TermLabel" lazy-init="true">
     <constructor-arg name="finder" ref="ThesaurusManager"/>

--- a/workers/wfsfeature-harvester/pom.xml
+++ b/workers/wfsfeature-harvester/pom.xml
@@ -57,6 +57,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
+              <escapeString>\</escapeString>
               <includeEmptyDirs>false</includeEmptyDirs>
               <outputDirectory>${project.build.directory}</outputDirectory>
               <resources>

--- a/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
@@ -34,7 +34,7 @@
         http://camel.apache.org/schema/spring
         http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-  <context:property-placeholder location="WEB-INF/config.properties"
+  <context:property-placeholder location="${app.properties}"
                                 file-encoding="UTF-8"
                                 ignore-unresolvable="true" />
 
@@ -49,8 +49,8 @@
 
   <bean id="esClient"
         class="org.fao.geonet.harvester.wfsfeatures.worker.EsClient">
-    <property name="serverUrl" value="${es.url}"/>
-    <property name="collection" value="${es.index.features}"/>
+    <property name="serverUrl" value="\${es.url}"/>
+    <property name="collection" value="\${es.index.features}"/>
   </bean>
 
 


### PR DESCRIPTION
Proposal: Add a pom property to configure property file location for the app and the db config. 

```
-  <context:property-placeholder location="WEB-INF/config.properties"
+  <context:property-placeholder location="${app.properties}"
```

This is useful when you have the need to move configuration outside the webapp.

Then you can set the location with full file path or using env variables like
```
location="file:/${geonetwork.dir}/jdbc.properties"
or
location="file:/c:/datadir/jdbc.properties"
```
 
Remove usage of "classpath*:" prefix which was not complaining if no file found but was unclear about which config files are required for each module.

See https://github.com/geonetwork/core-geonetwork/issues/1995

Runtime is ok, test are ok.