### PR TITLE
Improve multilingual authoring in thesaurus keyword editor

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -24,8 +24,11 @@
 (function() {
   goog.provide('gn_thesaurus_controller');
 
-  var module = angular.module('gn_thesaurus_controller',
-      ['blueimp.fileupload']);
+  goog.require('gn_multilingual_field_directive');
+
+  var module = angular.module('gn_thesaurus_controller', [
+      'blueimp.fileupload',
+      'gn_multilingual_field_directive']);
 
 
   /**
@@ -127,16 +130,15 @@
       $scope.availableLangs = gnConfig['ui.config'].mods.header.languages;
       $scope.switchLang = function(lang3) {
         $scope.currentLangShown = lang3;
-        $scope.currentKeywordEditor = lang3;
       };
 
       /**
-       * Language switch for keyword editor
+       * Language list for gn-multilingual-directive
        */
-      $scope.currentKeywordEditorLang = $scope.lang;
-      $scope.switchKeywordEditorLang = function(lang3) {
-        $scope.currentKeywordEditorLang = lang3;
-      };
+      $scope.langList = angular.copy($scope.availableLangs);
+      angular.forEach($scope.langList, function (lang2, lang3) {
+        $scope.langList[lang3] = '#' + lang2;
+      });
 
       /**
        * The type of thesaurus import. Could be new, file or url.
@@ -414,9 +416,6 @@
        * Edit an existing keyword, open the modal, search relations
        */
       $scope.editKeyword = function(k) {
-        // reset keyword editor lang to list lanugage
-        $scope.currentKeywordEditorLang = $scope.currentLangShown;
-
         $scope.keywordSelected = angular.copy(k);
         $scope.keywordSelected.oldId = $scope.keywordSelected.uri;
         creatingKeyword = false;
@@ -428,9 +427,6 @@
        * Edit a new keyword and open the modal
        */
       $scope.addKeyword = function() {
-        // reset keyword editor lang to list lanugage
-        $scope.currentKeywordEditorLang = $scope.currentLangShown;
-
         creatingKeyword = true;
         $scope.keywordSuggestedUri = '';
         $scope.keywordSelected = {
@@ -652,6 +648,11 @@
       }
 
       loadThesaurus();
+
+      // clear selected keyword on modal close
+      $('#keywordModal').on('hide.bs.modal', function() {
+        $scope.keywordSelected = null;
+      });
 
     }]);
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1132,5 +1132,9 @@
     "switchLangTo": "Switch language...",
     "showResultsCount": "Show {{count}} results",
     "keywordMissingValue": "missing value",
-    "editKeyword": "Edit keyword"
+    "editKeyword": "Edit keyword",
+    "allLanguage": "All",
+    "allLanguage-help": "Display all languages",
+    "oneLanguage": "One",
+    "oneLanguage-help": "Choose one language to edit using the selector"
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -746,6 +746,21 @@ input.ng-invalid {
   }
 }
 
+.gn-multilingual-field {
+  .nav > li > a {
+    padding: 2px 5px;
+    font-size: 11px;
+    margin-top: 2px;
+  }
+  .label {
+    line-height: 2;
+    font-size: 11px;
+  }
+  .no-data a {
+    color: @gray-light;
+  }
+}
+
 // general purpose layout helpers
 .pos-relative { position: relative; }
 .pos-absolute { position: absolute; }

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -156,11 +156,4 @@ ul.pager {
     padding: 8px;
     line-height: 1em;
   }
-
-  .lang-selector li > a {
-    padding: 2px 5px;
-    font-size: 0.85em;
-    border-top-right-radius: 0px;
-    border-top-left-radius: 0px;
-  }
 }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -590,21 +590,6 @@ table.gn-data-store {
   color: @label-primary-bg;
 }
 
-.gn-multilingual-field {
-  .nav > li > a {
-    padding: 2px 5px;
-    margin-top: 2px;
-    font-size: 8px;
-  }
-  .label {
-    line-height: 2;
-    font-size: 8px;
-  }
-  .no-data a {
-    color: @gray-light;
-  }
-}
-
 .gn-batch-editor {
   .gn-resultview li.list-group-item {
     margin-bottom: 0px;

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -411,42 +411,30 @@
             addKeyword</h4>
         </div>
         <div class="modal-body">
-          <form id="gn-edit-keyword" name="gn-edit-keyword">
+          <form id="gn-edit-keyword" name="gn-edit-keyword"
+            ng-if="keywordSelected">
             <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
             <div class="form-group">
               <label class="control-label" translate>keywordLabel</label>
-              <input type="text" name="name" class="form-control"
-                ng-disabled="isExternal()"
-                ng-keyup="computeKeywordId()"
-                ng-model="keywordSelected.values[currentKeywordEditorLang]"/>
-              <ul class="lang-selector nav nav-pills">
-                <li ng-repeat="(lang3, lang2) in availableLangs"
-                  ng-class="{ active: lang3 === currentKeywordEditorLang }">
-                  <a href ng-click="switchKeywordEditorLang(lang3)"
-                    ng-class="{ 'text-muted': !keywordSelected.values[lang3] }">
-                    <span ng-if="lang3 !== lang" translate>{{ lang3 }}</span>
-                    <strong ng-if="lang3 === lang" translate>{{ lang3 }}</strong>
-                  </a>
-                </li>
-              </ul>
+              <div gn-multilingual-field="{{langList}}"
+                main-language="{{currentLangShown}}">
+                <input ng-repeat="(lang3, lang2) in availableLangs" type="text"
+                  name="name" class="form-control" lang="{{lang2}}"
+                  ng-disabled="isExternal()"
+                  ng-model="keywordSelected.values[lang3]"/>
+              </div>
             </div>
 
             <div class="form-group">
               <label class="control-label" translate>keywordDefinition</label>
-              <input type="text" name="name" class="form-control"
-                ng-disabled="isExternal()"
-                ng-model="keywordSelected.definitions[currentKeywordEditorLang]"/>
-              <ul class="lang-selector nav nav-pills">
-                <li ng-repeat="(lang3, lang2) in availableLangs"
-                  ng-class="{ active: lang3 === currentKeywordEditorLang }">
-                  <a href ng-click="switchKeywordEditorLang(lang3)"
-                    ng-class="{ 'text-muted': !keywordSelected.definitions[lang3] }">
-                    <span ng-if="lang3 !== lang" translate>{{ lang3 }}</span>
-                    <strong ng-if="lang3 === lang" translate>{{ lang3 }}</strong>
-                  </a>
-                </li>
-              </ul>
+              <div gn-multilingual-field="{{langList}}"
+                main-language="{{currentLangShown}}">
+                <input ng-repeat="(lang3, lang2) in availableLangs" type="text"
+                  name="name" class="form-control" lang="{{lang2}}"
+                  ng-disabled="isExternal()"
+                  ng-model="keywordSelected.definitions[lang3]"/>
+              </div>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
Keyword editor now uses `gn-multilingual-field` directive: better code reuse & ability to edit many different languages at the same time:
![image](https://user-images.githubusercontent.com/10629150/29779681-9243d580-8c13-11e7-9479-d0b91af69939.png)