### PR TITLE
Continous Layertree loading

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -149,7 +149,12 @@
                   cache: true
                 })
                     .success(function(data, status, headers, config) {
-                      defer.resolve(parseWMTSCapabilities(data));
+                      if(data) {
+                        defer.resolve(parseWMTSCapabilities(data));
+                      }
+                      else {
+                        defer.reject();
+                      }
                     })
                     .error(function(data, status, headers, config) {
                       defer.reject(status);

--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/partials/baselayerswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/partials/baselayerswitcher.html
@@ -6,12 +6,16 @@
     class="caret"></span>
   </button>
   <ul class="dropdown-menu" role="menu">
-    <li ng-repeat="layer in layers">
-      <a href="" ng-click="setBgLayer(layer)">
+    <li ng-if="::layer" ng-repeat="layer in layers">
+      <a href="" ng-click="setBgLayer(layer)" ng-if="::!layer.get('loading')">
         <span class="fa"
               ng-class="(layer==map.getLayers().item(0)) ? 'fa-dot-circle-o' : 'fa-circle-o'"></span>
         {{layer.get('title')}}
       </a>
+      <a ng-if="::layer.get('loading')">
+        <span class="fa fa-spin fa-spinner"></span>
+      </a>
+
     <li>
   </ul>
 </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
@@ -65,7 +65,10 @@
                  if (layer && layer.get('featureTooltip')) {
                    return feature;
                  }
-               });
+               }, undefined, function(layer){
+                return layer instanceof ol.layer.Vector;
+
+              });
               if (feature) {
                 var props = feature.getProperties();
                 var tooltipContent = '<ul>';

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -139,7 +139,6 @@
       return {
         require: '^gnLayermanager',
         restrict: 'A',
-        replace: true,
         templateUrl: '../../catalog/components/viewer/layermanager/' +
             'partials/layermanageritem.html',
         scope: true,

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
@@ -1,4 +1,4 @@
-<div>
+<div ng-if="::!layer.get('loading')">
   <button class="btn btn-cog" data-ng-click="showInfo(layer)" title="{{'legend'|translate}}">
     <span class="fa fa-paint-brush"></span>
   </button>
@@ -96,4 +96,8 @@
 
     <div gn-ncwms-transect="" map="map" layer="layer" data-ng-if="layer.ncInfo"/>
   </div>
+</div>
+<div ng-if="::layer.get('loading')">
+  {{::layer.get('label')}}
+  <span class="pull-right fa fa-spin fa-spinner"></span>
 </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsDirective.js
@@ -241,7 +241,12 @@
           });
 
           scope.hasStyles = function() {
-            return Object.keys(scope.palettes).length > 1;
+            try {
+              return Object.keys(scope.palettes).length > 1;
+            }
+            catch(e) {
+              return false;
+            }
           };
 
           scope.updateStyle = function() {

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsService.js
@@ -138,7 +138,7 @@
               }
             }
             else if (s == 'contour') {
-              t[s] = s + '/' + p;
+              t[s] = s ; // TODO ????? + '/' + p;
             }
           });
         }

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/partials/ncwmstools.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/partials/ncwmstools.html
@@ -49,7 +49,7 @@
     </div>
 
     <!--Styles combo-->
-    <div class="form-group" data-ng-if="hasStyles()">
+    <div class="form-group" data-ng-if="::hasStyles()">
       <label class="col-sm-4" for="ncwmsstyles">Styles</label>
       <div class="col-sm-8">
         <select class="form-control input-sm" id="ncwmsstyles" data-ng-model="ctrl.palette" data-ng-change="updateStyle()">

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -140,11 +140,24 @@
 
         // load the resources
         var layers = context.resourceList.layer;
