### PR TITLE
Correct facet label rendering in search view

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-category.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-category.html
@@ -12,7 +12,7 @@
       <input type="checkbox"
              data-ng-checked="isInFilter(c)"
              data-ng-click="filter(c, $event)"/>&nbsp;
-      <span class="gn-facet-label">{{(c['@label'] || c['@value']) | characters:30}}</span>&nbsp;
+      <span class="gn-facet-label">{{c['@label'] || c['@value']}}</span>&nbsp;
       <span class="gn-facet-count">({{c['@count']}})</span>
     </label>
 

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -47,23 +47,36 @@
     padding: 0.1em;
     color: #555555;
     border: none;
+    display: flex;
+    flex-direction: row;
+    * { flex-shrink: 0; }
+
     label {
       margin-bottom: 0px;
       font-weight: 500;
       cursor: pointer;
+      display: flex;
+      flex-direction: row;
+      min-width: 0px;
+      flex-shrink: 1;
       &.gn-facet-active {
         color: @gray-darker
       }
     }
     input {
-      vertical-align: bottom;
-      position: relative;
-      top: -3px;
+      margin-right: 4px;
+      margin-top: 3px;
     }
     button {
       margin: 0px;
       padding: 0px;
       font-size: 13px;
+    }
+    .gn-facet-label {
+      flex-shrink: 1;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
     }
   }
   .gn-facet-count, .list-group-item > span.fa {


### PR DESCRIPTION
Facet label CSS was switched to using flexbox in order to better behave when the screen is narrowed. Text ellipsis is not done with angular filter anymore, but with the CSS `text-overflow: ellipsis` property.

Before:
![image](https://user-images.githubusercontent.com/10629150/27091175-ad088c66-505f-11e7-8116-aeb92babb2ca.png)

After:
![image](https://user-images.githubusercontent.com/10629150/27091102-7068acaa-505f-11e7-9011-661c182f51b2.png)