### PR TITLE
Removing deprecated SAML/Shibboleth configuration

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -50,7 +50,8 @@
         blur: 0
       }
     },
-    current: null
+    current: null,
+    shibbolethEnabled: false
   });
 
   module.constant('gnLangs', {
@@ -131,6 +132,7 @@
       $scope.logoPath = '../../images/harvesting/';
       $scope.isMapViewerEnabled = gnGlobalSettings.isMapViewerEnabled;
       $scope.isDebug = window.location.search.indexOf('debug') !== -1;
+      $scope.shibbolethEnabled = gnGlobalSettings.shibbolethEnabled;
 
       $scope.pages = {
         home: 'home',

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -40,10 +40,10 @@
   module.controller('GnLoginController',
       ['$scope', '$http', '$rootScope', '$translate',
        '$location', '$window', '$timeout',
-       'gnUtilityService', 'gnConfig',
+       'gnUtilityService', 'gnConfig', 'gnGlobalSettings', 
        function($scope, $http, $rootScope, $translate,
            $location, $window, $timeout,
-               gnUtilityService, gnConfig) {
+               gnUtilityService, gnConfig, gnGlobalSettings) {
           $scope.formAction = '../../signin#' +
          $location.path();
           $scope.registrationStatus = null;
@@ -56,6 +56,7 @@
           $scope.redirectUrl = gnUtilityService.getUrlParameter('redirect');
           $scope.signinFailure = gnUtilityService.getUrlParameter('failure');
           $scope.gnConfig = gnConfig;
+          $scope.shibbolethEnabled = gnGlobalSettings.shibbolethEnabled;
 
           function initForm() {
            if ($window.location.pathname.indexOf('new.password') !== -1) {

--- a/web-ui/src/main/resources/catalog/templates/signin.html
+++ b/web-ui/src/main/resources/catalog/templates/signin.html
@@ -1,7 +1,7 @@
 <div class="container" data-ng-controller="GnLoginController">
   <div class="col-lg-6">
     <form class="form-horizontal" name="gnSigninForm" action="{{formAction}}"
-          method="post" role="form" data-ng-if="::user">
+          method="post" role="form" data-ng-if="::user" data-ng-show="!shibbolethEnabled">
       <input type="hidden" name="_csrf" value="{{csrf}}"/>
       <div class="form-group">
         <label class="col-sm-3 control-label"

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -132,7 +132,7 @@
           {{'signout' | translate}}
         </a>
       </li>
-      <li data-ng-show="!authenticated && service !== 'catalog.signin'">
+      <li data-ng-show="!authenticated && service !== 'catalog.signin' && !shibbolethEnabled">
         <a href="{{pages.signin}}"
            title="{{'signIn'|translate}}"
            data-ng-keypress="$event">

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
@@ -40,11 +40,11 @@
   <!-- the shibboleth authentication filter -->
   <bean id="shibbolethPreAuthFilter"
         class="org.fao.geonet.kernel.security.shibboleth.ShibbolethPreAuthFilter">
-    <!--<property name="requestCache" ref="requestCache" /> -->
   </bean>
 
   <bean id="shibbolethUserUtils"
         class="org.fao.geonet.kernel.security.shibboleth.ShibbolethUserUtils">
+    <!-- Uncomment to combine with LDAP -->
     <!-- <property name="userDetailsManager" ref="ldapUserDetailsService" /> -->
     <!-- <property name="udetailsmapper" ref="ldapUserContextMapper"/> -->
   </bean>
@@ -62,34 +62,13 @@
     <property name="updateGroup" value="${shibbolethConfiguration.updateGroup}"/>
     <property name="updateProfile" value="${shibbolethConfiguration.updateProfile}"/>
   </bean>
-
-  <!-- The filter chain for the shib.user.login service -->
-  <alias name="shibFilterChainImplementation" alias="shibFilterChainPlaceholder"/>
-
-  <bean id="shibFilterChainImplementation"
-        class="org.springframework.security.web.DefaultSecurityFilterChain">
-    <constructor-arg>
-      <bean class="org.springframework.security.web.util.AntPathRequestMatcher">
-        <constructor-arg value="/srv/???/shib.user.login"/>
-      </bean>
-    </constructor-arg>
-    <constructor-arg>
-      <ref bean="filterChainFilters"/>
-    </constructor-arg>
-  </bean>
-
+  
   <bean id="filterChainFilters" class="java.util.ArrayList">
     <constructor-arg>
       <list>
         <ref bean="securityContextPersistenceFilter"/>
         <ref bean="logoutFilter"/>
-        <!-- A filter that check if an external service already authenticated user
-             (default implementation does nothing but can be overridden) -->
-        <ref bean="multiNodeAuthenticationFilter"/>
-        <ref bean="preAuthenticationFilter"/>
         <ref bean="shibbolethPreAuthFilter"/>
-        <ref bean="basicAuthenticationFilter"/>
-        <ref bean="formLoginFilter"/>
         <ref bean="requestCacheFilter"/>
         <ref bean="anonymousFilter"/>
         <ref bean="sessionMgmtFilter"/>

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -210,7 +210,19 @@
         </xsl:if>
         gnViewerSettings.mapConfig = <xsl:value-of select="$mapConfig"/>;
         gnGlobalSettings.isMapViewerEnabled = <xsl:value-of select="$isMapViewerEnabled"/>;
+        gnGlobalSettings.shibbolethEnabled = <xsl:value-of select="$shibbolethOn"/>;
         gnViewerSettings.bingKey = '<xsl:value-of select="$bingKey"/>';
+        }]);
+      </script>
+    </xsl:if>
+
+    <xsl:if test="$angularApp = 'gn_login'">
+      <script type="text/javascript">
+        var module = angular.module('gn_login');
+        module.config(['gnGlobalSettings',
+        function(gnGlobalSettings) {
+        gnGlobalSettings.isMapViewerEnabled = <xsl:value-of select="$isMapViewerEnabled"/>;
+        gnGlobalSettings.shibbolethEnabled = <xsl:value-of select="$shibbolethOn"/>;
         }]);
       </script>
     </xsl:if>

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -66,6 +66,9 @@
   <xsl:variable name="angularModule"
                 select="if ($angularApp = 'gn_search') then concat('gn_search_', $searchView) else $angularApp"></xsl:variable>
 
+  <xsl:variable name="shibbolethOn" 
+                select="util:existsBean('shibbolethConfiguration')"/>
+
   <!-- Define which JS module to load using Closure -->
   <xsl:variable name="angularApp" select="
     if ($service = 'admin.console') then 'gn_admin'


### PR DESCRIPTION
I am removing deprecated configuration on SAML/Shibboleth. Right now it only works on an external login interface like on Apache Shibboleth that will take care of the login and logout and will send the proper headers to GN for login.

If shibboleth is enabled, no login form is shown.

Fixes #2107