### PR TITLE
Disable or enable 'filter' button based on previous filter state

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -605,7 +605,7 @@
     };
   });
 
-
+  
   /**
    * Make an element able to collapse/expand
    * the next element. An icon is added before
@@ -652,7 +652,7 @@
         restrict: 'A',
         compile: function(scope, element, attr) {
           var fn = $parse(element['gnClickAndSpin'], null, true);
-          return function ngEventHandler(scope, element) {
+          return function ngEventHandler(scope, element, attr) {
             var running = false;
             var icon = element.find('i');
             var spinner = null;
@@ -667,7 +667,10 @@
             var done = function() {
               running = false;
               element.removeClass('running');
-              element.removeClass('disabled');
+              var stayDisabled = attr['gnClickAndSpinStayDisabled'];
+              if (!stayDisabled) {
+                element.removeClass('disabled');
+              }
               element.find('i').first().remove();
               icon.removeClass('hidden');
             };

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
@@ -149,6 +149,14 @@
             searchGeometry: undefined
           };
 
+          // if true, the "apply filters" button will be available
+          scope.filtersChanged = false;
+          scope.previousFilterState = {
+            params: {},
+            any: '',
+            geometry: ''
+          };
+
           // Get an instance of index object
           var indexObject, geometry, extentFilter;
 
@@ -441,6 +449,7 @@
            * @param {boolean} formInput the filter comes from input change
            */
           scope.filterFacets = function(formInput) {
+            scope.$broadcast('FiltersChanged');
 
             // Update the facet UI
             var expandedFields = [];
@@ -508,6 +517,7 @@
             }
 
             scope.layer.set('esConfig', null);
+            scope.$broadcast('FiltersChanged');
 
             // load all facet and fill ui structure for the list
             return indexObject.searchWithFacets({}).
@@ -560,6 +570,7 @@
                 }
               });
 
+              scope.$broadcast('FiltersChanged');
               refreshHeatmap();
             });
           };
@@ -576,6 +587,11 @@
            * that will be send to generateSLD service.
            */
           scope.filterWMS = function() {
+            // save this filter state for future comparison
+            scope.previousFilterState.params = angular.merge({}, scope.output);
+            scope.previousFilterState.geometry = scope.ctrl.searchGeometry;
+            scope.previousFilterState.any = scope.searchInput;
+
             var defer = $q.defer();
             var sldConfig = wfsFilterService.createSLDConfig(scope.output);
             var layer = scope.layer;
@@ -608,13 +624,15 @@
                     SLD: sldURL
                   });
                 }
-              }).finally(function() {
+                scope.filtersChanged = false;   // reset 'apply filters' button
+              }).finally (function() {
                 defer.resolve();
               });
             } else {
               layer.getSource().updateParams({
                 SLD: null
               });
+              scope.filtersChanged = false;
               defer.resolve();
             }
             return defer.promise;
@@ -680,7 +698,8 @@
               geometry = undefined;
               scope.filterFacets();
             }
-            // do nothing when reset from wfsFilter directive
+            // reset from wfsFilter directive: only signal change of filter
+            scope.$broadcast('FiltersChanged');
           });
 
           function resetHeatMap() {
@@ -714,6 +733,7 @@
             }
           });
 
+
           scope.showTable = function() {
             gnFeaturesTableManager.clear();
             gnFeaturesTableManager.addTable({
@@ -730,7 +750,6 @@
             scope.$destroy();
             resetHeatMap();
           });
-
 
           scope.toSqlOgr = function() {
             indexObject.pushState();
@@ -759,6 +778,27 @@
               });
             }
           };
+
+          // triggered when the filter state is changed (compares with previous state)
+          scope.$on('FiltersChanged', function (event, args) {
+            // this handles the cases where bbox string value is undefined
+            // or equal to ',,,' or '', which all amount to the same thing
+            function normalize(s) { return (s || '').replace(',,,', ''); }
+
+            var inputChanged = scope.searchInput !=
+              scope.previousFilterState.any;
+            var geomChanged = normalize(scope.ctrl.searchGeometry) !==
+              normalize(scope.previousFilterState.geometry);
+
+            // only compare params object if necessary
+            var paramsChanged = false;
+            if (!inputChanged && !geomChanged) {
+              paramsChanged = !angular.equals(
+                scope.previousFilterState.params, scope.output);
+            }
+
+            scope.filtersChanged = inputChanged || paramsChanged || geomChanged;
+          });
         }
       };
     }]);

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -95,7 +95,6 @@
       </div>
     </div>
 
-
     <div class="btn-group dropup">
       <a class="btn btn-default btn-xs"
          data-ng-if="!isFeaturesIndexed && (user.canEditRecord(md) || md.isHarvested == 'y')"
@@ -135,11 +134,11 @@
           </a>
         </li>
       </ul>
-      <button class="btn btn-default btn-xs"
-              data-ng-if="isFeaturesIndexed"
-              data-gn-click-and-spin="filterWMS()">
+      <button class="btn btn-default btn-xs" ng-class="{ disabled: !filtersChanged }"
+        data-gn-click-and-spin="filterWMS()"
+        data-gn-click-and-spin-stay-disabled="true">
         <i class="fa fa-filter"></i>&nbsp;
-        <span data-translate="">filter</span>
+        <span data-translate="">applyFilter</span>
       </button>
       <button class="btn btn-default btn-xs"
               data-ng-if="isFeaturesIndexed"

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -322,5 +322,6 @@
     "directoryManager": "Manage directory",
     "typeOfRecord": "Type of record",
     "load": "Load",
-    "indexAccessError": "Error during index access."
+    "indexAccessError": "Error during index access.",
+    "applyFilter": "Apply Filter"
 }

--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -322,5 +322,6 @@
     "directoryManager": "Gestion des annuaires",
     "typeOfRecord": "Type de fiche",
     "load": "Charger",
-    "indexAccessError": "Error during index access."
+    "indexAccessError": "Error during index access.",
+    "applyFilter": "Filtrer"
 }


### PR DESCRIPTION
This PR improves the usability of the 'filter' button in the map viewer:
![image](https://user-images.githubusercontent.com/10629150/27076526-b9bff3b8-502d-11e7-8fed-00645b5cb2c6.png)

The button will be greyed out if the currently selected filters have already been applied (this state is stored in `scope.previousFilterState`.

The saved state include bounding box selection & full text search.