### PR TITLE
Don't show RETIRED metadata in the search results by default

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -738,6 +738,10 @@ public class DataManager implements ApplicationEventPublisherAware {
                 moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.STATUS, status, true, true));
                 String statusChangeDate = stat.getId().getChangeDate().getDateAndTime();
                 moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.STATUS_CHANGE_DATE, statusChangeDate, true, true));
+            } else {
+                // _status
+                // 0 : unknown or workflow not enabled.
+                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.STATUS, Params.Status.UNKNOWN, true, true));
             }
 
             // getValidationInfo

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -294,7 +294,7 @@
 
         // Retrieve main search information
         var searchInfo = userLogin.then(function(value) {
-          var url = 'qi?_content_type=json&summaryOnly=true';
+          var url = 'qi?_content_type=json&summaryOnly=true&_status=0 or 1 or 2 or 4 or 5';
           return gnSearchManagerService.search(url).
               then(function(data) {
                 $scope.searchInfo = data;

--- a/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
@@ -37,6 +37,7 @@
         sortbyValues: gnSearchSettings.sortbyValues,
         hitsperpageValues: gnSearchSettings.hitsperpageValues,
         selectionBucket: 'be101',
+        showRetired: true,
         params: {
           sortBy: 'changeDate',
           _isTemplate: 'y or n',
@@ -47,6 +48,8 @@
         }
       };
       angular.extend($scope.searchObj, $scope.defaultSearchObj);
+      // Do not use the _status filter in the editor dashboard
+      delete $scope.searchObj.params._status;
 
 
       // Only my record toggle

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -52,6 +52,7 @@
         sortbyValues: gnSearchSettings.sortbyValues,
         hitsperpageValues: gnSearchSettings.hitsperpageValues,
         selectionBucket: 'e101',
+        showRetired: true,
         params: {
           sortBy: 'changeDate',
           _isTemplate: 'y or n or s',
@@ -61,6 +62,8 @@
         }
       };
       angular.extend($scope.searchObj, $scope.defaultSearchObj);
+      // Do not use the _status filter in the editor dashboard
+      delete $scope.searchObj.params._status;
 
       $scope.toggleOnlyMyRecord = function() {
         $scope.onlyMyRecord = !$scope.onlyMyRecord;

--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -49,11 +49,11 @@
 
       /** Object to be shared through directives and controllers */
       $scope.searchObj = {
-        params: {},
         permalink: true,
         sortbyValues: gnSearchSettings.sortbyValues,
         sortbyDefault: gnSearchSettings.sortbyDefault,
-        hitsperpageValues: gnSearchSettings.hitsperpageValues
+        hitsperpageValues: gnSearchSettings.hitsperpageValues,
+        showRetired: false
       };
 
       /** Facets configuration */

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -168,6 +168,7 @@
   "overview": "Overview",
   "chooseAView": "Display mode",
   "metadataContact": "Contact for the metadata",
+  "showRetired": "Show retired metadata",
   "metadataRemoved": "{{title}} removed.",
   "extent": "Spatial extent",
   "aboutThisResource": "About this resource",

--- a/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
@@ -66,7 +66,7 @@
                       </button>
 
                       <button type="button"
-                              data-ng-click="onlyMyRecord = false;resetSearch(defaultSearchObj.params);"
+                              data-ng-click="onlyMyRecord = false;resetSearch(defaultSearchObj.params, false);"
                               title="{{'ClearTitle' | translate}}"
                               class="btn btn-link">
                         <i class="fa fa-times"></i>

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -40,7 +40,7 @@
                 </button>
 
                 <button type="button"
-                        data-ng-click="onlyMyRecord = false;resetSearch(defaultSearchObj.params);"
+                        data-ng-click="onlyMyRecord = false;resetSearch(defaultSearchObj.params, false);"
                         title="{{'ClearTitle' | translate}}"
                         class="btn btn-link">
                   <i class="fa fa-times"></i>

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -50,7 +50,8 @@
         params: {
           sortBy: 'popularity',
           from: 1,
-          to: 9
+          to: 9,
+          _status: '0 or 1 or 2 or 4 or 5'
         }
       };
     }]);
@@ -64,7 +65,8 @@
         params: {
           sortBy: 'changeDate',
           from: 1,
-          to: 9
+          to: 9,
+          _status: '0 or 1 or 2 or 4 or 5'
         }
       };
     }]);
@@ -156,7 +158,11 @@
 
 
       $scope.goToSearch = function (any) {
-        $location.path('/search').search({'any': any});
+        $location.path('/search').search(
+          {
+            'any': any,
+            '_status': '0 or 1 or 2 or 4 or 5'
+          });
       };
       $scope.canEdit = function(record) {
         // TODO: take catalog config for harvested records
@@ -314,7 +320,8 @@
         },
         params: {
           'facet.q': '',
-          resultType: gnSearchSettings.facetsSummaryType || 'details'
+          resultType: gnSearchSettings.facetsSummaryType || 'details',
+          '_status': '0 or 1 or 2 or 4 or 5'
         }
       }, gnSearchSettings.sortbyDefault);
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -16,7 +16,7 @@
         <span class="input-group-btn">
           <a class="btn btn-primary btn-lg"
              type="button"
-             data-ng-href="#/search?any={{homeAnyField}}">
+             data-ng-href="#/search?any={{homeAnyField}}&_status=0 or 1 or 2 or 4 or 5">
             <i class="fa fa-search"></i>
           </a>
         </span>

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -108,6 +108,15 @@
               </div>
             </div>
             <div class="col-md-5">
+              <div class="checkbox">
+                <label for="showRetired"
+                       class="control-label">
+                  <input type="checkbox" id="showRetired"
+                         ng-model="searchObj.showRetired">
+                  <strong>
+                    <span data-translate="">showRetired</span>
+                  </strong>
+                </label>
 
             </div>
           </div>


### PR DESCRIPTION
Restrict the search results to the metadata with status `UNKNOWN`, `DRAFT`, `APPROVED`, `SUBMITTED` or `REJECTED`. To allow the search of the `RETIRED` metadata a checkbox is added to the advanced search form.

![image](https://user-images.githubusercontent.com/826920/27900223-c2a4e080-622d-11e7-8623-4ba94b1f14c7.png)

The `_status=0 or 1 or 2 or 4 or 5` filter is added to the search query unless the checkbox _Show retired metadata_ is checked. This filter is always added to the initial search to to get the records count in the main page and the newest and most popular records search.

If the workflow has not been ever enabled for a record there is no `_status` field in the index for it.  This change add `_status=0` _UNKNOWN_ to each record to allow the search filter. So a **full reindex is required after this change to show the metadata without workflow**.
