### PR TITLE
Added support for bounding polygons in MD editor

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -32,6 +32,7 @@
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
                 xmlns:java-xsl-util="java:org.fao.geonet.util.XslUtil"
                 xmlns:saxon="http://saxon.sf.net/"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
                 version="2.0"
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
@@ -277,13 +278,15 @@
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="subTreeSnippet">
 
-        <xsl:variable name="geometry" select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:MultiCurve"/>
+        <xsl:variable name="geometry" select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:LineString"/>
         <xsl:variable name="identifier"
-                      select="$geometry/gn:element/@ref"/>
+                      select="concat('_X', gmd:polygon/gn:element/@ref, '_replace')"/>
+        <xsl:variable name="readonly" select="ancestor-or-self::node()[@xlink:href] != ''"/>
+
         <br />
         <gn-bounding-polygon polygon-xml="{saxon:serialize($geometry, 'default-serialize-mode')}"
-                             identifier="_{$identifier}"
-                             read-only="false">
+                             identifier="{$identifier}"
+                             read-only="{$readonly}">
         </gn-bounding-polygon>
       </xsl:with-param>
     </xsl:call-template>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -277,11 +277,11 @@
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="subTreeSnippet">
 
-        <xsl:variable name="polygon" select="."/>
+        <xsl:variable name="geometry" select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:MultiCurve"/>
         <xsl:variable name="identifier"
-                      select="$polygon/gn:element/@ref"/>
+                      select="$geometry/gn:element/@ref"/>
         <br />
-        <gn-bounding-polygon polygon-xml="{saxon:serialize($polygon, 'default-serialize-mode')}"
+        <gn-bounding-polygon polygon-xml="{saxon:serialize($geometry, 'default-serialize-mode')}"
                              identifier="_{$identifier}"
                              read-only="false">
         </gn-bounding-polygon>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -262,6 +262,33 @@
     </xsl:call-template>
   </xsl:template>
 
+  <xsl:template mode="mode-iso19139" match="gmd:EX_BoundingPolygon" priority="2000">
+    <xsl:param name="schema" select="$schema" required="no"/>
+    <xsl:param name="labels" select="$labels" required="no"/>
+
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+    <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
+
+    <xsl:call-template name="render-boxed-element">
+      <xsl:with-param name="label"
+                      select="$labelConfig/label"/>
+      <xsl:with-param name="editInfo" select="../gn:element"/>
+      <xsl:with-param name="cls" select="local-name()"/>
+      <xsl:with-param name="subTreeSnippet">
+
+        <xsl:variable name="polygon" select="."/>
+        <xsl:variable name="identifier"
+                      select="$polygon/gn:element/@ref"/>
+        <br />
+        <gn-bounding-polygon polygon-xml="{saxon:serialize($polygon, 'default-serialize-mode')}"
+                             identifier="_{$identifier}"
+                             read-only="false">
+        </gn-bounding-polygon>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
   <!-- In flat mode do not display geographic identifier and description
   because it is part of the map widget - see previous template. -->
   <xsl:template mode="mode-iso19139"

--- a/web-ui/src/main/resources/catalog/components/edit/FieldsModule.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsModule.js
@@ -84,6 +84,7 @@
   goog.require('gn_organisation_entry_selector');
   goog.require('gn_record_fragment_selector');
   goog.require('gn_template_field_directive');
+  goog.require('gn_bounding');
 
 
 
@@ -100,6 +101,7 @@
     'gn_logo_selector_directive',
     'gn_date_picker_directive',
     'gn_record_fragment_selector',
-    'gn_checkbox_with_nilreason'
+    'gn_checkbox_with_nilreason',
+    'gn_bounding'
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_bounding_directive');
+
+
+  var module = angular.module('gn_bounding_directive', []);
+
+  /**
+   * @ngdoc directive
+   * @name gn_bounding.directive:gnBoundingPolygon
+   *
+   * @description
+   * This directive gives the user the possibility to define a bounding polygon,
+   * either by drawing it manually on a map or copy-pasting data in the desired 
+   * format. The user can also select an input projection.
+   * The directive has a hidden output in GML & EPSG:4326.
+   */
+  module.directive('gnBoundingPolygon', [
+    function() {
+      return {
+        restrict: 'E',
+        scope: {
+        },
+        templateUrl: '../../catalog/components/edit/bounding/' +
+          'partials/boundingpolygon.html',
+        link: function (scope, element) {
+        },
+        controllerAs: 'ctrl',
+        bindToController: true,
+        controller: [
+          'gnMap',
+          'gnOwsContextService',
+          'gnViewerSettings',
+          function BoundingPolygonController(
+            gnMap,
+            gnOwsContextService,
+            gnViewerSettings) {
+            // init map
+            this.map = new ol.Map({
+              layers: [
+                gnMap.getLayersFromConfig()
+              ],
+              view: new ol.View({})
+            });
+
+            // uses default context from database
+            var contextUrl = gnViewerSettings.mapConfig.map ||
+              '../../map/config-viewer.xml';
+            gnOwsContextService.loadContextFromUrl(contextUrl, this.map);
+
+            // projection list
+            this.projections = gnMap.getMapConfig().projectionList;
+            this.currentProjection = this.projections[0].code;
+
+            // available input formats
+            this.formats = [ 'GML', 'WKT', 'GeoJSON' ];
+            this.currentFormat = this.formats[0];
+          }
+        ]
+      };
+    }]);
+})();

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -77,6 +77,12 @@
             // available input formats
             this.formats = [ 'GML', 'WKT', 'GeoJSON' ];
             this.currentFormat = this.formats[0];
