### PR TITLE
Reverses layer order when displaying GetFeatureInfo results as tables

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
@@ -145,7 +145,7 @@
           return (layer.getSource() instanceof ol.source.ImageWMS ||
               layer.getSource() instanceof ol.source.TileWMS) &&
               layer.getVisible();
-        });
+        }).reverse();
 
         coordinates = e.coordinate;
         this.registerTables(layers, e.coordinate);


### PR DESCRIPTION
This aims to avoid confusing the user regarding layer order vs. table order when doing a GetFeatureInfo call (click on the map).

Layer order: top to bottom
Table order: left to right
![image](https://user-images.githubusercontent.com/10629150/29363543-b167207a-8290-11e7-8503-3f5758e621de.png)
