### PR TITLE
Subtemplate validation service

### DIFF
--- a/common/src/main/java/org/fao/geonet/exceptions/BadParameterEx.java
+++ b/common/src/main/java/org/fao/geonet/exceptions/BadParameterEx.java
@@ -38,6 +38,10 @@ public class BadParameterEx extends BadInputEx {
 
         id = "bad-parameter";
     }
+
+    public BadParameterEx(String msg) {
+        super(msg, null);
+    }
 }
 
 //=============================================================================

--- a/core/src/test/resources/WEB-INF/config-lucene.xml
+++ b/core/src/test/resources/WEB-INF/config-lucene.xml
@@ -125,7 +125,6 @@
       <field name="_valid_schematron-rules-iso" tagName="valid_schematron-rules-iso"/>
       <field name="_valid_schematron-rules-inspire" tagName="valid_schematron-rules-inspire"/>
       <field name="_valid_xsd" tagName="valid_xsd"/>
-      <field name="_valid_subtemplate" tagName="valid_subtemplate"/>
       <field name="_selected" tagName="selected"/>
       <field name="_source" tagName="source"/>
       <field name="_edit" tagName="edit"/>

--- a/core/src/test/resources/WEB-INF/config-lucene.xml
+++ b/core/src/test/resources/WEB-INF/config-lucene.xml
@@ -125,6 +125,7 @@
       <field name="_valid_schematron-rules-iso" tagName="valid_schematron-rules-iso"/>
       <field name="_valid_schematron-rules-inspire" tagName="valid_schematron-rules-inspire"/>
       <field name="_valid_xsd" tagName="valid_xsd"/>
+      <field name="_valid_subtemplate" tagName="valid_subtemplate"/>
       <field name="_selected" tagName="selected"/>
       <field name="_source" tagName="source"/>
       <field name="_edit" tagName="edit"/>

