### PR TITLE
Directory UI improvements

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -93,8 +93,7 @@
         data-popup-action="true"
         data-template-type="contact"
         data-insert-modes=""
-        data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"
-        data-show-valid-only="true"/>
+        data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
     </for>
     <for name="gmd:distributorContact" addDirective="data-gn-directory-entry-selector">
       <directiveAttributes

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -93,7 +93,8 @@
         data-popup-action="true"
         data-template-type="contact"
         data-insert-modes=""
-        data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
+        data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"
+        data-show-valid-only="true"/>
     </for>
     <for name="gmd:distributorContact" addDirective="data-gn-directory-entry-selector">
       <directiveAttributes

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -77,9 +77,11 @@
               // If not using the directive in an editor context, set
               // the schema id to properly retrieve the codelists.
               schema: '@',
-              selectEntryCb: '='
+              selectEntryCb: '=',
               // Can restrict how to insert the entry (xlink, text ..)
               // insertModes: '@'
+              // If true, will only show entries with a valid status of 1
+              showValidOnly: '@'
             },
             templateUrl: '../../catalog/components/edit/' +
                 'directoryentryselector/partials/' +
@@ -98,7 +100,8 @@
                       _root: 'gmd:CI_ResponsibleParty',
                       sortBy: 'title',
                       sortOrder: 'reverse',
-                      resultType: 'subtemplates'
+                      resultType: 'subtemplates',
+                      _valid: scope.showValidOnly ? 1 : undefined
                     }
                   };
 

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -101,7 +101,7 @@
                       sortBy: 'title',
                       sortOrder: 'reverse',
                       resultType: 'subtemplates',
-                      _valid: scope.showValidOnly ? 1 : undefined
+                      _valid: scope.$eval(scope.showValidOnly) ? 1 : undefined
                     }
                   };
 
@@ -280,7 +280,10 @@
                     openModal({
                       title: $translate.instant('chooseEntry'),
                       content:
-                     '<div gn-directory-entry-list-selector=""></div>',
+                        '<div gn-directory-entry-list-selector="" '+
+                        (scope.$eval(scope.showValidOnly) ?
+                          ' show-valid-only="true"' : '') +
+                        '></div>',
                       class: 'gn-modal-lg'
                     }, scope, 'EntrySelected');
                   };
@@ -299,62 +302,64 @@
 
   module.directive('gnDirectoryEntryListSelector',
       ['gnGlobalSettings',
-       function(gnGlobalSettings) {
-         return {
-           restrict: 'A',
-           templateUrl: '../../catalog/components/edit/' +
-           'directoryentryselector/partials/' +
-           'directoryentrylistselector.html',
+    function(gnGlobalSettings) {
+      return {
+        restrict: 'A',
+        templateUrl: '../../catalog/components/edit/' +
+        'directoryentryselector/partials/' +
+        'directoryentrylistselector.html',
 
-           compile: function compile(tElement, tAttrs, transclude) {
-             return {
-               pre: function preLink(scope) {
-                 scope.searchObj = {
-                   defaultParams: {
-                     _isTemplate: 's',
-                     any: '',
-                     from: 1,
-                     to: 10,
-                     _root: 'gmd:CI_ResponsibleParty',
-                     sortBy: 'title',
-                     sortOrder: 'reverse',
-                     resultType: 'contact'
-                   }
-                 };
-                 scope.searchObj.params = angular.extend({},
-                 scope.searchObj.defaultParams);
-                 scope.stateObj = {
-                   selectRecords: []
-                 };
-                 if (scope.filter) {
-                   var filter = angular.fromJson(scope.filter);
-                   angular.extend(scope.searchObj.params, filter);
-                   angular.extend(scope.searchObj.defaultParams, filter);
-                 }
-                 scope.modelOptions = angular.copy(
-                 gnGlobalSettings.modelOptions);
-               },
-               post: function postLink(scope, iElement, iAttrs) {
-                 scope.ctrl = {};
+        compile: function compile(tElement, tAttrs, transclude) {
+          return {
+            pre: function preLink(scope) {
+              scope.searchObj = {
+                defaultParams: {
+                  _isTemplate: 's',
+                  any: '',
+                  from: 1,
+                  to: 10,
+                  _root: 'gmd:CI_ResponsibleParty',
+                  sortBy: 'title',
+                  sortOrder: 'reverse',
+                  resultType: 'contact',
+                  _valid: scope.$eval(tAttrs['showValidOnly']) ? 1 : undefined
+                }
+              };
+              scope.searchObj.params = angular.extend({},
+                scope.searchObj.params,
+                scope.searchObj.defaultParams);
+              scope.stateObj = {
+                selectRecords: []
+              };
+              if (scope.filter) {
+                var filter = angular.fromJson(scope.filter);
+                angular.extend(scope.searchObj.params, filter);
+                angular.extend(scope.searchObj.defaultParams, filter);
+              }
+              scope.modelOptions = angular.copy(
+              gnGlobalSettings.modelOptions);
+            },
+            post: function postLink(scope, iElement, iAttrs) {
+              scope.ctrl = {};
 
-                 scope.defaultRoleCode = iAttrs['defaultRole'] || null;
-                 scope.defaultRole = null;
-                 angular.forEach(scope.roles, function(r) {
-                   if (r.code == scope.defaultRoleCode) {
-                     scope.defaultRole = r;
-                   }
-                 });
-                 scope.addSelectedEntry = function(role, usingXlink) {
-                   scope.addEntry(
-                   scope.stateObj.selectRecords[0],
-                   role,
-                   usingXlink).then(function(r) {
-                     scope.closeModal();
-                   });
-                 };
-               }
-             };
-           }
-         };
-       }]);
+              scope.defaultRoleCode = iAttrs['defaultRole'] || null;
+              scope.defaultRole = null;
+              angular.forEach(scope.roles, function(r) {
+                if (r.code == scope.defaultRoleCode) {
+                  scope.defaultRole = r;
+                }
+              });
+              scope.addSelectedEntry = function(role, usingXlink) {
+                scope.addEntry(
+                scope.stateObj.selectRecords[0],
+                role,
+                usingXlink).then(function(r) {
+                  scope.closeModal();
+                });
+              };
+            }
+          };
+        }
+      };
+    }]);
 })();

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentrylistselector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentrylistselector.html
@@ -39,7 +39,7 @@
     <div class="col-md-8">
 
       <div data-gn-search-form-results
