### PR TITLE
Add a new setting to specify extent & background for editor maps

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
@@ -40,7 +40,10 @@
         link: function(scope, element, attrs) {
           var testAppUrl = '../../catalog/views/api/?config=';
 
-          scope.jsonConfig = angular.fromJson(scope.config);
+          // merge on top of default config
+          scope.jsonConfig = angular.merge(
+            gnGlobalSettings.getMergeableDefaultConfig(),
+            angular.fromJson(scope.config));
 
           scope.sortOrderChoices = ['', 'reverse'];
 

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -608,6 +608,31 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <div data-ng-switch-when="mapExtent">
+        <label class="control-label">{{('ui-' + key) | translate}}</label>
+        <div class="input-group">
+          <span class="input-group-addon">MinX</span>
+          <input type="number" step="any"
+                 class="form-control"
+                 data-ng-model="mCfg[key][0]"/>
+          <span class="input-group-addon">MinY</span>
+          <input type="number" step="any"
+                 class="form-control"
+                 data-ng-model="mCfg[key][1]"/>
+          <span class="input-group-addon">MaxX</span>
+          <input type="number" step="any"
+                 class="form-control"
+                 data-ng-model="mCfg[key][2]"/>
+          <span class="input-group-addon">MaxY</span>
+          <input type="number" step="any"
+                 class="form-control"
+                 data-ng-model="mCfg[key][3]"/>
+        </div>
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
       <div data-ng-switch-default>
         <label class="control-label">{{('ui-' + key) | translate}}</label>
         <input type="text"

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -633,6 +633,27 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <div data-ng-switch-when="mapBackgroundLayer">
+        <label class="control-label">{{('ui-' + key) | translate}}</label>
+        <div class="input-group">
+          <span class="input-group-addon">Type </span>
+          <input type="text"
+                 class="form-control"
+                 data-ng-model="mCfg[key].type"/>
+          <span class="input-group-addon">Layer </span>
+          <input type="text"
+                 class="form-control"
+                 data-ng-model="mCfg[key].layer"/>
+          <span class="input-group-addon">Url </span>
+          <input type="text"
+                 class="form-control"
+                 data-ng-model="mCfg[key].url"/>
+        </div>
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
       <div data-ng-switch-default>
         <label class="control-label">{{('ui-' + key) | translate}}</label>
         <input type="text"

--- a/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
@@ -33,104 +33,104 @@
   };
 
   angular.module('gn_map_directive',
-      ['gn_owscontext_service'])
+    ['gn_owscontext_service'])
 