-        var i, j, olLayer, bgLayers = [];
+        var i, j, olLayer;
         var self = this;
         var promises = [];
         var overlays = [];
         if (angular.isArray(layers)) {
+
+          // ----  Clean bg layers
+          if (map.getLayers().getLength() > 0) {
+            map.getLayers().removeAt(0);
+          }
+          if (!gnViewerSettings.bgLayers) {
+            gnViewerSettings.bgLayers = [];
+          }
+          gnViewerSettings.bgLayers.length = 0;
+          var bgLayers = gnViewerSettings.bgLayers;
+          var isFirstBgLayer = false;
+          // -------
+
           for (i = 0; i < layers.length; i++) {
             var type, layer = layers[i];
             if (layer.name) {
@@ -163,27 +176,52 @@
                   var olLayer =
                       gnMap.createLayerForType(type, opt, layer.title);
                   if (olLayer) {
-                    bgLayers.push({layer: olLayer, idx: i});
                     olLayer.displayInLayerManager = false;
                     olLayer.background = true;
                     olLayer.set('group', 'Background layers');
                     olLayer.setVisible(!layer.hidden);
+                    bgLayers.push(olLayer);
+
+                    if (!layer.hidden && !isFirstBgLayer) {
+                      isFirstBgLayer = true;
+                      map.getLayers().insertAt(0, olLayer);
+                    }
                   }
                 }
 
                 // {type=wmts,name=Ocean_Basemap} or WMS
                 else {
-                  promises.push(this.createLayer(layer, map, i).then(
-                      function(olLayer) {
-                        if (olLayer) {
-                          bgLayers.push({
-                            layer: olLayer,
-                            idx: olLayer.get('bgIdx')
-                          });
-                          olLayer.displayInLayerManager = false;
-                          olLayer.background = true;
-                        }
-                      }));
+
+                  var loadingLayer = new ol.layer.Image({
+                    loading: true,
+                    label: 'loading',
+                    url: '',
+                    visible: false
+                  });
+
+                  if (!layer.hidden && !isFirstBgLayer) {
+                    isFirstBgLayer = true;
+                    loadingLayer.set('bgLayer', true);
+                  }
+
+                  var layerIndex = bgLayers.push(loadingLayer);
+                  var p = self.createLayer(layer, map, i);
+
+                  (function(idx) {
+                    p.then(function(layer) {
+                      bgLayers[idx-1] = layer;
+
+                      if(!layer) {
+                        return;
+                      }
+                      layer.displayInLayerManager = false;
+                      layer.background = true;
+
+                      if(loadingLayer.get('bgLayer')) {
+                        map.getLayers().insertAt(0, layer);
+                      }
+                    });
+                  })(layerIndex);
                 }
               }
               // WMS layer not in background
@@ -204,7 +242,7 @@
 
                   (function(idx) {
                     p.then(function(layer) {
-                      map.getLayers().setAt(idx, layer);
+                      map.getLayers().setAt(idx-1, layer);
                     });
                   })(layerIndex);
                 }
@@ -213,42 +251,6 @@
             firstLoad = false;
           }
         }
-
-        // if there's at least one valid bg layer in the context use them for
-        // the application otherwise use the defaults from config
-        $q.all(promises).then(function() {
-          if (bgLayers.length > 0) {
-            // make sure we remove any existing bglayer
-            if (map.getLayers().getLength() > 0) {
-              map.getLayers().removeAt(0);
-            }
-
-            // first clear settings bgLayers
-            if (!gnViewerSettings.bgLayers) {
-              gnViewerSettings.bgLayers = [];
-            }
-
-            gnViewerSettings.bgLayers.length = 0;
-
-            var firstVisibleBgLayer = true;
-            bgLayers = $filter('orderBy')(bgLayers, 'idx');
-
-            $.each(bgLayers, function(index, item) {
-              gnViewerSettings.bgLayers.push(item.layer);
-              // the first visible bg layer wins and get displayed in the map
-              if (item.layer.getVisible() && firstVisibleBgLayer) {
-                map.getLayers().insertAt(0, item.layer);
-                firstVisibleBgLayer = false;
-              }
-            });
-            if (firstVisibleBgLayer && gnViewerSettings.bgLayers.length) {
-              var l = gnViewerSettings.bgLayers[0];
-              l.setVisible(true);
-              map.getLayers().insertAt(0, l);
-              firstVisibleBgLayer = false;
-            }
-          }
-        });
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -185,14 +185,28 @@
                         }
                       }));
                 }
