### PR TITLE
ISO19139 / Use PT_FreeText element for default language.

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -366,7 +366,48 @@ relevant to have parent defined to have more control over the list.
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="1" maxOccurs="unbounded" ref="name"/>
+        <xs:element name="name" minOccurs="1" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[
+        The element name including its namespace prefix (eg.
+        gmd:identificationInfo).
+        ]]>
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="parent" type="xs:string" use="optional">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[
+          The parent element name including its namespace prefix (eg.
+          gmd:identificationInfo).
+          ]]>
+                </xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ancestor" type="xs:string" use="optional">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[
+          One of the element ancestors name including its namespace prefix (eg.
+          gmd:identificationInfo).
+          ]]>
+                </xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="child" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[
+          The first child name including its namespace prefix (eg.
+          gmd:identificationInfo).
+          ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          </xs:complexType>
+        </xs:element>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -175,59 +175,8 @@
     <xsl:param name="refToDelete" required="no"/>
 
     <xsl:variable name="elementName" select="name()"/>
-    <xsl:variable name="exclusionMatchesParent">
-      <xsl:variable name="parent">
-        <xsl:value-of separator=","
-                      select="$editorConfig/editor/multilingualFields/exclude/name[. = $elementName]/@parent"/>
-      </xsl:variable>
-      <xsl:choose>
-        <xsl:when test="string-length($parent) > 0">
-          <xsl:value-of select="contains($parent, ../name())"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="false()"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:variable name="exclusionMatchesAncestor">
-      <xsl:variable name="ancestor">
-        <xsl:value-of separator=","
-                      select="$editorConfig/editor/multilingualFields/exclude/name[. = $elementName]/@ancestor"/>
-      </xsl:variable>
-      <xsl:choose>
-        <xsl:when
-          test="string-length($ancestor) > 0 and count(ancestor::*[contains($ancestor, name())]) != 0">
-          <xsl:value-of select="true()"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="false()"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:variable name="exclusionMatchesChild">
-      <xsl:variable name="child">
-        <xsl:value-of separator=","
-                      select="$editorConfig/editor/multilingualFields/exclude/name[. = $elementName]/@child"/>
-      </xsl:variable>
-      <xsl:choose>
-        <xsl:when test="string-length($child) > 0 and count(*[contains($child, name())]) != 0">
-          <xsl:value-of select="true()"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="false()"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
     <xsl:variable name="excluded"
-                  select="(
-                    count($editorConfig/editor/multilingualFields/exclude/name[. = $elementName]) > 0 and
-                    not($editorConfig/editor/multilingualFields/exclude/name[. = $elementName]/@ancestor) and
-                    not($editorConfig/editor/multilingualFields/exclude/name[. = $elementName]/@child) and
-                    not($editorConfig/editor/multilingualFields/exclude/name[. = $elementName]/@parent)) or
-                      $exclusionMatchesAncestor = true() or 
-                      $exclusionMatchesParent = true() or 
-                      $exclusionMatchesChild = true() or
-                      count(gco:Boolean) > 0"/>
+                  select="gn-fn-iso19139:isNotMultilingualField(., $editorConfig)"/>
 
     <xsl:variable name="hasPTFreeText"
                   select="count(gmd:PT_FreeText) > 0"/>
@@ -246,9 +195,10 @@
     <xsl:variable name="monoLingualValue" select="gco:CharacterString|gco:Integer|gco:Decimal|
       gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
       gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|gco:LocalName"/>
-    <xsl:variable name="theElement" select="if ($isMultilingualElement and $hasOnlyPTFreeText or not($monoLingualValue))
-      then gmd:PT_FreeText
-      else $monoLingualValue"/>
+    <xsl:variable name="theElement"
+                  select="if ($isMultilingualElement and $hasOnlyPTFreeText or not($monoLingualValue))
+                          then gmd:PT_FreeText
+                          else $monoLingualValue"/>
     <!--
       This may not work if node context is lost eg. when an element is rendered
       after a selection with copy-of.
@@ -294,12 +244,16 @@
       <xsl:if test="$isMultilingualElement">
 
         <values>
-          <!-- Or the PT_FreeText element matching the main language -->
+          <!--
+          CharacterString is not edited anymore, but it's PT_FreeText
+          counterpart is.
+
+          Or the PT_FreeText element matching the main language
           <xsl:if test="gco:CharacterString">
             <value ref="{$theElement/gn:element/@ref}" lang="{$metadataLanguage}">
               <xsl:value-of select="gco:CharacterString"/>
             </value>
