### PR TITLE
Improve WPS tool & handle complex input

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -362,13 +362,15 @@
 
             scope.defaultLayout = attrs.layout;
             scope.auto = true;
+            scope.activatedOnce = false;
 
             // Deactivate only if it has been activated once first
             scope.$watch('printActive', function(isActive, old) {
               if (angular.isDefined(isActive) &&
-                  (angular.isDefined(old) || isActive)) {
+                  (scope.activatedOnce || isActive)) {
                 if (isActive) {
                   ctrl.activate();
+                  scope.activatedOnce = true;
                 } else {
                   ctrl.deactivate();
                 }

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerModule.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerModule.js
@@ -91,6 +91,7 @@
   goog.require('gn_baselayerswitcher');
   goog.require('gn_draw');
   goog.require('gn_featurestable');
+  goog.require('gn_geometry');
   goog.require('gn_graticule');
   goog.require('gn_index');
   goog.require('gn_layermanager');
@@ -141,7 +142,8 @@
     'gn_wfsfilter',
     'gn_index',
     'gn_wps',
-    'gn_featurestable'
+    'gn_featurestable',
+    'gn_geometry'
   ]);
 
   module.controller('gnViewerController', [
@@ -149,7 +151,8 @@
     '$timeout',
     'gnViewerSettings',
     'gnMap',
-    function($scope, $timeout, gnViewerSettings, gnMap) {
+    'gnViewerService',
+    function($scope, $timeout, gnViewerSettings, gnMap, gnViewerService) {
 
       var map = $scope.searchObj.viewerMap;
 
@@ -217,6 +220,31 @@
       $(div).on('mouseleave', function() {
         hovering = false;
       });
+
+      // watch service data: when a profile graph is available, render it
+      var me = this;
+      $scope.$watch(
+        function () {
+          return gnViewerService.getProfileGraphData();
+        },
+        function (newData, oldData) {
+          me.profileGraph = newData && JSON.parse(newData).profile;
+        }
+      );
+      this.profileOptions = {
+        elevationExtractor: {
+          dist: function (data) { return data.dist },
+          z: function (data) { return data.values.z }
+        },
+        linesConfiguration: { }
+
+        // TODO: callbacks for interaction with the map
+        // hoverCallback,
+        // outCallback
+      };
+      this.closeProfileGraph = function () {
+        gnViewerService.clearProfileGraph();
+      }
     }]);
 
 })();

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerService.js
@@ -26,8 +26,51 @@
 
   var module = angular.module('gn_viewer_service', []);
 
+  /**
+   * @ngdoc service
+   * @kind function
+   * @name gn_viewer.service:gnViewerService
+   * @requires $http
+   *
+   * @description
+   * The `gnViewerService` service provides methods to access viewer functions
+   * from everywhere in the application.
+   */
   module.service('gnViewerService', [
-    function() {
+    '$http',
+    function($http) {
+      // Profile graph handling
+      this._profileGraph = undefined;    // this will be watched by the directive
+
+      /**
+       * Renders JSON data as a graph in the viewer. The expected format is:
+       * {
+       *   "profile": [{
+       *       "lat": 48.38589820151259,
+       *       "dist": 0.0,
+       *       "lon": -4.4995880126953125,
+       *       "values": {
+       *           "z": 23.0
+       *       }
+       *   }, {
+       *      ...
+       *   }]
+       * }
+       *
+       * @param  {type} rawData raw graph data
+       */
+      this.displayProfileGraph = function (rawData) {
+        // TODO: check validity
+        this._profileGraph = rawData;
+      }
+
+      this.getProfileGraphData = function () {
+        return this._profileGraph;
+      }
+      this.clearProfileGraph = function () {
+        return this._profileGraph = undefined;
+      }
+
       this.activeTool = {
         name: '',
         tab: '',

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryDirective.js
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_geometry_directive');
+
+
+  var module = angular.module('gn_geometry_directive', []);
+
+  /**
+   * @ngdoc directive
+   * @name gn_viewer.directive:gnGeometryTool
+   *
+   * @description
+   * This directive adds behavior to an interactive element (link, button).
+   * When clicked, the provided map will enter draw mode for the specified type
+   * of geometry, and update the linked output object.
+   * Possible output formats are: 'object' (ol.Geometry reference), 'gml',
+   * 'geojson', 'wkt'; default if undefined is 'object'
+   * If 'outputAsFeatures' is true, a FeatureCollection object will be output
+   * instead of a single feature
+   */
+  module.directive('gnGeometryTool', [
+    function() {
+      return {
+        restrict: 'E',
+        scope: {
+          map: '<',
+          geometryType: '<',
+          output: '=',
+          outputFormat: '<',
+          allowReset: '@',
+          allowModify: '@',
+          outputAsFeatures: '@'
+        },
+        templateUrl: '../../catalog/components/viewer/geometry/' +
+            'partials/geometrytool.html',
+        controller: ['$scope', 'ngeoDecorateInteraction',
+          function GeometryToolController($scope, ngeoDecorateInteraction) {
+            // internal vars
+            var source = new ol.source.Vector({
+              useSpatialIndex: false
+            });
+            var layer = new ol.layer.Vector({
+              source: source,
+              style: [
+                new ol.style.Style({          // this is the default editing style
+                  fill: new ol.style.Fill({
+                    color: 'rgba(255, 255, 255, 0.5)'
+                  }),
+                  stroke: new ol.style.Stroke({
+                    color: 'white',
+                    width: 5
+                  })
+                }),
+                new ol.style.Style({
+                  stroke: new ol.style.Stroke({
+                    color: 'rgba(0, 153, 255, 1)',
+                    width: 3
+                  }),
+                  image: new ol.style.Circle({
+                    radius: 6,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 153, 255, 1)'
+                    }),
+                    stroke: new ol.style.Stroke({
+                      color: 'white',
+                      width: 1.5
+                    })
+                  })
+                })
+              ]
+            });
+            $scope.drawInteraction = new ol.interaction.Draw({
+              type: $scope.geometryType,
+              source: source
+            });
+            $scope.modifyInteraction = new ol.interaction.Modify({
+              features: source.getFeaturesCollection()
+            });
+
+            // add our layer&interactions to the map
+            $scope.map.addLayer(layer);
+            $scope.map.addInteraction($scope.drawInteraction);
+            $scope.map.addInteraction($scope.modifyInteraction);
+            $scope.drawInteraction.setActive(false);
+            $scope.modifyInteraction.setActive(false);
+            ngeoDecorateInteraction($scope.drawInteraction);
+            ngeoDecorateInteraction($scope.modifyInteraction);
+
+            // cleanup when scope is destroyed
+            // FIXME: this event is not triggered!
+            // (when switching form, the DOM is simply cleared with jQuery)
+            $scope.$on('$destroy', function () {
+              $scope.map.removeLayer(layer);
+              $scope.map.removeInteraction($scope.drawInteraction);
+              $scope.map.removeInteraction($scope.modifyInteraction);
+            });
+
+            // modifies the output value
+            var updateOutput = function (feature) {
+              if (!feature) {
+                $scope.output = null;
+                return;
+              }
+
+              // set id on feature
+              feature.setId('geometry-tool-output');
+
+              var formatLabel = ($scope.outputFormat || '').toLowerCase();
+              var format;
+              var outputValue;
+              switch (formatLabel) {
+                case 'json':
+                case 'geojson':
+                  format = new ol.format.GeoJSON();
+                  if ($scope.outputAsFeatures) {
+                    outputValue = format.writeFeatures([feature]);
+                  } else {
+                    outputValue = format.writeGeometry(feature.getGeometry());
+                  }
+                  break;
+
+                case 'wkt':
+                  format = new ol.format.WKT();
+                  if ($scope.outputAsFeatures) {
+                    outputValue = format.writeFeatures([feature]);
+                  } else {
+                    outputValue = format.writeGeometry(feature.getGeometry());
+                  }
+                  break;
+
+                case 'gml':
+                  format = new ol.format.GML({
+                    featureNS: 'http://mapserver.gis.umn.edu/mapserver',
+                    featureType: 'features'
+                    // srsName: $scope.map.getView().getProjection().getCode()
+                  });
+
+                  // TODO: refactor this: first clone geom & transform, then if necessary create a new feature with this geom
+                  var feature2 = new ol.Feature({
+                    id: 'geometry-tool-output',
+                    geometry: feature.getGeometry().clone()
+                  })
+                  feature2.getGeometry().transform($scope.map.getView().getProjection(), 'EPSG:4326');
+
+                  if ($scope.outputAsFeatures) {
+                    outputValue = '<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs">' +
+                      format.writeFeatures([feature2]) +
+                      '</wfs:FeatureCollection>';
+                  } else {
+                    outputValue = format.writeGeometryNode(feature2.getGeometry())
+                      .innerHTML;
+                  }
+                  break;
+
+                // no valid format specified: output as object + give warning
+                default:
+                  console.warn('No valid output format specified for '+
+                    'gn-geometry-tool (value=' + $scope.outputFormat + '); ' +
+                    'outputting geometry as object');
+
+                case 'object':
+                  if ($scope.outputAsFeatures) {
+                    outputValue = [feature];
+                  } else {
+                    outputValue = feature.getGeometry().clone();
+                  }
+                  break;
+              }
+
+              $scope.output = outputValue;
+            }
+
+            // clear existing features on draw end
+            $scope.drawInteraction.on('drawend', function (event) {
+              source.clear();
+              updateOutput(event.feature);
+              $scope.drawInteraction.setActive(false);
+            });
+
+            // update output on modify end
+            $scope.modifyInteraction.on('modifyend', function (event) {
+              updateOutput(event.feature);
+            })
+
+            // reset drawing
+            $scope.reset = function () {
+              source.clear();
+              updateOutput();
+            }
+          }
+        ]
+      };
+    }]);
+})();

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryModule.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryModule.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_geometry');
+
+
+  goog.require('gn_geometry_service');
+  goog.require('gn_geometry_directive');
+
+  var module = angular.module('gn_geometry', [
+    'gn_geometry_service',
+    'gn_geometry_directive'
+  ]);
+})();

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_geometry_service');
+
+  var module = angular.module('gn_geometry_service', []);
+
+  /**
+   * @ngdoc service
+   * @kind function
+   * @name gn_geometry.service:gnGeometryService
+   * @requires gnMap
+   *
+   * @description
+   * The `gnGeometryService` service provides utility related to handling
+   * geometry and mime types
+   */
+  module.service('gnGeometryService', [
+    function() {
+
+      /**
+       * @ngdoc method
+       * @methodOf gn_geometry.service:gnGeometryService
+       * @name gnGeometryService#getFormatFromMimeType
+       *
+       * @description
+       * Guess the output format to use in a gn-geometry-tool directive based
+       * on a mime type received from a DescribeProcess call.
+       *
+       * @param {string} mimeType mime type from the process description
+       * @return {string} format to be used by a gn-geometry-tool directive
+       */
+      this.getFormatFromMimeType = function (mimeType) {
+        var parts = mimeType.split(';');
+        parts.forEach(function (p) {
+          p = p.trim().toLowerCase();
+        });
+
+        switch (parts[0]) {
+          case 'application/json':
+            return 'geojson';
+
+          case 'application/wkt':
+            return 'wkt';
+
+          case 'application/gml+xml':
+          case 'text/xml':
+            return 'gml';
+
+          default:
+            return 'object';
+        }
+      }
+
+    }
+  ]);
+})();

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/partials/geometrytool.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/partials/geometrytool.html
@@ -1,0 +1,22 @@
+<div gi-btn-group class="btn-group">
+
+  <button class="btn btn-default draw-button"
+    gi-btn="active" ng-model="drawInteraction.active">
+    <span class="fa fa-pencil"></span>
+    <span ng-translate>drawGeometry</span>
+  </button>
+
+  <button class="btn btn-default modify-button"
+    ng-if="allowModify !== undefined"
+    gi-btn="active" ng-model="modifyInteraction.active">
+    <span class="fa fa-pencil"></span>
+    <span ng-translate>modifyGeometry</span>
+  </button>
+
+  <button class="btn btn-default btn-icon reset-button"
+    ng-if="allowReset !== undefined"
+    ng-click="reset()">
+    <span class="fa fa-trash-o"></span>
+  </button>
+
+</div>

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -1,4 +1,4 @@
-<div class="wrapper" data-ng-controller="gnViewerController">
+<div class="wrapper" data-ng-controller="gnViewerController as ctrl">
 
   <div id="map"
        ngeo-map="map"
@@ -10,6 +10,20 @@
   <gn-features-tables gn-features-tables-map="map"></gn-features-tables>
 
   <div gn-localisation-input map="map"></div>
+
+  <!-- graph showing a WPS response containing a profile -->
+  <div class="profile-graph gn-viewer-info-pane"
+    ng-style="{ visibility: ctrl.profileGraph ? 'visible' : 'hidden' }"
+    ng-class="{'leftBarExpanded': isContainerOpened()}">
+    <div class="panel-heading">
+      <button type="button" class="btn btn-default close" ng-click="ctrl.closeProfileGraph()" title="close">
+        ×
+      </button>
+      <h5><span data-translate="">profileGraph</span></h5>
+    </div>
+    <div class="profile" ngeo-profile="ctrl.profileGraph"
+      ngeo-profile-options="ctrl.profileOptions" />
+  </div>
 
   <!--Top right buttons - Tools-->
   <div class="tools" gi-btn-group>

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -168,7 +168,7 @@
       /**
        * @ngdoc method
        * @methodOf gn_viewer.service:gnWpsService
-       * @name gnWpsService#printExecuteMessage
+       * @name gnWpsService#execute
        *
        * @description
        * Prints a WPS Execute message as XML to be posted to a WPS service.

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -30,18 +30,22 @@
   goog.require('OWS_1_1_0');
   goog.require('WPS_1_0_0');
   goog.require('XLink_1_0');
+  goog.require('GML_3_1_1');
+  goog.require('SMIL_2_0');
+  goog.require('SMIL_2_0_Language');
 
   var module = angular.module('gn_wps_service', []);
 
   // WPS Client
   // Jsonix wrapper to read or write WPS response or request
   var context = new Jsonix.Context(
-      [XLink_1_0, OWS_1_1_0, WPS_1_0_0],
+      [XLink_1_0, OWS_1_1_0, WPS_1_0_0, GML_3_1_1, SMIL_2_0, SMIL_2_0_Language],
       {
         namespacePrefixes: {
           'http://www.w3.org/1999/xlink': 'xlink',
           'http://www.opengis.net/ows/1.1': 'ows',
-          'http://www.opengis.net/wps/1.0.0': 'wps'
+          'http://www.opengis.net/wps/1.0.0': 'wps',
+          'http://www.opengis.net/gml': 'gml'
         }
       }
       );
@@ -164,6 +168,117 @@
       /**
        * @ngdoc method
        * @methodOf gn_viewer.service:gnWpsService
+       * @name gnWpsService#printExecuteMessage
+       *
+       * @description
+       * Prints a WPS Execute message as XML to be posted to a WPS service.
+       * Does a DescribeProcess call first
+       *
+       * @param {string} uri of the wps service
+       * @param {string} processId of the process
+       * @param {Object} inputs of the process
+       * @param {Object} options such as storeExecuteResponse,
+       * lineage and status
+       * @return {defer} promise
+       */
+      this.printExecuteMessage = function(uri, processId, inputs,
+        responseDocument) {
+        var me = this;
+
+        return this.describeProcess(uri, processId).then(
+          function(data) {
+            var description = data.processDescription[0];
+
+            var url = uri;
+            var request = {
+              name: {
+                localPart: 'Execute',
+                namespaceURI: 'http://www.opengis.net/wps/1.0.0'
+              },
+              value: {
+                service: 'WPS',
+                version: '1.0.0',
+                identifier: {
+                  value: description.identifier.value
+                },
+                dataInputs: {
+                  input: []
+                }
+              }
+            };
+
+            var setInputData = function(input, data) {
+              if (input.literalData && data) {
+                request.value.dataInputs.input.push({
+                  identifier: {
+                    value: input.identifier.value
+                  },
+                  data: {
+                    literalData: {
+                      value: data.toString()
+                    }
+                  }
+                });
+              }
+              if (input.complexData && data) {
+                var mimeType = input.complexData._default.format.mimeType;
+                request.value.dataInputs.input.push({
+                  identifier: {
+                    value: input.identifier.value
+                  },
+                  data: {
+                    complexData: {
+                      mimeType: mimeType,
+                      content: data
+                    }
+                  }
+                });
+              }
+              if (input.boundingBoxData) {
+                var bbox = data.split(',');
+                request.value.dataInputs.input.push({
+                  identifier: {
+                    value: input.identifier.value
+                  },
+                  data: {
+                    boundingBoxData: {
+                      dimensions: 2,
+                      lowerCorner: [bbox[0], bbox[1]],
+                      upperCorner: [bbox[2], bbox[3]]
+                    }
+                  }
+                });
+              }
+            };
+
+            for (var i = 0; i < description.dataInputs.input.length; ++i) {
+              var input = description.dataInputs.input[i];
+              if (inputs[input.identifier.value] !== undefined) {
+                setInputData(input, inputs[input.identifier.value]);
+              }
+            }
+
+            request.value.responseForm = {
+              responseDocument: $.extend(true, {
+                lineage: false,
+                storeExecuteResponse: true,
+                status: false
+              }, responseDocument)
+            };
+
+            var body = marshaller.marshalString(request);
+
+            return body;
+          },
+          function(data) {
+            return data;
+          }
+        );
+      };
+
+      /**
+       * @ngdoc method
+       * @methodOf gn_viewer.service:gnWpsService
        * @name gnWpsService#execute
        *
        * @description
@@ -180,95 +295,20 @@
       this.execute = function(uri, processId, inputs, responseDocument) {
         var defer = $q.defer();
 
-        var me = this;
-
-        this.describeProcess(uri, processId).then(
-            function(data) {
-              var description = data.processDescription[0];
-
-              var url = uri;
-              var request = {
-                name: {
-                  localPart: 'Execute',
-                  namespaceURI: 'http://www.opengis.net/wps/1.0.0'
-                },
-                value: {
-                  service: 'WPS',
-                  version: '1.0.0',
-                  identifier: {
-                    value: description.identifier.value
-                  },
-                  dataInputs: {
-                    input: []
-                  }
-                }
-              };
-
-              var setInputData = function(input, data) {
-                if (input.literalData && data) {
-                  request.value.dataInputs.input.push({
-                    identifier: {
-                      value: input.identifier.value
-                    },
-                    data: {
-                      literalData: {
-                        value: data.toString()
-                      }
-                    }
-                  });
-                }
-                if (input.boundingBoxData) {
-                  var bbox = data.split(',');
-                  request.value.dataInputs.input.push({
-                    identifier: {
-                      value: input.identifier.value
-                    },
-                    data: {
-                      boundingBoxData: {
-                        dimensions: 2,
-                        lowerCorner: [bbox[0], bbox[1]],
-                        upperCorner: [bbox[2], bbox[3]]
-                      }
-                    }
-                  });
-                }
-              };
-
-              for (var i = 0; i < description.dataInputs.input.length; ++i) {
-                var input = description.dataInputs.input[i];
-                if (inputs[input.identifier.value] !== undefined) {
-                  setInputData(input, inputs[input.identifier.value]);
-                }
-              }
-
-              request.value.responseForm = {
-                responseDocument: $.extend(true, {
-                  lineage: false,
-                  storeExecuteResponse: true,
-                  status: false
-                }, responseDocument)
-              };
-
-              var body = marshaller.marshalString(request);
-
-              $http.post(url, body, {
-                headers: {'Content-Type': 'application/xml'}
-              }).then(
-                  function(data) {
-                    var response =
-                        unmarshaller.unmarshalString(data.data).value;
-                    defer.resolve(response);
-                  },
-                  function(data) {
-                    defer.reject(data);
-                  }
-              );
-
-            },
-            function(data) {
-              defer.reject(data);
-            }
-        );
+        this.printExecuteMessage(uri, processId, inputs,
+          responseDocument)
+          .then(function (body) {
+            return $http.post(url, body, {
+              headers: {'Content-Type': 'application/xml'}
+            });
+          })
+          .then(function(data) {
+            var response =
+                unmarshaller.unmarshalString(data.data).value;
+            defer.resolve(response);
+          }, function(data) {
+            defer.reject(data);
+          });
 
         return defer.promise;
       };

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -82,6 +82,14 @@
                     data-required="false">
                 </gn-bbox-input>
               </div>
+
+              <!-- complex input (geometry on map) -->
+              <div ng-if="::input.complexData">
+                <gn-geometry-tool allow-reset allow-modify output="input.value"
+                  output-format="input.outputFormat" geometry-type="input.geometryType"
+                  output-as-features="true" map="map"/>
+              </div>
+
               <div ng-if="input.invalid">
                 <p class="text-danger">{{input.invalid}}</p>
               </div>

--- a/web-ui/src/main/resources/catalog/js/jsonix/OWC_0_3_1.js
+++ b/web-ui/src/main/resources/catalog/js/jsonix/OWC_0_3_1.js
@@ -182,7 +182,6 @@ var OWC_0_3_1_Module_Factory = function() {
         n: 'boundingBox',
         mx: false,
         dom: false,
-        typed: false,
         en: {
           lp: 'BoundingBox',
           ns: 'http:\/\/www.opengis.net\/ows'

--- a/web-ui/src/main/resources/catalog/js/jsonix/OWS_1_1_0.js
+++ b/web-ui/src/main/resources/catalog/js/jsonix/OWS_1_1_0.js
@@ -478,7 +478,7 @@ var OWS_1_1_0_Module_Factory = function() {
         col: true,
         mx: false,
         dom: false,
-        typed: false,
+        typed: true,
         etis: [{
                 en: 'Get',
                 ti: '.RequestMethodType'

--- a/web-ui/src/main/resources/catalog/js/jsonix/WPS_1_0_0.js
+++ b/web-ui/src/main/resources/catalog/js/jsonix/WPS_1_0_0.js
@@ -599,9 +599,8 @@ var WPS_1_0_0_Module_Factory = function() {
         t: 'aa'
       }, {
         n: 'content',
-        col: true,
-        typed: false,
-        t: 'ae'
+        t: 'value',
+        asCDATA: true
       }, {
         n: 'mimeType',
         an: {

--- a/web-ui/src/main/resources/catalog/lib/jsonix/jsonix/Jsonix-all.js
+++ b/web-ui/src/main/resources/catalog/lib/jsonix/jsonix/Jsonix-all.js
@@ -1,0 +1,6161 @@
+var _jsonix_factory = function(_jsonix_xmldom, _jsonix_xmlhttprequest, _jsonix_fs)
+{
+	// Complete Jsonix script is included below 
+var Jsonix = {
+	singleFile : true
+};
+Jsonix.Util = {};
+
+Jsonix.Util.extend = function(destination, source) {
+	destination = destination || {};
+	if (source) {
+		/*jslint forin: true */
+		for ( var property in source) {
+			var value = source[property];
+			if (value !== undefined) {
+				destination[property] = value;
+			}
+		}
+
+		/**
+		 * IE doesn't include the toString property when iterating over an
+		 * object's properties with the for(property in object) syntax.
+		 * Explicitly check if the source has its own toString property.
+		 */
+
+		/*
+		 * FF/Windows < 2.0.0.13 reports "Illegal operation on WrappedNative
+		 * prototype object" when calling hawOwnProperty if the source object is
+		 * an instance of window.Event.
+		 */
+
+		// REWORK
+		// Node.js
+		sourceIsEvt = typeof window !== 'undefined' && window !== null && typeof window.Event === "function" && source instanceof window.Event;
+
+		if (!sourceIsEvt && source.hasOwnProperty && source.hasOwnProperty('toString')) {
+			destination.toString = source.toString;
+		}
+	}
+	return destination;
+};
+Jsonix.Class = function() {
+	var Class = function() {
+		this.initialize.apply(this, arguments);
+	};
+	var extended = {};
+	var empty = function() {
+	};
+	var parent, initialize, Type;
+	for (var i = 0, len = arguments.length; i < len; ++i) {
+		Type = arguments[i];
+		if (typeof Type == "function") {
+			// make the class passed as the first argument the superclass
+			if (i === 0 && len > 1) {
+				initialize = Type.prototype.initialize;
+				// replace the initialize method with an empty function,
+				// because we do not want to create a real instance here
+				Type.prototype.initialize = empty;
+				// the line below makes sure that the new class has a
+				// superclass
+				extended = new Type();
+				// restore the original initialize method
+				if (initialize === undefined) {
+					delete Type.prototype.initialize;
+				} else {
+					Type.prototype.initialize = initialize;
+				}
+			}
+			// get the prototype of the superclass
+			parent = Type.prototype;
+		} else {
+			// in this case we're extending with the prototype
+			parent = Type;
+		}
+		Jsonix.Util.extend(extended, parent);
+	}
+	Class.prototype = extended;
+	return Class;
+};
+
+Jsonix.XML = {
+		XMLNS_NS : 'http://www.w3.org/2000/xmlns/',
+		XMLNS_P : 'xmlns'
+};
+
+
+Jsonix.DOM = {
+	isDomImplementationAvailable : function () {
+		if (typeof _jsonix_xmldom !== 'undefined')
+		{
+			return true;
+		} else if (typeof document !== 'undefined' && Jsonix.Util.Type.exists(document.implementation) && Jsonix.Util.Type.isFunction(document.implementation.createDocument)) {
+			return true;
+		} else {
+			return false;
+		}
+	},
+	createDocument : function() {
+		// REWORK
+		// Node.js
+		if (typeof _jsonix_xmldom !== 'undefined')
+		{
+			return new (_jsonix_xmldom.DOMImplementation)().createDocument();
+		} else if (typeof document !== 'undefined' && Jsonix.Util.Type.exists(document.implementation) && Jsonix.Util.Type.isFunction(document.implementation.createDocument)) {
+			return document.implementation.createDocument('', '', null);
+		} else if (typeof ActiveXObject !== 'undefined') {
+			return new ActiveXObject('MSXML2.DOMDocument');
+		} else {
+			throw new Error('Error created the DOM document.');
+		}
+	},
+	serialize : function(node) {
+		Jsonix.Util.Ensure.ensureExists(node);
+		// REWORK
+		// Node.js
+		if (typeof _jsonix_xmldom !== 'undefined')
+		{
+			return (new (_jsonix_xmldom).XMLSerializer()).serializeToString(node);
+		} else if (Jsonix.Util.Type.exists(XMLSerializer)) {
+			return (new XMLSerializer()).serializeToString(node);
+		} else if (Jsonix.Util.Type.exists(node.xml)) {
+			return node.xml;
+		} else {
+			throw new Error('Could not serialize the node, neither XMLSerializer nor the [xml] property were found.');
+		}
+	},
+	parse : function(text) {
+		Jsonix.Util.Ensure.ensureExists(text);
+		if (typeof _jsonix_xmldom !== 'undefined')
+		{
+			return (new (_jsonix_xmldom).DOMParser()).parseFromString(text, 'application/xml');
+		} else if (typeof DOMParser != 'undefined') {
+			return (new DOMParser()).parseFromString(text, 'application/xml');
+		} else if (typeof ActiveXObject != 'undefined') {
+			var doc = Jsonix.DOM.createDocument('', '');
+			doc.loadXML(text);
+			return doc;
+		} else {
+			var url = 'data:text/xml;charset=utf-8,' + encodeURIComponent(text);
+			var request = new XMLHttpRequest();
+			request.open('GET', url, false);
+			if (request.overrideMimeType) {
+				request.overrideMimeType("text/xml");
+			}
+			request.send(null);
+			return request.responseXML;
+		}
+	},
+	load : function(url, callback, options) {
+
+		var request = Jsonix.Request.INSTANCE;
+
+		request.issue(
+						url,
+						function(transport) {
+							var result;
+							if (Jsonix.Util.Type.exists(transport.responseXML) && Jsonix.Util.Type.exists(transport.responseXML.documentElement)) {
+								result = transport.responseXML;
+							} else if (Jsonix.Util.Type.isString(transport.responseText)) {
+								result = Jsonix.DOM.parse(transport.responseText);
+							} else {
+								throw new Error('Response does not have valid [responseXML] or [responseText].');
+							}
+							callback(result);
+
+						}, function(transport) {
+							throw new Error('Could not retrieve XML from URL [' + url	+ '].');
+
+						}, options);
+	},
+	xlinkFixRequired : null,
+	isXlinkFixRequired : function ()
+	{
+		if (Jsonix.DOM.xlinkFixRequired === null)
+		{
+			if (typeof navigator === 'undefined')
+			{
+				Jsonix.DOM.xlinkFixRequired = false;
+			}
+			else if (!!navigator.userAgent && (/Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor)))
+			{
+				var doc = Jsonix.DOM.createDocument();
+				var el = doc.createElement('test');
+				el.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'urn:test');
+				doc.appendChild(el);
+				var testString = Jsonix.DOM.serialize(doc);
+				Jsonix.DOM.xlinkFixRequired = (testString.indexOf('xmlns:xlink') === -1);
+			}
+			else
+			{
+				Jsonix.DOM.xlinkFixRequired = false;
+			}
+		}
+		return Jsonix.DOM.xlinkFixRequired;
+	}
+};
+Jsonix.Request = Jsonix
+		.Class({
+			// REWORK
+			factories : [ function() {
+				return new XMLHttpRequest();
+			}, function() {
+				return new ActiveXObject('Msxml2.XMLHTTP');
+			}, function() {
+				return new ActiveXObject("Msxml2.XMLHTTP.6.0");
+			}, function() {
+				return new ActiveXObject("Msxml2.XMLHTTP.3.0");
+			}, function() {
+				return new ActiveXObject('Microsoft.XMLHTTP');
+			}, function() {
+				// Node.js
+				if (typeof _jsonix_xmlhttprequest !== 'undefined')
+				{
+					var XMLHttpRequest = _jsonix_xmlhttprequest.XMLHttpRequest;
+					return new XMLHttpRequest();
+				}
+				else
+				{
+					return null;
+				}
+			}],
+			initialize : function() {
+			},
+			issue : function(url, onSuccess, onFailure, options) {
+				Jsonix.Util.Ensure.ensureString(url);
+				if (Jsonix.Util.Type.exists(onSuccess)) {
+					Jsonix.Util.Ensure.ensureFunction(onSuccess);
+				} else {
+					onSuccess = function() {
+					};
+				}
+				if (Jsonix.Util.Type.exists(onFailure)) {
+					Jsonix.Util.Ensure.ensureFunction(onFailure);
+				} else {
+					onFailure = function() {
+					};
+				}
+				if (Jsonix.Util.Type.exists(options)) {
+					Jsonix.Util.Ensure.ensureObject(options);
+				} else {
+					options = {};
+				}
+
+				var transport = this.createTransport();
+
+				var method = Jsonix.Util.Type.isString(options.method) ? options.method
+						: 'GET';
+				var async = Jsonix.Util.Type.isBoolean(options.async) ? options.async
+						: true;
+				var proxy = Jsonix.Util.Type.isString(options.proxy) ? options.proxy
+						: Jsonix.Request.PROXY;
+
+				var user = Jsonix.Util.Type.isString(options.user) ? options.user
+						: null;
+				var password = Jsonix.Util.Type.isString(options.password) ? options.password
+						: null;
+
+				if (Jsonix.Util.Type.isString(proxy) && (url.indexOf("http") === 0)) {
+					url = proxy + encodeURIComponent(url);
+				}
+
+				if (Jsonix.Util.Type.isString(user)) {
+					transport.open(method, url, async, user, password);
+				} else {
+					transport.open(method, url, async);
+				}
+
+				if (Jsonix.Util.Type.isObject(options.headers)) {
+
+					for ( var header in options.headers) {
+						if (options.headers.hasOwnProperty(header)) {
+							transport.setRequestHeader(header,
+									options.headers[header]);
+						}
+					}
+				}
+
+				var data = Jsonix.Util.Type.exists(options.data) ? options.data
+						: null;
+				if (!async) {
+					transport.send(data);
+					this.handleTransport(transport, onSuccess, onFailure);
+				} else {
+					var that = this;
+					if (typeof window !== 'undefined') {
+
+						transport.onreadystatechange = function() {
+							that.handleTransport(transport, onSuccess,
+									onFailure);
+						};
+
+						window.setTimeout(function() {
+							transport.send(data);
+						}, 0);
+					} else {
+
+						transport.onreadystatechange = function() {
+							that.handleTransport(transport, onSuccess, onFailure);
+						};
+						transport.send(data);
+					}
+				}
+				return transport;
+
+			},
+			handleTransport : function(transport, onSuccess, onFailure) {
+				if (transport.readyState == 4) {
+					if (!transport.status || (transport.status >= 200 && transport.status < 300)) {
+						onSuccess(transport);
+					}
+					if (transport.status && (transport.status < 200 || transport.status >= 300)) {
+						onFailure(transport);
+					}
+				}
+			},
+			createTransport : function() {
+				for ( var index = 0, length = this.factories.length; index < length; index++) {
+					try {
+						var transport = this.factories[index]();
+						if (transport !== null) {
+							return transport;
+						}
+					} catch (e) {
+						// TODO log
+					}
+				}
+				throw new Error('Could not create XML HTTP transport.');
+			},
+			CLASS_NAME : 'Jsonix.Request'
+		});
+Jsonix.Request.INSTANCE = new Jsonix.Request();
+Jsonix.Request.PROXY = null;
+Jsonix.Schema = {};
+Jsonix.Model = {};
+Jsonix.Util.Type = {
+	exists : function(value) {
+		return (typeof value !== 'undefined' && value !== null);
+	},
+	isUndefined : function(value) {
+		return typeof value === 'undefined';
+	},
+	isString : function(value) {
+		return typeof value === 'string';
+	},
+	isBoolean : function(value) {
+		return typeof value === 'boolean';
+	},
+	isObject : function(value) {
+		return typeof value === 'object';
+	},
+	isFunction : function(value) {
+		return typeof value === 'function';
+	},
+	isNumber : function(value) {
+		return (typeof value === 'number') && !isNaN(value);
+	},
+	isNumberOrNaN : function(value) {
+		return (value === +value) || (Object.prototype.toString.call(value) === '[object Number]');
+	},
+	isNaN : function(value) {
+		return Jsonix.Util.Type.isNumberOrNaN(value) && isNaN(value);
+	},
+	isArray : function(value) {
+		// return value instanceof Array;
+		return !!(value && value.concat && value.unshift && !value.callee);
+	},
+	isDate : function(value) {
+		return !!(value && value.getTimezoneOffset && value.setUTCFullYear);
+	},
+	isRegExp : function(value) {
+		return !!(value && value.test && value.exec && (value.ignoreCase || value.ignoreCase === false));
+	},
+	isNode : function(value) {
+		return (typeof Node === "object" || typeof Node === "function") ? (value instanceof Node) : (value && (typeof value === "object") && (typeof value.nodeType === "number") && (typeof value.nodeName==="string"));
+	},
+	isEqual : function(a, b, report) {
+		var doReport = Jsonix.Util.Type.isFunction(report);
+		// TODO rework
+		var _range = function(start, stop, step) {
+			var args = slice.call(arguments);
+			var solo = args.length <= 1;
+			var start_ = solo ? 0 : args[0];
+			var stop_ = solo ? args[0] : args[1];
+			var step_ = args[2] || 1;
+			var len = Math.max(Math.ceil((stop_ - start_) / step_), 0);
+			var idx = 0;
+			var range = new Array(len);
+			while (idx < len) {
+				range[idx++] = start_;
+				start_ += step_;
+			}
+			return range;
+		};
+
+		var _keys = Object.keys || function(obj) {
+			if (Jsonix.Util.Type.isArray(obj)) {
+				return _range(0, obj.length);
+			}
+			var keys = [];
+			for ( var key in obj) {
+				if (obj.hasOwnProperty(key)) {
+					keys[keys.length] = key;
+				}
+			}
+			return keys;
+		};
+
+		// Check object identity.
+		if (a === b) {
+			return true;
+		}
+
+		// Check if both are NaNs
+		if (Jsonix.Util.Type.isNaN(a) && Jsonix.Util.Type.isNaN(b)) {
+			return true;
+		}
+		// Different types?
+		var atype = typeof a;
+		var btype = typeof b;
+		if (atype != btype) {
+			if (doReport) {
+				report('Types differ [' + atype + '], [' + btype + '].');
+			}
+			return false;
+		}
+		// Basic equality test (watch out for coercions).
+		if (a == b) {
+			return true;
+		}
+		// One is falsy and the other truthy.
+		if ((!a && b) || (a && !b)) {
+			if (doReport) {
+				report('One is falsy, the other is truthy.');
+			}
+			return false;
+		}
+		// Check dates' integer values.
+		if (Jsonix.Util.Type.isDate(a) && Jsonix.Util.Type.isDate(b)) {
+			return a.getTime() === b.getTime();
+		}
+		// Both are NaN?
+		if (Jsonix.Util.Type.isNaN(a) && Jsonix.Util.Type.isNaN(b)) {
+			return false;
+		}
+		// Compare regular expressions.
+		if (Jsonix.Util.Type.isRegExp(a) && Jsonix.Util.Type.isRegExp(b)) {
+			return a.source === b.source && a.global === b.global && a.ignoreCase === b.ignoreCase && a.multiline === b.multiline;
+		}
+		
+		if (Jsonix.Util.Type.isNode(a) && Jsonix.Util.Type.isNode(b))
+		{
+			var aSerialized = Jsonix.DOM.serialize(a);
+			var bSerialized = Jsonix.DOM.serialize(b);
+			if (aSerialized !== bSerialized)
+			{
+				if (doReport)
+				{
+					report('Nodes differ.');
+					report('A=' + aSerialized);
+					report('B=' + bSerialized);
+				}
+				return false;
+			}
+			else
+			{
+				return true;
+			}
+		}
+		
+		// If a is not an object by this point, we can't handle it.
+		if (atype !== 'object') {
+			return false;
+		}
+		// Check for different array lengths before comparing contents.
+		if (Jsonix.Util.Type.isArray(a) && (a.length !== b.length)) {
+			if (doReport) {
+					report('Lengths differ.');
+					report('A.length=' + a.length);
+					report('B.length=' + b.length);
+			}
+			return false;
+		}
+		// Nothing else worked, deep compare the contents.
+		var aKeys = _keys(a);
+		var bKeys = _keys(b);
+		// Different object sizes?
+		if (aKeys.length !== bKeys.length) {
+			if (doReport) {
+				report('Different number of properties [' + aKeys.length + '], [' + bKeys.length + '].');
+			}
+			for ( var andex = 0; andex < aKeys.length; andex++) {
+				if (doReport) {
+					report('A [' + aKeys[andex] + ']=' + a[aKeys[andex]]);
+				}
+			}
+			for ( var bndex = 0; bndex < bKeys.length; bndex++) {
+				if (doReport) {
+					report('B [' + bKeys[bndex] + ']=' + b[bKeys[bndex]]);
+				}
+			}
+			return false;
+		}
+		// Recursive comparison of contents.
+		for (var kndex = 0; kndex < aKeys.length; kndex++) {
+			var key = aKeys[kndex];
+			if (!(key in b) || !Jsonix.Util.Type.isEqual(a[key], b[key], report)) {
+				if (doReport) {
+					report('One of the properties differ.');
+					report('Key: [' + key + '].');
+					report('Left: [' + a[key] + '].');
+					report('Right: [' + b[key] + '].');
+				}
+				return false;
+			}
+		}
+		return true;
+	},
+	cloneObject : function (source, target)
+	{
+		target = target || {};
+		for (var p in source)
+		{
+			if (source.hasOwnProperty(p))
+			{
+				target[p] = source[p];
+			}
+		}
+		return target;
+	},
+	defaultValue : function()
+	{
+		var args = arguments;
+		if (args.length === 0)
+		{
+			return undefined;
+		}
+		else
+		{
+			var defaultValue = args[args.length - 1];
+			var typeOfDefaultValue = typeof defaultValue;
+			for (var index = 0; index < args.length - 1; index++)
+			{
+				var candidateValue = args[index];
+				if (typeof candidateValue === typeOfDefaultValue)
+				{
+					return candidateValue;
+				}
+			}
+			return defaultValue;
+			
+		}
+	}
+};
+Jsonix.Util.NumberUtils = {
+	isInteger : function(value) {
+		return Jsonix.Util.Type.isNumber(value) && ((value % 1) === 0);
+	}
+};
+Jsonix.Util.StringUtils = {
+	trim : (!!String.prototype.trim) ?
+	function(str) {
+		Jsonix.Util.Ensure.ensureString(str);
+		return str.trim();
+	} :
+	function(str) {
+		Jsonix.Util.Ensure.ensureString(str);
+		return str.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
+	},
+	/* isEmpty : function(str) {
+		var wcm = Jsonix.Util.StringUtils.whitespaceCharactersMap;
+		for (var index = 0; index < str.length; index++)
+		{
+			if (!wcm[str[index]])
+			{
+				return false;
+			}
+		}
+		return true;
+	}, */
+	isEmpty : function(str) {
+		var length = str.length;
+		if (!length) {
+			return true;
+		}
+		for (var index = 0; index < length; index++)
+		{
+			var c = str[index];
+			if (c === ' ')
+			{
+				// skip
+			}
+			else if (c > '\u000D' && c < '\u0085')
+			{
+				return false;
+			}
+			else if (c < '\u00A0')
+			{
+				if (c < '\u0009')
+				{
+					return false;
+				}
+				else if (c > '\u0085')
+				{
+					return false;
+				}
+			}
+			else if (c > '\u00A0')
+			{
+				if (c < '\u2028')
+				{
+					if (c < '\u180E')
+					{
+						if (c < '\u1680')
+						{
+							return false;
+						}
+						else if(c > '\u1680')
+						{
+							return false;
+						}
+					}
+					else if (c > '\u180E')
+					{
+						if (c < '\u2000')
+						{
+							return false;
+						}
+						else if (c > '\u200A')
+						{
+							return false;
+						}
+					}
+				}
+				else if (c > '\u2029')
+				{
+					if (c < '\u205F')
+					{
+						if (c < '\u202F')
+						{
+							return false;
+						}
+						else if (c > '\u202F')
+						{
+							return false;
+						}
+					}
+					else if (c > '\u205F')
+					{
+						if (c < '\u3000')
+						{
+							return false;
+						}
+						else if (c > '\u3000')
+						{
+							return false;
+						}
+					}
+				}
+			}
+		}
+		return true;
+	},
+	isNotBlank : function(str) {
+		return Jsonix.Util.Type.isString(str) && !Jsonix.Util.StringUtils.isEmpty(str);
+	},
+	whitespaceCharacters: '\u0009\u000A\u000B\u000C\u000D \u0085\u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000',
+	whitespaceCharactersMap: {
+		'\u0009' : true,
+		'\u000A' : true,
+		'\u000B' : true,
+		'\u000C' : true,
+		'\u000D' : true,
+		' ' : true,
+		'\u0085' : true,
+		'\u00A0' : true,
+		'\u1680' : true,
+		'\u180E' : true,
+		'\u2000' : true,
+		'\u2001' : true,
+		'\u2002' : true,
+		'\u2003' : true,
+		'\u2004' : true,
+		'\u2005' : true,
+		'\u2006' : true,
+		'\u2007' : true,
+		'\u2008' : true,
+		'\u2009' : true,
+		'\u200A' : true,
+		'\u2028' : true,
+		'\u2029' : true,
+		'\u202F' : true,
+		'\u205F' : true,
+		'\u3000' : true
+	},
+	splitBySeparatorChars : function(str, separatorChars) {
+		Jsonix.Util.Ensure.ensureString(str);
+		Jsonix.Util.Ensure.ensureString(separatorChars);
+		var len = str.length;
+		if (len === 0) {
+			return [];
+		}
+		if (separatorChars.length === 1)
+		{
+			return str.split(separatorChars);
+		}
+		else
+		{
+			var list = [];
+			var sizePlus1 = 1;
+			var i = 0;
+			var start = 0;
+			var match = false;
+			var lastMatch = false;
+			var max = -1;
+			var preserveAllTokens = false;
+			// standard case
+				while (i < len) {
+						if (separatorChars.indexOf(str.charAt(i)) >= 0) {
+								if (match || preserveAllTokens) {
+										lastMatch = true;
+										if (sizePlus1++ == max) {
+												i = len;
+												lastMatch = false;
+										}
+										list.push(str.substring(start, i));
+										match = false;
+								}
+								start = ++i;
+								continue;
+						}
+						lastMatch = false;
+						match = true;
+						i++;
+				}
+				if (match || (preserveAllTokens && lastMatch)) {
+					list.push(str.substring(start, i));
+			}
+			return list;
+		}
+	}
+};
+Jsonix.Util.Ensure = {
+	ensureBoolean : function(value) {
+		if (!Jsonix.Util.Type.isBoolean(value)) {
+			throw new Error('Argument [' + value + '] must be a boolean.');
+		}
+	},
+	ensureString : function(value) {
+		if (!Jsonix.Util.Type.isString(value)) {
+			throw new Error('Argument [' + value + '] must be a string.');
+		}
+	},
+	ensureNumber : function(value) {
+		if (!Jsonix.Util.Type.isNumber(value)) {
+			throw new Error('Argument [' + value + '] must be a number.');
+		}
+	},
+	ensureNumberOrNaN : function(value) {
+		if (!Jsonix.Util.Type.isNumberOrNaN(value)) {
+			throw new Error('Argument [' + value + '] must be a number or NaN.');
+		}
+	},
+	ensureInteger : function(value) {
+		if (!Jsonix.Util.Type.isNumber(value)) {
+			throw new Error('Argument must be an integer, but it is not a number.');
+		} else if (!Jsonix.Util.NumberUtils.isInteger(value)) {
+			throw new Error('Argument [' + value + '] must be an integer.');
+		}
+	},
+	ensureDate : function(value) {
+		if (!(value instanceof Date)) {
+			throw new Error('Argument [' + value + '] must be a date.');
+		}
+	},
+	ensureObject : function(value) {
+		if (!Jsonix.Util.Type.isObject(value)) {
+			throw new Error('Argument [' + value + '] must be an object.');
+		}
+	},
+	ensureArray : function(value) {
+		if (!Jsonix.Util.Type.isArray(value)) {
+			throw new Error('Argument [' + value + '] must be an array.');
+		}
+	},
+	ensureFunction : function(value) {
+		if (!Jsonix.Util.Type.isFunction(value)) {
+			throw new Error('Argument [' + value + '] must be a function.');
+		}
+	},
+	ensureExists : function(value) {
+		if (!Jsonix.Util.Type.exists(value)) {
+			throw new Error('Argument [' + value + '] does not exist.');
+		}
+	}
+};
+Jsonix.XML.QName = Jsonix.Class({
+	key : null,
+	namespaceURI : null,
+	localPart : null,
+	prefix : null,
+	string : null,
+	initialize : function(one, two, three) {
+		var namespaceURI;
+		var localPart;
+		var prefix;
+		var key;
+		var string;
+
+		if (!Jsonix.Util.Type.exists(two)) {
+			namespaceURI = '';
+			localPart = one;
+			prefix = '';
+		} else if (!Jsonix.Util.Type.exists(three)) {
+			namespaceURI = Jsonix.Util.Type.exists(one) ? one : '';
+			localPart = two;
+			var colonPosition = two.indexOf(':');
+			if (colonPosition > 0 && colonPosition < two.length) {
+				prefix = two.substring(0, colonPosition);
+				localPart = two.substring(colonPosition + 1);
+			} else {
+				prefix = '';
+				localPart = two;
+			}
+		} else {
+			namespaceURI = Jsonix.Util.Type.exists(one) ? one : '';
+			localPart = two;
+			prefix = Jsonix.Util.Type.exists(three) ? three : '';
+		}
+		this.namespaceURI = namespaceURI;
+		this.localPart = localPart;
+		this.prefix = prefix;
+
+		this.key = (namespaceURI !== '' ? ('{' + namespaceURI + '}') : '') + localPart;
+		this.string = (namespaceURI !== '' ? ('{' + namespaceURI + '}') : '') + (prefix !== '' ? (prefix + ':') : '') + localPart;
+	},
+	toString : function() {
+		return this.string;
+	},
+	// foo:bar
+	toCanonicalString: function(namespaceContext) {
+		var canonicalPrefix = namespaceContext ? namespaceContext.getPrefix(this.namespaceURI, this.prefix) : this.prefix;
+		return this.prefix + (this.prefix === '' ? '' : ':') + this.localPart;
+	},
+	clone : function() {
+		return new Jsonix.XML.QName(this.namespaceURI, this.localPart, this.prefix);
+	},
+	equals : function(that) {
+		if (!that) {
+			return false;
+		} else {
+			return (this.namespaceURI == that.namespaceURI) && (this.localPart == that.localPart);
+		}
+
+	},
+	CLASS_NAME : "Jsonix.XML.QName"
+});
+Jsonix.XML.QName.fromString = function(qNameAsString, namespaceContext, defaultNamespaceURI) {
+	var leftBracket = qNameAsString.indexOf('{');
+	var rightBracket = qNameAsString.lastIndexOf('}');
+	var namespaceURI;
+	var prefixedName;
+	if ((leftBracket === 0) && (rightBracket > 0) && (rightBracket < qNameAsString.length)) {
+		namespaceURI = qNameAsString.substring(1, rightBracket);
+		prefixedName = qNameAsString.substring(rightBracket + 1);
+	} else {
+		namespaceURI = null;
+		prefixedName = qNameAsString;
+	}
+	var colonPosition = prefixedName.indexOf(':');
+	var prefix;
+	var localPart;
+	if (colonPosition > 0 && colonPosition < prefixedName.length) {
+		prefix = prefixedName.substring(0, colonPosition);
+		localPart = prefixedName.substring(colonPosition + 1);
+	} else {
+		prefix = '';
+		localPart = prefixedName;
+	}
+	// If namespace URI was not set and we have a namespace context, try to find the namespace URI via this context
+	if (namespaceURI === null)
+	{
+		if (prefix === '' && Jsonix.Util.Type.isString(defaultNamespaceURI))
+		{
+			namespaceURI = defaultNamespaceURI;
+		}
+		else if (namespaceContext)
+		{
+			namespaceURI = namespaceContext.getNamespaceURI(prefix);
+		}
+	}
+	// If we don't have a namespace URI, assume '' by default
+	// TODO document the assumption
+	if (!Jsonix.Util.Type.isString(namespaceURI))
+	{
+		namespaceURI = defaultNamespaceURI || '';
+	}
+	return new Jsonix.XML.QName(namespaceURI, localPart, prefix);
+};
+Jsonix.XML.QName.fromObject = function(object) {
+	Jsonix.Util.Ensure.ensureObject(object);
+	if (object instanceof Jsonix.XML.QName || (Jsonix.Util.Type.isString(object.CLASS_NAME) && object.CLASS_NAME === 'Jsonix.XML.QName')) {
+		return object;
+	}
+	var localPart = object.localPart||object.lp||null;
+	Jsonix.Util.Ensure.ensureString(localPart);
+	var namespaceURI = object.namespaceURI||object.ns||'';
+	var prefix = object.prefix||object.p||'';
+	return new Jsonix.XML.QName(namespaceURI, localPart, prefix);
+};
+Jsonix.XML.QName.fromObjectOrString = function(value, namespaceContext, defaultNamespaceURI) {
+	if (Jsonix.Util.Type.isString(value))
+	{
+		return Jsonix.XML.QName.fromString(value, namespaceContext, defaultNamespaceURI);
+	}
+	else
+	{
+		return Jsonix.XML.QName.fromObject(value);
+	}
+};
+Jsonix.XML.QName.key = function(namespaceURI, localPart) {
+	Jsonix.Util.Ensure.ensureString(localPart);
+	if (namespaceURI) {
+		var colonPosition = localPart.indexOf(':');
+		if (colonPosition > 0 && colonPosition < localPart.length) {
+			localName = localPart.substring(colonPosition + 1);
+		} else {
+			localName = localPart;
+		}
+		return '{' + namespaceURI + '}' + localName;
+	} else {
+		return localPart;
+	}
+};
+Jsonix.XML.Calendar = Jsonix.Class({
+	year : NaN,
+	month : NaN,
+	day : NaN,
+	hour : NaN,
+	minute : NaN,
+	second : NaN,
+	fractionalSecond : NaN,
+	timezone : NaN,
+	date : null,
+	initialize : function(data) {
+		Jsonix.Util.Ensure.ensureObject(data);
+		// Year
+		if (Jsonix.Util.Type.exists(data.year)) {
+			Jsonix.Util.Ensure.ensureInteger(data.year);
+			Jsonix.XML.Calendar.validateYear(data.year);
+			this.year = data.year;
+		} else {
+			this.year = NaN;
+		}
+		// Month
+		if (Jsonix.Util.Type.exists(data.month)) {
+			Jsonix.Util.Ensure.ensureInteger(data.month);
+			Jsonix.XML.Calendar.validateMonth(data.month);
+			this.month = data.month;
+		} else {
+			this.month = NaN;
+		}
+		// Day
+		if (Jsonix.Util.Type.exists(data.day)) {
+			Jsonix.Util.Ensure.ensureInteger(data.day);
+			if (Jsonix.Util.NumberUtils.isInteger(data.year) && Jsonix.Util.NumberUtils.isInteger(data.month)) {
+				Jsonix.XML.Calendar.validateYearMonthDay(data.year, data.month, data.day);
+			} else if (Jsonix.Util.NumberUtils.isInteger(data.month)) {
+				Jsonix.XML.Calendar.validateMonthDay(data.month, data.day);
+			} else {
+				Jsonix.XML.Calendar.validateDay(data.day);
+			}
+			this.day = data.day;
+		} else {
+			this.day = NaN;
+		}
+		// Hour
+		if (Jsonix.Util.Type.exists(data.hour)) {
+			Jsonix.Util.Ensure.ensureInteger(data.hour);
+			Jsonix.XML.Calendar.validateHour(data.hour);
+			this.hour = data.hour;
+		} else {
+			this.hour = NaN;
+		}
+		// Minute
+		if (Jsonix.Util.Type.exists(data.minute)) {
+			Jsonix.Util.Ensure.ensureInteger(data.minute);
+			Jsonix.XML.Calendar.validateMinute(data.minute);
+			this.minute = data.minute;
+		} else {
+			this.minute = NaN;
+		}
+		// Second
+		if (Jsonix.Util.Type.exists(data.second)) {
+			Jsonix.Util.Ensure.ensureInteger(data.second);
+			Jsonix.XML.Calendar.validateSecond(data.second);
+			this.second = data.second;
+		} else {
+			this.second = NaN;
+		}
+		// Fractional second
+		if (Jsonix.Util.Type.exists(data.fractionalSecond)) {
+			Jsonix.Util.Ensure.ensureNumber(data.fractionalSecond);
+			Jsonix.XML.Calendar.validateFractionalSecond(data.fractionalSecond);
+			this.fractionalSecond = data.fractionalSecond;
+		} else {
+			this.fractionalSecond = NaN;
+		}
+		// Timezone
+		if (Jsonix.Util.Type.exists(data.timezone)) {
+			if (Jsonix.Util.Type.isNaN(data.timezone)) {
+				this.timezone = NaN;
+			} else {
+				Jsonix.Util.Ensure.ensureInteger(data.timezone);
+				Jsonix.XML.Calendar.validateTimezone(data.timezone);
+				this.timezone = data.timezone;
+			}
+		} else {
+			this.timezone = NaN;
+		}
+
+		var initialDate = new Date(0);
+		initialDate.setUTCFullYear(this.year || 1970);
+		initialDate.setUTCMonth(this.month - 1 || 0);
+		initialDate.setUTCDate(this.day || 1);
+		initialDate.setUTCHours(this.hour || 0);
+		initialDate.setUTCMinutes(this.minute || 0);
+		initialDate.setUTCSeconds(this.second || 0);
+		initialDate.setUTCMilliseconds((this.fractionalSecond || 0) * 1000);
+		var timezoneOffset = -60000 * (this.timezone || 0);
+		this.date = new Date(initialDate.getTime() + timezoneOffset);
+	},
+	CLASS_NAME : "Jsonix.XML.Calendar"
+});
+Jsonix.XML.Calendar.MIN_TIMEZONE = -14 * 60;
+Jsonix.XML.Calendar.MAX_TIMEZONE = 14 * 60;
+Jsonix.XML.Calendar.DAYS_IN_MONTH = [ 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ];
+Jsonix.XML.Calendar.fromObject = function(object) {
+	Jsonix.Util.Ensure.ensureObject(object);
+	if (Jsonix.Util.Type.isString(object.CLASS_NAME) && object.CLASS_NAME === 'Jsonix.XML.Calendar') {
+		return object;
+	}
+	return new Jsonix.XML.Calendar(object);
+};
+Jsonix.XML.Calendar.validateYear = function(year) {
+	if (year === 0) {
+		throw new Error('Invalid year [' + year + ']. Year must not be [0].');
+	}
+};
+Jsonix.XML.Calendar.validateMonth = function(month) {
+	if (month < 1 || month > 12) {
+		throw new Error('Invalid month [' + month + ']. Month must be in range [1, 12].');
+	}
+};
+Jsonix.XML.Calendar.validateDay = function(day) {
+	if (day < 1 || day > 31) {
+		throw new Error('Invalid day [' + day + ']. Day must be in range [1, 31].');
+	}
+};
+Jsonix.XML.Calendar.validateMonthDay = function(month, day) {
+	Jsonix.XML.Calendar.validateMonth(month);
+	var maxDaysInMonth = Jsonix.XML.Calendar.DAYS_IN_MONTH[month - 1];
+	if (day < 1 || day > Jsonix.XML.Calendar.DAYS_IN_MONTH[month - 1]) {
+		throw new Error('Invalid day [' + day + ']. Day must be in range [1, ' + maxDaysInMonth + '].');
+	}
+};
+Jsonix.XML.Calendar.validateYearMonthDay = function(year, month, day) {
+	// #93 TODO proper validation of 28/29 02
+	Jsonix.XML.Calendar.validateYear(year);
+	Jsonix.XML.Calendar.validateMonthDay(month, day);
+};
+Jsonix.XML.Calendar.validateHour = function(hour) {
+	if (hour < 0 || hour > 23) {
+		throw new Error('Invalid hour [' + hour + ']. Hour must be in range [0, 23].');
+	}
+};
+Jsonix.XML.Calendar.validateMinute = function(minute) {
+	if (minute < 0 || minute > 59) {
+		throw new Error('Invalid minute [' + minute + ']. Minute must be in range [0, 59].');
+	}
+};
+Jsonix.XML.Calendar.validateSecond = function(second) {
+	if (second < 0 || second > 59) {
+		throw new Error('Invalid second [' + second + ']. Second must be in range [0, 59].');
+	}
+};
+Jsonix.XML.Calendar.validateFractionalSecond = function(fractionalSecond) {
+	if (fractionalSecond < 0 || fractionalSecond > 59) {
+		throw new Error('Invalid fractional second [' + fractionalSecond + ']. Fractional second must be in range [0, 1).');
+	}
+};
+Jsonix.XML.Calendar.validateTimezone = function(timezone) {
+	if (timezone < Jsonix.XML.Calendar.MIN_TIMEZONE || timezone > Jsonix.XML.Calendar.MAX_TIMEZONE) {
+		throw new Error('Invalid timezone [' + timezone + ']. Timezone must not be in range [' + Jsonix.XML.Calendar.MIN_TIMEZONE + ', ' + Jsonix.XML.Calendar.MAX_TIMEZONE + '].');
+	}
+};
+Jsonix.XML.Input = Jsonix.Class({
+	root : null,
+	node : null,
+	attributes : null,
+	eventType : null,
+	pns : null,
+	initialize : function(node) {
+		Jsonix.Util.Ensure.ensureExists(node);
+		this.root = node;
+		var rootPnsItem =
+		{
+			'' : ''
+		};
+		rootPnsItem[Jsonix.XML.XMLNS_P] = Jsonix.XML.XMLNS_NS;
+		this.pns = [rootPnsItem];
+	},
+	hasNext : function() {
+		// No current node, we've not started yet
+		if (this.node === null) {
+			return true;
+		} else if (this.node === this.root) {
+			var nodeType = this.node.nodeType;
+			// Root node is document, last event type is END_DOCUMENT
+			if (nodeType === 9 && this.eventType === 8) {
+				return false;
+			}
+			// Root node is element, last event type is END_ELEMENT
+			else if (nodeType === 1 && this.eventType === 2) {
+				return false;
+			} else {
+				return true;
+			}
+		} else {
+			return true;
+		}
+	},
+	next : function() {
+		if (this.eventType === null) {
+			return this.enter(this.root);
+		}
+		// START_DOCUMENT
+		if (this.eventType === 7) {
+			var documentElement = this.node.documentElement;
+			if (documentElement) {
+				return this.enter(documentElement);
+			} else {
+				return this.leave(this.node);
+			}
+		} else if (this.eventType === 1) {
+			var firstChild = this.node.firstChild;
+			if (firstChild) {
+				return this.enter(firstChild);
+			} else {
+				return this.leave(this.node);
+			}
+		} else if (this.eventType === 2) {
+			var nextSibling = this.node.nextSibling;
+			if (nextSibling) {
+				return this.enter(nextSibling);
+			} else {
+				return this.leave(this.node);
+			}
+		} else {
+			return this.leave(this.node);
+		}
+	},
+	enter : function(node) {
+		var nodeType = node.nodeType;
+		this.node = node;
+		this.attributes = null;
+		// Document node
+		if (nodeType === 1) {
+			// START_ELEMENT
+			this.eventType = 1;
+			this.pushNS(node);
+			return this.eventType;
+		} else if (nodeType === 2) {
+			// ATTRIBUTE
+			this.eventType = 10;
+			return this.eventType;
+		} else if (nodeType === 3) {
+			var nodeValue = node.nodeValue;
+			if (Jsonix.Util.StringUtils.isEmpty(nodeValue)) {
+				// SPACE
+				this.eventType = 6;
+			} else {
+				// CHARACTERS
+				this.eventType = 4;
+			}
+			return this.eventType;
+		} else if (nodeType === 4) {
+			// CDATA
+			this.eventType = 12;
+			return this.eventType;
+		} else if (nodeType === 5) {
+			// ENTITY_REFERENCE_NODE = 5
+			// ENTITY_REFERENCE
+			this.eventType = 9;
+			return this.eventType;
+		} else if (nodeType === 6) {
+			// ENTITY_DECLARATION
+			this.eventType = 15;
+			return this.eventType;
+		} else if (nodeType === 7) {
+			// PROCESSING_INSTRUCTION
+			this.eventType = 3;
+			return this.eventType;
+		} else if (nodeType === 8) {
+			// COMMENT
+			this.eventType = 5;
+			return this.eventType;
+		} else if (nodeType === 9) {
+			// START_DOCUMENT
+			this.eventType = 7;
+			return this.eventType;
+		} else if (nodeType === 10) {
+			// DTD
+			this.eventType = 12;
+			return this.eventType;
+		} else if (nodeType === 12) {
+			// NOTATION_DECLARATION
+			this.eventType = 14;
+			return this.eventType;
+		} else {
+			// DOCUMENT_FRAGMENT_NODE = 11
+			throw new Error("Node type [" + nodeType + '] is not supported.');
+		}
+	},
+	leave : function(node) {
+		if (node.nodeType === 9) {
+			if (this.eventType == 8) {
+				throw new Error("Invalid state.");
+			} else {
+				this.node = node;
+				this.attributes = null;
+				// END_ELEMENT
+				this.eventType = 8;
+				return this.eventType;
+			}
+		} else if (node.nodeType === 1) {
+			if (this.eventType == 2) {
+				var nextSibling = node.nextSibling;
+				if (nextSibling) {
+					return this.enter(nextSibling);
+				}
+			} else {
+				this.node = node;
+				this.attributes = null;
+				// END_ELEMENT
+				this.eventType = 2;
+				this.popNS();
+				return this.eventType;
+			}
+		}
+
+		var nextSibling1 = node.nextSibling;
+		if (nextSibling1) {
+			return this.enter(nextSibling1);
+		} else {
+			var parentNode = node.parentNode;
+			this.node = parentNode;
+			this.attributes = null;
+			if (parentNode.nodeType === 9) {
+				this.eventType = 8;
+			} else {
+				this.eventType = 2;
+			}
+			return this.eventType;
+		}
+	},
+	getName : function() {
+		var node = this.node;
+		if (Jsonix.Util.Type.isString(node.nodeName)) {
+			if (Jsonix.Util.Type.isString(node.namespaceURI)) {
+				return new Jsonix.XML.QName(node.namespaceURI, node.nodeName);
+			} else {
+				return new Jsonix.XML.QName(node.nodeName);
+			}
+		} else {
+			return null;
+		}
+	},
+	getNameKey : function() {
+		var node = this.node;
+		if (Jsonix.Util.Type.isString(node.nodeName)) {
+			return Jsonix.XML.QName.key(node.namespaceURI, node.nodeName);
+		} else {
+			return null;
+		}
+	},
+	getText : function() {
+		return this.node.nodeValue;
+	},
+	nextTag : function() {
+		var et = this.next();
+		// TODO isWhiteSpace
+		while (et === 7 || et === 4 || et === 12 || et === 6 || et === 3 || et === 5) {
+			et = this.next();
+		}
+		if (et !== 1 && et !== 2) {
+			// TODO location
+			throw new Error('Expected start or end tag.');
+		}
+		return et;
+	},
+	skipElement : function() {
+		if (this.eventType !== Jsonix.XML.Input.START_ELEMENT) {
+			throw new Error("Parser must be on START_ELEMENT to skip element.");
+		}
+		var numberOfOpenTags = 1;
+		var et;
+		do {
+			et = this.nextTag();
+		    numberOfOpenTags += (et === Jsonix.XML.Input.START_ELEMENT) ? 1 : -1;
+		  } while (numberOfOpenTags > 0);
+		return et;
+	},	
+	getElementText : function() {
+		if (this.eventType != 1) {
+			throw new Error("Parser must be on START_ELEMENT to read next text.");
+		}
+		var et = this.next();
+		var content = '';
+		while (et !== 2) {
+			if (et === 4 || et === 12 || et === 6 || et === 9) {
+				content = content + this.getText();
+			} else if (et === 3 || et === 5) {
+				// Skip PI or comment
+			} else if (et === 8) {
+				// End document
+				throw new Error("Unexpected end of document when reading element text content.");
+			} else if (et === 1) {
+				// End element
+				// TODO location
+				throw new Error("Element text content may not contain START_ELEMENT.");
+			} else {
+				// TODO location
+				throw new Error("Unexpected event type [" + et + "].");
+			}
+			et = this.next();
+		}
+		return content;
+	},
+	retrieveElement : function () {
+		var element;
+		if (this.eventType === 1) {
+			element = this.node;
+		} else if (this.eventType === 10) {
+			element = this.node.parentNode;
+		} else {
+			throw new Error("Element can only be retrieved for START_ELEMENT or ATTRIBUTE nodes.");
+		}
+		return element;
+	},
+	retrieveAttributes : function () {
+		var attributes;
+		if (this.attributes)
+		{
+			attributes = this.attributes;
+		} else if (this.eventType === 1) {
+			attributes = this.node.attributes;
+			this.attributes = attributes;
+		} else if (this.eventType === 10) {
+			attributes = this.node.parentNode.attributes;
+			this.attributes = attributes;
+		} else {
+			throw new Error("Attributes can only be retrieved for START_ELEMENT or ATTRIBUTE nodes.");
+		}
+		return attributes;
+	},
+	getAttributeCount : function() {
+		var attributes = this.retrieveAttributes();
+		return attributes.length;
+	},
+	getAttributeName : function(index) {
+		var attributes = this.retrieveAttributes();
+		if (index < 0 || index >= attributes.length) {
+			throw new Error("Invalid attribute index [" + index + "].");
+		}
+		var attribute = attributes[index];
+		if (Jsonix.Util.Type.isString(attribute.namespaceURI)) {
+			return new Jsonix.XML.QName(attribute.namespaceURI, attribute.nodeName);
+		} else {
+			return new Jsonix.XML.QName(attribute.nodeName);
+		}
+	},
+	getAttributeNameKey : function(index) {
+		var attributes = this.retrieveAttributes();
+		if (index < 0 || index >= attributes.length) {
+			throw new Error("Invalid attribute index [" + index + "].");
+		}
+		var attribute = attributes[index];
+
+		return Jsonix.XML.QName.key(attribute.namespaceURI, attribute.nodeName);
+	},
+	getAttributeValue : function(index) {
+		var attributes = this.retrieveAttributes();
+		if (index < 0 || index >= attributes.length) {
+			throw new Error("Invalid attribute index [" + index + "].");
+		}
+		var attribute = attributes[index];
+		return attribute.value;
+	},
+	getAttributeValueNS : null,
+	getAttributeValueNSViaElement : function(namespaceURI, localPart) {
+		var element = this.retrieveElement();
+		return element.getAttributeNS(namespaceURI, localPart);
+	},
+	getAttributeValueNSViaAttribute : function(namespaceURI, localPart) {
+		var attributeNode = this.getAttributeNodeNS(namespaceURI, localPart);
+		if (Jsonix.Util.Type.exists(attributeNode)) {
+			return attributeNode.nodeValue;
+		}
+		else
+		{
+			return null;
+		}
+	},
+	getAttributeNodeNS : null,
+	getAttributeNodeNSViaElement : function(namespaceURI, localPart) {
+		var element = this.retrieveElement();
+		return element.getAttributeNodeNS(namespaceURI, localPart);
+	},
+	getAttributeNodeNSViaAttributes : function(namespaceURI, localPart) {
+		var attributeNode = null;
+		var attributes = this.retrieveAttributes();
+		var potentialNode, fullName;
+		for (var i = 0, len = attributes.length; i < len; ++i) {
+			potentialNode = attributes[i];
+			if (potentialNode.namespaceURI === namespaceURI) {
+				fullName = (potentialNode.prefix) ? (potentialNode.prefix + ':' + localPart) : localPart;
+				if (fullName === potentialNode.nodeName) {
+					attributeNode = potentialNode;
+					break;
+				}
+			}
+		}
+		return attributeNode;
+	},
+	getElement : function() {
+		if (this.eventType === 1 || this.eventType === 2) {
+			// Go to the END_ELEMENT
+			this.eventType = 2;
+			return this.node;
+		} else {
+			throw new Error("Parser must be on START_ELEMENT or END_ELEMENT to return current element.");
+		}
+	},
+	pushNS : function (node) {
+		var pindex = this.pns.length - 1;
+		var parentPnsItem = this.pns[pindex];
+		var pnsItem = Jsonix.Util.Type.isObject(parentPnsItem) ? pindex : parentPnsItem;
+		this.pns.push(pnsItem);
+		pindex++;
+		var reference = true;
+		if (node.attributes)
+		{
+			var attributes = node.attributes;
+			var alength = attributes.length;
+			if (alength > 0)
+			{
+				// If given node has attributes
+				for (var aindex = 0; aindex < alength; aindex++)
+				{
+					var attribute = attributes[aindex];
+					var attributeName = attribute.nodeName;
+					var p = null;
+					var ns = null;
+					var isNS = false;
+					if (attributeName === 'xmlns')
+					{
+						p = '';
+						ns = attribute.value;
+						isNS = true;
+					}
+					else if (attributeName.substring(0, 6) === 'xmlns:')
+					{
+						p = attributeName.substring(6);
+						ns = attribute.value;
+						isNS = true;
+					}
+					// Attribute is a namespace declaration
+					if (isNS)
+					{
+						if (reference)
+						{
+							pnsItem = Jsonix.Util.Type.cloneObject(this.pns[pnsItem], {});
+							this.pns[pindex] = pnsItem;
+							reference = false;
+						}
+						pnsItem[p] = ns;
+					}
+				}
+			}
+		}		
+	},
+	popNS : function () {
+		this.pns.pop();
+	},
+	getNamespaceURI : function (p) {
+		var pindex = this.pns.length - 1;
+		var pnsItem = this.pns[pindex];
+		pnsItem = Jsonix.Util.Type.isObject(pnsItem) ? pnsItem : this.pns[pnsItem];
+		return pnsItem[p];
+	},
+	CLASS_NAME : "Jsonix.XML.Input"
+
+});
+
+Jsonix.XML.Input.prototype.getAttributeValueNS = (Jsonix.DOM.isDomImplementationAvailable()) ? Jsonix.XML.Input.prototype.getAttributeValueNSViaElement : Jsonix.XML.Input.prototype.getAttributeValueNSViaAttribute;
+Jsonix.XML.Input.prototype.getAttributeNodeNS = (Jsonix.DOM.isDomImplementationAvailable()) ? Jsonix.XML.Input.prototype.getAttributeNodeNSViaElement : Jsonix.XML.Input.prototype.getAttributeNodeNSViaAttributes;
+
+Jsonix.XML.Input.START_ELEMENT = 1;
+Jsonix.XML.Input.END_ELEMENT = 2;
+Jsonix.XML.Input.PROCESSING_INSTRUCTION = 3;
+Jsonix.XML.Input.CHARACTERS = 4;
+Jsonix.XML.Input.COMMENT = 5;
+Jsonix.XML.Input.SPACE = 6;
+Jsonix.XML.Input.START_DOCUMENT = 7;
+Jsonix.XML.Input.END_DOCUMENT = 8;
+Jsonix.XML.Input.ENTITY_REFERENCE = 9;
+Jsonix.XML.Input.ATTRIBUTE = 10;
+Jsonix.XML.Input.DTD = 11;
+Jsonix.XML.Input.CDATA = 12;
+Jsonix.XML.Input.NAMESPACE = 13;
+Jsonix.XML.Input.NOTATION_DECLARATION = 14;
+Jsonix.XML.Input.ENTITY_DECLARATION = 15;
+
+Jsonix.XML.Output = Jsonix.Class({
+	document : null,
+	documentElement : null,
+	node : null,
+	nodes : null,
+	nsp : null,
+	pns : null,
+	namespacePrefixIndex : 0,
+	xmldom : null,
+	initialize : function(options) {
+		// REWORK
+		if (typeof ActiveXObject !== 'undefined') {
+			this.xmldom = new ActiveXObject("Microsoft.XMLDOM");
+		} else {
+			this.xmldom = null;
+		}
+		this.nodes = [];
+		var rootNspItem =
+		{
+			'' : ''
+		};
+		rootNspItem[Jsonix.XML.XMLNS_NS] = Jsonix.XML.XMLNS_P;
+		if (Jsonix.Util.Type.isObject(options)) {
+			if (Jsonix.Util.Type.isObject(options.namespacePrefixes)) {
+				Jsonix.Util.Type.cloneObject(options.namespacePrefixes, rootNspItem);
+			}
+		}
+		this.nsp = [rootNspItem];
+		var rootPnsItem =
+		{
+			'' : ''
+		};
+		rootPnsItem[Jsonix.XML.XMLNS_P] = Jsonix.XML.XMLNS_NS;
+		this.pns = [rootPnsItem];
+	},
+	destroy : function() {
+		this.xmldom = null;
+	},
+	writeStartDocument : function() {
+		// TODO Check
+		var doc = Jsonix.DOM.createDocument();
+		this.document = doc;
+		return this.push(doc);
+	},
+	writeEndDocument : function() {
+		return this.pop();
+
+	},
+	writeStartElement : function(name) {
+		Jsonix.Util.Ensure.ensureObject(name);
+		var localPart = name.localPart || name.lp || null;
+		Jsonix.Util.Ensure.ensureString(localPart);
+		var ns = name.namespaceURI || name.ns || null;
+		var namespaceURI = Jsonix.Util.Type.isString(ns) ? ns : '';
+
+		var p = name.prefix || name.p;
+		var prefix = this.getPrefix(namespaceURI, p);
+
+		var qualifiedName = (!prefix ? localPart : prefix + ':' + localPart);
+
+		var element;
+		if (Jsonix.Util.Type.isFunction(this.document.createElementNS))	{
+			element = this.document.createElementNS(namespaceURI, qualifiedName);
+		}
+		else if (this.xmldom) {
+			element = this.xmldom.createNode(1, qualifiedName, namespaceURI);
+
+		} else {
+			throw new Error("Could not create an element node.");
+		}
+		this.peek().appendChild(element);
+		this.push(element);
+		this.declareNamespace(namespaceURI, prefix);
+		if (this.documentElement === null)
+		{
+			this.documentElement = element;
+			this.declareNamespaces();
+		}
+		return element;
+	},
+	writeEndElement : function() {
+		return this.pop();
+	},
+	writeCharacters : function(text) {
+		var node;
+		if (Jsonix.Util.Type.isFunction(this.document.createTextNode))	{
+			node = this.document.createTextNode(text);
+		}
+		else if (this.xmldom) {
+			node = this.xmldom.createTextNode(text);
+		} else {
+			throw new Error("Could not create a text node.");
+		}
+		this.peek().appendChild(node);
+		return node;
+
+	},
+	writeCdata : function(text) {
+		var node;
+		if (Jsonix.Util.Type.isFunction(this.document.createCDATASection))	{
+			node = this.document.createCDATASection(text);
+		}
+		else if (this.xmldom) {
+			node = this.xmldom.createCDATASection(text);
+		} else {
+			throw new Error("Could not create a CDATA section node.");
+		}
+		this.peek().appendChild(node);
+		return node;
+	},
+	writeAttribute : function(name, value) {
+		Jsonix.Util.Ensure.ensureString(value);
+		Jsonix.Util.Ensure.ensureObject(name);
+		var localPart = name.localPart || name.lp || null;
+		Jsonix.Util.Ensure.ensureString(localPart);
+		var ns = name.namespaceURI || name.ns || null;
+		var namespaceURI = Jsonix.Util.Type.isString(ns) ? ns : '';
+		var p = name.prefix || name.p || null;
+		var prefix = this.getPrefix(namespaceURI, p);
+
+		var qualifiedName = (!prefix ? localPart : prefix + ':' + localPart);
+
+		var node = this.peek();
+
+		if (namespaceURI === '') {
+			node.setAttribute(qualifiedName, value);
+		} else {
+			if (node.setAttributeNS) {
+				node.setAttributeNS(namespaceURI, qualifiedName, value);
+			} else {
+				if (this.xmldom) {
+					var attribute = this.document.createNode(2, qualifiedName, namespaceURI);
+					attribute.nodeValue = value;
+					node.setAttributeNode(attribute);
+				}
+				else if (namespaceURI === Jsonix.XML.XMLNS_NS)
+				{
+					// XMLNS namespace may be processed unqualified
+					node.setAttribute(qualifiedName, value);
+				}
+				else
+				{
+					throw new Error("The [setAttributeNS] method is not implemented");
+				}
+			}
+			this.declareNamespace(namespaceURI, prefix);
+		}
+
+	},
+	writeNode : function(node) {
+		var importedNode;
+		if (Jsonix.Util.Type.exists(this.document.importNode)) {
+			importedNode = this.document.importNode(node, true);
+		} else {
+			importedNode = node;
+		}
+		this.peek().appendChild(importedNode);
+		return importedNode;
+	},
+	push : function(node) {
+		this.nodes.push(node);
+		this.pushNS();
+		return node;
+	},
+	peek : function() {
+		return this.nodes[this.nodes.length - 1];
+	},
+	pop : function() {
+		this.popNS();
+		var result = this.nodes.pop();
+		return result;
+	},
+	pushNS : function ()
+	{
+		var nindex = this.nsp.length - 1;
+		var pindex = this.pns.length - 1;
+		var parentNspItem = this.nsp[nindex];
+		var parentPnsItem = this.pns[pindex];
+		var nspItem = Jsonix.Util.Type.isObject(parentNspItem) ? nindex : parentNspItem;
+		var pnsItem = Jsonix.Util.Type.isObject(parentPnsItem) ? pindex : parentPnsItem;
+		this.nsp.push(nspItem);
+		this.pns.push(pnsItem);
+	},
+	popNS : function ()
+	{
+		this.nsp.pop();
+		this.pns.pop();
+	},
+	declareNamespaces : function ()
+	{
+		var index = this.nsp.length - 1;
+		var nspItem = this.nsp[index];
+		nspItem = Jsonix.Util.Type.isNumber(nspItem) ? this.nsp[nspItem] : nspItem;
+		var ns, p;
+		for (ns in nspItem)
+		{
+			if (nspItem.hasOwnProperty(ns))
+			{
+				p = nspItem[ns];
+				this.declareNamespace(ns, p);
+			}
+		}
+	},
+	declareNamespace : function (ns, p)
+	{
+		var index = this.pns.length - 1;
+		var pnsItem = this.pns[index];
+		var reference;
+		if (Jsonix.Util.Type.isNumber(pnsItem))
+		{
+			// Resolve the reference
+			reference = true;
+			pnsItem = this.pns[pnsItem];
+		}
+		else
+		{
+			reference = false;
+		}
+		// If this prefix is mapped to a different namespace and must be redeclared
+		if (pnsItem[p] !== ns)
+		{
+			if (p === '')
+			{
+				this.writeAttribute({lp : Jsonix.XML.XMLNS_P}, ns);
+			}
+			else
+			{
+				this.writeAttribute({ns : Jsonix.XML.XMLNS_NS, lp : p, p : Jsonix.XML.XMLNS_P}, ns);
+			}
+			if (reference)
+			{
+				// If this was a reference, clone it and replace the reference
+				pnsItem = Jsonix.Util.Type.cloneObject(pnsItem, {});
+				this.pns[index] = pnsItem;
+			}
+			pnsItem[p] = ns;
+		}
+	},
+	getPrefix : function (ns, p)
+	{
+		var index = this.nsp.length - 1;
+		var nspItem = this.nsp[index];
+		var reference;
+		if (Jsonix.Util.Type.isNumber(nspItem))
+		{
+			// This is a reference, the item is the index of the parent item
+			reference = true;
+			nspItem = this.nsp[nspItem];
+		}
+		else
+		{
+			reference = false;
+		}
+		if (Jsonix.Util.Type.isString(p))
+		{
+			var oldp = nspItem[ns];
+			// If prefix is already declared and equals the proposed prefix
+			if (p === oldp)
+			{
+				// Nothing to do
+			}
+			else
+			{
+				// If this was a reference, we have to clone it now
+				if (reference)
+				{
+					nspItem = Jsonix.Util.Type.cloneObject(nspItem, {});
+					this.nsp[index] = nspItem;
+				}
+				nspItem[ns] = p;
+			}
+		}
+		else
+		{
+			p = nspItem[ns];
+			if (!Jsonix.Util.Type.exists(p)) {
+				p = 'p' + (this.namespacePrefixIndex++);
+				// If this was a reference, we have to clone it now
+				if (reference)
+				{
+					nspItem = Jsonix.Util.Type.cloneObject(nspItem, {});
+					this.nsp[index] = nspItem;
+				}
+				nspItem[ns] = p;
+			}
+		}
+		return p;
+	},
+	getNamespaceURI : function (p) {
+		var pindex = this.pns.length - 1;
+		var pnsItem = this.pns[pindex];
+		pnsItem = Jsonix.Util.Type.isObject(pnsItem) ? pnsItem : this.pns[pnsItem];
+		return pnsItem[p];
+	},
+	CLASS_NAME : "Jsonix.XML.Output"
+});
+
+Jsonix.Mapping = {};
+Jsonix.Mapping.Style = Jsonix.Class({
+	marshaller : null,
+	unmarshaller : null,
+	module : null,
+	elementInfo : null,
+	classInfo : null,
+	enumLeafInfo : null,
+	anyAttributePropertyInfo : null,
+	anyElementPropertyInfo : null,
+	attributePropertyInfo : null,
+	elementMapPropertyInfo : null,
+	elementPropertyInfo : null,
+	elementsPropertyInfo : null,
+	elementRefPropertyInfo : null,
+	elementRefsPropertyInfo : null,
+	valuePropertyInfo : null,
+	initialize : function() {
+	},
+	CLASS_NAME : 'Jsonix.Mapping.Style'
+});
+
+Jsonix.Mapping.Style.STYLES = {};
+Jsonix.Mapping.Styled = Jsonix.Class({
+	mappingStyle : null,
+	initialize : function(options) {
+		if (Jsonix.Util.Type.exists(options)) {
+			Jsonix.Util.Ensure.ensureObject(options);
+			if (Jsonix.Util.Type.isString(options.mappingStyle)) {
+				var mappingStyle = Jsonix.Mapping.Style.STYLES[options.mappingStyle];
+				if (!mappingStyle) {
+					throw new Error("Mapping style [" + options.mappingStyle + "] is not known.");
+				}
+				this.mappingStyle = mappingStyle;
+			} else if (Jsonix.Util.Type.isObject(options.mappingStyle)) {
+				this.mappingStyle = options.mappingStyle;
+			}
+		}
+		if (!this.mappingStyle) {
+			this.mappingStyle = Jsonix.Mapping.Style.STYLES.standard;
+		}
+	},
+	CLASS_NAME : 'Jsonix.Mapping.Styled'
+});
+Jsonix.Binding = {};
+Jsonix.Binding.Marshalls = {
+};
+
+Jsonix.Binding.Marshalls.Element = Jsonix.Class({
+	marshalElement : function(value, context, output, scope) {
+		var elementValue = this.convertToTypedNamedValue(value, context, output, scope);
+		var declaredTypeInfo = elementValue.typeInfo;
+		var actualTypeInfo = undefined;
+		if (context.supportXsiType && Jsonix.Util.Type.exists(elementValue.value))
+		{
+			var typeInfoByValue = context.getTypeInfoByValue(elementValue.value);
+			if (typeInfoByValue && typeInfoByValue.typeName)
+			{
+				actualTypeInfo = typeInfoByValue;
+			}
+		}
+		var typeInfo = actualTypeInfo || declaredTypeInfo;
+
+		if (typeInfo) {
+			output.writeStartElement(elementValue.name);
+			if (actualTypeInfo && declaredTypeInfo !== actualTypeInfo) {
+				var xsiTypeName = actualTypeInfo.typeName;
+				var xsiType = Jsonix.Schema.XSD.QName.INSTANCE.print(xsiTypeName, context, output, scope);
+				output.writeAttribute(Jsonix.Schema.XSI.TYPE_QNAME, xsiType);
+			}
+			if (Jsonix.Util.Type.exists(elementValue.value)) {
+				typeInfo.marshal(elementValue.value, context, output, scope);
+			}
+			output.writeEndElement();
+		} else {
+			throw new Error("Element [" + elementValue.name.key + "] is not known in this context, could not determine its type.");
+		}
+	},
+	getTypeInfoByElementName : function(name, context, scope) {
+		var elementInfo = context.getElementInfo(name, scope);
+		if (Jsonix.Util.Type.exists(elementInfo)) {
+			return elementInfo.typeInfo;
+		} else {
+			return undefined;
+		}
+	}
+});
+Jsonix.Binding.Marshalls.Element.AsElementRef = Jsonix.Class({
+	convertToTypedNamedValue : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		var elementValue = this.convertToNamedValue(value, context, output, scope);
+		return {
+			name : elementValue.name,
+			value : elementValue.value,
+			typeInfo : this.getTypeInfoByElementName(elementValue.name, context, scope)
+		};
+	},
+	convertToNamedValue : function(elementValue, context, output, scope) {
+		var name;
+		var value;
+		if (Jsonix.Util.Type.exists(elementValue.name) && !Jsonix.Util.Type.isUndefined(elementValue.value)) {
+			name = Jsonix.XML.QName.fromObjectOrString(elementValue.name, context);
+			value = Jsonix.Util.Type.exists(elementValue.value) ? elementValue.value : null;
+			return {
+				name : name,
+				value : value
+			};
+		} else {
+			for ( var propertyName in elementValue) {
+				if (elementValue.hasOwnProperty(propertyName)) {
+					name = Jsonix.XML.QName.fromObjectOrString(propertyName, context);
+					value = elementValue[propertyName];
+					return {
+						name : name,
+						value : value
+					};
+				}
+			}
+		}
+		throw new Error("Invalid element value [" + elementValue + "]. Element values must either have {name:'myElementName', value: elementValue} or {myElementName:elementValue} structure.");
+	}
+});
+
+Jsonix.Binding.Unmarshalls = {};
+
+Jsonix.Binding.Unmarshalls.WrapperElement = Jsonix.Class({
+	mixed : false,
+	unmarshalWrapperElement : function(context, input, scope, callback) {
+		var et = input.next();
+		while (et !== Jsonix.XML.Input.END_ELEMENT) {
+			if (et === Jsonix.XML.Input.START_ELEMENT) {
+				this.unmarshalElement(context, input, scope, callback);
+			} else
+			// Characters
+			if (this.mixed && (et === Jsonix.XML.Input.CHARACTERS || et === Jsonix.XML.Input.CDATA || et === Jsonix.XML.Input.ENTITY_REFERENCE)) {
+				callback(input.getText());
+			} else if (et === Jsonix.XML.Input.SPACE || et === Jsonix.XML.Input.COMMENT || et === Jsonix.XML.Input.PROCESSING_INSTRUCTION) {
+				// Skip whitespace
+			} else {
+				throw new Error("Illegal state: unexpected event type [" + et + "].");
+			}
+			et = input.next();
+		}
+	}
+});
+
+Jsonix.Binding.Unmarshalls.Element = Jsonix.Class({
+	allowTypedObject : true,
+	allowDom : false,
+	unmarshalElement : function(context, input, scope, callback) {
+		if (input.eventType != 1) {
+			throw new Error("Parser must be on START_ELEMENT to read next element.");
+		}
+		var typeInfo = this.getTypeInfoByInputElement(context, input, scope);
+		var name = input.getName();
+		var elementValue;
+		if (this.allowTypedObject) {
+			if (Jsonix.Util.Type.exists(typeInfo)) {
+				var value = typeInfo.unmarshal(context, input, scope);
+				var typedNamedValue = {
+					name : name,
+					value : value,
+					typeInfo : typeInfo
+				};
+				elementValue = this.convertFromTypedNamedValue(typedNamedValue, context, input, scope);
+			} else if (this.allowDom) {
+				elementValue = input.getElement();
+			} else {
+				throw new Error("Element [" + name.toString() + "] could not be unmarshalled as is not known in this context and the property does not allow DOM content.");
+			}
+		} else if (this.allowDom) {
+			elementValue = input.getElement();
+		} else {
+			throw new Error("Element [" + name.toString() + "] could not be unmarshalled as the property neither allows typed objects nor DOM as content. This is a sign of invalid mappings, do not use [allowTypedObject : false] and [allowDom : false] at the same time.");
+		}
+		callback(elementValue);
+	},
+	getTypeInfoByInputElement : function(context, input, scope) {
+		var xsiTypeInfo = null;
+		if (context.supportXsiType) {
+			var xsiType = input.getAttributeValueNS(Jsonix.Schema.XSI.NAMESPACE_URI, Jsonix.Schema.XSI.TYPE);
+			if (Jsonix.Util.StringUtils.isNotBlank(xsiType)) {
+				var xsiTypeName = Jsonix.Schema.XSD.QName.INSTANCE.parse(xsiType, context, input, scope);
+				xsiTypeInfo = context.getTypeInfoByTypeNameKey(xsiTypeName.key);
+			}
+		}
+		var name = input.getName();
+		var typeInfo = xsiTypeInfo ? xsiTypeInfo : this.getTypeInfoByElementName(name, context, scope);
+		return typeInfo;
+	},
+	getTypeInfoByElementName : function(name, context, scope) {
+		var elementInfo = context.getElementInfo(name, scope);
+		if (Jsonix.Util.Type.exists(elementInfo)) {
+			return elementInfo.typeInfo;
+		} else {
+			return undefined;
+		}
+	}
+});
+
+Jsonix.Binding.Unmarshalls.Element.AsElementRef = Jsonix.Class({
+	convertFromTypedNamedValue : function(typedNamedValue, context, input, scope) {
+		return {
+			name : typedNamedValue.name,
+			value : typedNamedValue.value
+		};
+	}
+});
+
+Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef = Jsonix.Class({
+	convertFromTypedNamedValue : function(typedNamedValue, context, input, scope) {
+		var propertyName = typedNamedValue.name.toCanonicalString(context);
+		var value = {};
+		value[propertyName] = typedNamedValue.value;
+		return value;
+	}
+});
+Jsonix.Binding.Marshaller = Jsonix.Class(Jsonix.Binding.Marshalls.Element, Jsonix.Binding.Marshalls.Element.AsElementRef, {
+	context : null,
+	initialize : function(context) {
+		Jsonix.Util.Ensure.ensureObject(context);
+		this.context = context;
+	},
+	marshalString : function(value) {
+		var doc = this.marshalDocument(value);
+		var text = Jsonix.DOM.serialize(doc);
+		return text;
+	},
+	marshalDocument : function(value) {
+		var output = new Jsonix.XML.Output({
+			namespacePrefixes : this.context.namespacePrefixes
+		});
+
+		var doc = output.writeStartDocument();
+		this.marshalElement(value, this.context, output, undefined);
+		output.writeEndDocument();
+		return doc;
+	},
+	CLASS_NAME : 'Jsonix.Binding.Marshaller'
+});
+Jsonix.Binding.Marshaller.Simplified = Jsonix.Class(Jsonix.Binding.Marshaller, {
+	CLASS_NAME : 'Jsonix.Binding.Marshaller.Simplified'
+});
+Jsonix.Binding.Unmarshaller = Jsonix.Class(Jsonix.Binding.Unmarshalls.Element, Jsonix.Binding.Unmarshalls.Element.AsElementRef, {
+	context : null,
+	allowTypedObject : true,
+	allowDom : false,
+	initialize : function(context) {
+		Jsonix.Util.Ensure.ensureObject(context);
+		this.context = context;
+	},
+	unmarshalString : function(text) {
+		Jsonix.Util.Ensure.ensureString(text);
+		var doc = Jsonix.DOM.parse(text);
+		return this.unmarshalDocument(doc);
+	},
+	unmarshalURL : function(url, callback, options) {
+		Jsonix.Util.Ensure.ensureString(url);
+		Jsonix.Util.Ensure.ensureFunction(callback);
+		if (Jsonix.Util.Type.exists(options)) {
+			Jsonix.Util.Ensure.ensureObject(options);
+		}
+		that = this;
+		Jsonix.DOM.load(url, function(doc) {
+			callback(that.unmarshalDocument(doc));
+		}, options);
+	},
+	unmarshalFile : function(fileName, callback, options) {
+		if (typeof _jsonix_fs === 'undefined') {
+			throw new Error("File unmarshalling is only available in environments which support file systems.");
+		}
+		Jsonix.Util.Ensure.ensureString(fileName);
+		Jsonix.Util.Ensure.ensureFunction(callback);
+		if (Jsonix.Util.Type.exists(options)) {
+			Jsonix.Util.Ensure.ensureObject(options);
+		}
+		that = this;
+		var fs = _jsonix_fs;
+		fs.readFile(fileName, options, function(err, data) {
+			if (err) {
+				throw err;
+			} else {
+				var text = data.toString();
+				var doc = Jsonix.DOM.parse(text);
+				callback(that.unmarshalDocument(doc));
+			}
+		});
+	},
+	unmarshalDocument : function(doc, scope) {
+		var input = new Jsonix.XML.Input(doc);
+		var result = null;
+		var callback = function(_result) {
+			result = _result;
+		};
+		input.nextTag();
+		this.unmarshalElement(this.context, input, scope, callback);
+		return result;
+
+	},
+	CLASS_NAME : 'Jsonix.Binding.Unmarshaller'
+});
+Jsonix.Binding.Unmarshaller.Simplified = Jsonix.Class(Jsonix.Binding.Unmarshaller, Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef, {
+	CLASS_NAME : 'Jsonix.Binding.Unmarshaller.Simplified'
+});
+Jsonix.Model.TypeInfo = Jsonix.Class({
+	module: null,			
+	name : null,
+	baseTypeInfo : null,
+	initialize : function() {
+	},
+	isBasedOn : function(typeInfo) {
+		var currentTypeInfo = this;
+		while (currentTypeInfo) {
+			if (typeInfo === currentTypeInfo) {
+				return true;
+			}
+			currentTypeInfo = currentTypeInfo.baseTypeInfo;
+		}
+		return false;
+	},
+	CLASS_NAME : 'Jsonix.Model.TypeInfo'
+});
+Jsonix.Model.ClassInfo = Jsonix
+		.Class(Jsonix.Model.TypeInfo, Jsonix.Mapping.Styled, {
+			name : null,
+			localName : null,
+			typeName : null,
+			instanceFactory : null,
+			properties : null,
+			propertiesMap : null,
+			structure : null,
+			targetNamespace : '',
+			defaultElementNamespaceURI : '',
+			defaultAttributeNamespaceURI : '',
+			built : false,
+			initialize : function(mapping, options) {
+				Jsonix.Model.TypeInfo.prototype.initialize.apply(this, []);
+				Jsonix.Mapping.Styled.prototype.initialize.apply(this, [options]);
+				Jsonix.Util.Ensure.ensureObject(mapping);
+				var n = mapping.name||mapping.n||undefined;
+				Jsonix.Util.Ensure.ensureString(n);
+				this.name = n;
+
+				var ln = mapping.localName||mapping.ln||null;
+				this.localName = ln;
+
+				var dens = mapping.defaultElementNamespaceURI||mapping.dens||mapping.targetNamespace||mapping.tns||'';
+				this.defaultElementNamespaceURI = dens;
+
+				var tns =  mapping.targetNamespace||mapping.tns||mapping.defaultElementNamespaceURI||mapping.dens||this.defaultElementNamespaceURI;
+				this.targetNamespace = tns;
+
+				var dans = mapping.defaultAttributeNamespaceURI||mapping.dans||'';
+				this.defaultAttributeNamespaceURI = dans;
+
+				var bti = mapping.baseTypeInfo||mapping.bti||null;
+				this.baseTypeInfo = bti;
+
+				var inF = mapping.instanceFactory||mapping.inF||undefined;
+				if (Jsonix.Util.Type.exists(inF)) {
+					// TODO: should we support instanceFactory as functions?
+					// For the pure JSON configuration?
+					Jsonix.Util.Ensure.ensureFunction(inF);
+					this.instanceFactory = inF;
+				}
+
+				var tn = mapping.typeName||mapping.tn||undefined;
+
+				if (Jsonix.Util.Type.exists(tn))
+				{
+					if (Jsonix.Util.Type.isString(tn))
+					{
+						this.typeName = new Jsonix.XML.QName(this.targetNamespace, tn);
+					}
+					else {
+						this.typeName = Jsonix.XML.QName.fromObject(tn);
+					}
+				}
+				else if (Jsonix.Util.Type.exists(ln))
+				{
+					this.typeName = new Jsonix.XML.QName(tns, ln);
+				}
+
+				this.properties = [];
+				this.propertiesMap = {};
+				var ps = mapping.propertyInfos||mapping.ps||[];
+				Jsonix.Util.Ensure.ensureArray(ps);
+				for ( var index = 0; index < ps.length; index++) {
+					this.p(ps[index]);
+				}
+			},
+			getPropertyInfoByName : function(name) {
+				return this.propertiesMap[name];
+			},
+			// Obsolete
+			destroy : function() {
+			},
+			build : function(context) {
+				if (!this.built) {
+					this.baseTypeInfo = context.resolveTypeInfo(this.baseTypeInfo, this.module);
+					if (Jsonix.Util.Type.exists(this.baseTypeInfo)) {
+						this.baseTypeInfo.build(context);
+					}
+
+					// Build properties in this context
+					for ( var index = 0; index < this.properties.length; index++) {
+						var propertyInfo = this.properties[index];
+						propertyInfo.build(context, this.module);
+					}
+
+					// Build the structure
+					var structure = {
+						elements : null,
+						attributes : {},
+						anyAttribute : null,
+						value : null,
+						any : null
+					};
+					this.buildStructure(context, structure);
+					this.structure = structure;
+				}
+			},
+			buildStructure : function(context, structure) {
+				if (Jsonix.Util.Type.exists(this.baseTypeInfo)) {
+					this.baseTypeInfo.buildStructure(context, structure);
+				}
+				for ( var index = 0; index < this.properties.length; index++) {
+					var propertyInfo = this.properties[index];
+					propertyInfo.buildStructure(context, structure);
+				}
+			},
+			unmarshal : function(context, input) {
+				this.build(context);
+				var result;
+
+				if (this.instanceFactory) {
+					result = new this.instanceFactory();
+				}
+				else
+				{
+					result = { TYPE_NAME : this.name };
+				}
+
+				if (input.eventType !== 1) {
+					throw new Error("Parser must be on START_ELEMENT to read a class info.");
+				}
+
+				// Read attributes
+				if (Jsonix.Util.Type.exists(this.structure.attributes)) {
+					var attributeCount = input.getAttributeCount();
+					if (attributeCount !== 0) {
+						for ( var index = 0; index < attributeCount; index++) {
+							var attributeNameKey = input
+									.getAttributeNameKey(index);
+							if (Jsonix.Util.Type
+									.exists(this.structure.attributes[attributeNameKey])) {
+								var attributeValue = input
+										.getAttributeValue(index);
+								if (Jsonix.Util.Type.isString(attributeValue)) {
+									var attributePropertyInfo = this.structure.attributes[attributeNameKey];
+									this.unmarshalPropertyValue(context, input,
+											attributePropertyInfo, result,
+											attributeValue);
+								}
+							}
+						}
+					}
+				}
+				// Read any attribute
+				if (Jsonix.Util.Type.exists(this.structure.anyAttribute)) {
+					var propertyInfo = this.structure.anyAttribute;
+					this
+							.unmarshalProperty(context, input, propertyInfo,
+									result);
+				}
+				// Read elements
+				if (Jsonix.Util.Type.exists(this.structure.elements)) {
+
+					var et = input.next();
+					while (et !== Jsonix.XML.Input.END_ELEMENT) {
+						if (et === Jsonix.XML.Input.START_ELEMENT) {
+							// New sub-element starts
+							var elementNameKey = input.getNameKey();
+							if (Jsonix.Util.Type
+									.exists(this.structure.elements[elementNameKey])) {
+								var elementPropertyInfo = this.structure.elements[elementNameKey];
+								this.unmarshalProperty(context, input,
+										elementPropertyInfo, result);
+							} else if (Jsonix.Util.Type
+									.exists(this.structure.any)) {
+								// TODO Refactor
+
+								var anyPropertyInfo = this.structure.any;
+								this.unmarshalProperty(context, input,
+										anyPropertyInfo, result);
+							} else {
+								// TODO optionally report a validation error that the element is not expected
+								et = input.skipElement();
+							}
+						} else if ((et === Jsonix.XML.Input.CHARACTERS || et === Jsonix.XML.Input.CDATA || et === Jsonix.XML.Input.ENTITY_REFERENCE)) {
+							if (Jsonix.Util.Type.exists(this.structure.mixed))
+							{
+								// Characters and structure has a mixed property
+								var mixedPropertyInfo = this.structure.mixed;
+								this.unmarshalProperty(context, input,
+										mixedPropertyInfo, result);
+							}
+						} else if (et === Jsonix.XML.Input.SPACE || et === Jsonix.XML.Input.COMMENT	|| et === Jsonix.XML.Input.PROCESSING_INSTRUCTION) {
+							// Ignore
+						} else {
+							throw new Error("Illegal state: unexpected event type [" + et	+ "].");
+						}
+						et = input.next();
+					}
+				} else if (Jsonix.Util.Type.exists(this.structure.value)) {
+					var valuePropertyInfo = this.structure.value;
+					this.unmarshalProperty(context, input, valuePropertyInfo,
+							result);
+				} else {
+					// Just skip everything
+					input.nextTag();
+				}
+				if (input.eventType !== 2) {
+					throw new Error("Illegal state: must be END_ELEMENT.");
+				}
+				return result;
+			},
+			unmarshalProperty : function(context, input, propertyInfo, result) {
+				var propertyValue = propertyInfo
+						.unmarshal(context, input, this);
+				propertyInfo.setProperty(result, propertyValue);
+			},
+			unmarshalPropertyValue : function(context, input, propertyInfo,
+					result, value) {
+				var propertyValue = propertyInfo.unmarshalValue(value, context, input, this);
+				propertyInfo.setProperty(result, propertyValue);
+			},
+			marshal : function(value, context, output, scope) {
+				if (this.isMarshallable(value, context, scope))
+				{
+					// TODO This must be reworked
+					if (Jsonix.Util.Type.exists(this.baseTypeInfo)) {
+						this.baseTypeInfo.marshal(value, context, output);
+					}
+					for ( var index = 0; index < this.properties.length; index++) {
+						var propertyInfo = this.properties[index];
+						var propertyValue = value[propertyInfo.name];
+						if (Jsonix.Util.Type.exists(propertyValue)) {
+							propertyInfo.marshal(propertyValue, context, output, this);
+						}
+					}
+				}
+				else
+				{
+					// Otherwise if there is just one property, use this property to marshal
+					if (this.structure.value)
+					{
+						var valuePropertyInfo = this.structure.value;
+						valuePropertyInfo.marshal(value, context, output, this);
+					}
+					else if (this.properties.length === 1)
+					{
+						var singlePropertyInfo = this.properties[0];
+						singlePropertyInfo.marshal(value, context, output, this);
+					}
+					else
+					{
+						// TODO throw an error
+						throw new Error("The passed value [" + value + "] is not an object and there is no single suitable property to marshal it.");
+					}
+				}
+			},
+			// Checks if the value is marshallable
+			isMarshallable : function(value, context, scope) {
+				return this.isInstance(value, context, scope) || (Jsonix.Util.Type.isObject(value) && !Jsonix.Util.Type.isArray(value));
+			},
+			isInstance : function(value, context, scope) {
+				if (this.instanceFactory) {
+					return value instanceof this.instanceFactory;
+				}
+				else {
+					return Jsonix.Util.Type.isObject(value) && Jsonix.Util.Type.isString(value.TYPE_NAME) && value.TYPE_NAME === this.name;
+				}
+			},
+
+			// Obsolete, left for backwards compatibility
+			b : function(baseTypeInfo) {
+				Jsonix.Util.Ensure.ensureObject(baseTypeInfo);
+				this.baseTypeInfo = baseTypeInfo;
+				return this;
+			},
+			// Obsolete, left for backwards compatibility
+			ps : function() {
+				return this;
+			},
+			p : function(mapping) {
+				Jsonix.Util.Ensure.ensureObject(mapping);
+				// If mapping is an instance of the property class
+				if (mapping instanceof Jsonix.Model.PropertyInfo) {
+					this.addProperty(mapping);
+				}
+				// Else create it via generic mapping configuration
+				else {
+					mapping = Jsonix.Util.Type.cloneObject(mapping);
+					var type = mapping.type||mapping.t||'element';
+					// Locate the creator function
+					if (Jsonix.Util.Type
+							.isFunction(this.propertyInfoCreators[type])) {
+						var propertyInfoCreator = this.propertyInfoCreators[type];
+						// Call the creator function
+						propertyInfoCreator.call(this, mapping);
+					} else {
+						throw new Error("Unknown property info type [" + type + "].");
+					}
+				}
+			},
+			aa : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this
+						.addProperty(new this.mappingStyle.anyAttributePropertyInfo(
+								mapping, {
+									mappingStyle : this.mappingStyle
+								}));
+			},
+			ae : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this
+						.addProperty(new this.mappingStyle.anyElementPropertyInfo(
+								mapping, {
+									mappingStyle : this.mappingStyle
+								}));
+			},
+			a : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this.addProperty(new this.mappingStyle.attributePropertyInfo(
+						mapping, {
+							mappingStyle : this.mappingStyle
+						}));
+			},
+			em : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this
+						.addProperty(new this.mappingStyle.elementMapPropertyInfo(
+								mapping, {
+									mappingStyle : this.mappingStyle
+								}));
+			},
+			e : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this.addProperty(new this.mappingStyle.elementPropertyInfo(
+						mapping, {
+							mappingStyle : this.mappingStyle
+						}));
+			},
+			es : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this.addProperty(new this.mappingStyle.elementsPropertyInfo(
+						mapping, {
+							mappingStyle : this.mappingStyle
+						}));
+			},
+			er : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this
+						.addProperty(new this.mappingStyle.elementRefPropertyInfo(
+								mapping, {
+									mappingStyle : this.mappingStyle
+								}));
+			},
+			ers : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this
+						.addProperty(new this.mappingStyle.elementRefsPropertyInfo(
+								mapping, {
+									mappingStyle : this.mappingStyle
+								}));
+			},
+			v : function(mapping) {
+				this.addDefaultNamespaces(mapping);
+				return this.addProperty(new this.mappingStyle.valuePropertyInfo(
+						mapping, {
+							mappingStyle : this.mappingStyle
+						}));
+			},
+			addDefaultNamespaces : function(mapping) {
+				if (Jsonix.Util.Type.isObject(mapping)) {
+					if (!Jsonix.Util.Type
+							.isString(mapping.defaultElementNamespaceURI)) {
+						mapping.defaultElementNamespaceURI = this.defaultElementNamespaceURI;
+					}
+					if (!Jsonix.Util.Type
+							.isString(mapping.defaultAttributeNamespaceURI)) {
+						mapping.defaultAttributeNamespaceURI = this.defaultAttributeNamespaceURI;
+					}
+				}
+			},
+			addProperty : function(property) {
+				this.properties.push(property);
+				this.propertiesMap[property.name] = property;
+				return this;
+			},
+			CLASS_NAME : 'Jsonix.Model.ClassInfo'
+		});
+Jsonix.Model.ClassInfo.prototype.propertyInfoCreators = {
+	"aa" : Jsonix.Model.ClassInfo.prototype.aa,
+	"anyAttribute" : Jsonix.Model.ClassInfo.prototype.aa,
+	"ae" : Jsonix.Model.ClassInfo.prototype.ae,
+	"anyElement" : Jsonix.Model.ClassInfo.prototype.ae,
+	"a" : Jsonix.Model.ClassInfo.prototype.a,
+	"attribute" : Jsonix.Model.ClassInfo.prototype.a,
+	"em" : Jsonix.Model.ClassInfo.prototype.em,
+	"elementMap" : Jsonix.Model.ClassInfo.prototype.em,
+	"e" : Jsonix.Model.ClassInfo.prototype.e,
+	"element" : Jsonix.Model.ClassInfo.prototype.e,
+	"es" : Jsonix.Model.ClassInfo.prototype.es,
+	"elements" : Jsonix.Model.ClassInfo.prototype.es,
+	"er" : Jsonix.Model.ClassInfo.prototype.er,
+	"elementRef" : Jsonix.Model.ClassInfo.prototype.er,
+	"ers" : Jsonix.Model.ClassInfo.prototype.ers,
+	"elementRefs" : Jsonix.Model.ClassInfo.prototype.ers,
+	"v" : Jsonix.Model.ClassInfo.prototype.v,
+	"value" : Jsonix.Model.ClassInfo.prototype.v
+};
+
+Jsonix.Model.EnumLeafInfo = Jsonix.Class(Jsonix.Model.TypeInfo, {
+	name : null,
+	baseTypeInfo : 'String',
+	entries : null,
+	keys : null,
+	values : null,
+	built : false,
+	initialize : function(mapping) {
+		Jsonix.Model.TypeInfo.prototype.initialize.apply(this, []);
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		
+		var n = mapping.name||mapping.n||undefined;
+		Jsonix.Util.Ensure.ensureString(n);
+		this.name = n;
+		
+		var bti = mapping.baseTypeInfo||mapping.bti||'String';
+		this.baseTypeInfo = bti;
+		
+		var vs = mapping.values||mapping.vs||undefined;
+		Jsonix.Util.Ensure.ensureExists(vs);
+		if (!(Jsonix.Util.Type.isObject(vs) || Jsonix.Util.Type.isArray(vs))) {
+			throw new Error('Enum values must be either an array or an object.');
+		}
+		else
+		{
+			this.entries = vs;
+		}		
+	},
+	build : function(context) {
+		if (!this.built) {
+			this.baseTypeInfo = context.resolveTypeInfo(this.baseTypeInfo, this.module);
+			this.baseTypeInfo.build(context);
+			var items = this.entries;
+			var entries = {};
+			var keys = [];
+			var values = [];
+			var index = 0;
+			var key;
+			var value;
+			// If values is an array, process individual items
+			if (Jsonix.Util.Type.isArray(items))
+			{
+				// Build properties in this context
+				for (index = 0; index < items.length; index++) {
+					value = items[index];
+					if (Jsonix.Util.Type.isString(value)) {
+						key = value;
+						if (!(Jsonix.Util.Type.isFunction(this.baseTypeInfo.parse)))
+						{
+							throw new Error('Enum value is provided as string but the base type ['+this.baseTypeInfo.name+'] of the enum info [' + this.name + '] does not implement the parse method.');
+						}
+						// Using null as input since input is not available
+						value = this.baseTypeInfo.parse(value, context, null, this);
+					}
+					else
+					{
+						if (this.baseTypeInfo.isInstance(value, context, this))
+						{
+							if (!(Jsonix.Util.Type.isFunction(this.baseTypeInfo.print)))
+							{
+								throw new Error('The base type ['+this.baseTypeInfo.name+'] of the enum info [' + this.name + '] does not implement the print method, unable to produce the enum key as string.');
+							}
+							// Using null as output since output is not available at this moment
+							key = this.baseTypeInfo.print(value, context, null, this);
+						}
+						else
+						{
+							throw new Error('Enum value [' + value + '] is not an instance of the enum base type [' + this.baseTypeInfo.name + '].');
+						}
+					}
+					entries[key] = value;
+					keys[index] = key;
+					values[index] = value;
+				}
+			}
+			else if (Jsonix.Util.Type.isObject(items))
+			{
+				for (key in items) {
+					if (items.hasOwnProperty(key)) {
+						value = items[key];
+						if (Jsonix.Util.Type.isString(value)) {
+							if (!(Jsonix.Util.Type.isFunction(this.baseTypeInfo.parse)))
+							{
+								throw new Error('Enum value is provided as string but the base type ['+this.baseTypeInfo.name+'] of the enum info [' + this.name + '] does not implement the parse method.');
+							}
+							// Using null as input since input is not available
+							value = this.baseTypeInfo.parse(value, context, null, this);
+						}
+						else
+						{
+							if (!this.baseTypeInfo.isInstance(value, context, this))
+							{
+								throw new Error('Enum value [' + value + '] is not an instance of the enum base type [' + this.baseTypeInfo.name + '].');
+							}
+						}
+						entries[key] = value;
+						keys[index] = key;
+						values[index] = value;
+						index++;
+					}
+				}
+			}
+			else {
+				throw new Error('Enum values must be either an array or an object.');
+			}
+			this.entries = entries;
+			this.keys = keys;
+			this.values = values;
+			this.built = true;
+		}
+	},
+	unmarshal : function(context, input, scope) {
+		var text = input.getElementText();
+		return this.parse(text, context, input, scope);
+	},
+	marshal : function(value, context, output, scope) {
+		if (Jsonix.Util.Type.exists(value)) {
+			output.writeCharacters(this.reprint(value, context, output, scope));
+		}
+	},
+	reprint : function(value, context, output, scope) {
+		if (Jsonix.Util.Type.isString(value) && !this.isInstance(value, context, scope)) {
+			// Using null as input since input is not available
+			return this.print(this.parse(value, context, null, scope), context, output, scope);
+		} else {
+			return this.print(value, context, output, scope);
+		}
+	},
+	print : function(value, context, output, scope) {
+		for (var index = 0; index < this.values.length; index++)
+		{
+			if (this.values[index] === value)
+			{
+				return this.keys[index];
+			}
+		}
+		throw new Error('Value [' + value + '] is invalid for the enum type [' + this.name + '].');
+	},
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		if (this.entries.hasOwnProperty(text))
+		{
+			return this.entries[text];
+		}
+		else
+		{
+			throw new Error('Value [' + text + '] is invalid for the enum type [' + this.name + '].');
+		}
+	},
+	isInstance : function(value, context, scope) {
+		for (var index = 0; index < this.values.length; index++)
+		{
+			if (this.values[index] === value)
+			{
+				return true;
+			}
+		}
+		return false;
+	},
+	CLASS_NAME : 'Jsonix.Model.EnumLeafInfo'
+});
+Jsonix.Model.ElementInfo = Jsonix.Class({
+	module: null,			
+	elementName : null,
+	typeInfo : null,
+	substitutionHead : null,
+	scope : null,
+	built : false,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		
+		var dens = mapping.defaultElementNamespaceURI||mapping.dens||'';
+		this.defaultElementNamespaceURI = dens;
+		
+		var en = mapping.elementName || mapping.en||undefined;
+		if (Jsonix.Util.Type.isObject(en)) {
+			this.elementName = Jsonix.XML.QName.fromObject(en);
+		} else {
+			Jsonix.Util.Ensure.ensureString(en);
+			this.elementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, en);
+		}
+		
+		var ti = mapping.typeInfo||mapping.ti||'String';
+		this.typeInfo = ti;
+		
+		var sh = mapping.substitutionHead||mapping.sh||null;
+		this.substitutionHead = sh;
+		
+		var sc = mapping.scope||mapping.sc||null;
+		this.scope = sc;
+	},
+	build : function(context) {
+		// If element info is not yet built
+		if (!this.built) {
+			this.typeInfo = context.resolveTypeInfo(this.typeInfo, this.module);
+			this.scope = context.resolveTypeInfo(this.scope, this.module);
+			this.built = true;
+		}
+	},
+	CLASS_NAME : 'Jsonix.Model.ElementInfo'
+});
+Jsonix.Model.PropertyInfo = Jsonix.Class({
+	name : null,
+	collection : false,
+	targetNamespace : '',
+	defaultElementNamespaceURI : '',
+	defaultAttributeNamespaceURI : '',
+	built : false,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		var n = mapping.name || mapping.n || undefined;
+		Jsonix.Util.Ensure.ensureString(n);
+		this.name = n;
+		var dens = mapping.defaultElementNamespaceURI || mapping.dens || mapping.targetNamespace || mapping.tns || '';
+		this.defaultElementNamespaceURI = dens;
+		var tns = mapping.targetNamespace || mapping.tns || mapping.defaultElementNamespaceURI || mapping.dens || this.defaultElementNamespaceURI;
+		this.targetNamespace = tns;
+		var dans = mapping.defaultAttributeNamespaceURI || mapping.dans || '';
+		this.defaultAttributeNamespaceURI = dans;
+		var col = mapping.collection || mapping.col || false;
+		this.collection = col;
+		var rq = mapping.required || mapping.rq || false;
+		this.required = rq;
+		if (this.collection) {
+			var mno;
+			if (Jsonix.Util.Type.isNumber(mapping.minOccurs)) {
+				mno = mapping.minOccurs;
+			}
+			else if (Jsonix.Util.Type.isNumber(mapping.mno)) {
+				mno = mapping.mno;
+			}
+			else {
+				mno = 1;
+			}
+			this.minOccurs = mno;
+			var mxo;
+			if (Jsonix.Util.Type.isNumber(mapping.maxOccurs)) {
+				mxo = mapping.maxOccurs;
+			}
+			else if (Jsonix.Util.Type.isNumber(mapping.mxo)) {
+				mxo = mapping.mxo;
+			}
+			else {
+				mxo = null;
+			}
+			this.maxOccurs = mxo;
+		}
+	},
+	build : function(context, module) {
+		if (!this.built) {
+			this.doBuild(context, module);
+			this.built = true;
+		}
+	},
+	doBuild : function(context, module) {
+		throw new Error("Abstract method [doBuild].");
+	},
+	buildStructure : function(context, structure) {
+		throw new Error("Abstract method [buildStructure].");
+	},
+	setProperty : function(object, value) {
+		if (Jsonix.Util.Type.exists(value)) {
+			if (this.collection) {
+				Jsonix.Util.Ensure.ensureArray(value, 'Collection property requires an array value.');
+				if (!Jsonix.Util.Type.exists(object[this.name])) {
+					object[this.name] = [];
+				}
+				for (var index = 0; index < value.length; index++) {
+					object[this.name].push(value[index]);
+				}
+
+			} else {
+				object[this.name] = value;
+			}
+		}
+	},
+	CLASS_NAME : 'Jsonix.Model.PropertyInfo'
+});
+Jsonix.Model.AnyAttributePropertyInfo = Jsonix.Class(Jsonix.Model.PropertyInfo, {
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.PropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+	},
+	unmarshal : function(context, input, scope) {
+		var attributeCount = input.getAttributeCount();
+		if (attributeCount === 0) {
+			return null;
+		} else {
+			var result = {};
+			for ( var index = 0; index < attributeCount; index++) {
+				var value = input.getAttributeValue(index);
+				if (Jsonix.Util.Type.isString(value)) {
+					var propertyName = this.convertFromAttributeName(input.getAttributeName(index), context, input, scope);
+					result[propertyName] = value;
+				}
+			}
+			return result;
+		}
+	},
+	marshal : function(value, context, output, scope) {
+		if (!Jsonix.Util.Type.isObject(value)) {
+			// Nothing to do
+			return;
+		}
+		for ( var propertyName in value) {
+			if (value.hasOwnProperty(propertyName)) {
+				var propertyValue = value[propertyName];
+				if (Jsonix.Util.Type.isString(propertyValue)) {
+					var attributeName = this.convertToAttributeName(propertyName, context, output, scope);
+					output.writeAttribute(attributeName, propertyValue);
+				}
+			}
+		}
+	},
+	convertFromAttributeName : function(attributeName, context, input, scope) {
+		return attributeName.key;
+	},
+	convertToAttributeName : function(propertyName, context, output, scope) {
+		return Jsonix.XML.QName.fromObjectOrString(propertyName, context);
+	},
+	doBuild : function(context, module)	{
+		// Nothing to do
+	},
+	buildStructure : function(context, structure) {
+		Jsonix.Util.Ensure.ensureObject(structure);
+		// if (Jsonix.Util.Type.exists(structure.anyAttribute))
+		// {
+		// // TODO better exception
+		// throw new Error("The structure already defines an any attribute
+		// property.");
+		// } else
+		// {
+		structure.anyAttribute = this;
+		// }
+	},
+	CLASS_NAME : 'Jsonix.Model.AnyAttributePropertyInfo'
+});
+Jsonix.Model.AnyAttributePropertyInfo.Simplified = Jsonix.Class(Jsonix.Model.AnyAttributePropertyInfo, {
+	convertFromAttributeName : function(attributeName, context, input, scope)
+	{
+		return attributeName.toCanonicalString(context);
+	}
+});
+
+Jsonix.Model.SingleTypePropertyInfo = Jsonix.Class(Jsonix.Model.PropertyInfo, {
+	typeInfo : 'String',
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.PropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		var ti = mapping.typeInfo || mapping.ti || 'String';
+		this.typeInfo = ti;
+	},
+	doBuild : function(context, module) {
+		this.typeInfo = context.resolveTypeInfo(this.typeInfo, module);
+	},
+	unmarshalValue : function(value, context, input, scope) {
+		return this.parse(value, context, input, scope);
+	},
+	parse : function(value, context, input, scope) {
+		return this.typeInfo.parse(value, context, input, scope);
+	},
+	print : function(value, context, output, scope) {
+		return this.typeInfo.reprint(value, context, output, scope);
+	},
+	CLASS_NAME : 'Jsonix.Model.SingleTypePropertyInfo'
+});
+
+Jsonix.Model.AttributePropertyInfo = Jsonix.Class(Jsonix.Model.SingleTypePropertyInfo, {
+	attributeName : null,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.SingleTypePropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		var an = mapping.attributeName||mapping.an||undefined;
+		if (Jsonix.Util.Type.isObject(an)) {
+			this.attributeName = Jsonix.XML.QName.fromObject(an);
+		} else if (Jsonix.Util.Type.isString(an)) {
+			this.attributeName = new Jsonix.XML.QName(this.defaultAttributeNamespaceURI, an);
+		} else {
+			this.attributeName = new Jsonix.XML.QName(this.defaultAttributeNamespaceURI, this.name);
+		}
+	},
+	unmarshal : function(context, input, scope) {
+		var attributeCount = input.getAttributeCount();
+		var result = null;
+		for ( var index = 0; index < attributeCount; index++) {
+			var attributeNameKey = input.getAttributeNameKey(index);
+			if (this.attributeName.key === attributeNameKey) {
+				var attributeValue = input.getAttributeValue(index);
+				if (Jsonix.Util.Type.isString(attributeValue)) {
+					result = this.unmarshalValue(attributeValue, context, input, scope);
+				}
+			}
+		}
+		return result;
+	},
+	marshal : function(value, context, output, scope) {
+		if (Jsonix.Util.Type.exists(value)) {
+			output.writeAttribute(this.attributeName, this.print(value, context, output, scope));
+		}
+
+	},
+	buildStructure : function(context, structure) {
+		Jsonix.Util.Ensure.ensureObject(structure);
+		Jsonix.Util.Ensure.ensureObject(structure.attributes);
+		var key = this.attributeName.key;
+		// if (Jsonix.Util.Type.exists(structure.attributes[key])) {
+		// // TODO better exception
+		// throw new Error("The structure already defines an attribute for the key
+		// ["
+		// + key + "].");
+		// } else
+		// {
+		structure.attributes[key] = this;
+		// }
+	},
+	CLASS_NAME : 'Jsonix.Model.AttributePropertyInfo'
+});
+
+Jsonix.Model.ValuePropertyInfo = Jsonix.Class(Jsonix.Model.SingleTypePropertyInfo, {
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.SingleTypePropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+
+		var c = mapping.asCDATA || mapping.c || false;
+		this.asCDATA = c;
+	},
+	unmarshal : function(context, input, scope) {
+		var text = input.getElementText();
+		return this.unmarshalValue(text, context, input, scope);
+	},
+	marshal : function(value, context, output, scope) {
+		if (!Jsonix.Util.Type.exists(value)) {
+			return;
+		}
+
+		if (this.asCDATA) {
+			output.writeCdata(this.print(value, context, output, scope));
+		} else {
+			output.writeCharacters(this.print(value, context, output, scope));
+		}
+	},
+	buildStructure : function(context, structure) {
+		Jsonix.Util.Ensure.ensureObject(structure);
+		// if (Jsonix.Util.Type.exists(structure.value)) {
+		// // TODO better exception
+		// throw new Error("The structure already defines a value
+		// property.");
+		// } else
+		if (Jsonix.Util.Type.exists(structure.elements)) {
+			// TODO better exception
+			throw new Error("The structure already defines element mappings, it cannot define a value property.");
+		} else {
+			structure.value = this;
+		}
+	},
+	CLASS_NAME : 'Jsonix.Model.ValuePropertyInfo'
+});
+
+Jsonix.Model.AbstractElementsPropertyInfo = Jsonix.Class(Jsonix.Binding.Unmarshalls.Element, Jsonix.Binding.Unmarshalls.WrapperElement, Jsonix.Model.PropertyInfo, {
+	wrapperElementName : null,
+	allowDom : false,
+	allowTypedObject : true,
+	mixed : false,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.PropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		var wen = mapping.wrapperElementName||mapping.wen||undefined;
+		if (Jsonix.Util.Type.isObject(wen)) {
+			this.wrapperElementName = Jsonix.XML.QName.fromObject(wen);
+		} else if (Jsonix.Util.Type.isString(wen)) {
+			this.wrapperElementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, wen);
+		} else {
+			this.wrapperElementName = null;
+		}
+	},
+	unmarshal : function(context, input, scope) {
+		var result = null;
+		var that = this;
+		var callback = function(value) {
+			if (that.collection) {
+				if (result === null) {
+					result = [];
+				}
+				result.push(value);
+
+			} else {
+				if (result === null) {
+					result = value;
+				} else {
+					// TODO Report validation error
+					throw new Error("Value already set.");
+				}
+			}
+		};
+
+		if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			this.unmarshalWrapperElement(context, input, scope, callback);
+		} else {
+			this.unmarshalElement(context, input, scope, callback);
+		}
+		return result;
+	},
+	marshal : function(value, context, output, scope) {
+
+		if (!Jsonix.Util.Type.exists(value)) {
+			// Do nothing
+			return;
+		}
+
+		if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			output.writeStartElement(this.wrapperElementName);
+		}
+
+		if (!this.collection) {
+			this.marshalElement(value, context, output, scope);
+		} else {
+			Jsonix.Util.Ensure.ensureArray(value);
+			// TODO Exception if not array
+			for ( var index = 0; index < value.length; index++) {
+				var item = value[index];
+				// TODO Exception if item does not exist
+				this.marshalElement(item, context, output, scope);
+			}
+		}
+
+		if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			output.writeEndElement();
+		}
+	},
+	convertFromTypedNamedValue : function(elementValue, context, input, scope) {
+		return elementValue.value;
+	},
+	buildStructure : function(context, structure) {
+		Jsonix.Util.Ensure.ensureObject(structure);
+		if (Jsonix.Util.Type.exists(structure.value)) {
+			// TODO better exception
+			throw new Error("The structure already defines a value property.");
+		} else if (!Jsonix.Util.Type.exists(structure.elements)) {
+			structure.elements = {};
+		}
+
+		if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			structure.elements[this.wrapperElementName.key] = this;
+		} else {
+			this.buildStructureElements(context, structure);
+		}
+	},
+	buildStructureElements : function(context, structure) {
+		throw new Error("Abstract method [buildStructureElements].");
+	},
+	CLASS_NAME : 'Jsonix.Model.AbstractElementsPropertyInfo'
+});
+
+Jsonix.Model.ElementPropertyInfo = Jsonix.Class(Jsonix.Model.AbstractElementsPropertyInfo, Jsonix.Binding.Marshalls.Element, {
+	typeInfo : 'String',
+	elementName : null,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.AbstractElementsPropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		var ti = mapping.typeInfo || mapping.ti || 'String';
+		if (Jsonix.Util.Type.isObject(ti)) {
+			this.typeInfo = ti;
+		} else {
+			Jsonix.Util.Ensure.ensureString(ti);
+			this.typeInfo = ti;
+		}
+		var en = mapping.elementName || mapping.en || undefined;
+		if (Jsonix.Util.Type.isObject(en)) {
+			this.elementName = Jsonix.XML.QName.fromObject(en);
+		} else if (Jsonix.Util.Type.isString(en)) {
+			this.elementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, en);
+		} else {
+			this.elementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, this.name);
+		}
+	},
+	getTypeInfoByElementName : function(elementName, context, scope) {
+		return this.typeInfo;
+	},
+	convertToTypedNamedValue : function(value, context, output, scope) {
+		return {
+			name : this.elementName,
+			value : value,
+			typeInfo : this.typeInfo
+		};
+	},
+	doBuild : function(context, module) {
+		this.typeInfo = context.resolveTypeInfo(this.typeInfo, module);
+	},
+	buildStructureElements : function(context, structure) {
+		structure.elements[this.elementName.key] = this;
+	},
+	CLASS_NAME : 'Jsonix.Model.ElementPropertyInfo'
+});
+
+Jsonix.Model.ElementsPropertyInfo = Jsonix.Class(Jsonix.Model.AbstractElementsPropertyInfo, Jsonix.Binding.Marshalls.Element, {
+	elementTypeInfos : null,
+	elementTypeInfosMap : null,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.AbstractElementsPropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		var etis = mapping.elementTypeInfos || mapping.etis || [];
+		Jsonix.Util.Ensure.ensureArray(etis);
+		this.elementTypeInfos = [];
+		for (var index = 0; index < etis.length; index++) {
+			this.elementTypeInfos[index] = Jsonix.Util.Type.cloneObject(etis[index]);
+		}
+	},
+	getTypeInfoByElementName : function(elementName, context, scope) {
+		return this.elementTypeInfosMap[elementName.key];
+	},
+	convertToTypedNamedValue : function(value, context, output, scope) {
+		for (var index = 0; index < this.elementTypeInfos.length; index++) {
+			var elementTypeInfo = this.elementTypeInfos[index];
+			var typeInfo = elementTypeInfo.typeInfo;
+			if (typeInfo.isInstance(value, context, scope)) {
+				var elementName = elementTypeInfo.elementName;
+				return {
+					name : elementName,
+					value : value,
+					typeInfo : typeInfo
+				};
+			}
+		}
+		// If xsi:type is supported
+		if (context.supportXsiType) {
+			// Find the actual type
+			var actualTypeInfo = context.getTypeInfoByValue(value);
+			if (actualTypeInfo && actualTypeInfo.typeName) {
+				for (var jndex = 0; jndex < this.elementTypeInfos.length; jndex++) {
+					var eti = this.elementTypeInfos[jndex];
+					var ti = eti.typeInfo;
+					// TODO Can be optimized
+					// Find an element type info which has a type info that is a
+					// supertype of the actual type info
+					if (actualTypeInfo.isBasedOn(ti)) {
+						var en = eti.elementName;
+						return {
+							name : en,
+							value : value,
+							typeInfo : ti
+						};
+					}
+				}
+			}
+		}
+		// TODO harmonize error handling. See also marshallElement. Error must
+		// only be on one place.
+		throw new Error("Could not find an element with type info supporting the value [" + value + "].");
+	},
+	doBuild : function(context, module) {
+		this.elementTypeInfosMap = {};
+		var etiti, etien;
+		for (var index = 0; index < this.elementTypeInfos.length; index++) {
+			var elementTypeInfo = this.elementTypeInfos[index];
+			Jsonix.Util.Ensure.ensureObject(elementTypeInfo);
+			etiti = elementTypeInfo.typeInfo || elementTypeInfo.ti || 'String';
+			elementTypeInfo.typeInfo = context.resolveTypeInfo(etiti, module);
+			etien = elementTypeInfo.elementName || elementTypeInfo.en || undefined;
+			elementTypeInfo.elementName = Jsonix.XML.QName.fromObjectOrString(etien, context, this.defaultElementNamespaceURI);
+			this.elementTypeInfosMap[elementTypeInfo.elementName.key] = elementTypeInfo.typeInfo;
+		}
+	},
+	buildStructureElements : function(context, structure) {
+		for (var index = 0; index < this.elementTypeInfos.length; index++) {
+			var elementTypeInfo = this.elementTypeInfos[index];
+			structure.elements[elementTypeInfo.elementName.key] = this;
+		}
+	},
+	CLASS_NAME : 'Jsonix.Model.ElementsPropertyInfo'
+});
+
+Jsonix.Model.ElementMapPropertyInfo = Jsonix.Class(Jsonix.Model.AbstractElementsPropertyInfo, {
+	elementName : null,
+	key : null,
+	value : null,
+	entryTypeInfo : null,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.AbstractElementsPropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		// TODO Ensure correct argument
+		var k = mapping.key || mapping.k || undefined;
+		Jsonix.Util.Ensure.ensureObject(k);
+		var v = mapping.value || mapping.v || undefined;
+		Jsonix.Util.Ensure.ensureObject(v);
+		// TODO Ensure correct argument
+		var en = mapping.elementName || mapping.en || undefined;
+		if (Jsonix.Util.Type.isObject(en)) {
+			this.elementName = Jsonix.XML.QName.fromObject(en);
+		} else if (Jsonix.Util.Type.isString(en)) {
+			this.elementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, en);
+		} else {
+			this.elementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, this.name);
+		}
+		this.entryTypeInfo = new Jsonix.Model.ClassInfo({
+			name : 'Map<' + k.name + ',' + v.name + '>',
+			propertyInfos : [ k, v ]
+		});
+
+	},
+	unmarshal : function(context, input, scope) {
+		var result = null;
+		var that = this;
+		var callback = function(value) {
+
+			if (Jsonix.Util.Type.exists(value)) {
+				Jsonix.Util.Ensure.ensureObject(value, 'Map property requires an object.');
+				if (!Jsonix.Util.Type.exists(result)) {
+					result = {};
+				}
+				for ( var attributeName in value) {
+					if (value.hasOwnProperty(attributeName)) {
+						var attributeValue = value[attributeName];
+						if (that.collection) {
+							if (!Jsonix.Util.Type.exists(result[attributeName])) {
+								result[attributeName] = [];
+							}
+							result[attributeName].push(attributeValue);
+						} else {
+							if (!Jsonix.Util.Type.exists(result[attributeName])) {
+								result[attributeName] = attributeValue;
+							} else {
+								// TODO Report validation error
+								throw new Error("Value was already set.");
+							}
+						}
+					}
+				}
+			}
+		};
+
+		if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			this.unmarshalWrapperElement(context, input, scope, callback);
+		} else {
+			this.unmarshalElement(context, input, scope, callback);
+		}
+		return result;
+	},
+	getTypeInfoByInputElement : function(context, input, scope) {
+		return this.entryTypeInfo;
+	},
+	convertFromTypedNamedValue : function(elementValue, context, input, scope) {
+		var entry = elementValue.value;
+		var result = {};
+		if (Jsonix.Util.Type.isString(entry[this.key.name])) {
+			result[entry[this.key.name]] = entry[this.value.name];
+		}
+		return result;
+	},
+	marshal : function(value, context, output, scope) {
+
+		if (!Jsonix.Util.Type.exists(value)) {
+			// Do nothing
+			return;
+		}
+
+		if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			output.writeStartElement(this.wrapperElementName);
+		}
+
+		this.marshalElement(value, context, output, scope);
+
+		if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			output.writeEndElement();
+		}
+	},
+	marshalElement : function(value, context, output, scope) {
+		if (!!value) {
+			for ( var attributeName in value) {
+				if (value.hasOwnProperty(attributeName)) {
+					var attributeValue = value[attributeName];
+					if (!this.collection) {
+						var singleEntry = {};
+						singleEntry[this.key.name] = attributeName;
+						singleEntry[this.value.name] = attributeValue;
+						output.writeStartElement(this.elementName);
+						this.entryTypeInfo.marshal(singleEntry, context, output, scope);
+						output.writeEndElement();
+
+					} else {
+						for (var index = 0; index < attributeValue.length; index++) {
+							var collectionEntry = {};
+							collectionEntry[this.key.name] = attributeName;
+							collectionEntry[this.value.name] = attributeValue[index];
+							output.writeStartElement(this.elementName);
+							this.entryTypeInfo.marshal(collectionEntry, context, output, scope);
+							output.writeEndElement();
+						}
+					}
+				}
+			}
+		}
+	},
+	doBuild : function(context, module) {
+		this.entryTypeInfo.build(context, module);
+		// TODO get property by name
+		this.key = this.entryTypeInfo.properties[0];
+		this.value = this.entryTypeInfo.properties[1];
+	},
+	buildStructureElements : function(context, structure) {
+		structure.elements[this.elementName.key] = this;
+	},
+	setProperty : function(object, value) {
+		if (Jsonix.Util.Type.exists(value)) {
+			Jsonix.Util.Ensure.ensureObject(value, 'Map property requires an object.');
+			if (!Jsonix.Util.Type.exists(object[this.name])) {
+				object[this.name] = {};
+			}
+			var map = object[this.name];
+			for ( var attributeName in value) {
+				if (value.hasOwnProperty(attributeName)) {
+					var attributeValue = value[attributeName];
+					if (this.collection) {
+						if (!Jsonix.Util.Type.exists(map[attributeName])) {
+							map[attributeName] = [];
+						}
+
+						for (var index = 0; index < attributeValue.length; index++) {
+							map[attributeName].push(attributeValue[index]);
+						}
+					} else {
+						map[attributeName] = attributeValue;
+					}
+				}
+			}
+		}
+	},
+	CLASS_NAME : 'Jsonix.Model.ElementMapPropertyInfo'
+});
+
+Jsonix.Model.AbstractElementRefsPropertyInfo = Jsonix.Class(Jsonix.Binding.Marshalls.Element, Jsonix.Binding.Marshalls.Element.AsElementRef, Jsonix.Binding.Unmarshalls.Element, Jsonix.Binding.Unmarshalls.WrapperElement, Jsonix.Binding.Unmarshalls.Element.AsElementRef, Jsonix.Model.PropertyInfo, {
+	wrapperElementName : null,
+	allowDom : true,
+	allowTypedObject : true,
+	mixed : true,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping, 'Mapping must be an object.');
+		Jsonix.Model.PropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		var wen = mapping.wrapperElementName || mapping.wen || undefined;
+		if (Jsonix.Util.Type.isObject(wen)) {
+			this.wrapperElementName = Jsonix.XML.QName.fromObject(wen);
+		} else if (Jsonix.Util.Type.isString(wen)) {
+			this.wrapperElementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, wen);
+		} else {
+			this.wrapperElementName = null;
+		}
+		var dom = Jsonix.Util.Type.defaultValue(mapping.allowDom, mapping.dom, true);
+		var typed = Jsonix.Util.Type.defaultValue(mapping.allowTypedObject, mapping.typed, true);
+		var mx = Jsonix.Util.Type.defaultValue(mapping.mixed, mapping.mx, true);
+		this.allowDom = dom;
+		this.allowTypedObject = typed;
+		this.mixed = mx;
+	},
+	unmarshal : function(context, input, scope) {
+		var result = null;
+		var that = this;
+		var callback = function(value) {
+			if (that.collection) {
+				if (result === null) {
+					result = [];
+				}
+				result.push(value);
+
+			} else {
+				if (result === null) {
+					result = value;
+				} else {
+					// TODO Report validation error
+					throw new Error("Value already set.");
+				}
+			}
+		};
+
+		var et = input.eventType;
+		if (et === Jsonix.XML.Input.START_ELEMENT) {
+			if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+				this.unmarshalWrapperElement(context, input, scope, callback);
+			} else {
+				this.unmarshalElement(context, input, scope, callback);
+			}
+		} else if (this.mixed && (et === Jsonix.XML.Input.CHARACTERS || et === Jsonix.XML.Input.CDATA || et === Jsonix.XML.Input.ENTITY_REFERENCE)) {
+			callback(input.getText());
+		} else if (et === Jsonix.XML.Input.SPACE || et === Jsonix.XML.Input.COMMENT || et === Jsonix.XML.Input.PROCESSING_INSTRUCTION) {
+			// Skip whitespace
+		} else {
+			// TODO better exception
+			throw new Error("Illegal state: unexpected event type [" + et + "].");
+		}
+		return result;
+	},
+	marshal : function(value, context, output, scope) {
+
+		if (Jsonix.Util.Type.exists(value)) {
+			if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+				output.writeStartElement(this.wrapperElementName);
+			}
+
+			if (!this.collection) {
+				this.marshalItem(value, context, output, scope);
+			} else {
+				Jsonix.Util.Ensure.ensureArray(value, 'Collection property requires an array value.');
+				for (var index = 0; index < value.length; index++) {
+					var item = value[index];
+					this.marshalItem(item, context, output, scope);
+				}
+			}
+
+			if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+				output.writeEndElement();
+			}
+		}
+
+	},
+	marshalItem : function(value, context, output, scope) {
+		if (Jsonix.Util.Type.isString(value)) {
+			if (!this.mixed) {
+				// TODO
+				throw new Error("Property is not mixed, can't handle string values.");
+			} else {
+				output.writeCharacters(value);
+			}
+		} else if (this.allowDom && Jsonix.Util.Type.exists(value.nodeType)) {
+			// DOM node
+			output.writeNode(value);
+		} else if (Jsonix.Util.Type.isObject(value)) {
+			this.marshalElement(value, context, output, scope);
+
+		} else {
+			if (this.mixed) {
+				throw new Error("Unsupported content type, either objects or strings are supported.");
+			} else {
+				throw new Error("Unsupported content type, only objects are supported.");
+			}
+		}
+
+	},
+	getTypeInfoByElementName : function(elementName, context, scope) {
+		var propertyElementTypeInfo = this.getPropertyElementTypeInfo(elementName, context);
+		if (Jsonix.Util.Type.exists(propertyElementTypeInfo)) {
+			return propertyElementTypeInfo.typeInfo;
+		} else {
+			var contextElementTypeInfo = context.getElementInfo(elementName, scope);
+			if (Jsonix.Util.Type.exists(contextElementTypeInfo)) {
+				return contextElementTypeInfo.typeInfo;
+			} else {
+				return undefined;
+			}
+		}
+	},
+	getPropertyElementTypeInfo : function(elementName, context) {
+		throw new Error("Abstract method [getPropertyElementTypeInfo].");
+	},
+	buildStructure : function(context, structure) {
+		Jsonix.Util.Ensure.ensureObject(structure);
+		if (Jsonix.Util.Type.exists(structure.value)) {
+			// TODO better exception
+			throw new Error("The structure already defines a value property.");
+		} else if (!Jsonix.Util.Type.exists(structure.elements)) {
+			structure.elements = {};
+		}
+
+		if (Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			structure.elements[this.wrapperElementName.key] = this;
+		} else {
+			this.buildStructureElements(context, structure);
+		}
+
+		// if (Jsonix.Util.Type.exists(structure.elements[key]))
+		// {
+		// // TODO better exception
+		// throw new Error("The structure already defines an element for
+		// the key ["
+		// + key + "].");
+		// } else
+		// {
+		// structure.elements[key] = this;
+		// }
+
+		if ((this.allowDom || this.allowTypedObject)) {
+			structure.any = this;
+		}
+		if (this.mixed && !Jsonix.Util.Type.exists(this.wrapperElementName)) {
+			// if (Jsonix.Util.Type.exists(structure.mixed)) {
+			// // TODO better exception
+			// throw new Error("The structure already defines the mixed
+			// property.");
+			// } else
+			// {
+			structure.mixed = this;
+			// }
+		}
+	},
+	buildStructureElements : function(context, structure) {
+		throw new Error("Abstract method [buildStructureElements].");
+	},
+	buildStructureElementTypeInfos : function(context, structure, elementTypeInfo) {
+		structure.elements[elementTypeInfo.elementName.key] = this;
+		var substitutionMembers = context.getSubstitutionMembers(elementTypeInfo.elementName);
+		if (Jsonix.Util.Type.isArray(substitutionMembers)) {
+			for (var jndex = 0; jndex < substitutionMembers.length; jndex++) {
+				var substitutionElementInfo = substitutionMembers[jndex];
+				this.buildStructureElementTypeInfos(context, structure, substitutionElementInfo);
+			}
+
+		}
+	},
+	CLASS_NAME : 'Jsonix.Model.AbstractElementRefsPropertyInfo'
+});
+Jsonix.Model.ElementRefPropertyInfo = Jsonix.Class(Jsonix.Model.AbstractElementRefsPropertyInfo, {
+	typeInfo : 'String',
+	elementName : null,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.AbstractElementRefsPropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		// TODO Ensure correct argument
+		var ti = mapping.typeInfo || mapping.ti || 'String';
+		if (Jsonix.Util.Type.isObject(ti)) {
+			this.typeInfo = ti;
+		} else {
+			Jsonix.Util.Ensure.ensureString(ti);
+			this.typeInfo = ti;
+		}
+		var en = mapping.elementName || mapping.en || undefined;
+		if (Jsonix.Util.Type.isObject(en)) {
+			this.elementName = Jsonix.XML.QName.fromObject(en);
+		} else if (Jsonix.Util.Type.isString(en)) {
+			this.elementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, en);
+		} else {
+			this.elementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, this.name);
+		}
+	},
+	getPropertyElementTypeInfo : function(elementName, context) {
+		var name = Jsonix.XML.QName.fromObjectOrString(elementName, context);
+
+		if (name.key === this.elementName.key) {
+			return this;
+		} else {
+			return null;
+		}
+	},
+	doBuild : function(context, module) {
+		this.typeInfo = context.resolveTypeInfo(this.typeInfo, module);
+	},
+	buildStructureElements : function(context, structure) {
+		this.buildStructureElementTypeInfos(context, structure, this);
+	},
+	CLASS_NAME : 'Jsonix.Model.ElementRefPropertyInfo'
+});
+Jsonix.Model.ElementRefPropertyInfo.Simplified = Jsonix.Class(Jsonix.Model.ElementRefPropertyInfo, Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef, {
+	CLASS_NAME : 'Jsonix.Model.ElementRefPropertyInfo.Simplified'
+});
+Jsonix.Model.ElementRefsPropertyInfo = Jsonix.Class(Jsonix.Model.AbstractElementRefsPropertyInfo, {
+	elementTypeInfos : null,
+	elementTypeInfosMap : null,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.AbstractElementRefsPropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		// TODO Ensure correct arguments
+		var etis = mapping.elementTypeInfos || mapping.etis || [];
+		Jsonix.Util.Ensure.ensureArray(etis);
+		this.elementTypeInfos = [];
+		for (var index = 0; index < etis.length; index++)
+		{
+			this.elementTypeInfos[index] = Jsonix.Util.Type.cloneObject(etis[index]);
+		}
+	},
+	getPropertyElementTypeInfo : function(elementName, context) {
+		var name = Jsonix.XML.QName.fromObjectOrString(elementName, context);
+
+		var typeInfo = this.elementTypeInfosMap[name.key];
+		if (Jsonix.Util.Type.exists(typeInfo)) {
+			return {
+				elementName : name,
+				typeInfo : typeInfo
+			};
+		} else {
+			return null;
+		}
+	},
+	doBuild : function(context, module) {
+		this.elementTypeInfosMap = {};
+		var etiti, etien;
+		for (var index = 0; index < this.elementTypeInfos.length; index++) {
+			var elementTypeInfo = this.elementTypeInfos[index];
+			Jsonix.Util.Ensure.ensureObject(elementTypeInfo);
+			etiti = elementTypeInfo.typeInfo || elementTypeInfo.ti || 'String';
+			elementTypeInfo.typeInfo = context.resolveTypeInfo(etiti, module);
+			etien = elementTypeInfo.elementName || elementTypeInfo.en || undefined;
+			elementTypeInfo.elementName = Jsonix.XML.QName.fromObjectOrString(etien, context, this.defaultElementNamespaceURI);
+			this.elementTypeInfosMap[elementTypeInfo.elementName.key] = elementTypeInfo.typeInfo;
+		}
+	},
+	buildStructureElements : function(context, structure) {
+		for (var index = 0; index < this.elementTypeInfos.length; index++) {
+			var elementTypeInfo = this.elementTypeInfos[index];
+			this.buildStructureElementTypeInfos(context, structure, elementTypeInfo);
+		}
+	},
+	CLASS_NAME : 'Jsonix.Model.ElementRefsPropertyInfo'
+});
+Jsonix.Model.ElementRefsPropertyInfo.Simplified = Jsonix.Class(Jsonix.Model.ElementRefsPropertyInfo, Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef, {
+	CLASS_NAME : 'Jsonix.Model.ElementRefsPropertyInfo.Simplified'
+});
+
+Jsonix.Model.AnyElementPropertyInfo = Jsonix.Class(Jsonix.Binding.Marshalls.Element, Jsonix.Binding.Marshalls.Element.AsElementRef, Jsonix.Binding.Unmarshalls.Element, Jsonix.Binding.Unmarshalls.Element.AsElementRef, Jsonix.Model.PropertyInfo, {
+	allowDom : true,
+	allowTypedObject : true,
+	mixed : true,
+	initialize : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		Jsonix.Model.PropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+		var dom = Jsonix.Util.Type.defaultValue(mapping.allowDom, mapping.dom, true);
+		var typed = Jsonix.Util.Type.defaultValue(mapping.allowTypedObject, mapping.typed, true);
+		var mx = Jsonix.Util.Type.defaultValue(mapping.mixed, mapping.mx, true);
+		this.allowDom = dom;
+		this.allowTypedObject = typed;
+		this.mixed = mx;
+	},
+	unmarshal : function(context, input, scope) {
+		var result = null;
+		var that = this;
+		var callback = function(value) {
+			if (that.collection) {
+				if (result === null) {
+					result = [];
+				}
+				result.push(value);
+
+			} else {
+				if (result === null) {
+					result = value;
+				} else {
+					// TODO Report validation error
+					throw new Error("Value already set.");
+				}
+			}
+		};
+
+		var et = input.eventType;
+		if (et === Jsonix.XML.Input.START_ELEMENT) {
+			this.unmarshalElement(context, input, scope, callback);
+		} else if (this.mixed && (et === Jsonix.XML.Input.CHARACTERS || et === Jsonix.XML.Input.CDATA || et === Jsonix.XML.Input.ENTITY_REFERENCE)) {
+			callback(input.getText());
+		} else if (this.mixed && (et === Jsonix.XML.Input.SPACE)) {
+			// Whitespace
+			// return null;
+		} else if (et === Jsonix.XML.Input.COMMENT || et === Jsonix.XML.Input.PROCESSING_INSTRUCTION) {
+			// return null;
+		} else {
+			// TODO better exception
+			throw new Error("Illegal state: unexpected event type [" + et + "].");
+		}
+
+		return result;
+	},
+	marshal : function(value, context, output, scope) {
+		if (!Jsonix.Util.Type.exists(value)) {
+			return;
+		}
+		if (!this.collection) {
+			this.marshalItem(value, context, output, scope);
+		} else {
+			Jsonix.Util.Ensure.ensureArray(value);
+			for (var index = 0; index < value.length; index++) {
+				this.marshalItem(value[index], context, output, scope);
+			}
+		}
+	},
+	marshalItem : function(value, context, output, scope) {
+		if (this.mixed && Jsonix.Util.Type.isString(value)) {
+			// Mixed
+			output.writeCharacters(value);
+		} else if (this.allowDom && Jsonix.Util.Type.exists(value.nodeType)) {
+			// DOM node
+			output.writeNode(value);
+
+		} else {
+			if (this.allowTypedObject) {
+				this.marshalElement(value, context, output, scope);
+			}
+		}
+	},
+	doBuild : function(context, module) {
+		// Nothing to do
+	},
+	buildStructure : function(context, structure) {
+		Jsonix.Util.Ensure.ensureObject(structure);
+		if (Jsonix.Util.Type.exists(structure.value)) {
+			// TODO better exception
+			throw new Error("The structure already defines a value property.");
+		} else if (!Jsonix.Util.Type.exists(structure.elements)) {
+			structure.elements = {};
+		}
+
+		if ((this.allowDom || this.allowTypedObject)) {
+			// if (Jsonix.Util.Type.exists(structure.any)) {
+			// // TODO better exception
+			// throw new Error("The structure already defines the any
+			// property.");
+			// } else
+			// {
+			structure.any = this;
+			// }
+		}
+		if (this.mixed) {
+			// if (Jsonix.Util.Type.exists(structure.mixed)) {
+			// // TODO better exception
+			// throw new Error("The structure already defines the mixed
+			// property.");
+			// } else
+			// {
+			structure.mixed = this;
+			// }
+		}
+	},
+	CLASS_NAME : 'Jsonix.Model.AnyElementPropertyInfo'
+});
+Jsonix.Model.AnyElementPropertyInfo.Simplified = Jsonix.Class(Jsonix.Model.AnyElementPropertyInfo, Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef, {
+	CLASS_NAME : 'Jsonix.Model.AnyElementPropertyInfo.Simplified'
+});
+Jsonix.Model.Module = Jsonix.Class(Jsonix.Mapping.Styled, {
+	name : null,
+	typeInfos : null,
+	elementInfos : null,
+	targetNamespace : '',
+	defaultElementNamespaceURI : '',
+	defaultAttributeNamespaceURI : '',
+	initialize : function(mapping, options) {
+		Jsonix.Mapping.Styled.prototype.initialize.apply(this, [ options ]);
+		this.typeInfos = [];
+		this.elementInfos = [];
+		if (typeof mapping !== 'undefined') {
+			Jsonix.Util.Ensure.ensureObject(mapping);
+			var n = mapping.name || mapping.n || null;
+			this.name = n;
+			var dens = mapping.defaultElementNamespaceURI || mapping.dens || mapping.targetNamespace || mapping.tns || '';
+			this.defaultElementNamespaceURI = dens;
+			var tns = mapping.targetNamespace || mapping.tns || mapping.defaultElementNamespaceURI || mapping.dens || this.defaultElementNamespaceURI;
+			this.targetNamespace = tns;
+			var dans = mapping.defaultAttributeNamespaceURI || mapping.dans || '';
+			this.defaultAttributeNamespaceURI = dans;
+			// Initialize type infos
+			var tis = mapping.typeInfos || mapping.tis || [];
+			this.initializeTypeInfos(tis);
+
+			// Backwards compatibility: class infos can also be defined
+			// as properties of the schema, for instance Schema.MyType
+			for ( var typeInfoName in mapping) {
+				if (mapping.hasOwnProperty(typeInfoName)) {
+					if (mapping[typeInfoName] instanceof this.mappingStyle.classInfo) {
+						this.typeInfos.push(mapping[typeInfoName]);
+					}
+				}
+			}
+			var eis = mapping.elementInfos || mapping.eis || [];
+			// Initialize element infos
+			this.initializeElementInfos(eis);
+		}
+	},
+	initializeTypeInfos : function(typeInfoMappings) {
+		Jsonix.Util.Ensure.ensureArray(typeInfoMappings);
+		var index, typeInfoMapping, typeInfo;
+		for (index = 0; index < typeInfoMappings.length; index++) {
+			typeInfoMapping = typeInfoMappings[index];
+			typeInfo = this.createTypeInfo(typeInfoMapping);
+			this.typeInfos.push(typeInfo);
+		}
+	},
+	initializeElementInfos : function(elementInfoMappings) {
+		Jsonix.Util.Ensure.ensureArray(elementInfoMappings);
+		var index, elementInfoMapping, elementInfo;
+		for (index = 0; index < elementInfoMappings.length; index++) {
+			elementInfoMapping = elementInfoMappings[index];
+			elementInfo = this.createElementInfo(elementInfoMapping);
+			this.elementInfos.push(elementInfo);
+		}
+	},
+	createTypeInfo : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		var typeInfo;
+		// If mapping is already a type info, do nothing
+		if (mapping instanceof Jsonix.Model.TypeInfo) {
+			typeInfo = mapping;
+		}
+		// Else create it via generic mapping configuration
+		else {
+			mapping = Jsonix.Util.Type.cloneObject(mapping);
+			var type = mapping.type || mapping.t || 'classInfo';
+			// Locate the creator function
+			if (Jsonix.Util.Type.isFunction(this.typeInfoCreators[type])) {
+				var typeInfoCreator = this.typeInfoCreators[type];
+				// Call the creator function
+				typeInfo = typeInfoCreator.call(this, mapping);
+			} else {
+				throw new Error("Unknown type info type [" + type + "].");
+			}
+		}
+		return typeInfo;
+	},
+	initializeNames : function(mapping) {
+		var ln = mapping.localName || mapping.ln || null;
+		mapping.localName = ln;
+		var n = mapping.name || mapping.n || null;
+		mapping.name = n;
+		// Calculate both name as well as localName
+		// name is provided
+		if (Jsonix.Util.Type.isString(mapping.name)) {
+			// Obsolete code below
+			// // localName is not provided
+			// if (!Jsonix.Util.Type.isString(mapping.localName)) {
+			// // But module name is provided
+			// if (Jsonix.Util.Type.isString(this.name)) {
+			// // If name starts with module name, use second part
+			// // as local name
+			// if (mapping.name.indexOf(this.name + '.') === 0) {
+			// mapping.localName = mapping.name
+			// .substring(this.name.length + 1);
+			// }
+			// // Else use name as local name
+			// else {
+			// mapping.localName = mapping.name;
+			// }
+			// }
+			// // Module name is not provided, use name as local name
+			// else {
+			// mapping.localName = mapping.name;
+			// }
+			// }
+			if (mapping.name.length > 0 && mapping.name.charAt(0) === '.' && Jsonix.Util.Type.isString(this.name)) {
+				mapping.name = this.name + mapping.name;
+			}
+		}
+		// name is not provided but local name is provided
+		else if (Jsonix.Util.Type.isString(ln)) {
+			// Module name is provided
+			if (Jsonix.Util.Type.isString(this.name)) {
+				mapping.name = this.name + '.' + ln;
+			}
+			// Module name is not provided
+			else {
+				mapping.name = ln;
+			}
+		} else {
+			throw new Error("Neither [name/n] nor [localName/ln] was provided for the class info.");
+		}
+	},
+	createClassInfo : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		var dens = mapping.defaultElementNamespaceURI || mapping.dens || this.defaultElementNamespaceURI;
+		mapping.defaultElementNamespaceURI = dens;
+		var tns = mapping.targetNamespace || mapping.tns || this.targetNamespace;
+		mapping.targetNamespace = tns;
+		var dans = mapping.defaultAttributeNamespaceURI || mapping.dans || this.defaultAttributeNamespaceURI;
+		mapping.defaultAttributeNamespaceURI = dans;
+		this.initializeNames(mapping);
+		// Now both name an local name are initialized
+		var classInfo = new this.mappingStyle.classInfo(mapping, {
+			mappingStyle : this.mappingStyle
+		});
+		classInfo.module = this;
+		return classInfo;
+	},
+	createEnumLeafInfo : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		this.initializeNames(mapping);
+		// Now both name an local name are initialized
+		var enumLeafInfo = new this.mappingStyle.enumLeafInfo(mapping, {
+			mappingStyle : this.mappingStyle
+		});
+		enumLeafInfo.module = this;
+		return enumLeafInfo;
+	},
+	createList : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		var ti = mapping.baseTypeInfo || mapping.typeInfo || mapping.bti || mapping.ti || 'String';
+		var tn = mapping.typeName || mapping.tn || null;
+
+		if (Jsonix.Util.Type.exists(tn)) {
+			if (Jsonix.Util.Type.isString(tn)) {
+				tn = new Jsonix.XML.QName(this.targetNamespace, tn);
+			} else {
+				tn = Jsonix.XML.QName.fromObject(tn);
+			}
+		}
+		var s = mapping.separator || mapping.sep || ' ';
+		Jsonix.Util.Ensure.ensureExists(ti);
+		var listTypeInfo = new Jsonix.Schema.XSD.List(ti, tn, s);
+		listTypeInfo.module = this;
+		return listTypeInfo;
+	},
+	createElementInfo : function(mapping) {
+		Jsonix.Util.Ensure.ensureObject(mapping);
+		mapping = Jsonix.Util.Type.cloneObject(mapping);
+
+		var dens = mapping.defaultElementNamespaceURI || mapping.dens || this.defaultElementNamespaceURI;
+		mapping.defaultElementNamespaceURI = dens;
+		var en = mapping.elementName || mapping.en || undefined;
+		Jsonix.Util.Ensure.ensureExists(en);
+
+		var ti = mapping.typeInfo || mapping.ti || 'String';
+		Jsonix.Util.Ensure.ensureExists(ti);
+
+		mapping.typeInfo = ti;
+		if (Jsonix.Util.Type.isObject(en)) {
+			mapping.elementName = Jsonix.XML.QName.fromObject(en);
+		} else if (Jsonix.Util.Type.isString(en)) {
+			mapping.elementName = new Jsonix.XML.QName(this.defaultElementNamespaceURI, en);
+		} else {
+			throw new Error('Element info [' + mapping + '] must provide an element name.');
+		}
+
+		var sh = mapping.substitutionHead || mapping.sh || null;
+		if (Jsonix.Util.Type.exists(sh)) {
+			if (Jsonix.Util.Type.isObject(sh)) {
+				mapping.substitutionHead = Jsonix.XML.QName.fromObject(sh);
+			} else {
+				Jsonix.Util.Ensure.ensureString(sh);
+				mapping.substitutionHead = new Jsonix.XML.QName(this.defaultElementNamespaceURI, sh);
+			}
+		}
+
+		var elementInfo = new this.mappingStyle.elementInfo(mapping, {
+			mappingStyle : this.mappingStyle
+		});
+		elementInfo.module = this;
+		return elementInfo;
+	},
+	registerTypeInfos : function(context) {
+		for (var index = 0; index < this.typeInfos.length; index++) {
+			var typeInfo = this.typeInfos[index];
+			context.registerTypeInfo(typeInfo, this);
+		}
+	},
+	buildTypeInfos : function(context) {
+		for (var index = 0; index < this.typeInfos.length; index++) {
+			var typeInfo = this.typeInfos[index];
+			typeInfo.build(context, this);
+		}
+	},
+	registerElementInfos : function(context) {
+		for (var index = 0; index < this.elementInfos.length; index++) {
+			var elementInfo = this.elementInfos[index];
+			context.registerElementInfo(elementInfo, this);
+		}
+	},
+	buildElementInfos : function(context) {
+		for (var index = 0; index < this.elementInfos.length; index++) {
+			var elementInfo = this.elementInfos[index];
+			elementInfo.build(context, this);
+		}
+	},
+	// Obsolete, retained for backwards compatibility
+	cs : function() {
+		return this;
+	},
+	// Obsolete, retained for backwards compatibility
+	es : function() {
+		return this;
+	},
+	CLASS_NAME : 'Jsonix.Model.Module'
+});
+Jsonix.Model.Module.prototype.typeInfoCreators = {
+	"classInfo" : Jsonix.Model.Module.prototype.createClassInfo,
+	"c" : Jsonix.Model.Module.prototype.createClassInfo,
+	"enumInfo" : Jsonix.Model.Module.prototype.createEnumLeafInfo,
+	"enum" : Jsonix.Model.Module.prototype.createEnumLeafInfo,
+	"list" : Jsonix.Model.Module.prototype.createList,
+	"l" : Jsonix.Model.Module.prototype.createList
+};
+Jsonix.Mapping.Style.Standard = Jsonix.Class(Jsonix.Mapping.Style, {
+	marshaller : Jsonix.Binding.Marshaller,
+	unmarshaller : Jsonix.Binding.Unmarshaller,
+	module : Jsonix.Model.Module,
+	elementInfo : Jsonix.Model.ElementInfo,
+	classInfo : Jsonix.Model.ClassInfo,
+	enumLeafInfo : Jsonix.Model.EnumLeafInfo,
+	anyAttributePropertyInfo : Jsonix.Model.AnyAttributePropertyInfo,
+	anyElementPropertyInfo : Jsonix.Model.AnyElementPropertyInfo,
+	attributePropertyInfo : Jsonix.Model.AttributePropertyInfo,
+	elementMapPropertyInfo : Jsonix.Model.ElementMapPropertyInfo,
+	elementPropertyInfo : Jsonix.Model.ElementPropertyInfo,
+	elementsPropertyInfo : Jsonix.Model.ElementsPropertyInfo,
+	elementRefPropertyInfo : Jsonix.Model.ElementRefPropertyInfo,
+	elementRefsPropertyInfo : Jsonix.Model.ElementRefsPropertyInfo,
+	valuePropertyInfo : Jsonix.Model.ValuePropertyInfo,
+	initialize : function() {
+		Jsonix.Mapping.Style.prototype.initialize.apply(this);
+	},
+	CLASS_NAME : 'Jsonix.Mapping.Style.Standard'
+});
+Jsonix.Mapping.Style.STYLES.standard = new Jsonix.Mapping.Style.Standard();
+
+Jsonix.Mapping.Style.Simplified = Jsonix.Class(Jsonix.Mapping.Style, {
+	marshaller : Jsonix.Binding.Marshaller.Simplified,
+	unmarshaller : Jsonix.Binding.Unmarshaller.Simplified,
+	module : Jsonix.Model.Module,
+	elementInfo : Jsonix.Model.ElementInfo,
+	classInfo : Jsonix.Model.ClassInfo,
+	enumLeafInfo : Jsonix.Model.EnumLeafInfo,
+	anyAttributePropertyInfo : Jsonix.Model.AnyAttributePropertyInfo.Simplified,
+	anyElementPropertyInfo : Jsonix.Model.AnyElementPropertyInfo.Simplified,
+	attributePropertyInfo : Jsonix.Model.AttributePropertyInfo,
+	elementMapPropertyInfo : Jsonix.Model.ElementMapPropertyInfo,
+	elementPropertyInfo : Jsonix.Model.ElementPropertyInfo,
+	elementsPropertyInfo : Jsonix.Model.ElementsPropertyInfo,
+	elementRefPropertyInfo : Jsonix.Model.ElementRefPropertyInfo.Simplified,
+	elementRefsPropertyInfo : Jsonix.Model.ElementRefsPropertyInfo.Simplified,
+	valuePropertyInfo : Jsonix.Model.ValuePropertyInfo,
+	initialize : function() {
+		Jsonix.Mapping.Style.prototype.initialize.apply(this);
+	},
+	CLASS_NAME : 'Jsonix.Mapping.Style.Simplified'
+});
+Jsonix.Mapping.Style.STYLES.simplified = new Jsonix.Mapping.Style.Simplified();
+
+Jsonix.Schema.XSD = {};
+Jsonix.Schema.XSD.NAMESPACE_URI = 'http://www.w3.org/2001/XMLSchema';
+Jsonix.Schema.XSD.PREFIX = 'xsd';
+Jsonix.Schema.XSD.qname = function(localPart) {
+	Jsonix.Util.Ensure.ensureString(localPart);
+	return new Jsonix.XML.QName(Jsonix.Schema.XSD.NAMESPACE_URI, localPart,
+			Jsonix.Schema.XSD.PREFIX);
+};
+
+Jsonix.Schema.XSD.AnyType = Jsonix.Class(Jsonix.Model.ClassInfo, {
+	typeName : Jsonix.Schema.XSD.qname('anyType'),
+	initialize : function() {
+		Jsonix.Model.ClassInfo.prototype.initialize.call(this, {
+			name : 'AnyType',
+			propertyInfos : [ {
+				type : 'anyAttribute',
+				name : 'attributes'
+			}, {
+				type : 'anyElement',
+				name : 'content',
+				collection : true
+			} ]
+		});
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.AnyType'
+});
+Jsonix.Schema.XSD.AnyType.INSTANCE = new Jsonix.Schema.XSD.AnyType();
+Jsonix.Schema.XSD.AnySimpleType = Jsonix.Class(Jsonix.Model.TypeInfo, {
+	name : 'AnySimpleType',
+	typeName : Jsonix.Schema.XSD.qname('anySimpleType'),
+	initialize : function() {
+		Jsonix.Model.TypeInfo.prototype.initialize.apply(this, []);
+	},	
+	print : function(value, context, output, scope) {
+		return value;
+	},
+	parse : function(text, context, input, scope) {
+		return text;
+	},
+	isInstance : function(value, context, scope) {
+		return true;
+	},
+	reprint : function(value, context, output, scope) {
+		// Only reprint when the value is a string but not an instance
+		if (Jsonix.Util.Type.isString(value) && !this.isInstance(value, context, scope)) {
+			// Using null as input as input is not available
+			return this.print(this.parse(value, context, null, scope), context, output, scope);
+		}
+		else
+		{
+			return this.print(value, context, output, scope);
+		}
+	},
+	unmarshal : function(context, input, scope) {
+		var text = input.getElementText();
+		if (Jsonix.Util.StringUtils.isNotBlank(text)) {
+			return this.parse(text, context, input, scope);
+		}
+		else
+		{
+			return null;
+		}
+	},
+	marshal : function(value, context, output, scope) {
+		if (Jsonix.Util.Type.exists(value)) {
+			output.writeCharacters(this.reprint(value, context, output, scope));
+		}
+	},
+	build: function(context, module)
+	{
+		// Nothing to do
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.AnySimpleType'
+});
+Jsonix.Schema.XSD.AnySimpleType.INSTANCE = new Jsonix.Schema.XSD.AnySimpleType();
+Jsonix.Schema.XSD.List = Jsonix
+		.Class(
+				Jsonix.Schema.XSD.AnySimpleType,
+				{
+					name : null,
+					typeName : null,
+					typeInfo : null,
+					separator : ' ',
+					trimmedSeparator : Jsonix.Util.StringUtils.whitespaceCharacters,
+					simpleType : true,
+					built : false,
+					initialize : function(typeInfo, typeName, separator) {
+						Jsonix.Util.Ensure.ensureExists(typeInfo);
+						// TODO Ensure correct argument
+						this.typeInfo = typeInfo;
+						if (!Jsonix.Util.Type.exists(this.name)) {
+							this.name = typeInfo.name + "*";
+						}
+						if (Jsonix.Util.Type.exists(typeName)) {
+							// TODO Ensure correct argument
+							this.typeName = typeName;
+						}
+
+						if (Jsonix.Util.Type.isString(separator)) {
+							// TODO Ensure correct argument
+							this.separator = separator;
+						} else {
+							this.separator = ' ';
+						}
+
+						var trimmedSeparator = Jsonix.Util.StringUtils
+								.trim(this.separator);
+						if (trimmedSeparator.length === 0) {
+							this.trimmedSeparator = Jsonix.Util.StringUtils.whitespaceCharacters;
+						} else {
+							this.trimmedSeparator = trimmedSeparator;
+						}
+					},
+					build : function(context) {
+						if (!this.built) {
+							this.typeInfo = context.resolveTypeInfo(this.typeInfo, this.module);
+							this.built = true;
+						}
+					},
+					print : function(value, context, output, scope) {
+						if (!Jsonix.Util.Type.exists(value)) {
+							return null;
+						}
+						// TODO Exception if not an array
+						Jsonix.Util.Ensure.ensureArray(value);
+						var result = '';
+						for ( var index = 0; index < value.length; index++) {
+							if (index > 0) {
+								result = result + this.separator;
+							}
+							result = result + this.typeInfo.reprint(value[index], context, output, scope);
+						}
+						return result;
+					},
+					parse : function(text, context, input, scope) {
+						Jsonix.Util.Ensure.ensureString(text);
+						var items = Jsonix.Util.StringUtils
+								.splitBySeparatorChars(text,
+										this.trimmedSeparator);
+						var result = [];
+						for ( var index = 0; index < items.length; index++) {
+							result.push(this.typeInfo
+									.parse(Jsonix.Util.StringUtils.trim(items[index]), context, input, scope));
+						}
+						return result;
+					},
+					// TODO isInstance?
+					CLASS_NAME : 'Jsonix.Schema.XSD.List'
+				});
+
+Jsonix.Schema.XSD.String = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'String',
+	typeName : Jsonix.Schema.XSD.qname('string'),
+	unmarshal : function(context, input, scope) {
+		var text = input.getElementText();
+		return this.parse(text, context, input, scope);
+	},
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureString(value);
+		return value;
+	},
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		return text;
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isString(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.String'
+});
+Jsonix.Schema.XSD.String.INSTANCE = new Jsonix.Schema.XSD.String();
+Jsonix.Schema.XSD.String.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.String.INSTANCE);
+Jsonix.Schema.XSD.Strings = Jsonix.Class(Jsonix.Schema.XSD.List, {
+	name : 'Strings',
+	initialize : function() {
+		Jsonix.Schema.XSD.List.prototype.initialize.apply(this, [ Jsonix.Schema.XSD.String.INSTANCE, Jsonix.Schema.XSD.qname('strings'), ' ' ]);
+	},
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.Strings'
+});
+Jsonix.Schema.XSD.Strings.INSTANCE = new Jsonix.Schema.XSD.Strings();
+Jsonix.Schema.XSD.NormalizedString = Jsonix.Class(Jsonix.Schema.XSD.String, {
+	name : 'NormalizedString',
+	typeName : Jsonix.Schema.XSD.qname('normalizedString'),
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.NormalizedString'
+});
+Jsonix.Schema.XSD.NormalizedString.INSTANCE = new Jsonix.Schema.XSD.NormalizedString();
+Jsonix.Schema.XSD.NormalizedString.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.NormalizedString.INSTANCE);
+Jsonix.Schema.XSD.Token = Jsonix.Class(Jsonix.Schema.XSD.NormalizedString, {
+	name : 'Token',
+	typeName : Jsonix.Schema.XSD.qname('token'),
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.Token'
+});
+Jsonix.Schema.XSD.Token.INSTANCE = new Jsonix.Schema.XSD.Token();
+Jsonix.Schema.XSD.Token.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Token.INSTANCE);
+Jsonix.Schema.XSD.Language = Jsonix.Class(Jsonix.Schema.XSD.Token, {
+	name : 'Language',
+	typeName : Jsonix.Schema.XSD.qname('language'),
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.Language'
+});
+Jsonix.Schema.XSD.Language.INSTANCE = new Jsonix.Schema.XSD.Language();
+Jsonix.Schema.XSD.Language.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Language.INSTANCE);
+Jsonix.Schema.XSD.Name = Jsonix.Class(Jsonix.Schema.XSD.Token, {
+	name : 'Name',
+	typeName : Jsonix.Schema.XSD.qname('Name'),
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.Name'
+});
+Jsonix.Schema.XSD.Name.INSTANCE = new Jsonix.Schema.XSD.Name();
+Jsonix.Schema.XSD.Name.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Name.INSTANCE);
+Jsonix.Schema.XSD.NCName = Jsonix.Class(Jsonix.Schema.XSD.Name, {
+	name : 'NCName',
+	typeName : Jsonix.Schema.XSD.qname('NCName'),
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.NCName'
+});
+Jsonix.Schema.XSD.NCName.INSTANCE = new Jsonix.Schema.XSD.NCName();
+Jsonix.Schema.XSD.NCName.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.NCName.INSTANCE);
+Jsonix.Schema.XSD.NMToken = Jsonix.Class(Jsonix.Schema.XSD.Token, {
+	name : 'NMToken',
+	typeName : Jsonix.Schema.XSD.qname('NMTOKEN'),
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.NMToken'
+});
+Jsonix.Schema.XSD.NMToken.INSTANCE = new Jsonix.Schema.XSD.NMToken();
+Jsonix.Schema.XSD.NMTokens = Jsonix.Class(Jsonix.Schema.XSD.List, {
+	name : 'NMTokens',
+	initialize : function() {
+		Jsonix.Schema.XSD.List.prototype.initialize.apply(this, [ Jsonix.Schema.XSD.NMToken.INSTANCE, Jsonix.Schema.XSD.qname('NMTOKEN'), ' ' ]);
+	},
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.NMTokens'
+});
+Jsonix.Schema.XSD.NMTokens.INSTANCE = new Jsonix.Schema.XSD.NMTokens();
+Jsonix.Schema.XSD.Boolean = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'Boolean',
+	typeName : Jsonix.Schema.XSD.qname('boolean'),
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureBoolean(value);
+		return value ? 'true' : 'false';
+	},
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		if (text === 'true' || text === '1') {
+			return true;
+		} else if (text === 'false' || text === '0') {
+			return false;
+		} else {
+			throw new Error("Either [true], [1], [0] or [false] expected as boolean value.");
+		}
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isBoolean(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.Boolean'
+});
+Jsonix.Schema.XSD.Boolean.INSTANCE = new Jsonix.Schema.XSD.Boolean();
+Jsonix.Schema.XSD.Boolean.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Boolean.INSTANCE);
+Jsonix.Schema.XSD.Base64Binary = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'Base64Binary',
+	typeName : Jsonix.Schema.XSD.qname('base64Binary'),
+	charToByte : {},
+	byteToChar : [],
+	initialize : function() {
+		Jsonix.Schema.XSD.AnySimpleType.prototype.initialize.apply(this);
+		// Initialize charToByte and byteToChar table for fast
+		// lookups
+		var charTable = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+		for (var i = 0; i < charTable.length; i++) {
+			var _char = charTable.charAt(i);
+			var _byte = charTable.charCodeAt(i);
+			this.byteToChar[i] = _char;
+			this.charToByte[_char] = i;
+		}
+	},
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureArray(value);
+		return this.encode(value);
+	},
+
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		return this.decode(text);
+	},
+	encode : function(uarray) {
+		var output = "";
+		var byte0;
+		var byte1;
+		var byte2;
+		var char0;
+		var char1;
+		var char2;
+		var char3;
+		var i = 0;
+		var j = 0;
+		var length = uarray.length;
+
+		for (i = 0; i < length; i += 3) {
+			byte0 = uarray[i] & 0xFF;
+			char0 = this.byteToChar[byte0 >> 2];
+
+			if (i + 1 < length) {
+				byte1 = uarray[i + 1] & 0xFF;
+				char1 = this.byteToChar[((byte0 & 0x03) << 4) | (byte1 >> 4)];
+				if (i + 2 < length) {
+					byte2 = uarray[i + 2] & 0xFF;
+					char2 = this.byteToChar[((byte1 & 0x0F) << 2) | (byte2 >> 6)];
+					char3 = this.byteToChar[byte2 & 0x3F];
+				} else {
+					char2 = this.byteToChar[(byte1 & 0x0F) << 2];
+					char3 = "=";
+				}
+			} else {
+				char1 = this.byteToChar[(byte0 & 0x03) << 4];
+				char2 = "=";
+				char3 = "=";
+			}
+			output = output + char0 + char1 + char2 + char3;
+		}
+		return output;
+	},
+	decode : function(text) {
+
+		input = text.replace(/[^A-Za-z0-9\+\/\=]/g, "");
+
+		var length = (input.length / 4) * 3;
+		if (input.charAt(input.length - 1) === "=") {
+			length--;
+		}
+		if (input.charAt(input.length - 2) === "=") {
+			length--;
+		}
+
+		var uarray = new Array(length);
+
+		var byte0;
+		var byte1;
+		var byte2;
+		var char0;
+		var char1;
+		var char2;
+		var char3;
+		var i = 0;
+		var j = 0;
+
+		for (i = 0; i < length; i += 3) {
+			// get the 3 octects in 4 ascii chars
+			char0 = this.charToByte[input.charAt(j++)];
+			char1 = this.charToByte[input.charAt(j++)];
+			char2 = this.charToByte[input.charAt(j++)];
+			char3 = this.charToByte[input.charAt(j++)];
+
+			byte0 = (char0 << 2) | (char1 >> 4);
+			byte1 = ((char1 & 0x0F) << 4) | (char2 >> 2);
+			byte2 = ((char2 & 0x03) << 6) | char3;
+
+			uarray[i] = byte0;
+			if (char2 != 64) {
+				uarray[i + 1] = byte1;
+			}
+			if (char3 != 64) {
+				uarray[i + 2] = byte2;
+			}
+		}
+		return uarray;
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isArray(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.Base64Binary'
+});
+Jsonix.Schema.XSD.Base64Binary.INSTANCE = new Jsonix.Schema.XSD.Base64Binary();
+Jsonix.Schema.XSD.Base64Binary.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Base64Binary.INSTANCE);
+Jsonix.Schema.XSD.HexBinary = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'HexBinary',
+	typeName : Jsonix.Schema.XSD.qname('hexBinary'),
+	charToQuartet : {},
+	byteToDuplet : [],
+	initialize : function() {
+		Jsonix.Schema.XSD.AnySimpleType.prototype.initialize.apply(this);
+		var charTableUpperCase = "0123456789ABCDEF";
+		var charTableLowerCase = charTableUpperCase.toLowerCase();
+		var i;
+		for (i = 0; i < 16; i++) {
+			this.charToQuartet[charTableUpperCase.charAt(i)] = i;
+			if (i >= 0xA) {
+				this.charToQuartet[charTableLowerCase.charAt(i)] = i;
+			}
+		}
+		for (i = 0; i < 256; i++) {
+			this.byteToDuplet[i] =
+			//
+			charTableUpperCase[i >> 4] + charTableUpperCase[i & 0xF];
+		}
+	},
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureArray(value);
+		return this.encode(value);
+	},
+
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		return this.decode(text);
+	},
+	encode : function(uarray) {
+		var output = "";
+		for ( var i = 0; i < uarray.length; i++) {
+			output = output + this.byteToDuplet[uarray[i] & 0xFF];
+		}
+		return output;
+	},
+	decode : function(text) {
+		var input = text.replace(/[^A-Fa-f0-9]/g, "");
+		// Round by two
+		var length = input.length >> 1;
+		var uarray = new Array(length);
+		for ( var i = 0; i < length; i++) {
+			var char0 = input.charAt(2 * i);
+			var char1 = input.charAt(2 * i + 1);
+			uarray[i] = this.charToQuartet[char0] << 4
+					| this.charToQuartet[char1];
+		}
+		return uarray;
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isArray(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.HexBinary'
+});
+Jsonix.Schema.XSD.HexBinary.INSTANCE = new Jsonix.Schema.XSD.HexBinary();
+Jsonix.Schema.XSD.HexBinary.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.HexBinary.INSTANCE);
+Jsonix.Schema.XSD.Number = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'Number',
+	typeName : Jsonix.Schema.XSD.qname('number'),
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureNumberOrNaN(value);
+		if (Jsonix.Util.Type.isNaN(value)) {
+			return 'NaN';
+		} else if (value === Infinity) {
+			return 'INF';
+		} else if (value === -Infinity) {
+			return '-INF';
+		} else {
+			var text = String(value);
+			return text;
+		}
+	},
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		if (text === '-INF') {
+			return -Infinity;
+		} else if (text === 'INF') {
+			return Infinity;
+		} else if (text === 'NaN') {
+			return NaN;
+		} else {
+			var value = Number(text);
+			Jsonix.Util.Ensure.ensureNumber(value);
+			return value;
+		}
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isNumberOrNaN(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.Number'
+});
+Jsonix.Schema.XSD.Number.INSTANCE = new Jsonix.Schema.XSD.Number();
+Jsonix.Schema.XSD.Number.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Number.INSTANCE);
+Jsonix.Schema.XSD.Float = Jsonix.Class(Jsonix.Schema.XSD.Number, {
+	name : 'Float',
+	typeName : Jsonix.Schema.XSD.qname('float'),
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isNaN(value) || value === -Infinity || value === Infinity || (Jsonix.Util.Type.isNumber(value) && value >= this.MIN_VALUE && value <= this.MAX_VALUE);
+	},
+	MIN_VALUE : -3.4028235e+38,
+	MAX_VALUE : 3.4028235e+38,
+	CLASS_NAME : 'Jsonix.Schema.XSD.Float'
+});
+Jsonix.Schema.XSD.Float.INSTANCE = new Jsonix.Schema.XSD.Float();
+Jsonix.Schema.XSD.Float.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Float.INSTANCE);
+Jsonix.Schema.XSD.Decimal = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'Decimal',
+	typeName : Jsonix.Schema.XSD.qname('decimal'),
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureNumber(value);
+		var text = String(value);
+		return text;
+	},
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		var value = Number(text);
+		Jsonix.Util.Ensure.ensureNumber(value);
+		return value;
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isNumber(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.Decimal'
+});
+Jsonix.Schema.XSD.Decimal.INSTANCE = new Jsonix.Schema.XSD.Decimal();
+Jsonix.Schema.XSD.Decimal.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Decimal.INSTANCE);
+Jsonix.Schema.XSD.Integer = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'Integer',
+	typeName : Jsonix.Schema.XSD.qname('integer'),
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureInteger(value);
+		var text = String(value);
+		return text;
+	},
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		var value = Number(text);
+		Jsonix.Util.Ensure.ensureInteger(value);
+		return value;
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.NumberUtils.isInteger(value) && value >= this.MIN_VALUE && value <= this.MAX_VALUE;
+	},
+	MIN_VALUE : -9223372036854775808,
+	MAX_VALUE : 9223372036854775807,
+	CLASS_NAME : 'Jsonix.Schema.XSD.Integer'
+});
+Jsonix.Schema.XSD.Integer.INSTANCE = new Jsonix.Schema.XSD.Integer();
+Jsonix.Schema.XSD.Integer.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Integer.INSTANCE);
+Jsonix.Schema.XSD.NonPositiveInteger = Jsonix.Class(Jsonix.Schema.XSD.Integer, {
+	name : 'NonPositiveInteger',
+	typeName : Jsonix.Schema.XSD.qname('nonPositiveInteger'),
+	MIN_VALUE: -9223372036854775808,
+	MAX_VALUE: 0,
+	CLASS_NAME : 'Jsonix.Schema.XSD.NonPositiveInteger'
+});
+Jsonix.Schema.XSD.NonPositiveInteger.INSTANCE = new Jsonix.Schema.XSD.NonPositiveInteger();
+Jsonix.Schema.XSD.NonPositiveInteger.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.NonPositiveInteger.INSTANCE);
+Jsonix.Schema.XSD.NegativeInteger = Jsonix.Class(Jsonix.Schema.XSD.NonPositiveInteger, {
+	name : 'NegativeInteger',
+	typeName : Jsonix.Schema.XSD.qname('negativeInteger'),
+	MIN_VALUE: -9223372036854775808,
+	MAX_VALUE: -1,
+	CLASS_NAME : 'Jsonix.Schema.XSD.NegativeInteger'
+});
+Jsonix.Schema.XSD.NegativeInteger.INSTANCE = new Jsonix.Schema.XSD.NegativeInteger();
+Jsonix.Schema.XSD.NegativeInteger.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.NegativeInteger.INSTANCE);
+Jsonix.Schema.XSD.Long = Jsonix.Class(Jsonix.Schema.XSD.Integer, {
+	name : 'Long',
+	typeName : Jsonix.Schema.XSD.qname('long'),
+	MIN_VALUE : -9223372036854775808,
+	MAX_VALUE : 9223372036854775807,
+	CLASS_NAME : 'Jsonix.Schema.XSD.Long'
+});
+Jsonix.Schema.XSD.Long.INSTANCE = new Jsonix.Schema.XSD.Long();
+Jsonix.Schema.XSD.Long.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.Long.INSTANCE);
+Jsonix.Schema.XSD.Int = Jsonix.Class(Jsonix.Schema.XSD.Long, {
+	name : 'Int',
+	typeName : Jsonix.Schema.XSD.qname('int'),
+	MIN_VALUE : -2147483648,
+	MAX_VALUE : 2147483647,
+	CLASS_NAME : 'Jsonix.Schema.XSD.Int'
+});
+Jsonix.Schema.XSD.Int.INSTANCE = new Jsonix.Schema.XSD.Int();
+Jsonix.Schema.XSD.Int.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.Int.INSTANCE);
+Jsonix.Schema.XSD.Short = Jsonix.Class(Jsonix.Schema.XSD.Int, {
+	name : 'Short',
+	typeName : Jsonix.Schema.XSD.qname('short'),
+	MIN_VALUE : -32768,
+	MAX_VALUE : 32767,
+	CLASS_NAME : 'Jsonix.Schema.XSD.Short'
+});
+Jsonix.Schema.XSD.Short.INSTANCE = new Jsonix.Schema.XSD.Short();
+Jsonix.Schema.XSD.Short.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Short.INSTANCE);
+Jsonix.Schema.XSD.Byte = Jsonix.Class(Jsonix.Schema.XSD.Short, {
+	name : 'Byte',
+	typeName : Jsonix.Schema.XSD.qname('byte'),
+	MIN_VALUE : -128,
+	MAX_VALUE : 127,
+	CLASS_NAME : 'Jsonix.Schema.XSD.Byte'
+});
+Jsonix.Schema.XSD.Byte.INSTANCE = new Jsonix.Schema.XSD.Byte();
+Jsonix.Schema.XSD.Byte.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Byte.INSTANCE);
+Jsonix.Schema.XSD.NonNegativeInteger = Jsonix.Class(Jsonix.Schema.XSD.Integer, {
+	name : 'NonNegativeInteger',
+	typeName : Jsonix.Schema.XSD.qname('nonNegativeInteger'),
+	MIN_VALUE: 0,
+	MAX_VALUE: 9223372036854775807,
+	CLASS_NAME : 'Jsonix.Schema.XSD.NonNegativeInteger'
+});
+Jsonix.Schema.XSD.NonNegativeInteger.INSTANCE = new Jsonix.Schema.XSD.NonNegativeInteger();
+Jsonix.Schema.XSD.NonNegativeInteger.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.NonNegativeInteger.INSTANCE);
+Jsonix.Schema.XSD.UnsignedLong = Jsonix.Class(Jsonix.Schema.XSD.NonNegativeInteger, {
+	name : 'UnsignedLong',
+	typeName : Jsonix.Schema.XSD.qname('unsignedLong'),
+	MIN_VALUE : 0,
+	MAX_VALUE : 18446744073709551615,
+	CLASS_NAME : 'Jsonix.Schema.XSD.UnsignedLong'
+});
+Jsonix.Schema.XSD.UnsignedLong.INSTANCE = new Jsonix.Schema.XSD.UnsignedLong();
+Jsonix.Schema.XSD.UnsignedLong.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.UnsignedLong.INSTANCE);
+Jsonix.Schema.XSD.UnsignedInt = Jsonix.Class(Jsonix.Schema.XSD.UnsignedLong, {
+	name : 'UnsignedInt',
+	typeName : Jsonix.Schema.XSD.qname('unsignedInt'),
+	MIN_VALUE : 0,
+	MAX_VALUE : 4294967295,
+	CLASS_NAME : 'Jsonix.Schema.XSD.UnsignedInt'
+});
+Jsonix.Schema.XSD.UnsignedInt.INSTANCE = new Jsonix.Schema.XSD.UnsignedInt();
+Jsonix.Schema.XSD.UnsignedInt.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.UnsignedInt.INSTANCE);
+Jsonix.Schema.XSD.UnsignedShort = Jsonix.Class(Jsonix.Schema.XSD.UnsignedInt, {
+	name : 'UnsignedShort',
+	typeName : Jsonix.Schema.XSD.qname('unsignedShort'),
+	MIN_VALUE : 0,
+	MAX_VALUE : 65535,
+	CLASS_NAME : 'Jsonix.Schema.XSD.UnsignedShort'
+});
+Jsonix.Schema.XSD.UnsignedShort.INSTANCE = new Jsonix.Schema.XSD.UnsignedShort();
+Jsonix.Schema.XSD.UnsignedShort.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.UnsignedShort.INSTANCE);
+Jsonix.Schema.XSD.UnsignedByte = Jsonix.Class(Jsonix.Schema.XSD.UnsignedShort, {
+	name : 'UnsignedByte',
+	typeName : Jsonix.Schema.XSD.qname('unsignedByte'),
+	MIN_VALUE : 0,
+	MAX_VALUE : 255,
+	CLASS_NAME : 'Jsonix.Schema.XSD.UnsignedByte'
+});
+Jsonix.Schema.XSD.UnsignedByte.INSTANCE = new Jsonix.Schema.XSD.UnsignedByte();
+Jsonix.Schema.XSD.UnsignedByte.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.UnsignedByte.INSTANCE);
+Jsonix.Schema.XSD.PositiveInteger = Jsonix.Class(Jsonix.Schema.XSD.NonNegativeInteger, {
+	name : 'PositiveInteger',
+	typeName : Jsonix.Schema.XSD.qname('positiveInteger'),
+	MIN_VALUE : 1,
+	MAX_VALUE : 9223372036854775807,
+	CLASS_NAME : 'Jsonix.Schema.XSD.PositiveInteger'
+});
+Jsonix.Schema.XSD.PositiveInteger.INSTANCE = new Jsonix.Schema.XSD.PositiveInteger();
+Jsonix.Schema.XSD.PositiveInteger.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.PositiveInteger.INSTANCE);
+Jsonix.Schema.XSD.Double = Jsonix.Class(Jsonix.Schema.XSD.Number, {
+	name : 'Double',
+	typeName : Jsonix.Schema.XSD.qname('double'),
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isNaN(value) || value === -Infinity || value === Infinity || (Jsonix.Util.Type.isNumber(value) && value >= this.MIN_VALUE && value <= this.MAX_VALUE);
+	},
+	MIN_VALUE : -1.7976931348623157e+308,
+	MAX_VALUE : 1.7976931348623157e+308,
+	CLASS_NAME : 'Jsonix.Schema.XSD.Double'
+});
+Jsonix.Schema.XSD.Double.INSTANCE = new Jsonix.Schema.XSD.Double();
+Jsonix.Schema.XSD.Double.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Double.INSTANCE);
+Jsonix.Schema.XSD.AnyURI = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'AnyURI',
+	typeName : Jsonix.Schema.XSD.qname('anyURI'),
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureString(value);
+		return value;
+	},
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		return text;
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isString(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.AnyURI'
+});
+Jsonix.Schema.XSD.AnyURI.INSTANCE = new Jsonix.Schema.XSD.AnyURI();
+Jsonix.Schema.XSD.AnyURI.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.AnyURI.INSTANCE);
+Jsonix.Schema.XSD.QName = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'QName',
+	typeName : Jsonix.Schema.XSD.qname('QName'),
+	print : function(value, context, output, scope) {
+		var qName = Jsonix.XML.QName.fromObject(value);
+		var prefix;
+		var localPart = qName.localPart;
+		if (output) {
+			// If QName does not provide the prefix, let it be generated
+			prefix = output.getPrefix(qName.namespaceURI, qName.prefix||null);
+			output.declareNamespace(qName.namespaceURI, prefix);
+		} else {
+			prefix = qName.prefix;
+		}
+		return !prefix ? localPart : (prefix + ':' + localPart);
+	},
+	parse : function(value, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(value);
+		value = Jsonix.Util.StringUtils.trim(value);
+		var prefix;
+		var localPart;
+		var colonPosition = value.indexOf(':');
+		if (colonPosition === -1) {
+			prefix = '';
+			localPart = value;
+		} else if (colonPosition > 0 && colonPosition < (value.length - 1)) {
+			prefix = value.substring(0, colonPosition);
+			localPart = value.substring(colonPosition + 1);
+		} else {
+			throw new Error('Invalid QName [' + value + '].');
+		}
+		var namespaceContext = input || context || null;
+		if (!namespaceContext)
+		{
+			return value;
+		}
+		else
+		{
+			var namespaceURI = namespaceContext.getNamespaceURI(prefix);
+			if (Jsonix.Util.Type.isString(namespaceURI))
+			{
+				return new Jsonix.XML.QName(namespaceURI, localPart, prefix);
+			}
+			else
+			{
+				throw new Error('Prefix [' + prefix + '] of the QName [' + value + '] is not bound in this context.');
+			}
+		}
+	},
+	isInstance : function(value, context, scope) {
+		return (value instanceof Jsonix.XML.QName) || (Jsonix.Util.Type.isObject(value) && Jsonix.Util.Type.isString(value.localPart || value.lp));
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.QName'
+});
+Jsonix.Schema.XSD.QName.INSTANCE = new Jsonix.Schema.XSD.QName();
+Jsonix.Schema.XSD.QName.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.QName.INSTANCE);
+Jsonix.Schema.XSD.Calendar = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'Calendar',
+	typeName : Jsonix.Schema.XSD.qname('calendar'),
+	parse : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		if (text.match(new RegExp("^" + Jsonix.Schema.XSD.Calendar.DATETIME_PATTERN + "$"))) {
+			return this.parseDateTime(text, context, input, scope);
+		} else if (text.match(new RegExp("^" + Jsonix.Schema.XSD.Calendar.DATE_PATTERN + "$"))) {
+			return this.parseDate(text, context, input, scope);
+		} else if (text.match(new RegExp("^" + Jsonix.Schema.XSD.Calendar.TIME_PATTERN + "$"))) {
+			return this.parseTime(text, context, input, scope);
+		} else if (text.match(new RegExp("^" + Jsonix.Schema.XSD.Calendar.GYEAR_MONTH_PATTERN + "$"))) {
+			return this.parseGYearMonth(text, context, input, scope);
+		} else if (text.match(new RegExp("^" + Jsonix.Schema.XSD.Calendar.GYEAR_PATTERN + "$"))) {
+			return this.parseGYear(text, context, input, scope);
+		} else if (text.match(new RegExp("^" + Jsonix.Schema.XSD.Calendar.GMONTH_DAY_PATTERN + "$"))) {
+			return this.parseGMonthDay(text, context, input, scope);
+		} else if (text.match(new RegExp("^" + Jsonix.Schema.XSD.Calendar.GMONTH_PATTERN + "$"))) {
+			return this.parseGMonth(text, context, input, scope);
+		} else if (text.match(new RegExp("^" + Jsonix.Schema.XSD.Calendar.GDAY_PATTERN + "$"))) {
+			return this.parseGDay(text, context, input, scope);
+		} else {
+			throw new Error('Value [' + text + '] does not match xs:dateTime, xs:date, xs:time, xs:gYearMonth, xs:gYear, xs:gMonthDay, xs:gMonth or xs:gDay patterns.');
+		}
+	},
+	parseGYearMonth : function(value, context, input, scope) {
+		var gYearMonthExpression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.GYEAR_MONTH_PATTERN + "$");
+		var results = value.match(gYearMonthExpression);
+		if (results !== null) {
+			var data = {
+				year : parseInt(results[1], 10),
+				month : parseInt(results[5], 10),
+				timezone : this.parseTimezoneString(results[7])
+			};
+			return new Jsonix.XML.Calendar(data);
+		}
+		throw new Error('Value [' + value + '] does not match the xs:gYearMonth pattern.');
+	},
+	parseGYear : function(value, context, input, scope) {
+		var gYearExpression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.GYEAR_PATTERN + "$");
+		var results = value.match(gYearExpression);
+		if (results !== null) {
+			var data = {
+				year : parseInt(results[1], 10),
+				timezone : this.parseTimezoneString(results[5])
+			};
+			return new Jsonix.XML.Calendar(data);
+		}
+		throw new Error('Value [' + value + '] does not match the xs:gYear pattern.');
+	},
+	parseGMonthDay : function(value, context, input, scope) {
+		var gMonthDayExpression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.GMONTH_DAY_PATTERN + "$");
+		var results = value.match(gMonthDayExpression);
+		if (results !== null) {
+			var data = {
+				month : parseInt(results[2], 10),
+				day : parseInt(results[3], 10),
+				timezone : this.parseTimezoneString(results[5])
+			};
+			return new Jsonix.XML.Calendar(data);
+		}
+		throw new Error('Value [' + value + '] does not match the xs:gMonthDay pattern.');
+	},
+	parseGMonth : function(value, context, input, scope) {
+		var gMonthExpression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.GMONTH_PATTERN + "$");
+		var results = value.match(gMonthExpression);
+		if (results !== null) {
+			var data = {
+				month : parseInt(results[2], 10),
+				timezone : this.parseTimezoneString(results[3])
+			};
+			return new Jsonix.XML.Calendar(data);
+		}
+		throw new Error('Value [' + value + '] does not match the xs:gMonth pattern.');
+	},
+	parseGDay : function(value, context, input, scope) {
+		var gDayExpression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.GDAY_PATTERN + "$");
+		var results = value.match(gDayExpression);
+		if (results !== null) {
+			var data = {
+				day : parseInt(results[2], 10),
+				timezone : this.parseTimezoneString(results[3])
+			};
+			return new Jsonix.XML.Calendar(data);
+		}
+		throw new Error('Value [' + value + '] does not match the xs:gDay pattern.');
+	},
+	parseDateTime : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		var expression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.DATETIME_PATTERN + "$");
+		var results = text.match(expression);
+		if (results !== null) {
+			var data = {
+				year : parseInt(results[1], 10),
+				month : parseInt(results[5], 10),
+				day : parseInt(results[7], 10),
+				hour : parseInt(results[9], 10),
+				minute : parseInt(results[10], 10),
+				second : parseInt(results[11], 10),
+				fractionalSecond : (results[12] ? parseFloat(results[12]) : 0),
+				timezone : this.parseTimezoneString(results[14])
+			};
+			return new Jsonix.XML.Calendar(data);
+		}
+		throw new Error('Value [' + value + '] does not match the xs:date pattern.');
+	},
+	parseDate : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		var expression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.DATE_PATTERN + "$");
+		var results = text.match(expression);
+		if (results !== null) {
+			var data = {
+				year : parseInt(results[1], 10),
+				month : parseInt(results[5], 10),
+				day : parseInt(results[7], 10),
+				timezone : this.parseTimezoneString(results[9])
+			};
+			return new Jsonix.XML.Calendar(data);
+		}
+		throw new Error('Value [' + value + '] does not match the xs:date pattern.');
+	},
+	parseTime : function(text, context, input, scope) {
+		Jsonix.Util.Ensure.ensureString(text);
+		var expression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.TIME_PATTERN + "$");
+		var results = text.match(expression);
+		if (results !== null) {
+			var data = {
+				hour : parseInt(results[1], 10),
+				minute : parseInt(results[2], 10),
+				second : parseInt(results[3], 10),
+				fractionalSecond : (results[4] ? parseFloat(results[4]) : 0),
+				timezone : this.parseTimezoneString(results[6])
+			};
+			return new Jsonix.XML.Calendar(data);
+		}
+		throw new Error('Value [' + value + '] does not match the xs:time pattern.');
+	},
+	parseTimezoneString : function(text) {
+		// (('+' | '-') hh ':' mm) | 'Z'
+		if (!Jsonix.Util.Type.isString(text)) {
+			return NaN;
+		} else if (text === '') {
+			return NaN;
+		} else if (text === 'Z') {
+			return 0;
+		} else if (text === '+14:00') {
+			return 14 * 60;
+		} else if (text === '-14:00') {
+			return -14 * 60;
+		} else {
+			var expression = new RegExp("^" + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + "$");
+			var results = text.match(expression);
+			if (results !== null) {
+				var sign = results[1] === '+' ? 1 : -1;
+				var hour = parseInt(results[4], 10);
+				var minute = parseInt(results[5], 10);
+				return sign * (hour * 60 + minute);
+			}
+			throw new Error('Value [' + value + '] does not match the timezone pattern.');
+		}
+	},
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		if (Jsonix.Util.NumberUtils.isInteger(value.year) && Jsonix.Util.NumberUtils.isInteger(value.month) && Jsonix.Util.NumberUtils.isInteger(value.day) && Jsonix.Util.NumberUtils.isInteger(value.hour) && Jsonix.Util.NumberUtils.isInteger(value.minute) && Jsonix.Util.NumberUtils.isInteger(value.second)) {
+			return this.printDateTime(value);
+		} else if (Jsonix.Util.NumberUtils.isInteger(value.year) && Jsonix.Util.NumberUtils.isInteger(value.month) && Jsonix.Util.NumberUtils.isInteger(value.day)) {
+			return this.printDate(value);
+		} else if (Jsonix.Util.NumberUtils.isInteger(value.hour) && Jsonix.Util.NumberUtils.isInteger(value.minute) && Jsonix.Util.NumberUtils.isInteger(value.second)) {
+			return this.printTime(value);
+		} else if (Jsonix.Util.NumberUtils.isInteger(value.year) && Jsonix.Util.NumberUtils.isInteger(value.month)) {
+			return this.printGYearMonth(value);
+		} else if (Jsonix.Util.NumberUtils.isInteger(value.month) && Jsonix.Util.NumberUtils.isInteger(value.day)) {
+			return this.printGMonthDay(value);
+		} else if (Jsonix.Util.NumberUtils.isInteger(value.year)) {
+			return this.printGYear(value);
+		} else if (Jsonix.Util.NumberUtils.isInteger(value.month)) {
+			return this.printGMonth(value);
+		} else if (Jsonix.Util.NumberUtils.isInteger(value.day)) {
+			return this.printGDay(value);
+		} else {
+			throw new Error('Value [' + value + '] is not recognized as dateTime, date or time.');
+		}
+	},
+	printDateTime : function(value) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		Jsonix.Util.Ensure.ensureInteger(value.year);
+		Jsonix.Util.Ensure.ensureInteger(value.month);
+		Jsonix.Util.Ensure.ensureInteger(value.day);
+		Jsonix.Util.Ensure.ensureInteger(value.hour);
+		Jsonix.Util.Ensure.ensureInteger(value.minute);
+		Jsonix.Util.Ensure.ensureNumber(value.second);
+		if (Jsonix.Util.Type.exists(value.fractionalString)) {
+			Jsonix.Util.Ensure.ensureNumber(value.fractionalString);
+		}
+		if (Jsonix.Util.Type.exists(value.timezone) && !Jsonix.Util.Type.isNaN(value.timezone)) {
+			Jsonix.Util.Ensure.ensureInteger(value.timezone);
+		}
+		var result = this.printDateString(value);
+		result = result + 'T';
+		result = result + this.printTimeString(value);
+		if (Jsonix.Util.Type.exists(value.timezone)) {
+			result = result + this.printTimezoneString(value.timezone);
+		}
+		return result;
+	},
+	printDate : function(value) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		Jsonix.Util.Ensure.ensureNumber(value.year);
+		Jsonix.Util.Ensure.ensureNumber(value.month);
+		Jsonix.Util.Ensure.ensureNumber(value.day);
+		if (Jsonix.Util.Type.exists(value.timezone) && !Jsonix.Util.Type.isNaN(value.timezone)) {
+			Jsonix.Util.Ensure.ensureInteger(value.timezone);
+		}
+		var result = this.printDateString(value);
+		if (Jsonix.Util.Type.exists(value.timezone)) {
+			result = result + this.printTimezoneString(value.timezone);
+		}
+		return result;
+	},
+	printTime : function(value) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		Jsonix.Util.Ensure.ensureNumber(value.hour);
+		Jsonix.Util.Ensure.ensureNumber(value.minute);
+		Jsonix.Util.Ensure.ensureNumber(value.second);
+		if (Jsonix.Util.Type.exists(value.fractionalString)) {
+			Jsonix.Util.Ensure.ensureNumber(value.fractionalString);
+		}
+		if (Jsonix.Util.Type.exists(value.timezone) && !Jsonix.Util.Type.isNaN(value.timezone)) {
+			Jsonix.Util.Ensure.ensureInteger(value.timezone);
+		}
+
+		var result = this.printTimeString(value);
+		if (Jsonix.Util.Type.exists(value.timezone)) {
+			result = result + this.printTimezoneString(value.timezone);
+		}
+		return result;
+	},
+	printDateString : function(value) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		Jsonix.Util.Ensure.ensureInteger(value.year);
+		Jsonix.Util.Ensure.ensureInteger(value.month);
+		Jsonix.Util.Ensure.ensureInteger(value.day);
+		return (value.year < 0 ? ('-' + this.printYear(-value.year)) : this.printYear(value.year)) + '-' + this.printMonth(value.month) + '-' + this.printDay(value.day);
+	},
+	printTimeString : function(value) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		Jsonix.Util.Ensure.ensureInteger(value.hour);
+		Jsonix.Util.Ensure.ensureInteger(value.minute);
+		Jsonix.Util.Ensure.ensureInteger(value.second);
+		if (Jsonix.Util.Type.exists(value.fractionalSecond)) {
+			Jsonix.Util.Ensure.ensureNumber(value.fractionalSecond);
+		}
+		var result = this.printHour(value.hour);
+		result = result + ':';
+		result = result + this.printMinute(value.minute);
+		result = result + ':';
+		result = result + this.printSecond(value.second);
+		if (Jsonix.Util.Type.exists(value.fractionalSecond)) {
+			result = result + this.printFractionalSecond(value.fractionalSecond);
+		}
+		return result;
+	},
+	printTimezoneString : function(value) {
+		if (!Jsonix.Util.Type.exists(value) || Jsonix.Util.Type.isNaN(value)) {
+			return '';
+		} else {
+			Jsonix.Util.Ensure.ensureInteger(value);
+
+			var sign = value < 0 ? -1 : (value > 0 ? 1 : 0);
+			var data = value * sign;
+			var minute = data % 60;
+			var hour = Math.floor(data / 60);
+
+			var result;
+			if (sign === 0) {
+				return 'Z';
+			} else {
+				if (sign > 0) {
+					result = '+';
+				} else if (sign < 0) {
+					result = '-';
+				}
+				result = result + this.printHour(hour);
+				result = result + ':';
+				result = result + this.printMinute(minute);
+				return result;
+			}
+		}
+	},
+	printGDay : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		var day = undefined;
+		var timezone = undefined;
+
+		if (value instanceof Date) {
+			day = value.getDate();
+		} else {
+			Jsonix.Util.Ensure.ensureInteger(value.day);
+			day = value.day;
+			timezone = value.timezone;
+		}
+		Jsonix.XML.Calendar.validateDay(day);
+		Jsonix.XML.Calendar.validateTimezone(timezone);
+		return "---" + this.printDay(day) + this.printTimezoneString(timezone);
+	},
+	printGMonth : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		var month = undefined;
+		var timezone = undefined;
+
+		if (value instanceof Date) {
+			month = value.getMonth() + 1;
+		} else {
+			Jsonix.Util.Ensure.ensureInteger(value.month);
+			month = value.month;
+			timezone = value.timezone;
+		}
+		Jsonix.XML.Calendar.validateMonth(month);
+		Jsonix.XML.Calendar.validateTimezone(timezone);
+		return "--" + this.printMonth(month) + this.printTimezoneString(timezone);
+	},
+	printGMonthDay : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		var month = undefined;
+		var day = undefined;
+		var timezone = undefined;
+
+		if (value instanceof Date) {
+			month = value.getMonth() + 1;
+			day = value.getDate();
+		} else {
+			Jsonix.Util.Ensure.ensureInteger(value.month);
+			Jsonix.Util.Ensure.ensureInteger(value.day);
+			month = value.month;
+			day = value.day;
+			timezone = value.timezone;
+		}
+		Jsonix.XML.Calendar.validateMonthDay(month, day);
+		Jsonix.XML.Calendar.validateTimezone(timezone);
+		return "--" + this.printMonth(month) + "-" + this.printDay(day) + this.printTimezoneString(timezone);
+	},
+	printGYear : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		var year = undefined;
+		var timezone = undefined;
+
+		if (value instanceof Date) {
+			year = value.getFullYear();
+		} else {
+			Jsonix.Util.Ensure.ensureInteger(value.year);
+			year = value.year;
+			timezone = value.timezone;
+		}
+		Jsonix.XML.Calendar.validateYear(year);
+		Jsonix.XML.Calendar.validateTimezone(timezone);
+		return this.printSignedYear(year) + this.printTimezoneString(timezone);
+	},
+	printGYearMonth : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		var year = undefined;
+		var month = undefined;
+		var timezone = undefined;
+
+		if (value instanceof Date) {
+			year = value.getFullYear();
+			month = value.getMonth() + 1;
+		} else {
+			Jsonix.Util.Ensure.ensureInteger(value.year);
+			year = value.year;
+			month = value.month;
+			timezone = value.timezone;
+		}
+		Jsonix.XML.Calendar.validateYear(year);
+		Jsonix.XML.Calendar.validateMonth(month);
+		Jsonix.XML.Calendar.validateTimezone(timezone);
+		return this.printSignedYear(year) + "-" + this.printMonth(month) + this.printTimezoneString(timezone);
+	},
+	printSignedYear : function(value) {
+		return value < 0 ? ("-" + this.printYear(value * -1)) : (this.printYear(value));
+	},
+	printYear : function(value) {
+		return this.printInteger(value, 4);
+	},
+	printMonth : function(value) {
+		return this.printInteger(value, 2);
+	},
+	printDay : function(value) {
+		return this.printInteger(value, 2);
+	},
+	printHour : function(value) {
+		return this.printInteger(value, 2);
+	},
+	printMinute : function(value) {
+		return this.printInteger(value, 2);
+	},
+	printSecond : function(value) {
+		return this.printInteger(value, 2);
+	},
+	printFractionalSecond : function(value) {
+		Jsonix.Util.Ensure.ensureNumber(value);
+		if (value < 0 || value >= 1) {
+			throw new Error('Fractional second [' + value + '] must be between 0 and 1.');
+		} else if (value === 0) {
+			return '';
+		} else {
+			var string = String(value);
+			var dotIndex = string.indexOf('.');
+			if (dotIndex < 0) {
+				return '';
+			} else {
+				return string.substring(dotIndex);
+			}
+		}
+	},
+	printInteger : function(value, length) {
+		Jsonix.Util.Ensure.ensureInteger(value);
+		Jsonix.Util.Ensure.ensureInteger(length);
+		if (length <= 0) {
+			throw new Error('Length [' + value + '] must be positive.');
+		}
+		if (value < 0) {
+			throw new Error('Value [' + value + '] must not be negative.');
+		}
+		var result = String(value);
+		for (var i = result.length; i < length; i++) {
+			result = '0' + result;
+		}
+		return result;
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isObject(value) && ((Jsonix.Util.NumberUtils.isInteger(value.year) && Jsonix.Util.NumberUtils.isInteger(value.month) && Jsonix.Util.NumberUtils.isInteger(value.day)) || (Jsonix.Util.NumberUtils.isInteger(value.hour) && Jsonix.Util.NumberUtils.isInteger(value.minute) && Jsonix.Util.NumberUtils.isInteger(value.second)));
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.Calendar'
+});
+
+Jsonix.Schema.XSD.Calendar.YEAR_PATTERN = "-?([1-9][0-9]*)?((?!(0000))[0-9]{4})";
+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN = "Z|([\\-\\+])(((0[0-9]|1[0-3]):([0-5][0-9]))|(14:00))";
+Jsonix.Schema.XSD.Calendar.MONTH_PATTERN = "(0[1-9]|1[0-2])";
+Jsonix.Schema.XSD.Calendar.SINGLE_MONTH_PATTERN = "\\-\\-" + Jsonix.Schema.XSD.Calendar.MONTH_PATTERN;
+Jsonix.Schema.XSD.Calendar.DAY_PATTERN = "(0[1-9]|[12][0-9]|3[01])";
+Jsonix.Schema.XSD.Calendar.SINGLE_DAY_PATTERN = "\\-\\-\\-" + Jsonix.Schema.XSD.Calendar.DAY_PATTERN;
+Jsonix.Schema.XSD.Calendar.GYEAR_PATTERN = "(" + Jsonix.Schema.XSD.Calendar.YEAR_PATTERN + ")" + "(" + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + ")?";
+Jsonix.Schema.XSD.Calendar.GMONTH_PATTERN = "(" + Jsonix.Schema.XSD.Calendar.SINGLE_MONTH_PATTERN + ")" + "(" + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + ")?";
+Jsonix.Schema.XSD.Calendar.GDAY_PATTERN = "(" + Jsonix.Schema.XSD.Calendar.SINGLE_DAY_PATTERN + ")" + "(" + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + ")?";
+Jsonix.Schema.XSD.Calendar.GYEAR_MONTH_PATTERN = "(" + Jsonix.Schema.XSD.Calendar.YEAR_PATTERN + ")" + "-" + "(" + Jsonix.Schema.XSD.Calendar.DAY_PATTERN + ")" + "(" + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + ")?";
+Jsonix.Schema.XSD.Calendar.GMONTH_DAY_PATTERN = "(" + Jsonix.Schema.XSD.Calendar.SINGLE_MONTH_PATTERN + ")" + "-" + "(" + Jsonix.Schema.XSD.Calendar.DAY_PATTERN + ")" + "(" + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + ")?";
+Jsonix.Schema.XSD.Calendar.DATE_PART_PATTERN = "(" + Jsonix.Schema.XSD.Calendar.YEAR_PATTERN + ")" + "-" + "(" + Jsonix.Schema.XSD.Calendar.MONTH_PATTERN + ")" + "-" + "(" + Jsonix.Schema.XSD.Calendar.DAY_PATTERN + ")";
+Jsonix.Schema.XSD.Calendar.TIME_PART_PATTERN = "([0-1][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\\.([0-9]+))?";
+Jsonix.Schema.XSD.Calendar.TIME_PATTERN = Jsonix.Schema.XSD.Calendar.TIME_PART_PATTERN + '(' + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + ')?';
+Jsonix.Schema.XSD.Calendar.DATE_PATTERN = Jsonix.Schema.XSD.Calendar.DATE_PART_PATTERN + '(' + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + ')?';
+Jsonix.Schema.XSD.Calendar.DATETIME_PATTERN = Jsonix.Schema.XSD.Calendar.DATE_PART_PATTERN + 'T' + Jsonix.Schema.XSD.Calendar.TIME_PART_PATTERN + '(' + Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN + ')?';
+Jsonix.Schema.XSD.Calendar.INSTANCE = new Jsonix.Schema.XSD.Calendar();
+Jsonix.Schema.XSD.Calendar.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Calendar.INSTANCE);
+Jsonix.Schema.XSD.Duration = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
+	name : 'Duration',
+	typeName : Jsonix.Schema.XSD.qname('duration'),
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isObject(value) && (
+				(Jsonix.Util.Type.exists(value.sign) ? (value.sign === -1 || value.sign === 1) : true)
+				(Jsonix.Util.NumberUtils.isInteger(value.years) && value.years >=0) ||
+				(Jsonix.Util.NumberUtils.isInteger(value.months) && value.months >=0) ||
+				(Jsonix.Util.NumberUtils.isInteger(value.days) && value.days >= 0) ||
+				(Jsonix.Util.NumberUtils.isInteger(value.hours) && value.hours >= 0) ||
+				(Jsonix.Util.NumberUtils.isInteger(value.minutes) && value.minutes >= 0) ||
+				(Jsonix.Util.Type.isNumber(value.seconds) && value.seconds >= 0) );
+	},
+	validate : function(value) {
+		Jsonix.Util.Ensure.ensureObject(value);
+		if (Jsonix.Util.Type.exists(value.sign)) {
+			if (!(value.sign === 1 || value.sign === -1)) {
+				throw new Error("Sign of the duration [" + value.sign + "] must be either [1] or [-1].");
+			}
+		}
+		var empty = true;
+		var ifExistsEnsureUnsignedInteger = function(v, message) {
+			if (Jsonix.Util.Type.exists(v)) {
+				if (!(Jsonix.Util.NumberUtils.isInteger(v) && v >= 0)) {
+					throw new Error(message.replace("{0}", v));
+				} else {
+					return true;
+				}
+			} else {
+				return false;
+			}
+		};
+		var ifExistsEnsureUnsignedNumber = function(v, message) {
+			if (Jsonix.Util.Type.exists(v)) {
+				if (!(Jsonix.Util.Type.isNumber(v) && v >= 0)) {
+					throw new Error(message.replace("{0}", v));
+				} else {
+					return true;
+				}
+			} else {
+				return false;
+			}
+		};
+		empty = empty && !ifExistsEnsureUnsignedInteger(value.years, "Number of years [{0}] must be an unsigned integer.");
+		empty = empty && !ifExistsEnsureUnsignedInteger(value.months, "Number of months [{0}] must be an unsigned integer.");
+		empty = empty && !ifExistsEnsureUnsignedInteger(value.days, "Number of days [{0}] must be an unsigned integer.");
+		empty = empty && !ifExistsEnsureUnsignedInteger(value.hours, "Number of hours [{0}] must be an unsigned integer.");
+		empty = empty && !ifExistsEnsureUnsignedInteger(value.minutes, "Number of minutes [{0}] must be an unsigned integer.");
+		empty = empty && !ifExistsEnsureUnsignedNumber(value.seconds, "Number of seconds [{0}] must be an unsigned number.");
+		if (empty) {
+			throw new Error("At least one of the components (years, months, days, hours, minutes, seconds) must be set.");
+		}
+	},
+	print : function(value, context, output, scope) {
+		this.validate(value);
+		var result = '';
+		if (value.sign === -1)
+		{
+			result += '-';
+		}
+		result += 'P';
+		if (Jsonix.Util.Type.exists(value.years)) {
+			result += (value.years + 'Y');
+		}
+		if (Jsonix.Util.Type.exists(value.months)) {
+			result += (value.months + 'M');
+		}
+		if (Jsonix.Util.Type.exists(value.days)) {
+			result += (value.days + 'D');
+		}
+		if (Jsonix.Util.Type.exists(value.hours) || Jsonix.Util.Type.exists(value.minutes) || Jsonix.Util.Type.exists(value.seconds))
+		{
+			result += 'T';
+			if (Jsonix.Util.Type.exists(value.hours)) {
+				result += (value.hours + 'H');
+			}
+			if (Jsonix.Util.Type.exists(value.minutes)) {
+				result += (value.minutes + 'M');
+			}
+			if (Jsonix.Util.Type.exists(value.seconds)) {
+				result += (value.seconds + 'S');
+			}
+		}
+		return result;
+	},
+	parse : function(value, context, input, scope) {
+		var durationExpression = new RegExp("^" + Jsonix.Schema.XSD.Duration.PATTERN + "$");
+		var results = value.match(durationExpression);
+		if (results !== null) {
+			var empty = true;
+			var duration = {};
+			if (results[1]) { duration.sign = -1; }
+			if (results[3]) { duration.years = parseInt(results[3], 10); empty = false; }
+			if (results[5]) { duration.months = parseInt(results[5], 10); empty = false; }
+			if (results[7]) { duration.days = parseInt(results[7], 10); empty = false; }
+			if (results[10]) { duration.hours = parseInt(results[10], 10); empty = false; }
+			if (results[12]) { duration.minutes = parseInt(results[12], 10); empty = false; }
+			if (results[14]) { duration.seconds = Number(results[14]); empty = false; }
+			return duration;
+		} else {
+			throw new Error('Value [' + value + '] does not match the duration pattern.');
+		}
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.Duration'
+});
+Jsonix.Schema.XSD.Duration.PATTERN = '(-)?P(([0-9]+)Y)?(([0-9]+)M)?(([0-9]+)D)?(T(([0-9]+)H)?(([0-9]+)M)?(([0-9]+(\\.[0-9]+)?)S)?)?';
+Jsonix.Schema.XSD.Duration.INSTANCE = new Jsonix.Schema.XSD.Duration();
+Jsonix.Schema.XSD.Duration.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Duration.INSTANCE);
+Jsonix.Schema.XSD.DateTime = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'DateTime',
+	typeName : Jsonix.Schema.XSD.qname('dateTime'),
+	parse : function(value, context, input, scope) {
+		return this.parseDateTime(value);
+	},
+	print : function(value, context, output, scope) {
+		return this.printDateTime(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.DateTime'
+});
+Jsonix.Schema.XSD.DateTime.INSTANCE = new Jsonix.Schema.XSD.DateTime();
+Jsonix.Schema.XSD.DateTime.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.DateTime.INSTANCE);
+
+Jsonix.Schema.XSD.DateTimeAsDate = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'DateTimeAsDate',
+	typeName : Jsonix.Schema.XSD.qname('dateTime'),
+	parse : function(value, context, input, scope) {
+		var calendar = this.parseDateTime(value);
+		var date = new Date();
+		date.setFullYear(calendar.year);
+		date.setMonth(calendar.month - 1);
+		date.setDate(calendar.day);
+		date.setHours(calendar.hour);
+		date.setMinutes(calendar.minute);
+		date.setSeconds(calendar.second);
+		if (Jsonix.Util.Type.isNumber(calendar.fractionalSecond)) {
+			date.setMilliseconds(Math.floor(1000 * calendar.fractionalSecond));
+		}
+		var timezone;
+		var unknownTimezone;
+		var localTimezone = - date.getTimezoneOffset();
+		if (Jsonix.Util.NumberUtils.isInteger(calendar.timezone))
+		{
+			timezone = calendar.timezone;
+			unknownTimezone = false;
+		}
+		else
+		{
+			// Unknown timezone
+			timezone = localTimezone;
+			unknownTimezone = true;
+		}
+		//
+		var result = new Date(date.getTime() + (60000 * (- timezone + localTimezone)));
+		if (unknownTimezone)
+		{
+			// null denotes "unknown timezone"
+			result.originalTimezone = null;
+		}
+		else
+		{
+			result.originalTimezone = calendar.timezone;
+		}
+		return result;
+	},
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureDate(value);
+		var timezone;
+		var localTimezone = - value.getTimezoneOffset();
+		var correctedValue;
+		// If original time zone was unknown, print the given value without
+		// the timezone
+		if (value.originalTimezone === null)
+		{
+			return this.printDateTime(new Jsonix.XML.Calendar({
+				year : value.getFullYear(),
+				month : value.getMonth() + 1,
+				day : value.getDate(),
+				hour : value.getHours(),
+				minute : value.getMinutes(),
+				second : value.getSeconds(),
+				fractionalSecond : (value.getMilliseconds() / 1000)
+			}));
+		}
+		else
+		{
+			// If original timezone was known, correct and print the value with the timezone
+			if (Jsonix.Util.NumberUtils.isInteger(value.originalTimezone))
+			{
+				timezone = value.originalTimezone;
+				correctedValue = new Date(value.getTime() - (60000 * ( - timezone + localTimezone)));
+			}
+			// If original timezone was not specified, do not correct and use the local time zone
+			else
+			{
+				timezone = localTimezone;
+				correctedValue = value;
+			}
+			var x = this.printDateTime(new Jsonix.XML.Calendar({
+				year : correctedValue.getFullYear(),
+				month : correctedValue.getMonth() + 1,
+				day : correctedValue.getDate(),
+				hour : correctedValue.getHours(),
+				minute : correctedValue.getMinutes(),
+				second : correctedValue.getSeconds(),
+				fractionalSecond : (correctedValue.getMilliseconds() / 1000),
+				timezone: timezone
+			}));
+			return x;
+		}
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isDate(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.DateTimeAsDate'
+});
+Jsonix.Schema.XSD.DateTimeAsDate.INSTANCE = new Jsonix.Schema.XSD.DateTimeAsDate();
+Jsonix.Schema.XSD.DateTimeAsDate.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.DateTimeAsDate.INSTANCE);
+
+Jsonix.Schema.XSD.Time = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'Time',
+	typeName : Jsonix.Schema.XSD.qname('time'),
+	parse : function(value, context, input, scope) {
+		return this.parseTime(value);
+	},
+	print : function(value, context, output, scope) {
+		return this.printTime(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.Time'
+});
+Jsonix.Schema.XSD.Time.INSTANCE = new Jsonix.Schema.XSD.Time();
+Jsonix.Schema.XSD.Time.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Time.INSTANCE);
+Jsonix.Schema.XSD.TimeAsDate = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'TimeAsDate',
+	typeName : Jsonix.Schema.XSD.qname('time'),
+	parse : function(value, context, input, scope) {
+		var calendar = this.parseTime(value);
+		var date = new Date();
+		date.setFullYear(1970);
+		date.setMonth(0);
+		date.setDate(1);
+		date.setHours(calendar.hour);
+		date.setMinutes(calendar.minute);
+		date.setSeconds(calendar.second);
+		if (Jsonix.Util.Type.isNumber(calendar.fractionalSecond)) {
+			date.setMilliseconds(Math.floor(1000 * calendar.fractionalSecond));
+		}
+		var timezone;
+		var unknownTimezone;
+		var localTimezone = - date.getTimezoneOffset();
+		if (Jsonix.Util.NumberUtils.isInteger(calendar.timezone))
+		{
+			timezone = calendar.timezone;
+			unknownTimezone = false;
+		}
+		else
+		{
+			// Unknown timezone
+			timezone = localTimezone;
+			unknownTimezone = true;
+		}
+		//
+		var result = new Date(date.getTime() + (60000 * ( - timezone + localTimezone)));
+		if (unknownTimezone)
+		{
+			// null denotes "unknown timezone"
+			result.originalTimezone = null;
+		}
+		else
+		{
+			result.originalTimezone = timezone;
+		}
+		return result;
+	},
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureDate(value);
+		var time = value.getTime();
+		if (time <= -86400000 && time >= 86400000) {
+			throw new Error('Invalid time [' + value + '].');
+		}
+		// Original timezone was unknown, just use current time, no timezone
+		if (value.originalTimezone === null)
+		{
+			return this.printTime(new Jsonix.XML.Calendar({
+				hour : value.getHours(),
+				minute : value.getMinutes(),
+				second : value.getSeconds(),
+				fractionalSecond : (value.getMilliseconds() / 1000)
+			}));
+		}
+		else
+		{
+			var correctedValue;
+			var timezone;
+			var localTimezone = - value.getTimezoneOffset();
+			if (Jsonix.Util.NumberUtils.isInteger(value.originalTimezone))
+			{
+				timezone = value.originalTimezone;
+				correctedValue = new Date(value.getTime() - (60000 * ( - timezone + localTimezone)));
+			}
+			else
+			{
+				timezone = localTimezone;
+				correctedValue = value;
+			}
+			var correctedTime = correctedValue.getTime();
+			if (correctedTime >= (- localTimezone * 60000)) {
+				return this.printTime(new Jsonix.XML.Calendar({
+					hour : correctedValue.getHours(),
+					minute : correctedValue.getMinutes(),
+					second : correctedValue.getSeconds(),
+					fractionalSecond : (correctedValue.getMilliseconds() / 1000),
+					timezone: timezone
+				}));
+			} else {
+				var timezoneHours = Math.ceil(-correctedTime / 3600000);
+				
+				var correctedTimeInSeconds = correctedValue.getSeconds() +
+					correctedValue.getMinutes() * 60 +
+					correctedValue.getHours() * 3600 +
+					timezoneHours * 3600 -
+					timezone * 60;
+				
+				return this.printTime(new Jsonix.XML.Calendar({
+					hour : correctedTimeInSeconds % 86400,
+					minute : correctedTimeInSeconds % 3600,
+					second : correctedTimeInSeconds % 60,
+					fractionalSecond : (correctedValue.getMilliseconds() / 1000),
+					timezone : timezoneHours * 60
+				}));
+			}
+		}
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isDate(value) && value.getTime() > -86400000 && value.getTime() < 86400000;
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.TimeAsDate'
+});
+Jsonix.Schema.XSD.TimeAsDate.INSTANCE = new Jsonix.Schema.XSD.TimeAsDate();
+Jsonix.Schema.XSD.TimeAsDate.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.TimeAsDate.INSTANCE);
+Jsonix.Schema.XSD.Date = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'Date',
+	typeName : Jsonix.Schema.XSD.qname('date'),
+	parse : function(value, context, input, scope) {
+		return this.parseDate(value);
+	},
+	print : function(value, context, output, scope) {
+		return this.printDate(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.Date'
+});
+Jsonix.Schema.XSD.Date.INSTANCE = new Jsonix.Schema.XSD.Date();
+Jsonix.Schema.XSD.Date.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Date.INSTANCE);
+Jsonix.Schema.XSD.DateAsDate = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'DateAsDate',
+	typeName : Jsonix.Schema.XSD.qname('date'),
+	parse : function(value, context, input, scope) {
+		var calendar = this.parseDate(value);
+		var date = new Date();
+		date.setFullYear(calendar.year);
+		date.setMonth(calendar.month - 1);
+		date.setDate(calendar.day);
+		date.setHours(0);
+		date.setMinutes(0);
+		date.setSeconds(0);
+		date.setMilliseconds(0);
+		if (Jsonix.Util.Type.isNumber(calendar.fractionalSecond)) {
+			date.setMilliseconds(Math.floor(1000 * calendar.fractionalSecond));
+		}
+		var timezone;
+		var unknownTimezone;
+		var localTimezone = - date.getTimezoneOffset();
+		if (Jsonix.Util.NumberUtils.isInteger(calendar.timezone))
+		{
+			timezone = calendar.timezone;
+			unknownTimezone = false;
+		}
+		else
+		{
+			// Unknown timezone
+			timezone = localTimezone;
+			unknownTimezone = true;
+		}
+		//
+		var result = new Date(date.getTime() + (60000 * ( - timezone + localTimezone)));
+		if (unknownTimezone)
+		{
+			// null denotes "unknown timezone"
+			result.originalTimezone = null;
+		}
+		else
+		{
+			result.originalTimezone = timezone;
+		}
+		return result;
+	},
+	print : function(value, context, output, scope) {
+		Jsonix.Util.Ensure.ensureDate(value);
+		var localDate = new Date(value.getTime());
+		localDate.setHours(0);
+		localDate.setMinutes(0);
+		localDate.setSeconds(0);
+		localDate.setMilliseconds(0);
+		
+		// Original timezone is unknown
+		if (value.originalTimezone === null)
+		{
+			return this.printDate(new Jsonix.XML.Calendar({
+				year : value.getFullYear(),
+				month : value.getMonth() + 1,
+				day : value.getDate()
+			}));
+		}
+		else
+		{
+			// If original timezone was known, correct and print the value with the timezone
+			if (Jsonix.Util.NumberUtils.isInteger(value.originalTimezone))
+			{
+				var correctedValue = new Date(value.getTime() - (60000 * (- value.originalTimezone - value.getTimezoneOffset())));
+				return this.printDate(new Jsonix.XML.Calendar({
+					year : correctedValue.getFullYear(),
+					month : correctedValue.getMonth() + 1,
+					day : correctedValue.getDate(),
+					timezone : value.originalTimezone
+				}));
+			}
+			// If original timezone was not specified, do not correct and use the local time zone
+			else
+			{
+				// We assume that the difference between the date value and local midnight
+				// should be interpreted as a timezone offset.
+				// In case there's no difference, we assume default/unknown timezone
+				var localTimezone = - value.getTime() + localDate.getTime();
+				if (localTimezone === 0) {
+					return this.printDate(new Jsonix.XML.Calendar({
+						year : value.getFullYear(),
+						month : value.getMonth() + 1,
+						day : value.getDate()
+					}));
+				} else {
+					var timezone = localTimezone - (60000 * value.getTimezoneOffset());
+					if (timezone >= -43200000) {
+						return this.printDate(new Jsonix.XML.Calendar({
+							year : value.getFullYear(),
+							month : value.getMonth() + 1,
+							day : value.getDate(),
+							timezone : Math.floor(timezone / 60000)
+						}));
+					} else {
+						var nextDay = new Date(value.getTime() + 86400000);
+						return this.printDate(new Jsonix.XML.Calendar({
+							year : nextDay.getFullYear(),
+							month : nextDay.getMonth() + 1,
+							day : nextDay.getDate(),
+							timezone : (Math.floor(timezone / 60000) + 1440)
+						}));
+					}
+				}
+			}
+		}
+	},
+	isInstance : function(value, context, scope) {
+		return Jsonix.Util.Type.isDate(value);
+	},
+	CLASS_NAME : 'Jsonix.Schema.XSD.DateAsDate'
+});
+Jsonix.Schema.XSD.DateAsDate.INSTANCE = new Jsonix.Schema.XSD.DateAsDate();
+Jsonix.Schema.XSD.DateAsDate.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.DateAsDate.INSTANCE);
+Jsonix.Schema.XSD.GYearMonth = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'GYearMonth',
+	typeName : Jsonix.Schema.XSD.qname('gYearMonth'),
+	CLASS_NAME : 'Jsonix.Schema.XSD.GYearMonth',
+
+	parse : function(value, context, input, scope) {
+		return this.parseGYearMonth(value, context, input, scope);
+	},
+
+	print : function(value, context, output, scope) {
+		return this.printGYearMonth(value, context, output, scope);
+	}
+
+});
+Jsonix.Schema.XSD.GYearMonth.INSTANCE = new Jsonix.Schema.XSD.GYearMonth();
+Jsonix.Schema.XSD.GYearMonth.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GYearMonth.INSTANCE);
+Jsonix.Schema.XSD.GYear = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'GYear',
+	typeName : Jsonix.Schema.XSD.qname('gYear'),
+	CLASS_NAME : 'Jsonix.Schema.XSD.GYear',
+
+	parse : function(value, context, input, scope) {
+		return this.parseGYear(value, context, input, scope);
+	},
+
+	print : function(value, context, output, scope) {
+		return this.printGYear(value, context, output, scope);
+	}
+});
+Jsonix.Schema.XSD.GYear.INSTANCE = new Jsonix.Schema.XSD.GYear();
+Jsonix.Schema.XSD.GYear.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GYear.INSTANCE);
+Jsonix.Schema.XSD.GMonthDay = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'GMonthDay',
+	typeName : Jsonix.Schema.XSD.qname('gMonthDay'),
+	CLASS_NAME : 'Jsonix.Schema.XSD.GMonthDay',
+
+	parse : function(value, context, input, scope) {
+		return this.parseGMonthDay(value, context, input, scope);
+	},
+
+	print : function(value, context, output, scope) {
+		return this.printGMonthDay(value, context, output, scope);
+	}
+});
+Jsonix.Schema.XSD.GMonthDay.INSTANCE = new Jsonix.Schema.XSD.GMonthDay();
+Jsonix.Schema.XSD.GMonthDay.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GMonthDay.INSTANCE);
+Jsonix.Schema.XSD.GDay = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'GDay',
+	typeName : Jsonix.Schema.XSD.qname('gDay'),
+	CLASS_NAME : 'Jsonix.Schema.XSD.GDay',
+
+	parse : function(value, context, input, scope) {
+		return this.parseGDay(value, context, input, scope);
+	},
+
+	print : function(value, context, output, scope) {
+		return this.printGDay(value, context, output, scope);
+	}
+
+});
+Jsonix.Schema.XSD.GDay.INSTANCE = new Jsonix.Schema.XSD.GDay();
+Jsonix.Schema.XSD.GDay.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GDay.INSTANCE);
+Jsonix.Schema.XSD.GMonth = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
+	name : 'GMonth',
+	typeName : Jsonix.Schema.XSD.qname('gMonth'),
+	CLASS_NAME : 'Jsonix.Schema.XSD.GMonth',
+	parse : function(value, context, input, scope) {
+		return this.parseGMonth(value, context, input, scope);
+	},
+	print : function(value, context, output, scope) {
+		return this.printGMonth(value, context, output, scope);
+	}
+});
+Jsonix.Schema.XSD.GMonth.INSTANCE = new Jsonix.Schema.XSD.GMonth();
+Jsonix.Schema.XSD.GMonth.INSTANCE.LIST = new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GMonth.INSTANCE);
+Jsonix.Schema.XSD.ID = Jsonix.Class(Jsonix.Schema.XSD.String, {
+	name : 'ID',
+	typeName : Jsonix.Schema.XSD.qname('ID'),
+	CLASS_NAME : 'Jsonix.Schema.XSD.ID'
+});
+Jsonix.Schema.XSD.ID.INSTANCE = new Jsonix.Schema.XSD.ID();
+Jsonix.Schema.XSD.ID.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.ID.INSTANCE);
+Jsonix.Schema.XSD.IDREF = Jsonix.Class(Jsonix.Schema.XSD.String, {
+	name : 'IDREF',
+	typeName : Jsonix.Schema.XSD.qname('IDREF'),
+	CLASS_NAME : 'Jsonix.Schema.XSD.IDREF'
+});
+Jsonix.Schema.XSD.IDREF.INSTANCE = new Jsonix.Schema.XSD.IDREF();
+Jsonix.Schema.XSD.IDREF.INSTANCE.LIST = new Jsonix.Schema.XSD.List(
+		Jsonix.Schema.XSD.IDREF.INSTANCE);
+Jsonix.Schema.XSD.IDREFS = Jsonix.Class(Jsonix.Schema.XSD.List, {
+	name : 'IDREFS',
+	initialize : function() {
+		Jsonix.Schema.XSD.List.prototype.initialize.apply(this, [ Jsonix.Schema.XSD.IDREF.INSTANCE, Jsonix.Schema.XSD.qname('IDREFS'), ' ' ]);
+	},
+	// TODO Constraints
+	CLASS_NAME : 'Jsonix.Schema.XSD.IDREFS'
+});
+Jsonix.Schema.XSD.IDREFS.INSTANCE = new Jsonix.Schema.XSD.IDREFS();
+Jsonix.Schema.XSI = {};
+Jsonix.Schema.XSI.NAMESPACE_URI = 'http://www.w3.org/2001/XMLSchema-instance';
+Jsonix.Schema.XSI.PREFIX = 'xsi';
+Jsonix.Schema.XSI.TYPE = 'type';
+Jsonix.Schema.XSI.NIL = 'nil';
+Jsonix.Schema.XSI.qname = function(localPart) {
+	Jsonix.Util.Ensure.ensureString(localPart);
+	return new Jsonix.XML.QName(Jsonix.Schema.XSI.NAMESPACE_URI, localPart,
+			Jsonix.Schema.XSI.PREFIX);
+};
+Jsonix.Schema.XSI.TYPE_QNAME = Jsonix.Schema.XSI.qname(Jsonix.Schema.XSI.TYPE);
+
+Jsonix.Context = Jsonix
+		.Class(Jsonix.Mapping.Styled, {
+			modules : [],
+			typeInfos : null,
+			typeNameKeyToTypeInfo : null,
+			elementInfos : null,
+			options : null,
+			substitutionMembersMap : null,
+			scopedElementInfosMap : null,
+			supportXsiType : true,
+			initialize : function(mappings, options) {
+				Jsonix.Mapping.Styled.prototype.initialize.apply(this, [options]);
+				this.modules = [];
+				this.elementInfos = [];
+				this.typeInfos = {};
+				this.typeNameKeyToTypeInfo = {};
+				this.registerBuiltinTypeInfos();
+				this.namespacePrefixes = {};
+				this.prefixNamespaces = {};
+				this.substitutionMembersMap = {};
+				this.scopedElementInfosMap = {};
+
+				// Initialize options
+				if (Jsonix.Util.Type.exists(options)) {
+					Jsonix.Util.Ensure.ensureObject(options);
+					if (Jsonix.Util.Type
+							.isObject(options.namespacePrefixes)) {
+						this.namespacePrefixes =
+							Jsonix.Util.Type.cloneObject(options.namespacePrefixes, {});
+					}
+					if (Jsonix.Util.Type
+							.isBoolean(options.supportXsiType)) {
+						this.supportXsiType = options.supportXsiType;
+					}
+				}
+
+				// Initialize prefix/namespace mapping
+				for (var ns in this.namespacePrefixes)
+				{
+					if (this.namespacePrefixes.hasOwnProperty(ns))
+					{
+						p = this.namespacePrefixes[ns];
+						this.prefixNamespaces[p] = ns;
+					}
+				}
+				// Initialize modules
+				if (Jsonix.Util.Type.exists(mappings)) {
+					Jsonix.Util.Ensure.ensureArray(mappings);
+					// Initialize modules
+					var index, mapping, module;
+					for (index = 0; index < mappings.length; index++) {
+						mapping = mappings[index];
+						module = this.createModule(mapping);
+						this.modules[index] = module;
+					}
+				}
+				this.processModules();
+			},
+			createModule : function(mapping) {
+				var module;
+				if (mapping instanceof this.mappingStyle.module) {
+					module = mapping;
+				} else {
+					mapping = Jsonix.Util.Type.cloneObject(mapping);
+					module = new this.mappingStyle.module(mapping,
+					{
+						mappingStyle : this.mappingStyle
+					});
+				}
+				return module;
+			},
+			registerBuiltinTypeInfos : function() {
+				for ( var index = 0; index < this.builtinTypeInfos.length; index++) {
+					this.registerTypeInfo(this.builtinTypeInfos[index]);
+				}
+			},
+			processModules : function() {
+				var index, module;
+				for (index = 0; index < this.modules.length; index++) {
+					module = this.modules[index];
+					module.registerTypeInfos(this);
+				}
+				for (index = 0; index < this.modules.length; index++) {
+					module = this.modules[index];
+					module.registerElementInfos(this);
+				}
+				for (index = 0; index < this.modules.length; index++) {
+					module = this.modules[index];
+					module.buildTypeInfos(this);
+				}
+				for (index = 0; index < this.modules.length; index++) {
+					module = this.modules[index];
+					module.buildElementInfos(this);
+				}
+			},
+			registerTypeInfo : function(typeInfo) {
+				Jsonix.Util.Ensure.ensureObject(typeInfo);
+				var n = typeInfo.name||typeInfo.n||null;
+				Jsonix.Util.Ensure.ensureString(n);
+				this.typeInfos[n] = typeInfo;
+				if (typeInfo.typeName && typeInfo.typeName.key)
+				{
+					this.typeNameKeyToTypeInfo[typeInfo.typeName.key] = typeInfo;
+				}
+			},
+			resolveTypeInfo : function(mapping, module) {
+				if (!Jsonix.Util.Type.exists(mapping)) {
+					return null;
+				} else if (mapping instanceof Jsonix.Model.TypeInfo) {
+					return mapping;
+				} else if (Jsonix.Util.Type.isString(mapping)) {
+					var typeInfoName;
+					// If mapping starts with '.' consider it to be a local type name in this module
+					if (mapping.length > 0 && mapping.charAt(0) === '.')
+					{
+						var n = module.name || module.n || undefined;
+						Jsonix.Util.Ensure.ensureObject(module, 'Type info mapping can only be resolved if module is provided.');
+						Jsonix.Util.Ensure.ensureString(n, 'Type info mapping can only be resolved if module name is provided.');
+						typeInfoName = n + mapping;
+					}
+					else
+					{
+						typeInfoName = mapping;
+					}
+					if (!this.typeInfos[typeInfoName]) {
+						throw new Error('Type info [' + typeInfoName + '] is not known in this context.');
+					} else {
+						return this.typeInfos[typeInfoName];
+					}
+				} else {
+					Jsonix.Util.Ensure.ensureObject(module, 'Type info mapping can only be resolved if module is provided.');
+					var typeInfo = module.createTypeInfo(mapping);
+					typeInfo.build(this, module);
+					return typeInfo;
+				}
+			},
+			registerElementInfo : function(elementInfo, module) {
+				Jsonix.Util.Ensure.ensureObject(elementInfo);
+				this.elementInfos.push(elementInfo);
+
+				if (Jsonix.Util.Type.exists(elementInfo.substitutionHead)) {
+					var substitutionHead = elementInfo.substitutionHead;
+					var substitutionHeadKey = substitutionHead.key;
+					var substitutionMembers = this.substitutionMembersMap[substitutionHeadKey];
+
+					if (!Jsonix.Util.Type.isArray(substitutionMembers)) {
+						substitutionMembers = [];
+						this.substitutionMembersMap[substitutionHeadKey] = substitutionMembers;
+					}
+					substitutionMembers.push(elementInfo);
+				}
+
+				var scopeKey;
+				if (Jsonix.Util.Type.exists(elementInfo.scope)) {
+					scopeKey = this.resolveTypeInfo(elementInfo.scope, module).name;
+				} else {
+					scopeKey = '##global';
+				}
+
+				var scopedElementInfos = this.scopedElementInfosMap[scopeKey];
+
+				if (!Jsonix.Util.Type.isObject(scopedElementInfos)) {
+					scopedElementInfos = {};
+					this.scopedElementInfosMap[scopeKey] = scopedElementInfos;
+				}
+				scopedElementInfos[elementInfo.elementName.key] = elementInfo;
+
+			},
+			getTypeInfoByValue : function(value)
+			{
+				if (!Jsonix.Util.Type.exists(value))
+				{
+					return undefined;
+				}
+				if (Jsonix.Util.Type.isObject(value))
+				{
+					var typeName = value.TYPE_NAME;
+					if (Jsonix.Util.Type.isString(typeName))
+					{
+						var typeInfoByName = this.getTypeInfoByName(typeName);
+						if (typeInfoByName)
+						{
+							return typeInfoByName;
+						}
+					}
+				}
+				return undefined;
+			},
+			// TODO public API
+			getTypeInfoByName : function(name) {
+				return this.typeInfos[name];
+			},
+			getTypeInfoByTypeName : function(typeName) {
+				var tn = Jsonix.XML.QName.fromObjectOrString(typeName, this);
+				return this.typeNameKeyToTypeInfo[tn.key];
+			},
+			getTypeInfoByTypeNameKey : function(typeNameKey) {
+				return this.typeNameKeyToTypeInfo[typeNameKey];
+			},
+			getElementInfo : function(name, scope) {
+				if (Jsonix.Util.Type.exists(scope)) {
+					var scopeKey = scope.name;
+					var scopedElementInfos = this.scopedElementInfosMap[scopeKey];
+					if (Jsonix.Util.Type.exists(scopedElementInfos)) {
+						var scopedElementInfo = scopedElementInfos[name.key];
+						if (Jsonix.Util.Type.exists(scopedElementInfo)) {
+							return scopedElementInfo;
+						}
+					}
+				}
+
+				var globalScopeKey = '##global';
+				var globalScopedElementInfos = this.scopedElementInfosMap[globalScopeKey];
+				if (Jsonix.Util.Type.exists(globalScopedElementInfos)) {
+					var globalScopedElementInfo = globalScopedElementInfos[name.key];
+					if (Jsonix.Util.Type.exists(globalScopedElementInfo)) {
+						return globalScopedElementInfo;
+					}
+				}
+				return null;
+				//
+				// throw new Error("Element [" + name.key
+				// + "] could not be found in the given context.");
+			},
+			getSubstitutionMembers : function(name) {
+				return this.substitutionMembersMap[Jsonix.XML.QName
+						.fromObject(name).key];
+			},
+			createMarshaller : function() {
+				return new this.mappingStyle.marshaller(this);
+			},
+			createUnmarshaller : function() {
+				return new this.mappingStyle.unmarshaller(this);
+			},
+			getNamespaceURI : function(prefix) {
+				Jsonix.Util.Ensure.ensureString(prefix);
+				return this.prefixNamespaces[prefix];
+			},
+			getPrefix : function(namespaceURI, defaultPrefix) {
+				Jsonix.Util.Ensure.ensureString(namespaceURI);
+				var prefix = this.namespacePrefixes[namespaceURI];
+				if (Jsonix.Util.Type.isString(prefix))
+				{
+					return prefix;
+				}
+				else
+				{
+					return defaultPrefix;
+				}
+			},
+			/**
+			 * Builtin type infos.
+			 */
+			builtinTypeInfos : [
+			        Jsonix.Schema.XSD.AnyType.INSTANCE,
+			        Jsonix.Schema.XSD.AnySimpleType.INSTANCE,
+					Jsonix.Schema.XSD.AnyURI.INSTANCE,
+					Jsonix.Schema.XSD.Base64Binary.INSTANCE,
+					Jsonix.Schema.XSD.Boolean.INSTANCE,
+					Jsonix.Schema.XSD.Byte.INSTANCE,
+					Jsonix.Schema.XSD.Calendar.INSTANCE,
+					Jsonix.Schema.XSD.DateAsDate.INSTANCE,
+					Jsonix.Schema.XSD.Date.INSTANCE,
+					Jsonix.Schema.XSD.DateTimeAsDate.INSTANCE,
+					Jsonix.Schema.XSD.DateTime.INSTANCE,
+					Jsonix.Schema.XSD.Decimal.INSTANCE,
+					Jsonix.Schema.XSD.Double.INSTANCE,
+					Jsonix.Schema.XSD.Duration.INSTANCE,
+					Jsonix.Schema.XSD.Float.INSTANCE,
+					Jsonix.Schema.XSD.GDay.INSTANCE,
+					Jsonix.Schema.XSD.GMonth.INSTANCE,
+					Jsonix.Schema.XSD.GMonthDay.INSTANCE,
+					Jsonix.Schema.XSD.GYear.INSTANCE,
+					Jsonix.Schema.XSD.GYearMonth.INSTANCE,
+					Jsonix.Schema.XSD.HexBinary.INSTANCE,
+					Jsonix.Schema.XSD.ID.INSTANCE,
+					Jsonix.Schema.XSD.IDREF.INSTANCE,
+					Jsonix.Schema.XSD.IDREFS.INSTANCE,
+					Jsonix.Schema.XSD.Int.INSTANCE,
+					Jsonix.Schema.XSD.Integer.INSTANCE,
+					Jsonix.Schema.XSD.Language.INSTANCE,
+					Jsonix.Schema.XSD.Long.INSTANCE,
+					Jsonix.Schema.XSD.Name.INSTANCE,
+					Jsonix.Schema.XSD.NCName.INSTANCE,
+					Jsonix.Schema.XSD.NegativeInteger.INSTANCE,
+					Jsonix.Schema.XSD.NMToken.INSTANCE,
+					Jsonix.Schema.XSD.NMTokens.INSTANCE,
+					Jsonix.Schema.XSD.NonNegativeInteger.INSTANCE,
+					Jsonix.Schema.XSD.NonPositiveInteger.INSTANCE,
+					Jsonix.Schema.XSD.NormalizedString.INSTANCE,
+					Jsonix.Schema.XSD.Number.INSTANCE,
+					Jsonix.Schema.XSD.PositiveInteger.INSTANCE,
+					Jsonix.Schema.XSD.QName.INSTANCE,
+					Jsonix.Schema.XSD.Short.INSTANCE,
+					Jsonix.Schema.XSD.String.INSTANCE,
+					Jsonix.Schema.XSD.Strings.INSTANCE,
+					Jsonix.Schema.XSD.TimeAsDate.INSTANCE,
+					Jsonix.Schema.XSD.Time.INSTANCE,
+					Jsonix.Schema.XSD.Token.INSTANCE,
+					Jsonix.Schema.XSD.UnsignedByte.INSTANCE,
+					Jsonix.Schema.XSD.UnsignedInt.INSTANCE,
+					Jsonix.Schema.XSD.UnsignedLong.INSTANCE,
+					Jsonix.Schema.XSD.UnsignedShort.INSTANCE ],
+			CLASS_NAME : 'Jsonix.Context'
+		});
+
+	// Complete Jsonix script is included above
+	return { Jsonix: Jsonix };
+};
+
+// If the require function exists ...
+if (typeof require === 'function') {
+	// ... but the define function does not exists
+	if (typeof define !== 'function') {
+		// Load the define function via amdefine
+		var define = require('amdefine')(module);
+		// If we're not in browser
+		if (typeof window === 'undefined')
+		{
+			// Require xmldom, xmlhttprequest and fs
+			define(["xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
+		}
+		else
+		{
+			// We're probably in browser, maybe browserify
+			// Do not require xmldom, xmlhttprequest as they'r provided by the browser
+			// Do not require fs since file system is not available anyway
+			define([], _jsonix_factory);
+		}
+	}
+	else {
+		// Otherwise assume we're in the browser/RequireJS environment
+		// Load the module without xmldom and xmlhttprequests dependencies
+		define([], _jsonix_factory);
+	}
+}
+// If the require function does not exists, we're not in Node.js and therefore in browser environment
+else
+{
+	// Just call the factory and set Jsonix as global.
+	var Jsonix = _jsonix_factory().Jsonix;
+}

--- a/web-ui/src/main/resources/catalog/lib/jsonix/jsonix/Jsonix-min.js
+++ b/web-ui/src/main/resources/catalog/lib/jsonix/jsonix/Jsonix-min.js
@@ -3,12 +3,12 @@ var _jsonix_factory = function(_jsonix_xmldom, _jsonix_xmlhttprequest, _jsonix_f
 	// Complete Jsonix script is included below 
 var Jsonix={singleFile:true};
 Jsonix.Util={};
-Jsonix.Util.extend=function(g,h){g=g||{};
-if(h){for(var i in h){var j=h[i];
-if(j!==undefined){g[i]=j
-}}var f=typeof window!=="undefined"&&window!==null&&typeof window.Event=="function"&&h instanceof window.Event;
-if(!f&&h.hasOwnProperty&&h.hasOwnProperty("toString")){g.toString=h.toString
-}}return g
+Jsonix.Util.extend=function(f,g){f=f||{};
+if(g){for(var h in g){var e=g[h];
+if(e!==undefined){f[h]=e
+}}sourceIsEvt=typeof window!=="undefined"&&window!==null&&typeof window.Event==="function"&&g instanceof window.Event;
+if(!sourceIsEvt&&g.hasOwnProperty&&g.hasOwnProperty("toString")){f.toString=g.toString
+}}return f
 };
 Jsonix.Class=function(){var n=function(){this.initialize.apply(this,arguments)
 };
@@ -30,7 +30,10 @@ if(i===undefined){delete o.prototype.initialize
 return n
 };
 Jsonix.XML={XMLNS_NS:"http://www.w3.org/2000/xmlns/",XMLNS_P:"xmlns"};
-Jsonix.DOM={createDocument:function(){if(typeof _jsonix_xmldom!=="undefined"){return new (_jsonix_xmldom.DOMImplementation)().createDocument()
+Jsonix.DOM={isDomImplementationAvailable:function(){if(typeof _jsonix_xmldom!=="undefined"){return true
+}else{if(typeof document!=="undefined"&&Jsonix.Util.Type.exists(document.implementation)&&Jsonix.Util.Type.isFunction(document.implementation.createDocument)){return true
+}else{return false
+}}},createDocument:function(){if(typeof _jsonix_xmldom!=="undefined"){return new (_jsonix_xmldom.DOMImplementation)().createDocument()
 }else{if(typeof document!=="undefined"&&Jsonix.Util.Type.exists(document.implementation)&&Jsonix.Util.Type.isFunction(document.implementation.createDocument)){return document.implementation.createDocument("","",null)
 }else{if(typeof ActiveXObject!=="undefined"){return new ActiveXObject("MSXML2.DOMDocument")
 }else{throw new Error("Error created the DOM document.")
@@ -104,7 +107,6 @@ window.setTimeout(function(){w.send(t)
 },0)
 }else{w.onreadystatechange=function(){r.handleTransport(w,q,x)
 };
-console.log("Sending.");
 w.send(t)
 }}return w
 },handleTransport:function(f,d,e){if(f.readyState==4){if(!f.status||(f.status>=200&&f.status<300)){d(f)
@@ -120,6 +122,7 @@ Jsonix.Request.PROXY=null;
 Jsonix.Schema={};
 Jsonix.Model={};
 Jsonix.Util.Type={exists:function(b){return(typeof b!=="undefined"&&b!==null)
+},isUndefined:function(b){return typeof b==="undefined"
 },isString:function(b){return typeof b==="string"
 },isBoolean:function(b){return typeof b==="boolean"
 },isObject:function(b){return typeof b==="object"
@@ -130,64 +133,81 @@ Jsonix.Util.Type={exists:function(b){return(typeof b!=="undefined"&&b!==null)
 },isArray:function(b){return !!(b&&b.concat&&b.unshift&&!b.callee)
 },isDate:function(b){return !!(b&&b.getTimezoneOffset&&b.setUTCFullYear)
 },isRegExp:function(b){return !!(b&&b.test&&b.exec&&(b.ignoreCase||b.ignoreCase===false))
-},isEqual:function(r,t,w){var a=Jsonix.Util.Type.isFunction(w);
-var v=function(g,i,d){var k=slice.call(arguments);
-var j=k.length<=1;
-var f=j?0:k[0];
-var h=j?k[0]:k[1];
-var l=k[2]||1;
-var m=Math.max(Math.ceil((h-f)/l),0);
-var e=0;
-var c=new Array(m);
-while(e<m){c[e++]=f;
-f+=l
-}return c
+},isNode:function(b){return(typeof Node==="object"||typeof Node==="function")?(b instanceof Node):(b&&(typeof b==="object")&&(typeof b.nodeType==="number")&&(typeof b.nodeName==="string"))
+},isEqual:function(u,w,A){var a=Jsonix.Util.Type.isFunction(A);
+var y=function(g,e,m){var i=slice.call(arguments);
+var h=i.length<=1;
+var f=h?0:i[0];
+var d=h?i[0]:i[1];
+var j=i[2]||1;
+var k=Math.max(Math.ceil((d-f)/j),0);
+var c=0;
+var l=new Array(k);
+while(c<k){l[c++]=f;
+f+=j
+}return l
 };
-var u=Object.keys||function(e){if(Jsonix.Util.Type.isArray(e)){return v(0,e.length)
+var x=Object.keys||function(e){if(Jsonix.Util.Type.isArray(e)){return y(0,e.length)
 }var c=[];
 for(var d in e){if(e.hasOwnProperty(d)){c[c.length]=d
 }}return c
 };
-if(r===t){return true
-}if(Jsonix.Util.Type.isNaN(r)&&Jsonix.Util.Type.isNaN(t)){return true
-}var y=typeof r;
-var A=typeof t;
-if(y!=A){if(a){w("Types differ ["+y+"], ["+A+"].")
+if(u===w){return true
+}if(Jsonix.Util.Type.isNaN(u)&&Jsonix.Util.Type.isNaN(w)){return true
+}var C=typeof u;
+var E=typeof w;
+if(C!=E){if(a){A("Types differ ["+C+"], ["+E+"].")
 }return false
-}if(r==t){return true
-}if((!r&&t)||(r&&!t)){if(a){w("One is falsy, the other is truthy.")
+}if(u==w){return true
+}if((!u&&w)||(u&&!w)){if(a){A("One is falsy, the other is truthy.")
 }return false
-}if(Jsonix.Util.Type.isDate(r)&&Jsonix.Util.Type.isDate(t)){return r.getTime()===t.getTime()
-}if(Jsonix.Util.Type.isNaN(r)&&Jsonix.Util.Type.isNaN(t)){return false
-}if(Jsonix.Util.Type.isRegExp(r)&&Jsonix.Util.Type.isRegExp(t)){return r.source===t.source&&r.global===t.global&&r.ignoreCase===t.ignoreCase&&r.multiline===t.multiline
-}if(y!=="object"){return false
-}if(r.length&&(r.length!==t.length)){if(a){w("Lengths differ.");
-w("A.length="+r.length);
-w("B.length="+t.length)
+}if(Jsonix.Util.Type.isDate(u)&&Jsonix.Util.Type.isDate(w)){return u.getTime()===w.getTime()
+}if(Jsonix.Util.Type.isNaN(u)&&Jsonix.Util.Type.isNaN(w)){return false
+}if(Jsonix.Util.Type.isRegExp(u)&&Jsonix.Util.Type.isRegExp(w)){return u.source===w.source&&u.global===w.global&&u.ignoreCase===w.ignoreCase&&u.multiline===w.multiline
+}if(Jsonix.Util.Type.isNode(u)&&Jsonix.Util.Type.isNode(w)){var b=Jsonix.DOM.serialize(u);
+var z=Jsonix.DOM.serialize(w);
+if(b!==z){if(a){A("Nodes differ.");
+A("A="+b);
+A("B="+z)
 }return false
-}var b=u(r);
-var s=u(t);
-if(b.length!=s.length){if(a){w("Different number of properties ["+b.length+"], ["+s.length+"].")
-}for(var z=0;
-z<b.length;
-z++){if(a){w("A ["+b[z]+"]="+r[b[z]])
-}}for(var B=0;
-B<s.length;
-B++){if(a){w("B ["+s[B]+"]="+t[s[B]])
+}else{return true
+}}if(C!=="object"){return false
+}if(Jsonix.Util.Type.isArray(u)&&(u.length!==w.length)){if(a){A("Lengths differ.");
+A("A.length="+u.length);
+A("B.length="+w.length)
+}return false
+}var s=x(u);
+var v=x(w);
+if(s.length!==v.length){if(a){A("Different number of properties ["+s.length+"], ["+v.length+"].")
+}for(var D=0;
+D<s.length;
+D++){if(a){A("A ["+s[D]+"]="+u[s[D]])
+}}for(var F=0;
+F<v.length;
+F++){if(a){A("B ["+v[F]+"]="+w[v[F]])
 }}return false
-}for(var x=0;
-x<b.length;
-x++){var q=b[x];
-if(!(q in t)||!Jsonix.Util.Type.isEqual(r[q],t[q],w)){if(a){w("One of the properties differ.");
-w("Key: ["+q+"].");
-w("Left: ["+r[q]+"].");
-w("Right: ["+t[q]+"].")
+}for(var B=0;
+B<s.length;
+B++){var t=s[B];
+if(!(t in w)||!Jsonix.Util.Type.isEqual(u[t],w[t],A)){if(a){A("One of the properties differ.");
+A("Key: ["+t+"].");
+A("Left: ["+u[t]+"].");
+A("Right: ["+w[t]+"].")
 }return false
 }}return true
 },cloneObject:function(e,f){f=f||{};
 for(var d in e){if(e.hasOwnProperty(d)){f[d]=e[d]
 }}return f
-}};
+},defaultValue:function(){var i=arguments;
+if(i.length===0){return undefined
+}else{var g=i[i.length-1];
+var f=typeof g;
+for(var j=0;
+j<i.length-1;
+j++){var h=i[j];
+if(typeof h===f){return h
+}}return g
+}}};
 Jsonix.Util.NumberUtils={isInteger:function(b){return Jsonix.Util.Type.isNumber(b)&&((b%1)===0)
 }};
 Jsonix.Util.StringUtils={trim:(!!String.prototype.trim)?function(b){Jsonix.Util.Ensure.ensureString(b);
@@ -274,26 +294,31 @@ this.prefix=m;
 this.key=(q!==""?("{"+q+"}"):"")+o;
 this.string=(q!==""?("{"+q+"}"):"")+(m!==""?(m+":"):"")+o
 },toString:function(){return this.string
+},toCanonicalString:function(c){var d=c?c.getPrefix(this.namespaceURI,this.prefix):this.prefix;
+return this.prefix+(this.prefix===""?"":":")+this.localPart
 },clone:function(){return new Jsonix.XML.QName(this.namespaceURI,this.localPart,this.prefix)
 },equals:function(b){if(!b){return false
 }else{return(this.namespaceURI==b.namespaceURI)&&(this.localPart==b.localPart)
 }},CLASS_NAME:"Jsonix.XML.QName"});
-Jsonix.XML.QName.fromString=function(k){var m=k.indexOf("{");
-var o=k.lastIndexOf("}");
+Jsonix.XML.QName.fromString=function(n,r,m){var t=n.indexOf("{");
+var l=n.lastIndexOf("}");
+var s;
+var k;
+if((t===0)&&(l>0)&&(l<n.length)){s=n.substring(1,l);
+k=n.substring(l+1)
+}else{s=null;
+k=n
+}var q=k.indexOf(":");
+var o;
 var p;
-var n;
-if((m===0)&&(o>0)&&(o<k.length)){p=k.substring(1,o);
-n=k.substring(o+1)
-}else{p="";
-n=k
-}var i=n.indexOf(":");
-var l;
-var j;
-if(i>0&&i<n.length){l=n.substring(0,i);
-j=n.substring(i+1)
-}else{l="";
-j=n
-}return new Jsonix.XML.QName(p,j,l)
+if(q>0&&q<k.length){o=k.substring(0,q);
+p=k.substring(q+1)
+}else{o="";
+p=k
+}if(s===null){if(o===""&&Jsonix.Util.Type.isString(m)){s=m
+}else{if(r){s=r.getNamespaceURI(o)
+}}}if(!Jsonix.Util.Type.isString(s)){s=m||""
+}return new Jsonix.XML.QName(s,p,o)
 };
 Jsonix.XML.QName.fromObject=function(h){Jsonix.Util.Ensure.ensureObject(h);
 if(h instanceof Jsonix.XML.QName||(Jsonix.Util.Type.isString(h.CLASS_NAME)&&h.CLASS_NAME==="Jsonix.XML.QName")){return h
@@ -303,6 +328,9 @@ var e=h.namespaceURI||h.ns||"";
 var g=h.prefix||h.p||"";
 return new Jsonix.XML.QName(e,f,g)
 };
+Jsonix.XML.QName.fromObjectOrString=function(f,d,e){if(Jsonix.Util.Type.isString(f)){return Jsonix.XML.QName.fromString(f,d,e)
+}else{return Jsonix.XML.QName.fromObject(f)
+}};
 Jsonix.XML.QName.key=function(f,e){Jsonix.Util.Ensure.ensureString(e);
 if(f){var d=e.indexOf(":");
 if(d>0&&d<e.length){localName=e.substring(d+1)
@@ -310,45 +338,83 @@ if(d>0&&d<e.length){localName=e.substring(d+1)
 }return"{"+f+"}"+localName
 }else{return e
 }};
-Jsonix.XML.Calendar=Jsonix.Class({year:NaN,month:NaN,day:NaN,hour:NaN,minute:NaN,second:NaN,fractionalSecond:NaN,timezone:NaN,initialize:function(b){Jsonix.Util.Ensure.ensureObject(b);
-if(Jsonix.Util.Type.exists(b.year)){Jsonix.Util.Ensure.ensureInteger(b.year);
-if(b.year>=-9999&&b.year<=9999){this.year=b.year
-}else{throw new Error("Invalid year ["+b.year+"].")
-}}else{this.year=NaN
-}if(Jsonix.Util.Type.exists(b.month)){Jsonix.Util.Ensure.ensureInteger(b.month);
-if(b.month>=1&&b.month<=12){this.month=b.month
-}else{throw new Error("Invalid month ["+b.month+"].")
-}}else{this.month=NaN
-}if(Jsonix.Util.Type.exists(b.day)){Jsonix.Util.Ensure.ensureInteger(b.day);
-if(b.day>=1&&b.day<=31){this.day=b.day
-}else{throw new Error("Invalid day ["+b.day+"].")
-}}else{this.day=NaN
-}if(Jsonix.Util.Type.exists(b.hour)){Jsonix.Util.Ensure.ensureInteger(b.hour);
-if(b.hour>=0&&b.hour<=23){this.hour=b.hour
-}else{throw new Error("Invalid hour ["+b.hour+"].")
-}}else{this.hour=NaN
-}if(Jsonix.Util.Type.exists(b.minute)){Jsonix.Util.Ensure.ensureInteger(b.minute);
-if(b.minute>=0&&b.minute<=59){this.minute=b.minute
-}else{throw new Error("Invalid minute ["+b.minute+"].")
-}}else{this.minute=NaN
-}if(Jsonix.Util.Type.exists(b.second)){Jsonix.Util.Ensure.ensureInteger(b.second);
-if(b.second>=0&&b.second<=59){this.second=b.second
-}else{throw new Error("Invalid second ["+b.second+"].")
-}}else{this.second=NaN
-}if(Jsonix.Util.Type.exists(b.fractionalSecond)){Jsonix.Util.Ensure.ensureNumber(b.fractionalSecond);
-if(b.fractionalSecond>=0&&b.fractionalSecond<1){this.fractionalSecond=b.fractionalSecond
-}else{throw new Error("Invalid fractional second ["+b.fractionalSecond+"].")
-}}else{this.fractionalSecond=NaN
-}if(Jsonix.Util.Type.exists(b.timezone)){if(Jsonix.Util.Type.isNaN(b.timezone)){this.timezone=NaN
-}else{Jsonix.Util.Ensure.ensureInteger(b.timezone);
-if(b.timezone>=-1440&&b.timezone<1440){this.timezone=b.timezone
-}else{throw new Error("Invalid timezone ["+b.timezone+"].")
-}}}else{this.timezone=NaN
-}},CLASS_NAME:"Jsonix.XML.Calendar"});
+Jsonix.XML.Calendar=Jsonix.Class({year:NaN,month:NaN,day:NaN,hour:NaN,minute:NaN,second:NaN,fractionalSecond:NaN,timezone:NaN,date:null,initialize:function(f){Jsonix.Util.Ensure.ensureObject(f);
+if(Jsonix.Util.Type.exists(f.year)){Jsonix.Util.Ensure.ensureInteger(f.year);
+Jsonix.XML.Calendar.validateYear(f.year);
+this.year=f.year
+}else{this.year=NaN
+}if(Jsonix.Util.Type.exists(f.month)){Jsonix.Util.Ensure.ensureInteger(f.month);
+Jsonix.XML.Calendar.validateMonth(f.month);
+this.month=f.month
+}else{this.month=NaN
+}if(Jsonix.Util.Type.exists(f.day)){Jsonix.Util.Ensure.ensureInteger(f.day);
+if(Jsonix.Util.NumberUtils.isInteger(f.year)&&Jsonix.Util.NumberUtils.isInteger(f.month)){Jsonix.XML.Calendar.validateYearMonthDay(f.year,f.month,f.day)
+}else{if(Jsonix.Util.NumberUtils.isInteger(f.month)){Jsonix.XML.Calendar.validateMonthDay(f.month,f.day)
+}else{Jsonix.XML.Calendar.validateDay(f.day)
+}}this.day=f.day
+}else{this.day=NaN
+}if(Jsonix.Util.Type.exists(f.hour)){Jsonix.Util.Ensure.ensureInteger(f.hour);
+Jsonix.XML.Calendar.validateHour(f.hour);
+this.hour=f.hour
+}else{this.hour=NaN
+}if(Jsonix.Util.Type.exists(f.minute)){Jsonix.Util.Ensure.ensureInteger(f.minute);
+Jsonix.XML.Calendar.validateMinute(f.minute);
+this.minute=f.minute
+}else{this.minute=NaN
+}if(Jsonix.Util.Type.exists(f.second)){Jsonix.Util.Ensure.ensureInteger(f.second);
+Jsonix.XML.Calendar.validateSecond(f.second);
+this.second=f.second
+}else{this.second=NaN
+}if(Jsonix.Util.Type.exists(f.fractionalSecond)){Jsonix.Util.Ensure.ensureNumber(f.fractionalSecond);
+Jsonix.XML.Calendar.validateFractionalSecond(f.fractionalSecond);
+this.fractionalSecond=f.fractionalSecond
+}else{this.fractionalSecond=NaN
+}if(Jsonix.Util.Type.exists(f.timezone)){if(Jsonix.Util.Type.isNaN(f.timezone)){this.timezone=NaN
+}else{Jsonix.Util.Ensure.ensureInteger(f.timezone);
+Jsonix.XML.Calendar.validateTimezone(f.timezone);
+this.timezone=f.timezone
+}}else{this.timezone=NaN
+}var d=new Date(0);
+d.setUTCFullYear(this.year||1970);
+d.setUTCMonth(this.month-1||0);
+d.setUTCDate(this.day||1);
+d.setUTCHours(this.hour||0);
+d.setUTCMinutes(this.minute||0);
+d.setUTCSeconds(this.second||0);
+d.setUTCMilliseconds((this.fractionalSecond||0)*1000);
+var e=-60000*(this.timezone||0);
+this.date=new Date(d.getTime()+e)
+},CLASS_NAME:"Jsonix.XML.Calendar"});
+Jsonix.XML.Calendar.MIN_TIMEZONE=-14*60;
+Jsonix.XML.Calendar.MAX_TIMEZONE=14*60;
+Jsonix.XML.Calendar.DAYS_IN_MONTH=[31,29,31,30,31,30,31,31,30,31,30,31];
 Jsonix.XML.Calendar.fromObject=function(b){Jsonix.Util.Ensure.ensureObject(b);
 if(Jsonix.Util.Type.isString(b.CLASS_NAME)&&b.CLASS_NAME==="Jsonix.XML.Calendar"){return b
 }return new Jsonix.XML.Calendar(b)
 };
+Jsonix.XML.Calendar.validateYear=function(b){if(b===0){throw new Error("Invalid year ["+b+"]. Year must not be [0].")
+}};
+Jsonix.XML.Calendar.validateMonth=function(b){if(b<1||b>12){throw new Error("Invalid month ["+b+"]. Month must be in range [1, 12].")
+}};
+Jsonix.XML.Calendar.validateDay=function(b){if(b<1||b>31){throw new Error("Invalid day ["+b+"]. Day must be in range [1, 31].")
+}};
+Jsonix.XML.Calendar.validateMonthDay=function(f,d){Jsonix.XML.Calendar.validateMonth(f);
+var e=Jsonix.XML.Calendar.DAYS_IN_MONTH[f-1];
+if(d<1||d>Jsonix.XML.Calendar.DAYS_IN_MONTH[f-1]){throw new Error("Invalid day ["+d+"]. Day must be in range [1, "+e+"].")
+}};
+Jsonix.XML.Calendar.validateYearMonthDay=function(d,f,e){Jsonix.XML.Calendar.validateYear(d);
+Jsonix.XML.Calendar.validateMonthDay(f,e)
+};
+Jsonix.XML.Calendar.validateHour=function(b){if(b<0||b>23){throw new Error("Invalid hour ["+b+"]. Hour must be in range [0, 23].")
+}};
+Jsonix.XML.Calendar.validateMinute=function(b){if(b<0||b>59){throw new Error("Invalid minute ["+b+"]. Minute must be in range [0, 59].")
+}};
+Jsonix.XML.Calendar.validateSecond=function(b){if(b<0||b>59){throw new Error("Invalid second ["+b+"]. Second must be in range [0, 59].")
+}};
+Jsonix.XML.Calendar.validateFractionalSecond=function(b){if(b<0||b>59){throw new Error("Invalid fractional second ["+b+"]. Fractional second must be in range [0, 1).")
+}};
+Jsonix.XML.Calendar.validateTimezone=function(b){if(b<Jsonix.XML.Calendar.MIN_TIMEZONE||b>Jsonix.XML.Calendar.MAX_TIMEZONE){throw new Error("Invalid timezone ["+b+"]. Timezone must not be in range ["+Jsonix.XML.Calendar.MIN_TIMEZONE+", "+Jsonix.XML.Calendar.MAX_TIMEZONE+"].")
+}};
 Jsonix.XML.Input=Jsonix.Class({root:null,node:null,attributes:null,eventType:null,pns:null,initialize:function(c){Jsonix.Util.Ensure.ensureExists(c);
 this.root=c;
 var d={"":""};
@@ -432,6 +498,13 @@ if(Jsonix.Util.Type.isString(b.nodeName)){return Jsonix.XML.QName.key(b.namespac
 while(b===7||b===4||b===12||b===6||b===3||b===5){b=this.next()
 }if(b!==1&&b!==2){throw new Error("Expected start or end tag.")
 }return b
+},skipElement:function(){if(this.eventType!==Jsonix.XML.Input.START_ELEMENT){throw new Error("Parser must be on START_ELEMENT to skip element.")
+}var d=1;
+var c;
+do{c=this.nextTag();
+d+=(c===Jsonix.XML.Input.START_ELEMENT)?1:-1
+}while(d>0);
+return c
 },getElementText:function(){if(this.eventType!=1){throw new Error("Parser must be on START_ELEMENT to read next text.")
 }var c=this.next();
 var d="";
@@ -441,45 +514,51 @@ while(c!==2){if(c===4||c===12||c===6||c===9){d=d+this.getText()
 }else{throw new Error("Unexpected event type ["+c+"].")
 }}}}c=this.next()
 }return d
-},getAttributeCount:function(){var b;
+},retrieveElement:function(){var b;
+if(this.eventType===1){b=this.node
+}else{if(this.eventType===10){b=this.node.parentNode
+}else{throw new Error("Element can only be retrieved for START_ELEMENT or ATTRIBUTE nodes.")
+}}return b
+},retrieveAttributes:function(){var b;
 if(this.attributes){b=this.attributes
 }else{if(this.eventType===1){b=this.node.attributes;
 this.attributes=b
 }else{if(this.eventType===10){b=this.node.parentNode.attributes;
 this.attributes=b
-}else{throw new Error("Number of attributes can only be retrieved for START_ELEMENT or ATTRIBUTE.")
-}}}return b.length
-},getAttributeName:function(d){var e;
-if(this.attributes){e=this.attributes
-}else{if(this.eventType===1){e=this.node.attributes;
-this.attributes=e
-}else{if(this.eventType===10){e=this.node.parentNode.attributes;
-this.attributes=e
-}else{throw new Error("Attribute name can only be retrieved for START_ELEMENT or ATTRIBUTE.")
-}}}if(d<0||d>=e.length){throw new Error("Invalid attribute index ["+d+"].")
+}else{throw new Error("Attributes can only be retrieved for START_ELEMENT or ATTRIBUTE nodes.")
+}}}return b
+},getAttributeCount:function(){var b=this.retrieveAttributes();
+return b.length
+},getAttributeName:function(d){var e=this.retrieveAttributes();
+if(d<0||d>=e.length){throw new Error("Invalid attribute index ["+d+"].")
 }var f=e[d];
 if(Jsonix.Util.Type.isString(f.namespaceURI)){return new Jsonix.XML.QName(f.namespaceURI,f.nodeName)
 }else{return new Jsonix.XML.QName(f.nodeName)
-}},getAttributeNameKey:function(d){var e;
-if(this.attributes){e=this.attributes
-}else{if(this.eventType===1){e=this.node.attributes;
-this.attributes=e
-}else{if(this.eventType===10){e=this.node.parentNode.attributes;
-this.attributes=e
-}else{throw new Error("Attribute name key can only be retrieved for START_ELEMENT or ATTRIBUTE.")
-}}}if(d<0||d>=e.length){throw new Error("Invalid attribute index ["+d+"].")
+}},getAttributeNameKey:function(d){var e=this.retrieveAttributes();
+if(d<0||d>=e.length){throw new Error("Invalid attribute index ["+d+"].")
 }var f=e[d];
 return Jsonix.XML.QName.key(f.namespaceURI,f.nodeName)
-},getAttributeValue:function(d){var e;
-if(this.attributes){e=this.attributes
-}else{if(this.eventType===1){e=this.node.attributes;
-this.attributes=e
-}else{if(this.eventType===10){e=this.node.parentNode.attributes;
-this.attributes=e
-}else{throw new Error("Attribute value can only be retrieved for START_ELEMENT or ATTRIBUTE.")
-}}}if(d<0||d>=e.length){throw new Error("Invalid attribute index ["+d+"].")
+},getAttributeValue:function(d){var e=this.retrieveAttributes();
+if(d<0||d>=e.length){throw new Error("Invalid attribute index ["+d+"].")
 }var f=e[d];
 return f.value
+},getAttributeValueNS:null,getAttributeValueNSViaElement:function(d,e){var f=this.retrieveElement();
+return f.getAttributeNS(d,e)
+},getAttributeValueNSViaAttribute:function(d,e){var f=this.getAttributeNodeNS(d,e);
+if(Jsonix.Util.Type.exists(f)){return f.nodeValue
+}else{return null
+}},getAttributeNodeNS:null,getAttributeNodeNSViaElement:function(d,e){var f=this.retrieveElement();
+return f.getAttributeNodeNS(d,e)
+},getAttributeNodeNSViaAttributes:function(o,p){var l=null;
+var i=this.retrieveAttributes();
+var m,k;
+for(var n=0,j=i.length;
+n<j;
+++n){m=i[n];
+if(m.namespaceURI===o){k=(m.prefix)?(m.prefix+":"+p):p;
+if(k===m.nodeName){l=m;
+break
+}}}return l
 },getElement:function(){if(this.eventType===1||this.eventType===2){this.eventType=2;
 return this.node
 }else{throw new Error("Parser must be on START_ELEMENT or END_ELEMENT to return current element.")
@@ -514,6 +593,8 @@ var f=this.pns[e];
 f=Jsonix.Util.Type.isObject(f)?f:this.pns[f];
 return f[d]
 },CLASS_NAME:"Jsonix.XML.Input"});
+Jsonix.XML.Input.prototype.getAttributeValueNS=(Jsonix.DOM.isDomImplementationAvailable())?Jsonix.XML.Input.prototype.getAttributeValueNSViaElement:Jsonix.XML.Input.prototype.getAttributeValueNSViaAttribute;
+Jsonix.XML.Input.prototype.getAttributeNodeNS=(Jsonix.DOM.isDomImplementationAvailable())?Jsonix.XML.Input.prototype.getAttributeNodeNSViaElement:Jsonix.XML.Input.prototype.getAttributeNodeNSViaAttributes;
 Jsonix.XML.Input.START_ELEMENT=1;
 Jsonix.XML.Input.END_ELEMENT=2;
 Jsonix.XML.Input.PROCESSING_INSTRUCTION=3;
@@ -529,7 +610,7 @@ Jsonix.XML.Input.CDATA=12;
 Jsonix.XML.Input.NAMESPACE=13;
 Jsonix.XML.Input.NOTATION_DECLARATION=14;
 Jsonix.XML.Input.ENTITY_DECLARATION=15;
-Jsonix.XML.Output=Jsonix.Class({document:null,node:null,nodes:null,nsp:null,pns:null,namespacePrefixIndex:0,xmldom:null,initialize:function(e){if(typeof ActiveXObject!=="undefined"){this.xmldom=new ActiveXObject("Microsoft.XMLDOM")
+Jsonix.XML.Output=Jsonix.Class({document:null,documentElement:null,node:null,nodes:null,nsp:null,pns:null,namespacePrefixIndex:0,xmldom:null,initialize:function(e){if(typeof ActiveXObject!=="undefined"){this.xmldom=new ActiveXObject("Microsoft.XMLDOM")
 }else{this.xmldom=null
 }this.nodes=[];
 var f={"":""};
@@ -559,12 +640,20 @@ if(Jsonix.Util.Type.isFunction(this.document.createElementNS)){o=this.document.c
 }}this.peek().appendChild(o);
 this.push(o);
 this.declareNamespace(i,m);
-return o
+if(this.documentElement===null){this.documentElement=o;
+this.declareNamespaces()
+}return o
 },writeEndElement:function(){return this.pop()
 },writeCharacters:function(c){var d;
 if(Jsonix.Util.Type.isFunction(this.document.createTextNode)){d=this.document.createTextNode(c)
 }else{if(this.xmldom){d=this.xmldom.createTextNode(c)
 }else{throw new Error("Could not create a text node.")
+}}this.peek().appendChild(d);
+return d
+},writeCdata:function(c){var d;
+if(Jsonix.Util.Type.isFunction(this.document.createCDATASection)){d=this.document.createCDATASection(c)
+}else{if(this.xmldom){d=this.xmldom.createCDATASection(c)
+}else{throw new Error("Could not create a CDATA section node.")
 }}this.peek().appendChild(d);
 return d
 },writeAttribute:function(t,k){Jsonix.Util.Ensure.ensureString(k);
@@ -607,13 +696,19 @@ this.nsp.push(l);
 this.pns.push(i)
 },popNS:function(){this.nsp.pop();
 this.pns.pop()
-},declareNamespace:function(j,i){var f=this.pns.length-1;
+},declareNamespaces:function(){var f=this.nsp.length-1;
+var h=this.nsp[f];
+h=Jsonix.Util.Type.isNumber(h)?this.nsp[h]:h;
+var e,g;
+for(e in h){if(h.hasOwnProperty(e)){g=h[e];
+this.declareNamespace(e,g)
+}}},declareNamespace:function(j,i){var f=this.pns.length-1;
 var h=this.pns[f];
 var g;
 if(Jsonix.Util.Type.isNumber(h)){g=true;
 h=this.pns[h]
 }else{g=false
-}if(h[i]!==j){if(i===""){this.writeAttribute({ns:Jsonix.XML.XMLNS_NS,lp:Jsonix.XML.XMLNS_P},j)
+}if(h[i]!==j){if(i===""){this.writeAttribute({lp:Jsonix.XML.XMLNS_P},j)
 }else{this.writeAttribute({ns:Jsonix.XML.XMLNS_NS,lp:i,p:Jsonix.XML.XMLNS_P},j)
 }if(g){h=Jsonix.Util.Type.cloneObject(h,{});
 this.pns[f]=h
@@ -634,44 +729,178 @@ if(h){k=Jsonix.Util.Type.cloneObject(k,{});
 this.nsp[g]=k
 }k[j]=i
 }}return i
+},getNamespaceURI:function(d){var e=this.pns.length-1;
+var f=this.pns[e];
+f=Jsonix.Util.Type.isObject(f)?f:this.pns[f];
+return f[d]
 },CLASS_NAME:"Jsonix.XML.Output"});
-Jsonix.Model.TypeInfo=Jsonix.Class({name:null,initialize:function(){},CLASS_NAME:"Jsonix.Model.TypeInfo"});
-Jsonix.Model.Adapter=Jsonix.Class({initialize:function(){},unmarshal:function(g,e,f,h){return g.unmarshal(e,f,h)
-},marshal:function(h,i,f,g,j){h.marshal(i,f,g,j)
-},CLASS_NAME:"Jsonix.Model.Adapter"});
-Jsonix.Model.Adapter.INSTANCE=new Jsonix.Model.Adapter();
-Jsonix.Model.Adapter.getAdapter=function(b){Jsonix.Util.Ensure.ensureObject(b);
-return Jsonix.Util.Type.exists(b.adapter)?b.adapter:Jsonix.Model.Adapter.INSTANCE
+Jsonix.Mapping={};
+Jsonix.Mapping.Style=Jsonix.Class({marshaller:null,unmarshaller:null,module:null,elementInfo:null,classInfo:null,enumLeafInfo:null,anyAttributePropertyInfo:null,anyElementPropertyInfo:null,attributePropertyInfo:null,elementMapPropertyInfo:null,elementPropertyInfo:null,elementsPropertyInfo:null,elementRefPropertyInfo:null,elementRefsPropertyInfo:null,valuePropertyInfo:null,initialize:function(){},CLASS_NAME:"Jsonix.Mapping.Style"});
+Jsonix.Mapping.Style.STYLES={};
+Jsonix.Mapping.Styled=Jsonix.Class({mappingStyle:null,initialize:function(d){if(Jsonix.Util.Type.exists(d)){Jsonix.Util.Ensure.ensureObject(d);
+if(Jsonix.Util.Type.isString(d.mappingStyle)){var c=Jsonix.Mapping.Style.STYLES[d.mappingStyle];
+if(!c){throw new Error("Mapping style ["+d.mappingStyle+"] is not known.")
+}this.mappingStyle=c
+}else{if(Jsonix.Util.Type.isObject(d.mappingStyle)){this.mappingStyle=d.mappingStyle
+}}}if(!this.mappingStyle){this.mappingStyle=Jsonix.Mapping.Style.STYLES.standard
+}},CLASS_NAME:"Jsonix.Mapping.Styled"});
+Jsonix.Binding={};
+Jsonix.Binding.Marshalls={};
+Jsonix.Binding.Marshalls.Element=Jsonix.Class({marshalElement:function(o,u,t,l){var q=this.convertToTypedNamedValue(o,u,t,l);
+var p=q.typeInfo;
+var v=undefined;
+if(u.supportXsiType&&Jsonix.Util.Type.exists(q.value)){var r=u.getTypeInfoByValue(q.value);
+if(r&&r.typeName){v=r
+}}var m=v||p;
+if(m){t.writeStartElement(q.name);
+if(v&&p!==v){var n=v.typeName;
+var s=Jsonix.Schema.XSD.QName.INSTANCE.print(n,u,t,l);
+t.writeAttribute(Jsonix.Schema.XSI.TYPE_QNAME,s)
+}if(Jsonix.Util.Type.exists(q.value)){m.marshal(q.value,u,t,l)
+}t.writeEndElement()
+}else{throw new Error("Element ["+q.name.key+"] is not known in this context, could not determine its type.")
+}},getTypeInfoByElementName:function(f,e,g){var h=e.getElementInfo(f,g);
+if(Jsonix.Util.Type.exists(h)){return h.typeInfo
+}else{return undefined
+}}});
+Jsonix.Binding.Marshalls.Element.AsElementRef=Jsonix.Class({convertToTypedNamedValue:function(i,f,g,j){Jsonix.Util.Ensure.ensureObject(i);
+var h=this.convertToNamedValue(i,f,g,j);
+return{name:h.name,value:h.value,typeInfo:this.getTypeInfoByElementName(h.name,f,j)}
+},convertToNamedValue:function(j,m,h,l){var n;
+var k;
+if(Jsonix.Util.Type.exists(j.name)&&!Jsonix.Util.Type.isUndefined(j.value)){n=Jsonix.XML.QName.fromObjectOrString(j.name,m);
+k=Jsonix.Util.Type.exists(j.value)?j.value:null;
+return{name:n,value:k}
+}else{for(var i in j){if(j.hasOwnProperty(i)){n=Jsonix.XML.QName.fromObjectOrString(i,m);
+k=j[i];
+return{name:n,value:k}
+}}}throw new Error("Invalid element value ["+j+"]. Element values must either have {name:'myElementName', value: elementValue} or {myElementName:elementValue} structure.")
+}});
+Jsonix.Binding.Unmarshalls={};
+Jsonix.Binding.Unmarshalls.WrapperElement=Jsonix.Class({mixed:false,unmarshalWrapperElement:function(f,g,j,h){var i=g.next();
+while(i!==Jsonix.XML.Input.END_ELEMENT){if(i===Jsonix.XML.Input.START_ELEMENT){this.unmarshalElement(f,g,j,h)
+}else{if(this.mixed&&(i===Jsonix.XML.Input.CHARACTERS||i===Jsonix.XML.Input.CDATA||i===Jsonix.XML.Input.ENTITY_REFERENCE)){h(g.getText())
+}else{if(i===Jsonix.XML.Input.SPACE||i===Jsonix.XML.Input.COMMENT||i===Jsonix.XML.Input.PROCESSING_INSTRUCTION){}else{throw new Error("Illegal state: unexpected event type ["+i+"].")
+}}}i=g.next()
+}}});
+Jsonix.Binding.Unmarshalls.Element=Jsonix.Class({allowTypedObject:true,allowDom:false,unmarshalElement:function(q,o,j,l){if(o.eventType!=1){throw new Error("Parser must be on START_ELEMENT to read next element.")
+}var k=this.getTypeInfoByInputElement(q,o,j);
+var r=o.getName();
+var p;
+if(this.allowTypedObject){if(Jsonix.Util.Type.exists(k)){var n=k.unmarshal(q,o,j);
+var m={name:r,value:n,typeInfo:k};
+p=this.convertFromTypedNamedValue(m,q,o,j)
+}else{if(this.allowDom){p=o.getElement()
+}else{throw new Error("Element ["+r.toString()+"] could not be unmarshalled as is not known in this context and the property does not allow DOM content.")
+}}}else{if(this.allowDom){p=o.getElement()
+}else{throw new Error("Element ["+r.toString()+"] could not be unmarshalled as the property neither allows typed objects nor DOM as content. This is a sign of invalid mappings, do not use [allowTypedObject : false] and [allowDom : false] at the same time.")
+}}l(p)
+},getTypeInfoByInputElement:function(n,p,m){var i=null;
+if(n.supportXsiType){var j=p.getAttributeValueNS(Jsonix.Schema.XSI.NAMESPACE_URI,Jsonix.Schema.XSI.TYPE);
+if(Jsonix.Util.StringUtils.isNotBlank(j)){var k=Jsonix.Schema.XSD.QName.INSTANCE.parse(j,n,p,m);
+i=n.getTypeInfoByTypeNameKey(k.key)
+}}var o=p.getName();
+var l=i?i:this.getTypeInfoByElementName(o,n,m);
+return l
+},getTypeInfoByElementName:function(f,e,g){var h=e.getElementInfo(f,g);
+if(Jsonix.Util.Type.exists(h)){return h.typeInfo
+}else{return undefined
+}}});
+Jsonix.Binding.Unmarshalls.Element.AsElementRef=Jsonix.Class({convertFromTypedNamedValue:function(g,e,f,h){return{name:g.name,value:g.value}
+}});
+Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef=Jsonix.Class({convertFromTypedNamedValue:function(i,l,g,k){var h=i.name.toCanonicalString(l);
+var j={};
+j[h]=i.value;
+return j
+}});
+Jsonix.Binding.Marshaller=Jsonix.Class(Jsonix.Binding.Marshalls.Element,Jsonix.Binding.Marshalls.Element.AsElementRef,{context:null,initialize:function(b){Jsonix.Util.Ensure.ensureObject(b);
+this.context=b
+},marshalString:function(e){var d=this.marshalDocument(e);
+var f=Jsonix.DOM.serialize(d);
+return f
+},marshalDocument:function(d){var e=new Jsonix.XML.Output({namespacePrefixes:this.context.namespacePrefixes});
+var f=e.writeStartDocument();
+this.marshalElement(d,this.context,e,undefined);
+e.writeEndDocument();
+return f
+},CLASS_NAME:"Jsonix.Binding.Marshaller"});
+Jsonix.Binding.Marshaller.Simplified=Jsonix.Class(Jsonix.Binding.Marshaller,{CLASS_NAME:"Jsonix.Binding.Marshaller.Simplified"});
+Jsonix.Binding.Unmarshaller=Jsonix.Class(Jsonix.Binding.Unmarshalls.Element,Jsonix.Binding.Unmarshalls.Element.AsElementRef,{context:null,allowTypedObject:true,allowDom:false,initialize:function(b){Jsonix.Util.Ensure.ensureObject(b);
+this.context=b
+},unmarshalString:function(c){Jsonix.Util.Ensure.ensureString(c);
+var d=Jsonix.DOM.parse(c);
+return this.unmarshalDocument(d)
+},unmarshalURL:function(d,f,e){Jsonix.Util.Ensure.ensureString(d);
+Jsonix.Util.Ensure.ensureFunction(f);
+if(Jsonix.Util.Type.exists(e)){Jsonix.Util.Ensure.ensureObject(e)
+}that=this;
+Jsonix.DOM.load(d,function(a){f(that.unmarshalDocument(a))
+},e)
+},unmarshalFile:function(g,h,e){if(typeof _jsonix_fs==="undefined"){throw new Error("File unmarshalling is only available in environments which support file systems.")
+}Jsonix.Util.Ensure.ensureString(g);
+Jsonix.Util.Ensure.ensureFunction(h);
+if(Jsonix.Util.Type.exists(e)){Jsonix.Util.Ensure.ensureObject(e)
+}that=this;
+var f=_jsonix_fs;
+f.readFile(g,e,function(d,c){if(d){throw d
+}else{var a=c.toString();
+var b=Jsonix.DOM.parse(a);
+h(that.unmarshalDocument(b))
+}})
+},unmarshalDocument:function(i,j){var f=new Jsonix.XML.Input(i);
+var g=null;
+var h=function(a){g=a
 };
-Jsonix.Model.ClassInfo=Jsonix.Class(Jsonix.Model.TypeInfo,{name:null,baseTypeInfo:null,instanceFactory:null,properties:null,structure:null,defaultElementNamespaceURI:"",defaultAttributeNamespaceURI:"",built:false,initialize:function(i){Jsonix.Model.TypeInfo.prototype.initialize.apply(this,[]);
-Jsonix.Util.Ensure.ensureObject(i);
-var k=i.name||i.n||undefined;
-Jsonix.Util.Ensure.ensureString(k);
-this.name=k;
-var o=i.defaultElementNamespaceURI||i.dens||"";
-this.defaultElementNamespaceURI=o;
-var l=i.defaultAttributeNamespaceURI||i.dans||"";
-this.defaultAttributeNamespaceURI=l;
-var m=i.baseTypeInfo||i.bti||null;
-this.baseTypeInfo=m;
-var p=i.instanceFactory||i.inF||undefined;
-if(Jsonix.Util.Type.exists(p)){Jsonix.Util.Ensure.ensureFunction(p);
-this.instanceFactory=p
-}this.properties=[];
-var n=i.propertyInfos||i.ps||[];
-Jsonix.Util.Ensure.ensureArray(n);
-for(var j=0;
-j<n.length;
-j++){this.p(n[j])
-}},destroy:function(){},build:function(i,j){if(!this.built){this.baseTypeInfo=i.resolveTypeInfo(this.baseTypeInfo,j);
-if(Jsonix.Util.Type.exists(this.baseTypeInfo)){this.baseTypeInfo.build(i,j)
-}for(var f=0;
-f<this.properties.length;
-f++){var h=this.properties[f];
-h.build(i,j)
-}var g={elements:null,attributes:{},anyAttribute:null,value:null,any:null};
-this.buildStructure(i,g);
-this.structure=g
+f.nextTag();
+this.unmarshalElement(this.context,f,j,h);
+return g
+},CLASS_NAME:"Jsonix.Binding.Unmarshaller"});
+Jsonix.Binding.Unmarshaller.Simplified=Jsonix.Class(Jsonix.Binding.Unmarshaller,Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef,{CLASS_NAME:"Jsonix.Binding.Unmarshaller.Simplified"});
+Jsonix.Model.TypeInfo=Jsonix.Class({module:null,name:null,baseTypeInfo:null,initialize:function(){},isBasedOn:function(c){var d=this;
+while(d){if(c===d){return true
+}d=d.baseTypeInfo
+}return false
+},CLASS_NAME:"Jsonix.Model.TypeInfo"});
+Jsonix.Model.ClassInfo=Jsonix.Class(Jsonix.Model.TypeInfo,Jsonix.Mapping.Styled,{name:null,localName:null,typeName:null,instanceFactory:null,properties:null,propertiesMap:null,structure:null,targetNamespace:"",defaultElementNamespaceURI:"",defaultAttributeNamespaceURI:"",built:false,initialize:function(w,m){Jsonix.Model.TypeInfo.prototype.initialize.apply(this,[]);
+Jsonix.Mapping.Styled.prototype.initialize.apply(this,[m]);
+Jsonix.Util.Ensure.ensureObject(w);
+var v=w.name||w.n||undefined;
+Jsonix.Util.Ensure.ensureString(v);
+this.name=v;
+var q=w.localName||w.ln||null;
+this.localName=q;
+var r=w.defaultElementNamespaceURI||w.dens||w.targetNamespace||w.tns||"";
+this.defaultElementNamespaceURI=r;
+var n=w.targetNamespace||w.tns||w.defaultElementNamespaceURI||w.dens||this.defaultElementNamespaceURI;
+this.targetNamespace=n;
+var p=w.defaultAttributeNamespaceURI||w.dans||"";
+this.defaultAttributeNamespaceURI=p;
+var u=w.baseTypeInfo||w.bti||null;
+this.baseTypeInfo=u;
+var t=w.instanceFactory||w.inF||undefined;
+if(Jsonix.Util.Type.exists(t)){Jsonix.Util.Ensure.ensureFunction(t);
+this.instanceFactory=t
+}var o=w.typeName||w.tn||undefined;
+if(Jsonix.Util.Type.exists(o)){if(Jsonix.Util.Type.isString(o)){this.typeName=new Jsonix.XML.QName(this.targetNamespace,o)
+}else{this.typeName=Jsonix.XML.QName.fromObject(o)
+}}else{if(Jsonix.Util.Type.exists(q)){this.typeName=new Jsonix.XML.QName(n,q)
+}}this.properties=[];
+this.propertiesMap={};
+var x=w.propertyInfos||w.ps||[];
+Jsonix.Util.Ensure.ensureArray(x);
+for(var s=0;
+s<x.length;
+s++){this.p(x[s])
+}},getPropertyInfoByName:function(b){return this.propertiesMap[b]
+},destroy:function(){},build:function(h){if(!this.built){this.baseTypeInfo=h.resolveTypeInfo(this.baseTypeInfo,this.module);
+if(Jsonix.Util.Type.exists(this.baseTypeInfo)){this.baseTypeInfo.build(h)
+}for(var e=0;
+e<this.properties.length;
+e++){var g=this.properties[e];
+g.build(h,this.module)
+}var f={elements:null,attributes:{},anyAttribute:null,value:null,any:null};
+this.buildStructure(h,f);
+this.structure=f
 }},buildStructure:function(h,f){if(Jsonix.Util.Type.exists(this.baseTypeInfo)){this.baseTypeInfo.buildStructure(h,f)
 }for(var e=0;
 e<this.properties.length;
@@ -697,10 +926,10 @@ if(Jsonix.Util.Type.exists(this.structure.elements[q])){var r=this.structure.ele
 this.unmarshalProperty(B,w,r,p)
 }else{if(Jsonix.Util.Type.exists(this.structure.any)){var s=this.structure.any;
 this.unmarshalProperty(B,w,s,p)
-}else{throw new Error("Unexpected element ["+q+"].")
-}}}else{if((v===Jsonix.XML.Input.CHARACTERS||v===Jsonix.XML.Input.CDATA||v===Jsonix.XML.Input.ENTITY_REFERENCE)&&Jsonix.Util.Type.exists(this.structure.mixed)){var x=this.structure.mixed;
+}else{v=w.skipElement()
+}}}else{if((v===Jsonix.XML.Input.CHARACTERS||v===Jsonix.XML.Input.CDATA||v===Jsonix.XML.Input.ENTITY_REFERENCE)){if(Jsonix.Util.Type.exists(this.structure.mixed)){var x=this.structure.mixed;
 this.unmarshalProperty(B,w,x,p)
-}else{if(v===Jsonix.XML.Input.SPACE||v===Jsonix.XML.Input.COMMENT||v===Jsonix.XML.Input.PROCESSING_INSTRUCTION){}else{throw new Error("Illegal state: unexpected event type ["+v+"].")
+}}else{if(v===Jsonix.XML.Input.SPACE||v===Jsonix.XML.Input.COMMENT||v===Jsonix.XML.Input.PROCESSING_INSTRUCTION){}else{throw new Error("Illegal state: unexpected event type ["+v+"].")
 }}}v=w.next()
 }}else{if(Jsonix.Util.Type.exists(this.structure.value)){var t=this.structure.value;
 this.unmarshalProperty(B,w,t,p)
@@ -711,45 +940,53 @@ this.unmarshalProperty(B,w,t,p)
 h.setProperty(g,f)
 },unmarshalPropertyValue:function(k,l,i,h,j){var g=i.unmarshalValue(j,k,l,this);
 i.setProperty(h,g)
-},marshal:function(i,k,g){if(Jsonix.Util.Type.exists(this.baseTypeInfo)){this.baseTypeInfo.marshal(i,k,g)
-}for(var l=0;
-l<this.properties.length;
-l++){var j=this.properties[l];
-var h=i[j.name];
-if(Jsonix.Util.Type.exists(h)){j.marshal(h,k,g,this)
-}}},isInstance:function(f,e,d){if(this.instanceFactory){return f instanceof this.instanceFactory
+},marshal:function(l,q,p,k){if(this.isMarshallable(l,q,k)){if(Jsonix.Util.Type.exists(this.baseTypeInfo)){this.baseTypeInfo.marshal(l,q,p)
+}for(var n=0;
+n<this.properties.length;
+n++){var m=this.properties[n];
+var o=l[m.name];
+if(Jsonix.Util.Type.exists(o)){m.marshal(o,q,p,this)
+}}}else{if(this.structure.value){var j=this.structure.value;
+j.marshal(l,q,p,this)
+}else{if(this.properties.length===1){var r=this.properties[0];
+r.marshal(l,q,p,this)
+}else{throw new Error("The passed value ["+l+"] is not an object and there is no single suitable property to marshal it.")
+}}}},isMarshallable:function(f,e,d){return this.isInstance(f,e,d)||(Jsonix.Util.Type.isObject(f)&&!Jsonix.Util.Type.isArray(f))
+},isInstance:function(f,e,d){if(this.instanceFactory){return f instanceof this.instanceFactory
 }else{return Jsonix.Util.Type.isObject(f)&&Jsonix.Util.Type.isString(f.TYPE_NAME)&&f.TYPE_NAME===this.name
 }},b:function(b){Jsonix.Util.Ensure.ensureObject(b);
 this.baseTypeInfo=b;
 return this
 },ps:function(){return this
-},p:function(f){Jsonix.Util.Ensure.ensureObject(f);
-if(f instanceof Jsonix.Model.PropertyInfo){this.addProperty(f)
-}else{var d=f.type||f.t||"element";
-if(Jsonix.Util.Type.isFunction(this.propertyInfoCreators[d])){var e=this.propertyInfoCreators[d];
-e.call(this,f)
-}else{throw new Error("Unknown property info type ["+d+"].")
+},p:function(e){Jsonix.Util.Ensure.ensureObject(e);
+if(e instanceof Jsonix.Model.PropertyInfo){this.addProperty(e)
+}else{e=Jsonix.Util.Type.cloneObject(e);
+var f=e.type||e.t||"element";
+if(Jsonix.Util.Type.isFunction(this.propertyInfoCreators[f])){var d=this.propertyInfoCreators[f];
+d.call(this,e)
+}else{throw new Error("Unknown property info type ["+f+"].")
 }}},aa:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.AnyAttributePropertyInfo(b))
+return this.addProperty(new this.mappingStyle.anyAttributePropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },ae:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.AnyElementPropertyInfo(b))
+return this.addProperty(new this.mappingStyle.anyElementPropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },a:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.AttributePropertyInfo(b))
+return this.addProperty(new this.mappingStyle.attributePropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },em:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.ElementMapPropertyInfo(b))
+return this.addProperty(new this.mappingStyle.elementMapPropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },e:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.ElementPropertyInfo(b))
+return this.addProperty(new this.mappingStyle.elementPropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },es:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.ElementsPropertyInfo(b))
+return this.addProperty(new this.mappingStyle.elementsPropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },er:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.ElementRefPropertyInfo(b))
+return this.addProperty(new this.mappingStyle.elementRefPropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },ers:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.ElementRefsPropertyInfo(b))
+return this.addProperty(new this.mappingStyle.elementRefsPropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },v:function(b){this.addDefaultNamespaces(b);
-return this.addProperty(new Jsonix.Model.ValuePropertyInfo(b))
+return this.addProperty(new this.mappingStyle.valuePropertyInfo(b,{mappingStyle:this.mappingStyle}))
 },addDefaultNamespaces:function(b){if(Jsonix.Util.Type.isObject(b)){if(!Jsonix.Util.Type.isString(b.defaultElementNamespaceURI)){b.defaultElementNamespaceURI=this.defaultElementNamespaceURI
 }if(!Jsonix.Util.Type.isString(b.defaultAttributeNamespaceURI)){b.defaultAttributeNamespaceURI=this.defaultAttributeNamespaceURI
 }}},addProperty:function(b){this.properties.push(b);
+this.propertiesMap[b.name]=b;
 return this
 },CLASS_NAME:"Jsonix.Model.ClassInfo"});
 Jsonix.Model.ClassInfo.prototype.propertyInfoCreators={aa:Jsonix.Model.ClassInfo.prototype.aa,anyAttribute:Jsonix.Model.ClassInfo.prototype.aa,ae:Jsonix.Model.ClassInfo.prototype.ae,anyElement:Jsonix.Model.ClassInfo.prototype.ae,a:Jsonix.Model.ClassInfo.prototype.a,attribute:Jsonix.Model.ClassInfo.prototype.a,em:Jsonix.Model.ClassInfo.prototype.em,elementMap:Jsonix.Model.ClassInfo.prototype.em,e:Jsonix.Model.ClassInfo.prototype.e,element:Jsonix.Model.ClassInfo.prototype.e,es:Jsonix.Model.ClassInfo.prototype.es,elements:Jsonix.Model.ClassInfo.prototype.es,er:Jsonix.Model.ClassInfo.prototype.er,elementRef:Jsonix.Model.ClassInfo.prototype.er,ers:Jsonix.Model.ClassInfo.prototype.ers,elementRefs:Jsonix.Model.ClassInfo.prototype.ers,v:Jsonix.Model.ClassInfo.prototype.v,value:Jsonix.Model.ClassInfo.prototype.v};
@@ -764,44 +1001,43 @@ var h=f.values||f.vs||undefined;
 Jsonix.Util.Ensure.ensureExists(h);
 if(!(Jsonix.Util.Type.isObject(h)||Jsonix.Util.Type.isArray(h))){throw new Error("Enum values must be either an array or an object.")
 }else{this.entries=h
-}},build:function(r,q){if(!this.built){this.baseTypeInfo=r.resolveTypeInfo(this.baseTypeInfo,q);
-this.baseTypeInfo.build(r,q);
-var n=this.entries;
-var p={};
-var j=[];
-var k=[];
+}},build:function(m){if(!this.built){this.baseTypeInfo=m.resolveTypeInfo(this.baseTypeInfo,this.module);
+this.baseTypeInfo.build(m);
+var p=this.entries;
+var j={};
+var l=[];
+var i=[];
 var o=0;
-var l;
-var m;
-if(Jsonix.Util.Type.isArray(n)){for(o=0;
-o<n.length;
-o++){m=n[o];
-if(Jsonix.Util.Type.isString(m)){l=m;
+var n;
+var k;
+if(Jsonix.Util.Type.isArray(p)){for(o=0;
+o<p.length;
+o++){k=p[o];
+if(Jsonix.Util.Type.isString(k)){n=k;
 if(!(Jsonix.Util.Type.isFunction(this.baseTypeInfo.parse))){throw new Error("Enum value is provided as string but the base type ["+this.baseTypeInfo.name+"] of the enum info ["+this.name+"] does not implement the parse method.")
-}m=this.baseTypeInfo.parse(m,r,null,this)
-}else{if(this.baseTypeInfo.isInstance(m,r,this)){if(!(Jsonix.Util.Type.isFunction(this.baseTypeInfo.print))){throw new Error("The base type ["+this.baseTypeInfo.name+"] of the enum info ["+this.name+"] does not implement the print method, unable to produce the enum key as string.")
-}l=this.baseTypeInfo.print(m,r,null,this)
-}else{throw new Error("Enum value ["+m+"] is not an instance of the enum base type ["+this.baseTypeInfo.name+"].")
-}}p[l]=m;
-j[o]=l;
-k[o]=m
-}}else{if(Jsonix.Util.Type.isObject(n)){for(l in n){if(n.hasOwnProperty(l)){m=n[l];
-if(Jsonix.Util.Type.isString(m)){if(!(Jsonix.Util.Type.isFunction(this.baseTypeInfo.parse))){throw new Error("Enum value is provided as string but the base type ["+this.baseTypeInfo.name+"] of the enum info ["+this.name+"] does not implement the parse method.")
-}m=this.baseTypeInfo.parse(m,r,null,this)
-}else{if(!this.baseTypeInfo.isInstance(m,r,this)){throw new Error("Enum value ["+m+"] is not an instance of the enum base type ["+this.baseTypeInfo.name+"].")
-}}p[l]=m;
-j[o]=l;
-k[o]=m;
+}k=this.baseTypeInfo.parse(k,m,null,this)
+}else{if(this.baseTypeInfo.isInstance(k,m,this)){if(!(Jsonix.Util.Type.isFunction(this.baseTypeInfo.print))){throw new Error("The base type ["+this.baseTypeInfo.name+"] of the enum info ["+this.name+"] does not implement the print method, unable to produce the enum key as string.")
+}n=this.baseTypeInfo.print(k,m,null,this)
+}else{throw new Error("Enum value ["+k+"] is not an instance of the enum base type ["+this.baseTypeInfo.name+"].")
+}}j[n]=k;
+l[o]=n;
+i[o]=k
+}}else{if(Jsonix.Util.Type.isObject(p)){for(n in p){if(p.hasOwnProperty(n)){k=p[n];
+if(Jsonix.Util.Type.isString(k)){if(!(Jsonix.Util.Type.isFunction(this.baseTypeInfo.parse))){throw new Error("Enum value is provided as string but the base type ["+this.baseTypeInfo.name+"] of the enum info ["+this.name+"] does not implement the parse method.")
+}k=this.baseTypeInfo.parse(k,m,null,this)
+}else{if(!this.baseTypeInfo.isInstance(k,m,this)){throw new Error("Enum value ["+k+"] is not an instance of the enum base type ["+this.baseTypeInfo.name+"].")
+}}j[n]=k;
+l[o]=n;
+i[o]=k;
 o++
 }}}else{throw new Error("Enum values must be either an array or an object.")
-}}this.entries=p;
-this.keys=j;
-this.values=k;
+}}this.entries=j;
+this.keys=l;
+this.values=i;
 this.built=true
 }},unmarshal:function(e,f,h){var g=f.getElementText();
-if(Jsonix.Util.StringUtils.isNotBlank(g)){return this.parse(g,e,f,h)
-}else{return null
-}},marshal:function(g,e,f,h){if(Jsonix.Util.Type.exists(g)){f.writeCharacters(this.reprint(g,e,f,h))
+return this.parse(g,e,f,h)
+},marshal:function(g,e,f,h){if(Jsonix.Util.Type.exists(g)){f.writeCharacters(this.reprint(g,e,f,h))
 }},reprint:function(g,e,f,h){if(Jsonix.Util.Type.isString(g)&&!this.isInstance(g,e,h)){return this.print(this.parse(g,e,null,h),e,f,h)
 }else{return this.print(g,e,f,h)
 }},print:function(h,j,g,i){for(var f=0;
@@ -816,7 +1052,7 @@ f<this.values.length;
 f++){if(this.values[f]===g){return true
 }}return false
 },CLASS_NAME:"Jsonix.Model.EnumLeafInfo"});
-Jsonix.Model.ElementInfo=Jsonix.Class({elementName:null,typeInfo:null,substitutionHead:null,scope:null,built:false,initialize:function(g){Jsonix.Util.Ensure.ensureObject(g);
+Jsonix.Model.ElementInfo=Jsonix.Class({module:null,elementName:null,typeInfo:null,substitutionHead:null,scope:null,built:false,initialize:function(g){Jsonix.Util.Ensure.ensureObject(g);
 var j=g.defaultElementNamespaceURI||g.dens||"";
 this.defaultElementNamespaceURI=j;
 var h=g.elementName||g.en||undefined;
@@ -829,21 +1065,35 @@ var l=g.substitutionHead||g.sh||null;
 this.substitutionHead=l;
 var i=g.scope||g.sc||null;
 this.scope=i
-},build:function(c,d){if(!this.built){this.typeInfo=c.resolveTypeInfo(this.typeInfo,d);
-this.scope=c.resolveTypeInfo(this.scope,d);
+},build:function(b){if(!this.built){this.typeInfo=b.resolveTypeInfo(this.typeInfo,this.module);
+this.scope=b.resolveTypeInfo(this.scope,this.module);
 this.built=true
 }},CLASS_NAME:"Jsonix.Model.ElementInfo"});
-Jsonix.Model.PropertyInfo=Jsonix.Class({name:null,collection:false,defaultElementNamespaceURI:"",defaultAttributeNamespaceURI:"",built:false,initialize:function(f){Jsonix.Util.Ensure.ensureObject(f);
-var h=f.name||f.n||undefined;
-Jsonix.Util.Ensure.ensureString(h);
-this.name=h;
-var j=f.defaultElementNamespaceURI||f.dens||"";
-this.defaultElementNamespaceURI=j;
-var i=f.defaultAttributeNamespaceURI||f.dans||"";
-this.defaultAttributeNamespaceURI=i;
-var g=f.collection||f.col||false;
-this.collection=g
-},build:function(c,d){if(!this.built){this.doBuild(c,d);
+Jsonix.Model.PropertyInfo=Jsonix.Class({name:null,collection:false,targetNamespace:"",defaultElementNamespaceURI:"",defaultAttributeNamespaceURI:"",built:false,initialize:function(r){Jsonix.Util.Ensure.ensureObject(r);
+var p=r.name||r.n||undefined;
+Jsonix.Util.Ensure.ensureString(p);
+this.name=p;
+var m=r.defaultElementNamespaceURI||r.dens||r.targetNamespace||r.tns||"";
+this.defaultElementNamespaceURI=m;
+var j=r.targetNamespace||r.tns||r.defaultElementNamespaceURI||r.dens||this.defaultElementNamespaceURI;
+this.targetNamespace=j;
+var k=r.defaultAttributeNamespaceURI||r.dans||"";
+this.defaultAttributeNamespaceURI=k;
+var o=r.collection||r.col||false;
+this.collection=o;
+var n=r.required||r.rq||false;
+this.required=n;
+if(this.collection){var l;
+if(Jsonix.Util.Type.isNumber(r.minOccurs)){l=r.minOccurs
+}else{if(Jsonix.Util.Type.isNumber(r.mno)){l=r.mno
+}else{l=1
+}}this.minOccurs=l;
+var q;
+if(Jsonix.Util.Type.isNumber(r.maxOccurs)){q=r.maxOccurs
+}else{if(Jsonix.Util.Type.isNumber(r.mxo)){q=r.mxo
+}else{q=null
+}}this.maxOccurs=q
+}},build:function(c,d){if(!this.built){this.doBuild(c,d);
 this.built=true
 }},doBuild:function(c,d){throw new Error("Abstract method [doBuild].")
 },buildStructure:function(c,d){throw new Error("Abstract method [buildStructure].")
@@ -856,21 +1106,26 @@ e++){d[this.name].push(f[e])
 }}},CLASS_NAME:"Jsonix.Model.PropertyInfo"});
 Jsonix.Model.AnyAttributePropertyInfo=Jsonix.Class(Jsonix.Model.PropertyInfo,{initialize:function(b){Jsonix.Util.Ensure.ensureObject(b);
 Jsonix.Model.PropertyInfo.prototype.initialize.apply(this,[b])
-},unmarshal:function(m,p,k){var n=p.getAttributeCount();
+},unmarshal:function(m,p,l){var n=p.getAttributeCount();
 if(n===0){return null
 }else{var j={};
 for(var o=0;
 o<n;
-o++){var i=p.getAttributeNameKey(o);
-var l=p.getAttributeValue(o);
-if(Jsonix.Util.Type.isString(l)){j[i]=l
+o++){var k=p.getAttributeValue(o);
+if(Jsonix.Util.Type.isString(k)){var i=this.convertFromAttributeName(p.getAttributeName(o),m,p,l);
+j[i]=k
 }}return j
-}},marshal:function(i,l,h,j){if(!Jsonix.Util.Type.isObject(i)){return
-}for(var g in i){if(i.hasOwnProperty(g)){var k=i[g];
-if(Jsonix.Util.Type.isString(k)){h.writeAttribute(Jsonix.XML.QName.fromString(g),k)
-}}}},doBuild:function(c,d){},buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
+}},marshal:function(j,l,n,k){if(!Jsonix.Util.Type.isObject(j)){return
+}for(var h in j){if(j.hasOwnProperty(h)){var i=j[h];
+if(Jsonix.Util.Type.isString(i)){var m=this.convertToAttributeName(h,l,n,k);
+n.writeAttribute(m,i)
+}}}},convertFromAttributeName:function(e,h,f,g){return e.key
+},convertToAttributeName:function(e,h,f,g){return Jsonix.XML.QName.fromObjectOrString(e,h)
+},doBuild:function(c,d){},buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
 d.anyAttribute=this
 },CLASS_NAME:"Jsonix.Model.AnyAttributePropertyInfo"});
+Jsonix.Model.AnyAttributePropertyInfo.Simplified=Jsonix.Class(Jsonix.Model.AnyAttributePropertyInfo,{convertFromAttributeName:function(e,h,f,g){return e.toCanonicalString(h)
+}});
 Jsonix.Model.SingleTypePropertyInfo=Jsonix.Class(Jsonix.Model.PropertyInfo,{typeInfo:"String",initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
 Jsonix.Model.PropertyInfo.prototype.initialize.apply(this,[d]);
 var c=d.typeInfo||d.ti||"String";
@@ -900,18 +1155,20 @@ Jsonix.Util.Ensure.ensureObject(e.attributes);
 var d=this.attributeName.key;
 e.attributes[d]=this
 },CLASS_NAME:"Jsonix.Model.AttributePropertyInfo"});
-Jsonix.Model.ValuePropertyInfo=Jsonix.Class(Jsonix.Model.SingleTypePropertyInfo,{initialize:function(b){Jsonix.Util.Ensure.ensureObject(b);
-Jsonix.Model.SingleTypePropertyInfo.prototype.initialize.apply(this,[b])
+Jsonix.Model.ValuePropertyInfo=Jsonix.Class(Jsonix.Model.SingleTypePropertyInfo,{initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
+Jsonix.Model.SingleTypePropertyInfo.prototype.initialize.apply(this,[d]);
+var c=d.asCDATA||d.c||false;
+this.asCDATA=c
 },unmarshal:function(e,f,h){var g=f.getElementText();
-if(Jsonix.Util.StringUtils.isNotBlank(g)){return this.unmarshalValue(g,e,f,h)
-}else{return null
-}},marshal:function(g,e,f,h){if(!Jsonix.Util.Type.exists(g)){return
-}f.writeCharacters(this.print(g,e,f,h))
-},buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
+return this.unmarshalValue(g,e,f,h)
+},marshal:function(g,e,f,h){if(!Jsonix.Util.Type.exists(g)){return
+}if(this.asCDATA){f.writeCdata(this.print(g,e,f,h))
+}else{f.writeCharacters(this.print(g,e,f,h))
+}},buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
 if(Jsonix.Util.Type.exists(d.elements)){throw new Error("The structure already defines element mappings, it cannot define a value property.")
 }else{d.value=this
 }},CLASS_NAME:"Jsonix.Model.ValuePropertyInfo"});
-Jsonix.Model.AbstractElementsPropertyInfo=Jsonix.Class(Jsonix.Model.PropertyInfo,{wrapperElementName:null,initialize:function(c){Jsonix.Util.Ensure.ensureObject(c);
+Jsonix.Model.AbstractElementsPropertyInfo=Jsonix.Class(Jsonix.Binding.Unmarshalls.Element,Jsonix.Binding.Unmarshalls.WrapperElement,Jsonix.Model.PropertyInfo,{wrapperElementName:null,allowDom:false,allowTypedObject:true,mixed:false,initialize:function(c){Jsonix.Util.Ensure.ensureObject(c);
 Jsonix.Model.PropertyInfo.prototype.initialize.apply(this,[c]);
 var d=c.wrapperElementName||c.wen||undefined;
 if(Jsonix.Util.Type.isObject(d)){this.wrapperElementName=Jsonix.XML.QName.fromObject(d)
@@ -927,11 +1184,6 @@ var i=function(a){if(j.collection){if(h===null){h=[]
 if(Jsonix.Util.Type.exists(this.wrapperElementName)){this.unmarshalWrapperElement(l,g,k,i)
 }else{this.unmarshalElement(l,g,k,i)
 }return h
-},unmarshalWrapperElement:function(f,g,j,h){var i=g.next();
-while(i!==Jsonix.XML.Input.END_ELEMENT){if(i===Jsonix.XML.Input.START_ELEMENT){this.unmarshalElement(f,g,j,h)
-}else{if(i===Jsonix.XML.Input.SPACE||i===Jsonix.XML.Input.COMMENT||i===Jsonix.XML.Input.PROCESSING_INSTRUCTION){}else{throw new Error("Illegal state: unexpected event type ["+i+"].")
-}}i=g.next()
-}},unmarshalElement:function(e,f,h,g){throw new Error("Abstract method [unmarshalElement].")
 },marshal:function(i,l,h,k){if(!Jsonix.Util.Type.exists(i)){return
 }if(Jsonix.Util.Type.exists(this.wrapperElementName)){h.writeStartElement(this.wrapperElementName)
 }if(!this.collection){this.marshalElement(i,l,h,k)
@@ -941,10 +1193,7 @@ g<i.length;
 g++){var j=i[g];
 this.marshalElement(j,l,h,k)
 }}if(Jsonix.Util.Type.exists(this.wrapperElementName)){h.writeEndElement()
-}},marshalElement:function(g,e,f,h){throw new Error("Abstract method [marshalElement].")
-},marshalElementTypeInfo:function(h,i,j,l,g,k){g.writeStartElement(h);
-i.marshal(j,l,g,k);
-g.writeEndElement()
+}},convertFromTypedNamedValue:function(g,e,f,h){return g.value
 },buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
 if(Jsonix.Util.Type.exists(d.value)){throw new Error("The structure already defines a value property.")
 }else{if(!Jsonix.Util.Type.exists(d.elements)){d.elements={}
@@ -952,7 +1201,7 @@ if(Jsonix.Util.Type.exists(d.value)){throw new Error("The structure already defi
 }else{this.buildStructureElements(c,d)
 }},buildStructureElements:function(c,d){throw new Error("Abstract method [buildStructureElements].")
 },CLASS_NAME:"Jsonix.Model.AbstractElementsPropertyInfo"});
-Jsonix.Model.ElementPropertyInfo=Jsonix.Class(Jsonix.Model.AbstractElementsPropertyInfo,{typeInfo:"String",elementName:null,initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
+Jsonix.Model.ElementPropertyInfo=Jsonix.Class(Jsonix.Model.AbstractElementsPropertyInfo,Jsonix.Binding.Marshalls.Element,{typeInfo:"String",elementName:null,initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
 Jsonix.Model.AbstractElementsPropertyInfo.prototype.initialize.apply(this,[d]);
 var f=d.typeInfo||d.ti||"String";
 if(Jsonix.Util.Type.isObject(f)){this.typeInfo=f
@@ -962,28 +1211,34 @@ this.typeInfo=f
 if(Jsonix.Util.Type.isObject(e)){this.elementName=Jsonix.XML.QName.fromObject(e)
 }else{if(Jsonix.Util.Type.isString(e)){this.elementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,e)
 }else{this.elementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,this.name)
-}}},unmarshalElement:function(e,f,h,g){return g(this.typeInfo.unmarshal(e,f,h))
-},marshalElement:function(g,e,f,h){this.marshalElementTypeInfo(this.elementName,this.typeInfo,g,e,f,h)
+}}},getTypeInfoByElementName:function(e,d,f){return this.typeInfo
+},convertToTypedNamedValue:function(g,e,f,h){return{name:this.elementName,value:g,typeInfo:this.typeInfo}
 },doBuild:function(c,d){this.typeInfo=c.resolveTypeInfo(this.typeInfo,d)
 },buildStructureElements:function(c,d){d.elements[this.elementName.key]=this
 },CLASS_NAME:"Jsonix.Model.ElementPropertyInfo"});
-Jsonix.Model.ElementsPropertyInfo=Jsonix.Class(Jsonix.Model.AbstractElementsPropertyInfo,{elementTypeInfos:null,elementTypeInfosMap:null,initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
+Jsonix.Model.ElementsPropertyInfo=Jsonix.Class(Jsonix.Model.AbstractElementsPropertyInfo,Jsonix.Binding.Marshalls.Element,{elementTypeInfos:null,elementTypeInfosMap:null,initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
 Jsonix.Model.AbstractElementsPropertyInfo.prototype.initialize.apply(this,[d]);
-var c=d.elementTypeInfos||d.etis||[];
-Jsonix.Util.Ensure.ensureArray(c);
-this.elementTypeInfos=c
-},unmarshalElement:function(g,h,l,i){var k=h.getNameKey();
-var j=this.elementTypeInfosMap[k];
-if(Jsonix.Util.Type.exists(j)){return i(j.unmarshal(g,h,l))
-}throw new Error("Element ["+k+"] is not known in this context")
-},marshalElement:function(k,n,p,m){for(var o=0;
-o<this.elementTypeInfos.length;
-o++){var i=this.elementTypeInfos[o];
-var l=i.typeInfo;
-if(l.isInstance(k,n,m)){var j=i.elementName;
-this.marshalElementTypeInfo(j,l,k,n,p,m);
-return
-}}throw new Error("Could not find an element with type info supporting the value ["+k+"].")
+var f=d.elementTypeInfos||d.etis||[];
+Jsonix.Util.Ensure.ensureArray(f);
+this.elementTypeInfos=[];
+for(var e=0;
+e<f.length;
+e++){this.elementTypeInfos[e]=Jsonix.Util.Type.cloneObject(f[e])
+}},getTypeInfoByElementName:function(e,d,f){return this.elementTypeInfosMap[e.key]
+},convertToTypedNamedValue:function(q,v,u,o){for(var s=0;
+s<this.elementTypeInfos.length;
+s++){var r=this.elementTypeInfos[s];
+var p=r.typeInfo;
+if(p.isInstance(q,v,o)){var n=r.elementName;
+return{name:n,value:q,typeInfo:p}
+}}if(v.supportXsiType){var w=v.getTypeInfoByValue(q);
+if(w&&w.typeName){for(var t=0;
+t<this.elementTypeInfos.length;
+t++){var z=this.elementTypeInfos[t];
+var x=z.typeInfo;
+if(w.isBasedOn(x)){var y=z.elementName;
+return{name:y,value:q,typeInfo:x}
+}}}}throw new Error("Could not find an element with type info supporting the value ["+q+"].")
 },doBuild:function(k,l){this.elementTypeInfosMap={};
 var i,j;
 for(var g=0;
@@ -993,10 +1248,8 @@ Jsonix.Util.Ensure.ensureObject(h);
 i=h.typeInfo||h.ti||"String";
 h.typeInfo=k.resolveTypeInfo(i,l);
 j=h.elementName||h.en||undefined;
-if(Jsonix.Util.Type.isObject(j)){h.elementName=Jsonix.XML.QName.fromObject(j)
-}else{Jsonix.Util.Ensure.ensureString(j);
-h.elementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,j)
-}this.elementTypeInfosMap[h.elementName.key]=h.typeInfo
+h.elementName=Jsonix.XML.QName.fromObjectOrString(j,k,this.defaultElementNamespaceURI);
+this.elementTypeInfosMap[h.elementName.key]=h.typeInfo
 }},buildStructureElements:function(g,f){for(var h=0;
 h<this.elementTypeInfos.length;
 h++){var e=this.elementTypeInfos[h];
@@ -1013,7 +1266,6 @@ if(Jsonix.Util.Type.isObject(h)){this.elementName=Jsonix.XML.QName.fromObject(h)
 }else{if(Jsonix.Util.Type.isString(h)){this.elementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,h)
 }else{this.elementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,this.name)
 }}this.entryTypeInfo=new Jsonix.Model.ClassInfo({name:"Map<"+e.name+","+f.name+">",propertyInfos:[e,f]})
-},unmarshalWrapperElement:function(h,e,g){var f=Jsonix.Model.AbstractElementsPropertyInfo.prototype.unmarshalWrapperElement.apply(this,arguments)
 },unmarshal:function(l,g,k){var h=null;
 var j=this;
 var i=function(a){if(Jsonix.Util.Type.exists(a)){Jsonix.Util.Ensure.ensureObject(a,"Map property requires an object.");
@@ -1027,10 +1279,11 @@ if(j.collection){if(!Jsonix.Util.Type.exists(h[c])){h[c]=[]
 if(Jsonix.Util.Type.exists(this.wrapperElementName)){this.unmarshalWrapperElement(l,g,k,i)
 }else{this.unmarshalElement(l,g,k,i)
 }return h
-},unmarshalElement:function(l,g,k,i){var j=this.entryTypeInfo.unmarshal(l,g,k);
+},getTypeInfoByInputElement:function(d,e,f){return this.entryTypeInfo
+},convertFromTypedNamedValue:function(i,l,g,k){var j=i.value;
 var h={};
-if(!!j[this.key.name]){h[j[this.key.name]]=j[this.value.name]
-}return i(h)
+if(Jsonix.Util.Type.isString(j[this.key.name])){h[j[this.key.name]]=j[this.value.name]
+}return h
 },marshal:function(g,e,f,h){if(!Jsonix.Util.Type.exists(g)){return
 }if(Jsonix.Util.Type.exists(this.wrapperElementName)){f.writeStartElement(this.wrapperElementName)
 }this.marshalElement(g,e,f,h);
@@ -1064,44 +1317,32 @@ h<k.length;
 h++){i[g].push(k[h])
 }}else{i[g]=k
 }}}}},CLASS_NAME:"Jsonix.Model.ElementMapPropertyInfo"});
-Jsonix.Model.AbstractElementRefsPropertyInfo=Jsonix.Class(Jsonix.Model.PropertyInfo,{wrapperElementName:null,mixed:true,initialize:function(d){Jsonix.Util.Ensure.ensureObject(d,"Mapping must be an object.");
-Jsonix.Model.PropertyInfo.prototype.initialize.apply(this,[d]);
-var e=d.wrapperElementName||d.wen||undefined;
-var f=d.mixed||d.mx||true;
-if(Jsonix.Util.Type.isObject(e)){this.wrapperElementName=Jsonix.XML.QName.fromObject(e)
-}else{if(Jsonix.Util.Type.isString(e)){this.wrapperElementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,e)
+Jsonix.Model.AbstractElementRefsPropertyInfo=Jsonix.Class(Jsonix.Binding.Marshalls.Element,Jsonix.Binding.Marshalls.Element.AsElementRef,Jsonix.Binding.Unmarshalls.Element,Jsonix.Binding.Unmarshalls.WrapperElement,Jsonix.Binding.Unmarshalls.Element.AsElementRef,Jsonix.Model.PropertyInfo,{wrapperElementName:null,allowDom:true,allowTypedObject:true,mixed:true,initialize:function(f){Jsonix.Util.Ensure.ensureObject(f,"Mapping must be an object.");
+Jsonix.Model.PropertyInfo.prototype.initialize.apply(this,[f]);
+var g=f.wrapperElementName||f.wen||undefined;
+if(Jsonix.Util.Type.isObject(g)){this.wrapperElementName=Jsonix.XML.QName.fromObject(g)
+}else{if(Jsonix.Util.Type.isString(g)){this.wrapperElementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,g)
 }else{this.wrapperElementName=null
-}}this.mixed=f
-},unmarshal:function(f,g,j){var h=g.eventType;
-if(h===Jsonix.XML.Input.START_ELEMENT){if(Jsonix.Util.Type.exists(this.wrapperElementName)){return this.unmarshalWrapperElement(f,g,j)
-}else{return this.unmarshalElement(f,g,j)
-}}else{if(this.mixed&&(h===Jsonix.XML.Input.CHARACTERS||h===Jsonix.XML.Input.CDATA||h===Jsonix.XML.Input.ENTITY_REFERENCE)){var i=g.getText();
-if(this.collection){return[i]
-}else{return i
-}}else{if(h===Jsonix.XML.Input.SPACE||h===Jsonix.XML.Input.COMMENT||h===Jsonix.XML.Input.PROCESSING_INSTRUCTION){}else{throw new Error("Illegal state: unexpected event type ["+h+"].")
-}}}},unmarshalWrapperElement:function(o,i,n){var j=null;
-var l=i.next();
-while(l!==Jsonix.XML.Input.END_ELEMENT){if(l===Jsonix.XML.Input.START_ELEMENT){var m=this.unmarshalElement(o,i,n);
-if(this.collection){if(j===null){j=[]
-}for(var p=0;
-p<m.length;
-p++){j.push(m[p])
-}}else{if(j===null){j=m
+}}var h=Jsonix.Util.Type.defaultValue(f.allowDom,f.dom,true);
+var j=Jsonix.Util.Type.defaultValue(f.allowTypedObject,f.typed,true);
+var i=Jsonix.Util.Type.defaultValue(f.mixed,f.mx,true);
+this.allowDom=h;
+this.allowTypedObject=j;
+this.mixed=i
+},unmarshal:function(n,h,m){var i=null;
+var l=this;
+var j=function(a){if(l.collection){if(i===null){i=[]
+}i.push(a)
+}else{if(i===null){i=a
 }else{throw new Error("Value already set.")
-}}}else{if(this.mixed&&(l===Jsonix.XML.Input.CHARACTERS||l===Jsonix.XML.Input.CDATA||l===Jsonix.XML.Input.ENTITY_REFERENCE)){var k=i.getText();
-if(this.collection){if(j===null){j=[]
-}j.push(k)
-}else{if(j===null){j=k
-}else{throw new Error("Value already set.")
-}}}else{if(l===Jsonix.XML.Input.SPACE||l===Jsonix.XML.Input.COMMENT||l===Jsonix.XML.Input.PROCESSING_INSTRUCTION){}else{throw new Error("Illegal state: unexpected event type ["+l+"].")
-}}}l=i.next()
-}return j
-},unmarshalElement:function(l,h,k){var g=h.getName();
-var i=this.getElementTypeInfo(l,g,k);
-var j={name:g,value:i.unmarshal(l,h,k)};
-if(this.collection){return[j]
-}else{return j
-}},marshal:function(i,l,h,k){if(Jsonix.Util.Type.exists(i)){if(Jsonix.Util.Type.exists(this.wrapperElementName)){h.writeStartElement(this.wrapperElementName)
+}}};
+var k=h.eventType;
+if(k===Jsonix.XML.Input.START_ELEMENT){if(Jsonix.Util.Type.exists(this.wrapperElementName)){this.unmarshalWrapperElement(n,h,m,j)
+}else{this.unmarshalElement(n,h,m,j)
+}}else{if(this.mixed&&(k===Jsonix.XML.Input.CHARACTERS||k===Jsonix.XML.Input.CDATA||k===Jsonix.XML.Input.ENTITY_REFERENCE)){j(h.getText())
+}else{if(k===Jsonix.XML.Input.SPACE||k===Jsonix.XML.Input.COMMENT||k===Jsonix.XML.Input.PROCESSING_INSTRUCTION){}else{throw new Error("Illegal state: unexpected event type ["+k+"].")
+}}}return i
+},marshal:function(i,l,h,k){if(Jsonix.Util.Type.exists(i)){if(Jsonix.Util.Type.exists(this.wrapperElementName)){h.writeStartElement(this.wrapperElementName)
 }if(!this.collection){this.marshalItem(i,l,h,k)
 }else{Jsonix.Util.Ensure.ensureArray(i,"Collection property requires an array value.");
 for(var g=0;
@@ -1111,26 +1352,22 @@ this.marshalItem(j,l,h,k)
 }}if(Jsonix.Util.Type.exists(this.wrapperElementName)){h.writeEndElement()
 }}},marshalItem:function(g,e,f,h){if(Jsonix.Util.Type.isString(g)){if(!this.mixed){throw new Error("Property is not mixed, can't handle string values.")
 }else{f.writeCharacters(g)
-}}else{if(Jsonix.Util.Type.isObject(g)){this.marshalElement(g,e,f,h)
+}}else{if(this.allowDom&&Jsonix.Util.Type.exists(g.nodeType)){f.writeNode(g)
+}else{if(Jsonix.Util.Type.isObject(g)){this.marshalElement(g,e,f,h)
 }else{if(this.mixed){throw new Error("Unsupported content type, either objects or strings are supported.")
 }else{throw new Error("Unsupported content type, only objects are supported.")
-}}}},marshalElement:function(i,l,g,k){var h=Jsonix.XML.QName.fromObject(i.name);
-var j=this.getElementTypeInfo(l,h,k);
-return this.marshalElementTypeInfo(h,j,i,l,g,k)
-},marshalElementTypeInfo:function(h,i,j,l,g,k){g.writeStartElement(h);
-if(Jsonix.Util.Type.exists(j.value)){i.marshal(j.value,l,g,k)
-}g.writeEndElement()
-},getElementTypeInfo:function(f,g,i){var j=this.getPropertyElementTypeInfo(g);
+}}}}},getTypeInfoByElementName:function(g,f,i){var j=this.getPropertyElementTypeInfo(g,f);
 if(Jsonix.Util.Type.exists(j)){return j.typeInfo
 }else{var h=f.getElementInfo(g,i);
 if(Jsonix.Util.Type.exists(h)){return h.typeInfo
-}else{throw new Error("Element ["+g.key+"] is not known in this context.")
-}}},getPropertyElementTypeInfo:function(b){throw new Error("Abstract method [getPropertyElementTypeInfo].")
+}else{return undefined
+}}},getPropertyElementTypeInfo:function(d,c){throw new Error("Abstract method [getPropertyElementTypeInfo].")
 },buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
 if(Jsonix.Util.Type.exists(d.value)){throw new Error("The structure already defines a value property.")
 }else{if(!Jsonix.Util.Type.exists(d.elements)){d.elements={}
 }}if(Jsonix.Util.Type.exists(this.wrapperElementName)){d.elements[this.wrapperElementName.key]=this
 }else{this.buildStructureElements(c,d)
+}if((this.allowDom||this.allowTypedObject)){d.any=this
 }if(this.mixed&&!Jsonix.Util.Type.exists(this.wrapperElementName)){d.mixed=this
 }},buildStructureElements:function(c,d){throw new Error("Abstract method [buildStructureElements].")
 },buildStructureElementTypeInfos:function(k,h,g){h.elements[g.elementName.key]=this;
@@ -1139,7 +1376,7 @@ if(Jsonix.Util.Type.isArray(l)){for(var i=0;
 i<l.length;
 i++){var j=l[i];
 this.buildStructureElementTypeInfos(k,h,j)
-}}},CLASS_NAME:"Jsonix.Model.ElementRefPropertyInfo"});
+}}},CLASS_NAME:"Jsonix.Model.AbstractElementRefsPropertyInfo"});
 Jsonix.Model.ElementRefPropertyInfo=Jsonix.Class(Jsonix.Model.AbstractElementRefsPropertyInfo,{typeInfo:"String",elementName:null,initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
 Jsonix.Model.AbstractElementRefsPropertyInfo.prototype.initialize.apply(this,[d]);
 var f=d.typeInfo||d.ti||"String";
@@ -1150,22 +1387,24 @@ this.typeInfo=f
 if(Jsonix.Util.Type.isObject(e)){this.elementName=Jsonix.XML.QName.fromObject(e)
 }else{if(Jsonix.Util.Type.isString(e)){this.elementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,e)
 }else{this.elementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,this.name)
-}}},getPropertyElementTypeInfo:function(d){Jsonix.Util.Ensure.ensureObject(d);
-var c=Jsonix.XML.QName.fromObject(d);
-if(c.key===this.elementName.key){return this
+}}},getPropertyElementTypeInfo:function(e,f){var d=Jsonix.XML.QName.fromObjectOrString(e,f);
+if(d.key===this.elementName.key){return this
 }else{return null
 }},doBuild:function(c,d){this.typeInfo=c.resolveTypeInfo(this.typeInfo,d)
 },buildStructureElements:function(c,d){this.buildStructureElementTypeInfos(c,d,this)
 },CLASS_NAME:"Jsonix.Model.ElementRefPropertyInfo"});
+Jsonix.Model.ElementRefPropertyInfo.Simplified=Jsonix.Class(Jsonix.Model.ElementRefPropertyInfo,Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef,{CLASS_NAME:"Jsonix.Model.ElementRefPropertyInfo.Simplified"});
 Jsonix.Model.ElementRefsPropertyInfo=Jsonix.Class(Jsonix.Model.AbstractElementRefsPropertyInfo,{elementTypeInfos:null,elementTypeInfosMap:null,initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
 Jsonix.Model.AbstractElementRefsPropertyInfo.prototype.initialize.apply(this,[d]);
-var c=d.elementTypeInfos||d.etis||[];
-Jsonix.Util.Ensure.ensureArray(c);
-this.elementTypeInfos=c
-},getPropertyElementTypeInfo:function(e){Jsonix.Util.Ensure.ensureObject(e);
-var d=Jsonix.XML.QName.fromObject(e);
-var f=this.elementTypeInfosMap[d.key];
-if(Jsonix.Util.Type.exists(f)){return{elementName:d,typeInfo:f}
+var f=d.elementTypeInfos||d.etis||[];
+Jsonix.Util.Ensure.ensureArray(f);
+this.elementTypeInfos=[];
+for(var e=0;
+e<f.length;
+e++){this.elementTypeInfos[e]=Jsonix.Util.Type.cloneObject(f[e])
+}},getPropertyElementTypeInfo:function(f,h){var e=Jsonix.XML.QName.fromObjectOrString(f,h);
+var g=this.elementTypeInfosMap[e.key];
+if(Jsonix.Util.Type.exists(g)){return{elementName:e,typeInfo:g}
 }else{return null
 }},doBuild:function(k,l){this.elementTypeInfosMap={};
 var i,j;
@@ -1176,77 +1415,67 @@ Jsonix.Util.Ensure.ensureObject(h);
 i=h.typeInfo||h.ti||"String";
 h.typeInfo=k.resolveTypeInfo(i,l);
 j=h.elementName||h.en||undefined;
-if(Jsonix.Util.Type.isObject(j)){h.elementName=Jsonix.XML.QName.fromObject(j)
-}else{Jsonix.Util.Ensure.ensureString(j);
-h.elementName=new Jsonix.XML.QName(this.defaultElementNamespaceURI,j)
-}this.elementTypeInfosMap[h.elementName.key]=h.typeInfo
+h.elementName=Jsonix.XML.QName.fromObjectOrString(j,k,this.defaultElementNamespaceURI);
+this.elementTypeInfosMap[h.elementName.key]=h.typeInfo
 }},buildStructureElements:function(g,f){for(var h=0;
 h<this.elementTypeInfos.length;
 h++){var e=this.elementTypeInfos[h];
 this.buildStructureElementTypeInfos(g,f,e)
 }},CLASS_NAME:"Jsonix.Model.ElementRefsPropertyInfo"});
-Jsonix.Model.AnyElementPropertyInfo=Jsonix.Class(Jsonix.Model.PropertyInfo,{allowDom:true,allowTypedObject:true,mixed:true,initialize:function(f){Jsonix.Util.Ensure.ensureObject(f);
+Jsonix.Model.ElementRefsPropertyInfo.Simplified=Jsonix.Class(Jsonix.Model.ElementRefsPropertyInfo,Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef,{CLASS_NAME:"Jsonix.Model.ElementRefsPropertyInfo.Simplified"});
+Jsonix.Model.AnyElementPropertyInfo=Jsonix.Class(Jsonix.Binding.Marshalls.Element,Jsonix.Binding.Marshalls.Element.AsElementRef,Jsonix.Binding.Unmarshalls.Element,Jsonix.Binding.Unmarshalls.Element.AsElementRef,Jsonix.Model.PropertyInfo,{allowDom:true,allowTypedObject:true,mixed:true,initialize:function(f){Jsonix.Util.Ensure.ensureObject(f);
 Jsonix.Model.PropertyInfo.prototype.initialize.apply(this,[f]);
-var g=f.allowDom||f.dom||true;
-var e=f.allowTypedObject||f.typed||true;
-var h=f.mixed||f.mx||true;
+var g=Jsonix.Util.Type.defaultValue(f.allowDom,f.dom,true);
+var e=Jsonix.Util.Type.defaultValue(f.allowTypedObject,f.typed,true);
+var h=Jsonix.Util.Type.defaultValue(f.mixed,f.mx,true);
 this.allowDom=g;
 this.allowTypedObject=e;
 this.mixed=h
-},unmarshal:function(f,g,j){var h=g.eventType;
-if(h===Jsonix.XML.Input.START_ELEMENT){return this.unmarshalElement(f,g,j)
-}else{if(this.mixed&&(h===Jsonix.XML.Input.CHARACTERS||h===Jsonix.XML.Input.CDATA||h===Jsonix.XML.Input.ENTITY_REFERENCE)){var i=g.getText();
-if(this.collection){return[i]
-}else{return i
-}}else{if(this.mixed&&(h===Jsonix.XML.Input.SPACE)){return null
-}else{if(h===Jsonix.XML.Input.COMMENT||h===Jsonix.XML.Input.PROCESSING_INSTRUCTION){return null
-}else{throw new Error("Illegal state: unexpected event type ["+h+"].")
-}}}}},unmarshalElement:function(n,p,m){var o=p.getName();
-var k;
-if(this.allowTypedObject&&Jsonix.Util.Type.exists(n.getElementInfo(o,m))){var i=n.getElementInfo(o,m);
-var l=i.typeInfo;
-var j=Jsonix.Model.Adapter.getAdapter(i);
-k={name:o,value:j.unmarshal(l,n,p,m)}
-}else{if(this.allowDom){k=p.getElement()
-}else{throw new Error("Element ["+o.toString()+"] is not known in this context and property does not allow DOM.")
-}}if(this.collection){return[k]
-}else{return k
-}},marshal:function(h,j,g,i){if(!Jsonix.Util.Type.exists(h)){return
+},unmarshal:function(n,h,m){var i=null;
+var l=this;
+var j=function(a){if(l.collection){if(i===null){i=[]
+}i.push(a)
+}else{if(i===null){i=a
+}else{throw new Error("Value already set.")
+}}};
+var k=h.eventType;
+if(k===Jsonix.XML.Input.START_ELEMENT){this.unmarshalElement(n,h,m,j)
+}else{if(this.mixed&&(k===Jsonix.XML.Input.CHARACTERS||k===Jsonix.XML.Input.CDATA||k===Jsonix.XML.Input.ENTITY_REFERENCE)){j(h.getText())
+}else{if(this.mixed&&(k===Jsonix.XML.Input.SPACE)){}else{if(k===Jsonix.XML.Input.COMMENT||k===Jsonix.XML.Input.PROCESSING_INSTRUCTION){}else{throw new Error("Illegal state: unexpected event type ["+k+"].")
+}}}}return i
+},marshal:function(h,j,g,i){if(!Jsonix.Util.Type.exists(h)){return
 }if(!this.collection){this.marshalItem(h,j,g,i)
 }else{Jsonix.Util.Ensure.ensureArray(h);
 for(var f=0;
 f<h.length;
 f++){this.marshalItem(h[f],j,g,i)
-}}},marshalItem:function(k,n,p,m){if(this.mixed&&Jsonix.Util.Type.isString(k)){p.writeCharacters(k)
-}else{if(this.allowDom&&Jsonix.Util.Type.exists(k.nodeType)){p.writeNode(k)
-}else{var o=Jsonix.XML.QName.fromObject(k.name);
-if(this.allowTypedObject&&Jsonix.Util.Type.exists(n.getElementInfo(o,m))){var i=n.getElementInfo(o,m);
-var l=i.typeInfo;
-var j=Jsonix.Model.Adapter.getAdapter(i);
-p.writeStartElement(o);
-j.marshal(l,k.value,n,p,m);
-p.writeEndElement()
-}else{throw new Error("Element ["+o.toString()+"] is not known in this context")
+}}},marshalItem:function(g,e,f,h){if(this.mixed&&Jsonix.Util.Type.isString(g)){f.writeCharacters(g)
+}else{if(this.allowDom&&Jsonix.Util.Type.exists(g.nodeType)){f.writeNode(g)
+}else{if(this.allowTypedObject){this.marshalElement(g,e,f,h)
 }}}},doBuild:function(c,d){},buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
 if(Jsonix.Util.Type.exists(d.value)){throw new Error("The structure already defines a value property.")
 }else{if(!Jsonix.Util.Type.exists(d.elements)){d.elements={}
 }}if((this.allowDom||this.allowTypedObject)){d.any=this
 }if(this.mixed){d.mixed=this
 }},CLASS_NAME:"Jsonix.Model.AnyElementPropertyInfo"});
-Jsonix.Model.Module=Jsonix.Class({name:null,typeInfos:null,elementInfos:null,defaultElementNamespaceURI:"",defaultAttributeNamespaceURI:"",initialize:function(h){this.typeInfos=[];
+Jsonix.Model.AnyElementPropertyInfo.Simplified=Jsonix.Class(Jsonix.Model.AnyElementPropertyInfo,Jsonix.Binding.Unmarshalls.Element.AsSimplifiedElementRef,{CLASS_NAME:"Jsonix.Model.AnyElementPropertyInfo.Simplified"});
+Jsonix.Model.Module=Jsonix.Class(Jsonix.Mapping.Styled,{name:null,typeInfos:null,elementInfos:null,targetNamespace:"",defaultElementNamespaceURI:"",defaultAttributeNamespaceURI:"",initialize:function(r,j){Jsonix.Mapping.Styled.prototype.initialize.apply(this,[j]);
+this.typeInfos=[];
 this.elementInfos=[];
-if(typeof h!=="undefined"){Jsonix.Util.Ensure.ensureObject(h);
-var j=h.name||h.n||null;
-this.name=j;
-var m=h.defaultElementNamespaceURI||h.dens||"";
-this.defaultElementNamespaceURI=m;
-var k=h.defaultAttributeNamespaceURI||h.dans||"";
-this.defaultAttributeNamespaceURI=k;
-var n=h.typeInfos||h.tis||[];
-this.initializeTypeInfos(n);
-for(var i in h){if(h.hasOwnProperty(i)){if(h[i] instanceof Jsonix.Model.ClassInfo){this.typeInfos.push(h[i])
-}}}var l=h.elementInfos||h.eis||[];
-this.initializeElementInfos(l)
+if(typeof r!=="undefined"){Jsonix.Util.Ensure.ensureObject(r);
+var q=r.name||r.n||null;
+this.name=q;
+var n=r.defaultElementNamespaceURI||r.dens||r.targetNamespace||r.tns||"";
+this.defaultElementNamespaceURI=n;
+var k=r.targetNamespace||r.tns||r.defaultElementNamespaceURI||r.dens||this.defaultElementNamespaceURI;
+this.targetNamespace=k;
+var l=r.defaultAttributeNamespaceURI||r.dans||"";
+this.defaultAttributeNamespaceURI=l;
+var m=r.typeInfos||r.tis||[];
+this.initializeTypeInfos(m);
+for(var p in r){if(r.hasOwnProperty(p)){if(r[p] instanceof this.mappingStyle.classInfo){this.typeInfos.push(r[p])
+}}}var o=r.elementInfos||r.eis||[];
+this.initializeElementInfos(o)
 }},initializeTypeInfos:function(f){Jsonix.Util.Ensure.ensureArray(f);
 var h,e,g;
 for(h=0;
@@ -1264,7 +1493,8 @@ this.elementInfos.push(g)
 }},createTypeInfo:function(f){Jsonix.Util.Ensure.ensureObject(f);
 var g;
 if(f instanceof Jsonix.Model.TypeInfo){g=f
-}else{var e=f.type||f.t||"classInfo";
+}else{f=Jsonix.Util.Type.cloneObject(f);
+var e=f.type||f.t||"classInfo";
 if(Jsonix.Util.Type.isFunction(this.typeInfoCreators[e])){var h=this.typeInfoCreators[e];
 g=h.call(this,f)
 }else{throw new Error("Unknown type info type ["+e+"].")
@@ -1274,28 +1504,37 @@ e.localName=d;
 var f=e.name||e.n||null;
 e.name=f;
 if(Jsonix.Util.Type.isString(e.name)){if(e.name.length>0&&e.name.charAt(0)==="."&&Jsonix.Util.Type.isString(this.name)){e.name=this.name+e.name
-}}else{if(Jsonix.Util.Type.isString(e.localName)){if(Jsonix.Util.Type.isString(this.name)){e.name=this.name+"."+e.localName
-}else{e.name=e.localName
+}}else{if(Jsonix.Util.Type.isString(d)){if(Jsonix.Util.Type.isString(this.name)){e.name=this.name+"."+d
+}else{e.name=d
 }}else{throw new Error("Neither [name/n] nor [localName/ln] was provided for the class info.")
 }}},createClassInfo:function(f){Jsonix.Util.Ensure.ensureObject(f);
-var e=f.defaultElementNamespaceURI||f.dens||this.defaultElementNamespaceURI;
-f.defaultElementNamespaceURI=e;
-var g=f.defaultAttributeNamespaceURI||f.dans||this.defaultAttributeNamespaceURI;
-f.defaultAttributeNamespaceURI=g;
+var j=f.defaultElementNamespaceURI||f.dens||this.defaultElementNamespaceURI;
+f.defaultElementNamespaceURI=j;
+var g=f.targetNamespace||f.tns||this.targetNamespace;
+f.targetNamespace=g;
+var h=f.defaultAttributeNamespaceURI||f.dans||this.defaultAttributeNamespaceURI;
+f.defaultAttributeNamespaceURI=h;
 this.initializeNames(f);
-var h=new Jsonix.Model.ClassInfo(f);
-return h
+var i=new this.mappingStyle.classInfo(f,{mappingStyle:this.mappingStyle});
+i.module=this;
+return i
 },createEnumLeafInfo:function(d){Jsonix.Util.Ensure.ensureObject(d);
 this.initializeNames(d);
-var c=new Jsonix.Model.EnumLeafInfo(d);
+var c=new this.mappingStyle.enumLeafInfo(d,{mappingStyle:this.mappingStyle});
+c.module=this;
 return c
-},createList:function(e){Jsonix.Util.Ensure.ensureObject(e);
-var g=e.baseTypeInfo||e.typeInfo||e.bti||e.ti||"String";
-var f=e.typeName||e.tn||null;
-var h=e.separator||e.sep||" ";
-Jsonix.Util.Ensure.ensureExists(g);
-return new Jsonix.Schema.XSD.List(g,f,h)
+},createList:function(f){Jsonix.Util.Ensure.ensureObject(f);
+var h=f.baseTypeInfo||f.typeInfo||f.bti||f.ti||"String";
+var g=f.typeName||f.tn||null;
+if(Jsonix.Util.Type.exists(g)){if(Jsonix.Util.Type.isString(g)){g=new Jsonix.XML.QName(this.targetNamespace,g)
+}else{g=Jsonix.XML.QName.fromObject(g)
+}}var i=f.separator||f.sep||" ";
+Jsonix.Util.Ensure.ensureExists(h);
+var j=new Jsonix.Schema.XSD.List(h,g,i);
+j.module=this;
+return j
 },createElementInfo:function(g){Jsonix.Util.Ensure.ensureObject(g);
+g=Jsonix.Util.Type.cloneObject(g);
 var i=g.defaultElementNamespaceURI||g.dens||this.defaultElementNamespaceURI;
 g.defaultElementNamespaceURI=i;
 var h=g.elementName||g.en||undefined;
@@ -1310,7 +1549,8 @@ if(Jsonix.Util.Type.isObject(h)){g.elementName=Jsonix.XML.QName.fromObject(h)
 if(Jsonix.Util.Type.exists(l)){if(Jsonix.Util.Type.isObject(l)){g.substitutionHead=Jsonix.XML.QName.fromObject(l)
 }else{Jsonix.Util.Ensure.ensureString(l);
 g.substitutionHead=new Jsonix.XML.QName(this.defaultElementNamespaceURI,l)
-}}var k=new Jsonix.Model.ElementInfo(g);
+}}var k=new this.mappingStyle.elementInfo(g,{mappingStyle:this.mappingStyle});
+k.module=this;
 return k
 },registerTypeInfos:function(d){for(var e=0;
 e<this.typeInfos.length;
@@ -1332,6 +1572,12 @@ f.build(d,this)
 },es:function(){return this
 },CLASS_NAME:"Jsonix.Model.Module"});
 Jsonix.Model.Module.prototype.typeInfoCreators={classInfo:Jsonix.Model.Module.prototype.createClassInfo,c:Jsonix.Model.Module.prototype.createClassInfo,enumInfo:Jsonix.Model.Module.prototype.createEnumLeafInfo,"enum":Jsonix.Model.Module.prototype.createEnumLeafInfo,list:Jsonix.Model.Module.prototype.createList,l:Jsonix.Model.Module.prototype.createList};
+Jsonix.Mapping.Style.Standard=Jsonix.Class(Jsonix.Mapping.Style,{marshaller:Jsonix.Binding.Marshaller,unmarshaller:Jsonix.Binding.Unmarshaller,module:Jsonix.Model.Module,elementInfo:Jsonix.Model.ElementInfo,classInfo:Jsonix.Model.ClassInfo,enumLeafInfo:Jsonix.Model.EnumLeafInfo,anyAttributePropertyInfo:Jsonix.Model.AnyAttributePropertyInfo,anyElementPropertyInfo:Jsonix.Model.AnyElementPropertyInfo,attributePropertyInfo:Jsonix.Model.AttributePropertyInfo,elementMapPropertyInfo:Jsonix.Model.ElementMapPropertyInfo,elementPropertyInfo:Jsonix.Model.ElementPropertyInfo,elementsPropertyInfo:Jsonix.Model.ElementsPropertyInfo,elementRefPropertyInfo:Jsonix.Model.ElementRefPropertyInfo,elementRefsPropertyInfo:Jsonix.Model.ElementRefsPropertyInfo,valuePropertyInfo:Jsonix.Model.ValuePropertyInfo,initialize:function(){Jsonix.Mapping.Style.prototype.initialize.apply(this)
+},CLASS_NAME:"Jsonix.Mapping.Style.Standard"});
+Jsonix.Mapping.Style.STYLES.standard=new Jsonix.Mapping.Style.Standard();
+Jsonix.Mapping.Style.Simplified=Jsonix.Class(Jsonix.Mapping.Style,{marshaller:Jsonix.Binding.Marshaller.Simplified,unmarshaller:Jsonix.Binding.Unmarshaller.Simplified,module:Jsonix.Model.Module,elementInfo:Jsonix.Model.ElementInfo,classInfo:Jsonix.Model.ClassInfo,enumLeafInfo:Jsonix.Model.EnumLeafInfo,anyAttributePropertyInfo:Jsonix.Model.AnyAttributePropertyInfo.Simplified,anyElementPropertyInfo:Jsonix.Model.AnyElementPropertyInfo.Simplified,attributePropertyInfo:Jsonix.Model.AttributePropertyInfo,elementMapPropertyInfo:Jsonix.Model.ElementMapPropertyInfo,elementPropertyInfo:Jsonix.Model.ElementPropertyInfo,elementsPropertyInfo:Jsonix.Model.ElementsPropertyInfo,elementRefPropertyInfo:Jsonix.Model.ElementRefPropertyInfo.Simplified,elementRefsPropertyInfo:Jsonix.Model.ElementRefsPropertyInfo.Simplified,valuePropertyInfo:Jsonix.Model.ValuePropertyInfo,initialize:function(){Jsonix.Mapping.Style.prototype.initialize.apply(this)
+},CLASS_NAME:"Jsonix.Mapping.Style.Simplified"});
+Jsonix.Mapping.Style.STYLES.simplified=new Jsonix.Mapping.Style.Simplified();
 Jsonix.Schema.XSD={};
 Jsonix.Schema.XSD.NAMESPACE_URI="http://www.w3.org/2001/XMLSchema";
 Jsonix.Schema.XSD.PREFIX="xsd";
@@ -1342,8 +1588,9 @@ Jsonix.Schema.XSD.AnyType=Jsonix.Class(Jsonix.Model.ClassInfo,{typeName:Jsonix.S
 },CLASS_NAME:"Jsonix.Schema.XSD.AnyType"});
 Jsonix.Schema.XSD.AnyType.INSTANCE=new Jsonix.Schema.XSD.AnyType();
 Jsonix.Schema.XSD.AnySimpleType=Jsonix.Class(Jsonix.Model.TypeInfo,{name:"AnySimpleType",typeName:Jsonix.Schema.XSD.qname("anySimpleType"),initialize:function(){Jsonix.Model.TypeInfo.prototype.initialize.apply(this,[])
-},print:function(g,e,f,h){throw new Error("Abstract method [print].")
-},parse:function(g,e,f,h){throw new Error("Abstract method [parse].")
+},print:function(g,e,f,h){return g
+},parse:function(g,e,f,h){return g
+},isInstance:function(f,e,d){return true
 },reprint:function(g,e,f,h){if(Jsonix.Util.Type.isString(g)&&!this.isInstance(g,e,h)){return this.print(this.parse(g,e,null,h),e,f,h)
 }else{return this.print(g,e,f,h)
 }},unmarshal:function(e,f,h){var g=f.getElementText();
@@ -1351,6 +1598,7 @@ if(Jsonix.Util.StringUtils.isNotBlank(g)){return this.parse(g,e,f,h)
 }else{return null
 }},marshal:function(g,e,f,h){if(Jsonix.Util.Type.exists(g)){f.writeCharacters(this.reprint(g,e,f,h))
 }},build:function(c,d){},CLASS_NAME:"Jsonix.Schema.XSD.AnySimpleType"});
+Jsonix.Schema.XSD.AnySimpleType.INSTANCE=new Jsonix.Schema.XSD.AnySimpleType();
 Jsonix.Schema.XSD.List=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:null,typeName:null,typeInfo:null,separator:" ",trimmedSeparator:Jsonix.Util.StringUtils.whitespaceCharacters,simpleType:true,built:false,initialize:function(e,f,h){Jsonix.Util.Ensure.ensureExists(e);
 this.typeInfo=e;
 if(!Jsonix.Util.Type.exists(this.name)){this.name=e.name+"*"
@@ -1360,7 +1608,7 @@ if(!Jsonix.Util.Type.exists(this.name)){this.name=e.name+"*"
 }var g=Jsonix.Util.StringUtils.trim(this.separator);
 if(g.length===0){this.trimmedSeparator=Jsonix.Util.StringUtils.whitespaceCharacters
 }else{this.trimmedSeparator=g
-}},build:function(c,d){if(!this.built){this.typeInfo=c.resolveTypeInfo(this.typeInfo,d);
+}},build:function(b){if(!this.built){this.typeInfo=b.resolveTypeInfo(this.typeInfo,this.module);
 this.built=true
 }},print:function(i,k,g,j){if(!Jsonix.Util.Type.exists(i)){return null
 }Jsonix.Util.Ensure.ensureArray(i);
@@ -1378,7 +1626,9 @@ m<h.length;
 m++){i.push(this.typeInfo.parse(Jsonix.Util.StringUtils.trim(h[m]),l,n,k))
 }return i
 },CLASS_NAME:"Jsonix.Schema.XSD.List"});
-Jsonix.Schema.XSD.String=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"String",typeName:Jsonix.Schema.XSD.qname("string"),print:function(g,e,f,h){Jsonix.Util.Ensure.ensureString(g);
+Jsonix.Schema.XSD.String=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"String",typeName:Jsonix.Schema.XSD.qname("string"),unmarshal:function(e,f,h){var g=f.getElementText();
+return this.parse(g,e,f,h)
+},print:function(g,e,f,h){Jsonix.Util.Ensure.ensureString(g);
 return g
 },parse:function(g,e,f,h){Jsonix.Util.Ensure.ensureString(g);
 return g
@@ -1639,140 +1889,82 @@ if(Jsonix.Util.Type.isString(q)){return new Jsonix.XML.QName(q,n,m)
 },CLASS_NAME:"Jsonix.Schema.XSD.QName"});
 Jsonix.Schema.XSD.QName.INSTANCE=new Jsonix.Schema.XSD.QName();
 Jsonix.Schema.XSD.QName.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.QName.INSTANCE);
-Jsonix.Schema.XSD.Calendar=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"Calendar",typeName:Jsonix.Schema.XSD.qname("calendar"),parse:function(k,n,p,m){Jsonix.Util.Ensure.ensureString(k);
-var o=(k.charAt(0)==="-");
-var i=o?-1:1;
-var l=o?k.substring(1):k;
-var j;
-if(l.length>=19&&l.charAt(4)==="-"&&l.charAt(7)==="-"&&l.charAt(10)==="T"&&l.charAt(13)===":"&&l.charAt(16)===":"){return this.parseDateTime(k)
-}else{if(l.length>=10&&l.charAt(4)==="-"&&l.charAt(7)==="-"){return this.parseDate(k)
-}else{if(l.length>=8&&l.charAt(2)===":"&&l.charAt(5)===":"){return this.parseTime(k)
-}else{throw new Error("Value ["+k+"] does not match dateTime, date or time patterns.")
-}}}},parseDateTime:function(p){Jsonix.Util.Ensure.ensureString(p);
-var w=(p.charAt(0)==="-");
-var B=w?-1:1;
-var v=w?p.substring(1):p;
-if(v.length<19||v.charAt(4)!=="-"||v.charAt(7)!=="-"||v.charAt(10)!=="T"||v.charAt(13)!==":"||v.charAt(16)!==":"){throw new Error("Date time string ["+v+"] must be a string in format ['-'? yyyy '-' mm '-' dd 'T' hh ':' mm ':' ss ('.' s+)? (zzzzzz)?].")
-}var x;
-var A=v.indexOf("+",19);
-if(A>=0){x=A
-}else{var u=v.indexOf("-",19);
-if(u>=0){x=u
-}else{var s=v.indexOf("Z",19);
-if(s>=0){x=s
-}else{x=v.length
-}}}var C=x>0&&x<v.length;
-var r=v.substring(0,10);
-var D=C?v.substring(11,x):v.substring(11);
-var q=C?v.substring(x):"";
-var y=this.parseDateString(r);
-var z=this.parseTimeString(D);
-var t=this.parseTimeZoneString(q);
-return Jsonix.XML.Calendar.fromObject({year:B*y.year,month:y.month,day:y.day,hour:z.hour,minute:z.minute,second:z.second,fractionalSecond:z.fractionalSecond,timezone:t})
-},parseDate:function(n){Jsonix.Util.Ensure.ensureString(n);
-var u=(n.charAt(0)==="-");
-var y=u?-1:1;
-var r=u?n.substring(1):n;
-var v;
-var x=r.indexOf("+",10);
-if(x>=0){v=x
-}else{var t=r.indexOf("-",10);
-if(t>=0){v=t
-}else{var q=r.indexOf("Z",10);
-if(q>=0){v=q
-}else{v=r.length
-}}}var z=v>0&&v<r.length;
-var p=z?r.substring(0,v):r;
-var w=this.parseDateString(p);
-var o=z?n.substring(v):"";
-var s=this.parseTimeZoneString(o);
-return Jsonix.XML.Calendar.fromObject({year:y*w.year,month:w.month,day:w.day,timezone:s})
-},parseTime:function(k){Jsonix.Util.Ensure.ensureString(k);
-var p;
-var r=k.indexOf("+",7);
-if(r>=0){p=r
-}else{var o=k.indexOf("-",7);
-if(o>=0){p=o
-}else{var m=k.indexOf("Z",7);
-if(m>=0){p=m
-}else{p=k.length
-}}}var s=p>0&&p<k.length;
-var t=s?k.substring(0,p):k;
-var q=this.parseTimeString(t);
-var l=s?k.substring(p):"";
-var n=this.parseTimeZoneString(l);
-return Jsonix.XML.Calendar.fromObject({hour:q.hour,minute:q.minute,second:q.second,fractionalSecond:q.fractionalSecond,timezone:n})
-},parseDateString:function(g){Jsonix.Util.Ensure.ensureString(g);
-if(g.length!==10){throw new Error("Date string ["+g+"] must be 10 characters long.")
-}if(g.charAt(4)!=="-"||g.charAt(7)!=="-"){throw new Error("Date string ["+g+"] must be a string in format [yyyy '-' mm '-' ss ].")
-}var e=this.parseYear(g.substring(0,4));
-var h=this.parseMonth(g.substring(5,7));
-var f=this.parseDay(g.substring(8,10));
-return{year:e,month:h,day:f}
-},parseTimeString:function(r){Jsonix.Util.Ensure.ensureString(r);
-if(r.length<8||r.charAt(2)!==":"||r.charAt(5)!==":"){throw new Error("Time string ["+r+"] must be a string in format [hh ':' mm ':' ss ('.' s+)?].")
-}var n=r.substring(0,2);
-var k=r.substring(3,5);
-var p=r.substring(6,8);
-var j=r.length>=9?r.substring(8):"";
-var m=this.parseHour(n);
-var o=this.parseHour(k);
-var q=this.parseSecond(p);
-var l=this.parseFractionalSecond(j);
-return{hour:m,minute:o,second:q,fractionalSecond:l}
-},parseTimeZoneString:function(i){Jsonix.Util.Ensure.ensureString(i);
-if(i===""){return NaN
+Jsonix.Schema.XSD.Calendar=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"Calendar",typeName:Jsonix.Schema.XSD.qname("calendar"),parse:function(g,e,f,h){Jsonix.Util.Ensure.ensureString(g);
+if(g.match(new RegExp("^"+Jsonix.Schema.XSD.Calendar.DATETIME_PATTERN+"$"))){return this.parseDateTime(g,e,f,h)
+}else{if(g.match(new RegExp("^"+Jsonix.Schema.XSD.Calendar.DATE_PATTERN+"$"))){return this.parseDate(g,e,f,h)
+}else{if(g.match(new RegExp("^"+Jsonix.Schema.XSD.Calendar.TIME_PATTERN+"$"))){return this.parseTime(g,e,f,h)
+}else{if(g.match(new RegExp("^"+Jsonix.Schema.XSD.Calendar.GYEAR_MONTH_PATTERN+"$"))){return this.parseGYearMonth(g,e,f,h)
+}else{if(g.match(new RegExp("^"+Jsonix.Schema.XSD.Calendar.GYEAR_PATTERN+"$"))){return this.parseGYear(g,e,f,h)
+}else{if(g.match(new RegExp("^"+Jsonix.Schema.XSD.Calendar.GMONTH_DAY_PATTERN+"$"))){return this.parseGMonthDay(g,e,f,h)
+}else{if(g.match(new RegExp("^"+Jsonix.Schema.XSD.Calendar.GMONTH_PATTERN+"$"))){return this.parseGMonth(g,e,f,h)
+}else{if(g.match(new RegExp("^"+Jsonix.Schema.XSD.Calendar.GDAY_PATTERN+"$"))){return this.parseGDay(g,e,f,h)
+}else{throw new Error("Value ["+g+"] does not match xs:dateTime, xs:date, xs:time, xs:gYearMonth, xs:gYear, xs:gMonthDay, xs:gMonth or xs:gDay patterns.")
+}}}}}}}}},parseGYearMonth:function(j,n,i,m){var l=new RegExp("^"+Jsonix.Schema.XSD.Calendar.GYEAR_MONTH_PATTERN+"$");
+var h=j.match(l);
+if(h!==null){var k={year:parseInt(h[1],10),month:parseInt(h[5],10),timezone:this.parseTimezoneString(h[7])};
+return new Jsonix.XML.Calendar(k)
+}throw new Error("Value ["+j+"] does not match the xs:gYearMonth pattern.")
+},parseGYear:function(j,n,i,m){var l=new RegExp("^"+Jsonix.Schema.XSD.Calendar.GYEAR_PATTERN+"$");
+var h=j.match(l);
+if(h!==null){var k={year:parseInt(h[1],10),timezone:this.parseTimezoneString(h[5])};
+return new Jsonix.XML.Calendar(k)
+}throw new Error("Value ["+j+"] does not match the xs:gYear pattern.")
+},parseGMonthDay:function(j,n,i,m){var k=new RegExp("^"+Jsonix.Schema.XSD.Calendar.GMONTH_DAY_PATTERN+"$");
+var h=j.match(k);
+if(h!==null){var l={month:parseInt(h[2],10),day:parseInt(h[3],10),timezone:this.parseTimezoneString(h[5])};
+return new Jsonix.XML.Calendar(l)
+}throw new Error("Value ["+j+"] does not match the xs:gMonthDay pattern.")
+},parseGMonth:function(k,n,i,m){var j=new RegExp("^"+Jsonix.Schema.XSD.Calendar.GMONTH_PATTERN+"$");
+var h=k.match(j);
+if(h!==null){var l={month:parseInt(h[2],10),timezone:this.parseTimezoneString(h[3])};
+return new Jsonix.XML.Calendar(l)
+}throw new Error("Value ["+k+"] does not match the xs:gMonth pattern.")
+},parseGDay:function(j,n,i,m){var l=new RegExp("^"+Jsonix.Schema.XSD.Calendar.GDAY_PATTERN+"$");
+var h=j.match(l);
+if(h!==null){var k={day:parseInt(h[2],10),timezone:this.parseTimezoneString(h[3])};
+return new Jsonix.XML.Calendar(k)
+}throw new Error("Value ["+j+"] does not match the xs:gDay pattern.")
+},parseDateTime:function(j,n,i,m){Jsonix.Util.Ensure.ensureString(j);
+var k=new RegExp("^"+Jsonix.Schema.XSD.Calendar.DATETIME_PATTERN+"$");
+var h=j.match(k);
+if(h!==null){var l={year:parseInt(h[1],10),month:parseInt(h[5],10),day:parseInt(h[7],10),hour:parseInt(h[9],10),minute:parseInt(h[10],10),second:parseInt(h[11],10),fractionalSecond:(h[12]?parseFloat(h[12]):0),timezone:this.parseTimezoneString(h[14])};
+return new Jsonix.XML.Calendar(l)
+}throw new Error("Value ["+value+"] does not match the xs:date pattern.")
+},parseDate:function(j,n,i,m){Jsonix.Util.Ensure.ensureString(j);
+var k=new RegExp("^"+Jsonix.Schema.XSD.Calendar.DATE_PATTERN+"$");
+var h=j.match(k);
+if(h!==null){var l={year:parseInt(h[1],10),month:parseInt(h[5],10),day:parseInt(h[7],10),timezone:this.parseTimezoneString(h[9])};
+return new Jsonix.XML.Calendar(l)
+}throw new Error("Value ["+value+"] does not match the xs:date pattern.")
+},parseTime:function(j,n,i,m){Jsonix.Util.Ensure.ensureString(j);
+var k=new RegExp("^"+Jsonix.Schema.XSD.Calendar.TIME_PATTERN+"$");
+var h=j.match(k);
+if(h!==null){var l={hour:parseInt(h[1],10),minute:parseInt(h[2],10),second:parseInt(h[3],10),fractionalSecond:(h[4]?parseFloat(h[4]):0),timezone:this.parseTimezoneString(h[6])};
+return new Jsonix.XML.Calendar(l)
+}throw new Error("Value ["+value+"] does not match the xs:time pattern.")
+},parseTimezoneString:function(i){if(!Jsonix.Util.Type.isString(i)){return NaN
+}else{if(i===""){return NaN
 }else{if(i==="Z"){return 0
-}else{if(i.length!==6){throw new Error("Time zone must be an empty string, 'Z' or a string in format [('+' | '-') hh ':' mm].")
-}var h=i.charAt(0);
-var f;
-if(h==="+"){f=1
-}else{if(h==="-"){f=-1
-}else{throw new Error("First character of the time zone ["+i+"] must be '+' or '-'.")
-}}var g=this.parseHour(i.substring(1,3));
-var j=this.parseMinute(i.substring(4,6));
-return -1*f*(g*60+j)
-}}},parseYear:function(c){Jsonix.Util.Ensure.ensureString(c);
-if(c.length!==4){throw new Error("Year ["+c+"] must be a four-digit number.")
-}var d=Number(c);
-Jsonix.Util.Ensure.ensureInteger(d);
-return d
-},parseMonth:function(c){Jsonix.Util.Ensure.ensureString(c);
-if(c.length!==2){throw new Error("Month ["+c+"] must be a two-digit number.")
-}var d=Number(c);
-Jsonix.Util.Ensure.ensureInteger(d);
-return d
-},parseDay:function(c){Jsonix.Util.Ensure.ensureString(c);
-if(c.length!==2){throw new Error("Day ["+c+"] must be a two-digit number.")
-}var d=Number(c);
-Jsonix.Util.Ensure.ensureInteger(d);
-return d
-},parseHour:function(c){Jsonix.Util.Ensure.ensureString(c);
-if(c.length!==2){throw new Error("Hour ["+c+"] must be a two-digit number.")
-}var d=Number(c);
-Jsonix.Util.Ensure.ensureInteger(d);
-return d
-},parseMinute:function(c){Jsonix.Util.Ensure.ensureString(c);
-if(c.length!==2){throw new Error("Minute ["+c+"] must be a two-digit number.")
-}var d=Number(c);
-Jsonix.Util.Ensure.ensureInteger(d);
-return d
-},parseSecond:function(c){Jsonix.Util.Ensure.ensureString(c);
-if(c.length!==2){throw new Error("Second ["+c+"] must be a two-digit number.")
-}var d=Number(c);
-Jsonix.Util.Ensure.ensureNumber(d);
-return d
-},parseFractionalSecond:function(c){Jsonix.Util.Ensure.ensureString(c);
-if(c===""){return 0
-}else{var d=Number(c);
-Jsonix.Util.Ensure.ensureNumber(d);
-return d
-}},print:function(g,e,f,h){Jsonix.Util.Ensure.ensureObject(g);
+}else{if(i==="+14:00"){return 14*60
+}else{if(i==="-14:00"){return -14*60
+}else{var j=new RegExp("^"+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+"$");
+var l=i.match(j);
+if(l!==null){var g=l[1]==="+"?1:-1;
+var h=parseInt(l[4],10);
+var k=parseInt(l[5],10);
+return g*(h*60+k)
+}throw new Error("Value ["+value+"] does not match the timezone pattern.")
+}}}}}},print:function(g,e,f,h){Jsonix.Util.Ensure.ensureObject(g);
 if(Jsonix.Util.NumberUtils.isInteger(g.year)&&Jsonix.Util.NumberUtils.isInteger(g.month)&&Jsonix.Util.NumberUtils.isInteger(g.day)&&Jsonix.Util.NumberUtils.isInteger(g.hour)&&Jsonix.Util.NumberUtils.isInteger(g.minute)&&Jsonix.Util.NumberUtils.isInteger(g.second)){return this.printDateTime(g)
 }else{if(Jsonix.Util.NumberUtils.isInteger(g.year)&&Jsonix.Util.NumberUtils.isInteger(g.month)&&Jsonix.Util.NumberUtils.isInteger(g.day)){return this.printDate(g)
 }else{if(Jsonix.Util.NumberUtils.isInteger(g.hour)&&Jsonix.Util.NumberUtils.isInteger(g.minute)&&Jsonix.Util.NumberUtils.isInteger(g.second)){return this.printTime(g)
+}else{if(Jsonix.Util.NumberUtils.isInteger(g.year)&&Jsonix.Util.NumberUtils.isInteger(g.month)){return this.printGYearMonth(g)
+}else{if(Jsonix.Util.NumberUtils.isInteger(g.month)&&Jsonix.Util.NumberUtils.isInteger(g.day)){return this.printGMonthDay(g)
+}else{if(Jsonix.Util.NumberUtils.isInteger(g.year)){return this.printGYear(g)
+}else{if(Jsonix.Util.NumberUtils.isInteger(g.month)){return this.printGMonth(g)
+}else{if(Jsonix.Util.NumberUtils.isInteger(g.day)){return this.printGDay(g)
 }else{throw new Error("Value ["+g+"] is not recognized as dateTime, date or time.")
-}}}},printDateTime:function(c){Jsonix.Util.Ensure.ensureObject(c);
+}}}}}}}}},printDateTime:function(c){Jsonix.Util.Ensure.ensureObject(c);
 Jsonix.Util.Ensure.ensureInteger(c.year);
 Jsonix.Util.Ensure.ensureInteger(c.month);
 Jsonix.Util.Ensure.ensureInteger(c.day);
@@ -1784,7 +1976,7 @@ if(Jsonix.Util.Type.exists(c.fractionalString)){Jsonix.Util.Ensure.ensureNumber(
 }var d=this.printDateString(c);
 d=d+"T";
 d=d+this.printTimeString(c);
-if(Jsonix.Util.Type.exists(c.timezone)){d=d+this.printTimeZoneString(c.timezone)
+if(Jsonix.Util.Type.exists(c.timezone)){d=d+this.printTimezoneString(c.timezone)
 }return d
 },printDate:function(c){Jsonix.Util.Ensure.ensureObject(c);
 Jsonix.Util.Ensure.ensureNumber(c.year);
@@ -1792,7 +1984,7 @@ Jsonix.Util.Ensure.ensureNumber(c.month);
 Jsonix.Util.Ensure.ensureNumber(c.day);
 if(Jsonix.Util.Type.exists(c.timezone)&&!Jsonix.Util.Type.isNaN(c.timezone)){Jsonix.Util.Ensure.ensureInteger(c.timezone)
 }var d=this.printDateString(c);
-if(Jsonix.Util.Type.exists(c.timezone)){d=d+this.printTimeZoneString(c.timezone)
+if(Jsonix.Util.Type.exists(c.timezone)){d=d+this.printTimezoneString(c.timezone)
 }return d
 },printTime:function(c){Jsonix.Util.Ensure.ensureObject(c);
 Jsonix.Util.Ensure.ensureNumber(c.hour);
@@ -1801,7 +1993,7 @@ Jsonix.Util.Ensure.ensureNumber(c.second);
 if(Jsonix.Util.Type.exists(c.fractionalString)){Jsonix.Util.Ensure.ensureNumber(c.fractionalString)
 }if(Jsonix.Util.Type.exists(c.timezone)&&!Jsonix.Util.Type.isNaN(c.timezone)){Jsonix.Util.Ensure.ensureInteger(c.timezone)
 }var d=this.printTimeString(c);
-if(Jsonix.Util.Type.exists(c.timezone)){d=d+this.printTimeZoneString(c.timezone)
+if(Jsonix.Util.Type.exists(c.timezone)){d=d+this.printTimezoneString(c.timezone)
 }return d
 },printDateString:function(b){Jsonix.Util.Ensure.ensureObject(b);
 Jsonix.Util.Ensure.ensureInteger(b.year);
@@ -1820,7 +2012,7 @@ d=d+":";
 d=d+this.printSecond(c.second);
 if(Jsonix.Util.Type.exists(c.fractionalSecond)){d=d+this.printFractionalSecond(c.fractionalSecond)
 }return d
-},printTimeZoneString:function(j){if(!Jsonix.Util.Type.exists(j)||Jsonix.Util.Type.isNaN(j)){return""
+},printTimezoneString:function(j){if(!Jsonix.Util.Type.exists(j)||Jsonix.Util.Type.isNaN(j)){return""
 }else{Jsonix.Util.Ensure.ensureInteger(j);
 var l=j<0?-1:(j>0?1:0);
 var k=j*l;
@@ -1828,13 +2020,72 @@ var i=k%60;
 var g=Math.floor(k/60);
 var h;
 if(l===0){return"Z"
-}else{if(l>0){h="-"
-}else{if(l<0){h="+"
+}else{if(l>0){h="+"
+}else{if(l<0){h="-"
 }}h=h+this.printHour(g);
 h=h+":";
 h=h+this.printMinute(i);
 return h
-}}},printYear:function(b){return this.printInteger(b,4)
+}}},printGDay:function(i,l,g,k){Jsonix.Util.Ensure.ensureObject(i);
+var h=undefined;
+var j=undefined;
+if(i instanceof Date){h=i.getDate()
+}else{Jsonix.Util.Ensure.ensureInteger(i.day);
+h=i.day;
+j=i.timezone
+}Jsonix.XML.Calendar.validateDay(h);
+Jsonix.XML.Calendar.validateTimezone(j);
+return"---"+this.printDay(h)+this.printTimezoneString(j)
+},printGMonth:function(j,g,h,l){Jsonix.Util.Ensure.ensureObject(j);
+var i=undefined;
+var k=undefined;
+if(j instanceof Date){i=j.getMonth()+1
+}else{Jsonix.Util.Ensure.ensureInteger(j.month);
+i=j.month;
+k=j.timezone
+}Jsonix.XML.Calendar.validateMonth(i);
+Jsonix.XML.Calendar.validateTimezone(k);
+return"--"+this.printMonth(i)+this.printTimezoneString(k)
+},printGMonthDay:function(k,n,h,m){Jsonix.Util.Ensure.ensureObject(k);
+var j=undefined;
+var i=undefined;
+var l=undefined;
+if(k instanceof Date){j=k.getMonth()+1;
+i=k.getDate()
+}else{Jsonix.Util.Ensure.ensureInteger(k.month);
+Jsonix.Util.Ensure.ensureInteger(k.day);
+j=k.month;
+i=k.day;
+l=k.timezone
+}Jsonix.XML.Calendar.validateMonthDay(j,i);
+Jsonix.XML.Calendar.validateTimezone(l);
+return"--"+this.printMonth(j)+"-"+this.printDay(i)+this.printTimezoneString(l)
+},printGYear:function(i,g,h,k){Jsonix.Util.Ensure.ensureObject(i);
+var l=undefined;
+var j=undefined;
+if(i instanceof Date){l=i.getFullYear()
+}else{Jsonix.Util.Ensure.ensureInteger(i.year);
+l=i.year;
+j=i.timezone
+}Jsonix.XML.Calendar.validateYear(l);
+Jsonix.XML.Calendar.validateTimezone(j);
+return this.printSignedYear(l)+this.printTimezoneString(j)
+},printGYearMonth:function(k,h,i,m){Jsonix.Util.Ensure.ensureObject(k);
+var n=undefined;
+var j=undefined;
+var l=undefined;
+if(k instanceof Date){n=k.getFullYear();
+j=k.getMonth()+1
+}else{Jsonix.Util.Ensure.ensureInteger(k.year);
+n=k.year;
+j=k.month;
+l=k.timezone
+}Jsonix.XML.Calendar.validateYear(n);
+Jsonix.XML.Calendar.validateMonth(j);
+Jsonix.XML.Calendar.validateTimezone(l);
+return this.printSignedYear(n)+"-"+this.printMonth(j)+this.printTimezoneString(l)
+},printSignedYear:function(b){return b<0?("-"+this.printYear(b*-1)):(this.printYear(b))
+},printYear:function(b){return this.printInteger(b,4)
 },printMonth:function(b){return this.printInteger(b,2)
 },printDay:function(b){return this.printInteger(b,2)
 },printHour:function(b){return this.printInteger(b,2)
@@ -1851,7 +2102,6 @@ if(d<0){return""
 Jsonix.Util.Ensure.ensureInteger(h);
 if(h<=0){throw new Error("Length ["+g+"] must be positive.")
 }if(g<0){throw new Error("Value ["+g+"] must not be negative.")
-}if(g>=Math.pow(10,h)){throw new Error("Value ["+g+"] must be less than ["+Math.pow(10,h)+"].")
 }var f=String(g);
 for(var e=f.length;
 e<h;
@@ -1859,12 +2109,84 @@ e++){f="0"+f
 }return f
 },isInstance:function(f,e,d){return Jsonix.Util.Type.isObject(f)&&((Jsonix.Util.NumberUtils.isInteger(f.year)&&Jsonix.Util.NumberUtils.isInteger(f.month)&&Jsonix.Util.NumberUtils.isInteger(f.day))||(Jsonix.Util.NumberUtils.isInteger(f.hour)&&Jsonix.Util.NumberUtils.isInteger(f.minute)&&Jsonix.Util.NumberUtils.isInteger(f.second)))
 },CLASS_NAME:"Jsonix.Schema.XSD.Calendar"});
+Jsonix.Schema.XSD.Calendar.YEAR_PATTERN="-?([1-9][0-9]*)?((?!(0000))[0-9]{4})";
+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN="Z|([\\-\\+])(((0[0-9]|1[0-3]):([0-5][0-9]))|(14:00))";
+Jsonix.Schema.XSD.Calendar.MONTH_PATTERN="(0[1-9]|1[0-2])";
+Jsonix.Schema.XSD.Calendar.SINGLE_MONTH_PATTERN="\\-\\-"+Jsonix.Schema.XSD.Calendar.MONTH_PATTERN;
+Jsonix.Schema.XSD.Calendar.DAY_PATTERN="(0[1-9]|[12][0-9]|3[01])";
+Jsonix.Schema.XSD.Calendar.SINGLE_DAY_PATTERN="\\-\\-\\-"+Jsonix.Schema.XSD.Calendar.DAY_PATTERN;
+Jsonix.Schema.XSD.Calendar.GYEAR_PATTERN="("+Jsonix.Schema.XSD.Calendar.YEAR_PATTERN+")("+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+")?";
+Jsonix.Schema.XSD.Calendar.GMONTH_PATTERN="("+Jsonix.Schema.XSD.Calendar.SINGLE_MONTH_PATTERN+")("+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+")?";
+Jsonix.Schema.XSD.Calendar.GDAY_PATTERN="("+Jsonix.Schema.XSD.Calendar.SINGLE_DAY_PATTERN+")("+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+")?";
+Jsonix.Schema.XSD.Calendar.GYEAR_MONTH_PATTERN="("+Jsonix.Schema.XSD.Calendar.YEAR_PATTERN+")-("+Jsonix.Schema.XSD.Calendar.DAY_PATTERN+")("+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+")?";
+Jsonix.Schema.XSD.Calendar.GMONTH_DAY_PATTERN="("+Jsonix.Schema.XSD.Calendar.SINGLE_MONTH_PATTERN+")-("+Jsonix.Schema.XSD.Calendar.DAY_PATTERN+")("+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+")?";
+Jsonix.Schema.XSD.Calendar.DATE_PART_PATTERN="("+Jsonix.Schema.XSD.Calendar.YEAR_PATTERN+")-("+Jsonix.Schema.XSD.Calendar.MONTH_PATTERN+")-("+Jsonix.Schema.XSD.Calendar.DAY_PATTERN+")";
+Jsonix.Schema.XSD.Calendar.TIME_PART_PATTERN="([0-1][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\\.([0-9]+))?";
+Jsonix.Schema.XSD.Calendar.TIME_PATTERN=Jsonix.Schema.XSD.Calendar.TIME_PART_PATTERN+"("+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+")?";
+Jsonix.Schema.XSD.Calendar.DATE_PATTERN=Jsonix.Schema.XSD.Calendar.DATE_PART_PATTERN+"("+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+")?";
+Jsonix.Schema.XSD.Calendar.DATETIME_PATTERN=Jsonix.Schema.XSD.Calendar.DATE_PART_PATTERN+"T"+Jsonix.Schema.XSD.Calendar.TIME_PART_PATTERN+"("+Jsonix.Schema.XSD.Calendar.TIMEZONE_PATTERN+")?";
 Jsonix.Schema.XSD.Calendar.INSTANCE=new Jsonix.Schema.XSD.Calendar();
 Jsonix.Schema.XSD.Calendar.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Calendar.INSTANCE);
-Jsonix.Schema.XSD.Duration=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"Duration",typeName:Jsonix.Schema.XSD.qname("duration"),CLASS_NAME:"Jsonix.Schema.XSD.Duration"});
+Jsonix.Schema.XSD.Duration=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"Duration",typeName:Jsonix.Schema.XSD.qname("duration"),isInstance:function(f,e,d){return Jsonix.Util.Type.isObject(f)&&((Jsonix.Util.Type.exists(f.sign)?(f.sign===-1||f.sign===1):true)(Jsonix.Util.NumberUtils.isInteger(f.years)&&f.years>=0)||(Jsonix.Util.NumberUtils.isInteger(f.months)&&f.months>=0)||(Jsonix.Util.NumberUtils.isInteger(f.days)&&f.days>=0)||(Jsonix.Util.NumberUtils.isInteger(f.hours)&&f.hours>=0)||(Jsonix.Util.NumberUtils.isInteger(f.minutes)&&f.minutes>=0)||(Jsonix.Util.Type.isNumber(f.seconds)&&f.seconds>=0))
+},validate:function(h){Jsonix.Util.Ensure.ensureObject(h);
+if(Jsonix.Util.Type.exists(h.sign)){if(!(h.sign===1||h.sign===-1)){throw new Error("Sign of the duration ["+h.sign+"] must be either [1] or [-1].")
+}}var e=true;
+var g=function(b,a){if(Jsonix.Util.Type.exists(b)){if(!(Jsonix.Util.NumberUtils.isInteger(b)&&b>=0)){throw new Error(a.replace("{0}",b))
+}else{return true
+}}else{return false
+}};
+var f=function(b,a){if(Jsonix.Util.Type.exists(b)){if(!(Jsonix.Util.Type.isNumber(b)&&b>=0)){throw new Error(a.replace("{0}",b))
+}else{return true
+}}else{return false
+}};
+e=e&&!g(h.years,"Number of years [{0}] must be an unsigned integer.");
+e=e&&!g(h.months,"Number of months [{0}] must be an unsigned integer.");
+e=e&&!g(h.days,"Number of days [{0}] must be an unsigned integer.");
+e=e&&!g(h.hours,"Number of hours [{0}] must be an unsigned integer.");
+e=e&&!g(h.minutes,"Number of minutes [{0}] must be an unsigned integer.");
+e=e&&!f(h.seconds,"Number of seconds [{0}] must be an unsigned number.");
+if(e){throw new Error("At least one of the components (years, months, days, hours, minutes, seconds) must be set.")
+}},print:function(h,j,f,i){this.validate(h);
+var g="";
+if(h.sign===-1){g+="-"
+}g+="P";
+if(Jsonix.Util.Type.exists(h.years)){g+=(h.years+"Y")
+}if(Jsonix.Util.Type.exists(h.months)){g+=(h.months+"M")
+}if(Jsonix.Util.Type.exists(h.days)){g+=(h.days+"D")
+}if(Jsonix.Util.Type.exists(h.hours)||Jsonix.Util.Type.exists(h.minutes)||Jsonix.Util.Type.exists(h.seconds)){g+="T";
+if(Jsonix.Util.Type.exists(h.hours)){g+=(h.hours+"H")
+}if(Jsonix.Util.Type.exists(h.minutes)){g+=(h.minutes+"M")
+}if(Jsonix.Util.Type.exists(h.seconds)){g+=(h.seconds+"S")
+}}return g
+},parse:function(m,p,j,o){var k=new RegExp("^"+Jsonix.Schema.XSD.Duration.PATTERN+"$");
+var i=m.match(k);
+if(i!==null){var n=true;
+var l={};
+if(i[1]){l.sign=-1
+}if(i[3]){l.years=parseInt(i[3],10);
+n=false
+}if(i[5]){l.months=parseInt(i[5],10);
+n=false
+}if(i[7]){l.days=parseInt(i[7],10);
+n=false
+}if(i[10]){l.hours=parseInt(i[10],10);
+n=false
+}if(i[12]){l.minutes=parseInt(i[12],10);
+n=false
+}if(i[14]){l.seconds=Number(i[14]);
+n=false
+}return l
+}else{throw new Error("Value ["+m+"] does not match the duration pattern.")
+}},CLASS_NAME:"Jsonix.Schema.XSD.Duration"});
+Jsonix.Schema.XSD.Duration.PATTERN="(-)?P(([0-9]+)Y)?(([0-9]+)M)?(([0-9]+)D)?(T(([0-9]+)H)?(([0-9]+)M)?(([0-9]+(\\.[0-9]+)?)S)?)?";
 Jsonix.Schema.XSD.Duration.INSTANCE=new Jsonix.Schema.XSD.Duration();
 Jsonix.Schema.XSD.Duration.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Duration.INSTANCE);
-Jsonix.Schema.XSD.DateTime=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"DateTime",typeName:Jsonix.Schema.XSD.qname("dateTime"),parse:function(o,t,p,l){var q=this.parseDateTime(o);
+Jsonix.Schema.XSD.DateTime=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"DateTime",typeName:Jsonix.Schema.XSD.qname("dateTime"),parse:function(g,e,f,h){return this.parseDateTime(g)
+},print:function(g,e,f,h){return this.printDateTime(g)
+},CLASS_NAME:"Jsonix.Schema.XSD.DateTime"});
+Jsonix.Schema.XSD.DateTime.INSTANCE=new Jsonix.Schema.XSD.DateTime();
+Jsonix.Schema.XSD.DateTime.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.DateTime.INSTANCE);
+Jsonix.Schema.XSD.DateTimeAsDate=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"DateTimeAsDate",typeName:Jsonix.Schema.XSD.qname("dateTime"),parse:function(n,t,o,l){var q=this.parseDateTime(n);
 var s=new Date();
 s.setFullYear(q.year);
 s.setMonth(q.month-1);
@@ -1873,32 +2195,38 @@ s.setHours(q.hour);
 s.setMinutes(q.minute);
 s.setSeconds(q.second);
 if(Jsonix.Util.Type.isNumber(q.fractionalSecond)){s.setMilliseconds(Math.floor(1000*q.fractionalSecond))
-}var n;
+}var p;
 var r;
-var m=s.getTimezoneOffset();
-if(Jsonix.Util.NumberUtils.isInteger(q.timezone)){n=q.timezone;
+var m=-s.getTimezoneOffset();
+if(Jsonix.Util.NumberUtils.isInteger(q.timezone)){p=q.timezone;
 r=false
-}else{n=m;
+}else{p=m;
 r=true
-}var k=new Date(s.getTime()+(60000*(n-m)));
-if(r){k.originalTimezoneOffset=null
-}else{k.originalTimezoneOffset=n
+}var k=new Date(s.getTime()+(60000*(-p+m)));
+if(r){k.originalTimezone=null
+}else{k.originalTimezone=q.timezone
 }return k
-},print:function(k,n,i,m){Jsonix.Util.Ensure.ensureDate(k);
-var l;
-var j=k.getTimezoneOffset();
-var h;
-if(k.originalTimezoneOffset===null){return this.printDateTime(new Jsonix.XML.Calendar({year:k.getFullYear(),month:k.getMonth()+1,day:k.getDate(),hour:k.getHours(),minute:k.getMinutes(),second:k.getSeconds(),fractionalSecond:(k.getMilliseconds()/1000)}))
-}else{if(Jsonix.Util.NumberUtils.isInteger(k.originalTimezoneOffset)){l=k.originalTimezoneOffset;
-h=new Date(k.getTime()-(60000*(l-j)))
-}else{l=j;
-h=k
-}return this.printDateTime(new Jsonix.XML.Calendar({year:h.getFullYear(),month:h.getMonth()+1,day:h.getDate(),hour:h.getHours(),minute:h.getMinutes(),second:h.getSeconds(),fractionalSecond:(h.getMilliseconds()/1000),timezone:l}))
+},print:function(k,o,i,n){Jsonix.Util.Ensure.ensureDate(k);
+var m;
+var l=-k.getTimezoneOffset();
+var p;
+if(k.originalTimezone===null){return this.printDateTime(new Jsonix.XML.Calendar({year:k.getFullYear(),month:k.getMonth()+1,day:k.getDate(),hour:k.getHours(),minute:k.getMinutes(),second:k.getSeconds(),fractionalSecond:(k.getMilliseconds()/1000)}))
+}else{if(Jsonix.Util.NumberUtils.isInteger(k.originalTimezone)){m=k.originalTimezone;
+p=new Date(k.getTime()-(60000*(-m+l)))
+}else{m=l;
+p=k
+}var j=this.printDateTime(new Jsonix.XML.Calendar({year:p.getFullYear(),month:p.getMonth()+1,day:p.getDate(),hour:p.getHours(),minute:p.getMinutes(),second:p.getSeconds(),fractionalSecond:(p.getMilliseconds()/1000),timezone:m}));
+return j
 }},isInstance:function(f,e,d){return Jsonix.Util.Type.isDate(f)
-},CLASS_NAME:"Jsonix.Schema.XSD.DateTime"});
-Jsonix.Schema.XSD.DateTime.INSTANCE=new Jsonix.Schema.XSD.DateTime();
-Jsonix.Schema.XSD.DateTime.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.DateTime.INSTANCE);
-Jsonix.Schema.XSD.Time=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"Time",typeName:Jsonix.Schema.XSD.qname("time"),parse:function(o,t,p,l){var q=this.parseTime(o);
+},CLASS_NAME:"Jsonix.Schema.XSD.DateTimeAsDate"});
+Jsonix.Schema.XSD.DateTimeAsDate.INSTANCE=new Jsonix.Schema.XSD.DateTimeAsDate();
+Jsonix.Schema.XSD.DateTimeAsDate.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.DateTimeAsDate.INSTANCE);
+Jsonix.Schema.XSD.Time=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"Time",typeName:Jsonix.Schema.XSD.qname("time"),parse:function(g,e,f,h){return this.parseTime(g)
+},print:function(g,e,f,h){return this.printTime(g)
+},CLASS_NAME:"Jsonix.Schema.XSD.Time"});
+Jsonix.Schema.XSD.Time.INSTANCE=new Jsonix.Schema.XSD.Time();
+Jsonix.Schema.XSD.Time.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Time.INSTANCE);
+Jsonix.Schema.XSD.TimeAsDate=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"TimeAsDate",typeName:Jsonix.Schema.XSD.qname("time"),parse:function(n,t,o,l){var q=this.parseTime(n);
 var s=new Date();
 s.setFullYear(1970);
 s.setMonth(0);
@@ -1907,37 +2235,43 @@ s.setHours(q.hour);
 s.setMinutes(q.minute);
 s.setSeconds(q.second);
 if(Jsonix.Util.Type.isNumber(q.fractionalSecond)){s.setMilliseconds(Math.floor(1000*q.fractionalSecond))
-}var n;
+}var p;
 var r;
-var m=s.getTimezoneOffset();
-if(Jsonix.Util.NumberUtils.isInteger(q.timezone)){n=q.timezone;
+var m=-s.getTimezoneOffset();
+if(Jsonix.Util.NumberUtils.isInteger(q.timezone)){p=q.timezone;
 r=false
-}else{n=m;
+}else{p=m;
 r=true
-}var k=new Date(s.getTime()+(60000*(n-m)));
-if(r){k.originalTimezoneOffset=null
-}else{k.originalTimezoneOffset=n
+}var k=new Date(s.getTime()+(60000*(-p+m)));
+if(r){k.originalTimezone=null
+}else{k.originalTimezone=p
 }return k
-},print:function(n,t,r,k){Jsonix.Util.Ensure.ensureDate(n);
-var q=n.getTime();
-if(q<=-86400000&&q>=86400000){throw new Error("Invalid time ["+n+"].")
-}if(n.originalTimezoneOffset===null){return this.printTime(new Jsonix.XML.Calendar({hour:n.getHours(),minute:n.getMinutes(),second:n.getSeconds(),fractionalSecond:(n.getMilliseconds()/1000)}))
-}else{var s;
-var m;
-var l=n.getTimezoneOffset();
-if(Jsonix.Util.NumberUtils.isInteger(n.originalTimezoneOffset)){m=n.originalTimezoneOffset;
-s=new Date(n.getTime()-(60000*(m-l)))
-}else{m=l;
-s=n
-}var o=s.getTime();
-if(o>=0){return this.printTime(new Jsonix.XML.Calendar({hour:s.getHours(),minute:s.getMinutes(),second:s.getSeconds(),fractionalSecond:(s.getMilliseconds()/1000),timezone:m}))
-}else{var p=Math.ceil(-o/3600000);
-return this.printTime(new Jsonix.XML.Calendar({hour:(s.getHours()+p+m/60)%24,minute:s.getMinutes(),second:s.getSeconds(),fractionalSecond:(s.getMilliseconds()/1000),timezone:-p*60}))
+},print:function(n,u,s,l){Jsonix.Util.Ensure.ensureDate(n);
+var r=n.getTime();
+if(r<=-86400000&&r>=86400000){throw new Error("Invalid time ["+n+"].")
+}if(n.originalTimezone===null){return this.printTime(new Jsonix.XML.Calendar({hour:n.getHours(),minute:n.getMinutes(),second:n.getSeconds(),fractionalSecond:(n.getMilliseconds()/1000)}))
+}else{var t;
+var p;
+var m=-n.getTimezoneOffset();
+if(Jsonix.Util.NumberUtils.isInteger(n.originalTimezone)){p=n.originalTimezone;
+t=new Date(n.getTime()-(60000*(-p+m)))
+}else{p=m;
+t=n
+}var o=t.getTime();
+if(o>=(-m*60000)){return this.printTime(new Jsonix.XML.Calendar({hour:t.getHours(),minute:t.getMinutes(),second:t.getSeconds(),fractionalSecond:(t.getMilliseconds()/1000),timezone:p}))
+}else{var q=Math.ceil(-o/3600000);
+var v=t.getSeconds()+t.getMinutes()*60+t.getHours()*3600+q*3600-p*60;
+return this.printTime(new Jsonix.XML.Calendar({hour:v%86400,minute:v%3600,second:v%60,fractionalSecond:(t.getMilliseconds()/1000),timezone:q*60}))
 }}},isInstance:function(f,e,d){return Jsonix.Util.Type.isDate(f)&&f.getTime()>-86400000&&f.getTime()<86400000
-},CLASS_NAME:"Jsonix.Schema.XSD.Time"});
-Jsonix.Schema.XSD.Time.INSTANCE=new Jsonix.Schema.XSD.Time();
-Jsonix.Schema.XSD.Time.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Time.INSTANCE);
-Jsonix.Schema.XSD.Date=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"Date",typeName:Jsonix.Schema.XSD.qname("date"),parse:function(o,t,p,l){var q=this.parseDate(o);
+},CLASS_NAME:"Jsonix.Schema.XSD.TimeAsDate"});
+Jsonix.Schema.XSD.TimeAsDate.INSTANCE=new Jsonix.Schema.XSD.TimeAsDate();
+Jsonix.Schema.XSD.TimeAsDate.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.TimeAsDate.INSTANCE);
+Jsonix.Schema.XSD.Date=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"Date",typeName:Jsonix.Schema.XSD.qname("date"),parse:function(g,e,f,h){return this.parseDate(g)
+},print:function(g,e,f,h){return this.printDate(g)
+},CLASS_NAME:"Jsonix.Schema.XSD.Date"});
+Jsonix.Schema.XSD.Date.INSTANCE=new Jsonix.Schema.XSD.Date();
+Jsonix.Schema.XSD.Date.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Date.INSTANCE);
+Jsonix.Schema.XSD.DateAsDate=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"DateAsDate",typeName:Jsonix.Schema.XSD.qname("date"),parse:function(n,t,o,l){var q=this.parseDate(n);
 var s=new Date();
 s.setFullYear(q.year);
 s.setMonth(q.month-1);
@@ -1947,49 +2281,59 @@ s.setMinutes(0);
 s.setSeconds(0);
 s.setMilliseconds(0);
 if(Jsonix.Util.Type.isNumber(q.fractionalSecond)){s.setMilliseconds(Math.floor(1000*q.fractionalSecond))
-}var n;
+}var p;
 var r;
-var m=s.getTimezoneOffset();
-if(Jsonix.Util.NumberUtils.isInteger(q.timezone)){n=q.timezone;
+var m=-s.getTimezoneOffset();
+if(Jsonix.Util.NumberUtils.isInteger(q.timezone)){p=q.timezone;
 r=false
-}else{n=m;
+}else{p=m;
 r=true
-}var k=new Date(s.getTime()+(60000*(n-m)));
-if(r){k.originalTimezoneOffset=null
-}else{k.originalTimezoneOffset=n
+}var k=new Date(s.getTime()+(60000*(-p+m)));
+if(r){k.originalTimezone=null
+}else{k.originalTimezone=p
 }return k
-},print:function(m,r,p,j){Jsonix.Util.Ensure.ensureDate(m);
-var o=new Date(m.getTime());
+},print:function(l,r,p,j){Jsonix.Util.Ensure.ensureDate(l);
+var o=new Date(l.getTime());
 o.setHours(0);
 o.setMinutes(0);
 o.setSeconds(0);
 o.setMilliseconds(0);
-if(m.originalTimezoneOffset===null){return this.printDate(new Jsonix.XML.Calendar({year:m.getFullYear(),month:m.getMonth()+1,day:m.getDate()}))
-}else{if(Jsonix.Util.NumberUtils.isInteger(m.originalTimezoneOffset)){var q=new Date(m.getTime()-(60000*(m.originalTimezoneOffset-m.getTimezoneOffset())));
-return this.printDate(new Jsonix.XML.Calendar({year:q.getFullYear(),month:q.getMonth()+1,day:q.getDate(),timezone:m.originalTimezoneOffset}))
-}else{var k=m.getTime()-o.getTime();
-if(k===0){return this.printDate(new Jsonix.XML.Calendar({year:m.getFullYear(),month:m.getMonth()+1,day:m.getDate()}))
-}else{var l=k+(60000*m.getTimezoneOffset());
-if(l<=43200000){return this.printDate(new Jsonix.XML.Calendar({year:m.getFullYear(),month:m.getMonth()+1,day:m.getDate(),timezone:Math.floor(l/60000)}))
-}else{var n=new Date(m.getTime()+86400000);
-return this.printDate(new Jsonix.XML.Calendar({year:n.getFullYear(),month:n.getMonth()+1,day:n.getDate(),timezone:(Math.floor(l/60000)-1440)}))
+if(l.originalTimezone===null){return this.printDate(new Jsonix.XML.Calendar({year:l.getFullYear(),month:l.getMonth()+1,day:l.getDate()}))
+}else{if(Jsonix.Util.NumberUtils.isInteger(l.originalTimezone)){var q=new Date(l.getTime()-(60000*(-l.originalTimezone-l.getTimezoneOffset())));
+return this.printDate(new Jsonix.XML.Calendar({year:q.getFullYear(),month:q.getMonth()+1,day:q.getDate(),timezone:l.originalTimezone}))
+}else{var k=-l.getTime()+o.getTime();
+if(k===0){return this.printDate(new Jsonix.XML.Calendar({year:l.getFullYear(),month:l.getMonth()+1,day:l.getDate()}))
+}else{var n=k-(60000*l.getTimezoneOffset());
+if(n>=-43200000){return this.printDate(new Jsonix.XML.Calendar({year:l.getFullYear(),month:l.getMonth()+1,day:l.getDate(),timezone:Math.floor(n/60000)}))
+}else{var m=new Date(l.getTime()+86400000);
+return this.printDate(new Jsonix.XML.Calendar({year:m.getFullYear(),month:m.getMonth()+1,day:m.getDate(),timezone:(Math.floor(n/60000)+1440)}))
 }}}}},isInstance:function(f,e,d){return Jsonix.Util.Type.isDate(f)
-},CLASS_NAME:"Jsonix.Schema.XSD.Date"});
-Jsonix.Schema.XSD.Date.INSTANCE=new Jsonix.Schema.XSD.Date();
-Jsonix.Schema.XSD.Date.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.Date.INSTANCE);
-Jsonix.Schema.XSD.GYearMonth=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"GYearMonth",typeName:Jsonix.Schema.XSD.qname("gYearMonth"),CLASS_NAME:"Jsonix.Schema.XSD.GYearMonth"});
+},CLASS_NAME:"Jsonix.Schema.XSD.DateAsDate"});
+Jsonix.Schema.XSD.DateAsDate.INSTANCE=new Jsonix.Schema.XSD.DateAsDate();
+Jsonix.Schema.XSD.DateAsDate.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.DateAsDate.INSTANCE);
+Jsonix.Schema.XSD.GYearMonth=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"GYearMonth",typeName:Jsonix.Schema.XSD.qname("gYearMonth"),CLASS_NAME:"Jsonix.Schema.XSD.GYearMonth",parse:function(g,e,f,h){return this.parseGYearMonth(g,e,f,h)
+},print:function(g,e,f,h){return this.printGYearMonth(g,e,f,h)
+}});
 Jsonix.Schema.XSD.GYearMonth.INSTANCE=new Jsonix.Schema.XSD.GYearMonth();
 Jsonix.Schema.XSD.GYearMonth.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GYearMonth.INSTANCE);
-Jsonix.Schema.XSD.GYear=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"GYear",typeName:Jsonix.Schema.XSD.qname("gYear"),CLASS_NAME:"Jsonix.Schema.XSD.GYear"});
+Jsonix.Schema.XSD.GYear=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"GYear",typeName:Jsonix.Schema.XSD.qname("gYear"),CLASS_NAME:"Jsonix.Schema.XSD.GYear",parse:function(g,e,f,h){return this.parseGYear(g,e,f,h)
+},print:function(g,e,f,h){return this.printGYear(g,e,f,h)
+}});
 Jsonix.Schema.XSD.GYear.INSTANCE=new Jsonix.Schema.XSD.GYear();
 Jsonix.Schema.XSD.GYear.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GYear.INSTANCE);
-Jsonix.Schema.XSD.GMonthDay=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"GMonthDay",typeName:Jsonix.Schema.XSD.qname("gMonthDay"),CLASS_NAME:"Jsonix.Schema.XSD.GMonthDay"});
+Jsonix.Schema.XSD.GMonthDay=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"GMonthDay",typeName:Jsonix.Schema.XSD.qname("gMonthDay"),CLASS_NAME:"Jsonix.Schema.XSD.GMonthDay",parse:function(g,e,f,h){return this.parseGMonthDay(g,e,f,h)
+},print:function(g,e,f,h){return this.printGMonthDay(g,e,f,h)
+}});
 Jsonix.Schema.XSD.GMonthDay.INSTANCE=new Jsonix.Schema.XSD.GMonthDay();
 Jsonix.Schema.XSD.GMonthDay.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GMonthDay.INSTANCE);
-Jsonix.Schema.XSD.GDay=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"GDay",typeName:Jsonix.Schema.XSD.qname("gDay"),CLASS_NAME:"Jsonix.Schema.XSD.GDay"});
+Jsonix.Schema.XSD.GDay=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"GDay",typeName:Jsonix.Schema.XSD.qname("gDay"),CLASS_NAME:"Jsonix.Schema.XSD.GDay",parse:function(g,e,f,h){return this.parseGDay(g,e,f,h)
+},print:function(g,e,f,h){return this.printGDay(g,e,f,h)
+}});
 Jsonix.Schema.XSD.GDay.INSTANCE=new Jsonix.Schema.XSD.GDay();
 Jsonix.Schema.XSD.GDay.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GDay.INSTANCE);
-Jsonix.Schema.XSD.GMonth=Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType,{name:"GMonth",typeName:Jsonix.Schema.XSD.qname("gMonth"),CLASS_NAME:"Jsonix.Schema.XSD.GMonth"});
+Jsonix.Schema.XSD.GMonth=Jsonix.Class(Jsonix.Schema.XSD.Calendar,{name:"GMonth",typeName:Jsonix.Schema.XSD.qname("gMonth"),CLASS_NAME:"Jsonix.Schema.XSD.GMonth",parse:function(g,e,f,h){return this.parseGMonth(g,e,f,h)
+},print:function(g,e,f,h){return this.printGMonth(g,e,f,h)
+}});
 Jsonix.Schema.XSD.GMonth.INSTANCE=new Jsonix.Schema.XSD.GMonth();
 Jsonix.Schema.XSD.GMonth.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.XSD.GMonth.INSTANCE);
 Jsonix.Schema.XSD.ID=Jsonix.Class(Jsonix.Schema.XSD.String,{name:"ID",typeName:Jsonix.Schema.XSD.qname("ID"),CLASS_NAME:"Jsonix.Schema.XSD.ID"});
@@ -2001,26 +2345,42 @@ Jsonix.Schema.XSD.IDREF.INSTANCE.LIST=new Jsonix.Schema.XSD.List(Jsonix.Schema.X
 Jsonix.Schema.XSD.IDREFS=Jsonix.Class(Jsonix.Schema.XSD.List,{name:"IDREFS",initialize:function(){Jsonix.Schema.XSD.List.prototype.initialize.apply(this,[Jsonix.Schema.XSD.IDREF.INSTANCE,Jsonix.Schema.XSD.qname("IDREFS")," "])
 },CLASS_NAME:"Jsonix.Schema.XSD.IDREFS"});
 Jsonix.Schema.XSD.IDREFS.INSTANCE=new Jsonix.Schema.XSD.IDREFS();
-Jsonix.Context=Jsonix.Class({modules:[],typeInfos:null,elementInfos:null,properties:null,substitutionMembersMap:null,scopedElementInfosMap:null,initialize:function(h,i){this.modules=[];
+Jsonix.Schema.XSI={};
+Jsonix.Schema.XSI.NAMESPACE_URI="http://www.w3.org/2001/XMLSchema-instance";
+Jsonix.Schema.XSI.PREFIX="xsi";
+Jsonix.Schema.XSI.TYPE="type";
+Jsonix.Schema.XSI.NIL="nil";
+Jsonix.Schema.XSI.qname=function(b){Jsonix.Util.Ensure.ensureString(b);
+return new Jsonix.XML.QName(Jsonix.Schema.XSI.NAMESPACE_URI,b,Jsonix.Schema.XSI.PREFIX)
+};
+Jsonix.Schema.XSI.TYPE_QNAME=Jsonix.Schema.XSI.qname(Jsonix.Schema.XSI.TYPE);
+Jsonix.Context=Jsonix.Class(Jsonix.Mapping.Styled,{modules:[],typeInfos:null,typeNameKeyToTypeInfo:null,elementInfos:null,options:null,substitutionMembersMap:null,scopedElementInfosMap:null,supportXsiType:true,initialize:function(i,l){Jsonix.Mapping.Styled.prototype.initialize.apply(this,[l]);
+this.modules=[];
 this.elementInfos=[];
 this.typeInfos={};
+this.typeNameKeyToTypeInfo={};
 this.registerBuiltinTypeInfos();
-this.properties={namespacePrefixes:{}};
+this.namespacePrefixes={};
+this.prefixNamespaces={};
 this.substitutionMembersMap={};
 this.scopedElementInfosMap={};
-if(Jsonix.Util.Type.exists(i)){Jsonix.Util.Ensure.ensureObject(i);
-if(Jsonix.Util.Type.isObject(i.namespacePrefixes)){this.properties.namespacePrefixes=Jsonix.Util.Type.cloneObject(i.namespacePrefixes,{})
-}}if(Jsonix.Util.Type.exists(h)){Jsonix.Util.Ensure.ensureArray(h);
-var f,g,j;
-for(f=0;
-f<h.length;
-f++){g=h[f];
-j=this.createModule(g);
-this.modules[f]=j
+if(Jsonix.Util.Type.exists(l)){Jsonix.Util.Ensure.ensureObject(l);
+if(Jsonix.Util.Type.isObject(l.namespacePrefixes)){this.namespacePrefixes=Jsonix.Util.Type.cloneObject(l.namespacePrefixes,{})
+}if(Jsonix.Util.Type.isBoolean(l.supportXsiType)){this.supportXsiType=l.supportXsiType
+}}for(var j in this.namespacePrefixes){if(this.namespacePrefixes.hasOwnProperty(j)){p=this.namespacePrefixes[j];
+this.prefixNamespaces[p]=j
+}}if(Jsonix.Util.Type.exists(i)){Jsonix.Util.Ensure.ensureArray(i);
+var g,h,k;
+for(g=0;
+g<i.length;
+g++){h=i[g];
+k=this.createModule(h);
+this.modules[g]=k
 }}this.processModules()
 },createModule:function(d){var c;
-if(d instanceof Jsonix.Model.Module){c=d
-}else{c=new Jsonix.Model.Module(d)
+if(d instanceof this.mappingStyle.module){c=d
+}else{d=Jsonix.Util.Type.cloneObject(d);
+c=new this.mappingStyle.module(d,{mappingStyle:this.mappingStyle})
 }return c
 },registerBuiltinTypeInfos:function(){for(var b=0;
 b<this.builtinTypeInfos.length;
@@ -2033,11 +2393,11 @@ c.registerTypeInfos(this)
 }for(d=0;
 d<this.modules.length;
 d++){c=this.modules[d];
-c.buildTypeInfos(this)
+c.registerElementInfos(this)
 }for(d=0;
 d<this.modules.length;
 d++){c=this.modules[d];
-c.registerElementInfos(this)
+c.buildTypeInfos(this)
 }for(d=0;
 d<this.modules.length;
 d++){c=this.modules[d];
@@ -2045,8 +2405,9 @@ c.buildElementInfos(this)
 }},registerTypeInfo:function(d){Jsonix.Util.Ensure.ensureObject(d);
 var c=d.name||d.n||null;
 Jsonix.Util.Ensure.ensureString(c);
-this.typeInfos[c]=d
-},resolveTypeInfo:function(f,j){if(!Jsonix.Util.Type.exists(f)){return null
+this.typeInfos[c]=d;
+if(d.typeName&&d.typeName.key){this.typeNameKeyToTypeInfo[d.typeName.key]=d
+}},resolveTypeInfo:function(f,j){if(!Jsonix.Util.Type.exists(f)){return null
 }else{if(f instanceof Jsonix.Model.TypeInfo){return f
 }else{if(Jsonix.Util.Type.isString(f)){var g;
 if(f.length>0&&f.charAt(0)==="."){var h=j.name||j.n||undefined;
@@ -2075,83 +2436,34 @@ if(Jsonix.Util.Type.exists(k.scope)){i=this.resolveTypeInfo(k.scope,m).name
 if(!Jsonix.Util.Type.isObject(j)){j={};
 this.scopedElementInfosMap[i]=j
 }j[k.elementName.key]=k
+},getTypeInfoByValue:function(f){if(!Jsonix.Util.Type.exists(f)){return undefined
+}if(Jsonix.Util.Type.isObject(f)){var d=f.TYPE_NAME;
+if(Jsonix.Util.Type.isString(d)){var e=this.getTypeInfoByName(d);
+if(e){return e
+}}}return undefined
+},getTypeInfoByName:function(b){return this.typeInfos[b]
+},getTypeInfoByTypeName:function(c){var d=Jsonix.XML.QName.fromObjectOrString(c,this);
+return this.typeNameKeyToTypeInfo[d.key]
+},getTypeInfoByTypeNameKey:function(b){return this.typeNameKeyToTypeInfo[b]
 },getElementInfo:function(o,m){if(Jsonix.Util.Type.exists(m)){var j=m.name;
 var k=this.scopedElementInfosMap[j];
 if(Jsonix.Util.Type.exists(k)){var n=k[o.key];
 if(Jsonix.Util.Type.exists(n)){return n
 }}}var l="##global";
-var p=this.scopedElementInfosMap[l];
-if(Jsonix.Util.Type.exists(p)){var i=p[o.key];
+var q=this.scopedElementInfosMap[l];
+if(Jsonix.Util.Type.exists(q)){var i=q[o.key];
 if(Jsonix.Util.Type.exists(i)){return i
 }}return null
 },getSubstitutionMembers:function(b){return this.substitutionMembersMap[Jsonix.XML.QName.fromObject(b).key]
-},createMarshaller:function(){return new Jsonix.Context.Marshaller(this)
-},createUnmarshaller:function(){return new Jsonix.Context.Unmarshaller(this)
+},createMarshaller:function(){return new this.mappingStyle.marshaller(this)
+},createUnmarshaller:function(){return new this.mappingStyle.unmarshaller(this)
 },getNamespaceURI:function(b){Jsonix.Util.Ensure.ensureString(b);
-return this.properties.namespacePrefixes[b]
-},builtinTypeInfos:[Jsonix.Schema.XSD.AnyType.INSTANCE,Jsonix.Schema.XSD.AnyURI.INSTANCE,Jsonix.Schema.XSD.Base64Binary.INSTANCE,Jsonix.Schema.XSD.Boolean.INSTANCE,Jsonix.Schema.XSD.Byte.INSTANCE,Jsonix.Schema.XSD.Calendar.INSTANCE,Jsonix.Schema.XSD.Date.INSTANCE,Jsonix.Schema.XSD.DateTime.INSTANCE,Jsonix.Schema.XSD.Decimal.INSTANCE,Jsonix.Schema.XSD.Double.INSTANCE,Jsonix.Schema.XSD.Duration.INSTANCE,Jsonix.Schema.XSD.Float.INSTANCE,Jsonix.Schema.XSD.GDay.INSTANCE,Jsonix.Schema.XSD.GMonth.INSTANCE,Jsonix.Schema.XSD.GMonthDay.INSTANCE,Jsonix.Schema.XSD.GYear.INSTANCE,Jsonix.Schema.XSD.GYearMonth.INSTANCE,Jsonix.Schema.XSD.HexBinary.INSTANCE,Jsonix.Schema.XSD.ID.INSTANCE,Jsonix.Schema.XSD.IDREF.INSTANCE,Jsonix.Schema.XSD.IDREFS.INSTANCE,Jsonix.Schema.XSD.Int.INSTANCE,Jsonix.Schema.XSD.Integer.INSTANCE,Jsonix.Schema.XSD.Language.INSTANCE,Jsonix.Schema.XSD.Long.INSTANCE,Jsonix.Schema.XSD.Name.INSTANCE,Jsonix.Schema.XSD.NCName.INSTANCE,Jsonix.Schema.XSD.NegativeInteger.INSTANCE,Jsonix.Schema.XSD.NMToken.INSTANCE,Jsonix.Schema.XSD.NMTokens.INSTANCE,Jsonix.Schema.XSD.NonNegativeInteger.INSTANCE,Jsonix.Schema.XSD.NonPositiveInteger.INSTANCE,Jsonix.Schema.XSD.NormalizedString.INSTANCE,Jsonix.Schema.XSD.Number.INSTANCE,Jsonix.Schema.XSD.PositiveInteger.INSTANCE,Jsonix.Schema.XSD.QName.INSTANCE,Jsonix.Schema.XSD.Short.INSTANCE,Jsonix.Schema.XSD.String.INSTANCE,Jsonix.Schema.XSD.Strings.INSTANCE,Jsonix.Schema.XSD.Time.INSTANCE,Jsonix.Schema.XSD.Token.INSTANCE,Jsonix.Schema.XSD.UnsignedByte.INSTANCE,Jsonix.Schema.XSD.UnsignedInt.INSTANCE,Jsonix.Schema.XSD.UnsignedLong.INSTANCE,Jsonix.Schema.XSD.UnsignedShort.INSTANCE],CLASS_NAME:"Jsonix.Context"});
-Jsonix.Context.Marshaller=Jsonix.Class({context:null,initialize:function(b){Jsonix.Util.Ensure.ensureObject(b);
-this.context=b
-},marshalString:function(e){var d=this.marshalDocument(e);
-var f=Jsonix.DOM.serialize(d);
-return f
-},marshalDocument:function(d){var e=new Jsonix.XML.Output({namespacePrefixes:this.context.properties.namespacePrefixes});
-var f=e.writeStartDocument();
-this.marshalElementNode(d,e);
-e.writeEndDocument();
-return f
-},marshalElementNode:function(k,p,m){Jsonix.Util.Ensure.ensureObject(k);
-Jsonix.Util.Ensure.ensureObject(k.name);
-Jsonix.Util.Ensure.ensureExists(k.value);
-var o=Jsonix.XML.QName.fromObject(k.name);
-var i=this.context.getElementInfo(o,m);
-if(!Jsonix.Util.Type.exists(i)){throw new Error("Could not find element declaration for the element ["+o.key+"].")
-}Jsonix.Util.Ensure.ensureObject(i.typeInfo);
-var l=i.typeInfo;
-var n=p.writeStartElement(k.name);
-var j=Jsonix.Model.Adapter.getAdapter(i);
-j.marshal(l,k.value,this.context,p,m);
-p.writeEndElement();
-return n
-},CLASS_NAME:"Jsonix.Context.Marshaller"});
-Jsonix.Context.Unmarshaller=Jsonix.Class({context:null,initialize:function(b){Jsonix.Util.Ensure.ensureObject(b);
-this.context=b
-},unmarshalString:function(c){Jsonix.Util.Ensure.ensureString(c);
-var d=Jsonix.DOM.parse(c);
-return this.unmarshalDocument(d)
-},unmarshalURL:function(d,f,e){Jsonix.Util.Ensure.ensureString(d);
-Jsonix.Util.Ensure.ensureFunction(f);
-if(Jsonix.Util.Type.exists(e)){Jsonix.Util.Ensure.ensureObject(e)
-}that=this;
-Jsonix.DOM.load(d,function(a){f(that.unmarshalDocument(a))
-},e)
-},unmarshalFile:function(g,h,e){if(typeof _jsonix_fs==="undefined"){throw new Error("File unmarshalling is only available in environments which support file systems.")
-}Jsonix.Util.Ensure.ensureString(g);
-Jsonix.Util.Ensure.ensureFunction(h);
-if(Jsonix.Util.Type.exists(e)){Jsonix.Util.Ensure.ensureObject(e)
-}that=this;
-var f=_jsonix_fs;
-f.readFile(g,e,function(d,c){if(d){throw d
-}else{var a=c.toString();
-var b=Jsonix.DOM.parse(a);
-h(that.unmarshalDocument(b))
-}})
-},unmarshalDocument:function(f){var d=new Jsonix.XML.Input(f);
-var e=null;
-d.nextTag();
-return this.unmarshalElementNode(d)
-},unmarshalElementNode:function(o,m){if(o.eventType!=1){throw new Error("Parser must be on START_ELEMENT to read next text.")
-}var j=null;
-var n=Jsonix.XML.QName.fromObject(o.getName());
-var p=this.context.getElementInfo(n,m);
-if(!Jsonix.Util.Type.exists(p)){throw new Error("Could not find element declaration for the element ["+n.key+"].")
-}Jsonix.Util.Ensure.ensureObject(p.typeInfo);
-var k=p.typeInfo;
-var i=Jsonix.Model.Adapter.getAdapter(p);
-var l=i.unmarshal(k,this.context,o,m);
-j={name:n,value:l};
-return j
-},CLASS_NAME:"Jsonix.Context.Unmarshaller"});
+return this.prefixNamespaces[b]
+},getPrefix:function(e,d){Jsonix.Util.Ensure.ensureString(e);
+var f=this.namespacePrefixes[e];
+if(Jsonix.Util.Type.isString(f)){return f
+}else{return d
+}},builtinTypeInfos:[Jsonix.Schema.XSD.AnyType.INSTANCE,Jsonix.Schema.XSD.AnySimpleType.INSTANCE,Jsonix.Schema.XSD.AnyURI.INSTANCE,Jsonix.Schema.XSD.Base64Binary.INSTANCE,Jsonix.Schema.XSD.Boolean.INSTANCE,Jsonix.Schema.XSD.Byte.INSTANCE,Jsonix.Schema.XSD.Calendar.INSTANCE,Jsonix.Schema.XSD.DateAsDate.INSTANCE,Jsonix.Schema.XSD.Date.INSTANCE,Jsonix.Schema.XSD.DateTimeAsDate.INSTANCE,Jsonix.Schema.XSD.DateTime.INSTANCE,Jsonix.Schema.XSD.Decimal.INSTANCE,Jsonix.Schema.XSD.Double.INSTANCE,Jsonix.Schema.XSD.Duration.INSTANCE,Jsonix.Schema.XSD.Float.INSTANCE,Jsonix.Schema.XSD.GDay.INSTANCE,Jsonix.Schema.XSD.GMonth.INSTANCE,Jsonix.Schema.XSD.GMonthDay.INSTANCE,Jsonix.Schema.XSD.GYear.INSTANCE,Jsonix.Schema.XSD.GYearMonth.INSTANCE,Jsonix.Schema.XSD.HexBinary.INSTANCE,Jsonix.Schema.XSD.ID.INSTANCE,Jsonix.Schema.XSD.IDREF.INSTANCE,Jsonix.Schema.XSD.IDREFS.INSTANCE,Jsonix.Schema.XSD.Int.INSTANCE,Jsonix.Schema.XSD.Integer.INSTANCE,Jsonix.Schema.XSD.Language.INSTANCE,Jsonix.Schema.XSD.Long.INSTANCE,Jsonix.Schema.XSD.Name.INSTANCE,Jsonix.Schema.XSD.NCName.INSTANCE,Jsonix.Schema.XSD.NegativeInteger.INSTANCE,Jsonix.Schema.XSD.NMToken.INSTANCE,Jsonix.Schema.XSD.NMTokens.INSTANCE,Jsonix.Schema.XSD.NonNegativeInteger.INSTANCE,Jsonix.Schema.XSD.NonPositiveInteger.INSTANCE,Jsonix.Schema.XSD.NormalizedString.INSTANCE,Jsonix.Schema.XSD.Number.INSTANCE,Jsonix.Schema.XSD.PositiveInteger.INSTANCE,Jsonix.Schema.XSD.QName.INSTANCE,Jsonix.Schema.XSD.Short.INSTANCE,Jsonix.Schema.XSD.String.INSTANCE,Jsonix.Schema.XSD.Strings.INSTANCE,Jsonix.Schema.XSD.TimeAsDate.INSTANCE,Jsonix.Schema.XSD.Time.INSTANCE,Jsonix.Schema.XSD.Token.INSTANCE,Jsonix.Schema.XSD.UnsignedByte.INSTANCE,Jsonix.Schema.XSD.UnsignedInt.INSTANCE,Jsonix.Schema.XSD.UnsignedLong.INSTANCE,Jsonix.Schema.XSD.UnsignedShort.INSTANCE],CLASS_NAME:"Jsonix.Context"});
 	// Complete Jsonix script is included above
 	return { Jsonix: Jsonix };
 };

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -573,7 +573,7 @@
   }
 }
 
-gn-features-tables {
+gn-features-tables, .gn-viewer-info-pane {
   display          : block;
   position         : absolute;
   bottom           : 1em;
@@ -607,6 +607,11 @@ gn-features-tables {
   .close {
     font-size : 24px;
     margin    : .25em .4em 0 0;
+  }
+
+  .profile {
+    width: 100%;
+    min-height: 20em;
   }
 }
 

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -126,7 +126,7 @@
                       $angularApp = 'gn_admin'">
           <script src="{$uiResourcesPath}lib/zip/zip.js"></script>
           <!-- Jsonix resources (OWS Context) -->
-          <script src="{$uiResourcesPath}lib/jsonix/jsonix/Jsonix-min.js"></script>
+          <script src="{$uiResourcesPath}lib/jsonix/jsonix/Jsonix-all.js"></script>
           <script type="text/javascript">
             zip.workerScriptsPath = "../../catalog/lib/zip/";
           </script>


### PR DESCRIPTION
This PR adds support for `ComplexData` inputs with a new directive that allows the user to draw shapes according to the format specified. Experimental support has also been added for profile graph display in the viewer.

This feature has been developed for a specific WPS service and may not work with others, although it can probably be expanded easily.

Also contains a fix with `PrintMapDirective` giving an error on page load.