--- a/core/src/test/resources/org/fao/geonet/kernel/sub-OnlineResource.xml
+++ b/core/src/test/resources/org/fao/geonet/kernel/sub-OnlineResource.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<gmd:MD_Distribution xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                     xmlns:gco="http://www.isotc211.org/2005/gco"
+>
+  <gmd:transferOptions>
+    <gmd:MD_DigitalTransferOptions>
+      <gmd:onLine>
+        <gmd:CI_OnlineResource>
+          <gmd:linkage>
+            <gmd:URL>Website URL</gmd:URL>
+          </gmd:linkage>
+          <gmd:protocol>
+            <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+          </gmd:protocol>
+          <gmd:name>
+            <gco:CharacterString/>
+          </gmd:name>
+          <gmd:description>
+            <gco:CharacterString>Website description</gco:CharacterString>
+          </gmd:description>
+        </gmd:CI_OnlineResource>
+      </gmd:onLine>
+      <gmd:onLine>
+        <gmd:CI_OnlineResource>
+          <gmd:linkage>
+            <gmd:URL/>
+          </gmd:linkage>
+          <gmd:protocol>
+            <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+          </gmd:protocol>
+          <gmd:name>
+            <gco:CharacterString/>
+          </gmd:name>
+          <gmd:description>
+            <gco:CharacterString>Short description of the data</gco:CharacterString>
+          </gmd:description>
+        </gmd:CI_OnlineResource>
+      </gmd:onLine>
+      <gmd:onLine>
+        <gmd:CI_OnlineResource>
+          <gmd:linkage>
+            <gmd:URL>http://serverIP/cgi-bin/wms?map=/directory/file.map</gmd:URL>
+          </gmd:linkage>
+          <gmd:protocol>
+            <gco:CharacterString>OGC:WMS-1.1.1-http-get-map</gco:CharacterString>
+          </gmd:protocol>
+          <gmd:name>
+            <gco:CharacterString>name_of_data_in_the_map_file</gco:CharacterString>
+          </gmd:name>
+          <gmd:description>
+            <gco:CharacterString>Short description of the data</gco:CharacterString>
+          </gmd:description>
+        </gmd:CI_OnlineResource>
+      </gmd:onLine>
+    </gmd:MD_DigitalTransferOptions>
+  </gmd:transferOptions>
+</gmd:MD_Distribution>

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
@@ -156,10 +156,10 @@ public class MetadataValidateApi {
         boolean isSubtemplate = metadata.getDataInfo().getType() == MetadataType.SUB_TEMPLATE;
         boolean validSet = (isvalid != null);
         if (!isSubtemplate && validSet) {
-            throw new BadParameterEx("Parameter isvalid can't be set if it is not a Subtemplate. You cannot force validation of a metadata or a template.", isvalid);
+            throw new BadParameterEx("Parameter isvalid can't be set if it is not a Subtemplate. You cannot force validation of a metadata or a template.");
         }
         if (isSubtemplate && !validSet) {
-            throw new BadParameterEx("Parameter isvalid MUST be set for subtemplate.", isvalid);
+            throw new BadParameterEx("Parameter isvalid MUST be set for subtemplate.");
         }
         if (isSubtemplate) {
             MetadataValidation metadataValidation = new MetadataValidation().

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
@@ -24,23 +24,33 @@
 package org.fao.geonet.api.records;
 
 import com.google.common.collect.Lists;
-
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import jeeves.server.context.ServiceContext;
+import jeeves.services.ReadWriteController;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.records.editing.AjaxEditUtils;
 import org.fao.geonet.api.records.model.validation.Reports;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.*;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.MetadataValidation;
+import org.fao.geonet.domain.MetadataValidationId;
+import org.fao.geonet.domain.MetadataValidationStatus;
+import org.fao.geonet.domain.Schematron;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.repository.MetadataValidationRepository;
 import org.fao.geonet.repository.SchematronRepository;
-import org.fao.geonet.api.records.editing.AjaxEditUtils;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Document;
@@ -51,11 +61,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import springfox.documentation.annotations.ApiIgnore;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,13 +81,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
-import jeeves.server.context.ServiceContext;
-import jeeves.services.ReadWriteController;
-import springfox.documentation.annotations.ApiIgnore;
 
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
@@ -123,10 +133,10 @@ public class MetadataValidateApi {
         @PathVariable
             String metadataUuid,
         @ApiParam(
-            value = "Validation status. Should be provided only in case of SUBTEMPLATE validation. If provided for another type, throw ",
+            value = "Validation status. Should be provided only in case of SUBTEMPLATE validation. If provided for another type, throw a BadParameter Exception",
             required = false)
         @RequestParam (required = false)
-            boolean isvalid,
+            Boolean isvalid,
         HttpServletRequest request,
         @ApiParam(hidden = true)
         @ApiIgnore
@@ -143,15 +153,23 @@ public class MetadataValidateApi {
 
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
 
-        // Valid a subtemplate
-        if(metadata.getDataInfo().getType() == MetadataType.SUB_TEMPLATE) {
+        boolean isSubtemplate = metadata.getDataInfo().getType() == MetadataType.SUB_TEMPLATE;
+        boolean validSet = (isvalid != null);
+        if (!isSubtemplate && validSet) {
+            throw new BadParameterEx("Parameter isvalid can't be set if it is not a Subtemplate. You cannot force validation of a metadata or a template.", isvalid);
+        }
+        if (isSubtemplate && !validSet) {
+            throw new BadParameterEx("Parameter isvalid MUST be set for subtemplate.", isvalid);
+        }
+        if (isSubtemplate) {
             MetadataValidation metadataValidation = new MetadataValidation().
                     setId(new MetadataValidationId(metadata.getId(), "subtemplate")).
                     setStatus(isvalid ? MetadataValidationStatus.VALID : MetadataValidationStatus.INVALID).
-                    setRequired(false).
+                    setRequired(true).
                     setNumTests(0).
                     setNumFailures(0);
             this.metadataValidationRepository.save(metadataValidation);
+            dataManager.indexMetadata(("" + metadata.getId()), true);
             return new Reports();
         }
 

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataValidateApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataValidateApiTest.java
@@ -1,0 +1,230 @@
+package org.fao.geonet.api.records;
+
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.AbstractCoreIntegrationTest;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.MetadataValidation;
+import org.fao.geonet.domain.MetadataValidationStatus;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.search.MetaSearcher;
+import org.fao.geonet.kernel.search.SearchManager;
+import org.fao.geonet.kernel.search.SearcherType;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.MetadataValidationRepository;
+import org.fao.geonet.repository.SourceRepository;
+import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.net.URL;
+import java.util.List;
+import java.util.UUID;
+
+import static junit.framework.Assert.assertEquals;
+import static org.fao.geonet.domain.MetadataValidationStatus.VALID;
+import static org.fao.geonet.kernel.UpdateDatestamp.NO;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
+    private static final int SUBTEMPLATE_TEST_OWNER = 42;
+    public static final String REQ_VALID_PARAM = "isvalid";
+    @Autowired
+    private WebApplicationContext wac;
+    @Autowired
+    private SchemaManager schemaManager;
+    @Autowired
+    private DataManager dataManager;
+    @Autowired
+    private SourceRepository sourceRepository;
+    @Autowired
+    private MetadataRepository metadataRepository;
+    @Autowired
+    MetadataValidationRepository metadataValidationRepository;
+    @Autowired
+    private SearchManager searchManager;
+
+    @Test
+    public void subTemplateValidIsTrue() throws Exception {
+        Metadata subTemplate = subTemplateOnLineResourceDbInsert();
+
+        MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAsAdmin();
+
+        toTest.perform(put("/api/records/" + subTemplate.getUuid() + "/validate")
+                .param(REQ_VALID_PARAM, "true")
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.report").value(hasSize(0)));
+
+        List<MetadataValidation> validations = metadataValidationRepository.findAllById_MetadataId(subTemplate.getId());
+        assertEquals(1, validations.size());
+        assertEquals(VALID, validations.get(0).getStatus());
+        assertEquals(1, countTemplateIndexed(subTemplate.getUuid(), "1"));
+    }
+
+    @Test
+    public void subTemplateValidIsFalse() throws Exception {
+        Metadata subTemplate = subTemplateOnLineResourceDbInsert();
+
+        MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAsAdmin();
+
+        toTest.perform(put("/api/records/" + subTemplate.getUuid() + "/validate")
+                .param(REQ_VALID_PARAM, "false")
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.report").value(hasSize(0)));
+
+        List<MetadataValidation> validations = metadataValidationRepository.findAllById_MetadataId(subTemplate.getId());
+        assertEquals(1, validations.size());
+        assertEquals(MetadataValidationStatus.INVALID, validations.get(0).getStatus());
+        assertEquals(1, countTemplateIndexed(subTemplate.getUuid(), "0"));
+    }
+
+    @Test
+    public void subTemplateValidIsNotSet() throws Exception {
+        Metadata subTemplate = subTemplateOnLineResourceDbInsert();
+
+        MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAsAdmin();
+
+        toTest.perform(put("/api/records/" + subTemplate.getUuid() + "/validate")
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("BadParameterEx"))
+                .andExpect(jsonPath("$.description").value("<Null> is not a valid value for: isvalid"));
+
+        List<MetadataValidation> validations = metadataValidationRepository.findAllById_MetadataId(subTemplate.getId());
+        assertEquals(0, validations.size());
+        assertEquals(1, countTemplateIndexed(subTemplate.getUuid(), "-1"));
+    }
+
+    @Test
+    public void subTemplateValidIsTrueButNotLoggedAsAdmin() throws Exception {
+        Metadata subTemplate = subTemplateOnLineResourceDbInsert();
+
+        MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAsAnonymous();
+
+        toTest.perform(put("/api/records/" + subTemplate.getUuid() + "/validate")
+                .param(REQ_VALID_PARAM, "true")
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("SecurityException"));
+
+        List<MetadataValidation> validations = metadataValidationRepository.findAllById_MetadataId(subTemplate.getId());
+        assertEquals(0, validations.size());
+        loginAsAdmin();
+        assertEquals(1, countTemplateIndexed(subTemplate.getUuid(), "-1"));
+    }
+
+    @Test
+    public void subTemplateValidSetButTemplate() throws Exception {
+        Metadata subTemplate = subTemplateOnLineResourceDbInsertAsMetadata();
+
+        MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAsAdmin();
+
+        toTest.perform(put("/api/records/" + subTemplate.getUuid() + "/validate")
+                .param(REQ_VALID_PARAM, "true")
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("BadParameterEx"))
+                .andExpect(jsonPath("$.description").value("<not Null for not subTemplate> is not a valid value for: isvalid"));
+
+        List<MetadataValidation> validations = metadataValidationRepository.findAllById_MetadataId(subTemplate.getId());
+        assertEquals(0, validations.size());
+        assertEquals(1, countTemplateIndexed(subTemplate.getUuid(), "-1", "n"));
+    }
+
+    private ServiceContext context;
+
+    @Before
+    public void setUp() throws Exception {
+        this.context = createServiceContext();
+    }
+
+    private Metadata subTemplateOnLineResourceDbInsert() throws Exception {
+        return subTemplateOnLineResourceDbInsert(MetadataType.SUB_TEMPLATE);
+    }
+
+    private Metadata subTemplateOnLineResourceDbInsertAsMetadata() throws Exception {
+        return subTemplateOnLineResourceDbInsert(MetadataType.METADATA);
+    }
+
+    private Metadata subTemplateOnLineResourceDbInsert(MetadataType type) throws Exception {
+        loginAsAdmin(context);
+
+        URL resource = AbstractCoreIntegrationTest.class.getResource("kernel/sub-OnlineResource.xml");
+        Element sampleMetadataXml = Xml.loadStream(resource.openStream());
+
+        Metadata metadata = new Metadata()
+                .setDataAndFixCR(sampleMetadataXml)
+                .setUuid(UUID.randomUUID().toString());
+        metadata.getDataInfo()
+                .setRoot(sampleMetadataXml.getQualifiedName())
+                .setSchemaId(schemaManager.autodetectSchema(sampleMetadataXml))
+                .setType(type)
+                .setPopularity(1000);
+        metadata.getSourceInfo()
+                .setOwner(SUBTEMPLATE_TEST_OWNER)
+                .setSourceId(sourceRepository.findAll().get(0).getUuid());
+        metadata.getHarvestInfo()
+                .setHarvested(false);
+
+        Metadata dbInsertedMetadata = dataManager.insertMetadata(
+                context,
+                metadata,
+                sampleMetadataXml,
+                false,
+                false,
+                false,
+                NO,
+                false,
+                false);
+
+        dataManager.indexMetadata("" + dbInsertedMetadata.getId(), true);
+        assertEquals(1, countTemplateIndexed(dbInsertedMetadata.getUuid(), "-1", type == MetadataType.SUB_TEMPLATE ? "s" : "n"));
+        return dbInsertedMetadata;
+    }
+
+    private int countTemplateIndexed(String uuid, String validStatus) throws Exception {
+        return countTemplateIndexed(uuid, validStatus, "s");
+    }
+
+    private int countTemplateIndexed(String uuid, String validStatus, String type) throws Exception {
+        MetaSearcher searcher = searchManager.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE);
+        Element request = new Element("request")
+                .addContent(new Element(Geonet.IndexFieldNames.UUID).setText(uuid))
+                .addContent(new Element(Geonet.IndexFieldNames.IS_TEMPLATE).setText(type))
+                .addContent(new Element(Geonet.IndexFieldNames.VALID).setText(validStatus));
+        searcher.search(context, request, new ServiceConfig());
+        return searcher.getSize();
+    }
+}

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataValidateApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataValidateApiTest.java
@@ -114,7 +114,7 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value("BadParameterEx"))
-                .andExpect(jsonPath("$.description").value("<Null> is not a valid value for: isvalid"));
+                .andExpect(jsonPath("$.description").value("Parameter isvalid MUST be set for subtemplate."));
 
         List<MetadataValidation> validations = metadataValidationRepository.findAllById_MetadataId(subTemplate.getId());
         assertEquals(0, validations.size());
@@ -156,7 +156,7 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value("BadParameterEx"))
-                .andExpect(jsonPath("$.description").value("<not Null for not subTemplate> is not a valid value for: isvalid"));
+                .andExpect(jsonPath("$.description").value("Parameter isvalid can't be set if it is not a Subtemplate. You cannot force validation of a metadata or a template."));
 
         List<MetadataValidation> validations = metadataValidationRepository.findAllById_MetadataId(subTemplate.getId());
         assertEquals(0, validations.size());


### PR DESCRIPTION
This PR allow manual validation of a subtemplate.

Validation of a subtemplate does not follow validation rules as for metadata and templates. It is done manually by the administrator who set it to `true` or `false`.

The metadatavalidate service has been updated to receive a `isvalid` param to validate only a subtemplate.

The validation will be set in the directory manager and will provide information about the state of a subtemplate to the users.

Thanks @cmangeat for contribution.