### PR TITLE
Update langs in subtemplate depending on metadata langs

### DIFF
--- a/schemas/iso19139/src/test/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPluginTest.java
+++ b/schemas/iso19139/src/test/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPluginTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.schema.iso19139;
+
+import org.fao.geonet.utils.TransformerFactoryFactory;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.xml.transform.TransformerConfigurationException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
+
+/**
+ * Created by fgravin on 7/31/17.
+ */
+public class ISO19139SchemaPluginTest {
+    protected Path root;
+    protected Map<String, String> ns = new HashMap<String, String>();
+
+    @Before
+    public void setup() throws TransformerConfigurationException, URISyntaxException {
+        TransformerFactoryFactory.init("net.sf.saxon.TransformerFactoryImpl");
+        root = Paths.get(ISO19139SchemaPluginTest.class.getResource("").toURI());
+
+        ns.put(
+                ISO19139Namespaces.GMD.getPrefix(),
+                ISO19139Namespaces.GMD.getURI()
+        );
+        ns.put(
+                ISO19139Namespaces.GCO.getPrefix(),
+                ISO19139Namespaces.GCO.getURI()
+        );
+
+    }
+
+    @Test
+    public void removeTranslationFromElement() throws Exception {
+        Element multilingualElement = Xml.loadFile(
+                root.resolve("multilingual-contact.xml"));
+
+        ISO19139SchemaPlugin plugin = new ISO19139SchemaPlugin();
+        plugin.removeTranslationFromElement(multilingualElement, "#EN");
+
+        String resultString = Xml.getString(multilingualElement);
+
+        assertThat(
+                resultString, hasXPath("count(//gmd:PT_FreeText)", equalTo("0")).withNamespaceContext(ns)
+        );
+        assertThat(
+                resultString, hasXPath("count(//gco:CharacterString[text() = 'Name (multilingual)'])",
+                        equalTo("0")).withNamespaceContext(ns)
+        );
+        assertThat(
+                resultString, hasXPath("count(//gco:CharacterString[text() = 'en-individualname'])",
+                        equalTo("1")).withNamespaceContext(ns)
+        );
+
+    }
+
+}

--- a/schemas/iso19139/src/test/resources/org/fao/geonet/schema/iso19139/multilingual-contact.xml
+++ b/schemas/iso19139/src/test/resources/org/fao/geonet/schema/iso19139/multilingual-contact.xml
@@ -1,0 +1,73 @@
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<gmd:CI_ResponsibleParty xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                         xmlns:gco="http://www.isotc211.org/2005/gco"
+                         xmlns:geonet="http://www.fao.org/geonetwork">
+    <gmd:individualName>
+        <gco:CharacterString>Name (multilingual)</gco:CharacterString>
+        <gmd:PT_FreeText>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">en-individualname</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">de-individualName</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">fr-individualName</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+
+        </gmd:PT_FreeText>
+    </gmd:individualName>
+    <gmd:organisationName>
+        <gco:CharacterString>Organisation (multilingual)</gco:CharacterString>
+        <gmd:PT_FreeText>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">en-organisation</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">de-organisation</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">fr-organisation</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+        </gmd:PT_FreeText>
+    </gmd:organisationName>
+    <gmd:positionName>
+        <gco:CharacterString>Position (multilingual)</gco:CharacterString>
+        <gmd:PT_FreeText>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">en-position</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">de-position</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">fr-position</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+        </gmd:PT_FreeText>
+    </gmd:positionName>
+    <gmd:role>
+        <gmd:CI_RoleCode codeList="./resources/codeList.xml#CI_RoleCode" codeListValue="user"/>
+    </gmd:role>
+</gmd:CI_ResponsibleParty>

--- a/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/MultilingualSchemaPlugin.java
+++ b/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/MultilingualSchemaPlugin.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.kernel.schema;
 
 import org.jdom.Element;
+import org.jdom.JDOMException;
 
 import java.util.List;
 
@@ -40,5 +41,7 @@ public interface MultilingualSchemaPlugin {
     public abstract List<Element> getTranslationForElement(Element element, String languageIdentifier);
 
     public abstract void addTranslationToElement(Element element, String languageIdentifier, String value);
+
+    public abstract  Element removeTranslationFromElement(Element element, String mdLang) throws JDOMException;
 
 }

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
@@ -16,6 +16,7 @@ import org.fao.geonet.kernel.search.SearcherType;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.services.subtemplate.Get;
 import org.fao.geonet.util.Sha1Encoder;
+import org.fao.geonet.util.XslUtil;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Attribute;
@@ -24,16 +25,16 @@ import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.jdom.Text;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import jeeves.constants.Jeeves;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.XLink;
+
+import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GCO;
+import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GMD;
+import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.SRV;
 
 /**
  * Created by francois on 11/03/16.
@@ -430,4 +431,22 @@ public class DirectoryUtils {
         }
         return null;
     }
+
+    public static Element removeUnsedLangsEntry(Element entry, final String[] langs) throws JDOMException {
+        List<Element> multilangElement = (List<Element>)Xml.selectNodes(entry, "*//node()[@locale]");
+
+        List<String> twoCharLangs = new ArrayList<String>();
+        for(String l : langs) {
+            twoCharLangs.add("#" + XslUtil.twoCharLangCode(l).toUpperCase());
+        }
+
+        for(Element el : multilangElement) {
+            if(!twoCharLangs.contains(el.getAttribute("locale").getValue())) {
+                Element parent = (Element)el.getParent();
+                parent.detach();
+            }
+        }
+        return entry;
+    }
+
 }


### PR DESCRIPTION
This PR updates languages in the subtemplate while inserted in the template as xlink.

As keyword, subtemplate api now takes array of langs as parameter and filter the XML on these langs.
If no lang is requested, then the multilingual part is deleted (`gmd:PT_FreeText`)
The xlink fragment in the metadata is inserted with languages:
```xml
<gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink"
                             xlink:href="local://srv/api/registries/entries/26b6901f-6914-40c4-bc1c-af237e296924?process=gmd:role/gmd:CI_RoleCode/@codeListValue~distributor&amp;lang=eng&lang=fre">
```

This way, the xlink subtemplate XML fragment contains the same languages as in the metadata.

Not covered: if user add new languages in the metadata (or remove them), the `xlink:href` is not update at the moment.