### PR TITLE
Send to ufo xslt the uuid from the metadata for schemas that have enabled the flag readwriteUuid.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -1786,7 +1786,18 @@ public class DataManager implements ApplicationEventPublisherAware {
         if (ufo) {
             String parentUuid = null;
             Integer intId = Integer.valueOf(metadataId);
-            metadataXml = updateFixedInfo(schema, Optional.of(intId), null, metadataXml, parentUuid, (updateDateStamp ? UpdateDatestamp.YES : UpdateDatestamp.NO), context);
+
+            // Notifies the metadata change to metatada notifier service
+            final Metadata metadata = getMetadataRepository().findOne(metadataId);
+
+            String uuid = null;
+
+            if (getSchemaManager().getSchema(schema).isReadwriteUUID()
+                && metadata.getDataInfo().getType() != MetadataType.SUB_TEMPLATE) {
+                uuid = extractUUID(schema, metadataXml);
+            }
+
+            metadataXml = updateFixedInfo(schema, Optional.of(intId), uuid, metadataXml, parentUuid, (updateDateStamp ? UpdateDatestamp.YES : UpdateDatestamp.NO), context);
         }
 
         //--- force namespace prefix for iso19139 metadata


### PR DESCRIPTION
This allows to edit the uuid to users in the metadata editor and get the value assigned in the xml, otherwise the ufo process, keeps the original uuid.

Most of the schemas have readwriteUuid disable as expected, so should not cause any side effect.