### PR TITLE
Bounding polygon editor fixes

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -155,15 +155,15 @@
             ctrl.formats = ['WKT', 'GeoJSON', 'GML'];
             ctrl.currentFormat = ctrl.formats[0];
 
-            // parse initial input coordinates to display shape (first in WKT)
+            // parse initial input coordinates to display shape
             ctrl.initValue = function() {
               if (ctrl.polygonXml) {
                 // parse first feature from source XML & set geometry name
                 var correctedXml = ctrl.polygonXml
-                    .replace('<gml:LinearRingTypeCHOICE_ELEMENT0>', '')
-                    .replace('</gml:LinearRingTypeCHOICE_ELEMENT0>', '')
-                    .replace('<gml:LineStringTypeCHOICE_ELEMENT1>', '')
-                    .replace('</gml:LineStringTypeCHOICE_ELEMENT1>', '');
+                    .replace(/<gml:LinearRingTypeCHOICE_ELEMENT0>/g, '')
+                    .replace(/<\/gml:LinearRingTypeCHOICE_ELEMENT0>/g, '')
+                    .replace(/<gml:LineStringTypeCHOICE_ELEMENT1>/g, '')
+                    .replace(/<\/gml:LineStringTypeCHOICE_ELEMENT1>/g, '');
                 var geometry = gnGeometryService.parseGeometryInput(
                     ctrl.map,
                     correctedXml,

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -39,8 +39,6 @@
   module.service('gnGeometryService', [
     function() {
 
-      this._layer = null;
-
       /**
        * @ngdoc method
        * @methodOf gn_geometry.service:gnGeometryService
@@ -88,12 +86,15 @@
        * @return {ol.layer.Vector} vector layer
        */
       this.getCommonLayer = function(map) {
-        if (this._layer) {
-          // add layer to map if not already there
-          if (!map.getLayers().getArray().indexOf(this._layer) === -1) {
-            map.addLayer(this._layer);
+        var commonLayer = null;
+        map.getLayers().getArray().forEach(function(layer) {
+          if (layer.get('name') === 'geometry-tool-layer') {
+            commonLayer = layer;
           }
-          return this._layer;
+        });
+
+        if (commonLayer) {
+          return commonLayer;
         }
 
         // layer & source
@@ -101,7 +102,7 @@
           useSpatialIndex: true,
           features: new ol.Collection()
         });
-        this._layer = new ol.layer.Vector({
+        commonLayer = new ol.layer.Vector({
           source: source,
           name: 'geometry-tool-layer',
           style: [
@@ -134,9 +135,9 @@
         });
 
         // add our layer to the map
-        map.addLayer(this._layer);
+        map.addLayer(commonLayer);
 
-        return this._layer;
+        return commonLayer;
       };
 
       /**


### PR DESCRIPTION
The `gn-bounding-polygon` directive had several problems that are fixed with this PR:
* it was not possible to have multiple active tools at the same time in one editor session
* the directive wouldn't work after an editor save without page refresh
* the xml parsing was broken when the MultiPolygon was composed of several polygons