### PR TITLE
There are locations that only have 1 character (like a Village of the…

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/localisation/LocalisationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/localisation/LocalisationDirective.js
@@ -75,6 +75,7 @@
              * @param {string} query string value of the search input
              */
             this.search = function(query) {
+              if (query.length < 1) return;
               var coord = gnGetCoordinate(
                   $scope.map.getView().getProjection().getWorldExtent(), query);
 

--- a/web-ui/src/main/resources/catalog/components/viewer/localisation/LocalisationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/localisation/LocalisationDirective.js
@@ -75,8 +75,6 @@
              * @param {string} query string value of the search input
              */
             this.search = function(query) {
-              if (query.length < 3) return;
-
               var coord = gnGetCoordinate(
                   $scope.map.getView().getProjection().getWorldExtent(), query);
 


### PR DESCRIPTION
As reported by the Austrian INSPIRE SDI:
"Search does not start until the input has at least 3 characters, which we think is not applicable for that kind of search, because I'm pretty sure that there are locations in the world that only have 1 character (like a Village of the Lofoten called "Å"), and also in Austria there is at least one village thats name only has 2 characters (like "Au")."