### PR TITLE
Minor UI fixes and improvements

### DIFF
--- a/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
+++ b/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
@@ -76,6 +76,7 @@
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/bootstrap.ext/tagsinput/bootstrap-tagsinput-angular.js"/>
     <jsSource webappPath="/catalog/lib/bootstrap.ext/datepicker/bootstrap-datepicker.js"/>
+    <jsSource webappPath="/catalog/lib/bootstrap.ext/datepicker/bootstrap-datepicker.fr.js"/>
     <jsSource webappPath="/catalog/lib/bootstrap-table/dist/bootstrap-table.min.js"
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/zip/zip.js"/>
@@ -139,6 +140,7 @@
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/bootstrap.ext/tagsinput/bootstrap-tagsinput-angular.js"/>
     <jsSource webappPath="/catalog/lib/bootstrap.ext/datepicker/bootstrap-datepicker.js"/>
+    <jsSource webappPath="/catalog/lib/bootstrap.ext/datepicker/bootstrap-datepicker.fr.js"/>
     <jsSource webappPath="/catalog/lib/bootstrap-table/dist/bootstrap-table.min.js"
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/FileSaver/FileSaver.min.js" minimize="false"/>

--- a/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
+++ b/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
@@ -134,6 +134,8 @@
      */
     this.states_ = [];
 
