### PR TITLE
Moving the "forcing a csrf token on angular" to the general catalog instead of only the login.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -148,9 +148,15 @@
       //Comment the following lines if you want to remove csrf support
       $http.defaults.xsrfHeaderName = 'X-XSRF-TOKEN';
       $http.defaults.xsrfCookieName = 'XSRF-TOKEN';
-      $scope.$watch(function() { return $cookies.get('XSRF-TOKEN'); }, function(value) {
+      $scope.$watch(function() { 
+          return $cookies.get($http.defaults.xsrfCookieName); 
+        }, function(value) {
         $rootScope.csrf = value;
       });
+      //If no csrf, ask for one:
+      if(!$rootScope.csrf) {
+        $http.post('info?type=me');
+      }
       //Comment the upper lines if you want to remove csrf support
 
       /**

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -57,11 +57,6 @@
           $scope.signinFailure = gnUtilityService.getUrlParameter('failure');
           $scope.gnConfig = gnConfig;
 
-          //If no csrf, ask for one:
-          if (!$rootScope.csrf) {
-            $http.post('info?type=me');
-          }
-
           function initForm() {
            if ($window.location.pathname.indexOf('new.password') !== -1) {
              // Retrieve username from URL parameter


### PR DESCRIPTION
This fixes for example when opening directly a search results in an anonymous tab (clean browser) and try to select all records. As it is a post call, it needs a csrf token already.