### PR TITLE
ISO19139 / On import update old style links to graphic overview and online resources.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -31,6 +31,7 @@ import jeeves.server.context.ServiceContext;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.MetadataResourceDatabaseMigration;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
@@ -122,6 +123,7 @@ public class Importer {
                                         final Path mefFile) throws Exception {
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         final DataManager dm = applicationContext.getBean(DataManager.class);
+        final SettingManager sm = applicationContext.getBean(SettingManager.class);
 
         // Load preferred schema and set to iso19139 by default
         String preferredSchema = applicationContext.getBean(ServiceConfig.class).getValue("preferredSchema", "iso19139");
@@ -182,6 +184,7 @@ public class Importer {
 
                 Element metadataValidForImport;
 
+
                 Map<String, Pair<String, Element>> mdFiles = new HashMap<String, Pair<String, Element>>();
                 for (Path file : metadataXmlFiles) {
                     if (file != null && java.nio.file.Files.isRegularFile(file)) {
@@ -195,6 +198,7 @@ public class Importer {
                             }
 
                             String currFile = "Found metadata file " + file.getParent().getParent().relativize(file);
+
                             mdFiles.put(metadataSchema, Pair.read(currFile, metadata));
 
                         } catch (NoSchemaMatchesException e) {
@@ -382,6 +386,15 @@ public class Importer {
                     }
                     rating = general.getChildText("rating");
                     popularity = general.getChildText("popularity");
+                }
+
+                if (schema.startsWith("iso19139")) {
+                    // In GeoNetwork 3.x, links to resources changed:
+                    // * thumbnails contains full URL instead of file name only
+                    // * API mode change old URL structure.
+                    MetadataResourceDatabaseMigration.updateMetadataResourcesLink(
+                        metadata, null, sm
+                    );
                 }
 
                 if (validate) {

--- a/services/src/test/resources/org/fao/geonet/api/records/attachments/record-with-old-links.xml
+++ b/services/src/test/resources/org/fao/geonet/api/records/attachments/record-with-old-links.xml
@@ -142,7 +142,7 @@
         <gmd:MD_BrowseGraphic>
           <gmd:fileName>
             <gco:CharacterString>
-              http://apps.titellus.net/geonetwork/srv/eng/resources.get?uuid=da165110-88fd-11da-a88f-000d939bc5d8&amp;fname=thumbnail_s.gif
+              thumbnail_s.gif
             </gco:CharacterString>
           </gmd:fileName>
           <gmd:fileDescription>
@@ -162,7 +162,7 @@
             </gco:CharacterString>
           </gmd:fileName>
           <gmd:fileDescription>
-            <gco:CharacterString>thumbnail</gco:CharacterString>
+            <gco:CharacterString>large_thumbnail</gco:CharacterString>
           </gmd:fileDescription>
           <gmd:fileType>
             <gco:CharacterString>gif</gco:CharacterString>
@@ -180,6 +180,24 @@
               <gmd:linkage>
                 <gmd:URL>
                   http://localhost:8080/geonetwork/srv/en/resources.get?uuid=da165110-88fd-11da-a88f-000d939bc5d8&amp;fname=basins.zip&amp;access=private
+                </gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>basins.zip</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Hydrological basins in Africa (Shapefile Format)
+                </gco:CharacterString>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine> <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>
+                  https://tc-geocat.int.bgdi.ch:443/geonetwork/srv/eng//resources.get?uuid=a8f15104-30aa-4c8d-805d-994243154410&amp;fname=canalisations_gaz.jpg
                 </gmd:URL>
               </gmd:linkage>
               <gmd:protocol>


### PR DESCRIPTION


* Fix Importing MEF file with thumbnails doesn't set the proper url in the xml used since 3.2.x #1730
* Fix links which may have been containing "//"