### PR TITLE
[#2018] use spring profile to allow discard of camel/es.

### DIFF
--- a/messaging/src/main/resources/config-spring-geonetwork-parent.xml
+++ b/messaging/src/main/resources/config-spring-geonetwork-parent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans profile="routes-to-harvesters"
+<beans profile="es"
         xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:amq="http://activemq.apache.org/schema/core"

--- a/messaging/src/main/resources/config-spring-geonetwork-parent.xml
+++ b/messaging/src/main/resources/config-spring-geonetwork-parent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans
+<beans profile="routes-to-harvesters"
         xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:amq="http://activemq.apache.org/schema/core"

--- a/pom.xml
+++ b/pom.xml
@@ -1261,6 +1261,7 @@
     <jetty.port>8080</jetty.port>
     <jetty.stop.port>8090</jetty.stop.port>
 
+    <!-- Begin es and camel stuffs -->
     <es.version>5.4.0</es.version>
     <es.version.md5>3f28a77368118aec107be24ec9fb6498</es.version.md5>
     <es.port>9200</es.port>
@@ -1269,11 +1270,17 @@
     <es.index.features>features</es.index.features>
     <es.username></es.username>
     <es.password></es.password>
-
+    <!-- to load spring configurations related to es and camel,
+    you should either set "es.spring.profile" to "routes-to-harvesters"
+    or use maven "routes-to-harvesters" profile (defined in web).
+    Devs may note that normally (not in this case), many spring profiles can
+    be defined at the same time: "active.profiles.spring" can also be overriden
+    in web.xml. -->
+    <es.spring.profile></es.spring.profile>
 
     <jms.url>tcp://localhost:61616</jms.url>
     <activemq.version>5.6.0</activemq.version>
-
+    <!-- End es and camel stuffs -->
 
     <!-- List of comma separated values of hosts for which
     CORS headers are added (eg. www.geonetwork-opensource.org,osgeo.org).
@@ -1314,5 +1321,6 @@
     <slf4j.version>1.7.7</slf4j.version>
     <xbean.version>3.18</xbean.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
+    <spring.profile></spring.profile>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1271,10 +1271,9 @@
     <es.username></es.username>
     <es.password></es.password>
     <!-- to load spring configurations related to es and camel,
-    you should either set "es.spring.profile" to "routes-to-harvesters"
-    or use maven "routes-to-harvesters" profile (defined in web).
+    you should use maven "es" profile (defined in web).
     Devs may note that normally (not in this case), many spring profiles can
-    be defined at the same time: "active.profiles.spring" can also be overriden
+    be defined at the same time: "active.profiles.spring" is overriden
     in web.xml. -->
     <es.spring.profile></es.spring.profile>
 
@@ -1321,6 +1320,5 @@
     <slf4j.version>1.7.7</slf4j.version>
     <xbean.version>3.18</xbean.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
-    <spring.profile></spring.profile>
   </properties>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -782,6 +782,12 @@
         <env>inspire</env>
       </properties>
     </profile>
+    <profile>
+      <id>routes-to-harvesters</id>
+      <properties>
+        <es.spring.profile>routes-to-harvesters</es.spring.profile>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -783,9 +783,9 @@
       </properties>
     </profile>
     <profile>
-      <id>routes-to-harvesters</id>
+      <id>es</id>
       <properties>
-        <es.spring.profile>routes-to-harvesters</es.spring.profile>
+        <es.spring.profile>es</es.spring.profile>
       </properties>
     </profile>
   </profiles>

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -418,4 +418,9 @@
   <session-config>
     <session-timeout>${sessionTimeout}</session-timeout>
   </session-config>
+
+  <context-param>
+    <param-name>spring.profiles.active</param-name>
+    <param-value>${es.spring.profile}</param-value>
+  </context-param>
 </web-app>

--- a/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork-jms.xml
+++ b/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork-jms.xml
@@ -22,7 +22,7 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<beans profile="routes-to-harvesters"
+<beans profile="es"
         xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:amq="http://activemq.apache.org/schema/core"

--- a/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork-jms.xml
+++ b/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork-jms.xml
@@ -22,7 +22,7 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<beans
+<beans profile="routes-to-harvesters"
         xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:amq="http://activemq.apache.org/schema/core"

--- a/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
@@ -22,7 +22,7 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<beans profile="routes-to-harvesters"
+<beans profile="es"
         xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:cm="http://camel.apache.org/schema/spring"

--- a/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/wfsfeature-harvester/src/main/resources/config-spring-geonetwork.xml
@@ -22,7 +22,8 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
+<beans profile="routes-to-harvesters"
+        xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:cm="http://camel.apache.org/schema/spring"
        xmlns:context="http://www.springframework.org/schema/context"


### PR DESCRIPTION
miss integration tests.

default is no messaging, no camel, no activemq, no es.

mvn -Pes
  or
setting "es.spring.profile" maven property to "es" to activate.