+
+            // this will receive errors from the geometry tool input parsing
+            this.parseError = null;
+            this.parseErrorHandler = function (error) {
+              this.parseError = error;
+            }.bind(this);
           }
         ]
       };

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -36,54 +36,127 @@
    * either by drawing it manually on a map or copy-pasting data in the desired 
    * format. The user can also select an input projection.
    * The directive has a hidden output in GML & EPSG:4326.
+   * 
+   * @attribute {string} coordinates list of coordinates separated with spaces
+   * @attribute {string} identifier id of the hidden input that will hold
+   *  the value entered by the user
    */
   module.directive('gnBoundingPolygon', [
     function() {
       return {
         restrict: 'E',
         scope: {
-          readOnly: '<'
+          polygonXml: '@',
+          identifier: '@'
         },
         templateUrl: '../../catalog/components/edit/bounding/' +
           'partials/boundingpolygon.html',
-        link: function (scope, element) {
+        link: {
+          post: function (scope, element) {
+            scope.ctrl.map.renderSync();
+            scope.ctrl.initValue();
+          }
         },
         controllerAs: 'ctrl',
         bindToController: true,
         controller: [
+          '$scope',
+          '$attrs',
+          '$http',
           'gnMap',
           'gnOwsContextService',
           'gnViewerSettings',
           function BoundingPolygonController(
+            $scope,
+            $attrs,
+            $http,
             gnMap,
             gnOwsContextService,
             gnViewerSettings) {
+            // set read only
+            this.readOnly = $scope.$eval($attrs['readOnly']);
+
             // init map
             this.map = new ol.Map({
               layers: [
                 gnMap.getLayersFromConfig()
               ],
-              view: new ol.View({})
+              view: new ol.View({
+                center: [0, 0],
+                projection: gnMap.getMapConfig().projection,
+                zoom: 2
+              })
             });
 
-            // uses default context from database
-            var contextUrl = gnViewerSettings.mapConfig.map ||
-              '../../map/config-viewer.xml';
-            gnOwsContextService.loadContextFromUrl(contextUrl, this.map);
+            // output for editor (equals input by default)
+            this.outputPolygonXml = this.polygonXml;
+            this.outputFormat = new ol.format.GML({
+              featureNS: 'http://www.isotc211.org/2005/gmd',
+              featureType: 'EX_BoundingPolygon',
+              srsName: 'EPSG:4326',
+              multiSurface: true
+            });
 
             // projection list
             this.projections = gnMap.getMapConfig().projectionList;
             this.currentProjection = this.projections[0].code;
 
             // available input formats
-            this.formats = [ 'WKT', 'GML', 'GeoJSON' ];
+            // GML is not available as it cannot be parsed without namespace info
+            this.formats = [ 'WKT', 'GeoJSON' ];
             this.currentFormat = this.formats[0];
+
+            // parse initial input coordinates to display shape (first in WKT)
+            this.initValue = function () {
+              if (this.polygonXml) {
+                this.currentFormat = 'WKT';
+                this.currentProjection = 'EPSG:4326';
+                var formatWkt = new ol.format.WKT();
+
+                // parse first feature from source XML & set geometry name
+                var correctedXml = '<gml:featureMembers>' +
+                  this.polygonXml
+                    .replace('<gml:LinearRingTypeCHOICE_ELEMENT0>', '')
+                    .replace('</gml:LinearRingTypeCHOICE_ELEMENT0>', '')
+                  + '</gml:featureMembers>';
+                var feature = this.outputFormat.readFeatures(correctedXml)[0];
+                feature.setGeometryName('polygon');
+
+                // write feature geometry
+                this.inputGeometry = formatWkt.writeGeometry(
+                  feature.getGeometry(),
+                  {
+                    featureProjection: 'EPSG:4326'
+                  }
+                );
+              }
+            }.bind(this);
 
             // this will receive errors from the geometry tool input parsing
             this.parseError = null;
             this.parseErrorHandler = function (error) {
               this.parseError = error;
             }.bind(this);
+
+            // outputs gm for the editor
+            $scope.$watch('ctrl.outputGeometry', function (geometry) {
+              if (!geometry) {
+                return;
+              }
+              if (!geometry instanceof ol.geom.Polygon) {
+                console.error('Error in gn-bounding-polygon: Geometry should ' +
+                  'be a Polygon; aborting.');
+                return;
+              }
+
+              // create a new feature & print the GML
+              var feature = new ol.Feature({
+                'polygon': geometry
+              });
+              feature.setGeometryName('polygon');
+              this.outputPolygonXml = this.outputFormat.writeFeaturesNode(
+                [feature]).innerHTML;
+            }.bind(this));
           }
         ]
       };

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -42,6 +42,7 @@
       return {
         restrict: 'E',
         scope: {
+          readOnly: '<'
         },
         templateUrl: '../../catalog/components/edit/bounding/' +
           'partials/boundingpolygon.html',
@@ -75,7 +76,7 @@
             this.currentProjection = this.projections[0].code;
 
             // available input formats
-            this.formats = [ 'GML', 'WKT', 'GeoJSON' ];
+            this.formats = [ 'WKT', 'GML', 'GeoJSON' ];
             this.currentFormat = this.formats[0];
 
             // this will receive errors from the geometry tool input parsing

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingModule.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingModule.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_bounding');
+
+
+
+  goog.require('gn_bounding_directive');
+  goog.require('gn_bounding_service');
+
+  var module = angular.module('gn_bounding', [
+    'gn_bounding_service',
+    'gn_bounding_directive'
+  ]);
+})();

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingService.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_bounding_service');
+
+  var module = angular.module('gn_bounding_service', []);
+})();

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -13,13 +13,11 @@
     <br />
     <select class="form-control" ng-model="ctrl.currentFormat"
       ng-options="format for format in ctrl.formats"
-      ng-change="ctrl.handleInputOptionsChange()"
-      ng-readonly="ctrl.readOnly">
+      ng-change="ctrl.handleInputOptionsChange()">
     </select>
     <select class="form-control" ng-model="ctrl.currentProjection"
       ng-options="proj.code as proj.label for proj in ctrl.projections"
-      ng-change="ctrl.handleInputOptionsChange()"
-      ng-readonly="ctrl.readOnly">
+      ng-change="ctrl.handleInputOptionsChange()">
     </select>
   </div>
   <div class="col-xs-6 col-md-6" ng-if="!ctrl.readOnly">
@@ -69,8 +67,11 @@
         ng-show="ctrl.fromTextInput && !ctrl.parseError" translate>
         inputGeometryIsValid</small>
       <small class="text-muted"
-        ng-show="!ctrl.fromTextInput" translate>
+        ng-show="!ctrl.fromTextInput && !ctrl.readOnly" translate>
         inputGeometryHint</small>
+      <small class="text-muted"
+        ng-show="ctrl.readOnly" translate>
+        inputGeometryRedOnlyHint</small>
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -7,24 +7,31 @@
 
 <!-- draw tool & select boxes -->
 <div class="row">
-  <div class="col-md-12 text-center form-inline">
-    <gn-geometry-tool map="ctrl.map"
+  <div class="col-xs-6 col-md-8 form-inline">
+    <label class="text-muted control-label" translate>
+      selectFormatAndProjection</label>
+    <br />
+    <select class="form-control" ng-model="ctrl.currentFormat"
+      ng-options="format for format in ctrl.formats"
+      ng-change="ctrl.parseError = null"
+      ng-readonly="ctrl.readOnly">
+    </select>
+    <select class="form-control" ng-model="ctrl.currentProjection"
+      ng-options="proj.code as proj.label for proj in ctrl.projections"
+      ng-change="ctrl.parseError = null"
+      ng-readonly="ctrl.readOnly">
+    </select>
+  </div>
+  <div class="col-xs-6 col-md-4">
+    <label class="text-muted control-label" translate>drawOnMap</label>
+    <gn-geometry-tool ng-if="!ctrl.readOnly" map="ctrl.map"
       geometry-type="Polygon" allow-modify allow-reset
       output="ctrl.outputGeometry" output-format="gml" output-crs="EPSG:4326"
       input="ctrl.inputGeometry"
       input-format="{{ctrl.currentFormat || 'gml'}}"
-      input-crs="{{ctrl.currentProjection.code || 'EPSG:4326'}}"
+      input-crs="{{ctrl.currentProjection || 'EPSG:4326'}}"
       input-error-handler="ctrl.parseErrorHandler">
     </gn-geometry-tool>
-    &nbsp;
-    <select class="form-control" ng-model="ctrl.currentFormat"
-      ng-options="format for format in ctrl.formats"
-      ng-change="ctrl.parseError = null">
-    </select>
-    <select class="form-control" ng-model="ctrl.currentProjection"
-      ng-options="proj.code as proj.label for proj in ctrl.projections"
-      ng-change="ctrl.parseError = null">
-    </select>
   </div>
 </div>
 
@@ -33,11 +40,24 @@
 <!-- input geometry field -->
 <div class="row">
   <div class="col-md-12">
-    <textarea class="form-control" rows="3" ng-model="ctrl.inputGeometry"
-      ng-model-options="{ debounce: 300 }"
-      placeholder="{{'outputGeometry' | translate}}"
-      ng-change="ctrl.parseError = null"/>
-      {{ ctrl.parseError }}
+    <div class="form-group has-feedback"
+      ng-class="{ 'has-success': ctrl.inputGeometry && !ctrl.parseError, 'has-error': ctrl.parseError }">
+      <label class="text-muted control-label" translate>inputGeometryText</label>
+      <textarea class="form-control" rows="3" ng-model="ctrl.inputGeometry"
+        ng-model-options="{ debounce: 300 }"
+        placeholder="{{'inputGeometryText' | translate}}"
+        ng-change="ctrl.parseError = null"
+        ng-readonly="ctrl.readOnly"/>
+      <small class="text-danger"
+        ng-show="ctrl.inputGeometry && ctrl.parseError">
+        {{ 'inputGeometryIsInvalid' | translate}} {{ctrl.parseError}}</small>
+      <small class="text-success"
+        ng-show="ctrl.inputGeometry && !ctrl.parseError" translate>
+        inputGeometryIsValid</small>
+      <small class="text-muted"
+        ng-show="!ctrl.inputGeometry" translate>
+        inputGeometryHint</small>
+    </div>
   </div>
 </div>
 

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -7,7 +7,7 @@
 
 <!-- draw tool & select boxes -->
 <div class="row">
-  <div class="col-xs-6 col-md-8 form-inline">
+  <div class="col-xs-6 col-md-7 form-inline">
     <label class="text-muted control-label" translate>
       selectFormatAndProjection</label>
     <br />
@@ -22,11 +22,11 @@
       ng-readonly="ctrl.readOnly">
     </select>
   </div>
-  <div class="col-xs-6 col-md-4">
+  <div class="col-xs-6 col-md-5" ng-if="!ctrl.readOnly">
     <label class="text-muted control-label" translate>drawOnMap</label>
-    <gn-geometry-tool ng-if="!ctrl.readOnly" map="ctrl.map"
+    <gn-geometry-tool map="ctrl.map"
       geometry-type="Polygon" allow-modify allow-reset
-      output="ctrl.outputGeometry" output-format="gml" output-crs="EPSG:4326"
+      output="ctrl.outputGeometry" output-format="object" output-crs="EPSG:4326"
       input="ctrl.inputGeometry"
       input-format="{{ctrl.currentFormat || 'gml'}}"
       input-crs="{{ctrl.currentProjection || 'EPSG:4326'}}"
@@ -40,10 +40,10 @@
 <!-- input geometry field -->
 <div class="row">
   <div class="col-md-12">
-    <div class="form-group has-feedback"
+    <div class="has-feedback"
       ng-class="{ 'has-success': ctrl.inputGeometry && !ctrl.parseError, 'has-error': ctrl.parseError }">
       <label class="text-muted control-label" translate>inputGeometryText</label>
-      <textarea class="form-control" rows="3" ng-model="ctrl.inputGeometry"
+      <textarea class="form-control" rows="4" ng-model="ctrl.inputGeometry"
         ng-model-options="{ debounce: 300 }"
         placeholder="{{'inputGeometryText' | translate}}"
         ng-change="ctrl.parseError = null"
@@ -62,4 +62,5 @@
 </div>
 
 <!-- final output in GML -->
-<input name="output-geometry" type="hidden" value="{{ ctrl.outputGeometry }}"/>
+<input name="{{ctrl.identifier}}"
+  type="hidden" value="{{ctrl.outputPolygonXml}}"/>

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -1,0 +1,39 @@
+<!-- full width map -->
+<div class="row">
+  <div class="col-md-12" ngeo-map="ctrl.map"></div>
+</div>
+
+<div class="spacer" />
+
+<!-- draw tool & select boxes -->
+<div class="row">
+  <div class="col-md-12 text-center form-inline">
+    <gn-geometry-tool map="ctrl.map"
+      geometry-type="Polygon" allow-modify allow-reset
+      output="ctrl.outputGeometry" output-format="gml" output-crs="EPSG:4326"
+      input="ctrl.inputGeometry" keep-input-in-sync
+      input-format="{{ctrl.currentFormat || 'gml'}}"
+      input-crs="{{ctrl.currentProjection.code || 'EPSG:4326'}}">
+    </gn-geometry-tool>
+    &nbsp;
+    <select class="form-control" ng-model="ctrl.currentFormat"
+      ng-options="format for format in ctrl.formats">
+    </select>
+    <select class="form-control" ng-model="ctrl.currentProjection"
+      ng-options="proj.code as proj.label for proj in ctrl.projections">
+    </select>
+  </div>
+</div>
+
+<div class="spacer" />
+
+<!-- draw tool & select boxes -->
+<div class="row">
+  {{ ctrl.outputGeometry }}
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <textarea class="form-control" rows="3" ng-model="ctrl.inputGeometry"
+      placeholder="{{'outputGeometry' | translate}}"/>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -11,29 +11,35 @@
     <gn-geometry-tool map="ctrl.map"
       geometry-type="Polygon" allow-modify allow-reset
       output="ctrl.outputGeometry" output-format="gml" output-crs="EPSG:4326"
-      input="ctrl.inputGeometry" keep-input-in-sync
+      input="ctrl.inputGeometry"
       input-format="{{ctrl.currentFormat || 'gml'}}"
-      input-crs="{{ctrl.currentProjection.code || 'EPSG:4326'}}">
+      input-crs="{{ctrl.currentProjection.code || 'EPSG:4326'}}"
+      input-error-handler="ctrl.parseErrorHandler">
     </gn-geometry-tool>
     &nbsp;
     <select class="form-control" ng-model="ctrl.currentFormat"
-      ng-options="format for format in ctrl.formats">
+      ng-options="format for format in ctrl.formats"
+      ng-change="ctrl.parseError = null">
     </select>
     <select class="form-control" ng-model="ctrl.currentProjection"
-      ng-options="proj.code as proj.label for proj in ctrl.projections">
+      ng-options="proj.code as proj.label for proj in ctrl.projections"
+      ng-change="ctrl.parseError = null">
     </select>
   </div>
 </div>
 
 <div class="spacer" />
 
-<!-- draw tool & select boxes -->
-<div class="row">
-  {{ ctrl.outputGeometry }}
-</div>
+<!-- input geometry field -->
 <div class="row">
   <div class="col-md-12">
     <textarea class="form-control" rows="3" ng-model="ctrl.inputGeometry"
-      placeholder="{{'outputGeometry' | translate}}"/>
+      ng-model-options="{ debounce: 300 }"
+      placeholder="{{'outputGeometry' | translate}}"
+      ng-change="ctrl.parseError = null"/>
+      {{ ctrl.parseError }}
   </div>
 </div>
+
+<!-- final output in GML -->
+<input name="output-geometry" type="hidden" value="{{ ctrl.outputGeometry }}"/>

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -7,30 +7,39 @@
 
 <!-- draw tool & select boxes -->
 <div class="row">
-  <div class="col-xs-6 col-md-7 form-inline">
+  <div class="col-xs-6 col-md-6 form-inline">
     <label class="text-muted control-label" translate>
       selectFormatAndProjection</label>
     <br />
     <select class="form-control" ng-model="ctrl.currentFormat"
       ng-options="format for format in ctrl.formats"
-      ng-change="ctrl.parseError = null"
+      ng-change="ctrl.handleInputOptionsChange()"
       ng-readonly="ctrl.readOnly">
     </select>
     <select class="form-control" ng-model="ctrl.currentProjection"
       ng-options="proj.code as proj.label for proj in ctrl.projections"
-      ng-change="ctrl.parseError = null"
+      ng-change="ctrl.handleInputOptionsChange()"
       ng-readonly="ctrl.readOnly">
     </select>
   </div>
-  <div class="col-xs-6 col-md-5" ng-if="!ctrl.readOnly">
+  <div class="col-xs-6 col-md-6" ng-if="!ctrl.readOnly">
     <label class="text-muted control-label" translate>drawOnMap</label>
     <br />
-    <div gi-btn-group class="btn-group">
-      <button class="btn btn-default btn-warning"
-        gi-btn="active" ng-model="ctrl.drawInteraction.active">
-        <span class="fa fa-pencil"></span>
-        <span translate>drawGeometry</span>
-      </button>
+    <div gi-btn-group>
+      <div class="btn-group">
+        <div class="btn-group">
+          <button class="btn btn-default btn-warning"
+            gi-btn="active" ng-model="ctrl.drawInteraction.active">
+            <span class="fa fa-pencil"></span>
+            <span translate>Polygon</span>
+          </button>
+          <button class="btn btn-default btn-warning"
+            gi-btn="active" ng-model="ctrl.drawLineInteraction.active">
+            <span class="fa fa-pencil"></span>
+            <span translate>Line</span>
+          </button>
+        </div>
+      </div>
       <button class="btn btn-default btn-warning"
         gi-btn="active" ng-model="ctrl.modifyInteraction.active">
         <span class="fa fa-pencil"></span>
@@ -46,21 +55,21 @@
 <div class="row">
   <div class="col-md-12">
     <div class="has-feedback"
-      ng-class="{ 'has-success': ctrl.inputGeometry && !ctrl.parseError, 'has-error': ctrl.parseError }">
+      ng-class="{ 'has-success': ctrl.fromTextInput && !ctrl.parseError, 'has-error': ctrl.parseError }">
       <label class="text-muted control-label" translate>inputGeometryText</label>
       <textarea class="form-control" rows="4" ng-model="ctrl.inputGeometry"
         ng-model-options="{ debounce: 300 }"
         placeholder="{{'inputGeometryText' | translate}}"
-        ng-change="ctrl.parseError = null"
+        ng-change="ctrl.handleInputChange()"
         ng-readonly="ctrl.readOnly"/>
       <small class="text-danger"
-        ng-show="ctrl.inputGeometry && ctrl.parseError">
+        ng-show="ctrl.fromTextInput && ctrl.parseError">
         {{ 'inputGeometryIsInvalid' | translate}} {{ctrl.parseError}}</small>
       <small class="text-success"
-        ng-show="ctrl.inputGeometry && !ctrl.parseError" translate>
+        ng-show="ctrl.fromTextInput && !ctrl.parseError" translate>
         inputGeometryIsValid</small>
       <small class="text-muted"
-        ng-show="!ctrl.inputGeometry" translate>
+        ng-show="!ctrl.fromTextInput" translate>
         inputGeometryHint</small>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -24,14 +24,19 @@
   </div>
   <div class="col-xs-6 col-md-5" ng-if="!ctrl.readOnly">
     <label class="text-muted control-label" translate>drawOnMap</label>
-    <gn-geometry-tool map="ctrl.map"
-      geometry-type="Polygon" allow-modify allow-reset
-      output="ctrl.outputGeometry" output-format="object" output-crs="EPSG:4326"
-      input="ctrl.inputGeometry"
-      input-format="{{ctrl.currentFormat || 'gml'}}"
-      input-crs="{{ctrl.currentProjection || 'EPSG:4326'}}"
-      input-error-handler="ctrl.parseErrorHandler">
-    </gn-geometry-tool>
+    <br />
+    <div gi-btn-group class="btn-group">
+      <button class="btn btn-default btn-warning"
+        gi-btn="active" ng-model="ctrl.drawInteraction.active">
+        <span class="fa fa-pencil"></span>
+        <span translate>drawGeometry</span>
+      </button>
+      <button class="btn btn-default btn-warning"
+        gi-btn="active" ng-model="ctrl.modifyInteraction.active">
+        <span class="fa fa-pencil"></span>
+        <span translate>modifyGeometry</span>
+      </button>
+    </div>
   </div>
 </div>
 

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryDirective.js
@@ -75,14 +75,14 @@
             var ctrl = this;
             var layer = gnGeometryService.getCommonLayer(ctrl.map);
             var source = layer.getSource();
-            var myFeatures = new ol.Collection();
+            ctrl.features = new ol.Collection();
 
             ctrl.drawInteraction = new ol.interaction.Draw({
               type: ctrl.geometryType,
               source: source
             });
             ctrl.modifyInteraction = new ol.interaction.Modify({
-              features: myFeatures
+              features: ctrl.features
             });
 
             // add our layer&interactions to the map
@@ -102,10 +102,10 @@
 
             // remove all my features from the map
             function removeMyFeatures () {
-              myFeatures.forEach(function (feature) {
+              ctrl.features.forEach(function (feature) {
                 source.removeFeature(feature);
               });
-              myFeatures.clear();
+              ctrl.features.clear();
             }
 
             // modifies the output value
@@ -132,7 +132,7 @@
               removeMyFeatures();
               updateOutput(event.feature);
               ctrl.drawInteraction.setActive(false);
-              myFeatures.push(event.feature);
+              ctrl.features.push(event.feature);
             });
 
             // update output on modify end
@@ -168,7 +168,7 @@
                 var feature = new ol.Feature({
                   geometry: geometry
                 });
-                myFeatures.push(feature);
+                ctrl.features.push(feature);
                 source.addFeature(feature);
               } catch (e) {
                 // send back error

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryDirective.js
@@ -101,7 +101,8 @@
             });
 
             // remove all my features from the map