-          </xsl:if>
+          </xsl:if>-->
 
           <!-- the existing translation -->
           <xsl:for-each select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString">

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-fn.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-fn.xsl
@@ -24,6 +24,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
                 version="2.0"
                 exclude-result-prefixes="#all">
@@ -58,6 +59,63 @@
     <xsl:variable name="configType" select="$editorConfig/editor/fields/for[@name = $name]/@use"/>
 
     <xsl:value-of select="if ($configType) then $configType else 'select'"/>
+  </xsl:function>
+
+
+
+
+
+  <xsl:function name="gn-fn-iso19139:isNotMultilingualField" as="xs:boolean">
+    <xsl:param name="element" as="node()"/>
+    <xsl:param name="editorConfig" as="node()"/>
+
+    <xsl:variable name="elementName" select="name($element)"/>
+
+    <xsl:variable name="exclusionMatchesParent" as="xs:boolean">
+      <xsl:variable name="parentName"
+                    select="name($element/..)"/>
+
+      <xsl:value-of select="count($editorConfig/editor/multilingualFields/exclude/
+                                  name[. = $elementName]/@parent[. = $parentName]) > 0"/>
+    </xsl:variable>
+
+
+    <xsl:variable name="exclusionMatchesAncestor" as="xs:boolean">
+      <xsl:variable name="ancestorNames"
+                    select="$element/ancestor::*/name()"/>
+
+      <xsl:value-of select="count($editorConfig/editor/multilingualFields/exclude/
+                                  name[. = $elementName]/@ancestor[. = $ancestorNames]) > 0"/>
+    </xsl:variable>
+
+
+    <xsl:variable name="exclusionMatchesChild" as="xs:boolean">
+      <xsl:variable name="childName"
+                    select="name($element/*[1])"/>
+
+      <xsl:value-of select="count($editorConfig/editor/multilingualFields/exclude/
+                                  name[. = $elementName]/@child[. = $childName]) > 0"/>
+    </xsl:variable>
+
+
+
+    <xsl:variable name="excluded"
+                  as="xs:boolean"
+                  select="
+                    count($editorConfig/editor/multilingualFields/exclude/name[. = $elementName and not(@*)]) > 0 or
+                      $exclusionMatchesAncestor = true() or
+                      $exclusionMatchesParent = true() or
+                      $exclusionMatchesChild = true() or
+                      count($element/gco:Boolean) > 0"/>
+
+   <!--
+    <xsl:message>===== elementName <xsl:copy-of select="$elementName"/></xsl:message>
+    <xsl:message>= <xsl:copy-of select="$exclusionMatchesParent"/></xsl:message>
+    <xsl:message>= <xsl:copy-of select="$exclusionMatchesAncestor"/></xsl:message>
+    <xsl:message>= <xsl:copy-of select="$exclusionMatchesChild"/></xsl:message>
+    <xsl:message>= excluded<xsl:copy-of select="$excluded"/></xsl:message>-->
+
+    <xsl:value-of select="$excluded"/>
   </xsl:function>
 
 

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -26,13 +26,16 @@
                 xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
                 xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:java="java:org.fao.geonet.util.XslUtil"
                 version="2.0" exclude-result-prefixes="#all">
 
   <xsl:include href="../iso19139/convert/functions.xsl"/>
   <xsl:include href="../iso19139/convert/thesaurus-transformation.xsl"/>
+  <xsl:include href="layout/utility-fn.xsl"/>
 
   <xsl:variable name="serviceUrl" select="/root/env/siteURL"/>
 
@@ -40,16 +43,39 @@
   <xsl:variable name="isSDS"
                 select="count(//gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gmx:Anchor[starts-with(@xlink:href, 'http://inspire.ec.europa.eu/metadata-codelist/Category')]) = 1"/>
 
