### PR TITLE
Editor / Keyword input as simple field (ie. without fieldset).

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -691,7 +691,8 @@ Customizing thesaurus
 ~~~~~~~~~~~~~~~~~~~~~
 
 To configure the type of transformations
-or the number of keyword allowed for e
+or the number of keyword allowed or if the widget
+has to be displayed in a fieldset or as simple field for e
 thesaurus define a specific configuration:
 
 eg. only 2 INSPIRE themes.
@@ -702,6 +703,7 @@ eg. only 2 INSPIRE themes.
       <thesaurusList>
         <thesaurus key="external.theme.inspire-theme"
                    maxtags="2"
+                   fieldset="false"
                    transformations=""/>
       </thesaurusList>
 
@@ -714,6 +716,7 @@ eg. only 2 INSPIRE themes.
           <xs:complexType>
             <xs:attribute name="key" type="xs:string" use="required"/>
             <xs:attribute name="maxtags" type="xs:integer" use="optional"/>
+            <xs:attribute name="fieldset" type="xs:string" use="optional" fixed="false"/>
             <xs:attribute name="transformations" type="xs:string" use="optional"/>
           </xs:complexType>
         </xs:element>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -2036,6 +2036,7 @@
       <thesaurusList>
         <thesaurus key="external.theme.inspire-theme"
                    maxtags="2"
+                   fieldset="false"
                    transformations="to-iso19139-keyword-with-anchor"/>
       </thesaurusList>
       -->

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -198,7 +198,8 @@
 
              // Max number of tags allowed. Use 1 to restrict to only
              // on keyword.
-             maxTags: '@'
+             maxTags: '@',
+             thesaurusTitle: '@'
            },
            templateUrl: '../../catalog/components/thesaurus/' +
            'partials/keywordselector.html',

--- a/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
@@ -9,7 +9,10 @@
 
   <span data-ng-show="!invalidKeywordMatch" ng-switch="mode">
     <div class="row" data-ng-switch-when="tagsinput">
-      <div class="col-sm-9 col-sm-offset-2"
+      <label class="col-sm-2 control-label">
+        {{thesaurusTitle}}
+      </label>
+      <div class="col-sm-9"
            data-ng-class="maxTags && selected.length == maxTags ? 'gn-maxtags' : ''"
            title="{{selected.length}}/{{maxTagsLabel}} {{'tagsAllowed' | translate}}">
         <input type="text" id="tagsinput_{{elementRef}}"


### PR DESCRIPTION
Add configuration in the editor to make thesaurus fields a simple field instead of fieldset.

![image](https://user-images.githubusercontent.com/1701393/28584607-a76b00e8-716d-11e7-8366-39a30b38c977.png)