-            function removeMyFeatures () {
+            function removeMyFeatures() {
+              var func = function (f) { return f.ol_uid; };
               ctrl.features.forEach(function (feature) {
                 source.removeFeature(feature);
               });
@@ -109,7 +110,7 @@
             }
 
             // modifies the output value
-            function updateOutput (feature) {
+            function updateOutput(feature) {
               // no feature: clear output
               if (!feature) {
                 ctrl.output = null;
@@ -133,6 +134,7 @@
               updateOutput(event.feature);
               ctrl.drawInteraction.setActive(false);
               ctrl.features.push(event.feature);
+              source.addFeature(event.feature);
             });
 
             // update output on modify end
@@ -163,13 +165,17 @@
                   }
                 );
 
+                // fit view
+                ctrl.map.getView().fit(geometry, ctrl.map.getSize());
+
                 // clear features & add a new one
                 removeMyFeatures();
                 var feature = new ol.Feature({
                   geometry: geometry
                 });
-                ctrl.features.push(feature);
+                feature.setId('geometry-tool-output');
                 source.addFeature(feature);
+                ctrl.features.push(feature);
               } catch (e) {
                 // send back error
                 if (ctrl.inputErrorHandler) {
@@ -177,9 +183,9 @@
                 }
               }
             }
-            $scope.$watch('ctrl.input', handleInputUpdate);
-            $scope.$watch('ctrl.inputCrs', handleInputUpdate);
-            $scope.$watch('ctrl.inputFormat', handleInputUpdate);
+            $scope.$watch(function () {
+              return ctrl.input + ctrl.inputCrs + ctrl.inputFormat;
+            }, handleInputUpdate);
           }
         ]
       };

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryDirective.js
@@ -123,7 +123,7 @@
                 {
                   crs: ctrl.outputCrs,
                   format: ctrl.outputFormat,
-                  outputAsFeatures: ctrl.outputAsFeatures
+                  outputAsWFSFeaturesCollection: ctrl.outputAsFeatures  // TODO: make sure this works everytime?
                 }
               );
             };