-              } else if (layer.server) {
+              }
+              // WMS layer not in background
+              else if (layer.server) {
                 var server = layer.server[0];
                 if (server.service == 'urn:ogc:serviceType:WMS') {
-                  var p = self.createLayer(layer, map, undefined, i);
-                  promises.push(p);
-                  p.then(function(layer) {
-                    overlays[layer.get('tree_index')] = layer;
+
+                  var loadingLayer = new ol.layer.Image({
+                    loading: true,
+                    label: 'loading',
+                    url: '',
+                    visible: false
                   });
+                  loadingLayer.displayInLayerManager = true;
+
+                  var layerIndex = map.getLayers().push(loadingLayer);
+                  var p = self.createLayer(layer, map, undefined, i);
+
+                  (function(idx) {
+                    p.then(function(layer) {
+                      map.getLayers().setAt(idx, layer);
+                    });
+                  })(layerIndex);
                 }
               }
             }
@@ -233,11 +247,6 @@
               map.getLayers().insertAt(0, l);
               firstVisibleBgLayer = false;
             }
-          }
-          if (overlays.length > 0) {
-            map.getLayers().extend(overlays.filter(function(l) {
-              return !!l;
-            }));
           }
         });
       };

--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/WfsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/WfsDirective.js
@@ -41,6 +41,13 @@
           scope.isWfsAvailable = false;
 
           function init() {
+
+            var source = scope.layer.getSource();
+            if(!source || !(source instanceof ol.source.ImageWMS ||
+              source instanceof ol.source.TileWMS)) {
+              return;
+            }
+
             // Get WFS URL from attrs or try by substituting WFS in WMS URLs.
             scope.url = attrs['url'] ||
                 scope.layer.get('url').replace(/wms/i, 'wfs');

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
@@ -112,7 +112,9 @@
                     if (layer == scope.heatmapLayer) {
                       return feature;
                     }
-                  });
+                  }, undefined, function(layer) {
+                  return layer instanceof ol.layer.Vector;
+                });
               if (feature) {
                 var mapTop = scope.map.getTarget().getBoundingClientRect().top;
                 info.css({
@@ -142,6 +144,11 @@
            * all different feature types.
            */
           function init() {
+
+            var source = scope.layer.getSource();
+            if(!source || !(source instanceof ol.source.ImageWMS || source instanceof ol.source.TileWMS)) {
+              return;
+            }
 
             angular.extend(scope, {
               fields: [],

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -127,7 +127,7 @@
     max-width: ~"calc(100% - 4em)";
     overflow-y: auto;
     transition: opacity @transition-params;
-    div[gn-layermanager-item] {
+    li[gn-layermanager-item] {
       .fa-arrows-alt,.gn-layer-ordering {
         opacity: 0;
         transition: opacity @transition-params;

--- a/web/src/main/webapp/WEB-INF/data/data/resources/map/config-viewer.xml
+++ b/web/src/main/webapp/WEB-INF/data/data/resources/map/config-viewer.xml
@@ -17,7 +17,6 @@
     </ows-context:Layer>
     <ows-context:Layer name="{type=bing_aerial}"
                        group="Background layers"
-                       hidden="true"
                        opacity="1">
       <ows:Title>Bing Aerial</ows:Title>
     </ows-context:Layer>


### PR DESCRIPTION
Change the way the layers are managed from `OWSContext`.
Initially, we called all getCapabilities and wait for all responses in the `$q.all()` but if a response is very long, then the layers are not displayed for a while.

We now process all layers as they come from the context.
During loading, an empty loading layer is added to the map, to keep layer position in the map and for the layermanager to display it while loading.
On response, this fake layer is either set to null or replaced in the map by the real one.
This is done for both background and top layers. A spinner is diplayed while loading.

Error are managed.