### PR TITLE
Add multilingual values in multilingual fields for directives managed in render-element template

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -108,7 +108,7 @@
     <xsl:variable name="isRequired" as="xs:boolean">
       <xsl:choose>
         <xsl:when
-          test="($parentEditInfo and $parentEditInfo/@min = 1 and $parentEditInfo/@max = 1) or 
+          test="($parentEditInfo and $parentEditInfo/@min = 1 and $parentEditInfo/@max = 1) or
           (not($parentEditInfo) and $editInfo and $editInfo/@min = 1 and $editInfo/@max = 1)">
           <xsl:value-of select="true()"/>
         </xsl:when>
@@ -125,7 +125,24 @@
       <xsl:when test="$directive != ''">
         <div class="form-group" id="gn-el-{$editInfo/@ref}">
           <div class="col-lg-10">
-            <xsl:attribute name="data-{$directive}" select="$value"/>
+            <xsl:choose>
+              <xsl:when test="$isMultilingual">
+                <xsl:attribute name="data-{$directive}">
+                {
+                <xsl:for-each select="$value/values/value">
+                  <xsl:sort select="@lang"/>
+                  "<xsl:value-of select="@lang" />":
+                  {"ref" : "<xsl:value-of select="@ref" />", "value": "<xsl:value-of select="." />"}
+                  <xsl:if test="position() != last()">,</xsl:if>
+                </xsl:for-each>
+                }
+                </xsl:attribute>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:attribute name="data-{$directive}" select="$value"/>
+              </xsl:otherwise>
+            </xsl:choose>
+
             <xsl:attribute name="data-ref" select="concat('_', $editInfo/@ref)"/>
             <xsl:attribute name="data-label" select="$label/label"/>
           </div>


### PR DESCRIPTION
In the `render-element` when using `directive` parameter, the value for multilingual fields is not handle properly, sending all translation values in the same field as a string:

https://github.com/geonetwork/core-geonetwork/blob/3.2.x/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl#L128

This Pull Request sends a JSON doc with the language/id/value for each multilingual element to the directive.

In any case, the `render-element` template accepts also a `type` parameter that can be used also for directives and is handle in https://github.com/geonetwork/core-geonetwork/blob/3.2.x/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl#L142, not very clear the reason to handle directives in 2 ways. The pull request only affects the `directive` parameter.
