### PR TITLE
Registries api

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSort.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSort.java
@@ -46,7 +46,11 @@ public final class KeywordSort {
     public static Comparator<KeywordBean> defaultLabelSorter(final SortDirection direction) {
         return new Comparator<KeywordBean>() {
             public int compare(final KeywordBean kw1, final KeywordBean kw2) {
-                return direction.multiplier * normalizeDesc(kw1.getDefaultValue()).compareTo(normalizeDesc(kw2.getDefaultValue()));
+                int comp = normalizeDesc(kw1.getDefaultValue()).compareTo(normalizeDesc(kw2.getDefaultValue()));
+                if(comp == 0) {
+                    comp = kw1.getUriCode().compareTo(kw2.getUriCode());
+                }
+                return direction.multiplier * comp;
             }
 
             @Override

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -110,7 +110,6 @@ public class KeywordsApi {
             required = false
         )
         @RequestParam(
-            value = "Number of rows",
             required = false,
             defaultValue = "1000"
         )

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -123,11 +123,15 @@ public class KeywordsApi {
             required = false
         )
             int start,
-//        @RequestParam(
-//            value = XmlParams.pLang,
-//            defaultValue = ""
-//        )
-//            List<String> targetLangs,
+        @ApiParam(
+                value = "Target langs",
+                required = false
+        )
+        @RequestParam(
+            value = XmlParams.pLang,
+                required = false
+        )
+            List<String> targetLangs,
         @ApiParam(
             value = "Thesaurus identifier",
             required = false
@@ -192,7 +196,6 @@ public class KeywordsApi {
         searcher = new KeywordsSearcher(context, thesaurusMan);
 
         IsoLanguagesMapper languagesMapper = applicationContext.getBean(IsoLanguagesMapper.class);
-        List<String> targetLangs = new ArrayList<>();
         String thesauriDomainName = null;
 
         KeywordSearchParamsBuilder builder = parseBuilder(
@@ -258,10 +261,12 @@ public class KeywordsApi {
         }
 
         boolean addedLang = false;
-        for (String targetLang : targetLangs) {
-            if (!targetLang.trim().isEmpty()) {
-                parsedParams.addLang(targetLang.trim());
-                addedLang = true;
+        if(targetLangs != null) {
+            for (String targetLang : targetLangs) {
+                if (!targetLang.trim().isEmpty()) {
+                    parsedParams.addLang(targetLang.trim());
+                    addedLang = true;
+                }
             }
         }
         if (!addedLang) {


### PR DESCRIPTION
Improve multilang keyword search api.

- Restore pLang attribute
Overrides the lang attribute, can be an array. If specified, all keywords will return translation for all requested languages.

- Fix response order TreeSet behavior cause if comparator returns 0 (when 2 keywords have no translation in a language) then the keyword is not added. Only one keyword were returned in the case of a thesaurus requested in a lang where it had no translation for.

- Fix API parameter `rows` that were set to `Number of rows`, issue with api config.