-  <!-- ================================================================= -->
+
+  <!-- The default language is also added as gmd:locale
+  for multilingual metadata records. -->
+  <xsl:variable name="mainLanguage"
+                select="/root/*/gmd:language/gco:CharacterString/text|
+                        /root/*/gmd:language/gmd:LanguageCode/@codeListValue"/>
+
+  <xsl:variable name="isMultilingual"
+                select="count(/root/*/gmd:locale[*/gmd:languageCode/*/@codeListValue != $mainLanguage]) > 0"/>
+
+  <xsl:variable name="mainLanguageId"
+                select="upper-case(java:twoCharLangCode($mainLanguage))"/>
+
+  <xsl:variable name="defaultEncoding"
+                select="'utf8'"/>
+
+  <xsl:variable name="editorConfig"
+                select="document('layout/config-editor.xml')"/>
+
+  <xsl:variable name="nonMultilingualFields"
+                select="$editorConfig/editor/multilingualFields/exclude"/>
+
+
 
   <xsl:template match="/root">
     <xsl:apply-templates select="*:MD_Metadata"/>
   </xsl:template>
 
-  <!-- ================================================================= -->
+
 
   <xsl:template match="gmd:MD_Metadata">
     <xsl:copy>
+      <xsl:namespace name="xsi" select="'http://www.w3.org/2001/XMLSchema-instance'"/>
       <xsl:apply-templates select="@*"/>
 
       <gmd:fileIdentifier>
@@ -70,20 +96,62 @@
           </gmd:parentIdentifier>
         </xsl:when>
         <xsl:when test="gmd:parentIdentifier">
-          <xsl:copy-of select="gmd:parentIdentifier"/>
+          <xsl:apply-templates select="gmd:parentIdentifier"/>
         </xsl:when>
       </xsl:choose>
-      <xsl:apply-templates
-        select="node()[not(self::gmd:language) and not(self::gmd:characterSet)]"/>
+
+      <xsl:apply-templates select="
+        gmd:hierarchyLevel|
+        gmd:hierarchyLevelName|
+        gmd:contact|
+        gmd:dateStamp|
+        gmd:metadataStandardName|
+        gmd:metadataStandardVersion|
+        gmd:dataSetURI"/>
+
+      <!-- Copy existing locales and create an extra one for the default metadata language. -->
+      <xsl:if test="$isMultilingual">
+        <xsl:apply-templates select="gmd:locale[*/gmd:languageCode/*/@codeListValue != $mainLanguage]"/>
+        <gmd:locale>
+          <gmd:PT_Locale id="{$mainLanguageId}">
+            <gmd:languageCode>
+              <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/"
+                                codeListValue="{$mainLanguage}"/>
+            </gmd:languageCode>
+            <gmd:characterEncoding>
+              <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                       codeListValue="{$defaultEncoding}"/>
+            </gmd:characterEncoding>
+          </gmd:PT_Locale>
+        </gmd:locale>
+      </xsl:if>
+
+      <xsl:apply-templates select="
+        gmd:spatialRepresentationInfo|
+        gmd:referenceSystemInfo|
+        gmd:metadataExtensionInfo|
+        gmd:identificationInfo|
+        gmd:contentInfo|
+        gmd:distributionInfo|
+        gmd:dataQualityInfo|
+        gmd:portrayalCatalogueInfo|
+        gmd:metadataConstraints|
+        gmd:applicationSchemaInfo|
+        gmd:metadataMaintenance|
+        gmd:series|
+        gmd:describes|
+        gmd:propertyType|
+        gmd:featureType|
+        gmd:featureAttribute"/>
+
+      <!-- Handle ISO profiles extensions. -->
+      <xsl:apply-templates select="
+        *[namespace-uri()!='http://www.isotc211.org/2005/gmd' and
+          namespace-uri()!='http://www.isotc211.org/2005/srv']"/>
     </xsl:copy>
   </xsl:template>
 
 
-  <!-- ================================================================= -->
-  <!-- Do not process MD_Metadata header generated by previous template  -->
-
-  <xsl:template match="gmd:MD_Metadata/gmd:fileIdentifier|gmd:MD_Metadata/gmd:parentIdentifier"
-                priority="10"/>
 
   <!-- ================================================================= -->
 
@@ -169,9 +237,11 @@
 
   <!-- ================================================================= -->
 
-  <xsl:template match="*[gco:CharacterString]">
+  <xsl:template match="*[gco:CharacterString|gmd:PT_FreeText]">
     <xsl:copy>
-      <xsl:apply-templates select="@*[not(name()='gco:nilReason')]"/>
+      <xsl:apply-templates select="@*[not(name() = 'gco:nilReason') and not(name() = 'xsi:type')]"/>
+
+      <!-- Add nileason if text is empty -->
       <xsl:choose>
         <xsl:when test="normalize-space(gco:CharacterString)=''">
           <xsl:attribute name="gco:nilReason">
@@ -187,7 +257,60 @@
           <xsl:copy-of select="@gco:nilReason"/>
         </xsl:when>
       </xsl:choose>
-      <xsl:apply-templates select="node()"/>
+
+
+      <!-- For multilingual records, for multilingual fields,
+       create a gco:CharacterString containing
+       the same value as the default language PT_FreeText.
+      -->
+      <xsl:variable name="element" select="name()"/>
+
+
+      <xsl:variable name="excluded"
+                    select="gn-fn-iso19139:isNotMultilingualField(., $editorConfig)"/>
+      <xsl:choose>
+        <xsl:when test="not($isMultilingual) or
+                        $excluded">
+          <!-- Copy what's in here ... probably only a gco:CharacterString -->
+          <xsl:apply-templates select="node()"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- Add xsi:type for multilingual element. -->
+          <xsl:attribute name="xsi:type" select="'gmd:PT_FreeText_PropertyType'"/>
+
+          <!-- Is the default language value set in a PT_FreeText ? -->
+          <xsl:variable name="isInPTFreeText"
+                        select="count(gmd:PT_FreeText/*/gmd:LocalisedCharacterString[
+                                            @locale = concat('#', $mainLanguageId)]) = 1"/>
+
+
+          <xsl:choose>
+            <xsl:when test="$isInPTFreeText">
+              <!-- Update gco:CharacterString to contains
+                   the default language value from the PT_FreeText.
+                   PT_FreeText takes priority. -->
+              <gco:CharacterString>
+                <xsl:value-of select="gmd:PT_FreeText/*/gmd:LocalisedCharacterString[
+                                            @locale = concat('#', $mainLanguageId)]/text()"/>
+              </gco:CharacterString>
+              <xsl:apply-templates select="gmd:PT_FreeText"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <!-- Populate PT_FreeText for default language if not existing. -->
+              <xsl:apply-templates select="gco:CharacterString"/>
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">
+                    <xsl:value-of select="gco:CharacterString"/>
+                  </gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+
+                <xsl:apply-templates select="gmd:PT_FreeText/gmd:textGroup"/>
+              </gmd:PT_FreeText>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:copy>
   </xsl:template>
 