+    this.initialParams = {};
+
     // Initialize all events
     angular.forEach(indexRequestEvents, function(k) {
       this.eventsListener[k] = [];
@@ -225,7 +227,8 @@
   geonetwork.gnIndexRequest.prototype.searchWithFacets =
       function(qParams, aggs) {
 
-    if (Object.keys(this.initialParams.stats).length > 0) {
+    if (this.initialParams.stats &&
+      Object.keys(this.initialParams.stats).length > 0) {
       angular.forEach(this.initialParams.stats, function(value, key) {
         if (key == 'undefined') {
           delete this.initialParams.stats[key];

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -752,6 +752,7 @@
               dragboxInteraction.active = false;
 
               scope.clear = function() {
+                scope.valueInternalChange = true;
                 scope.value = '';
                 scope.extent = extentFromValue(scope.value);
                 scope.updateMap();
@@ -780,14 +781,14 @@
                 scope.extent = extent.map(function(coord) {
                   return Math.round(coord * 10000) / 10000;
                 });
-                scope.value = valueFromExtent(scope.extent);
-                scope.updateMap();
+                scope.onBboxChange();
 
                 scope.$apply();
               });
               scope.dragboxInteraction = dragboxInteraction;
 
               scope.onBboxChange = function() {
+                scope.valueInternalChange = true;
                 scope.value = valueFromExtent(scope.extent);
                 scope.updateMap();
               };
@@ -796,6 +797,18 @@
                 clearMap();
                 scope.map.removeLayer(layer);
               });
+
+              // watch external change of value
+              if (scope.$eval(attrs['watchValueChange'])) {
+                scope.$watch('value', function (newValue) {
+                  if (scope.valueInternalChange) {
+                    scope.valueInternalChange = false;
+                  } else {
+                    scope.extent = extentFromValue(newValue);
+                    scope.updateMap();
+                  }
+                });
+              }
             }
           };
         }

--- a/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
@@ -32,8 +32,10 @@
           return {
             restrict: 'A',
             scope: true,
-            templateUrl: '../../catalog/components/search/map/' +
-                'partials/mapfield.html',
+            templateUrl: function (elem, attrs) {
+              return attrs.template || '../../catalog/components/search/map/' +
+                'partials/mapfield.html';
+            },
             compile: function compile(tElement, tAttrs, transclude) {
               return {
                 pre: function preLink(scope, iElement, iAttrs, controller) {

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -59,9 +59,12 @@
   module.directive('gnMetadataDisplay', [
     'gnMdView', 'gnSearchSettings', function(gnMdView, gnSearchSettings) {
       return {
-        templateUrl: '../../catalog/components/search/mdview/partials/' +
-            'mdpanel.html',
         scope: true,
+        templateUrl: function (elem, attrs) {
+          return attrs.template ||
+            '../../catalog/components/search/mdview/partials/' +
+            'mdpanel.html';
+        },
         link: function(scope, element, attrs, controller) {
 
           var unRegister;

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -128,17 +128,18 @@
           defaultParams);
 
       // Add hidden filters which may
-      // restrict search
+      // restrict search (do not add an existing filter)
       if ($scope.searchObj.filters) {
         angular.forEach($scope.searchObj.filters,
             function(value, key) {
               var p = $scope.searchObj.params[key];
               if (p) {
-                if (!angular.isArray(p)) {
-                  $scope.searchObj.params[key] = [p];
+                if (p !== value && (!p.indexOf || p.indexOf(value) === -1)) {
+                  if (!angular.isArray(p)) {
+                    $scope.searchObj.params[key] = [p];
+                  }
+                  $scope.searchObj.params[key].push(value);
                 }
-                $scope.searchObj.params[key].push(value);
-
               } else {
                 $scope.searchObj.params[key] = value;
               }

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -727,8 +727,8 @@
   /**
    * Use to initialize bootstrap datepicker
    */
-  module.directive('gnBootstrapDatepicker', [
-    function() {
+  module.directive('gnBootstrapDatepicker', ['$timeout', 'gnLangs',
+    function($timeout, gnLangs) {
 
       // to MM-dd-yyyy
       var formatDate = function(day, month, year) {
@@ -859,7 +859,8 @@
               autoclose: true,
               keepEmptyValues: true,
               clearBtn: true,
-              todayHighlight: false
+              todayHighlight: false,
+              language: gnLangs.getIso2Lang(gnLangs.getCurrent())
             } : {}).on('changeDate clearDate', function(ev) {
               // view -> model
               scope.$apply(function() {

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -205,11 +205,11 @@
             });
 
             if (options.outputAsWFSFeaturesCollection) {
-              outputValue =
+              outputValue = 
                   '<wfs:FeatureCollection ' +
                   'xmlns:wfs="http://www.opengis.net/wfs">' +
                   format.writeFeatures([outputFeature]) +
-                  '</FeatureCollection>';
+                  '</wfs:FeatureCollection>';
             } else if (options.outputAsFeatures) {
               outputValue = format.writeFeatures([outputFeature]);
             } else {

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -89,7 +89,10 @@
        */
       this.getCommonLayer = function(map) {
         if (this._layer) {
-          this._layer.setMap(map);
+          // add layer to map if not already there
+          if (!map.getLayers().getArray().indexOf(this._layer) === -1) {
+            map.addLayer(this._layer);
+          }
           return this._layer;
         }
 
@@ -131,7 +134,7 @@
         });
 
         // add our layer to the map
-        this._layer.setMap(map);
+        map.addLayer(this._layer);
 
         return this._layer;
       };

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -374,6 +374,11 @@
         // add the background layers
         // todo: grab this from config
         angular.forEach(gnViewerSettings.bgLayers, function(layer) {
+          // skip if no valid layer (ie: layer still loading)
+          if (!layer) {
+            return;
+          }
+
           var source = layer.getSource();
           var name;
           var params = {

--- a/web-ui/src/main/resources/catalog/components/viewer/profile/partials/profile.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/profile/partials/profile.html
@@ -1,6 +1,5 @@
 <div class="profile-graph gn-viewer-info-pane"
-  ng-if="ctrl.graphData.length"
-  ng-class="{'leftBarExpanded': isContainerOpened()}">
+  ng-if="ctrl.graphData.length">
   <div class="panel-heading">
     <button type="button" class="btn btn-default close"
       ng-click="ctrl.closeProfileGraph()" title="close">

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -92,6 +92,7 @@
            data-ng-class="{'collapse': !indexObject.geomField.expanded}">
         <gn-bbox-input data-value="ctrl.searchGeometry"
                        data-map="map"
+                       data-watch-value-change="true"
         />
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -69,9 +69,9 @@
                on-change-fn="onUpdateDate(field)"
                date-only-highlight="true"
                date-available="field.dates">
-            <input type="text" class="input-sm form-control" name="start" value="{{::output[field.name].value.from}}"/>
-            <span class="input-group-addon">to</span>
-            <input type="text" class="input-sm form-control" name="end" value="{{::output[field.name].value.to}}" />
+            <input type="text" class="input-sm form-control" name="start" value="{{::output[field.name].values.from}}"/>
+            <span class="input-group-addon" translate>dateToDate</span>
+            <input type="text" class="input-sm form-control" name="end" value="{{::output[field.name].values.to}}" />
           </div>
           <div data-ng-if="field.datesCount && field.display == 'graph'"
                gn-facet-graph field="field" callback="onUpdateDate"

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -409,7 +409,7 @@
                     scope.executeState = 'finished';
 
                     if (response.status.processSucceeded &&
-                        scope.wpsLink.layer) {
+                        gnWpsService.responseHasWmsService(response)) {
                       gnWpsService.extractWmsLayerFromResponse(
                           response, scope.map, scope.wpsLink.layer, {
                             exclude: /^OUTPUT_/

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -49,7 +49,7 @@
    *
    * @directiveInfo {Object} map
    * @directiveInfo {Object} wpsLink this object holds information on the WPS
-   *  service to use, namely name and url properties
+   *  service to use: name, url and applicationProfile (optional)
    * @directiveInfo {Object} wfsLink the WFS link object
    *  will be used to overload inputs based on active WFS feature filters
    * @directiveInfo {boolean} hideExecuteButton if true,
@@ -65,14 +65,6 @@
     'gnProfileService',
     function(gnWpsService, gnUrlUtils, $timeout, wfsFilterService,
         $window, gnGeometryService, gnProfileService) {
-
-      var toBool = function(str, defaultVal) {
-        if (str === undefined) {
-          return defaultVal;
-        }
-        return str.toLowerCase() === 'true';
-      };
-
       return {
         restrict: 'AE',
         scope: {
@@ -125,22 +117,42 @@
             // prepare inputs object (use existing one if available)
             scope.wpsLink.inputs = scope.wpsLink.inputs || [];
 
+            // inputs overriden by wfs filters are saved here
+            scope.inputWfsOverride = {};
+
             scope.describeState = 'sent';
 
-            // parse application profile as JSON
-            var applicationProfile;
-            try {
-              applicationProfile = scope.wpsLink.applicationProfile ?
-                  JSON.parse(scope.wpsLink.applicationProfile) : null;
-            }
-            catch (e) {
-              console.warn('Error while loading application profile.');
+            // parse application profile as JSON (if not already an object)
+            // application profile holds 2 arrays: inputs and outputs
+            var applicationProfile = scope.wpsLink.applicationProfile;
+            if (typeof applicationProfile === 'string') {
+              try {
+                applicationProfile = JSON.parse(applicationProfile);
+              }
+              catch (e) {
+                console.warn('Error while loading application profile.');
+              }
             }
 
-            // getting defaults
-            var defaults = scope.$eval(attrs['defaults']);
-            if (!defaults && applicationProfile) {
-              defaults = applicationProfile.defaults;
+            // get values from wfs filters
+            var wfsFilterValues = null;
+            if (scope.wfsLink) {
+              // this is the object holding current filter values
+              var esObject = wfsFilterService.getEsObject(scope.wfsLink.url,
+                scope.wfsLink.name);
+
+              // use filter values in ElasticSearch object state to overload input
+              if (esObject) {
+                // this will hold wfs filter values
+                var currentFilters = wfsFilterService.toObjectProperties(esObject);
+                wfsFilterValues = {};
+
+                // remove prefix & suffix on filter keys
+                Object.keys(currentFilters).forEach(function(key) {
+                  var cleanKey = key.replace(/^ft_|_s$|_dt$/g, '')
+                  wfsFilterValues[cleanKey] = currentFilters[key];
+                });
+              }
             }
 
             // query a description and build up the form
@@ -155,15 +167,8 @@
                     // Bind input directly in link object
                     scope.processDescription = response.processDescription[0];
 
-                    // check if we need to get into 'profile graph' mode
-                    // FIXME: look for an actual way to determine
-                    // the output type...
-                    if (scope.processDescription.identifier.value ==
-                    'script:computemultirasterprofile') {
-                      scope.outputAsGraph = true;
-                    } else {
-                      scope.outputAsGraph = false;
-                    }
+                    // by default, do not use profile graph output
+                    scope.outputAsGraph = false;
 
                     // loop on process expected inputs to prepare the form
                     angular.forEach(scope.processDescription.dataInputs.input,
@@ -171,19 +176,27 @@
                       var inputName = input.identifier.value;
                       var value;
                       var defaultValue;
+                      var wfsFilterValue;
 
-                      // look for default value from app profile field
-                      if (defaults && defaults[inputName]) {
-                        defaultValue = defaults[inputName];
+                      // look for input info in app profile
+                      if (applicationProfile && applicationProfile.inputs) {
+                        applicationProfile.inputs.forEach(function (input) {
+                          if (input.identifier == inputName) {
+                            defaultValue = input.defaultValue;
+
+                            // check if there is a wfs filter active & apply value
+                            var linkedWfsFilter = input.linkedWfsFilter;
+                            if (linkedWfsFilter && wfsFilterValues &&
+                              wfsFilterValues[linkedWfsFilter]) {
+                              wfsFilterValue = wfsFilterValues[linkedWfsFilter];
+                            }
+                          }
+                        });
                       }
 
-                      // use overloaded value if applicable
-                      if (scope.inputOverloads &&
-                      scope.inputOverloads[inputName]) {
-                        defaultValue =
-                        scope.inputOverloads[inputName]
-                        .currentValue;
-                      }
+                      // display field as overriden
+                      scope.inputWfsOverride[inputName] =
+                        wfsFilterValue !== undefined;
 
                       // literal data (basic form input)
                       if (input.literalData != undefined) {
@@ -253,53 +266,68 @@
                           value: defaultValue
                         });
                       }
+
+                      // force value if a wfs filter is present
+                      if (wfsFilterValue !== undefined) {
+                        scope.setInputValueByName(inputName, 0, wfsFilterValue);
+                      }
                     }
                     );
+
+                    var defaultOutput;
+                    var defaultMimeType;
 
                     angular.forEach(
                     scope.processDescription.processOutputs.output,
-                    function(output, idx) {
-                      output.asReference = scope.outputAsGraph ? false : true;
+                    function(output) {
+                      output.asReference = true;
+                      var outputName = output.identifier.value;
 
-                      // untested code
-                      var outputDefault = defaults &&
-                      defaults.responsedocument &&
-                      defaults.responsedocument[output.identifier.value];
-                      if (outputDefault) {
-                        output.value = true;
-                        var defaultAsReference =
-                        outputDefault.attributes['asreference'];
-                        if (defaultAsReference !== undefined) {
-                          output.asReference = toBool(defaultAsReference);
-                        }
-                        scope.selectedOutput.identifier =
-                        output.identifier.value;
-                        scope.selectedOutput.mimeType =
-                        output.complexOutput._default.format.mimeType;
+                      // output already selected yet: leave
+                      if (defaultOutput) {
+                        return;
                       }
-                      else if (idx == 0) {
-                        scope.selectedOutput.identifier =
-                        output.identifier.value;
-                        scope.selectedOutput.mimeType =
+
+                      // no output selected yet: take this one
+                      defaultOutput = outputName;
+                      defaultMimeType =
                         output.complexOutput._default.format.mimeType;
+
+                      // look for output info in app profile
+                      if (applicationProfile && applicationProfile.outputs) {
+                        applicationProfile.outputs.forEach(function(output) {
+                          if (output.identifier == outputName) {
+                            // assign mime type if available
+                            defaultMimeType = output.defaultMimeType ||
+                              defaultMimeType;
+
+                            // check if we need to get into 'profile graph' mode
+                            // (display graph options are defined)
+                            // TODO: actually parse these options
+                            if (output.displayGraphOptions) {
+                              scope.outputAsGraph = output.displayGraphOptions ?
+                                true : false;
+                            }
+                          }
+                        });
                       }
                     }
                     );
-                    var output = scope.processDescription.processOutputs.output;
-                    if (output.length == 1) {
-                      output[0].value = true;
-                    }
+
+                    // assign default output & mimeType
+                    scope.selectedOutput.identifier = defaultOutput;
+                    scope.selectedOutput.mimeType = defaultMimeType;
+
                     scope.outputsVisible = true;
 
                     scope.responseDocument = {
-                      lineage: toBool(defaults && defaults.lineage, false),
-                      storeExecuteResponse: toBool(defaults &&
-                      defaults.storeexecuteresponse, false),
-                      status: toBool(defaults && defaults.status, false)
+                      lineage: false,
+                      storeExecuteResponse: false,
+                      status: false
                     };
                     scope.optionsVisible = true;
 
-                    // use existing inputs if available
+                    // use existing process desc if available
                     var processKey = newLink.processId + '@' + newLink.uri;
                     var existingDesc = scope.loadedDescriptions[processKey];
                     if (existingDesc) {
@@ -322,6 +350,7 @@
           scope.close = function() {
             scope.wpsLink.name = '';
             scope.wpsLink.url = '';
+            scope.wpsLink.applicationProfile = null;
             scope.describeState = 'standby';
           };
 
@@ -366,9 +395,10 @@
             angular.forEach(scope.processDescription.processOutputs.output,
                 function(output) {
                   if (output.identifier.value ==
-                  scope.selectedOutput.identifier) {
+                      scope.selectedOutput.identifier) {
                     outputs.push({
-                      asReference: output.asReference,
+                      asReference: scope.outputAsGraph ?
+                        false : output.asReference,
                       mimeType: scope.selectedOutput.mimeType,
                       identifier: {
                         value: output.identifier.value
@@ -427,7 +457,7 @@
                   var jsonData = JSON.parse(response.processOutputs.output[0]
                       .data.complexData.content);
 
-                  // TODO: use applicationProfile for this
+                  // TODO: use applicationProfile.displayGraphOptions here
                   gnProfileService.displayProfileGraph(
                       jsonData.profile,
                       {
@@ -524,10 +554,21 @@
             }
           };
 
-          // get all input values
+          // get/set input values
           scope.getInputsByName = function(name) {
             return scope.wpsLink.inputs.filter(function(input) {
               return input.name == name;
+            });
+          };
+          scope.setInputValueByName = function (name, index, value) {
+            var current = 0;
+            scope.wpsLink.inputs.forEach(function (input) {
+              if (input.name === name) {
+                if (current == index) {
+                  input.value = value;
+                }
+                current++;
+              }
             });
           };
 
@@ -550,94 +591,6 @@
               scope.wpsLink.inputs.splice(realIndex, 1);
             }
           };
-
-          // helpers for accessing input values
-          var getInputValue = function(name) {
-            if (!scope.processDescription) { return; }
-
-            var result = null;
-            angular.forEach(scope.processDescription.dataInputs.input,
-                function(input) {
-                  if (input.identifier.value == name) {
-                    result = input.value;
-                  }
-                });
-            return result;
-          };
-          var setInputValue = function(name, value) {
-            if (!scope.processDescription) { return; }
-
-            angular.forEach(scope.processDescription.dataInputs.input,
-                function(input) {
-                  if (input.identifier.value == name) {
-                    input.value = value;
-                  }
-                });
-          };
-
-          // handle input overload from WFS link
-          if (scope.wfsLink) {
-            // this is the object holding current filter values
-            var esObject = wfsFilterService.getEsObject(scope.wfsLink.url,
-                scope.wfsLink.name);
-
-            // this will hold input overload info
-            // keys are overloaded inputs names, values are objects like so:
-            //  { currentValue: any, oldValue: any }
-            scope.inputOverloads = {};
-
-            // use filter values in ElasticSearch object state to overload input
-            if (esObject) {
-              var wfsFilterLinks = applicationProfile &&
-                  applicationProfile.wfsFilterLinks ?
-                  applicationProfile.wfsFilterLinks : {};
-
-              // get list of filters
-              var filterValues = wfsFilterService.toObjectProperties(esObject);
-
-              // transform according to app profile
-              var inputValues = {};
-              Object.keys(wfsFilterLinks).forEach(function(key) {
-
-                // prefix & suffix are added to the raw filter key
-                var filterKey = wfsFilterLinks[key];
-                var stringFilterKey = 'ft_' + wfsFilterLinks[key] + '_s';
-                var dateFilterKey = 'ft_' + wfsFilterLinks[key] + '_dt';
-
-                // testing each case
-                if (filterValues[filterKey]) {
-                  inputValues[key] = filterValues[filterKey];
-                }
-                else if (filterValues[stringFilterKey]) {
-                  inputValues[key] = filterValues[stringFilterKey];
-                }
-                else if (filterValues[dateFilterKey]) {
-                  inputValues[key] = filterValues[dateFilterKey];
-                }
-              });
-
-              // loop on these
-              Object.keys(inputValues).forEach(function(name) {
-                // new overload
-                if (!scope.inputOverloads[name]) {
-                  scope.inputOverloads[name] = {
-                    oldValue: getInputValue(name)
-                  };
-                }
-                scope.inputOverloads[name].currentValue = inputValues[name];
-                setInputValue(name, inputValues[name]);
-              });
-
-              // clear non existing overloads
-              Object.keys(scope.inputOverloads).forEach(function(name) {
-                // new overload
-                if (!inputValues[name]) {
-                  setInputValue(name, scope.inputOverloads[name].oldValue);
-                  delete scope.inputOverloads[name];
-                }
-              });
-            }
-          }
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -236,7 +236,7 @@
               }
             });
           }
-          if (input.boundingBoxData) {
+          if (input.boundingBoxData && data) {
             var bbox = data.split(',');
             request.value.dataInputs.input.push({
               identifier: {

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -354,8 +354,12 @@
        * @return {bool} true if WMS service
        */
       this.responseHasWmsService = function(response) {
-        var mimeType = response.processOutputs.output[0].reference.mimeType;
-        return this.WMS_MIMETYPE_REGEX.test(mimeType);
+        try {
+          var mimeType = response.processOutputs.output[0].reference.mimeType;
+          return this.WMS_MIMETYPE_REGEX.test(mimeType);
+        } catch (e) {
+          return false;
+        }
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -82,7 +82,7 @@
     function($http, gnOwsCapabilities, gnUrlUtils, gnGlobalSettings,
              gnMap, $q) {
 
-      this.WMS_MIMETYPE = 'application/x-ogc-wms';
+      this.WMS_MIMETYPE_REGEX = /.*ogc-wms/;
 
       /**
        * @ngdoc method
@@ -348,6 +348,17 @@
       };
 
       /**
+       * Returns true if the mime type matches a WMS service
+       *
+       * @param {object} response excecuteProcess response object.
+       * @return {bool} true if WMS service
+       */
+      this.responseHasWmsService = function(response) {
+        var mimeType = response.processOutputs.output[0].reference.mimeType;
+        return this.WMS_MIMETYPE_REGEX.test(mimeType);
+      };
+
+      /**
        * Try to see if the execute response is a reference with a WMS mimetype.
        * If yes, the href is a WMS getCapabilities, we load it and add all
        * the layers on the map.
@@ -356,7 +367,7 @@
        *
        * @param {object} response excecuteProcess response object.
        * @param {ol.Map} map
-       * @param {ol.layer.Base} parentLayer
+       * @param {ol.layer.Base} parentLayer optional
        * @param {object=} opt_options
        */
       this.extractWmsLayerFromResponse =
@@ -364,20 +375,19 @@
 
         try {
           var ref = response.processOutputs.output[0].reference;
-          if (ref.mimeType == this.WMS_MIMETYPE) {
             gnMap.addWmsAllLayersFromCap(map, ref.href, true).
-                then(function(layers) {
-                  layers.forEach(function(l) {
-                    l.set('fromWps', true);
-                    l.set('wpsParent', parentLayer);
-                    if (opt_options &&
-                        !opt_options.exclude.test(l.get('label'))) {
-                      map.addLayer(l);
-                    }
-                  });
+              then(function(layers) {
+                layers.forEach(function(l) {
+                  l.set('fromWps', true);
+                  l.set('wpsParent', parentLayer);
+                  if (opt_options &&
+                      !opt_options.exclude.test(l.get('label'))) {
+                    map.addLayer(l);
+                  }
                 });
-          }
-        } catch (e) { // no WMS found }
+              });
+        } catch (e) {
+          console.warn('Error extracting WMS layers from response: ', e);
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -55,7 +55,7 @@
 
                 <!-- This input is overloaded by a WFS filter -->
                 <small class="text-muted"
-                  ng-if="inputOverloads[input.identifier.value]">
+                  ng-if="inputWfsOverride[input.identifier.value]">
                   {{::'inputIsOverloaded' | translate}}</small>
               </span>
 
@@ -67,7 +67,7 @@
                     ng-if="::input.literalData.allowedValues"
                     ng-model="field.value"
                     ng-required="$index < input.minOccurs"
-                    ng-disabled="inputOverloads[input.identifier.value]">
+                    ng-disabled="inputWfsOverride[input.identifier.value]">
                     <option ng-repeat="value in input.literalData.allowedValues.valueOrRange"
                       value="{{::value.value}}">{{::value.value}}</option>
                   </select>
@@ -76,7 +76,7 @@
                     type="{{::getInputType(input.literalData.dataType.value)}}"
                     ng-model="field.value"
                     ng-required="$index < input.minOccurs"
-                    ng-disabled="inputOverloads[input.identifier.value]"></input>
+                    ng-disabled="inputWfsOverride[input.identifier.value]"></input>
 
                   <!-- delete button (disabled for mandatory values) -->
                   <a class="input-group-addon btn btn-default btn-icon"
@@ -96,8 +96,9 @@
                 <gn-bbox-input
                   ng-repeat="field in getInputsByName(input.identifier.value)"
                   crs="input._default.crs" value="field.value" map="map"
-                  ng-disabled="inputOverloads[input.identifier.value]"
-                  ng-required="$index < input.minOccurs"/>
+                  ng-disabled="inputWfsOverride[input.identifier.value]"
+                  ng-required="$index < input.minOccurs"
+                  watch-value-change="true"/>
               </div>
 
               <!-- Complex input (geometry on map) -->
@@ -139,7 +140,7 @@
                   &nbsp;<span translate>wpsSelectOutput</span>
                 </button>
                 <ul class="dropdown-menu pull-rightp">
-                  <li ng-repeat-start="output in ::processDescription.processOutputs.output"
+                  <li ng-repeat-start="output in processDescription.processOutputs.output"
                     class="dropdown-header">
                     {{::output.title.value}}
                   </li>

--- a/web-ui/src/main/resources/catalog/js/jsonix/OWC_0_3_1.js
+++ b/web-ui/src/main/resources/catalog/js/jsonix/OWC_0_3_1.js
@@ -273,7 +273,7 @@ var OWC_0_3_1_Module_Factory = function() {
       ln: 'ExtensionType',
       ps: [{
         n: 'any',
-        mx: false,
+        mx: true,
         t: 'ae'
       }]
     }, {

--- a/web-ui/src/main/resources/catalog/lib/bootstrap.ext/datepicker/bootstrap-datepicker.fr.js
+++ b/web-ui/src/main/resources/catalog/lib/bootstrap.ext/datepicker/bootstrap-datepicker.fr.js
@@ -1,0 +1,18 @@
+/**
+ * French translation for bootstrap-datepicker
+ * Nico Mollet <nico.mollet@gmail.com>
+ */
+;(function($){
+	$.fn.datepicker.dates['fr'] = {
+		days: ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"],
+		daysShort: ["dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam."],
+		daysMin: ["d", "l", "ma", "me", "j", "v", "s"],
+		months: ["janvier", "février", "mars", "avril", "mai", "juin", "juillet", "août", "septembre", "octobre", "novembre", "décembre"],
+		monthsShort: ["janv.", "févr.", "mars", "avril", "mai", "juin", "juil.", "août", "sept.", "oct.", "nov.", "déc."],
+		today: "Aujourd'hui",
+		monthsTitle: "Mois",
+		clear: "Effacer",
+		weekStart: 1,
+		format: "dd/mm/yyyy"
+	};
+}(jQuery));

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -341,5 +341,6 @@
     "inputIsOverloaded": "This value is set in a WFS filter",
     "insertNewInputValue": "Add a value for this input",
     "profileGraph": "Profile Graph",
-    "_valid": "Validity"
+    "_valid": "Validity",
+    "dateToDate": "to"
 }

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -113,7 +113,7 @@
     <ul data-ng-if="gnCfg.mods.signin.enabled"
         class="nav navbar-nav navbar-right">
       <li data-ng-show="authenticated">
-        <a href="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}"
+        <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}"
            title="{{'userDetails' | translate}}"
            class="hidden-xs btn btn-link">
           <img class="img-circle"

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -148,6 +148,8 @@
         <script src="{$uiResourcesPath}lib/bootstrap.ext/tagsinput/bootstrap-tagsinput.js"></script>
         <script
           src="{$uiResourcesPath}lib/bootstrap.ext/datepicker/bootstrap-datepicker.js"></script>
+        <script
+          src="{$uiResourcesPath}lib/bootstrap.ext/datepicker/bootstrap-datepicker.fr.js"></script>
         <script src="{$uiResourcesPath}lib/bootstrap-table/dist/bootstrap-table.js"></script>
         <script src="{$uiResourcesPath}lib/bootstrap-table/src/extensions/export/bootstrap-table-export.js"></script>
         <!--</xsl:if>-->


### PR DESCRIPTION
These fixes and improvements are backports from a customer fork:
* `GeometryService` had a typo that meant sending GML polygons to WPS services was broken
* JS errors were popping up when a context save was attempted while a layer was still loading
* i18n was added to the date-picker component; only `fr` for now though (each language is a separate include)
* Do not add duplicate filters in URL when searching for MD
* Fixed JSONIX schema for persistent WFS filters
* WPS response which are WMS layers is now added to the map
* The WPS directive was cleaned up & improved
* User account link is fixed in top toolbar

Note: there are features in there that may not yet be accessible with the current UI, mainly customizing WPS services with an `applicationProfile` field (adding default values & outputs, linking an input to a WFS filter, displaying response as profile graph).