### PR TITLE
Adds support for WMS layer in graticule directive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -587,6 +587,27 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <div data-ng-switch-when="graticuleOgcService">
+        <label class="control-label">{{('ui-' + key) | translate}}</label>
+        <div class="input-group">
+          <span class="input-group-addon">Type </span>
+          <input type="text"
+                 class="form-control"
+                 data-ng-model="mCfg[key].type"/>
+          <span class="input-group-addon">Layer </span>
+          <input type="text"
+                 class="form-control"
+                 data-ng-model="mCfg[key].layer"/>
+          <span class="input-group-addon">Url </span>
+          <input type="text"
+                 class="form-control"
+                 data-ng-model="mCfg[key].url"/>
+        </div>
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
       <div data-ng-switch-default>
         <label class="control-label">{{('ui-' + key) | translate}}</label>
         <input type="text"

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -234,6 +234,12 @@
                   scope.selectedWps.url = openedTool.url;
                 }
               }, true);
+
+              // ogc graticule
+              var ogcGraticule = gnViewerSettings.mapConfig.graticuleOgcService;
+              if (ogcGraticule && ogcGraticule.layer && ogcGraticule.url) {
+                scope.graticuleOgcService = ogcGraticule;
+              }
             },
             post: function postLink(scope, iElement, iAttrs, controller) {
               //TODO: find another solution to render the map

--- a/web-ui/src/main/resources/catalog/components/viewer/graticule/GraticuleDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/graticule/GraticuleDirective.js
@@ -128,33 +128,67 @@
       replace: true,
       templateUrl: '../../catalog/components/viewer/graticule/partials/' +
           'graticule.html',
+      scope: true,
       link: function(scope, element, attrs) {
-
         var map = scope.$eval(attrs['gnGraticuleBtn']);
+        var graticuleOgcService = scope.$eval(attrs['graticuleOgcService']);
+        var graticule = null;
 
-        var graticule = new ol.Graticule({
-          strokeStyle: new ol.style.Stroke({
-            color: 'rgba(255,120,0,0.9)',
-            width: 1,
-            lineDash: [0.5, 1]
-          })
-        });
-
-        Object.defineProperty(graticule, 'active', {
-          get: function() {
-            return !!graticule.getMap();
-          },
-          set: function(val) {
-            if (val) {
-              graticule.setMap(map);
-              map.on('postcompose', renderCoords);
-
-            } else {
-              graticule.setMap(null);
-              map.un('postcompose', renderCoords);
-            }
+        // for now, only WMS services are supported by the directive
+        if (graticuleOgcService) {
+          if (!graticuleOgcService.layer || !graticuleOgcService.url) {
+            console.error('Missing property for graticule layer ' +
+              '(required: \'url\', \'layer\'):\n', graticuleOgcService);
+            return;
           }
-        });
+
+          graticule = new ol.layer.Image({
+            source: new ol.source.ImageWMS({
+              url: graticuleOgcService.url,
+              params: { 'LAYERS': graticuleOgcService.layer },
+              ratio: 1
+            })
+          });
+          graticule.background = true;  // do not save it in context
+          // graticule.setZIndex(100);    // TODO: uncomment after OL upgrade
+          graticule.setVisible(false);  // hidden by default
+          map.addLayer(graticule);
+
+          // 'active' prop makes ogc layer visible/invisible
+          Object.defineProperty(graticule, 'active', {
+            get: function() {
+              return graticule.getVisible();
+            },
+            set: function(val) {
+              graticule.setVisible(val);
+            }
+          });
+        } else {
+          graticule = new ol.Graticule({
+            strokeStyle: new ol.style.Stroke({
+              color: 'rgba(255,120,0,0.9)',
+              width: 1,
+              lineDash: [0.5, 1]
+            })
+          });
+
+          // 'active' prop adds or remove ol.Graticule object
+          Object.defineProperty(graticule, 'active', {
+            get: function() {
+              return !!graticule.getMap();
+            },
+            set: function(val) {
+              if (val) {
+                graticule.setMap(map);
+                map.on('postcompose', renderCoords);
+
+              } else {
+                graticule.setMap(null);
+                map.un('postcompose', renderCoords);
+              }
+            }
+          });
+        }
         scope.graticule = graticule;
 
         var transform = ol.proj.getTransform(map.getView().getProjection(),

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -89,7 +89,8 @@
             data-ng-class="is3dEnabled ? 'fa-cube' : 'fa-square-o'"/>
       <span role="tooltip" data-translate="">switchFrom2DTo3D</span>
     </button>
-    <button gn-graticule-btn="map" class="btn btn-default" type="submit">
+    <button gn-graticule-btn="map" class="btn btn-default" type="submit"
+      graticule-ogc-service="graticuleOgcService">
   </div>
 
 

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -169,9 +169,12 @@
             'code': 'EPSG:3857',
             'label': 'Google mercator (EPSG:3857)'
           }],
+          'searchMapLayers': [],
+          'viewerMapLayers': [],
           'disabledTools': {
             'processes': true
-          }
+          },
+          'graticuleOgcService': {}
         },
         'editor': {
           'enabled': true,

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1111,5 +1111,7 @@
     "ui-viewerMapLayers": "Viewer Map Layers",
     "ui-viewerMapLayers-help": "Optional. Define here background layers to add on top of layers in the default map context.",
     "ui-disabledTools": "Optional Map Viewer Tools",
-    "ui-disabledTools-help": "You can decide to show or hide these tools in the map viewer. Selected tools will be shown to the users."
+    "ui-disabledTools-help": "You can decide to show or hide these tools in the map viewer. Selected tools will be shown to the users.",
+    "ui-graticuleOgcService": "OGC Service to use as graticule",
+    "ui-graticuleOgcService-help": "Optional. For now, only WMS services are supported."
 }


### PR DESCRIPTION
This PR extends the `GraticuleDirective` by adding a mode where a WMS service is used instead of software rendering with OpenLayers.
A setting has been added in the admin console too.