### PR TITLE
Enable custom projection in map viewer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1304,14 +1304,21 @@
               var resolutions = new Array(nbMatrix);
               var matrixIds = new Array(nbMatrix);
 
-              // sort tile resolutions
-              var tileMatrices = matrixSet.TileMatrix.splice(0)
-                .sort(function (a, b) {
-                  var id1 = parseInt(a.Identifier);
-                  var id2 = parseInt(b.Identifier);
-                  return id1 > id2 ? 1 :
-                    (id1 < id2 ? -1 : 0);
-                });
+              // sort tile resolutions if number
+              var tileMatrices;
+              if(matrixSet.TileMatrix.length &&
+                Number.isInteger(matrixSet.TileMatrix[0].Identifier)) {
+                tileMatrices = matrixSet.TileMatrix.splice(0)
+                  .sort(function (a, b) {
+                    var id1 = parseInt(a.Identifier);
+                    var id2 = parseInt(b.Identifier);
+                    return id1 > id2 ? 1 :
+                      (id1 < id2 ? -1 : 0);
+                  });
+              }
+              else {
+                tileMatrices = matrixSet.TileMatrix;
+              }
 
               for (var z = 0; z < nbMatrix; ++z) {
                 var matrix = tileMatrices[z];

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -294,7 +294,7 @@
             resolution >= minResolution) {
           if (src instanceof ol.source.WMTS) {
             encLayer = gnPrint.encoders.layers['WMTS'].call(this,
-                layer, layerConfig);
+                layer, layerConfig, $scope.map);
           } else if (src instanceof ol.source.OSM) {
             encLayer = gnPrint.encoders.layers['OSM'].call(this,
                 layer, layerConfig);
@@ -307,7 +307,7 @@
           } else if (src instanceof ol.source.ImageWMS ||
               src instanceof ol.source.TileWMS) {
             encLayer = gnPrint.encoders.layers['WMS'].call(this,
-                layer, layerConfig);
+                layer, layerConfig, $scope.map);
           } else if (src instanceof ol.source.Vector ||
               src instanceof ol.source.ImageVector) {
             if (src instanceof ol.source.ImageVector) {

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
@@ -38,6 +38,7 @@
     var DPI = 72;
     var MM_PER_INCHES = 25.4;
     var UNITS_RATIO = 39.37;
+    var METERS_PER_DEGREE = 222638.98158654716;
 
     /**
      * Get the map coordinates of the center of the given print rectangle.
@@ -69,8 +70,9 @@
       var s = parseFloat(scale.value);
       var size = layout.map; // papersize in dot!
       var view = map.getView();
-      var center = view.getCenter();
-      var resolution = view.getResolution();
+      var ratio = map.getView().getProjection().getCode() == 'EPSG:4326' ?
+        METERS_PER_DEGREE : 1;
+      var resolution = view.getResolution() * ratio;
       var w = size.width / DPI * MM_PER_INCHES / 1000.0 * s / resolution;
       var h = size.height / DPI * MM_PER_INCHES / 1000.0 * s / resolution;
       var mapSize = map.getSize();
@@ -96,7 +98,9 @@
      */
     this.getOptimalScale = function(map, scales, layout) {
       var size = map.getSize();
-      var resolution = map.getView().getResolution();
+      var ratio = map.getView().getProjection().getCode() == 'EPSG:4326' ?
+        METERS_PER_DEGREE : 1;
+      var resolution = map.getView().getResolution() * ratio;
       var width = resolution * (size[0] - (options.widthMargin * 2));
       var height = resolution * (size[1] - (options.heightMargin * 2));
       var layoutSize = layout.map;

--- a/web-ui/src/main/resources/catalog/components/viewer/localisation/LocalisationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/localisation/LocalisationDirective.js
@@ -88,7 +88,7 @@
                   view.setCenter(center);
                 }
                 moveTo($scope.map, 5, ol.proj.transform(coord,
-                    'EPSG:4326', 'EPSG:3857'));
+                    'EPSG:4326', $scope.map.getView().getProjection()));
                 return;
               }
               var formatter = function(loc) {

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -156,6 +156,14 @@
           if (map.getLayers().getLength() > 0) {
             map.getLayers().removeAt(0);
           }
+          var bgLoadingLayer = new ol.layer.Image({
+            loading: true,
+            label: 'loading',
+            url: '',
+            visible: false
+          });
+          map.getLayers().insertAt(0, bgLoadingLayer);
+
           if (!gnViewerSettings.bgLayers) {
             gnViewerSettings.bgLayers = [];
           }
@@ -191,7 +199,7 @@
 
                     if (!layer.hidden && !isFirstBgLayer) {
                       isFirstBgLayer = true;
-                      map.getLayers().insertAt(0, olLayer);
+                      map.getLayers().setAt(0, olLayer);
                     }
                   }
                 }
