### PR TITLE
Don't use proxy for URL with the same origin (#1943)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/UrlUtilsService.js
+++ b/web-ui/src/main/resources/catalog/components/UrlUtilsService.js
@@ -115,11 +115,56 @@
 
         // stolen from Angular
         // https://github.com/angular/angular.js/blob/master/src/ng/urlUtils.js
-        this.urlResolve = function(url, base) {
+        /**
+         *
+         * Implementation Notes for non-IE browsers
+         * ----------------------------------------
+         * Assigning a URL to the href property of an anchor DOM node, even one attached to the DOM,
+         * results both in the normalizing and parsing of the URL.  Normalizing means that a relative
+         * URL will be resolved into an absolute URL in the context of the application document.
+         * Parsing means that the anchor node's host, hostname, protocol, port, pathname and related
+         * properties are all populated to reflect the normalized URL.  This approach has wide
+         * compatibility - Safari 1+, Mozilla 1+ etc.  See
+         * http://www.aptana.com/reference/html/api/HTMLAnchorElement.html
+         *
+         * Implementation Notes for IE
+         * ---------------------------
+         * IE <= 10 normalizes the URL when assigned to the anchor node similar to the other
+         * browsers.  However, the parsed components will not be set if the URL assigned did not specify
+         * them.  (e.g. if you assign a.href = "foo", then a.protocol, a.host, etc. will be empty.)  We
+         * work around that by performing the parsing in a 2nd step by taking a previously normalized
+         * URL (e.g. by assigning to a.href) and assigning it a.href again.  This correctly populates the
+         * properties such as protocol, hostname, port, etc.
+         *
+         * References:
+         *   http://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement
+         *   http://www.aptana.com/reference/html/api/HTMLAnchorElement.html
+         *   http://url.spec.whatwg.org/#urlutils
+         *   https://github.com/angular/angular.js/pull/2902
+         *   http://james.padolsey.com/javascript/parsing-urls-with-the-dom/
+         *
+         * @kind function
+         * @param {string} url The URL to be parsed.
+         * @description Normalizes and parses a URL.
+         * @returns {object} Returns the normalized URL as a dictionary.
+         *
+         *   | member name   | Description    |
+         *   |---------------|----------------|
+         *   | href          | A normalized version of the provided URL if it was not an absolute URL |
+         *   | protocol      | The protocol including the trailing colon                              |
+         *   | host          | The host and port (if the port is non-default) of the normalizedUrl    |
+         *   | search        | The search params, minus the question mark                             |
+         *   | hash          | The hash string, minus the hash symbol
+         *   | hostname      | The hostname
+         *   | port          | The port, without ":"
+         *   | pathname      | The pathname, beginning with "/"
+         *
+         */
+        this.urlResolve = function(url) {
           var href = url;
           var urlParsingNode = document.createElement('a');
           var msie = parseInt((/msie (\d+)/.exec(
-              navigator.userAgent.toLowerCase()) || [])[1], 10);
+            navigator.userAgent.toLowerCase()) || [])[1], 10);
 
           if (msie) {
             // Normalize before parse. Refer Implementation Notes on why this
@@ -135,17 +180,33 @@
           return {
             href: urlParsingNode.href,
             protocol: urlParsingNode.protocol ?
-                urlParsingNode.protocol.replace(/:$/, '') : '',
+              urlParsingNode.protocol.replace(/:$/, '') : '',
             host: urlParsingNode.host,
             search: urlParsingNode.search ?
-                urlParsingNode.search.replace(/^\?/, '') : '',
+              urlParsingNode.search.replace(/^\?/, '') : '',
             hash: urlParsingNode.hash ?
-                urlParsingNode.hash.replace(/^#/, '') : '',
+              urlParsingNode.hash.replace(/^#/, '') : '',
             hostname: urlParsingNode.hostname,
             port: urlParsingNode.port,
             pathname: (urlParsingNode.pathname.charAt(0) === '/') ?
-                urlParsingNode.pathname : '/' + urlParsingNode.pathname
+              urlParsingNode.pathname : '/' + urlParsingNode.pathname
           };
+        };
+
+        /**
+         * Parse a request URL and determine whether this is a same-origin request as the application document.
+         *
+         * Taken from https://github.com/angular/angular.js/blob/v1.6.x/src/ng/urlUtils.js
+         *
+         * @param {string|object} requestUrl The url of the request as a string that will be resolved
+         * or a parsed URL object.
+         * @returns {boolean} Whether the request is for the same origin as the application document.
+         */
+        this.urlIsSameOrigin = function(requestUrl) {
+          var originUrl = this.urlResolve(window.location.href);
+          var parsed = (angular.isString(requestUrl)) ? this.urlResolve(requestUrl) : requestUrl;
+          return (parsed.protocol === originUrl.protocol &&
+          parsed.host === originUrl.host);
         };
 
       };

--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -24,7 +24,9 @@
 (function() {
   goog.provide('gn_cors_interceptor');
 
-  var module = angular.module('gn_cors_interceptor', []);
+  goog.require('gn_urlutils_service');
+
+  var module = angular.module('gn_cors_interceptor', ['gn_urlutils_service']);
 
   /**
    * CORS Interceptor
@@ -41,7 +43,8 @@
         '$injector',
         'gnGlobalSettings',
         'gnLangs',
-        function($q, $injector, gnGlobalSettings, gnLangs) {
+        'gnUrlUtils',
+        function($q, $injector, gnGlobalSettings, gnLangs, gnUrlUtils) {
           return {
             request: function(config) {
               if (gnLangs.current) {
@@ -51,7 +54,7 @@
                 var url = config.url.split('/');
                 url = url[0] + '/' + url[1] + '/' + url[2] + '/';
 
-                if ($.inArray(url, gnGlobalSettings.requireProxy) != -1) {
+                if ($.inArray(url, gnGlobalSettings.requireProxy) !== -1) {
                   // require proxy
                   config.url = gnGlobalSettings.proxyUrl +
                       encodeURIComponent(config.url);
@@ -66,31 +69,36 @@
               if (config.nointercept) {
                 return $q.when(config);
               // let it pass
-              } else if (!config.status || config.status == -1) {
+              } else if (!config.status || config.status === -1) {
                 var defer = $q.defer();
 
                 if (config.url.indexOf('http', 0) === 0) {
-                  var url = config.url.split('/');
-                  url = url[0] + '/' + url[1] + '/' + url[2] + '/';
+                  if (gnUrlUtils.urlIsSameOrigin(config.url)) {
+                    // if the target URL is in the GN host, don't use proxy and reject the promise.
+                    return $q.reject(response);
+                  } else {
+                    // if the target URL is in other site/protocol that GN, use the proxy to make the request.
+                    var url = config.url.split('/');
+                    url = url[0] + '/' + url[1] + '/' + url[2] + '/';
 
-                  if ($.inArray(url, gnGlobalSettings.requireProxy) == -1) {
-                    gnGlobalSettings.requireProxy.push(url);
+                    if ($.inArray(url, gnGlobalSettings.requireProxy) === -1) {
+                      gnGlobalSettings.requireProxy.push(url);
+                    }
+
+                    $injector.invoke(['$http', function ($http) {
+                      // This modification prevents interception (infinite
+                      // loop):
+
+                      config.nointercept = true;
+
+                      // retry again
+                      $http(config).then(function (resp) {
+                        defer.resolve(resp);
+                      }, function (resp) {
+                        defer.reject(resp);
+                      });
+                    }]);
                   }
-
-                  $injector.invoke(['$http', function($http) {
-                    // This modification prevents interception (infinite
-                    // loop):
-
-                    config.nointercept = true;
-
-                    // retry again
-                    $http(config).then(function(resp) {
-                      defer.resolve(resp);
-                    }, function(resp) {
-                      defer.reject(resp);
-                    });
-                  }]);
-
                 } else {
                   return $q.reject(response);
                 }


### PR DESCRIPTION
CORS errors and network/server errors can't be distinguished by the browser JS engine.
CORS errors usually happen when the requested URL is in other domain/protocol that
the current page current one.
With this commit requests made to the same origin that GN that result in an error will
not be retried using the proxy and the request will be rejected with the actual response
value from the server.
If the request is for another origin it will be retried using the proxy.