-           data-gn-search-form-results-mode="simple"
+           data-gn-search-form-results-mode="directory"
            data-gn-search-form-results-selection-mode="local simple"
            data-search-results="searchResults"
            data-select-records="stateObj.selectRecords"

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
@@ -26,63 +26,66 @@
     <div class="list-group tt-dropdown-menu gn-autocomplete-list"
          data-ng-show="searchResults.records.length > 0">
       <span class="tt-suggestions">
-        <div class="tt-suggestion"
-             data-ng-repeat="r in searchResults.records">
+        <div class="tt-suggestion flex-row"
+          data-ng-repeat="r in searchResults.records">
 
-            <!-- Add action for simple subtemplates -->
-            <div class="btn btn-default btn-sm pull-right"
-                 data-ng-if="insertAsXlink && !hasDynamicVariable"
-                 data-ng-click="addEntry(r, undefined, true)">
-              <i class="fa fa-link"></i>
-            </div>
-            <div class="btn btn-default btn-sm pull-right"
-                 data-ng-if="insertAsText && !hasDynamicVariable"
-                 data-ng-click="addEntry(r)">
-              <i class="fa fa-plus"></i>
-            </div>
+          <!-- Add action for simple subtemplates -->
+          <gn-md-type-widget metadata="r"></gn-md-type-widget>
+          <div class="btn btn-default btn-sm pull-right"
+                data-ng-if="insertAsXlink && !hasDynamicVariable"
+                data-ng-click="addEntry(r, undefined, true)">
+            <i class="fa fa-link"></i>
+          </div>
+          <div class="btn btn-default btn-sm pull-right"
+                data-ng-if="insertAsText && !hasDynamicVariable"
+                data-ng-click="addEntry(r)">
+            <i class="fa fa-plus"></i>
+          </div>
+
+          <div class="flex-spacer" />
+
+          <div class="text flex-grow"> {{r.title}}</div>
 
           <!--Add contact as Xlink with dynamic variable -->
-            <div ngeo-popover class="pull-right"
-                 ngeo-popover-dismiss=".content"
-                 data-ng-if="::gnConfig[gnConfig.key.isXLinkEnabled] && insertAsXlink  && hasDynamicVariable"
-                 title="{{'addContactAsLink-help' | translate}}">
-               <button ngeo-popover-anchor type="button" class="btn btn-default btn-sm">
-                <i class="fa fa-link"></i>&nbsp;<span class="caret"></span>
-              </button>
-              <div ngeo-popover-content>
-                <ul>
-                  <li data-ng-repeat="role in roles" data-ng-hide="role['@hideInEditMode']">
-                    <a href="" data-ng-click="addEntry(r, role.code, true)" title="{{role.description}}">
-                      {{role.label}}
-                    </a>
-                  </li>
-                </ul>
-              </div>
+          <div ngeo-popover class="pull-right"
+                ngeo-popover-dismiss=".content"
+                data-ng-if="::gnConfig[gnConfig.key.isXLinkEnabled] && insertAsXlink  && hasDynamicVariable"
+                title="{{'addContactAsLink-help' | translate}}">
+              <button ngeo-popover-anchor type="button" class="btn btn-default btn-sm">
+              <i class="fa fa-link"></i>&nbsp;<span class="caret"></span>
+            </button>
+            <div ngeo-popover-content>
+              <ul>
+                <li data-ng-repeat="role in roles" data-ng-hide="role['@hideInEditMode']">
+                  <a href="" data-ng-click="addEntry(r, role.code, true)" title="{{role.description}}">
+                    {{role.label}}
+                  </a>
+                </li>
+              </ul>
             </div>
+          </div>
 
           <!-- Add contact as text block with dynamic variable -->
