### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+
+Please have a look at our contributing guidelines at https://github.com/geonetwork/core-geonetwork/wiki/How-to-contribute


### PR DESCRIPTION
The canonical way of writing contributing guides is to have a `CONTRIBUTING.md` file in the root of the repo, as per https://github.com/blog/1184-contributing-guidelines . This simply creates a file with a pointer to the proper page in the wiki.