### PR TITLE
avoid randomly failing test

### DIFF
--- a/domain/src/test/java/org/fao/geonet/repository/UserRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/UserRepositoryTest.java
@@ -57,7 +57,7 @@ public class UserRepositoryTest extends AbstractSpringDataTest {
     private EntityManager _entityManager;
 
     public static User newUser(AtomicInteger inc) {
-        int val = inc.incrementAndGet();
+        String val = String.format("%04d", inc.incrementAndGet());
         User user = new User().setName("name" + val).setUsername("username" + val);
         user.getSecurity().setPassword("1234567");
         return user;


### PR DESCRIPTION
there are tests which expects users list to be ordered given their names
and names to be ordered given their creation order: the later a test user
is created, the later it has to appear in ordered users list, the problem
is that "9" is greater than "10", whereas "09" is smaller than "10".