### PR TITLE
MD editor fix when closing editor

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -445,13 +445,17 @@
         $scope.layout.hideTopToolBar = false;
         // Close the editor tab
         window.onbeforeunload = null;
+
+        // if there is no history, attempt to close tab
+        if (window.history.length == 1) {
+          window.close();
+          // This last point may trigger
+          // "Scripts may close only the windows that were opened by it."
+          // when the editor was not opened by a script.
+        }
+
         // Go to editor home
         $location.path('');
-        // Tentative to close the browser tab
-        window.close();
-        // This last point may trigger
-        // "Scripts may close only the windows that were opened by it."
-        // when the editor was not opened by a script.
       };
 
       $scope.cancel = function(refreshForm) {


### PR DESCRIPTION
When editing a document, click "close" might provoke an unintended and inconsistent behaviour across browsers.

Now the code will only attempt to close the tab if it has no history. Here is a comparison of behaviors across browsers:

Current:

| browser |  close editor (main tab)  |  close editor (new tab) |
| -----------| -----------------------------------------| -------------------------------------------------------------|
| edge / ie 11 |  ask user to confirm tab close | ask user to confirm tab close |
| firefox | go back to editor home | go back to editor home |
| chrome/chromium | go back to editor home | close tab without prompt |

With this PR:

| browser |  close editor (main tab)  |  close editor (new tab) |
| -----------| -----------------------------------------| -------------------------------------------------------------|
| edge / ie 11 |  go back to editor home | ask user to confirm tab close |
| firefox | go back to editor home | go back to editor home |
| chrome/chromium | go back to editor home | close tab without prompt |

This is the best I could do considering tab/window handling is mostly enforced by the browser...