@@ -214,7 +222,7 @@
                   var layerIndex = bgLayers.push(loadingLayer);
                   var p = self.createLayer(layer, map, i);
 
-                  (function(idx) {
+                  (function(idx, loadingLayer) {
                     p.then(function(layer) {
                       bgLayers[idx-1] = layer;
 
@@ -225,10 +233,10 @@
                       layer.background = true;
 
                       if(loadingLayer.get('bgLayer')) {
-                        map.getLayers().insertAt(0, layer);
+                        map.getLayers().setAt(0, layer);
                       }
                     });
-                  })(layerIndex);
+                  })(layerIndex, loadingLayer);
                 }
               }
               // WMS layer not in background
@@ -269,11 +277,11 @@
                   var layerIndex = map.getLayers().push(loadingLayer);
                   var p = self.createLayer(layer, map, undefined, i);
 
-                  (function(idx) {
+                  (function(idx, loadingLayer) {
                     p.then(function(layer) {
                       map.getLayers().setAt(idx, layer);
                     });
-                  })(layerIndex);
+                  })(layerIndex, loadingLayer);
                 }
               }
             }

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -114,35 +114,31 @@
           map.removeLayer(layersToRemove[i]);
         }
 
-        // set the General.BoundingBox
+        // -- set the Map view (extent/projection)
         var bbox = context.general.boundingBox.value;
         var ll = bbox.lowerCorner;
         var ur = bbox.upperCorner;
         var projection = bbox.crs;
 
-        if (projection == 'EPSG:4326') {
-          ll.reverse();
-          ur.reverse();
-        }
         var extent = ll.concat(ur);
-        // reproject in case bbox's projection doesn't match map's projection
-        extent = ol.proj.transformExtent(extent,
-            projection, map.getView().getProjection());
-
-        extent = gnMap.secureExtent(extent, map.getView().getProjection());
-
-        // store the extent into view settings so that it can be used later in
-        // case the map is not visible yet
         gnViewerSettings.initialExtent = extent;
+
+        // save this extent for later use (for example if the map
+        // is not currently visible)
+        map.set('lastExtent', extent);
+
+        if(map.getView().getProjection().getCode() != projection) {
+          var view = new ol.View({
+            extent: extent,
+            projection: projection
+          });
+          map.setView(view);
+        }
 
         // $timeout used to avoid map no rendered (eg: null size)
         $timeout(function() {
           map.getView().fit(extent, map.getSize(), { nearest: true });
         }, 0, false);
-
-        // save this extent for later use (for example if the map
-        // is not currently visible)
-        map.set('lastExtent', extent);
 
         // load the resources & add additional layers if available
         var layers = context.resourceList.layer;

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -328,7 +328,7 @@
               $.ajax(blobURL).then(function(response) {
                 var format = new ol.format.KML();
                 var features = format.readFeatures(response, {
-                  featureProjection: 'EPSG:3857'
+                  featureProjection: scope.map.getView().getProjection()
                 });
                 source.addFeatures(features);
               });


### PR DESCRIPTION
This PR enables support of other projection than `EPSG:3857`.
The active projection will be the one detected in the owscontext.

A context like:
```xml
    <ows-context:General>
        <ows:BoundingBox crs="EPSG:4326">
            <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
            <ows:UpperCorner>180.0 90.0</ows:UpperCorner>
        </ows:BoundingBox>
    </ows-context:General>
```
will load the map viewer in `EPSG:4326`.

- [x] Remove hardcode projections
- [x] Switch projection from owscontext loading
- [x] Update print to manage custom projection