@@ -134,7 +134,6 @@
               updateOutput(event.feature);
               ctrl.drawInteraction.setActive(false);
               ctrl.features.push(event.feature);
-              source.addFeature(event.feature);
             });
 
             // update output on modify end
@@ -164,9 +163,6 @@
                     format: ctrl.inputFormat
                   }
                 );
-
-                // fit view
-                ctrl.map.getView().fit(geometry, ctrl.map.getSize());
 
                 // clear features & add a new one
                 removeMyFeatures();

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -134,6 +134,102 @@
 
         return this._layer;
       };
+
+      /**
+       * @ngdoc method
+       * @methodOf gn_geometry.service:gnGeometryService
+       * @name gnGeometryService#printGeometryOutput
+       *
+       * @description
+       * This prints the output of a geometry tool according to options given
+       *
+       * @param {ol.Map} map open layers map
+       * @param {ol.Feature} feature feature to output
+       * @param {Object} options
+       * @param {string} options.crs default is EPSG:4326
+       * @param {string} options.format default is GML
+       * @param {bool} options.outputAsFeatures default is false
+       * @return {string | Object} output as string or object
+       */
+      this.printGeometryOutput = function(map, feature, options) {
+        var options = angular.extend({
+          crs: 'EPSG:4326',
+          format: 'gml'
+        }, options);
+
+        // clone & transform geom
+        var outputGeom = feature.getGeometry().clone().transform(
+          map.getView().getProjection(),
+          options.outputCrs || 'EPSG:4326'
+        );
+        var outputFeature = null;
+        if (options.outputAsFeatures) {
+          outputFeature = new ol.Feature({
+            id: 'geometry-tool-output',
+            geometry: outputGeom
+          });
+        }
+
+        // set id on feature
+        feature.setId('geometry-tool-output');
+
+        var formatLabel = options.format.toLowerCase();
+        var format;
+        var outputValue;
+        switch (formatLabel) {
+          case 'json':
+          case 'geojson':
+            format = new ol.format.GeoJSON();
+            if (options.outputAsFeatures) {
+              outputValue = format.writeFeatures([outputFeature]);
+            } else {
+              outputValue = format.writeGeometry(outputGeom);
+            }
+            break;
+
+          case 'wkt':
+            format = new ol.format.WKT();
+            if (options.outputAsFeatures) {
+              outputValue = format.writeFeatures([outputFeature]);
+            } else {
+              outputValue = format.writeGeometry(outputGeom);
+            }
+            break;
+
+          case 'gml':
+            format = new ol.format.GML({
+              featureNS: 'http://mapserver.gis.umn.edu/mapserver',
+              featureType: 'features'
+            });
+
+            if (options.outputAsFeatures) {
+              outputValue = '<wfs:FeatureCollection ' +
+                'xmlns:wfs="http://www.opengis.net/wfs">' +
+                format.writeFeatures([outputFeature]) +
+                '</wfs:FeatureCollection>';
+            } else {
+              outputValue = format.writeGeometryNode(
+                outputGeom).innerHTML;
+            }
+            break;
+
+          // no valid format specified: output as object + give warning
+          default:
+            console.warn('No valid output format specified for ' +
+              'gn-geometry-tool (value=' + options.format + '); ' +
+              'outputting geometry as object');
+
+          case 'object':
+            if (options.outputAsFeatures) {
+              outputValue = [outputFeature];
+            } else {
+              outputValue = outputGeom;
+            }
+            break;
+        }
+
+        return outputValue;
+      };
     }
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/partials/geometrytool.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/partials/geometrytool.html
@@ -1,23 +1,23 @@
 <div gi-btn-group class="btn-group">
 
   <button class="btn btn-default draw-button"
