### PR TITLE
Minor Directory UI improvements following suggestions

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -50,16 +50,18 @@
     'gnCurrentEdit',
     'gnMetadataManager',
     'gnGlobalSettings',
+    'gnConfig',
     function($scope, $routeParams, $http,
         $rootScope, $translate, $compile,
-            gnSearchManagerService,
-            gnUtilityService,
-            gnEditor,
-            gnUrlUtils,
-            gnCurrentEdit,
-            gnMetadataManager,
-            gnGlobalSettings) {
-
+        gnSearchManagerService,
+        gnUtilityService,
+        gnEditor,
+        gnUrlUtils,
+        gnCurrentEdit,
+        gnMetadataManager,
+        gnGlobalSettings,
+        gnConfig) {
+      $scope.gnConfig = gnConfig;
       $scope.hasEntries = false;
       $scope.mdList = null;
       $scope.activeType = null;
@@ -157,8 +159,10 @@
             });
           });
 
+        // fetch all entries + templates
+        var entryType = $scope.userCanEditTemplates ? 's or t' : 's';
         gnSearchManagerService.search('qi?_content_type=json&' +
-          'template=s&fast=index&summaryOnly=true&resultType=subtemplates').
+          'template=' + entryType + '&fast=index&summaryOnly=true&resultType=subtemplates').
           then(function(data) {
             $scope.$broadcast('setPagination', $scope.paginationInfo);
             $scope.mdList = data;

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -141,6 +141,8 @@ input[type=text], input[type=number], select {
   }
 
   .directory-entries-list {
+    margin: 0 1em;
+
     & > li {
       display: flex;
       flex-direction: column;
@@ -778,9 +780,9 @@ gn-md-type-widget {
 
   & > div {
     border-radius: 1000px;
-    width: 2em;
-    height: 2em;
-    line-height: 2.1em;
+    width: 1.8em;
+    height: 1.8em;
+    line-height: 2em;
     text-align: center;
     font-size: 0.9em;
     position: relative;
@@ -789,7 +791,7 @@ gn-md-type-widget {
     background-color: @gray-light;
 
     &.valid-status-1 {
-      background-color: @btn-warning-bg;
+      background-color: @gray-light;
     }
     &.valid-status0 {
       background-color: @btn-danger-bg;

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -23,13 +23,15 @@
           data-toggle="dropdown">
           <i class="caret"/>
         </button>
-        <ul class="dropdown-menu pull-right" role="menu">
-          <li class="dropdown-header text-left" translate
+        <ul class="dropdown-menu pull-right text-left" role="menu">
+          <li class="dropdown-header" translate
             ng-repeat-start="(typeName, templates) in templates | groupBy: 'root'">
             {{typeName}}</li>
           <li ng-repeat="t in templates" ng-repeat-end>
             <a href ng-click="createFromTemplate(t)">
-              {{t.title || t.defaultTitle}}</a>
+              <i class="fa fa-fw fa-bookmark-o"/>&nbsp;
+              {{t.title || t.defaultTitle}}
+            </a>
           </li>
           <li class="divider"/>
           <li><a href translate ng-click="startImporting(false)">
@@ -127,7 +129,12 @@
                 <i class="fa fa-spinner fa-spin" />
               </div>
 
-              <div class="search-options-header" ng-show="!searching">
+              <div translate ng-show="searchResults.count == 0 && !searching"
+                class="text-muted disabled">
+                noRecordFound
+              </div>
+
+              <div class="search-options-header" ng-show="searchResults.count > 0 && !searching">
                 <div data-gn-pagination="paginationInfo"
                      data-hits-values="[20, 50, 100]"></div>
 
@@ -187,14 +194,11 @@
                           <i class="fa fa-ban fa-fw text-danger" />&nbsp;
                           {{'directoryEntryReject' | translate}}</a>
                         </li>
-                        <li><a href ng-click="delEntry(e)">
-                          <i class="fa fa-trash fa-fw" />&nbsp;
-                          {{'delete' | translate}}</a>
-                        </li>
                       </ul>
                     </div>
 
-                    <div class="btn-group">
+                    <div class="btn-group"
+                      ng-if="::gnConfig[gnConfig.key.isXLinkEnabled]">
                       <button class="btn btn-default btn-sm dropdown-toggle"
                         ng-click="e.openAssociatedMD = true"
                         data-toggle="dropdown">
@@ -207,6 +211,11 @@
                         </li>
                       </ul>
                     </div>
+
+                    <button class="btn btn-default btn-sm" ng-click="delEntry(e)"
+                      title="{{'delete' | translate}}">
+                      <i class="fa fa-times text-danger" />
+                    </button>
                   </div>
 
                   <div class="entry-title entry-is-template"
@@ -237,19 +246,22 @@
                           <i class="fa fa-key fa-fw" />&nbsp;
                           {{'directoryEntryPermissions' | translate}}</a>
                         </li>
-                        <li><a href ng-click="delEntry(e)">
-                          <i class="fa fa-trash fa-fw" />&nbsp;
-                          {{'delete' | translate}}</a>
-                        </li>
                       </ul>
                     </div>
+
+                    <button class="btn btn-default btn-sm" ng-click="delEntry(e)"
+                      title="{{'delete' | translate}}">
+                      <i class="fa fa-times text-danger" />
+                    </button>
                   </div>
                 </li>
               </div>
 
-              <div ng-show="!searching">
+              <div class="search-options-header" ng-show="searchResults.count > 0 && !searching">
                 <div data-gn-pagination="paginationInfo"
                      data-hits-values="[20, 50, 100]"></div>
+
+                <div class="flex-spacer"></div>
               </div>
             </div>
           </div>
@@ -437,7 +449,9 @@
       </div>
     </div>
 
-    <div class="col-sm-12 col-md-4" ng-show="currentEditorAction === 'editEntry'">
+    <div class="col-sm-12 col-md-4"
+      ng-if="::gnConfig[gnConfig.key.isXLinkEnabled]"
+      ng-show="currentEditorAction === 'editEntry'">
       <div class="panel-default panel">
         <div class="panel-heading">
           <span translate>directoryEntryAssociatedMetadata</span>


### PR DESCRIPTION
See discussions on https://github.com/geonetwork/core-geonetwork/pull/2045

* Pagination is hidden and a message is given when no entry found
* Fix on entry types not showing if only templates are available
* Separated delete icon & used `fa-times` instead of `fa-trash`
* Do not show "Associated Metadata" menu if XLink resolution is not enabled in app settings
* Improve template dropdown list readability
* Fixed icon colors:
![image](https://user-images.githubusercontent.com/10629150/27725137-4fbec25a-5d75-11e7-9012-8b03345b456d.png)