### PR TITLE
Rework how metadata CRS are indexed & displayed in MD view

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -893,6 +893,17 @@
     <xsl:for-each select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
         <xsl:for-each select="gmd:referenceSystemIdentifier/gmd:RS_Identifier">
             <xsl:variable name="crs">
+                <xsl:for-each select="gmd:codeSpace/*/text() | gmd:code/*/text()">
+                    <xsl:value-of select="."/>
+                    <xsl:if test="not(position() = last())">::</xsl:if>
+                </xsl:for-each>
+            </xsl:variable>
+
+            <xsl:if test="$crs != ''">
+                <Field name="crs" string="{$crs}" store="true" index="true"/>
+            </xsl:if>
+
+            <xsl:variable name="crsDetails">
             {
               "code": "<xsl:value-of select="gmd:codeSpace/*/text()"/>:<xsl:value-of select="gmd:code/*/text()"/>",
               "name": "<xsl:value-of select="gmd:code/*/@xlink:title"/>",
@@ -900,8 +911,8 @@
             }
             </xsl:variable>
 
-            <Field name="crs"
-                   string="{normalize-space($crs)}"
+            <Field name="crsDetails"
+                   string="{normalize-space($crsDetails)}"
                    store="true"
                    index="false"/>
         </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -893,15 +893,17 @@
     <xsl:for-each select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
         <xsl:for-each select="gmd:referenceSystemIdentifier/gmd:RS_Identifier">
             <xsl:variable name="crs">
-                <xsl:for-each select="gmd:codeSpace/gco:CharacterString/text() | gmd:code/gco:CharacterString/text()">
-                    <xsl:value-of select="."/>
-                    <xsl:if test="not(position() = last())">::</xsl:if>
-                </xsl:for-each>
+            {
+              "code": "<xsl:value-of select="gmd:codeSpace/*/text()"/>:<xsl:value-of select="gmd:code/*/text()"/>",
+              "name": "<xsl:value-of select="gmd:code/*/@xlink:title"/>",
+              "url": "<xsl:value-of select="gmd:code/*/@xlink:href"/>"
+            }
             </xsl:variable>
 
-            <xsl:if test="$crs != ''">
-                <Field name="crs" string="{$crs}" store="true" index="true"/>
-            </xsl:if>
+            <Field name="crs"
+                   string="{normalize-space($crs)}"
+                   store="true"
+                   index="false"/>
         </xsl:for-each>
     </xsl:for-each>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -28,6 +28,7 @@
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:gml="http://www.opengis.net/gml"
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:geonet="http://www.fao.org/geonetwork"
@@ -709,15 +710,17 @@
     <xsl:for-each select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
         <xsl:for-each select="gmd:referenceSystemIdentifier/gmd:RS_Identifier">
             <xsl:variable name="crs">
-                <xsl:for-each select="gmd:codeSpace/gco:CharacterString/text() | gmd:code/gco:CharacterString/text()">
-                    <xsl:value-of select="."/>
-                    <xsl:if test="not(position() = last())">::</xsl:if>
-                </xsl:for-each>
+            {
+              "code": "<xsl:value-of select="gmd:codeSpace/*/text()"/>:<xsl:value-of select="gmd:code/*/text()"/>",
+              "name": "<xsl:value-of select="gmd:code/*/@xlink:title"/>",
+              "url": "<xsl:value-of select="gmd:code/*/@xlink:href"/>"
+            }
             </xsl:variable>
 
-            <xsl:if test="$crs != ''">
-                <Field name="crs" string="{$crs}" store="true" index="true"/>
-            </xsl:if>
+            <Field name="crs"
+                   string="{normalize-space($crs)}"
+                   store="true"
+                   index="false"/>
         </xsl:for-each>
     </xsl:for-each>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -710,15 +710,26 @@
     <xsl:for-each select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
         <xsl:for-each select="gmd:referenceSystemIdentifier/gmd:RS_Identifier">
             <xsl:variable name="crs">
+                <xsl:for-each select="gmd:codeSpace/*/text() | gmd:code/*/text()">
+                    <xsl:value-of select="."/>
+                    <xsl:if test="not(position() = last())">::</xsl:if>
+                </xsl:for-each>
+            </xsl:variable>
+
+            <xsl:if test="$crs != ''">
+                <Field name="crs" string="{$crs}" store="true" index="true"/>
+            </xsl:if>
+
+            <xsl:variable name="crsDetails">
             {
-              "code": "<xsl:value-of select="gmd:codeSpace/*/text()"/>:<xsl:value-of select="gmd:code/*/text()"/>",
-              "name": "<xsl:value-of select="gmd:code/*/@xlink:title"/>",
-              "url": "<xsl:value-of select="gmd:code/*/@xlink:href"/>"
+             "code": "<xsl:value-of select="gmd:codeSpace/*/text()"/>:<xsl:value-of select="gmd:code/*/text()"/>",
+             "name": "<xsl:value-of select="gmd:code/*/@xlink:title"/>",
+             "url": "<xsl:value-of select="gmd:code/*/@xlink:href"/>"
             }
             </xsl:variable>
 
-            <Field name="crs"
-                   string="{normalize-space($crs)}"
+            <Field name="crsDetails"
+                   string="{normalize-space($crsDetails)}"
                    store="true"
                    index="false"/>
         </xsl:for-each>

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -468,8 +468,8 @@
         'securityConstraints', 'resourceConstraints', 'legalConstraints',
         'denominator', 'resolution', 'geoDesc', 'geoBox', 'inspirethemewithac',
         'status', 'status_text', 'crs', 'identifier', 'responsibleParty',
-        'mdLanguage', 'datasetLang', 'type', 'link'];
-      var listOfJsonFields = ['keywordGroup'];
+        'mdLanguage', 'datasetLang', 'type', 'link', 'crsDetails'];
+      var listOfJsonFields = ['keywordGroup', 'crsDetails'];    // See below; probably not necessary
       var record = this;
       this.linksCache = [];
       $.each(listOfArrayFields, function(idx) {
@@ -479,7 +479,7 @@
           record[field] = [record[field]];
         }
       });
-      $.each(listOfJsonFields, function(idx) {
+      $.each(listOfJsonFields, function(idx) {    // Note: this step does not seem to be necessary; TODO: remove or refactor
         var field = listOfJsonFields[idx];
         if (angular.isDefined(record[field])) {
           try {

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -318,11 +318,11 @@
               </ul>
             </td>
           </tr>
-          <tr data-ng-if="::mdView.current.record.crs">
+          <tr data-ng-if="::mdView.current.record.crsDetails">
             <th data-translate="">crs</th>
             <td>
               <ul>
-                <li data-ng-repeat="r in ::mdView.current.record.crs">
+                <li data-ng-repeat="r in ::mdView.current.record.crsDetails">
                   <span ng-if="r.name != ''">{{ r.name }} ({{ r.code }})</span>
                   <span ng-if="r.name == ''">{{ r.code }}</span>
                 </li>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -322,7 +322,10 @@
             <th data-translate="">crs</th>
             <td>
               <ul>
-                <li data-ng-repeat="r in ::mdView.current.record.crs">{{r}}</li>
+                <li data-ng-repeat="r in ::mdView.current.record.crs">
+                  <span ng-if="r.name != ''">{{ r.name }} ({{ r.code }})</span>
+                  <span ng-if="r.name == ''">{{ r.code }}</span>
+                </li>
               </ul>
             </td>
           </tr>

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -150,6 +150,7 @@
       <field name="denominator" tagName="denominator"/>
       <field name="resolution" tagName="resolution"/>
       <field name="crs" tagName="crs"/>
+      <field name="crsDetails" tagName="crsDetails"/>
       <field name="credit" tagName="credit"/>
       <field name="cl_status" tagName="status"/>
       <field name="cl_status_text" tagName="status_text"/>
@@ -177,7 +178,6 @@
       <field name="_op0" tagName="publishedForGroup"/>
       <field name="_groupOwner" tagName="groupOwner"/>
       <field name="_logo" tagName="logo"/>
-      <field name="crs" tagName="crs"/>
       <field name="standardName" tagName="standardName"/>
       <field name="_groupWebsite" tagName="groupWebsite"/>
       <field name="attributeTable" tagName="attributeTable"/>


### PR DESCRIPTION
This PR has two objectives regarding a metadata CRS:
* Handle CRS codes encoded with a `<gmx:Anchor>` element instead of `<gco:CharacterString>`
* Provide additional info on the CRS to the frontend:
  * Name
  * Url

The template `recordView.html` has been adjusted to reflect this change.

This has been tested with the following XML structure:
```xml
<gmd:referenceSystemInfo>
  <gmd:MD_ReferenceSystem>
    <gmd:referenceSystemIdentifier>
      <gmd:RS_Identifier>
        <gmd:code>
            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/2154" xlink:title="RGF93 - Lambert 93">2154</gmx:Anchor>
        </gmd:code>
        <gmd:codeSpace>
            <gco:CharacterString>EPSG</gco:CharacterString>
        </gmd:codeSpace>
      </gmd:RS_Identifier>
    </gmd:referenceSystemIdentifier>
  </gmd:MD_ReferenceSystem>
</gmd:referenceSystemInfo>
```