-    gi-btn="active" ng-model="drawInteraction.active">
+    gi-btn="active" ng-model="ctrl.drawInteraction.active">
     <span class="fa fa-pencil"></span>
     <span translate>drawGeometry</span>
   </button>
 
   <button class="btn btn-default modify-button"
-    ng-if="allowModify !== undefined"
-    ng-disabled="output == null"
-    gi-btn="active" ng-model="modifyInteraction.active">
+    ng-if="ctrl.allowModify !== undefined"
+    ng-disabled="ctrl.output == null"
+    gi-btn="active" ng-model="ctrl.modifyInteraction.active">
     <span class="fa fa-pencil"></span>
     <span translate>modifyGeometry</span>
   </button>
 
   <button class="btn btn-danger btn-icon reset-button"
-    ng-if="allowReset !== undefined"
-    ng-disabled="output == null"
-    ng-click="reset()">
+    ng-if="ctrl.allowReset !== undefined"
+    ng-disabled="ctrl.output == null"
+    ng-click="ctrl.reset()">
     <span class="fa fa-trash-o"></span>
   </button>
 

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/partials/geometrytool.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/partials/geometrytool.html
@@ -8,7 +8,7 @@
 
   <button class="btn btn-default modify-button"
     ng-if="ctrl.allowModify !== undefined"