-            <div ngeo-popover class="pull-right"
-                 ngeo-popover-dismiss=".content"
-                 data-ng-if="isContact && hasDynamicVariable && insertAsText"
-                 title="{{'addContactAsText-help' | translate}}">
-               <button ngeo-popover-anchor type="button"
-                       class="btn btn-default btn-sm">
-                <i class="fa fa-plus"></i>&nbsp;<span class="caret"></span>
-              </button>
-              <div ngeo-popover-content>
-                <ul>
-                  <li data-ng-repeat="role in roles"
-                      data-ng-hide="role['@hideInEditMode']">
-                    <a href="" data-ng-click="addEntry(r, role.code)"
-                       title="{{role.description}}">
-                      {{role.label}}
-                    </a>
-                  </li>
-                </ul>
-              </div>
+          <div ngeo-popover class="pull-right"
+                ngeo-popover-dismiss=".content"
+                data-ng-if="isContact && hasDynamicVariable && insertAsText"
+                title="{{'addContactAsText-help' | translate}}">
+              <button ngeo-popover-anchor type="button"
+                      class="btn btn-default btn-sm">
+              <i class="fa fa-plus"></i>&nbsp;<span class="caret"></span>
+            </button>
+            <div ngeo-popover-content>
+              <ul>
+                <li data-ng-repeat="role in roles"
+                    data-ng-hide="role['@hideInEditMode']">
+                  <a href="" data-ng-click="addEntry(r, role.code)"
+                      title="{{role.description}}">
+                    {{role.label}}
+                  </a>
+                </li>
+              </ul>
             </div>
-
-          <div class="text"> {{r.title}}</div>
+          </div>
         </div>
       </span>
     </div>

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
@@ -42,6 +42,14 @@
             <p ng-if="::md.abstract" class="small">{{md.abstract | characters:200}}</p>
           </div>
         </div>
+        <div data-ng-if="options.mode == 'directory'">
+          <div class="flex-row flex-align-center">
+            <gn-md-type-widget metadata="md"></gn-md-type-widget>
+            <div class="flex-spacer" />
+            <strong>{{md.title || md.defaultTitle}}</strong>
+          </div>
+          <p ng-if="::md.abstract" class="small">{{md.abstract | characters:200}}</p>
+        </div>
       </li>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -78,17 +78,24 @@
           any: '',
           _root: '',
           sortBy: 'title',
+          sortOrder: 'reverse',
           resultType: 'subtemplates'
         },
         sortbyValues: [
           {
-            sortBy: 'title'
+            sortBy: 'title',
+            sortOrder: 'reverse'
           },
           {
-            sortBy: 'owner'
+            sortBy: 'owner',
+            sortOrder: 'reverse'
           },
           {
             sortBy: 'changeDate',
+            sortOrder: 'reverse'
+          },
+          {
+            sortBy: '_valid',
             sortOrder: 'reverse'
           }
         ]

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -340,5 +340,6 @@
     "inputValueRequiredError": "A value is required for this field",
     "inputIsOverloaded": "This value is set in a WFS filter",
     "insertNewInputValue": "Add a value for this input",
-    "profileGraph": "Profile Graph"
+    "profileGraph": "Profile Graph",
+    "_valid": "Validity"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -352,5 +352,5 @@
     "notADirectoryEntryTemplate": "This entry is not a directory entry template.",
     "saveAsDirectoryEntry": "Save as directory entry",
     "confirmDeleteEntry": "Are you sure you want to delete this entry?",
-    "filterByValidityStatus": "Filter by status"
+    "filterBy": "Filter by..."
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -698,6 +698,19 @@ input.ng-invalid {
   border-color: #a94442;
 }
 
