### PR TITLE
[WIP] - Add Oceanotron support

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -129,6 +129,7 @@
 
         }.bind(this));
 
+    return this.promise;
   };
 
   geonetwork.GnFeaturesGFILoader.prototype.getBsTableConfig = function() {

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsDirective.js
@@ -121,9 +121,10 @@
                 function(evt) {
 
                   var url;
+                  var coordinates = evt.feature.getGeometry().getCoordinates();
                   if (activeTool == 'time') {
                     url = scope.layer.getSource().getGetFeatureInfoUrl(
-                        evt.feature.getGeometry().getCoordinates(),
+                        coordinates,
                         map.getView().getResolution(),
                         map.getView().getProjection(), {
                           TIME: gnNcWms.formatTimeSeries(
@@ -134,10 +135,22 @@
                           INFO_FORMAT: 'image/png'
                         });
                   } else {
+
+                    if(isOceanotron) {
+                      var loader = new GnFeaturesGFILoader({
+                        layer: scope.layer,
+                        coordinates: coordinates,
+                        map: scope.map
+                      });
+                      loader.loadAll().then(function(data) {
+                        //TODO: extract feature id
+
+                      });
+                    }
                     url = gnNcWms.getNcwmsServiceUrl(
                         scope.layer,
                         scope.map.getView().getProjection(),
-                        evt.feature.getGeometry().getCoordinates(),
+                        coordinates,
                         activeTool);
                   }
 

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsDirective.js
@@ -37,6 +37,9 @@
    * a additional list of tools for this specific layer.
    * The directive `gnNcwmsTransect` provides the form for all NCWMS parameters.
    */
+
+  var DATE_INPUT_FORMAT = 'DD-MM-YYYY';
+
   module.directive('gnNcwmsTransect', [
     'gnHttp',
     'gnNcWms',
@@ -54,6 +57,10 @@
 
           var drawInteraction, featureOverlay;
           var map = scope.map;
+          var isOceanotron = false;
+          var elevationMin = 0;
+          var elevationMax = 1;
+
 
           scope.ctrl = {};
 
@@ -172,13 +179,22 @@
             var layer = scope.layer;
             var ncInfo = layer.ncInfo;
 
-            layer.set('cextent', ol.proj.transformExtent([
+            isOceanotron = !!ncInfo.multiFeature;
+            scope.ctrl.isOceanotron = isOceanotron;
+
+            var proj = map.getView().getProjection();
+            var bbox = [
               parseFloat(ncInfo.bbox[0]),
               parseFloat(ncInfo.bbox[1]),
               parseFloat(ncInfo.bbox[2]),
-              parseFloat(ncInfo.bbox[3])],
-            'EPSG:4326',
-            map.getView().getProjection().getCode())
+              parseFloat(ncInfo.bbox[3])
+            ];
+
+            // use bbox only if it is contained in the world extent
+            layer.set('cextent',
+              ol.extent.containsExtent(proj.getWorldExtent(), bbox) ?
+                ol.proj.transformExtent(bbox, 'EPSG:4326', proj.getCode()) :
+                proj.getExtent()
             );
 
             scope.params = layer.getSource().getParams() || {};
@@ -189,12 +205,53 @@
             };
             scope.colorscalerange = [scope.colorRange.min,
               scope.colorRange.max];
-            scope.timeSeries = {};
+            scope.timeSeries = {
+              from: undefined,
+              to: undefined
+            };
             scope.elevations = ncInfo.zaxis ? ncInfo.zaxis.values : [];
             scope.palettes = gnNcWms.parseStyles(ncInfo);
 
             if (angular.isUndefined(scope.params.LOGSCALE)) {
               scope.params.LOGSCALE = false;
+            }
+
+            // Set default STYLES= to WMS
+            if(isOceanotron) {
+              scope.layer.set('oceanotron', true);
+              scope.ctrl.palette = ncInfo.defaultPalette || ncInfo.palettes[0];
+
+              scope.ctrl.elevationMinFn = function(elev) {
+                if(elev) {
+                  scope.params.ELEVATION = elev + '/' + elevationMax;
+                  scope.updateLayerParams();
+                }
+                return angular.isDefined(elev) ?
+                  (elevationMin = elev) : elevationMin;
+              };
+              scope.ctrl.elevationMaxFn = function(elev) {
+                if(elev) {
+                  scope.params.ELEVATION = elevationMin + '/' + elev;
+                  scope.updateLayerParams();
+                }
+                return angular.isDefined(elev) ?
+                  (elevationMax = elev) : elevationMax;
+              };
+              scope.params.ELEVATION = elevationMin + '/' + elevationMax;
+
+              // Init mendatory time range with day and day before
+              var day = new Date();
+              day.setDate(day.getDate() - 5);
+              var to = moment(day).format(DATE_INPUT_FORMAT);
+              day.setDate(day.getDate() - 1);
+              var from = moment(day).format(DATE_INPUT_FORMAT);
+
+              scope.ncTime.value = {
+                from: from,
+                to: to
+              };
+
+              scope.updateStyle();
             }
           };
 
@@ -231,14 +288,26 @@
           };
 
           scope.ncTime = {};
+
           scope.$watch('ncTime.value', function(time) {
             if (time) {
-              scope.params.TIME =
-                  moment(time, 'DD-MM-YYYY').format(
-                  'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
-              scope.updateLayerParams();
+              var timeA = [];
+              if(angular.isString(time)) {
+                timeA.push(time);
+              }
+              else if(time.from && time.to) {
+                timeA.push(time.from, time.to);
+              }
+
+              if(timeA.length) {
+                scope.params.TIME = timeA.map(function(t){
+                  return moment(t, 'DD-MM-YYYY').format(
+                    'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]')
+                }).join('/');
+                scope.updateLayerParams();
+              }
             }
-          });
+          }, true);
 
           scope.hasStyles = function() {
             try {

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/NcwmsService.js
@@ -128,7 +128,8 @@
 
       this.parseStyles = function(info) {
         var t = {};
-        if (angular.isArray(info.supportedStyles)) {
+        if (angular.isArray(info.supportedStyles) &&
+          info.supportedStyles.length) {
           angular.forEach(info.supportedStyles, function(s) {
             if (s == 'boxfill') {
               if (angular.isArray(info.palettes)) {
@@ -140,6 +141,11 @@
             else if (s == 'contour') {
               t[s] = s ; // TODO ????? + '/' + p;
             }
+          });
+        }
+        else {
+          info.palettes.forEach(function(p) {
+            t[p] = p;
           });
         }
         return t;
@@ -282,6 +288,8 @@
        * @return {string}
        */
       this.updateLengendUrl = function(legendUrl, params) {
+        if(!legendUrl) return;
+
         var parts = legendUrl.split('?');
 
         var p = parts.length > 1 ?

--- a/web-ui/src/main/resources/catalog/components/viewer/ncwms/partials/ncwmstools.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/ncwms/partials/ncwmstools.html
@@ -1,5 +1,5 @@
 <div class="panel-body panel-ncwms">
-  <form class="form-horizontal" role="form">
+  <form class="form-horizontal" role="form" name="ncswmsForm">
               <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
     <!--Scales-->
@@ -30,21 +30,58 @@
         </span>
       </label>
       <div class="col-sm-6">
-        <div ui-slider="{range: true}" min="{{colorRange.min}}" max="{{colorRange.max}}"
-             id="ncwmsscales"
-             use-decimals ng-model="colorscalerange"
-             data-ng-change="onColorscaleChange(colorscalerange)"></div>
+        <div ui-slider="{range: true}" min="{{colorRange.min}}" max="{{colorRange.max}}" id="ncwmsscales"
+             use-decimals ng-model="colorscalerange" data-ng-change="onColorscaleChange(colorscalerange)"></div>
+      </div>
+    </div>
+
+    <!---------- Times inputs --------- -->
+    <!--Ncwms optional single date (feed from getMetadata)-->
+    <div class="form-group" ng-if="::layer.get('time') && !ctrl.isOceanotron">
+      <label class="col-sm-4" translate>time</label>
+      <div class="col-sm-8">
+        <div class="input-group date" data-date="" data-date-format="dd-mm-yyyy"
+             gn-bootstrap-datepicker="ncTime.value" date-available="layer.ncInfo.datesWithData">
+          <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
+          <input class="form-control input-sm" type="text">
+        </div>
+      </div>
+    </div>
+
+    <!--Oceanotron required time range-->
+    <div class="form-group gn-required" ng-if="::ctrl.isOceanotron" ng-class="{'has-error': !ncTime.value.from || !ncTime.value.to}">
+      <label class="col-sm-4" translate>time</label>
+      <div class="col-sm-8">
+        <div class="input-group date" data-date="" data-date-format="dd-mm-yyyy"
+             gn-bootstrap-datepicker="ncTime.value.from" date-available="layer.ncInfo.datesWithData">
+          <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
+          <input class="form-control input-sm" type="text">
+        </div>
+        <div class="input-group date" data-date="" data-date-format="dd-mm-yyyy"
+             gn-bootstrap-datepicker="ncTime.value.to" date-available="layer.ncInfo.datesWithData">
+          <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
+          <input class="form-control input-sm" type="text">
+        </div>
       </div>
     </div>
 
     <!--Elevations combo-->
-    <div class="form-group">
-      <label class="col-sm-4" for="ncwmselevation">Elévation</label>
+    <div class="form-group" ng-if="::!ctrl.isOceanotron && params.ELEVATION">
+      <label class="col-sm-4" for="ncwmselevation"><span translate="">elevation</span></label>
       <div class="col-sm-8">
         <select class="form-control input-sm" id="ncwmselevation" data-ng-model="params.ELEVATION"
                 data-ng-change="updateLayerParams()">
           <option value="{{el}}" data-ng-repeat="el in elevations">{{el | number: 1}}</option>
         </select>
+      </div>
+    </div>
+    <div class="form-group gn-required" ng-if="::ctrl.isOceanotron">
+      <label class="col-sm-4" for="ncwmselevation"><span translate="">elevation</span></label>
+      <div class="col-sm-4">
+        Min: <input class="form-control input-sm" name="elevMin" ng-model-options="{ getterSetter: true, debounce: 400 }" ng-model="ctrl.elevationMinFn" type="number" required/>
+      </div>
+      <div class="col-sm-4">
+        Max: <input class="form-control input-sm" ng-model-options="{ getterSetter: true, debounce: 400 }" ng-model="ctrl.elevationMaxFn" type="number"/>
       </div>
     </div>
 


### PR DESCRIPTION
This PR add supports for `oceanotron` specific WMS. Geonetwork already supports `NCWMS` that is really similar.

A `getMetadata` request is send when a layer is added, if there is a response with specific format, then it's an oceaonotron layer. Additionnal UI is then provided :

![image](https://user-images.githubusercontent.com/1491924/27834911-1a869376-60d9-11e7-88c8-258c9904a3e3.png)

Reference:
- sources: https://github.com/Reading-eScience-Centre/edal-java/commits/oceanotron-branch
- demo: http://www.ifremer.fr/oceanotron/WMS/Godiva.html