-    ng-disabled="ctrl.output == null"
+    ng-disabled="!ctrl.features.getLength()"
     gi-btn="active" ng-model="ctrl.modifyInteraction.active">
     <span class="fa fa-pencil"></span>
     <span translate>modifyGeometry</span>
@@ -16,7 +16,7 @@
 
   <button class="btn btn-danger btn-icon reset-button"
     ng-if="ctrl.allowReset !== undefined"
-    ng-disabled="ctrl.output == null"
+    ng-disabled="!ctrl.features.getLength()"
     ng-click="ctrl.reset()">
     <span class="fa fa-trash-o"></span>
   </button>

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -105,7 +105,8 @@
                 <gn-geometry-tool
                   ng-repeat="field in getInputsByName(input.identifier.value)"
                   allow-reset allow-modify output="field.value"
-                  output-format="input.outputFormat" geometry-type="input.geometryType"
+                  output-format="{{ input.outputFormat }}"
+                  geometry-type="{{ input.geometryType }}"
                   output-as-features="true" map="map"/>
               </div>
 

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -352,5 +352,10 @@
     "notADirectoryEntryTemplate": "This entry is not a directory entry template.",
     "saveAsDirectoryEntry": "Save as directory entry",
     "confirmDeleteEntry": "Are you sure you want to delete this entry?",