+.gn-input-clear {
+  position: absolute;
+  right: 0.5em;
+  top: 50%;
+  transform: translate(0, -50%);
+  cursor: pointer;
+  opacity: 0.4;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 /* Highlight updated checkboxes in sharing form */
 .gn-sharing-batch {
   input.ng-dirty:after {
@@ -732,3 +745,11 @@ input.ng-invalid {
     }
   }
 }
+
+// general purpose layout helpers
+.pos-relative { position: relative; }
+.pos-absolute { position: absolute; }
+.spacer, .flex-grow { flex-grow: 1; }
+.flex-no-grow { flex-grow: 0; }
+.flex-shrink { flex-shrink: 1; }
+.flex-no-shrink { flex-shrink: 0; }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -749,7 +749,24 @@ input.ng-invalid {
 // general purpose layout helpers
 .pos-relative { position: relative; }
 .pos-absolute { position: absolute; }
-.spacer, .flex-grow { flex-grow: 1; }
+.spacer, .flex-spacer { flex-grow: 0; flex-shrink: 0; min-width: 0.7em; }
+.flex-grow { flex-grow: 1; }
 .flex-no-grow { flex-grow: 0; }
 .flex-shrink { flex-shrink: 1; }
-.flex-no-shrink { flex-shrink: 0; }
+.flex-no-shrink, .fa { flex-shrink: 0; }
+.flex-row, .flex-col, .flex-row-r, .flex-col-r {
+  display: flex !important;
+  align-items: baseline;
+}
+.flex-col { flex-direction: column; }
+.flex-col-r { flex-direction: column-reverse; }
+.flex-row { flex-direction: row; }
+.flex-row-r { flex-direction: row-reverse; }
+.flex-start { justify-content: flex-start; }
+.flex-end { justify-content: flex-end; }
+.flex-center { justify-content: center; }
+.flex-align-center { align-items: center; }
+.flex-align-end { align-items: flex-end; }
+.flex-align-start { align-items: flex-start; }
+.text-wrap { white-space: normal; }
+.text-nowrap, .text-no-wrap { white-space: nowrap; }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -108,11 +108,6 @@ input[type=text], input[type=number], select {
 
 
 #gn-directory-container {
-  // note: this could be useful in other places in gn.less
-  .flex-spacer {
-    flex-grow: 1;
-  }
-
   .gn-facet-dropdown {
     min-width: 300px;
     padding: 0px 10px;
@@ -225,6 +220,11 @@ input[type=text], input[type=number], select {
         width: 650px;
       }
     }
+  }
+
+  .dropdown-menu {
+    max-width: 40em;
+    width: 100%;
   }
 }
 

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -739,11 +739,6 @@ gn-directory-associated-md {
     display: block;
   }
 
-  // general purpose flex spacer
-  .spacer {
-    flex-grow: 1;
-  }
-
   .form-controls {
     display: flex;
     align-items: center;

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -784,6 +784,7 @@ gn-md-type-widget {
     color: white;
     margin-top: -0.2em;
     background-color: @gray-light;
+    overflow: hidden;
 
     &.valid-status-1 {
       background-color: @gray-light;

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -709,9 +709,6 @@ form.gn-tab-xml {
     strong {
       font-weight: normal;
     }
-    .fa {
-      display: none;
-    }
   }
 
   ng-pluralize {
@@ -783,6 +780,7 @@ gn-md-type-widget {
     position: relative;
     color: white;
     margin-top: -0.2em;
+    margin-bottom: -0.4em;
     background-color: @gray-light;
     overflow: hidden;
 

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -14,14 +14,11 @@
   <div class="row" ng-show="currentEditorAction == ''">
     <div class="col-md-12 text-right">
       <h5 class="btn-group">
-        <button type="button" class="btn btn-success"
-            ng-click="startImporting(false)">
-          <i class="fa fa-plus"/>&nbsp;
-          <span translate>addNewDirectoryEntry</span>
-        </button>
         <button type="button" class="btn btn-success dropdown-toggle"
           data-toggle="dropdown">
-          <i class="caret"/>
+          <i class="fa fa-plus"/>&nbsp;
+          <span translate>addNewDirectoryEntry</span>
+          &nbsp;<i class="caret"/>
         </button>
         <ul class="dropdown-menu pull-right text-left" role="menu">
           <li class="dropdown-header" translate
@@ -80,193 +77,201 @@
       <form data-ng-search-form>
         <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
-          <div class="panel panel-default dynamic-list">
-            <div class="panel-heading">
-              <i class="fa fa-list-ul fa-fw"/>&nbsp;
-              <span translate ng-if="!userCanEditTemplates">
-                directoryEntries</span>
+        <div class="panel panel-default dynamic-list">
+          <div class="panel-heading">
+            <i class="fa fa-list-ul fa-fw"/>&nbsp;
+            <span translate ng-if="!userCanEditTemplates">
+              directoryEntries</span>
 
-              <ul class="nav nav-pills" ng-if="userCanEditTemplates">
-                <li ng-class="{active : !templatesShown()}">
-                  <a href ng-click="showTemplates(false)" translate>
-                    directoryEntries</a>
-                </li>
-                <li ng-class="{active : templatesShown()}">
-                  <a href ng-click="showTemplates(true)" translate>
-                    directoryTemplates</a>
-                </li>
+            <ul class="nav nav-pills" ng-if="userCanEditTemplates">
+              <li ng-class="{active : !templatesShown()}">
+                <a href ng-click="showTemplates(false)" translate>
+                  directoryEntries</a>
+              </li>
+              <li ng-class="{active : templatesShown()}">
+                <a href ng-click="showTemplates(true)" translate>
+                  directoryTemplates</a>
+              </li>
+            </ul>
+
+            <div class="flex-spacer"></div>
+
+            <div class="pos-relative">
+              <input class="form-control filter-text" type="search"
+                ng-change="triggerSearch()"
+                ng-model="searchObj.params.any"
+                ng-model-options="modelOptions"
+                placeholder="{{'filter' | translate}}" autofocus=""/>
+              <span class="fa fa-times gn-input-clear"
+                ng-click="searchObj.params.any = ''"
+                ng-show="searchObj.params.any"></span>
+            </div>
+            &nbsp;
+            
+            <div class="btn-group">
+              <button type="button"
+                class="btn btn-default dropdown-toggle btn-sm"
+                data-toggle="dropdown"
+                title="{{'filterGroup' | translate}}">
+                <span translate class="hidden-xs">filterGroup</span>
+                &nbsp;<i class="caret" />
+              </button>
+              <ul class="dropdown-menu gn-facet-dropdown pull-right">
+                <div data-gn-facet="searchResults.facet"
+                      data-current-facets="currentFacets"
+                      data-no-collapse="true"
+                      data-facet="groupOwners"
+                      data-index-key="_groupOwner"></div>
+                <div data-gn-facet-breadcrumb=""></div>
               </ul>
+            </div>
+          </div>
+          <div class="panel-body">
+
+            <div ng-show="searching" class="text-center">
+              <br /><br />
+              <i class="fa fa-spinner fa-spin" />
+              <br /><br /><br />
+            </div>
+
+            <div translate ng-show="searchResults.count == 0 && !searching"
+              class="text-muted disabled">
+              noRecordFound
+            </div>
+
+            <div class="search-options-header" ng-show="searchResults.count > 0 && !searching">
+              <div data-gn-pagination="paginationInfo"
+                    data-hits-values="[20, 50, 100]"></div>
 
               <div class="flex-spacer"></div>
 
-              <input class="form-control filter-text" type="search"
-                     data-ng-change="triggerSearch()"
-                     data-ng-model-options="modelOptions"
-                     placeholder="{{'filter' | translate}}" autofocus=""
-                     data-ng-model="searchObj.params.any"/>&nbsp;
-
-              <div class="btn-group">
-                <button type="button"
-                  class="btn btn-default dropdown-toggle btn-sm"
-                  data-toggle="dropdown"
-                  title="{{'filterGroup' | translate}}">
-                  <span translate class="hidden-xs">filterGroup</span>
-                  &nbsp;<i class="caret" />
-                </button>
-                <ul class="dropdown-menu gn-facet-dropdown pull-right">
-                  <div data-gn-facet="searchResults.facet"
-                       data-current-facets="currentFacets"
-                       data-no-collapse="true"
-                       data-facet="groupOwners"
-                       data-index-key="_groupOwner"></div>
-                  <div data-gn-facet-breadcrumb=""></div>
-                </ul>
-              </div>
+              <div data-sortby-combo=""
+                    data-params="searchObj.params"
+                    data-gn-sortby-values="searchObj.sortbyValues"></div>
             </div>
-            <div class="panel-body">
 
-              <div ng-show="searching" class="text-center">
-                <i class="fa fa-spinner fa-spin" />
-              </div>
+            <div class="list-group directory-entries-list" ng-show="!searching">
+              <li class="list-group-item clearfix"
+                  data-ng-repeat="e in searchResults.records">
 
-              <div translate ng-show="searchResults.count == 0 && !searching"
-                class="text-muted disabled">
-                noRecordFound
-              </div>
+                <div class="entry-title" ng-if="!templatesShown()">
+                  <gn-md-type-widget metadata="e"></gn-md-type-widget>
+                  <a href ng-click="startEditing(e)" title="{{e.title || e.defaultTitle}}">
+                    {{e.title || e.defaultTitle}}</a>
+                </div>
 
-              <div class="search-options-header" ng-show="searchResults.count > 0 && !searching">
-                <div data-gn-pagination="paginationInfo"
-                     data-hits-values="[20, 50, 100]"></div>
+                <div class="entry-info" ng-if="!templatesShown()">
+                  <small class="text-muted" translate
+                    translate-values="{ownerName: getOwnerName(e), updateDate: getChangeDate(e)}">
+                    directoryEntryInfo
+                  </small>
 
-                <div class="flex-spacer"></div>
+                  <div class="flex-spacer"></div>
 
-                <div data-sortby-combo=""
-                     data-params="searchObj.params"
-                     data-gn-sortby-values="searchObj.sortbyValues"></div>
-              </div>
-
-              <div class="list-group directory-entries-list">
-                <li class="list-group-item clearfix"
-                    data-ng-repeat="e in searchResults.records">
-
-                  <div class="entry-title" ng-if="!templatesShown()">
-                    <gn-md-type-widget metadata="e"></gn-md-type-widget>
-                    <a href ng-click="startEditing(e)" title="{{e.title || e.defaultTitle}}">
-                      {{e.title || e.defaultTitle}}</a>
-                  </div>
-
-                  <div class="entry-info" ng-if="!templatesShown()">
-                    <small class="text-muted" translate
-                      translate-values="{ownerName: getOwnerName(e), updateDate: getChangeDate(e)}">
-                      directoryEntryInfo
-                    </small>
-
-                    <div class="flex-spacer"></div>
-
-                    <div class="btn-group">
-                      <button class="btn btn-default btn-sm dropdown-toggle"
-                        data-toggle="dropdown">
-                        {{'actions' |  translate}}
-                        &nbsp;<i class="caret"/>
-                      </button>
-                      <ul class="dropdown-menu pull-right" role="menu">
-                        <li><a href ng-click="startEditing(e)">
-                          <i class="fa fa-pencil fa-fw" />&nbsp;
-                          {{'edit' | translate}}</a>
-                        </li>
-                        <li><a href ng-click="copyEntry(e)">
-                          <i class="fa fa-copy fa-fw" />&nbsp;
-                          {{'duplicate' | translate}}</a>
-                        </li>
-                        <li><a href ng-click="startPermissionsEdit(e)">
-                          <i class="fa fa-key fa-fw" />&nbsp;
-                          {{'directoryEntryPermissions' | translate}}</a>
-                        </li>
-                        <!-- <li><a href ng-click="convertToTemplate(e)">
-                          <i class="fa fa-mail-forward fa-fw text-info" />&nbsp;
-                          {{'directoryEntryToTemplate' | translate}}</a>
-                        </li> -->
-                        <li><a href ng-click="validateEntry(e)">
-                          <i class="fa fa-check fa-fw text-success" />&nbsp;
-                          {{'directoryEntryValidate' | translate}}</a>
-                        </li>
-                        <li><a href ng-click="rejectEntry(e)">
-                          <i class="fa fa-ban fa-fw text-danger" />&nbsp;
-                          {{'directoryEntryReject' | translate}}</a>
-                        </li>
-                      </ul>
-                    </div>
-
-                    <div class="btn-group"
-                      ng-if="::gnConfig[gnConfig.key.isXLinkEnabled]">
-                      <button class="btn btn-default btn-sm dropdown-toggle"
-                        ng-click="e.openAssociatedMD = true"
-                        data-toggle="dropdown">
-                        {{'directoryEntryAssociatedMetadata' |  translate}}
-                        &nbsp;<i class="caret"/>
-                      </button>
-                      <ul class="dropdown-menu pull-right" role="menu">
-                        <li ng-if="e.openAssociatedMD">
-                          <gn-directory-associated-md entry-uuid="e['geonet:info'].uuid" />
-                        </li>
-                      </ul>
-                    </div>
-
-                    <button class="btn btn-default btn-sm" ng-click="delEntry(e)"
-                      title="{{'delete' | translate}}">
-                      <i class="fa fa-times text-danger" />
+                  <div class="btn-group">
+                    <button class="btn btn-default btn-sm dropdown-toggle"
+                      data-toggle="dropdown">
+                      {{'actions' |  translate}}
+                      &nbsp;<i class="caret"/>
                     </button>
+                    <ul class="dropdown-menu pull-right" role="menu">
+                      <li><a href ng-click="startEditing(e)">
+                        <i class="fa fa-pencil fa-fw" />&nbsp;
+                        {{'edit' | translate}}</a>
+                      </li>
+                      <li><a href ng-click="copyEntry(e)">
+                        <i class="fa fa-copy fa-fw" />&nbsp;
+                        {{'duplicate' | translate}}</a>
+                      </li>
+                      <li><a href ng-click="startPermissionsEdit(e)">
+                        <i class="fa fa-key fa-fw" />&nbsp;
+                        {{'directoryEntryPermissions' | translate}}</a>
+                      </li>
+                      <!-- <li><a href ng-click="convertToTemplate(e)">
+                        <i class="fa fa-mail-forward fa-fw text-info" />&nbsp;
+                        {{'directoryEntryToTemplate' | translate}}</a>
+                      </li> -->
+                      <li><a href ng-click="validateEntry(e)">
+                        <i class="fa fa-check fa-fw text-success" />&nbsp;
+                        {{'directoryEntryValidate' | translate}}</a>
+                      </li>
+                      <li><a href ng-click="rejectEntry(e)">
+                        <i class="fa fa-ban fa-fw text-danger" />&nbsp;
+                        {{'directoryEntryReject' | translate}}</a>
+                      </li>
+                    </ul>
                   </div>
 
-                  <div class="entry-title entry-is-template"
-                    ng-if="templatesShown()">
-                    <gn-md-type-widget metadata="e"></gn-md-type-widget>
-
-                    <a href ng-click="startEditing(e)" title="{{e.title}}">
-                      {{e.title || e.defaultTitle}}</a>
-
-                    <div class="flex-spacer"></div>
-
-                    <div class="btn-group">
-                      <button class="btn btn-default btn-sm dropdown-toggle"
-                        data-toggle="dropdown">
-                        {{'actions' |  translate}}
-                        &nbsp;<i class="caret"/>
-                      </button>
-                      <ul class="dropdown-menu pull-right" role="menu">
-                        <li><a href ng-click="startEditing(e)">
-                          <i class="fa fa-pencil fa-fw" />&nbsp;
-                          {{'edit' | translate}}</a>
-                        </li>
-                        <li><a href ng-click="copyEntry(e)">
-                          <i class="fa fa-copy fa-fw" />&nbsp;
-                          {{'duplicate' | translate}}</a>
-                        </li>
-                        <li><a href ng-click="startPermissionsEdit(e)">
-                          <i class="fa fa-key fa-fw" />&nbsp;
-                          {{'directoryEntryPermissions' | translate}}</a>
-                        </li>
-                      </ul>
-                    </div>
-
-                    <button class="btn btn-default btn-sm" ng-click="delEntry(e)"
-                      title="{{'delete' | translate}}">
-                      <i class="fa fa-times text-danger" />
+                  <div class="btn-group"
+                    ng-if="::gnConfig[gnConfig.key.isXLinkEnabled]">
+                    <button class="btn btn-default btn-sm dropdown-toggle"
+                      ng-click="e.openAssociatedMD = true"
+                      data-toggle="dropdown">
+                      {{'directoryEntryAssociatedMetadata' |  translate}}
+                      &nbsp;<i class="caret"/>
                     </button>
+                    <ul class="dropdown-menu pull-right" role="menu">
+                      <li ng-if="e.openAssociatedMD">
+                        <gn-directory-associated-md entry-uuid="e['geonet:info'].uuid" />
+                      </li>
+                    </ul>
                   </div>
-                </li>
-              </div>
 
-              <div class="search-options-header" ng-show="searchResults.count > 0 && !searching">
-                <div data-gn-pagination="paginationInfo"
-                     data-hits-values="[20, 50, 100]"></div>
+                  <button class="btn btn-default btn-sm" ng-click="delEntry(e)"
+                    title="{{'delete' | translate}}">
+                    <i class="fa fa-times text-danger" />
+                  </button>
+                </div>
 
-                <div class="flex-spacer"></div>
-              </div>
+                <div class="entry-title entry-is-template"
+                  ng-if="templatesShown()">
+                  <gn-md-type-widget metadata="e"></gn-md-type-widget>
+
+                  <a href ng-click="startEditing(e)" title="{{e.title}}">
+                    {{e.title || e.defaultTitle}}</a>
+
+                  <div class="flex-spacer"></div>
+
+                  <div class="btn-group">
+                    <button class="btn btn-default btn-sm dropdown-toggle"
+                      data-toggle="dropdown">
+                      {{'actions' |  translate}}
+                      &nbsp;<i class="caret"/>
+                    </button>
+                    <ul class="dropdown-menu pull-right" role="menu">
+                      <li><a href ng-click="startEditing(e)">
+                        <i class="fa fa-pencil fa-fw" />&nbsp;
+                        {{'edit' | translate}}</a>
+                      </li>
+                      <li><a href ng-click="copyEntry(e)">
+                        <i class="fa fa-copy fa-fw" />&nbsp;
+                        {{'duplicate' | translate}}</a>
+                      </li>
+                      <li><a href ng-click="startPermissionsEdit(e)">
+                        <i class="fa fa-key fa-fw" />&nbsp;
+                        {{'directoryEntryPermissions' | translate}}</a>
+                      </li>
+                    </ul>
+                  </div>
+
+                  <button class="btn btn-default btn-sm" ng-click="delEntry(e)"
+                    title="{{'delete' | translate}}">
+                    <i class="fa fa-times text-danger" />
+                  </button>
+                </div>
+              </li>
+            </div>
+
+            <div class="search-options-header" ng-show="searchResults.count > 0 && !searching">
+              <div data-gn-pagination="paginationInfo"
+                    data-hits-values="[20, 50, 100]"></div>
+
+              <div class="flex-spacer"></div>
             </div>
           </div>
+        </div>
 
-        </form>
+      </form>
     </div>
   </div>
 

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -118,8 +118,8 @@
               <button type="button"
                 class="btn btn-default dropdown-toggle btn-sm"
                 data-toggle="dropdown"
-                title="{{'filterGroup' | translate}}">
-                <span translate class="hidden-xs">filterGroup</span>
+                title="{{'filterBy' | translate}}">
+                <span translate class="hidden-xs">filterBy</span>
                 &nbsp;<i class="caret" />
               </button>
               <ul class="dropdown-menu gn-facet-dropdown pull-right">
@@ -128,6 +128,11 @@
                       data-no-collapse="true"
                       data-facet="groupOwners"
                       data-index-key="_groupOwner"></div>
+                <div data-gn-facet="searchResults.facet" ng-if="!templatesShown()"
+                      data-current-facets="currentFacets"
+                      data-no-collapse="true"
+                      data-facet="isValid"
+                      data-index-key="_valid"></div>
                 <div data-gn-facet-breadcrumb=""></div>
               </ul>
             </div>

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -12,9 +12,9 @@
   </div>
 
   <div class="row" ng-show="currentEditorAction == ''">
-    <div class="col-md-12 text-right">
-      <h5 class="btn-group">
-        <button type="button" class="btn btn-success dropdown-toggle"
+    <div class="col-md-12 flex-row flex-end">
+      <h5 class="btn-group flex-grow">
+        <button type="button" class="btn btn-success dropdown-toggle pull-right"
           data-toggle="dropdown">
           <i class="fa fa-plus"/>&nbsp;
           <span translate>addNewDirectoryEntry</span>
@@ -25,17 +25,23 @@
             ng-repeat-start="(typeName, templates) in templates | groupBy: 'root'">
             {{typeName}}</li>
           <li ng-repeat="t in templates" ng-repeat-end>
-            <a href ng-click="createFromTemplate(t)">
-              <i class="fa fa-fw fa-bookmark-o"/>&nbsp;
-              {{t.title || t.defaultTitle}}
+            <a href ng-click="createFromTemplate(t)" class="flex-row flex-start">
+              <div class="flex-spacer" />
+              <i class="fa fa-fw fa-bookmark-o"/>
+              <div class="text-wrap">{{::t.title || t.defaultTitle}}</div>
             </a>
           </li>
           <li class="divider"/>
-          <li><a href translate ng-click="startImporting(false)">
-            directoryEntryFromScratch</a></li>
+          <li>
+            <a href ng-click="startImporting(false)" class="flex-row flex-start">
+              <div class="flex-spacer" />
+              <i class="fa fa-fw fa-plus"/>
+              <div class="text-wrap">{{'directoryEntryFromScratch' | translate}}</div>
+            </a>
+          </li>
         </ul>
       </h5>
-
+      <div class="flex-spacer" />
       <h5 class="btn-group">
         <button type="button" class="btn btn-success"
             ng-click="startImporting(true)"
@@ -94,7 +100,7 @@
               </li>
             </ul>
 
-            <div class="flex-spacer"></div>
+            <div class="flex-spacer flex-grow"></div>
 
             <div class="pos-relative">
               <input class="form-control filter-text" type="search"
@@ -143,7 +149,7 @@
               <div data-gn-pagination="paginationInfo"
                     data-hits-values="[20, 50, 100]"></div>
 
-              <div class="flex-spacer"></div>
+              <div class="flex-spacer flex-grow"></div>
 
               <div data-sortby-combo=""
                     data-params="searchObj.params"
@@ -166,7 +172,7 @@
                     directoryEntryInfo
                   </small>
 
-                  <div class="flex-spacer"></div>
+                  <div class="flex-spacer flex-grow"></div>
 
                   <div class="btn-group">
                     <button class="btn btn-default btn-sm dropdown-toggle"
@@ -230,7 +236,7 @@
                   <a href ng-click="startEditing(e)" title="{{e.title}}">
                     {{e.title || e.defaultTitle}}</a>
 
-                  <div class="flex-spacer"></div>
+                  <div class="flex-spacer flex-grow"></div>
 
                   <div class="btn-group">
                     <button class="btn btn-default btn-sm dropdown-toggle"
@@ -266,7 +272,7 @@
               <div data-gn-pagination="paginationInfo"
                     data-hits-values="[20, 50, 100]"></div>
 
-              <div class="flex-spacer"></div>
+              <div class="flex-spacer flex-grow"></div>
             </div>
           </div>
         </div>
@@ -307,7 +313,7 @@
           <span translate class="entry-editor-title">
             directoryEntryEditor</span>
 
-          <div class="flex-spacer"></div>
+          <div class="flex-spacer flex-grow"></div>
 
           <div class="entry-editor-controls">
             <button type="button" class="btn btn-primary"
@@ -361,7 +367,7 @@
           <span translate class="entry-editor-title">
             directoryEntryEditor</span>
 
-          <div class="flex-spacer"></div>
+          <div class="flex-spacer flex-grow"></div>
 
           <div class="entry-editor-controls">
             <div gn-metadata-group-updater="activeEntry.groupOwner"

--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -209,6 +209,7 @@
       <item facet="orgNameTree" max="99"/>
       <item facet="groupOwner" max="99" sortBy="value"
             translator="db:org.fao.geonet.repository.GroupRepository:findOne:int"/>
+      <item facet="isValid" max="3" sortBy="value" translator="apploc:validStatus-"/>
     </summaryType>
     <summaryType name="titles">
       <item facet="title" sortOrder="desc" max="100"/>

--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -203,6 +203,7 @@
       <item facet="subTemplateType"/>
       <item facet="groupOwner" max="99" sortBy="value"
             translator="db:org.fao.geonet.repository.GroupRepository:findOne:int"/>
+      <item facet="isValid" max="3" sortBy="value" translator="apploc:validStatus-"/>
     </summaryType>
     <summaryType name="contact" format="DIMENSION">
       <item facet="orgNameTree" max="99"/>


### PR DESCRIPTION
Again, some improvements to the UI:
* Directory entries can be filtered and/or sorted by validity status
* The entry creation button has been clarified (now only available as a dropdown with the list of templates):
![image](https://user-images.githubusercontent.com/10629150/28569767-880c7fba-713b-11e7-98af-facc36eb8ee2.png)

Also, it is now possible to filter directory entries by validity status in the metadata editor using `show-valid-only="true"` on the `gn-directory-entry-selector` directive.

Without filter:
![image](https://user-images.githubusercontent.com/10629150/28569871-fa741996-713b-11e7-88a0-6e0bff33ffd9.png)

With filter:
![image](https://user-images.githubusercontent.com/10629150/28569894-11c7ebcc-713c-11e7-89c5-4f051b5c9f59.png)

Please note: I've added the following css classes to `gn.less` in order to facilitate creating elaborate layouts. These are mostly self explaining and combining them in HTML templates should allow us to write less stylesheet code.
```css
.pos-relative { position: relative; }
.pos-absolute { position: absolute; }
.spacer, .flex-spacer { flex-grow: 0; flex-shrink: 0; min-width: 0.7em; }
.flex-grow { flex-grow: 1; }
.flex-no-grow { flex-grow: 0; }
.flex-shrink { flex-shrink: 1; }
.flex-no-shrink, .fa { flex-shrink: 0; }
.flex-row, .flex-col, .flex-row-r, .flex-col-r {
  display: flex !important;
  align-items: baseline;
}
.flex-col { flex-direction: column; }
.flex-col-r { flex-direction: column-reverse; }
.flex-row { flex-direction: row; }
.flex-row-r { flex-direction: row-reverse; }
.flex-start { justify-content: flex-start; }
.flex-end { justify-content: flex-end; }
.flex-center { justify-content: center; }
.flex-align-center { align-items: center; }
.flex-align-end { align-items: flex-end; }
.flex-align-start { align-items: flex-start; }
.text-wrap { white-space: normal; }
.text-nowrap, .text-no-wrap { white-space: nowrap; }
```