### PR DESCRIPTION
Currently multilingual metadata records in ISO19139, encode translation using the following form (a):

```
<gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
  <gco:CharacterString>Carte indicative des dangers eaux</gco:CharacterString>
  <gmd:PT_FreeText>
    <gmd:textGroup>
      <gmd:LocalisedCharacterString locale="#EN">Water risk information map</gmd:LocalisedCharacterString>
    </gmd:textGroup>
```

Another XSD valid encoding (b) would be to use only PT_FreeText:
```
<gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
  <gmd:PT_FreeText>
     <gmd:textGroup>
      <gmd:LocalisedCharacterString locale="#FR">Carte indicative des dangers eaux</gmd:LocalisedCharacterString>
    </gmd:textGroup>
    <gmd:textGroup>
      <gmd:LocalisedCharacterString locale="#EN">Water risk information map</gmd:LocalisedCharacterString>
    </gmd:textGroup>
```

For compatibility with validation rules (and external validator like INSPIRE one), the following encoding (c) is proposed:
```
<gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
  <gco:CharacterString>Carte indicative des dangers eaux</gco:CharacterString>
  <gmd:PT_FreeText>
     <gmd:textGroup>
      <gmd:LocalisedCharacterString locale="#FR">Carte indicative des dangers eaux</gmd:LocalisedCharacterString>
    </gmd:textGroup>
    <gmd:textGroup>
      <gmd:LocalisedCharacterString locale="#EN">Water risk information map</gmd:LocalisedCharacterString>
    </gmd:textGroup>
```

This change in encoding is made for the following reasons:
* Subtemplates currently do not support multilingualism. In order to add that feature (future proposal coming), the use of only PT_FreeText is required (because subtemplate can not define the languages they are in).

* INSPIRE validator does not handle records with only PT_FreeText even if it is valid from an XSD point of view. Validator report empty elements. To preserve compatibility with those system, the encoding (c) is used.

Changes:
* For multilingual record, default language is added to list of locales (with an ID which is used in PT_FreeText)
* For all multilingual element (using the editor config), create a gco:CharacterString and a PT_FreeText element containing the default language value
* config-editor.xsd / Add missing elements in schema added for multilingual exclusion in (https://github.com/geonetwork/core-geonetwork/commit/59bc2df49c2568edecdab68c0d9db45e44890a3f)

Note:
* In the editor / XML view, gco:CharacterString are displayed. We could warn user that in case of multilingual record, PT_FreeText elements take priority over gco:CharacterString for advanced user using the XML mode.

Previous implementation:
* geocat.ch https://github.com/geoadmin/geocat/blob/geocat_develop/web/src/main/webapp/xsl/characterstring-to-localisedcharacterstring.xsl

Related issue:
* Fix https://github.com/geonetwork/core-geonetwork/issues/1985
* ISO19139.che / Also implement this mechanism for che:PT_FreeURL
* ISO19115-3 / Plugin needs update for this