-    "filterBy": "Filter by..."
+    "filterBy": "Filter by...",
+    "selectFormatAndProjection": "Select a format and projection system",
+    "inputGeometryText": "Geometry Text Input",
+    "inputGeometryIsValid": "The input geometry is valid and is now visible on the map.",
+    "inputGeometryIsInvalid": "An error was found in the input geometry:",
+    "inputGeometryHint": "Paste here a geometry in the selected format and projection system."
 }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -357,5 +357,6 @@
     "inputGeometryText": "Geometry Text Input",
     "inputGeometryIsValid": "The input geometry is valid and is now visible on the map.",
     "inputGeometryIsInvalid": "An error was found in the input geometry:",
-    "inputGeometryHint": "Paste here a geometry in the selected format and projection system."
+    "inputGeometryHint": "Paste here a geometry in the selected format and projection system.",
+    "inputGeometryReadOnlyHint": "This geometry is read-only."
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -749,7 +749,10 @@ input.ng-invalid {
 // general purpose layout helpers
 .pos-relative { position: relative; }
 .pos-absolute { position: absolute; }
-.spacer, .flex-spacer { flex-grow: 0; flex-shrink: 0; min-width: 0.7em; }
+.spacer, .flex-spacer {
+  flex-grow: 0; flex-shrink: 0;
+  min-width: 0.7em; min-height: 0.7em;
+}
 .flex-grow { flex-grow: 1; }
 .flex-no-grow { flex-grow: 0; }
 .flex-shrink { flex-shrink: 1; }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -810,13 +810,14 @@ gn-md-type-widget {
 }
 
 gn-bounding-polygon {
-  .map {
-    height: 300px;
-  }
-
   label {
     font-size: 0.9em;
     line-height: 0.8em;
     margin-bottom: 0px;
+  }
+
+  textarea {
+    font-family: Consolas, monospace;
+    font-size: 0.9em;
   }
 }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -813,4 +813,10 @@ gn-bounding-polygon {
   .map {
     height: 300px;
   }
+
+  label {
+    font-size: 0.9em;
+    line-height: 0.8em;
+    margin-bottom: 0px;
+  }
 }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -808,3 +808,9 @@ gn-md-type-widget {
     }
   }
 }
+
+gn-bounding-polygon {
+  .map {
+    height: 300px;
+  }
+}

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -640,10 +640,14 @@ gn-wps-process-form {
   }
 }
 
-gn-geometry-tool .btn-group .btn {
-  flex-basis: initial !important;
-  &.btn-icon {
-    flex-grow: 0 !important;
+gn-geometry-tool .btn-group {
+  display: flex;
+  .btn {
+    flex-basis: initial !important;
+    flex-grow: 1;
+    &.btn-icon {
+      flex-grow: 0 !important;
+    }
   }
 }
 


### PR DESCRIPTION
A new `gn-bounding-polygon`  directive was created, similar to the one that handles bounding-box drawing:

![image](https://user-images.githubusercontent.com/10629150/28660552-b35e4198-72b3-11e7-887f-8d996673e8bf.png)

The bounding polygon can be drawn/modified on the map, and a new one can be set by pasting text in the input and selection format and projection.

Remaining:
- [x] saving with the editor does not take into account the output of the directive
- [x] support for line strings
- [x] set the directive in read-only when the bounding polygon was resolved using an XLink
- [x] when modifying the geometry in the map, update the text input accordingly (?)
- [x] support for GML input