-      .directive(
-      'gnDrawBbox',
+    .directive(
+    'gnDrawBbox',
       [
-       'gnMap',
-       'gnOwsContextService',
-       function(gnMap, gnOwsContextService) {
-         return {
-           restrict: 'A',
-           replace: true,
-           templateUrl: '../../catalog/components/common/map/' +
-           'partials/drawbbox.html',
-           scope: {
-             htopRef: '@',
-             hbottomRef: '@',
-             hleftRef: '@',
-             hrightRef: '@',
-             identifierRef: '@',
-             identifier: '@',
-             descriptionRef: '@',
-             description: '@',
-             dcRef: '@',
-             extentXml: '=?',
-             lang: '=',
-             schema: '@',
-             location: '@'
-           },
-           link: function(scope, element, attrs) {
-             scope.drawing = false;
-             var mapRef = scope.htopRef || scope.dcRef || '';
-             scope.mapId = 'map-drawbbox-' +
-             mapRef.substring(1, mapRef.length);
+      'gnMap',
+      'gnOwsContextService',
+      function(gnMap, gnOwsContextService) {
+        return {
+          restrict: 'A',
+          replace: true,
+          templateUrl: '../../catalog/components/common/map/' +
+          'partials/drawbbox.html',
+          scope: {
+            htopRef: '@',
+            hbottomRef: '@',
+            hleftRef: '@',
+            hrightRef: '@',
+            identifierRef: '@',
+            identifier: '@',
+            descriptionRef: '@',
+            description: '@',
+            dcRef: '@',
+            extentXml: '=?',
+            lang: '=',
+            schema: '@',
+            location: '@'
+          },
+          link: function(scope, element, attrs) {
+            scope.drawing = false;
+            var mapRef = scope.htopRef || scope.dcRef || '';
+            scope.mapId = 'map-drawbbox-' +
+            mapRef.substring(1, mapRef.length);
 
-             var extentTpl = {
-               'iso19139': '<gmd:EX_Extent ' +
-               'xmlns:gmd="http://www.isotc211.org/2005/gmd" ' +
-               'xmlns:gco="http://www.isotc211.org/2005/gco">' +
-               '<gmd:geographicElement>' +
-               '<gmd:EX_GeographicBoundingBox>' +
-               '<gmd:westBoundLongitude><gco:Decimal>{{west}}</gco:Decimal>' +
-               '</gmd:westBoundLongitude>' +
-               '<gmd:eastBoundLongitude><gco:Decimal>{{east}}</gco:Decimal>' +
-               '</gmd:eastBoundLongitude>' +
-               '<gmd:southBoundLatitude><gco:Decimal>{{south}}</gco:Decimal>' +
-               '</gmd:southBoundLatitude>' +
-               '<gmd:northBoundLatitude><gco:Decimal>{{north}}</gco:Decimal>' +
-               '</gmd:northBoundLatitude>' +
-               '</gmd:EX_GeographicBoundingBox></gmd:geographicElement>' +
-               '</gmd:EX_Extent>',
-               'iso19115-3': '<gex:EX_Extent ' +
-               'xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" ' +
-               'xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">' +
-               '<gex:geographicElement>' +
-               '<gex:EX_GeographicBoundingBox>' +
-               '<gex:westBoundLongitude><gco:Decimal>{{west}}</gco:Decimal>' +
-               '</gex:westBoundLongitude>' +
-               '<gex:eastBoundLongitude><gco:Decimal>{{east}}</gco:Decimal>' +
-               '</gex:eastBoundLongitude>' +
-               '<gex:southBoundLatitude><gco:Decimal>{{south}}</gco:Decimal>' +
-               '</gex:southBoundLatitude>' +
-               '<gex:northBoundLatitude><gco:Decimal>{{north}}</gco:Decimal>' +
-               '</gex:northBoundLatitude>' +
-               '</gex:EX_GeographicBoundingBox></gex:geographicElement>' +
-               '</gex:EX_Extent>'
-             };
-             var xmlExtentFn = function(coords, location) {
-               if (angular.isArray(coords) &&
-               coords.length === 4 &&
-               !isNaN(coords[0]) &&
-               !isNaN(coords[1]) &&
-               !isNaN(coords[2]) &&
-               !isNaN(coords[3]) &&
-               angular.isNumber(coords[0]) &&
-               angular.isNumber(coords[1]) &&
-               angular.isNumber(coords[2]) &&
-               angular.isNumber(coords[3])) {
-                 scope.extentXml = extentTpl[scope.schema || 'iso19139']
-                 .replace('{{west}}', coords[0])
-                 .replace('{{south}}', coords[1])
-                 .replace('{{east}}', coords[2])
-                 .replace('{{north}}', coords[3]);
-               }
-             };
+            var extentTpl = {
+              'iso19139': '<gmd:EX_Extent ' +
+              'xmlns:gmd="http://www.isotc211.org/2005/gmd" ' +
+              'xmlns:gco="http://www.isotc211.org/2005/gco">' +
+              '<gmd:geographicElement>' +
+              '<gmd:EX_GeographicBoundingBox>' +
+              '<gmd:westBoundLongitude><gco:Decimal>{{west}}</gco:Decimal>' +
+              '</gmd:westBoundLongitude>' +
+              '<gmd:eastBoundLongitude><gco:Decimal>{{east}}</gco:Decimal>' +
+              '</gmd:eastBoundLongitude>' +
+              '<gmd:southBoundLatitude><gco:Decimal>{{south}}</gco:Decimal>' +
+              '</gmd:southBoundLatitude>' +
+              '<gmd:northBoundLatitude><gco:Decimal>{{north}}</gco:Decimal>' +
+              '</gmd:northBoundLatitude>' +
+              '</gmd:EX_GeographicBoundingBox></gmd:geographicElement>' +
+              '</gmd:EX_Extent>',
+              'iso19115-3': '<gex:EX_Extent ' +
+              'xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" ' +
+              'xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">' +
+              '<gex:geographicElement>' +
+              '<gex:EX_GeographicBoundingBox>' +
+              '<gex:westBoundLongitude><gco:Decimal>{{west}}</gco:Decimal>' +
+              '</gex:westBoundLongitude>' +
+              '<gex:eastBoundLongitude><gco:Decimal>{{east}}</gco:Decimal>' +
+              '</gex:eastBoundLongitude>' +
+              '<gex:southBoundLatitude><gco:Decimal>{{south}}</gco:Decimal>' +
+              '</gex:southBoundLatitude>' +
+              '<gex:northBoundLatitude><gco:Decimal>{{north}}</gco:Decimal>' +
+              '</gex:northBoundLatitude>' +
+              '</gex:EX_GeographicBoundingBox></gex:geographicElement>' +
+              '</gex:EX_Extent>'
+            };
+            var xmlExtentFn = function(coords, location) {
+              if (angular.isArray(coords) &&
+              coords.length === 4 &&
+              !isNaN(coords[0]) &&
+              !isNaN(coords[1]) &&
+              !isNaN(coords[2]) &&
+              !isNaN(coords[3]) &&
+              angular.isNumber(coords[0]) &&
+              angular.isNumber(coords[1]) &&
+              angular.isNumber(coords[2]) &&
+              angular.isNumber(coords[3])) {
+                scope.extentXml = extentTpl[scope.schema || 'iso19139']
+                .replace('{{west}}', coords[0])
+                .replace('{{south}}', coords[1])
+                .replace('{{east}}', coords[2])
+                .replace('{{north}}', coords[3]);
+              }
+            };
 
-             /**
+            /**
               * set dublin-core coverage output
               */
-             var setDcOutput = function() {
-               if (scope.dcRef) {
-                 scope.dcExtent = gnMap.getDcExtent(
-                 scope.extent.md,
-                 scope.location);
-               }
-               xmlExtentFn(scope.extent.md, scope.location);
-             };
+            var setDcOutput = function() {
+              if (scope.dcRef) {
+                scope.dcExtent = gnMap.getDcExtent(
+                scope.extent.md,
+                scope.location);
+              }
+              xmlExtentFn(scope.extent.md, scope.location);
+            };
 
-             /**
+            /**
               * Different projections used in the directive:
               * - md : the proj system in the metadata. It is defined as
               *   4326 by iso19139 schema
@@ -139,224 +139,243 @@
               * - form : projection used for the form, it is chosen
               *   from the combo list.
               */
-             scope.projs = {
-               list: gnMap.getMapConfig().projectionList,
-               md: 'EPSG:4326',
-               map: gnMap.getMapConfig().projection,
-               form: gnMap.getMapConfig().projectionList[0].code,
-               formLabel: gnMap.getMapConfig().projectionList[0].label
-             };
+            scope.projs = {
+              list: gnMap.getMapConfig().projectionList,
+              md: 'EPSG:4326',
+              map: gnMap.getMapConfig().projection,
+              form: gnMap.getMapConfig().projectionList[0].code,
+              formLabel: gnMap.getMapConfig().projectionList[0].label
+            };
 
-             scope.extent = {
-               md: null,
-               map: [],
-               form: []
-             };
+            scope.extent = {
+              md: null,
+              map: [],
+              form: []
+            };
 
-             if (attrs.hleft !== '' && attrs.hbottom !== '' &&
-                 attrs.hright !== '' && attrs.htop !== '') {
-               scope.extent.md = [
-                 parseFloat(attrs.hleft), parseFloat(attrs.hbottom),
-                 parseFloat(attrs.hright), parseFloat(attrs.htop)
-               ];
-             }
+            if (attrs.hleft !== '' && attrs.hbottom !== '' &&
+                attrs.hright !== '' && attrs.htop !== '') {
+              scope.extent.md = [
+                parseFloat(attrs.hleft), parseFloat(attrs.hbottom),
+                parseFloat(attrs.hright), parseFloat(attrs.htop)
+              ];
+            }
 
-             var reprojExtent = function(from, to) {
-               var extent = gnMap.reprojExtent(
-                   scope.extent[from],
-                   scope.projs[from], scope.projs[to]
-               );
-               if (extent && extent.map) {
-                 var decimals = getDigitNumber(scope.projs.form);
-                 scope.extent[to] = extent.map(function(coord) {
-                   return coord.toFixed(decimals) / 1;
-                 });
-               }
-             };
+            var reprojExtent = function(from, to) {
+              var extent = gnMap.reprojExtent(
+                  scope.extent[from],
+                  scope.projs[from], scope.projs[to]
+              );
+              if (extent && extent.map) {
+                var decimals = getDigitNumber(scope.projs.form);
+                scope.extent[to] = extent.map(function(coord) {
+                  return coord.toFixed(decimals) / 1;
+                });
+              }
+            };
 
-             // Init extent from md for map and form
-             reprojExtent('md', 'map');
-             reprojExtent('md', 'form');
-             setDcOutput();
+            // Init extent from md for map and form
+            reprojExtent('md', 'map');
+            reprojExtent('md', 'form');
+            setDcOutput();
 
-             scope.$watch('projs.form', function(newValue, oldValue) {
-               var extent = gnMap.reprojExtent(
-                   scope.extent.form, oldValue, newValue
-               );
-               if (extent && extent.map) {
-                 var decimals = getDigitNumber(scope.projs.form);
+            scope.$watch('projs.form', function(newValue, oldValue) {
+              var extent = gnMap.reprojExtent(
+                  scope.extent.form, oldValue, newValue
+              );
+              if (extent && extent.map) {
+                var decimals = getDigitNumber(scope.projs.form);
 
-                 scope.extent.form = extent.map(function(coord) {
-                   return coord.toFixed(decimals) / 1;
-                 });
-               }
-             });
+                scope.extent.form = extent.map(function(coord) {
+                  return coord.toFixed(decimals) / 1;
+                });
+              }
+            });
 
-             // TODO: move style in db config
-             var boxStyle = new ol.style.Style({
-               stroke: new ol.style.Stroke({
-                 color: 'rgba(255,0,0,1)',
-                 width: 2
-               }),
-               fill: new ol.style.Fill({
-                 color: 'rgba(255,0,0,0.3)'
-               }),
-               image: new ol.style.Circle({
-                 radius: 7,
-                 fill: new ol.style.Fill({
-                   color: 'rgba(255,0,0,1)'
-                 })
-               })
-             });
+            // TODO: move style in db config
+            var boxStyle = new ol.style.Style({
+              stroke: new ol.style.Stroke({
+                color: 'rgba(255,0,0,1)',
+                width: 2
+              }),
+              fill: new ol.style.Fill({
+                color: 'rgba(255,0,0,0.3)'
+              }),
+              image: new ol.style.Circle({
+                radius: 7,
+                fill: new ol.style.Fill({
+                  color: 'rgba(255,0,0,1)'
+                })
+              })
+            });
 
-             var feature = new ol.Feature();
-             var source = new ol.source.Vector();
-             source.addFeature(feature);
+            var feature = new ol.Feature();
+            var source = new ol.source.Vector();
+            source.addFeature(feature);
 
-             var bboxLayer = new ol.layer.Vector({
-               source: source,
-               style: boxStyle
-             });
+            var bboxLayer = new ol.layer.Vector({
+              source: source,
+              style: boxStyle
+            });
+            bboxLayer.setZIndex(100)
 
-             var map = new ol.Map({
-               layers: [
-                 gnMap.getLayersFromConfig(),
-                 bboxLayer
-               ],
-               renderer: 'canvas',
-               view: new ol.View({
-                 center: [0, 0],
-                 projection: scope.projs.map,
-                 zoom: 2
-               })
-             });
-             element.data('map', map);
+            var map = new ol.Map({
+              layers: [
+                gnMap.getLayersFromConfig(),
+                bboxLayer
+              ],
+              renderer: 'canvas',
+              view: new ol.View({
+                center: [0, 0],
+                projection: scope.projs.map,
+                zoom: 2
+              })
+            });
+            element.data('map', map);
 
-             //Uses configuration from database
-             if (gnMap.getMapConfig().context) {
-               gnOwsContextService.
-                   loadContextFromUrl(gnMap.getMapConfig().context, map);
-             }
+            //Uses configuration from database
+            if (gnMap.getMapConfig().context) {
+              gnOwsContextService.
+                  loadContextFromUrl(gnMap.getMapConfig().context, map);
+            }
 
-             var dragbox = new ol.interaction.DragBox({
-               style: boxStyle,
-               condition: function() {
-                  return scope.drawing;
-               }
-             });
+            // apply background layer from settings
+            var bgLayer = gnMap.getMapConfig().mapBackgroundLayer;
+            if (bgLayer) {
+              map.getLayers().removeAt(0)
+              gnMap.createLayerForType(bgLayer.type, {
+                name: bgLayer.layer,
+                url: bgLayer.url
+              }, null, map);
+            }
 
-             dragbox.on('boxstart', function(mapBrowserEvent) {
-               feature.setGeometry(null);
-             });
+            var dragbox = new ol.interaction.DragBox({
+              style: boxStyle,
+              condition: function() {
+                return scope.drawing;
+              }
+            });
 
-             dragbox.on('boxend', function(mapBrowserEvent) {
-               scope.extent.map = dragbox.getGeometry().getExtent();
-               feature.setGeometry(dragbox.getGeometry());
+            dragbox.on('boxstart', function(mapBrowserEvent) {
+              feature.setGeometry(null);
+            });
 
-               scope.$apply(function() {
-                 reprojExtent('map', 'form');
-                 reprojExtent('map', 'md');
-                 setDcOutput();
-               });
-             });
+            dragbox.on('boxend', function(mapBrowserEvent) {
+              scope.extent.map = dragbox.getGeometry().getExtent();
+              feature.setGeometry(dragbox.getGeometry());
 
-             map.addInteraction(dragbox);
+              scope.$apply(function() {
+                reprojExtent('map', 'form');
+                reprojExtent('map', 'md');
+                setDcOutput();
+              });
+            });
 
-             /**
-              * Draw the map extent as a bbox onto the map.
-              */
-             var drawBbox = function() {
-               var coordinates, geom;
+            map.addInteraction(dragbox);
 
-               // no geometry
-               if (scope.extent.map == null) {
-                 return;
-               }
+            /**
+            * Draw the map extent as a bbox onto the map.
+            */
+            var drawBbox = function() {
+              var coordinates, geom;
 
-               if (gnMap.isPoint(scope.extent.map)) {
-                 coordinates = [scope.extent.map[0],
-                   scope.extent.map[1]];
-                 geom = new ol.geom.Point(coordinates);
-               }
-               else {
-                 coordinates = gnMap.getPolygonFromExtent(
-                     scope.extent.map);
-                 geom = new ol.geom.Polygon(coordinates);
-               }
-               feature.setGeometry(geom);
-               feature.getGeometry().setCoordinates(coordinates);
-               scope.extent.map = geom.getExtent();
-             };
+              // no geometry
+              if (scope.extent.map == null) {
+                return;
+              }
 
-             /**
-              * When form is loaded
-              * - set map div
-              * - draw the feature with MD initial coordinates
-              * - fit map extent
-              */
-             scope.$watch('gnCurrentEdit.version', function(newValue) {
-               map.setTarget(scope.mapId);
-               drawBbox();
-               if (gnMap.isValidExtent(scope.extent.map)) {
-                 map.getView().fit(scope.extent.map, map.getSize());
-               }
-             });
+              if (gnMap.isPoint(scope.extent.map)) {
+                coordinates = [scope.extent.map[0],
+                  scope.extent.map[1]];
+                geom = new ol.geom.Point(coordinates);
+              }
+              else {
+                coordinates = gnMap.getPolygonFromExtent(
+                    scope.extent.map);
+                geom = new ol.geom.Polygon(coordinates);
+              }
+              feature.setGeometry(geom);
+              feature.getGeometry().setCoordinates(coordinates);
+              scope.extent.map = geom.getExtent();
+            };
 
-             /**
-              * Switch mode (panning or drawing)
-              */
-             scope.drawMap = function() {
-               scope.drawing = !scope.drawing;
-             };
+            /**
+            * When form is loaded
+            * - set map div
+            * - draw the feature with MD initial coordinates
+            * - fit map extent
+            */
+            scope.$watch('gnCurrentEdit.version', function(newValue) {
+              map.setTarget(scope.mapId);
+              drawBbox();
 
-             /**
-              * Called on form input change.
-              * Set map and md extent from form reprojection, and draw
-              * the bbox from the map extent.
-              */
-             scope.updateBbox = function() {
+              // apply extent from settings
+              var mapExtent = gnMap.getMapConfig().mapExtent;
+              if (mapExtent && ol.extent.getWidth(mapExtent) &&
+                ol.extent.getHeight(mapExtent)) {
+                  map.getView().fit(mapExtent, map.getSize());
+              }
 
-               reprojExtent('form', 'map');
-               reprojExtent('form', 'md');
-               setDcOutput();
-               drawBbox();
-               map.getView().fit(scope.extent.map, map.getSize());
-             };
+              if (gnMap.isValidExtent(scope.extent.map)) {
+                map.getView().fit(scope.extent.map, map.getSize());
+              }
+            });
 
-             /**
-              * Callback sent to gn-country-picker directive.
-              * Called on region selection from typeahead.
-              * Zoom to extent.
-              */
-             scope.onRegionSelect = function(region) {
-               // Manage regions service and geonames
-               var bbox = region.bbox || region;
-               scope.$apply(function() {
-                 scope.extent.md = [parseFloat(bbox.west),
-                   parseFloat(bbox.south),
-                   parseFloat(bbox.east),
-                   parseFloat(bbox.north)];
-                 scope.location = region.name;
+            /**
+            * Switch mode (panning or drawing)
+            */
+            scope.drawMap = function() {
+              scope.drawing = !scope.drawing;
+            };
 
-                 if (attrs.identifierRef !== undefined) {
-                   scope.identifier = region.id;
-                 }
-                 if (attrs.descriptionRef !== undefined) {
-                   scope.description = region.name;
-                 }
+            /**
+            * Called on form input change.
+            * Set map and md extent from form reprojection, and draw
+            * the bbox from the map extent.
+            */
+            scope.updateBbox = function() {
 
-                 reprojExtent('md', 'map');
-                 reprojExtent('md', 'form');
-                 setDcOutput();
-                 drawBbox();
-                 map.getView().fit(scope.extent.map, map.getSize());
-               });
-             };
+              reprojExtent('form', 'map');
+              reprojExtent('form', 'md');
+              setDcOutput();
+              drawBbox();
+              map.getView().fit(scope.extent.map, map.getSize());
+            };
 
-             scope.resetRegion = function() {
-               element.find('.twitter-typeahead').find('input').val('');
-             };
-           }
-         };
-       }]);
+            /**
+            * Callback sent to gn-country-picker directive.
+            * Called on region selection from typeahead.
+            * Zoom to extent.
+            */
+            scope.onRegionSelect = function(region) {
+              // Manage regions service and geonames
+              var bbox = region.bbox || region;
+              scope.$apply(function() {
+                scope.extent.md = [parseFloat(bbox.west),
+                  parseFloat(bbox.south),
+                  parseFloat(bbox.east),
+                  parseFloat(bbox.north)];
+                scope.location = region.name;
+
+                if (attrs.identifierRef !== undefined) {
+                  scope.identifier = region.id;
+                }
+                if (attrs.descriptionRef !== undefined) {
+                  scope.description = region.name;
+                }
+
+                reprojExtent('md', 'map');
+                reprojExtent('md', 'form');
+                setDcOutput();
+                drawBbox();
+                map.getView().fit(scope.extent.map, map.getSize());
+              });
+            };
+
+            scope.resetRegion = function() {
+              element.find('.twitter-typeahead').find('input').val('');
+            };
+          }
+        };
+      }]);
 })();

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1156,7 +1156,7 @@
             var $this = this;
 
             if (!isLayerInMap(map, name, url)) {
-              gnWmsQueue.add(url, name);
+              gnWmsQueue.add(url, name, map);
               gnOwsCapabilities.getWMTSCapabilities(url).then(function(capObj) {
 
                 var capL = gnOwsCapabilities.getLayerInfoFromCap(
@@ -1177,7 +1177,7 @@
                     if (!createOnly) {
                       map.addLayer(olL);
                     }
-                    gnWmsQueue.removeFromQueue(url, name);
+                    gnWmsQueue.removeFromQueue(url, name, map);
                     defer.resolve(olL);
                   };
 
@@ -1234,7 +1234,7 @@
             var defer = $q.defer();
             var $this = this;
 
-            gnWmsQueue.add(url, name);
+            gnWmsQueue.add(url, name, map);
             gnWfsService.getCapabilities(url).then(function(capObj) {
               var capL = gnOwsCapabilities.
                   getLayerInfoFromWfsCap(name, capObj, md.getUuid()),
@@ -1278,7 +1278,7 @@
                   $this.feedLayerMd(olL);
                 }
 
-                gnWmsQueue.removeFromQueue(url, name);
+                gnWmsQueue.removeFromQueue(url, name, map);
                 defer.resolve(olL);
               }
 

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -324,9 +324,8 @@
            * @return {Object} defaultMapConfig mapconfig
            */
           getMapConfig: function() {
-            if (gnConfig['map.config'] &&
-                angular.isObject(gnConfig['map.config'])) {
-              return gnConfig['map.config'];
+            if (gnConfig['ui.config'].mods.map) {
+              return gnConfig['ui.config'].mods.map;
             } else {
               return defaultMapConfig;
             }

--- a/web-ui/src/main/resources/catalog/components/common/map/wmsQueue.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/wmsQueue.js
@@ -48,7 +48,7 @@
       var idx = -1;
       for (var i = 0; i < a.length; i++) {
         var o = a[i];
-        if (o.name == layer.name && o.url == layer.url) {
+        if (o.name == layer.name && o.url == layer.url && o.map == layer.map) {
           idx = i;
         }
       }
@@ -63,11 +63,13 @@
      * Add the layer to the queue
      * @param {string} url
      * @param {string} name
+     * @param {ol.Map} map
      */
-    this.add = function(url, name) {
+    this.add = function(url, name, map) {
       queue.push({
         url: url,
-        name: name
+        name: name,
+        map: map
       });
     };
 
@@ -96,11 +98,13 @@
      *
      * @param {string} url
      * @param {string} name
+     * @param {ol.Map} map
      */
-    this.isPending = function(url, name) {
+    this.isPending = function(url, name, map) {
       var layer = {
         url: url,
-        name: name
+        name: name,
+        map: map
       };
       return getLayerIndex(queue, layer) >= 0;
     };

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -67,6 +67,15 @@
                   scope.ctrl.map.getSize());
             }
 
+            // apply background layer from settings
+            var bgLayer = gnViewerSettings.mapConfig.mapBackgroundLayer;
+            if (bgLayer) {
+              gnMap.createLayerForType(bgLayer.type, {
+                name: bgLayer.layer,
+                url: bgLayer.url
+              }, null, scope.ctrl.map);
+            }
+
             scope.ctrl.initValue();
           }
         },

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -44,7 +44,9 @@
    *  the value entered by the user
    */
   module.directive('gnBoundingPolygon', [
-    function() {
+    'gnViewerSettings',
+    'gnMap',
+    function(gnViewerSettings, gnMap) {
       return {
         restrict: 'E',
         scope: {
@@ -56,6 +58,15 @@
         link: {
           post: function(scope, element) {
             scope.ctrl.map.renderSync();
+
+            // apply extent from settings
+            var mapExtent = gnViewerSettings.mapConfig.mapExtent;
+            if (mapExtent && ol.extent.getWidth(mapExtent) &&
+              ol.extent.getHeight(mapExtent)) {
+                scope.ctrl.map.getView().fit(mapExtent,
+                  scope.ctrl.map.getSize());
+            }
+
             scope.ctrl.initValue();
           }
         },

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -44,9 +44,8 @@
    *  the value entered by the user
    */
   module.directive('gnBoundingPolygon', [
-    'gnViewerSettings',
     'gnMap',
-    function(gnViewerSettings, gnMap) {
+    function(gnMap) {
       return {
         restrict: 'E',
         scope: {
@@ -60,7 +59,7 @@
             scope.ctrl.map.renderSync();
 
             // apply extent from settings
-            var mapExtent = gnViewerSettings.mapConfig.mapExtent;
+            var mapExtent = gnMap.getMapConfig().mapExtent;
             if (mapExtent && ol.extent.getWidth(mapExtent) &&
               ol.extent.getHeight(mapExtent)) {
                 scope.ctrl.map.getView().fit(mapExtent,
@@ -68,8 +67,9 @@
             }
 
             // apply background layer from settings
-            var bgLayer = gnViewerSettings.mapConfig.mapBackgroundLayer;
+            var bgLayer = gnMap.getMapConfig().mapBackgroundLayer;
             if (bgLayer) {
+              scope.ctrl.map.getLayers().removeAt(0)
               gnMap.createLayerForType(bgLayer.type, {
                 name: bgLayer.layer,
                 url: bgLayer.url
@@ -87,7 +87,6 @@
           '$http',
           'gnMap',
           'gnOwsContextService',
-          'gnViewerSettings',
           'ngeoDecorateInteraction',
           'gnGeometryService',
           function BoundingPolygonController(
@@ -96,7 +95,6 @@
               $http,
               gnMap,
               gnOwsContextService,
-              gnViewerSettings,
               ngeoDecorateInteraction,
               gnGeometryService) {
             var ctrl = this;

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -133,6 +133,7 @@
             })
           ]
         });
+        commonLayer.setZIndex(100);
 
         // add our layer to the map
         map.addLayer(commonLayer);

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -171,7 +171,8 @@
           'disabledTools': {
             'processes': true
           },
-          'graticuleOgcService': {}
+          'graticuleOgcService': {},
+          'mapExtent': [0, 0, 0, 0]
         },
         'editor': {
           'enabled': true,
@@ -233,6 +234,14 @@
       },
       getDefaultConfig: function() {
         return angular.copy(defaultConfig);
+      },
+      // this returns a copy of the default config without the languages object
+      // this way, the object can be used as reference for a complete ui
+      // settings page
+      getMergeableDefaultConfig: function() {
+        var copy = angular.copy(defaultConfig);
+        copy.mods.header.languages = {};
+        return copy;
       }
     };
   }());

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -172,7 +172,8 @@
             'processes': true
           },
           'graticuleOgcService': {},
-          'mapExtent': [0, 0, 0, 0]
+          'mapExtent': [0, 0, 0, 0],
+          'mapBackgroundLayer': {}
         },
         'editor': {
           'enabled': true,

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1136,5 +1136,7 @@
     "allLanguage": "All",
     "allLanguage-help": "Display all languages",
     "oneLanguage": "One",
-    "oneLanguage-help": "Choose one language to edit using the selector"
+    "oneLanguage-help": "Choose one language to edit using the selector",
+    "ui-mapExtent": "Map Extent",
+    "ui-mapExtent-help": "Extent coordinates to use for maps other that viewer and search maps."
 }

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1138,5 +1138,7 @@
     "oneLanguage": "One",
     "oneLanguage-help": "Choose one language to edit using the selector",
     "ui-mapExtent": "Map Extent",
-    "ui-mapExtent-help": "Extent coordinates to use for maps other that viewer and search maps."
+    "ui-mapExtent-help": "Extent coordinates to use for maps other that viewer and search maps.",
+    "ui-mapBackgroundLayer": "Map Background Layer",
+    "ui-mapBackgroundLayer-help": "Define here the background layer to use for maps other that viewer and search maps."
 }


### PR DESCRIPTION
This is intended to be used mainly by maps other than search & viewer, as the search map is centered according to search results and the viewer map according to the OWS context.

* A new UI setting `mapExtent` has been added: the extent will be applied to editor maps (bounding polygon editor & bounding box editor) if defined
* A new UI setting `mapBackgroundLayer` has been added: if defined, the WMS/WMTS layer will be used in the editor maps instead of OSM
* Minor fixes to `gnMap` service to make that work
* Tweak to the UI settings controller to show settings which have not been defined yet by the user

Only `gn-draw-bbox` and `gn-bounding-polygon` directives are affected by this PR.

Side note: I added new UI settings to handle these features, but this is clearly not the ideal way as there are heavy redundancies on this part of the code. Doing it differently would require a good chunk of refactoring IMO, so I've gone this way for now.