### PR TITLE
Refactoring DataManager.java into smaller helper classes 

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -27,3352 +27,656 @@
 
 package org.fao.geonet.kernel;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-import jeeves.transaction.TransactionManager;
-import jeeves.transaction.TransactionTask;
-import jeeves.xlink.Processor;
-import org.apache.commons.lang.StringUtils;
-import org.eclipse.jetty.util.ConcurrentHashSet;
-import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.NodeInfo;
-import org.fao.geonet.constants.Edit;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Geonet.Namespaces;
-import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Constants;
-import org.fao.geonet.domain.Group;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.InspireAtomFeed;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataCategory;
-import org.fao.geonet.domain.MetadataDataInfo;
-import org.fao.geonet.domain.MetadataDataInfo_;
-import org.fao.geonet.domain.MetadataFileUpload;
-import org.fao.geonet.domain.MetadataFileUpload_;
-import org.fao.geonet.domain.MetadataHarvestInfo;
-import org.fao.geonet.domain.MetadataRatingByIp;
-import org.fao.geonet.domain.MetadataRatingByIpId;
-import org.fao.geonet.domain.MetadataSourceInfo;
-import org.fao.geonet.domain.MetadataStatus;
-import org.fao.geonet.domain.MetadataStatusId;
-import org.fao.geonet.domain.MetadataStatusId_;
-import org.fao.geonet.domain.MetadataStatus_;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.MetadataValidation;
-import org.fao.geonet.domain.MetadataValidationId;
-import org.fao.geonet.domain.MetadataValidationStatus;
-import org.fao.geonet.domain.Metadata_;
-import org.fao.geonet.domain.OperationAllowed;
-import org.fao.geonet.domain.OperationAllowedId;
-import org.fao.geonet.domain.OperationAllowedId_;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.domain.Profile;
-import org.fao.geonet.domain.ReservedGroup;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.domain.User;
-import org.fao.geonet.domain.UserGroup;
-import org.fao.geonet.domain.UserGroupId;
-import org.fao.geonet.events.md.MetadataIndexCompleted;
-import org.fao.geonet.exceptions.JeevesException;
-import org.fao.geonet.exceptions.NoSchemaMatchesException;
-import org.fao.geonet.exceptions.SchemaMatchConflictException;
-import org.fao.geonet.exceptions.SchematronValidationErrorEx;
-import org.fao.geonet.exceptions.ServiceNotAllowedEx;
-import org.fao.geonet.exceptions.XSDValidationErrorEx;
-import org.fao.geonet.kernel.schema.MetadataSchema;
-import org.fao.geonet.kernel.search.ISearchManager;
-import org.fao.geonet.kernel.search.LuceneSearcher;
-import org.fao.geonet.kernel.search.MetaSearcher;
-import org.fao.geonet.kernel.search.SearchManager;
-import org.fao.geonet.kernel.search.SearchParameter;
-import org.fao.geonet.kernel.search.SearcherType;
-import org.fao.geonet.kernel.search.index.IndexingList;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.notifier.MetadataNotifierManager;
-import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.InspireAtomFeedRepository;
-import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataFileUploadRepository;
-import org.fao.geonet.repository.MetadataRatingByIpRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.MetadataStatusRepository;
-import org.fao.geonet.repository.MetadataValidationRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
-import org.fao.geonet.repository.PathSpec;
-import org.fao.geonet.repository.SortUtils;
-import org.fao.geonet.repository.StatusValueRepository;
-import org.fao.geonet.repository.Updater;
-import org.fao.geonet.repository.UserGroupRepository;
-import org.fao.geonet.repository.UserRepository;
-import org.fao.geonet.repository.UserSavedSelectionRepository;
-import org.fao.geonet.repository.specification.MetadataFileUploadSpecs;
-import org.fao.geonet.repository.specification.MetadataSpecs;
-import org.fao.geonet.repository.specification.MetadataStatusSpecs;
-import org.fao.geonet.repository.specification.OperationAllowedSpecs;
-import org.fao.geonet.repository.specification.UserGroupSpecs;
-import org.fao.geonet.repository.specification.UserSpecs;
-import org.fao.geonet.resources.Resources;
-import org.fao.geonet.util.ThreadUtils;
-import org.fao.geonet.utils.IO;
-import org.fao.geonet.utils.Log;
-import org.fao.geonet.utils.Xml;
-import org.fao.geonet.utils.Xml.ErrorHandler;
-import org.jdom.Attribute;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.Namespace;
-import org.jdom.filter.ElementFilter;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.transaction.NoTransactionException;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.interceptor.TransactionAspectSupport;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.persistence.criteria.Root;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.Vector;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static org.fao.geonet.repository.specification.MetadataSpecs.hasMetadataUuid;
-import static org.springframework.data.jpa.domain.Specifications.where;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.domain.MetadataStatus;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.MetadataValidation;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.exceptions.NoSchemaMatchesException;
+import org.fao.geonet.exceptions.SchemaMatchConflictException;
+import org.fao.geonet.kernel.datamanager.IMetadataCategory;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataOperations;
+import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataStatus;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataValidator;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.search.ISearchManager;
+import org.fao.geonet.repository.UserGroupRepository;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml.ErrorHandler;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Handles all operations on metadata (select,insert,update,delete etc...).
+ * 
+ * Deprecated in favor of
+ * 
+ * {@link IMetadataManager} {@link IMetadataUtils} {@link IMetadataIndexer} {@link IMetadataValidator} {@link IMetadataOperations}
+ * {@link IMetadataStatus} {@link IMetadataSchemaUtils} {@link IMetadataCategory}
+ * 
  */
-//@Transactional(propagation = Propagation.REQUIRED, noRollbackFor = {XSDValidationErrorEx.class, NoSchemaMatchesException.class})
-public class DataManager implements ApplicationEventPublisherAware {
+@Deprecated
+public class DataManager {
 
-    private static final int METADATA_BATCH_PAGE_SIZE = 100000;
-    Lock indexLock = new ReentrantLock();
-    Set<String> waitForIndexing = new HashSet<String>();
-    Set<String> indexing = new HashSet<String>();
-    Set<IndexMetadataTask> batchIndex = new ConcurrentHashSet<IndexMetadataTask>();
-    @PersistenceContext
-    private EntityManager _entityManager;
     @Autowired
-    private ApplicationContext _applicationContext;
-    // initialize in init method
-    private ServiceContext servContext;
-    private EditLib editLib;
-
-    //--------------------------------------------------------------------------
-    //---
-    //--- Constructor
-    //---
-    //--------------------------------------------------------------------------
-    private java.nio.file.Path thesaurusDir;
-    private java.nio.file.Path stylePath;
-    private String baseURL;
-    private ApplicationEventPublisher applicationEventPublisher;
-
-    /**
-     * Validates metadata against XSD and schematron files related to metadata schema throwing
-     * XSDValidationErrorEx if xsd errors or SchematronValidationErrorEx if schematron rules fails.
-     */
-    public static void validateMetadata(String schema, Element xml, ServiceContext context) throws Exception {
-        validateMetadata(schema, xml, context, " ");
-    }
+    private IMetadataManager metadataManager;
+    @Autowired
+    private IMetadataUtils metadataUtils;
+    @Autowired
+    private IMetadataIndexer metadataIndexer;
+    @Autowired
+    private IMetadataValidator metadataValidator;
+    @Autowired
+    private IMetadataOperations metadataOperations;
+    @Autowired
+    private IMetadataStatus metadataStatus;
+    @Autowired
+    private IMetadataSchemaUtils metadataSchemaUtils;
+    @Autowired
+    private IMetadataCategory metadataCategory;
+    @Autowired
+    private AccessManager accessManager;
 
     /**
-     * Validates metadata against XSD and schematron files related to metadata schema throwing
-     * XSDValidationErrorEx if xsd errors or SchematronValidationErrorEx if schematron rules fails.
-     */
-    public static void validateMetadata(String schema, Element xml, ServiceContext context, String fileName) throws Exception {
-        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
-
-        DataManager dataMan = gc.getBean(DataManager.class);
-
-        DataManager.setNamespacePrefix(xml);
-        try {
-            dataMan.validate(schema, xml);
-        } catch (XSDValidationErrorEx e) {
-            if (!fileName.equals(" ")) {
-                throw new XSDValidationErrorEx(e.getMessage() + "(in " + fileName + "): ", e.getObject());
-            } else {
-                throw new XSDValidationErrorEx(e.getMessage(), e.getObject());
-            }
-        }
-
-        //--- Now do the schematron validation on this file - if there are errors
-        //--- then we say what they are!
-        //--- Note we have to use uuid here instead of id because we don't have
-        //--- an id...
-
-        Element schemaTronXml = dataMan.doSchemaTronForEditor(schema, xml, context.getLanguage());
-        xml.detach();
-        if (schemaTronXml != null && schemaTronXml.getContent().size() > 0) {
-            Element schemaTronReport = dataMan.doSchemaTronForEditor(schema, xml, context.getLanguage());
-
-            List<Namespace> theNSs = new ArrayList<Namespace>();
-            theNSs.add(Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork"));
-            theNSs.add(Namespace.getNamespace("svrl", "http://purl.oclc.org/dsdl/svrl"));
-
-            Element failedAssert = Xml.selectElement(schemaTronReport, "geonet:report/svrl:schematron-output/svrl:failed-assert", theNSs);
-
-            Element failedSchematronVerification = Xml.selectElement(schemaTronReport, "geonet:report/geonet:schematronVerificationError", theNSs);
-
-            if ((failedAssert != null) || (failedSchematronVerification != null)) {
-                throw new SchematronValidationErrorEx("Schematron errors detected for file " + fileName + " - "
-                    + Xml.getString(schemaTronReport) + " for more details", schemaTronReport);
-            }
-        }
-
-    }
-
-    /**
-     *
-     * @param root
-     * @param name
-     * @param value
-     */
-    private static void addElement(Element root, String name, Object value) {
-        root.addContent(new Element(name).setText(value == null ? "" : value.toString()));
-    }
-
-    /**
-     *
-     * @param md
-     */
-    public static void setNamespacePrefix(final Element md) {
-        //--- if the metadata has no namespace or already has a namespace then
-        //--- we must skip this phase
-
-        Namespace ns = md.getNamespace();
-        if (ns != Namespace.NO_NAMESPACE && (md.getNamespacePrefix().equals(""))) {
-            //--- set prefix for iso19139 metadata
-
-            ns = Namespace.getNamespace("gmd", md.getNamespace().getURI());
-            setNamespacePrefix(md, ns);
-        }
-    }
-
-    /**
-     *
-     * @param md
-     * @param ns
-     */
-    private static void setNamespacePrefix(final Element md, final Namespace ns) {
-        if (md.getNamespaceURI().equals(ns.getURI())) {
-            md.setNamespace(ns);
-        }
-
-        Attribute xsiType = md.getAttribute("type", Namespaces.XSI);
-        if (xsiType != null) {
-            String xsiTypeValue = xsiType.getValue();
-
-            if (StringUtils.isNotEmpty(xsiTypeValue) && !xsiTypeValue.contains(":")) {
-                xsiType.setValue(ns.getPrefix() + ":" + xsiType.getValue());
-            }
-        }
-
-
-        for (Object o : md.getChildren()) {
-            setNamespacePrefix((Element) o, ns);
-        }
-    }
-
-    /**
-     *
-     * @return
-     */
-    public EditLib getEditLib() {
-        return editLib;
-    }
-
-    /**
-     * Init Data manager and refresh index if needed. Can also be called after GeoNetwork startup in
-     * order to rebuild the lucene index
+     * Init Data manager and refresh index if needed. Can also be called after GeoNetwork startup in order to rebuild the lucene index
      *
      * @param force Force reindexing all from scratch
      **/
-    public synchronized void init(ServiceContext context, Boolean force) throws Exception {
-        this.servContext = context;
-        final GeonetworkDataDirectory dataDirectory = context.getBean(GeonetworkDataDirectory.class);
-        stylePath = dataDirectory.resolveWebResource(Geonet.Path.STYLESHEETS);
-        editLib = new EditLib(getSchemaManager());
-        thesaurusDir = getApplicationContext().getBean(ThesaurusManager.class).getThesauriDirectory();
+    public void init(ServiceContext context, Boolean force) throws Exception {
+        // FIXME remove all the inits when/if ever autowiring works fine
+        this.metadataManager = context.getBean(IMetadataManager.class);
+        this.metadataManager.init(context, force);
+        this.metadataUtils = context.getBean(IMetadataUtils.class);
+        this.metadataUtils.init(context, force);
+        this.metadataIndexer = context.getBean(IMetadataIndexer.class);
+        this.metadataIndexer.init(context, force);
+        this.metadataValidator = context.getBean(IMetadataValidator.class);
+        this.metadataValidator.init(context, force);
+        this.metadataOperations = context.getBean(IMetadataOperations.class);
+        this.metadataOperations.init(context, force);
+        this.metadataStatus = context.getBean(IMetadataStatus.class);
+        this.metadataStatus.init(context, force);
+        this.metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
+        this.metadataSchemaUtils.init(context, force);
+        this.metadataCategory = context.getBean(IMetadataCategory.class);
+        this.metadataCategory.init(context, force);
+        this.accessManager = context.getBean(AccessManager.class);
+        // remove all the inits when/if ever autowiring works fine
 
+        // FIXME this shouldn't login automatically ever!
         if (context.getUserSession() == null) {
+            Log.debug(Geonet.DATA_MANAGER, "Automatically login in as Administrator. Who is this? Who is calling this?");
             UserSession session = new UserSession();
             context.setUserSession(session);
             session.loginAs(new User().setUsername("admin").setId(-1).setProfile(Profile.Administrator));
-        }
-        // get lastchangedate of all metadata in index
-        Map<String, String> docs = getSearchManager().getDocsChangeDate();
-
-        // set up results HashMap for post processing of records to be indexed
-        ArrayList<String> toIndex = new ArrayList<String>();
-
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "INDEX CONTENT:");
-
-
-        Sort sortByMetadataChangeDate = SortUtils.createSort(Metadata_.dataInfo, MetadataDataInfo_.changeDate);
-        int currentPage = 0;
-        Page<Pair<Integer, ISODate>> results = getMetadataRepository().findAllIdsAndChangeDates(new PageRequest(currentPage,
-            METADATA_BATCH_PAGE_SIZE, sortByMetadataChangeDate));
-
-
-        // index all metadata in DBMS if needed
-        while (results.getNumberOfElements() > 0) {
-            for (Pair<Integer, ISODate> result : results) {
-
-                // get metadata
-                String id = String.valueOf(result.one());
-
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, "- record (" + id + ")");
-                }
-
-                String idxLastChange = docs.get(id);
-
-                // if metadata is not indexed index it
-                if (idxLastChange == null) {
-                    Log.debug(Geonet.DATA_MANAGER, "-  will be indexed");
-                    toIndex.add(id);
-
-                    // else, if indexed version is not the latest index it
-                } else {
-                    docs.remove(id);
-
-                    String lastChange = result.two().toString();
-
-                    if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                        Log.debug(Geonet.DATA_MANAGER, "- lastChange: " + lastChange);
-                    if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                        Log.debug(Geonet.DATA_MANAGER, "- idxLastChange: " + idxLastChange);
-
-                    // date in index contains 't', date in DBMS contains 'T'
-                    if (force || !idxLastChange.equalsIgnoreCase(lastChange)) {
-                        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                            Log.debug(Geonet.DATA_MANAGER, "-  will be indexed");
-                        toIndex.add(id);
-                    }
-                }
-            }
-
-            currentPage++;
-            results = getMetadataRepository().findAllIdsAndChangeDates(new PageRequest(currentPage, METADATA_BATCH_PAGE_SIZE,
-                sortByMetadataChangeDate));
-        }
-
-        // if anything to index then schedule it to be done after servlet is
-        // up so that any links to local fragments are resolvable
-        if (toIndex.size() > 0) {
-            batchIndexInThreadPool(context, toIndex);
-        }
-
-        if (docs.size() > 0) { // anything left?
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                Log.debug(Geonet.DATA_MANAGER, "INDEX HAS RECORDS THAT ARE NOT IN DB:");
-            }
-        }
-
-        // remove from index metadata not in DBMS
-        for (String id : docs.keySet()) {
-            getSearchManager().delete(id);
-
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                Log.debug(Geonet.DATA_MANAGER, "- removed record (" + id + ") from index");
+            try {
+                Log.debug(Geonet.DATA_MANAGER, "Hopefully this is cron job or routinely background task. Who called us?",
+                        new Exception("Dummy Exception to know the stacktrace"));
+            } catch (Exception e) {
+                // Silent. This is just to log the stacktrace here
             }
         }
     }
 
-    /**
-     * Search for all records having XLinks (ie. indexed with _hasxlinks flag), clear the cache and
-     * reindex all records found.
-     */
+    @Deprecated
+    public static void validateMetadata(String schema, Element xml, ServiceContext context) throws Exception {
+        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+        gc.getBean(IMetadataValidator.class).validateMetadata(schema, xml, context, " ");
+    }
+
+    @Deprecated
+    public static void validateMetadata(String schema, Element xml, ServiceContext context, String fileName) throws Exception {
+        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+        gc.getBean(IMetadataValidator.class).validateMetadata(schema, xml, context, fileName);
+    }
+
+    @Deprecated
+    public static void setNamespacePrefix(final Element md) {
+        GeonetContext gc = (GeonetContext) ServiceContext.get().getHandlerContext(Geonet.CONTEXT_NAME);
+        gc.getBean(IMetadataValidator.class).setNamespacePrefix(md);
+    }
+
+    @Deprecated
     public synchronized void rebuildIndexXLinkedMetadata(final ServiceContext context) throws Exception {
-
-        // get all metadata with XLinks
-        Set<Integer> toIndex = getSearchManager().getDocsWithXLinks();
-
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Will index " + toIndex.size() + " records with XLinks");
-        if (toIndex.size() > 0) {
-            // clean XLink Cache so that cache and index remain in sync
-            Processor.clearCache();
-
-            ArrayList<String> stringIds = new ArrayList<String>();
-            for (Integer id : toIndex) {
-                stringIds.add(id.toString());
-            }
-            // execute indexing operation
-            batchIndexInThreadPool(context, stringIds);
-        }
+        metadataIndexer.rebuildIndexXLinkedMetadata(context);
     }
 
-    /**
-     * Reindex all records in current selection.
-     */
-    public synchronized void rebuildIndexForSelection(final ServiceContext context,
-                                                      String bucket,
-                                                      boolean clearXlink)
-        throws Exception {
-
-        // get all metadata ids from selection
-        ArrayList<String> listOfIdsToIndex = new ArrayList<String>();
-        UserSession session = context.getUserSession();
-        SelectionManager sm = SelectionManager.getManager(session);
-
-        synchronized (sm.getSelection(bucket)) {
-            for (Iterator<String> iter = sm.getSelection(bucket).iterator();
-                 iter.hasNext(); ) {
-                String uuid = (String) iter.next();
-                String id = getMetadataId(uuid);
-                if (id != null) {
-                    listOfIdsToIndex.add(id);
-                }
-            }
-        }
-
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-            Log.debug(Geonet.DATA_MANAGER, "Will index " +
-                listOfIdsToIndex.size() + " records from selection.");
-        }
-
-        if (listOfIdsToIndex.size() > 0) {
-            // clean XLink Cache so that cache and index remain in sync
-            if (clearXlink) {
-                Processor.clearCache();
-            }
-
-            // execute indexing operation
-            batchIndexInThreadPool(context, listOfIdsToIndex);
-        }
+    @Deprecated
+    public synchronized void rebuildIndexForSelection(final ServiceContext context, String bucket, boolean clearXlink) throws Exception {
+        metadataIndexer.rebuildIndexForSelection(context, bucket, clearXlink);
     }
 
-    /**
-     * Index multiple metadata in a separate thread.  Wait until the current transaction commits
-     * before starting threads (to make sure that all metadata are committed).
-     *
-     * @param context     context object
-     * @param metadataIds the metadata ids to index
-     */
+    @Deprecated
     public void batchIndexInThreadPool(ServiceContext context, List<?> metadataIds) {
-
-        TransactionStatus transactionStatus = null;
-        try {
-            transactionStatus = TransactionAspectSupport.currentTransactionStatus();
-        } catch (NoTransactionException e) {
-            // not in a transaction so we can go ahead.
-        }
-        // split reindexing task according to number of processors we can assign
-        int threadCount = ThreadUtils.getNumberOfThreads();
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-
-        int perThread;
-        if (metadataIds.size() < threadCount) perThread = metadataIds.size();
-        else perThread = metadataIds.size() / threadCount;
-        int index = 0;
-        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
-            Log.debug(Geonet.INDEX_ENGINE, "Indexing " + metadataIds.size() + " records.");
-            Log.debug(Geonet.INDEX_ENGINE, metadataIds.toString());
-        }
-        AtomicInteger numIndexedTracker = new AtomicInteger();
-        while (index < metadataIds.size()) {
-            int start = index;
-            int count = Math.min(perThread, metadataIds.size() - start);
-            int nbRecords = start + count;
-
-            if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
-                Log.debug(Geonet.INDEX_ENGINE, "Indexing records from " + start + " to " + nbRecords);
-            }
-
-            List<?> subList = metadataIds.subList(start, nbRecords);
-
-            if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
-                Log.debug(Geonet.INDEX_ENGINE, subList.toString());
-            }
-
-            // create threads to process this chunk of ids
-            Runnable worker = new IndexMetadataTask(context, subList,
-                batchIndex, transactionStatus, numIndexedTracker);
-            executor.execute(worker);
-            index += count;
-        }
-
-        executor.shutdown();
+        metadataIndexer.batchIndexInThreadPool(context, metadataIds);
     }
 
+    @Deprecated
     public boolean isIndexing() {
-        indexLock.lock();
-        try {
-            return !indexing.isEmpty() || !batchIndex.isEmpty();
-        } finally {
-            indexLock.unlock();
-        }
+        return metadataIndexer.isIndexing();
     }
 
-
-    //--------------------------------------------------------------------------
-    //---
-    //--- Schema management API
-    //---
-    //--------------------------------------------------------------------------
-
+    @Deprecated
     public void indexMetadata(final List<String> metadataIds) throws Exception {
-        for (String metadataId : metadataIds) {
-            indexMetadata(metadataId, false, null);
-        }
-
-        getSearchManager().forceIndexChanges();
+        metadataIndexer.indexMetadata(metadataIds);
     }
 
-    /**
-     * TODO javadoc.
-     */
+    @Deprecated
     public void indexMetadata(final String metadataId, boolean forceRefreshReaders, ISearchManager searchManager) throws Exception {
-        indexLock.lock();
-        try {
-            if (waitForIndexing.contains(metadataId)) {
-                return;
-            }
-            while (indexing.contains(metadataId)) {
-                try {
-                    waitForIndexing.add(metadataId);
-                    // don't index the same metadata 2x
-                    wait(200);
-                } catch (InterruptedException e) {
-                    return;
-                } finally {
-                    waitForIndexing.remove(metadataId);
-                }
-            }
-            indexing.add(metadataId);
-        } finally {
-            indexLock.unlock();
-        }
-        Metadata fullMd;
-
-        try {
-            Vector<Element> moreFields = new Vector<Element>();
-            int id$ = Integer.parseInt(metadataId);
-
-            // get metadata, extracting and indexing any xlinks
-            Element md = getXmlSerializer().selectNoXLinkResolver(metadataId, true, false);
-            final ServiceContext serviceContext = getServiceContext();
-            if (getXmlSerializer().resolveXLinks()) {
-                List<Attribute> xlinks = Processor.getXLinks(md);
-                if (xlinks.size() > 0) {
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.HASXLINKS, "1", true, true));
-                    StringBuilder sb = new StringBuilder();
-                    for (Attribute xlink : xlinks) {
-                        sb.append(xlink.getValue());
-                        sb.append(" ");
-                    }
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.XLINK, sb.toString(), true, true));
-                    Processor.detachXLink(md, getServiceContext());
-                } else {
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.HASXLINKS, "0", true, true));
-                }
-            } else {
-                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.HASXLINKS, "0", true, true));
-            }
-
-            fullMd = getMetadataRepository().findOne(id$);
-
-            final String schema = fullMd.getDataInfo().getSchemaId();
-            final String createDate = fullMd.getDataInfo().getCreateDate().getDateAndTime();
-            final String changeDate = fullMd.getDataInfo().getChangeDate().getDateAndTime();
-            final String source = fullMd.getSourceInfo().getSourceId();
-            final MetadataType metadataType = fullMd.getDataInfo().getType();
-            final String root = fullMd.getDataInfo().getRoot();
-            final String uuid = fullMd.getUuid();
-            final String extra = fullMd.getDataInfo().getExtra();
-            final String isHarvested = String.valueOf(Constants.toYN_EnabledChar(fullMd.getHarvestInfo().isHarvested()));
-            final String owner = String.valueOf(fullMd.getSourceInfo().getOwner());
-            final Integer groupOwner = fullMd.getSourceInfo().getGroupOwner();
-            final String popularity = String.valueOf(fullMd.getDataInfo().getPopularity());
-            final String rating = String.valueOf(fullMd.getDataInfo().getRating());
-            final String displayOrder = fullMd.getDataInfo().getDisplayOrder() == null ? null : String.valueOf(fullMd.getDataInfo().getDisplayOrder());
-
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                Log.debug(Geonet.DATA_MANAGER, "record schema (" + schema + ")"); //DEBUG
-                Log.debug(Geonet.DATA_MANAGER, "record createDate (" + createDate + ")"); //DEBUG
-            }
-
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.ROOT, root, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.SCHEMA, schema, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DATABASE_CREATE_DATE, createDate, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DATABASE_CHANGE_DATE, changeDate, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.SOURCE, source, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.IS_TEMPLATE, metadataType.codeString, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.UUID, uuid, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.IS_HARVESTED, isHarvested, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.OWNER, owner, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DUMMY, "0", false, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.POPULARITY, popularity, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.RATING, rating, true, true));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DISPLAY_ORDER, displayOrder, true, false));
-            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.EXTRA, extra, false, true));
-
-            // If the metadata has an atom document, index related information
-            InspireAtomFeedRepository inspireAtomFeedRepository = getApplicationContext().getBean(InspireAtomFeedRepository.class);
-            InspireAtomFeed feed = inspireAtomFeedRepository.findByMetadataId(id$);
-
-            if ((feed != null) && StringUtils.isNotEmpty(feed.getAtom())) {
-                moreFields.add(SearchManager.makeField("has_atom", "y", true, true));
-                moreFields.add(SearchManager.makeField("any", feed.getAtom(), false, true));
-            }
-
-            if (owner != null) {
-                User user = getApplicationContext().getBean(UserRepository.class).findOne(fullMd.getSourceInfo().getOwner());
-                if (user != null) {
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.USERINFO, user.getUsername() + "|" + user.getSurname() + "|" + user
-                        .getName() + "|" + user.getProfile(), true, false));
-                }
-            }
-
-            OperationAllowedRepository operationAllowedRepository = getApplicationContext().getBean(OperationAllowedRepository.class);
-            GroupRepository groupRepository = getApplicationContext().getBean(GroupRepository.class);
-
-            String logoUUID = null;
-            if (groupOwner != null) {
-                final Group group = groupRepository.findOne(groupOwner);
-                if (group != null) {
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_OWNER, String.valueOf(groupOwner), true, true));
-                    final boolean preferGroup = getSettingManager().getValueAsBool(Settings.SYSTEM_PREFER_GROUP_LOGO, true);
-                    if (group.getWebsite() != null && !group.getWebsite().isEmpty() && preferGroup) {
-                        moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_WEBSITE, group.getWebsite(), true, false));
-                    }
-                    if (group.getLogo() != null && preferGroup) {
-                        logoUUID = group.getLogo();
-                    }
-                }
-            }
-
-            // Group logo are in the harvester folder and contains extension in file name
-            final Path harvesterLogosDir = Resources.locateHarvesterLogosDir(serviceContext);
-            boolean added = false;
-            if (StringUtils.isNotEmpty(logoUUID)) {
-                final Path logoPath = harvesterLogosDir.resolve(logoUUID);
-                if (Files.exists(logoPath)) {
-                    added = true;
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.LOGO, "/images/harvesting/" + logoPath.getFileName(), true, false));
-                }
-            }
-
-            // If not available, use the local catalog logo
-            if (!added) {
-                logoUUID = source + ".png";
-                final Path logosDir = Resources.locateLogosDir(serviceContext);
-                final Path logoPath = logosDir.resolve(logoUUID);
-                if (Files.exists(logoPath)) {
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.LOGO, "/images/logos/" + logoUUID, true, false));
-                }
-            }
-
-            // get privileges
-            List<OperationAllowed> operationsAllowed = operationAllowedRepository.findAllById_MetadataId(id$);
-
-            for (OperationAllowed operationAllowed : operationsAllowed) {
-                OperationAllowedId operationAllowedId = operationAllowed.getId();
-                int groupId = operationAllowedId.getGroupId();
-                int operationId = operationAllowedId.getOperationId();
-
-                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.OP_PREFIX + operationId, String.valueOf(groupId), true, true));
-                if (operationId == ReservedOperation.view.getId()) {
-                    Group g = groupRepository.findOne(groupId);
-                    if (g != null) {
-                        moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_PUBLISHED, g.getName(), true, true));
-                    }
-                }
-            }
-
-            for (MetadataCategory category : fullMd.getMetadataCategories()) {
-                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.CAT, category.getName(), true, true));
-            }
-
-            final MetadataStatusRepository statusRepository = getApplicationContext().getBean(MetadataStatusRepository.class);
-
-            // get status
-            Sort statusSort = new Sort(Sort.Direction.DESC, MetadataStatus_.id.getName() + "." + MetadataStatusId_.changeDate.getName());
-            List<MetadataStatus> statuses = statusRepository.findAllById_MetadataId(id$, statusSort);
-            if (!statuses.isEmpty()) {
-                MetadataStatus stat = statuses.get(0);
-                String status = String.valueOf(stat.getId().getStatusId());
-                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.STATUS, status, true, true));
-                String statusChangeDate = stat.getId().getChangeDate().getDateAndTime();
-                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.STATUS_CHANGE_DATE, statusChangeDate, true, true));
-            }
-
-            // getValidationInfo
-            // -1 : not evaluated
-            // 0 : invalid
-            // 1 : valid
-            MetadataValidationRepository metadataValidationRepository = getBean(MetadataValidationRepository
-                .class);
-            List<MetadataValidation> validationInfo = metadataValidationRepository.findAllById_MetadataId(id$);
-            if (validationInfo.isEmpty()) {
-                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.VALID, "-1", true, true));
-            } else {
-                String isValid = "1";
-                for (MetadataValidation vi : validationInfo) {
-                    String type = vi.getId().getValidationType();
-                    MetadataValidationStatus status = vi.getStatus();
-                    if (status == MetadataValidationStatus.INVALID && vi.isRequired()) {
-                        isValid = "0";
-                    }
-                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.VALID + "_" + type, status.getCode(), true, true));
-                }
-                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.VALID, isValid, true, true));
-            }
-
-            if (searchManager == null) {
-                getSearchManager().index(getSchemaManager().getSchemaDir(schema), md, metadataId, moreFields, metadataType, root, forceRefreshReaders);
-            } else {
-                searchManager.index(getSchemaManager().getSchemaDir(schema), md, metadataId, moreFields, metadataType, root, forceRefreshReaders);
-            }
-        } catch (Exception x) {
-            Log.error(Geonet.DATA_MANAGER, "The metadata document index with id=" + metadataId + " is corrupt/invalid - ignoring it. Error: " + x.getMessage(), x);
-            fullMd = null;
-        } finally {
-            indexLock.lock();
-            try {
-                indexing.remove(metadataId);
-            } finally {
-                indexLock.unlock();
-            }
-        }
-        if (fullMd != null) {
-            applicationEventPublisher.publishEvent(new MetadataIndexCompleted(fullMd));
-        }
+        metadataIndexer.indexMetadata(metadataId, forceRefreshReaders, searchManager);
     }
 
-    protected ServiceContext getServiceContext() {
-        ServiceContext context = ServiceContext.get();
-        return context == null ? servContext : context;
-    }
-
-    /**
-     *
-     * @param beginAt
-     * @param interval
-     * @throws Exception
-     */
+    @Deprecated
     public void rescheduleOptimizer(Calendar beginAt, int interval) throws Exception {
-        getSearchManager().rescheduleOptimizer(beginAt, interval);
+        metadataIndexer.rescheduleOptimizer(beginAt, interval);
     }
 
-    /**
-     *
-     * @throws Exception
-     */
+    @Deprecated
     public void disableOptimizer() throws Exception {
-        getSearchManager().disableOptimizer();
+        metadataIndexer.disableOptimizer();
     }
 
-    /**
-     *
-     * @param name
-     * @return
-     */
+    @Deprecated
     public MetadataSchema getSchema(String name) {
-        return getSchemaManager().getSchema(name);
+        return metadataSchemaUtils.getSchema(name);
     }
 
-    /**
-     *
-     * @return
-     */
+    @Deprecated
     public Set<String> getSchemas() {
-        return getSchemaManager().getSchemas();
+        return metadataSchemaUtils.getSchemas();
     }
 
-    /**
-     *
-     * @param name
-     * @return
-     */
+    @Deprecated
     public boolean existsSchema(String name) {
-        return getSchemaManager().existsSchema(name);
+        return metadataSchemaUtils.existsSchema(name);
     }
 
-    /**
-     *
-     * @param name
-     * @return
-     */
+    @Deprecated
     public Path getSchemaDir(String name) {
-        return getSchemaManager().getSchemaDir(name);
+        return metadataSchemaUtils.getSchemaDir(name);
     }
 
-    /**
-     * Use this validate method for XML documents with dtd.
-     */
+    @Deprecated
     public void validate(String schema, Document doc) throws Exception {
-        Xml.validate(doc);
+        metadataValidator.validate(schema, doc);
     }
 
-    /**
-     * Use this validate method for XML documents with xsd validation.
-     */
+    @Deprecated
     public void validate(String schema, Element md) throws Exception {
-        String schemaLoc = md.getAttributeValue("schemaLocation", Namespaces.XSI);
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Extracted schemaLocation of " + schemaLoc);
-        if (schemaLoc == null) schemaLoc = "";
-
-        if (schema == null) {
-            // must use schemaLocation
-            Xml.validate(md);
-        } else {
-            // if schemaLocation use that
-            if (!schemaLoc.equals("")) {
-                Xml.validate(md);
-                // otherwise use supplied schema name
-            } else {
-                Xml.validate(getSchemaDir(schema).resolve(Geonet.File.SCHEMA), md);
-            }
-        }
+        metadataValidator.validate(schema, md);
     }
 
-    /**
-     * TODO javadoc.
-     */
+    @Deprecated
     public Element validateInfo(String schema, Element md, ErrorHandler eh) throws Exception {
-        String schemaLoc = md.getAttributeValue("schemaLocation", Namespaces.XSI);
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Extracted schemaLocation of " + schemaLoc);
-        if (schemaLoc == null) schemaLoc = "";
-
-        if (schema == null) {
-            // must use schemaLocation
-            return Xml.validateInfo(md, eh);
-        } else {
-            // if schemaLocation use that
-            if (!schemaLoc.equals("")) {
-                return Xml.validateInfo(md, eh);
-                // otherwise use supplied schema name
-            } else {
-                return Xml.validateInfo(getSchemaDir(schema).resolve(Geonet.File.SCHEMA), md, eh);
-            }
-        }
+        return metadataValidator.validateInfo(schema, md, eh);
     }
 
-    /**
-     * Creates XML schematron report.
-     */
+    @Deprecated
     public Element doSchemaTronForEditor(String schema, Element md, String lang) throws Exception {
-        // enumerate the metadata xml so that we can report any problems found
-        // by the schematron_xml script to the geonetwork editor
-        editLib.enumerateTree(md);
-
-        // get an xml version of the schematron errors and return for error display
-        Element schemaTronXmlReport = getSchemaTronXmlReport(schema, md, lang, null);
-
-        // remove editing info added by enumerateTree
-        editLib.removeEditingInfo(md);
-
-        return schemaTronXmlReport;
+        return metadataValidator.doSchemaTronForEditor(schema, md, lang);
     }
 
-    /**
-     * TODO javadoc.
-     */
+    @Deprecated
     public String getMetadataSchema(String id) throws Exception {
-        Metadata md = getMetadataRepository().findOne(id);
-
-        if (md == null) {
-            throw new IllegalArgumentException("Metadata not found for id : " + id);
-        } else {
-            // get metadata
-            return md.getDataInfo().getSchemaId();
-        }
+        return metadataSchemaUtils.getMetadataSchema(id);
     }
 
-    /**
-     * Extract the title field from the Metadata Repository. This is only valid for subtemplates as the title
-     * can be stored with the subtemplate (since subtemplates don't have a title) - metadata records don't store the
-     * title here as this is part of the metadata.
-     *
-     * @param id metadata id to retrieve
-     */
+    @Deprecated
     public String getMetadataTitle(String id) throws Exception {
-        Metadata md = getMetadataRepository().findOne(id);
-
-        if (md == null) {
-            throw new IllegalArgumentException("Metadata not found for id : " + id);
-        } else {
-            // get metadata title
-            return md.getDataInfo().getTitle();
-        }
+        return metadataUtils.getMetadataTitle(id);
     }
 
-    /**
-     *
-     * @param context
-     * @param id
-     * @param md
-     * @throws Exception
-     */
+    @Deprecated
     public void versionMetadata(ServiceContext context, String id, Element md) throws Exception {
-        if (getSvnManager() != null) {
-            getSvnManager().createMetadataDir(id, context, md);
-        }
+        metadataIndexer.versionMetadata(context, id, md);
     }
 
-    /**
-     * Start an editing session. This will record the original metadata record in the session under
-     * the {@link org.fao.geonet.constants.Geonet.Session#METADATA_BEFORE_ANY_CHANGES} + id session
-     * property.
-     *
-     * The record contains geonet:info element.
-     *
-     * Note: Only the metadata record is stored in session. If the editing session upload new
-     * documents or thumbnails, those documents will not be cancelled. This needs improvements.
-     */
-    public void startEditingSession(ServiceContext context, String id)
-        throws Exception {
-        if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
-            Log.debug(Geonet.EDITOR_SESSION, "Editing session starts for record " + id);
-        }
-
-        boolean keepXlinkAttributes = true;
-        boolean forEditing = false;
-        boolean withValidationErrors = false;
-        Element metadataBeforeAnyChanges = getMetadata(context, id, forEditing, withValidationErrors, keepXlinkAttributes);
-        context.getUserSession().setProperty(Geonet.Session.METADATA_BEFORE_ANY_CHANGES + id, metadataBeforeAnyChanges);
+    @Deprecated
+    public void startEditingSession(ServiceContext context, String id) throws Exception {
+        metadataUtils.startEditingSession(context, id);
     }
 
-    /**
-     * Rollback to the record in the state it was when the editing session started (See {@link
-     * #startEditingSession(ServiceContext, String)}).
-     */
-    public void cancelEditingSession(ServiceContext context,
-                                     String id) throws Exception {
-        UserSession session = context.getUserSession();
-        Element metadataBeforeAnyChanges = (Element) session.getProperty(Geonet.Session.METADATA_BEFORE_ANY_CHANGES + id);
-
-        if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
-            Log.debug(Geonet.EDITOR_SESSION,
-                "Editing session end. Cancel changes. Restore record " + id +
-                    ". Replace by original record which was: ");
-        }
-
-        if (metadataBeforeAnyChanges != null) {
-            if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
-                Log.debug(Geonet.EDITOR_SESSION, " > restoring record: ");
-                Log.debug(Geonet.EDITOR_SESSION, Xml.getString(metadataBeforeAnyChanges));
-            }
-            Element info = metadataBeforeAnyChanges.getChild(Edit.RootChild.INFO, Edit.NAMESPACE);
-            boolean validate = false;
-            boolean ufo = false;
-            boolean index = true;
-            metadataBeforeAnyChanges.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);
-            updateMetadata(context, id, metadataBeforeAnyChanges,
-                validate, ufo, index,
-                context.getLanguage(), info.getChildText(Edit.Info.Elem.CHANGE_DATE), false);
-            endEditingSession(id, session);
-        } else {
-            if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
-                Log.debug(Geonet.EDITOR_SESSION,
-                    " > nothing to cancel for record " + id +
-                        ". Original record was null. Use starteditingsession to.");
-            }
-        }
+    @Deprecated
+    public void cancelEditingSession(ServiceContext context, String id) throws Exception {
+        metadataUtils.cancelEditingSession(context, id);
     }
 
-    /**
-     * Remove the original record stored in session.
-     */
+    @Deprecated
     public void endEditingSession(String id, UserSession session) {
-        if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
-            Log.debug(Geonet.EDITOR_SESSION, "Editing session end.");
-        }
-        session.removeProperty(Geonet.Session.METADATA_BEFORE_ANY_CHANGES + id);
+        metadataUtils.endEditingSession(id, session);
     }
 
-
-    //--------------------------------------------------------------------------
-    //---
-    //--- General purpose API
-    //---
-    //--------------------------------------------------------------------------
-
-    /**
-     *
-     * @param md
-     * @return
-     * @throws Exception
-     */
+    @Deprecated
     public Element enumerateTree(Element md) throws Exception {
-        editLib.enumerateTree(md);
-        return md;
+        return metadataUtils.enumerateTree(md);
     }
 
-    /**
-     * Creates XML schematron report for each set of rules defined in schema directory.
-     */
-    private Element getSchemaTronXmlReport(String schema, Element md, String lang, Map<String, Integer[]> valTypeAndStatus) throws Exception {
-        // NOTE: this method assumes that you've run enumerateTree on the
-        // metadata
-
-        MetadataSchema metadataSchema = getSchema(schema);
-        String[] rules = metadataSchema.getSchematronRules();
-
-        // Schematron report is composed of one or more report(s)
-        // for each set of rules.
-        Element schemaTronXmlOut = new Element("schematronerrors",
-            Edit.NAMESPACE);
-        if (rules != null) {
-            for (String rule : rules) {
-                // -- create a report for current rules.
-                // Identified by a rule attribute set to shematron file name
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                    Log.debug(Geonet.DATA_MANAGER, " - rule:" + rule);
-                String ruleId = rule.substring(0, rule.indexOf(".xsl"));
-                Element report = new Element("report", Edit.NAMESPACE);
-                report.setAttribute("rule", ruleId,
-                    Edit.NAMESPACE);
-
-                java.nio.file.Path schemaTronXmlXslt = metadataSchema.getSchemaDir().resolve("schematron").resolve(rule);
-                try {
-                    Map<String, Object> params = new HashMap<String, Object>();
-                    params.put("lang", lang);
-                    params.put("rule", rule);
-                    params.put("thesaurusDir", this.thesaurusDir);
-                    Element xmlReport = Xml.transform(md, schemaTronXmlXslt, params);
-                    if (xmlReport != null) {
-                        report.addContent(xmlReport);
-                        // add results to persitent validation information
-                        int firedRules = 0;
-                        Iterator<?> firedRulesElems = xmlReport.getDescendants(new ElementFilter("fired-rule", Namespaces.SVRL));
-                        while (firedRulesElems.hasNext()) {
-                            firedRulesElems.next();
-                            firedRules++;
-                        }
-                        int invalidRules = 0;
-                        Iterator<?> faileAssertElements = xmlReport.getDescendants(new ElementFilter("failed-assert",
-                            Namespaces.SVRL));
-                        while (faileAssertElements.hasNext()) {
-                            faileAssertElements.next();
-                            invalidRules++;
-                        }
-                        Integer[] results = {invalidRules != 0 ? 0 : 1, firedRules, invalidRules};
-                        if (valTypeAndStatus != null) {
-                            valTypeAndStatus.put(ruleId, results);
-                        }
-                    }
-                } catch (Exception e) {
-                    Log.error(Geonet.DATA_MANAGER, "WARNING: schematron xslt " + schemaTronXmlXslt + " failed");
-
-                    // If an error occurs that prevents to verify schematron rules, add to show in report
-                    Element errorReport = new Element("schematronVerificationError", Edit.NAMESPACE);
-                    errorReport.addContent("Schematron error ocurred, rules could not be verified: " + e.getMessage());
-                    report.addContent(errorReport);
-
-                    e.printStackTrace();
-                }
-
-                // -- append report to main XML report.
-                schemaTronXmlOut.addContent(report);
-            }
-        }
-        return schemaTronXmlOut;
-    }
-
-    /**
-     * Valid the metadata record against its schema. For each error found, an xsderror attribute is
-     * added to the corresponding element trying to find the element based on the xpath return by
-     * the ErrorHandler.
-     */
-    private synchronized Element getXSDXmlReport(String schema, Element md) {
-        // NOTE: this method assumes that enumerateTree has NOT been run on the metadata
-        ErrorHandler errorHandler = new ErrorHandler();
-        errorHandler.setNs(Edit.NAMESPACE);
-        Element xsdErrors;
-
-        try {
-            xsdErrors = validateInfo(schema,
-                md, errorHandler);
-        } catch (Exception e) {
-            xsdErrors = JeevesException.toElement(e);
-            return xsdErrors;
-        }
-
-        if (xsdErrors != null) {
-            MetadataSchema mds = getSchema(schema);
-            List<Namespace> schemaNamespaces = mds.getSchemaNS();
-
-            //-- now get each xpath and evaluate it
-            //-- xsderrors/xsderror/{message,xpath}
-            @SuppressWarnings("unchecked")
-            List<Element> list = xsdErrors.getChildren();
-            for (Element elError : list) {
-                String xpath = elError.getChildText("xpath", Edit.NAMESPACE);
-                String message = elError.getChildText("message", Edit.NAMESPACE);
-                message = "\\n" + message;
-
-                //-- get the element from the xpath and add the error message to it
-                Element elem = null;
-                try {
-                    elem = Xml.selectElement(md, xpath, schemaNamespaces);
-                } catch (JDOMException je) {
-                    je.printStackTrace();
-                    Log.error(Geonet.DATA_MANAGER, "Attach xsderror message to xpath " + xpath + " failed: " + je.getMessage());
-                }
-                if (elem != null) {
-                    String existing = elem.getAttributeValue("xsderror", Edit.NAMESPACE);
-                    if (existing != null) message = existing + message;
-                    elem.setAttribute("xsderror", message, Edit.NAMESPACE);
-                } else {
-                    Log.warning(Geonet.DATA_MANAGER, "WARNING: evaluating XPath " + xpath + " against metadata failed - XSD validation message: " + message + " will NOT be shown by the editor");
-                }
-            }
-        }
-        return xsdErrors;
-    }
-
-    /**
-     * Extract UUID from the metadata record using the schema XSL for UUID extraction)
-     */
+    @Deprecated
     public String extractUUID(String schema, Element md) throws Exception {
-        Path styleSheet = getSchemaDir(schema).resolve(Geonet.File.EXTRACT_UUID);
-        String uuid = Xml.transform(md, styleSheet).getText().trim();
-
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Extracted UUID '" + uuid + "' for schema '" + schema + "'");
-
-        //--- needed to detach md from the document
-        md.detach();
-
-        return uuid;
+        return metadataUtils.extractUUID(schema, md);
     }
 
-    /**
-     *
-     * @param schema
-     * @param md
-     * @return
-     * @throws Exception
-     */
+    @Deprecated
     public String extractDateModified(String schema, Element md) throws Exception {
-        Path styleSheet = getSchemaDir(schema).resolve(Geonet.File.EXTRACT_DATE_MODIFIED);
-        String dateMod = Xml.transform(md, styleSheet).getText().trim();
-
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Extracted Date Modified '" + dateMod + "' for schema '" + schema + "'");
-
-        //--- needed to detach md from the document
-        md.detach();
-
-        return dateMod;
+        return metadataUtils.extractDateModified(schema, md);
     }
 
-    /**
-     *
-     * @param schema
-     * @param uuid
-     * @param md
-     * @return
-     * @throws Exception
-     */
+    @Deprecated
     public Element setUUID(String schema, String uuid, Element md) throws Exception {
-        //--- setup environment
-
-        Element env = new Element("env");
-        env.addContent(new Element("uuid").setText(uuid));
-
-        //--- setup root element
-
-        Element root = new Element("root");
-        root.addContent(md.detach());
-        root.addContent(env.detach());
-
-        //--- do an XSL  transformation
-
-        Path styleSheet = getSchemaDir(schema).resolve(Geonet.File.SET_UUID);
-
-        return Xml.transform(root, styleSheet);
+        return metadataUtils.setUUID(schema, uuid, md);
     }
 
-    /**
-     *
-     * @param md
-     * @return
-     * @throws Exception
-     */
+    @Deprecated
     public Element extractSummary(Element md) throws Exception {
-        Path styleSheet = stylePath.resolve(Geonet.File.METADATA_BRIEF);
-        Element summary = Xml.transform(md, styleSheet);
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Extracted summary '\n" + Xml.getString(summary));
-
-        //--- needed to detach md from the document
-        md.detach();
-
-        return summary;
+        return metadataUtils.extractSummary(md);
     }
 
-    /**
-     *
-     * @param uuid
-     * @return
-     * @throws Exception
-     */
-    public
-    @Nullable
-    String getMetadataId(@Nonnull String uuid) throws Exception {
-        final List<Integer> idList = getMetadataRepository().findAllIdsBy(hasMetadataUuid(uuid));
-        if (idList.isEmpty()) {
-            return null;
-        }
-        return String.valueOf(idList.get(0));
+    @Deprecated
+    public @Nullable String getMetadataId(@Nonnull String uuid) throws Exception {
+        return metadataUtils.getMetadataId(uuid);
     }
 
-    /**
-     *
-     * @param id
-     * @return
-     * @throws Exception
-     */
-    public
-    @Nullable
-    String getMetadataUuid(@Nonnull String id) throws Exception {
-        Metadata metadata = getMetadataRepository().findOne(id);
-
-        if (metadata == null)
-            return null;
-
-        return metadata.getUuid();
+    @Deprecated
+    public @Nullable String getMetadataUuid(@Nonnull String id) throws Exception {
+        return metadataUtils.getMetadataUuid(id);
     }
 
-    /**
-     *
-     * @param id
-     * @return
-     */
+    @Deprecated
     public String getVersion(String id) {
-        return editLib.getVersion(id);
+        return metadataUtils.getVersion(id);
     }
 
-    /**
-     *
-     * @param id
-     * @return
-     */
+    @Deprecated
     public String getNewVersion(String id) {
-        return editLib.getNewVersion(id);
+        return metadataUtils.getNewVersion(id);
     }
 
-    /**
-     * TODO javadoc.
-     */
+    @Deprecated
     public void setTemplate(final int id, final MetadataType type, final String title) throws Exception {
-        setTemplateExt(id, type);
-        indexMetadata(Integer.toString(id), true, null);
+        metadataUtils.setTemplate(id, type, title);
     }
 
-    /**
-     * TODO javadoc.
-     */
+    @Deprecated
     public void setTemplateExt(final int id, final MetadataType metadataType) throws Exception {
-        getMetadataRepository().update(id, new Updater<Metadata>() {
-            @Override
-            public void apply(@Nonnull Metadata metadata) {
-                final MetadataDataInfo dataInfo = metadata.getDataInfo();
-                dataInfo.setType(metadataType);
-            }
-        });
+        metadataUtils.setTemplateExt(id, metadataType);
     }
 
-    /**
-     * Set metadata type to subtemplate and set the title. Only subtemplates
-     * need to persist the title as it is used to give a meaningful title for
-     * use when offering the subtemplate to users in the editor.
-     *
-     * @param id Metadata id to set to type subtemplate
-     * @param title Title of metadata of subtemplate/fragment
-     */
+    @Deprecated
     public void setSubtemplateTypeAndTitleExt(final int id, String title) throws Exception {
-        getMetadataRepository().update(id, new Updater<Metadata>() {
-            @Override
-            public void apply(@Nonnull Metadata metadata) {
-                final MetadataDataInfo dataInfo = metadata.getDataInfo();
-                dataInfo.setType(MetadataType.SUB_TEMPLATE);
-                if (title != null) {
-                  dataInfo.setTitle(title);
-                }
-            }
-        });
+        metadataUtils.setSubtemplateTypeAndTitleExt(id, title);
     }
 
-    /**
-     * TODO javadoc.
-     */
+    @Deprecated
     public void setHarvested(int id, String harvestUuid) throws Exception {
-        setHarvestedExt(id, harvestUuid);
-        indexMetadata(Integer.toString(id), true, null);
+        metadataUtils.setHarvested(id, harvestUuid);
     }
 
-    /**
-     * TODO javadoc.
-     */
+    @Deprecated
     public void setHarvestedExt(int id, String harvestUuid) throws Exception {
-        setHarvestedExt(id, harvestUuid, Optional.<String>absent());
+        metadataUtils.setHarvestedExt(id, harvestUuid);
     }
 
-    /**
-     * TODO javadoc.
-     */
+    @Deprecated
     public void setHarvestedExt(final int id, final String harvestUuid, final Optional<String> harvestUri) throws Exception {
-        getMetadataRepository().update(id, new Updater<Metadata>() {
-            @Override
-            public void apply(Metadata metadata) {
-                MetadataHarvestInfo harvestInfo = metadata.getHarvestInfo();
-                harvestInfo.setUuid(harvestUuid);
-                harvestInfo.setHarvested(harvestUuid != null);
-                harvestInfo.setUri(harvestUri.orNull());
-            }
-        });
+        metadataUtils.setHarvestedExt(id, harvestUuid, harvestUri);
     }
 
-    /**
-     * Checks autodetect elements in installed schemas to determine whether the metadata record
-     * belongs to that schema. Use this method when you want the default schema from the geonetwork
-     * config to be returned when no other match can be found.
-     *
-     * @param md Record to checked against schemas
-     */
-    public
-    @CheckForNull
-    String autodetectSchema(Element md) throws SchemaMatchConflictException, NoSchemaMatchesException {
-        return autodetectSchema(md, getSchemaManager().getDefaultSchema());
+    @Deprecated
+    public @CheckForNull String autodetectSchema(Element md) throws SchemaMatchConflictException, NoSchemaMatchesException {
+        return metadataSchemaUtils.autodetectSchema(md);
     }
 
-    /**
-     * Checks autodetect elements in installed schemas to determine whether the metadata record
-     * belongs to that schema. Use this method when you want to set the default schema to be
-     * returned when no other match can be found.
-     *
-     * @param md            Record to checked against schemas
-     * @param defaultSchema Schema to be assigned when no other schema matches
-     */
-    public
-    @CheckForNull
-    String autodetectSchema(Element md, String defaultSchema) throws SchemaMatchConflictException, NoSchemaMatchesException {
-
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Autodetect schema for metadata with :\n * root element:'" + md.getQualifiedName()
-                + "'\n * with namespace:'" + md.getNamespace()
-                + "\n * with additional namespaces:" + md.getAdditionalNamespaces().toString());
-        String schema = getSchemaManager().autodetectSchema(md, defaultSchema);
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Schema detected was " + schema);
-        return schema;
+    @Deprecated
+    public @CheckForNull String autodetectSchema(Element md, String defaultSchema)
+            throws SchemaMatchConflictException, NoSchemaMatchesException {
+        return metadataSchemaUtils.autodetectSchema(md, defaultSchema);
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Metadata Insert API
-    //---
-    //--------------------------------------------------------------------------
-
-    /**
-     *
-     * @param id
-     * @param displayOrder
-     * @throws Exception
-     */
+    @Deprecated
     public void updateDisplayOrder(final String id, final String displayOrder) throws Exception {
-        getMetadataRepository().update(Integer.valueOf(id), new Updater<Metadata>() {
-            @Override
-            public void apply(Metadata entity) {
-                entity.getDataInfo().setDisplayOrder(Integer.parseInt(displayOrder));
-            }
-        });
+        metadataUtils.updateDisplayOrder(id, displayOrder);
     }
 
-    /**
-     * @throws Exception hmm
-     */
+    @Deprecated
     public void increasePopularity(ServiceContext srvContext, String id) throws Exception {
-        // READONLYMODE
-        if (!srvContext.getBean(NodeInfo.class).isReadOnly()) {
-            // Update the popularity in database
-            int iId = Integer.parseInt(id);
-            getMetadataRepository().incrementPopularity(iId);
-
-            // And register the metadata to be indexed in the near future
-            final IndexingList list = srvContext.getBean(IndexingList.class);
-            list.add(iId);
-        } else {
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                Log.debug(Geonet.DATA_MANAGER, "GeoNetwork is operating in read-only mode. IncreasePopularity is skipped.");
-            }
-        }
+        metadataUtils.increasePopularity(srvContext, id);
     }
 
-    /**
-     * Rates a metadata.
-     *
-     * @param ipAddress ipAddress IP address of the submitting client
-     * @param rating    range should be 1..5
-     * @throws Exception hmm
-     */
+    @Deprecated
     public int rateMetadata(final int metadataId, final String ipAddress, final int rating) throws Exception {
-        MetadataRatingByIp ratingEntity = new MetadataRatingByIp();
-        ratingEntity.setRating(rating);
-        ratingEntity.setId(new MetadataRatingByIpId(metadataId, ipAddress));
-
-        final MetadataRatingByIpRepository ratingByIpRepository = getApplicationContext().getBean(MetadataRatingByIpRepository.class);
-        ratingByIpRepository.save(ratingEntity);
-
-        //
-        // calculate new rating
-        //
-        final int newRating = ratingByIpRepository.averageRating(metadataId);
-
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Setting rating for id:" + metadataId + " --> rating is:" + newRating);
-
-
-        getMetadataRepository().update(metadataId, new Updater<Metadata>() {
-            @Override
-            public void apply(Metadata entity) {
-                entity.getDataInfo().setRating(newRating);
-            }
-        });
-
-        indexMetadata(Integer.toString(metadataId), true, null);
-
-        return rating;
+        return metadataUtils.rateMetadata(metadataId, ipAddress, rating);
     }
 
-    /**
-     * Creates a new metadata duplicating an existing template creating a random uuid.
-     *
-     * @param isTemplate         TODO
-     * @param fullRightsForGroup TODO
-     */
-    public String createMetadata(ServiceContext context, String templateId, String groupOwner,
-                                 String source, int owner,
-                                 String parentUuid, String isTemplate, boolean fullRightsForGroup) throws Exception {
-
-        return createMetadata(context, templateId, groupOwner, source,
-            owner, parentUuid, isTemplate, fullRightsForGroup, UUID.randomUUID().toString());
+    @Deprecated
+    public String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
+            String isTemplate, boolean fullRightsForGroup) throws Exception {
+        return metadataManager.createMetadata(context, templateId, groupOwner, source, owner, parentUuid, isTemplate, fullRightsForGroup);
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Metadata Get API
-    //---
-    //--------------------------------------------------------------------------
-
-    /**
-     * Creates a new metadata duplicating an existing template with an specified uuid.
-     *
-     * @param isTemplate         TODO
-     * @param fullRightsForGroup TODO
-     */
-    public String createMetadata(ServiceContext context, String templateId, String groupOwner,
-                                 String source, int owner,
-                                 String parentUuid, String isTemplate, boolean fullRightsForGroup, String uuid) throws Exception {
-        Metadata templateMetadata = getMetadataRepository().findOne(templateId);
-        if (templateMetadata == null) {
-            throw new IllegalArgumentException("Template id not found : " + templateId);
-        }
-
-        String schema = templateMetadata.getDataInfo().getSchemaId();
-        String data = templateMetadata.getData();
-        Element xml = Xml.loadString(data, false);
-        if (templateMetadata.getDataInfo().getType() == MetadataType.METADATA) {
-            xml = updateFixedInfo(schema, Optional.<Integer>absent(), uuid, xml, parentUuid, UpdateDatestamp.NO, context);
-        }
-        final Metadata newMetadata = new Metadata().setUuid(uuid);
-        newMetadata.getDataInfo()
-            .setChangeDate(new ISODate())
-            .setCreateDate(new ISODate())
-            .setSchemaId(schema)
-            .setType(MetadataType.lookup(isTemplate));
-        newMetadata.getSourceInfo()
-            .setGroupOwner(Integer.valueOf(groupOwner))
-            .setOwner(owner)
-            .setSourceId(source);
-
-        //If there is a default category for the group, use it:
-        Group group = getApplicationContext()
-            .getBean(GroupRepository.class)
-            .findOne(Integer.valueOf(groupOwner));
-        if (group.getDefaultCategory() != null) {
-            newMetadata.getMetadataCategories().add(group.getDefaultCategory());
-        }
-        Collection<MetadataCategory> filteredCategories = Collections2.filter(templateMetadata.getMetadataCategories(),
-            new Predicate<MetadataCategory>() {
-                @Override
-                public boolean apply(@Nullable MetadataCategory input) {
-                    return input != null;
-                }
-            });
-
-        newMetadata.getMetadataCategories().addAll(filteredCategories);
-
-        int finalId = insertMetadata(context, newMetadata, xml, false, true, true, UpdateDatestamp.YES,
-            fullRightsForGroup, true).getId();
-
-        return String.valueOf(finalId);
+    @Deprecated
+    public String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
+            String isTemplate, boolean fullRightsForGroup, String uuid) throws Exception {
+        return metadataManager.createMetadata(context, templateId, groupOwner, source, owner, parentUuid, isTemplate, fullRightsForGroup,
+                uuid);
     }
 
-    /**
-     * Inserts a metadata into the database, optionally indexing it, and optionally applying
-     * automatic changes to it (update-fixed-info).
-     *
-     * @param context      the context describing the user and service
-     * @param schema       XSD this metadata conforms to
-     * @param metadataXml  the metadata to store
-     * @param uuid         unique id for this metadata
-     * @param owner        user who owns this metadata
-     * @param groupOwner   group this metadata belongs to
-     * @param source       id of the origin of this metadata (harvesting source, etc.)
-     * @param metadataType whether this metadata is a template
-     * @param docType      ?!
-     * @param category     category of this metadata
-     * @param createDate   date of creation
-     * @param changeDate   date of modification
-     * @param ufo          whether to apply automatic changes
-     * @param index        whether to index this metadata
-     * @return id, as a string
-     * @throws Exception hmm
-     */
-    public String insertMetadata(ServiceContext context, String schema, Element metadataXml, String uuid, int owner, String groupOwner, String source,
-                                 String metadataType, String docType, String category, String createDate, String changeDate, boolean ufo, boolean index) throws Exception {
-
-        boolean notifyChange = true;
-
-        if (source == null) {
-            source = getSettingManager().getSiteId();
-        }
-
-        if (StringUtils.isBlank(metadataType)) {
-            metadataType = MetadataType.METADATA.codeString;
-        }
-        final Metadata newMetadata = new Metadata().setUuid(uuid);
-        final ISODate isoChangeDate = changeDate != null ? new ISODate(changeDate) : new ISODate();
-        final ISODate isoCreateDate = createDate != null ? new ISODate(createDate) : new ISODate();
-        newMetadata.getDataInfo()
-            .setChangeDate(isoChangeDate)
-            .setCreateDate(isoCreateDate)
-            .setSchemaId(schema)
-            .setDoctype(docType)
-            .setRoot(metadataXml.getQualifiedName())
-            .setType(MetadataType.lookup(metadataType));
-        newMetadata.getSourceInfo()
-            .setOwner(owner)
-            .setSourceId(source);
-        if (StringUtils.isNotEmpty(groupOwner)) {
-            newMetadata.getSourceInfo().setGroupOwner(Integer.valueOf(groupOwner));
-        }
-        if (StringUtils.isNotEmpty(category)) {
-            MetadataCategory metadataCategory = getApplicationContext().getBean(MetadataCategoryRepository.class).findOneByName(category);
-            if (metadataCategory == null) {
-                throw new IllegalArgumentException("No category found with name: " + category);
-            }
-            newMetadata.getMetadataCategories().add(metadataCategory);
-        } else if (StringUtils.isNotEmpty(groupOwner)) {
-            //If the group has a default category, use it
-            Group group = getApplicationContext()
-                .getBean(GroupRepository.class)
-                .findOne(Integer.valueOf(groupOwner));
-            if (group.getDefaultCategory() != null) {
-                newMetadata.getMetadataCategories().add(group.getDefaultCategory());
-            }
-        }
-
-        boolean fullRightsForGroup = false;
-
-        int finalId = insertMetadata(context, newMetadata, metadataXml, notifyChange, index, ufo, UpdateDatestamp.NO,
-            fullRightsForGroup, false).getId();
-
-        return String.valueOf(finalId);
+    @Deprecated
+    public String insertMetadata(ServiceContext context, String schema, Element metadataXml, String uuid, int owner, String groupOwner,
+            String source, String metadataType, String docType, String category, String createDate, String changeDate, boolean ufo,
+            boolean index) throws Exception {
+        return metadataManager.insertMetadata(context, schema, metadataXml, uuid, owner, groupOwner, source, metadataType, docType,
+                category, createDate, changeDate, ufo, index);
     }
 
-    public Metadata insertMetadata(ServiceContext context, Metadata newMetadata, Element metadataXml, boolean notifyChange,
-                                   boolean index, boolean updateFixedInfo, UpdateDatestamp updateDatestamp,
-                                   boolean fullRightsForGroup, boolean forceRefreshReaders) throws Exception {
-        final String schema = newMetadata.getDataInfo().getSchemaId();
-
-        // Check if the schema is allowed by settings
-        String mdImportSetting = getSettingManager().getValue(Settings.METADATA_IMPORT_RESTRICT);
-        if(mdImportSetting != null && !mdImportSetting.equals("")) {
-            if(!Arrays.asList(mdImportSetting.split(",")).contains(schema)) {
-                throw new IllegalArgumentException(schema+" is not permitted in the database as a non-harvested metadata.  " +
-                        "Apply a import stylesheet to convert file to allowed schemas");
-            }
-        }
-
-        //--- force namespace prefix for iso19139 metadata
-        setNamespacePrefixUsingSchemas(schema, metadataXml);
-
-        if (updateFixedInfo && newMetadata.getDataInfo().getType() == MetadataType.METADATA) {
-            String parentUuid = null;
-            metadataXml = updateFixedInfo(schema, Optional.<Integer>absent(), newMetadata.getUuid(), metadataXml, parentUuid, updateDatestamp, context);
-        }
-
-        //--- store metadata
-        final Metadata savedMetadata = getXmlSerializer().insert(newMetadata, metadataXml, context);
-
-        final String stringId = String.valueOf(savedMetadata.getId());
-        String groupId = null;
-        final Integer groupIdI = newMetadata.getSourceInfo().getGroupOwner();
-        if (groupIdI != null) {
-            groupId = String.valueOf(groupIdI);
-        }
-        copyDefaultPrivForGroup(context, stringId, groupId, fullRightsForGroup);
-
-        if (index) {
-            indexMetadata(stringId, forceRefreshReaders, null);
-        }
-
-        if (notifyChange) {
-            // Notifies the metadata change to metatada notifier service
-            notifyMetadataChange(metadataXml, stringId);
-        }
-        return savedMetadata;
+    @Deprecated
+    public Metadata insertMetadata(ServiceContext context, Metadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
+            boolean updateFixedInfo, UpdateDatestamp updateDatestamp, boolean fullRightsForGroup, boolean forceRefreshReaders)
+            throws Exception {
+        return metadataManager.insertMetadata(context, newMetadata, metadataXml, notifyChange, index, updateFixedInfo, updateDatestamp,
+                fullRightsForGroup, forceRefreshReaders);
     }
 
-    /**
-     * Retrieves a metadata (in xml) given its id with no geonet:info.
-     */
+    @Deprecated
     public Element getMetadataNoInfo(ServiceContext srvContext, String id) throws Exception {
-        Element md = getMetadata(srvContext, id, false, false, false);
-        md.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);
-
-        // Drop Geonet namespace declaration. It may be contained
-        // multiple times, so loop on all.
-        final List<Namespace> additionalNamespaces =
-            new ArrayList<>(md.getAdditionalNamespaces());
-        for (Namespace n : additionalNamespaces) {
-            if (Edit.NAMESPACE.getURI().equals(n.getURI())) {
-                md.removeNamespaceDeclaration(Edit.NAMESPACE);
-            }
-        }
-        return md;
+        return metadataUtils.getMetadataNoInfo(srvContext, id);
     }
 
-    /**
-     * Retrieves a metadata (in xml) given its id. Use this method when you must retrieve a metadata
-     * in the same transaction.
-     */
+    @Deprecated
     public Element getMetadata(String id) throws Exception {
-        Element md = getXmlSerializer().selectNoXLinkResolver(id, false, false);
-        if (md == null) return null;
-        md.detach();
-        return md;
+        return metadataManager.getMetadata(id);
     }
 
-    /**
-     * Retrieves a metadata (in xml) given its id; adds editing information if requested and
-     * validation errors if requested.
-     *
-     * @param forEditing          Add extra element to build metadocument {@link
-     *                            EditLib#expandElements(String, Element)}
-     * @param keepXlinkAttributes When XLinks are resolved in non edit mode, do not remove XLink
-     *                            attributes.
-     */
-    public Element getMetadata(ServiceContext srvContext, String id, boolean forEditing,
-                               boolean withEditorValidationErrors, boolean keepXlinkAttributes) throws Exception {
-        boolean doXLinks = getXmlSerializer().resolveXLinks();
-        Element metadataXml = getXmlSerializer().selectNoXLinkResolver(id, false, forEditing);
-        if (metadataXml == null) return null;
-
-        String version = null;
-
-        if (forEditing) { // copy in xlink'd fragments but leave xlink atts to editor
-            if (doXLinks) Processor.processXLink(metadataXml, srvContext);
-            String schema = getMetadataSchema(id);
-
-            // Inflate metadata
-            Path inflateStyleSheet = getSchemaDir(schema).resolve(Geonet.File.INFLATE_METADATA);
-            if (Files.exists(inflateStyleSheet)) {
-                //--- setup environment
-                Element env = new Element("env");
-                env.addContent(new Element("lang").setText(srvContext.getLanguage()));
-
-                // add original metadata to result
-                Element result = new Element("root");
-                result.addContent(metadataXml);
-                result.addContent(env);
-
-                metadataXml = Xml.transform(result, inflateStyleSheet);
-            }
-
-            if (withEditorValidationErrors) {
-                version = doValidate(srvContext.getUserSession(), schema, id, metadataXml, srvContext.getLanguage(), forEditing).two();
-            } else {
-                editLib.expandElements(schema, metadataXml);
-                version = editLib.getVersionForEditing(schema, id, metadataXml);
-            }
-        } else {
-            if (doXLinks) {
-                if (keepXlinkAttributes) {
-                    Processor.processXLink(metadataXml, srvContext);
-                } else {
-                    Processor.detachXLink(metadataXml, srvContext);
-                }
-            }
-        }
-
-        metadataXml.addNamespaceDeclaration(Edit.NAMESPACE);
-        Element info = buildInfoElem(srvContext, id, version);
-        metadataXml.addContent(info);
-
-        metadataXml.detach();
-        return metadataXml;
+    @Deprecated
+    public Element getMetadata(ServiceContext srvContext, String id, boolean forEditing, boolean withEditorValidationErrors,
+            boolean keepXlinkAttributes) throws Exception {
+        return metadataManager.getMetadata(srvContext, id, forEditing, withEditorValidationErrors, keepXlinkAttributes);
     }
 
-    /**
-     * Retrieves a metadata element given it's ref.
-     */
+    @Deprecated
     public Element getElementByRef(Element md, String ref) {
-        return editLib.findElement(md, ref);
+        return metadataUtils.getElementByRef(md, ref);
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Metadata Update API
-    //---
-    //--------------------------------------------------------------------------
-
-    /**
-     * Returns true if the metadata exists in the database.
-     */
+    @Deprecated
     public boolean existsMetadata(int id) throws Exception {
-        return getMetadataRepository().exists(id);
+        return metadataUtils.existsMetadata(id);
     }
 
-    /**
-     * Returns true if the metadata uuid exists in the database.
-     */
+    @Deprecated
     public boolean existsMetadataUuid(String uuid) throws Exception {
-        return !getMetadataRepository().findAllIdsBy(hasMetadataUuid(uuid)).isEmpty();
+        return metadataUtils.existsMetadataUuid(uuid);
     }
 
-    /**
-     * Returns all the keywords in the system.
-     */
+    @Deprecated
     public Element getKeywords() throws Exception {
-        // TODO ES
-//        Collection<String> keywords = getSearchManager().getTerms("keyword");
-        Element el = new Element("keywords");
-
-//        for (Object keyword : keywords) {
-//            el.addContent(new Element("keyword").setText((String) keyword));
-//        }
-        return el;
+        return metadataUtils.getKeywords();
     }
 
-    /**
-     * For update of owner info.
-     */
-    public synchronized void updateMetadataOwner(final int id, final String owner, final String groupOwner) throws Exception {
-        getMetadataRepository().update(id, new Updater<Metadata>() {
-            @Override
-            public void apply(@Nonnull Metadata entity) {
-                entity.getSourceInfo().setGroupOwner(Integer.valueOf(groupOwner));
-                entity.getSourceInfo().setOwner(Integer.valueOf(owner));
-            }
-        });
+    @Deprecated
+    public void updateMetadataOwner(final int id, final String owner, final String groupOwner) throws Exception {
+        metadataManager.updateMetadataOwner(id, owner, groupOwner);
     }
 
-    /**
-     * Updates a metadata record. Deletes validation report currently in session (if any). If user
-     * asks for validation the validation report will be (re-)created then.
-     *
-     * @return metadata if the that was updated
-     */
+    @Deprecated
     public synchronized Metadata updateMetadata(final ServiceContext context, final String metadataId, final Element md,
-                                                final boolean validate, final boolean ufo, final boolean index, final String lang,
-                                                final String changeDate, final boolean updateDateStamp) throws Exception {
-        Element metadataXml = md;
-
-        // when invoked from harvesters, session is null?
-        UserSession session = context.getUserSession();
-        if (session != null) {
-            session.removeProperty(Geonet.Session.VALIDATION_REPORT + metadataId);
-        }
-        String schema = getMetadataSchema(metadataId);
-        if (ufo) {
-            String parentUuid = null;
-            Integer intId = Integer.valueOf(metadataId);
-
-            // Notifies the metadata change to metatada notifier service
-            final Metadata metadata = getMetadataRepository().findOne(metadataId);
-
-            String uuid = null;
-
-            if (getSchemaManager().getSchema(schema).isReadwriteUUID()
-                && metadata.getDataInfo().getType() != MetadataType.SUB_TEMPLATE
-                && metadata.getDataInfo().getType() != MetadataType.TEMPLATE_OF_SUB_TEMPLATE) {
-                uuid = extractUUID(schema, metadataXml);
-            }
-
-            metadataXml = updateFixedInfo(schema, Optional.of(intId), uuid, metadataXml, parentUuid, (updateDateStamp ? UpdateDatestamp.YES : UpdateDatestamp.NO), context);
-        }
-
-        //--- force namespace prefix for iso19139 metadata
-        setNamespacePrefixUsingSchemas(schema, metadataXml);
-
-        final Metadata metadata = getMetadataRepository().findOne(metadataId);
-
-        String uuid = null;
-        if (getSchemaManager().getSchema(schema).isReadwriteUUID()
-            && metadata.getDataInfo().getType() != MetadataType.SUB_TEMPLATE
-            && metadata.getDataInfo().getType() != MetadataType.TEMPLATE_OF_SUB_TEMPLATE) {
-            uuid = extractUUID(schema, metadataXml);
-        }
-
-        //--- write metadata to dbms
-        getXmlSerializer().update(metadataId, metadataXml, changeDate, updateDateStamp, uuid, context);
-        // Notifies the metadata change to metadata notifier service
-        notifyMetadataChange(metadataXml, metadataId);
-
-        try {
-            //--- do the validation last - it throws exceptions
-            if (session != null && validate) {
-                doValidate(session, schema, metadataId, metadataXml, lang, false);
-            }
-        } finally {
-            if (index) {
-                //--- update search criteria
-                indexMetadata(metadataId, true, null);
-            }
-        }
-
-        if (metadata.getDataInfo().getType() == MetadataType.SUB_TEMPLATE) {
-            if (!index) {
-                indexMetadata(metadataId, true, null);
-            }
-            MetaSearcher searcher = context.getBean(SearchManager.class).newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE);
-            Element parameters =  new Element(Jeeves.Elem.REQUEST);
-            parameters.addContent(new Element(Geonet.IndexFieldNames.XLINK).addContent("*" + metadata.getUuid() + "*"));
-            parameters.addContent(new Element(Geonet.SearchResult.BUILD_SUMMARY).setText("false"));
-            parameters.addContent(new Element(SearchParameter.ISADMIN).addContent("true"));
-            parameters.addContent(new Element(SearchParameter.ISTEMPLATE).addContent("y or n"));
-            ServiceConfig config = new ServiceConfig();
-            searcher.search(context, parameters, config);
-            Map<Integer, Metadata> result = ((LuceneSearcher) searcher).getAllMdInfo(context, 500);
-            for (Integer id: result.keySet()) {
-                IndexingList list = context.getBean(IndexingList.class);
-                list.add(id);
-            }
-        }
-
-        // Return an up to date metadata record
-        return getMetadataRepository().findOne(metadataId);
+            final boolean validate, final boolean ufo, final boolean index, final String lang, final String changeDate,
+            final boolean updateDateStamp) throws Exception {
+        return metadataManager.updateMetadata(context, metadataId, md, validate, ufo, index, lang, changeDate, updateDateStamp);
     }
 
-    /**
-     * Validates an xml document, using autodetectschema to determine how.
-     *
-     * @return true if metadata is valid
-     */
+    @Deprecated
     public boolean validate(Element xml) {
-        try {
-            String schema = autodetectSchema(xml);
-            validate(schema, xml);
-            return true;
-        }
-        // XSD validation error(s)
-        catch (Exception x) {
-            // do not print stacktrace as this is 'normal' program flow
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                Log.debug(Geonet.DATA_MANAGER, "invalid metadata: " + x.getMessage(), x);
-            return false;
-        }
+        return metadataValidator.validate(xml);
     }
 
-    /**
-     * Used by harvesters that need to validate metadata.
-     *
-     * @param schema     name of the schema to validate against
-     * @param metadataId metadata id - used to record validation status
-     * @param doc        metadata document as JDOM Document not JDOM Element
-     * @param lang       Language from context
-     */
+    @Deprecated
     public boolean doValidate(String schema, String metadataId, Document doc, String lang) {
-        Integer intMetadataId = Integer.valueOf(metadataId);
-        List<MetadataValidation> validations = new ArrayList<>();
-        boolean valid = true;
-
-        if (doc.getDocType() != null) {
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                Log.debug(Geonet.DATA_MANAGER, "Validating against dtd " + doc.getDocType());
-
-            // if document has a doctype then validate using that (assuming that the
-            // dtd is either mapped locally or will be cached after first validate)
-            try {
-                Xml.validate(doc);
-                validations.add(new MetadataValidation().
-                    setId(new MetadataValidationId(intMetadataId, "dtd")).
-                    setStatus(MetadataValidationStatus.VALID).
-                    setRequired(true).
-                    setNumTests(1).
-                    setNumFailures(0));
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, "Valid.");
-                }
-            } catch (Exception e) {
-                validations.add(new MetadataValidation().
-                    setId(new MetadataValidationId(intMetadataId, "dtd")).
-                    setStatus(MetadataValidationStatus.INVALID).
-                    setRequired(true).
-                    setNumTests(1).
-                    setNumFailures(1));
-
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, "Invalid.", e);
-                }
-                valid = false;
-            }
-        } else {
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                Log.debug(Geonet.DATA_MANAGER, "Validating against XSD " + schema);
-            }
-            // do XSD validation
-            Element md = doc.getRootElement();
-            Element xsdErrors = getXSDXmlReport(schema, md);
-
-            int xsdErrorCount = 0;
-            if (xsdErrors != null && xsdErrors.getContent().size() > 0) {
-                xsdErrorCount = xsdErrors.getContent().size();
-            }
-            if (xsdErrorCount > 0) {
-                validations.add(new MetadataValidation().
-                    setId(new MetadataValidationId(intMetadataId, "xsd")).
-                    setStatus(MetadataValidationStatus.INVALID).
-                    setRequired(true).
-                    setNumTests(xsdErrorCount).
-                    setNumFailures(xsdErrorCount));
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                    Log.debug(Geonet.DATA_MANAGER, "Invalid.");
-                valid = false;
-            } else {
-                validations.add(new MetadataValidation().
-                    setId(new MetadataValidationId(intMetadataId, "xsd")).
-                    setStatus(MetadataValidationStatus.VALID).
-                    setRequired(true).
-                    setNumTests(1).
-                    setNumFailures(0));
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                    Log.debug(Geonet.DATA_MANAGER, "Valid.");
-            }
-            try {
-                editLib.enumerateTree(md);
-                //Apply custom schematron rules
-                Element errors = applyCustomSchematronRules(schema, Integer.parseInt(metadataId), doc.getRootElement(), lang, validations);
-                valid = valid && errors == null;
-                editLib.removeEditingInfo(md);
-            } catch (Exception e) {
-                e.printStackTrace();
-                Log.error(Geonet.DATA_MANAGER, "Could not run schematron validation on metadata " + metadataId + ": " + e.getMessage());
-                valid = false;
-            }
-        }
-
-        // now save the validation status
-        try {
-            saveValidationStatus(intMetadataId, validations);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Log.error(Geonet.DATA_MANAGER, "Could not save validation status on metadata " + metadataId + ": " + e.getMessage());
-        }
-
-        return valid;
+        return metadataValidator.doValidate(schema, metadataId, doc, lang);
     }
 
-
-    //--------------------------------------------------------------------------
-    //---
-    //--- Metadata Delete API
-    //---
-    //--------------------------------------------------------------------------
-
-    /**
-     * Used by the validate embedded service. The validation report is stored in the session.
-     *
-     * @param forEditing TODO
-     */
-    public Pair<Element, String> doValidate(UserSession session, String schema, String metadataId, Element md, String lang, boolean forEditing) throws Exception {
-        int intMetadataId = Integer.parseInt(metadataId);
-        String version = null;
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Creating validation report for record #" + metadataId + " [schema: " + schema + "].");
-
-        Element sessionReport = (Element) session.getProperty(Geonet.Session.VALIDATION_REPORT + metadataId);
-        if (sessionReport != null && !forEditing) {
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                Log.debug(Geonet.DATA_MANAGER, "  Validation report available in session.");
-            sessionReport.detach();
-            return Pair.read(sessionReport, version);
-        }
-
-        List<MetadataValidation> validations = new ArrayList<>();
-        Element errorReport = new Element("report", Edit.NAMESPACE);
-        errorReport.setAttribute("id", metadataId, Edit.NAMESPACE);
-
-        //-- get an XSD validation report and add results to the metadata
-        //-- as geonet:xsderror attributes on the affected elements
-        Element xsdErrors = getXSDXmlReport(schema, md);
-        int xsdErrorCount = 0;
-        if (xsdErrors != null) {
-            xsdErrorCount = xsdErrors.getContent().size();
-        }
-        if (xsdErrorCount > 0) {
-            errorReport.addContent(xsdErrors);
-            validations.add(new MetadataValidation().
-                setId(new MetadataValidationId(intMetadataId, "xsd")).
-                setStatus(MetadataValidationStatus.INVALID).
-                setRequired(true).
-                setNumTests(xsdErrorCount).
-                setNumFailures(xsdErrorCount));
-
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                Log.debug(Geonet.DATA_MANAGER, "  - XSD error: " + Xml.getString(xsdErrors));
-            }
-        } else {
-            validations.add(new MetadataValidation().
-                setId(new MetadataValidationId(intMetadataId, "xsd")).
-                setStatus(MetadataValidationStatus.VALID).
-                setRequired(true).
-                setNumTests(1).
-                setNumFailures(0));
-
-            if (Log.isTraceEnabled(Geonet.DATA_MANAGER)) {
-                Log.trace(Geonet.DATA_MANAGER, "Valid.");
-            }
-        }
-
-        // ...then schematrons
-        // edit mode
-        Element error = null;
-        if (forEditing) {
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                Log.debug(Geonet.DATA_MANAGER, "  - Schematron in editing mode.");
-            //-- now expand the elements and add the geonet: elements
-            editLib.expandElements(schema, md);
-            version = editLib.getVersionForEditing(schema, metadataId, md);
-
-            //Apply custom schematron rules
-            error = applyCustomSchematronRules(schema, Integer.parseInt(metadataId), md, lang, validations);
-        } else {
-            try {
-                // enumerate the metadata xml so that we can report any problems found
-                // by the schematron_xml script to the geonetwork editor
-                editLib.enumerateTree(md);
-
-                //Apply custom schematron rules
-                error = applyCustomSchematronRules(schema, Integer.parseInt(metadataId), md, lang, validations);
-
-                // remove editing info added by enumerateTree
-                editLib.removeEditingInfo(md);
-
-            } catch (Exception e) {
-                e.printStackTrace();
-                Log.error(Geonet.DATA_MANAGER, "Could not run schematron validation on metadata " + metadataId + ": " + e.getMessage());
-            }
-        }
-
-        if (error != null) {
-            errorReport.addContent(error);
-        }
-
-        // Save report in session (invalidate by next update) and db
-        try {
-            saveValidationStatus(intMetadataId, validations);
-        } catch (Exception e) {
-            Log.error(Geonet.DATA_MANAGER, "Could not save validation status on metadata " + metadataId + ": " + e.getMessage(), e);
-        }
-
-        return Pair.read(errorReport, version);
+    @Deprecated
+    public Pair<Element, String> doValidate(UserSession session, String schema, String metadataId, Element md, String lang,
+            boolean forEditing) throws Exception {
+        return metadataValidator.doValidate(session, schema, metadataId, md, lang, forEditing);
     }
 
-    /**
-     * Creates XML schematron report for each set of rules defined in schema directory. This method
-     * assumes that you've run enumerateTree on the metadata
-     *
-     * Returns null if no error on validation.
-     */
-    public Element applyCustomSchematronRules(String schema, int metadataId, Element md,
-                                              String lang, List<MetadataValidation> validations) {
-        final SchematronValidator schematronValidator = getApplicationContext().getBean(SchematronValidator.class);
-        return schematronValidator.applyCustomSchematronRules(schema, metadataId, md, lang, validations);
+    @Deprecated
+    public Element applyCustomSchematronRules(String schema, int metadataId, Element md, String lang,
+            List<MetadataValidation> validations) {
+        return metadataValidator.applyCustomSchematronRules(schema, metadataId, md, lang, validations);
     }
 
-    /**
-     * Saves validation status information into the database for the current record.
-     *
-     * @param id          the metadata record internal identifier
-     * @param validations the validation reports for each type of validation and schematron
-     *                    validation
-     */
-    private void saveValidationStatus(int id, List<MetadataValidation> validations) throws Exception {
-        final MetadataValidationRepository validationRepository = getBean(MetadataValidationRepository.class);
-        validationRepository.deleteAllById_MetadataId(id);
-        validationRepository.save(validations);
-    }
-
-    /**
-     * TODO Javadoc.
-     */
-    private void deleteMetadataFromDB(ServiceContext context, String id) throws Exception {
-        //--- remove operations
-        deleteMetadataOper(context, id, false);
-
-        int intId = Integer.parseInt(id);
-        getApplicationContext().getBean(MetadataRatingByIpRepository.class).deleteAllById_MetadataId(intId);
-        getBean(MetadataValidationRepository.class).deleteAllById_MetadataId(intId);
-        getApplicationContext().getBean(MetadataStatusRepository.class).deleteAllById_MetadataId(intId);
-        getApplicationContext().getBean(UserSavedSelectionRepository.class).deleteAllByUuid(getMetadataUuid(id));
-
-        // Logical delete for metadata file uploads
-        PathSpec<MetadataFileUpload, String> deletedDatePathSpec = new PathSpec<MetadataFileUpload, String>() {
-            @Override
-            public javax.persistence.criteria.Path<String> getPath(Root<MetadataFileUpload> root) {
-                return root.get(MetadataFileUpload_.deletedDate);
-            }
-        };
-
-        getApplicationContext().getBean(MetadataFileUploadRepository.class).createBatchUpdateQuery(deletedDatePathSpec,
-            new ISODate().toString(),
-            MetadataFileUploadSpecs.isNotDeletedForMetadata(intId));
-
-        //--- remove metadata
-        getXmlSerializer().delete(id, context);
-    }
-
-    //--------------------------------------------------------------------------
-    //---
-    //--- Metadata thumbnail API
-    //---
-    //--------------------------------------------------------------------------
-
-    /**
-     * Removes a metadata.
-     */
+    @Deprecated
     public synchronized void deleteMetadata(ServiceContext context, String metadataId) throws Exception {
-        String uuid = getMetadataUuid(metadataId);
-        Metadata findOne = getMetadataRepository().findOne(metadataId);
-        if (findOne != null) {
-            boolean isMetadata = findOne.getDataInfo().getType() == MetadataType.METADATA;
-
-            deleteMetadataFromDB(context, metadataId);
-
-            // Notifies the metadata change to metatada notifier service
-            if (isMetadata) {
-                context.getBean(MetadataNotifierManager.class).deleteMetadata(metadataId, uuid, context);
-            }
-        }
-
-        //--- update search criteria
-        getSearchManager().delete(metadataId + "");
-//        _entityManager.flush();
-//        _entityManager.clear();
+        metadataManager.deleteMetadataGroup(context, metadataId);
     }
 
-    /**
-     *
-     * @param context
-     * @param metadataId
-     * @throws Exception
-     */
+    @Deprecated
     public synchronized void deleteMetadataGroup(ServiceContext context, String metadataId) throws Exception {
-        deleteMetadataFromDB(context, metadataId);
-        //--- update search criteria
-        getSearchManager().delete(metadataId + "");
+        metadataManager.deleteMetadata(context, metadataId);
     }
 
-    /**
-     * Removes all operations stored for a metadata.
-     */
+    @Deprecated
     public void deleteMetadataOper(ServiceContext context, String metadataId, boolean skipAllReservedGroup) throws Exception {
-        OperationAllowedRepository operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
-
-        if (skipAllReservedGroup) {
-            int[] exclude = new int[] {
-                ReservedGroup.all.getId(),
-                    ReservedGroup.intranet.getId(),
-                    ReservedGroup.guest.getId()
-            };
-            operationAllowedRepository.deleteAllByMetadataIdExceptGroupId(
-                Integer.parseInt(metadataId), exclude
-            );
-        } else {
-            operationAllowedRepository.deleteAllByIdAttribute(OperationAllowedId_.metadataId, Integer.parseInt(metadataId));
-        }
+        metadataOperations.deleteMetadataOper(context, metadataId, skipAllReservedGroup);
     }
 
-    /**
-     *
-     * @param metadataId
-     * @return
-     * @throws Exception
-     */
+    @Deprecated
     public Element getThumbnails(ServiceContext context, String metadataId) throws Exception {
-        Element md = getXmlSerializer().select(context, metadataId);
-
-        if (md == null)
-            return null;
-
-        md.detach();
-
-        String schema = getMetadataSchema(metadataId);
-
-        //--- do an XSL  transformation
-        Path styleSheet = getSchemaDir(schema).resolve(Geonet.File.EXTRACT_THUMBNAILS);
-
-        Element result = Xml.transform(md, styleSheet);
-        result.addContent(new Element("id").setText(metadataId));
-
-        return result;
+        return metadataUtils.getThumbnails(context, metadataId);
     }
 
-    /**
-     *
-     * @param context
-     * @param id
-     * @param small
-     * @param file
-     * @throws Exception
-     */
+    @Deprecated
     public void setThumbnail(ServiceContext context, String id, boolean small, String file, boolean indexAfterChange) throws Exception {
-        int pos = file.lastIndexOf('.');
-        String ext = (pos == -1) ? "???" : file.substring(pos + 1);
-
-        Element env = new Element("env");
-        env.addContent(new Element("file").setText(file));
-        env.addContent(new Element("ext").setText(ext));
-
-        String host = getSettingManager().getValue(Settings.SYSTEM_SERVER_HOST);
-        String port = getSettingManager().getValue(Settings.SYSTEM_SERVER_PORT);
-        String baseUrl = context.getBaseUrl();
-
-        env.addContent(new Element("host").setText(host));
-        env.addContent(new Element("port").setText(port));
-        env.addContent(new Element("baseUrl").setText(baseUrl));
-        // TODO: Remove host, port, baseUrl and simplify the
-        // URL created in the XSLT. Keeping it for the time
-        // as many profiles depend on it.
-        env.addContent(new Element("url").setText(getSettingManager().getSiteURL(context)));
-
-        manageThumbnail(context, id, small, env, Geonet.File.SET_THUMBNAIL, indexAfterChange);
+        metadataUtils.setThumbnail(context, id, small, file, indexAfterChange);
     }
 
-    /**
-     *
-     * @param context
-     * @param id
-     * @param small
-     * @throws Exception
-     */
+    @Deprecated
     public void unsetThumbnail(ServiceContext context, String id, boolean small, boolean indexAfterChange) throws Exception {
-        Element env = new Element("env");
-
-        manageThumbnail(context, id, small, env, Geonet.File.UNSET_THUMBNAIL, indexAfterChange);
+        metadataUtils.unsetThumbnail(context, id, small, indexAfterChange);
     }
 
-    /**
-     *
-     * @param context
-     * @param id
-     * @param small
-     * @param env
-     * @param styleSheet
-     * @param indexAfterChange
-     * @throws Exception
-     */
-    private void manageThumbnail(ServiceContext context, String id, boolean small, Element env,
-                                 String styleSheet, boolean indexAfterChange) throws Exception {
-        boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = true;
-        Element md = getMetadata(context, id, forEditing, withValidationErrors, keepXlinkAttributes);
-
-        if (md == null)
-            return;
-
-        md.detach();
-
-        String schema = getMetadataSchema(id);
-
-        //--- setup environment
-        String type = small ? "thumbnail" : "large_thumbnail";
-        env.addContent(new Element("type").setText(type));
-        transformMd(context, id, md, env, schema, styleSheet, indexAfterChange);
+    @Deprecated
+    public void setDataCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction,
+            String licensename, String type) throws Exception {
+        metadataUtils.setDataCommons(context, id, licenseurl, imageurl, jurisdiction, licensename, type);
     }
 
-    /**
-     *
-     * @param context
-     * @param metadataId
-     * @param md
-     * @param env
-     * @param schema
-     * @param styleSheet
-     * @param indexAfterChange
-     * @throws Exception
-     */
-    private void transformMd(ServiceContext context, String metadataId, Element md, Element env, String schema, String styleSheet, boolean indexAfterChange) throws Exception {
-
-        if (env.getChild("host") == null) {
-            String host = getSettingManager().getValue(Settings.SYSTEM_SERVER_HOST);
-            String port = getSettingManager().getValue(Settings.SYSTEM_SERVER_PORT);
-            env.addContent(new Element("host").setText(host));
-            env.addContent(new Element("port").setText(port));
-        }
-
-        //--- setup root element
-        Element root = new Element("root");
-        root.addContent(md);
-        root.addContent(env);
-
-        //--- do an XSL  transformation
-        Path styleSheetPath = getSchemaDir(schema).resolve(styleSheet);
-
-        md = Xml.transform(root, styleSheetPath);
-        String changeDate = null;
-        String uuid = null;
-        if (getSchemaManager().getSchema(schema).isReadwriteUUID()) {
-            uuid = extractUUID(schema, md);
-        }
-
-        getXmlSerializer().update(metadataId, md, changeDate, true, uuid, context);
-
-        if (indexAfterChange) {
-            // Notifies the metadata change to metatada notifier service
-            notifyMetadataChange(md, metadataId);
-
-            //--- update search criteria
-            indexMetadata(metadataId, true, null);
-        }
+    @Deprecated
+    public void setCreativeCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction,
+            String licensename, String type) throws Exception {
+        metadataUtils.setCreativeCommons(context, id, licenseurl, imageurl, jurisdiction, licensename, type);
     }
 
-    /**
-     *
-     * @param context
-     * @param id
-     * @param licenseurl
-     * @param imageurl
-     * @param jurisdiction
-     * @param licensename
-     * @param type
-     * @throws Exception
-     */
-    public void setDataCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction, String licensename, String type) throws Exception {
-        Element env = prepareCommonsEnv(licenseurl, imageurl, jurisdiction, licensename, type);
-        manageCommons(context, id, env, Geonet.File.SET_DATACOMMONS);
-    }
-
-    //--------------------------------------------------------------------------
-    //---
-    //--- Privileges API
-    //---
-    //--------------------------------------------------------------------------
-
-    private Element prepareCommonsEnv(String licenseurl, String imageurl, String jurisdiction, String licensename, String type) {
-        Element env = new Element("env");
-        env.addContent(new Element("imageurl").setText(imageurl));
-        env.addContent(new Element("licenseurl").setText(licenseurl));
-        env.addContent(new Element("jurisdiction").setText(jurisdiction));
-        env.addContent(new Element("licensename").setText(licensename));
-        env.addContent(new Element("type").setText(type));
-        return env;
-    }
-
-    /**
-     *
-     * @param context
-     * @param id
-     * @param licenseurl
-     * @param imageurl
-     * @param jurisdiction
-     * @param licensename
-     * @param type
-     * @throws Exception
-     */
-    public void setCreativeCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction, String licensename, String type) throws Exception {
-        Element env = prepareCommonsEnv(licenseurl, imageurl, jurisdiction, licensename, type);
-        manageCommons(context, id, env, Geonet.File.SET_CREATIVECOMMONS);
-    }
-
-    /**
-     *
-     * @param context
-     * @param id
-     * @param env
-     * @param styleSheet
-     * @throws Exception
-     */
-    private void manageCommons(ServiceContext context, String id, Element env, String styleSheet) throws Exception {
-        Lib.resource.checkEditPrivilege(context, id);
-        Element md = getXmlSerializer().select(context, id);
-
-        if (md == null) return;
-
-        md.detach();
-
-        String schema = getMetadataSchema(id);
-        transformMd(context, id, md, env, schema, styleSheet, true);
-    }
-
-    /**
-     * Adds a permission to a group. Metadata is not reindexed.
-     */
+    @Deprecated
     public void setOperation(ServiceContext context, String mdId, String grpId, ReservedOperation op) throws Exception {
-        setOperation(context, Integer.parseInt(mdId), Integer.parseInt(grpId), op.getId());
+        metadataOperations.setOperation(context, mdId, grpId, op);
     }
 
-    /**
-     * Adds a permission to a group. Metadata is not reindexed.
-     */
+    @Deprecated
     public void setOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception {
-        setOperation(context, Integer.parseInt(mdId), Integer.parseInt(grpId), Integer.valueOf(opId));
+        metadataOperations.setOperation(context, mdId, grpId, opId);
     }
 
-    /**
-     * Set metadata privileges.
-     *
-     * Administrator can set operation for any groups.
-     *
-     * For reserved group (ie. Internet, Intranet & Guest), user MUST be reviewer of one group. For
-     * other group, if "Only set privileges to user's groups" is set in catalog configuration user
-     * MUST be a member of the group.
-     *
-     * @param mdId  The metadata identifier
-     * @param grpId The group identifier
-     * @param opId  The operation identifier
-     * @return true if the operation was set.
-     */
+    @Deprecated
     public boolean setOperation(ServiceContext context, int mdId, int grpId, int opId) throws Exception {
-        OperationAllowedRepository opAllowedRepo = getApplicationContext().getBean(OperationAllowedRepository.class);
-        Optional<OperationAllowed> opAllowed = getOperationAllowedToAdd(context, mdId, grpId, opId);
-
-        // Set operation
-        if (opAllowed.isPresent()) {
-            opAllowedRepo.save(opAllowed.get());
-            getSvnManager().setHistory(mdId + "", context);
-            return true;
-        }
-
-        return false;
+        return metadataOperations.setOperation(context, mdId, grpId, opId);
     }
 
-    /**
-     * Check that the operation has not been added and if not that it can be added. <ul> <li> If the
-     * operation can be added then an non-empty optional is return. </li> <li> If it has already
-     * been added the return empty optional </li> <li> If it is not permitted to be added throw
-     * exception. </li> </ul>
-     */
-    public Optional<OperationAllowed> getOperationAllowedToAdd(final ServiceContext context, final int mdId, final int grpId, final int opId) {
-        OperationAllowedRepository opAllowedRepo = getApplicationContext().getBean(OperationAllowedRepository.class);
-        UserGroupRepository userGroupRepo = getApplicationContext().getBean(UserGroupRepository.class);
-        final OperationAllowed operationAllowed = opAllowedRepo
-            .findOneById_GroupIdAndId_MetadataIdAndId_OperationId(grpId, mdId, opId);
-
-        if (operationAllowed == null) {
-            checkOperationPermission(context, grpId, userGroupRepo);
-        }
-
-        if (operationAllowed == null) {
-            return Optional.of(new OperationAllowed(new OperationAllowedId().setGroupId(grpId).setMetadataId(mdId).setOperationId(opId)));
-        } else {
-            return Optional.absent();
-        }
+    @Deprecated
+    public Optional<OperationAllowed> getOperationAllowedToAdd(final ServiceContext context, final int mdId, final int grpId,
+            final int opId) {
+        return metadataOperations.getOperationAllowedToAdd(context, mdId, grpId, opId);
     }
 
+    @Deprecated
     public void checkOperationPermission(ServiceContext context, int grpId, UserGroupRepository userGroupRepo) {
-        // Check user privileges
-        // Session may not be defined when a harvester is running
-        if (context.getUserSession() != null) {
-            Profile userProfile = context.getUserSession().getProfile();
-            if (!(userProfile == Profile.Administrator || userProfile == Profile.UserAdmin)) {
-                int userId = context.getUserSession().getUserIdAsInt();
-                // Reserved groups
-                if (ReservedGroup.isReserved(grpId)) {
-
-                    Specification<UserGroup> hasUserIdAndProfile = where(UserGroupSpecs.hasProfile(Profile.Reviewer))
-                        .and(UserGroupSpecs.hasUserId(userId));
-                    List<Integer> groupIds = userGroupRepo.findGroupIds(hasUserIdAndProfile);
-
-                    if (groupIds.isEmpty()) {
-                        throw new ServiceNotAllowedEx("User can't set operation for group " + grpId + " because the user in not a "
-                            + "Reviewer of any group.");
-                    }
-                } else {
-                    String userGroupsOnly = getSettingManager().getValue(Settings.SYSTEM_METADATAPRIVS_USERGROUPONLY);
-                    if (userGroupsOnly.equals("true")) {
-                        // If user is member of the group, user can set operation
-
-                        if (userGroupRepo.exists(new UserGroupId().setGroupId(grpId).setUserId(userId))) {
-                            throw new ServiceNotAllowedEx("User can't set operation for group " + grpId + " because the user in not"
-                                + " member of this group.");
-                        }
-                    }
-                }
-            }
-        }
+        metadataOperations.checkOperationPermission(context, grpId, userGroupRepo);
     }
 
-    /**
-     *
-     * @param context
-     * @param mdId
-     * @param grpId
-     * @param opId
-     * @throws Exception
-     */
+    @Deprecated
     public void unsetOperation(ServiceContext context, String mdId, String grpId, ReservedOperation opId) throws Exception {
-        unsetOperation(context, Integer.parseInt(mdId), Integer.parseInt(grpId), opId.getId());
+        metadataOperations.unsetOperation(context, mdId, grpId, opId);
     }
 
-    /**
-     *
-     * @param context
-     * @param mdId
-     * @param grpId
-     * @param opId
-     * @throws Exception
-     */
+    @Deprecated
     public void unsetOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception {
-        unsetOperation(context, Integer.parseInt(mdId), Integer.parseInt(grpId), Integer.valueOf(opId));
+        metadataOperations.unsetOperation(context, mdId, grpId, opId);
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Check User Id to avoid foreign key problems
-    //---
-    //--------------------------------------------------------------------------
-
-    /**
-     * @param mdId    metadata id
-     * @param groupId group id
-     * @param operId  operation id
-     */
+    @Deprecated
     public void unsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception {
-        checkOperationPermission(context, groupId, context.getBean(UserGroupRepository.class));
-        forceUnsetOperation(context, mdId, groupId, operId);
+        metadataOperations.unsetOperation(context, mdId, groupId, operId);
     }
 
-    /**
-     * Unset operation without checking if user privileges allows the operation. This may be useful
-     * when a user is an editor and internal operations needs to update privilages for reserved
-     * group. eg. {@link org.fao.geonet.kernel.metadata.DefaultStatusActions}
-     */
+    @Deprecated
     public void forceUnsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception {
-        OperationAllowedId id = new OperationAllowedId().setGroupId(groupId).setMetadataId(mdId).setOperationId(operId);
-        final OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
-        if (repository.exists(id)) {
-            repository.delete(id);
-            if (getSvnManager() != null) {
-                getSvnManager().setHistory(mdId + "", context);
-            }
-        }
+        metadataOperations.forceUnsetOperation(context, mdId, groupId, operId);
     }
 
-    /**
-     * Sets VIEW and NOTIFY privileges for a metadata to a group.
-     *
-     * @param context            service context
-     * @param id                 metadata id
-     * @param groupId            group id
-     * @param fullRightsForGroup TODO
-     * @throws Exception hmmm
-     */
+    @Deprecated
     public void copyDefaultPrivForGroup(ServiceContext context, String id, String groupId, boolean fullRightsForGroup) throws Exception {
-        if (StringUtils.isBlank(groupId)) {
-            Log.info(Geonet.DATA_MANAGER, "Attempt to set default privileges for metadata " + id + " to an empty groupid");
-            return;
-        }
-        //--- store access operations for group
-
-        setOperation(context, id, groupId, ReservedOperation.view);
-        setOperation(context, id, groupId, ReservedOperation.notify);
-        //
-        // Restrictive: new and inserted records should not be editable,
-        // their resources can't be downloaded and any interactive maps can't be
-        // displayed by users in the same group
-        if (fullRightsForGroup) {
-            setOperation(context, id, groupId, ReservedOperation.editing);
-            setOperation(context, id, groupId, ReservedOperation.download);
-            setOperation(context, id, groupId, ReservedOperation.dynamic);
-        }
-        // Ultimately this should be configurable elsewhere
+        metadataOperations.copyDefaultPrivForGroup(context, id, groupId, fullRightsForGroup);
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Status API
-    //---
-    //--------------------------------------------------------------------------
-
+    @Deprecated
     public boolean isUserMetadataOwner(int userId) throws Exception {
-        return getMetadataRepository().count(MetadataSpecs.isOwnedByUser(userId)) > 0;
+        return metadataOperations.isUserMetadataOwner(userId);
     }
 
+    @Deprecated
     public boolean isUserMetadataStatus(int userId) throws Exception {
-        MetadataStatusRepository statusRepository = getApplicationContext().getBean(MetadataStatusRepository.class);
-
-        return statusRepository.count(MetadataStatusSpecs.hasUserId(userId)) > 0;
+        return metadataStatus.isUserMetadataStatus(userId);
     }
 
+    @Deprecated
     public boolean existsUser(ServiceContext context, int id) throws Exception {
-        return context.getBean(UserRepository.class).count(where(UserSpecs.hasUserId(id))) > 0;
+        return metadataOperations.existsUser(context, id);
     }
 
-    /**
-     * Return all status records for the metadata id - current status is the first child due to sort
-     * by DESC on changeDate
-     */
+    @Deprecated
     public MetadataStatus getStatus(int metadataId) throws Exception {
-        String sortField = SortUtils.createPath(MetadataStatus_.id, MetadataStatusId_.changeDate);
-        final MetadataStatusRepository statusRepository = getApplicationContext().getBean(MetadataStatusRepository.class);
-        List<MetadataStatus> status = statusRepository.findAllById_MetadataId(metadataId, new Sort(Sort.Direction.DESC, sortField));
-        if (status.isEmpty()) {
-            return null;
-        } else {
-            return status.get(0);
-        }
+        return metadataStatus.getStatus(metadataId);
     }
 
-    /**
-     * Return status of metadata id.
-     */
+    @Deprecated
     public String getCurrentStatus(int metadataId) throws Exception {
-        MetadataStatus status = getStatus(metadataId);
-        if (status == null) {
-            return Params.Status.UNKNOWN;
-        }
-
-        return String.valueOf(status.getId().getStatusId());
+        return metadataStatus.getCurrentStatus(metadataId);
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Categories API
-    //---
-    //--------------------------------------------------------------------------
-
-    /**
-     * Set status of metadata id and reindex metadata id afterwards.
-     *
-     * @return the saved status entity object
-     */
+    @Deprecated
     public MetadataStatus setStatus(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception {
-        MetadataStatus statusObject = setStatusExt(context, id, status, changeDate, changeMessage);
-        indexMetadata(Integer.toString(id), true, null);
-        return statusObject;
+        return metadataStatus.setStatus(context, id, status, changeDate, changeMessage);
     }
 
-    /**
-     * Set status of metadata id and do not reindex metadata id afterwards.
-     *
-     * @return the saved status entity object
-     */
-    public MetadataStatus setStatusExt(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception {
-        final StatusValueRepository statusValueRepository = getApplicationContext().getBean(StatusValueRepository.class);
-
-        MetadataStatus metatatStatus = new MetadataStatus();
-        metatatStatus.setChangeMessage(changeMessage);
-        metatatStatus.setStatusValue(statusValueRepository.findOne(status));
-        int userId = context.getUserSession().getUserIdAsInt();
-        MetadataStatusId mdStatusId = new MetadataStatusId()
-            .setStatusId(status)
-            .setMetadataId(id)
-            .setChangeDate(changeDate)
-            .setUserId(userId);
-        mdStatusId.setChangeDate(changeDate);
-
-        metatatStatus.setId(mdStatusId);
-
-        return getApplicationContext().getBean(MetadataStatusRepository.class).save(metatatStatus);
+    @Deprecated
+    public MetadataStatus setStatusExt(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage)
+            throws Exception {
+        return metadataStatus.setStatusExt(context, id, status, changeDate, changeMessage);
     }
 
-    /**
-     * If groupOwner match regular expression defined in setting metadata/workflow/draftWhenInGroup,
-     * then set status to draft to enable workflow.
-     */
+    @Deprecated
     public void activateWorkflowIfConfigured(ServiceContext context, String newId, String groupOwner) throws Exception {
-        if (StringUtils.isEmpty(groupOwner)) {
-            return;
-        }
-        String groupMatchingRegex =
-            getApplicationContext().getBean(SettingManager.class).
-                getValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP);
-        if (!StringUtils.isEmpty(groupMatchingRegex)) {
-            final Group group = getApplicationContext().getBean(GroupRepository.class)
-                .findOne(Integer.valueOf(groupOwner));
-            String groupName = "";
-            if (group != null) {
-                groupName = group.getName();
-            }
-
-            final Pattern pattern = Pattern.compile(groupMatchingRegex);
-            final Matcher matcher = pattern.matcher(groupName);
-            if (matcher.find()) {
-                setStatus(context, Integer.valueOf(newId),
-                    Integer.valueOf(Params.Status.DRAFT),
-                    new ISODate(),
-                    String.format("Workflow automatically enabled for record in group %s. Record status is set to %s.",
-                        groupName, Params.Status.DRAFT));
-            }
-        }
+        metadataStatus.activateWorkflowIfConfigured(context, newId, groupOwner);
     }
 
-    /**
-     * Adds a category to a metadata. Metadata is not reindexed.
-     */
+    @Deprecated
     public void setCategory(ServiceContext context, String mdId, String categId) throws Exception {
-        final MetadataCategoryRepository categoryRepository = getApplicationContext().getBean(MetadataCategoryRepository.class);
-
-        final MetadataCategory newCategory = categoryRepository.findOne(Integer.valueOf(categId));
-        final boolean[] changed = new boolean[1];
-        getMetadataRepository().update(Integer.valueOf(mdId), new Updater<Metadata>() {
-            @Override
-            public void apply(@Nonnull Metadata entity) {
-                changed[0] = !entity.getMetadataCategories().contains(newCategory);
-                entity.getMetadataCategories().add(newCategory);
-            }
-        });
-
-        if (changed[0]) {
-            if (getSvnManager() != null) {
-                getSvnManager().setHistory(mdId, context);
-            }
-        }
+        metadataCategory.setCategory(context, mdId, categId);
     }
 
-    /**
-     *
-     * @param mdId
-     * @param categId
-     * @return
-     * @throws Exception
-     */
+    @Deprecated
     public boolean isCategorySet(final String mdId, final int categId) throws Exception {
-        Set<MetadataCategory> categories = getMetadataRepository().findOne(mdId).getMetadataCategories();
-        for (MetadataCategory category : categories) {
-            if (category.getId() == categId) {
-                return true;
-            }
-        }
-        return false;
+        return metadataCategory.isCategorySet(mdId, categId);
     }
 
-    /**
-     *
-     * @param mdId
-     * @param categId
-     * @throws Exception
-     */
+    @Deprecated
     public void unsetCategory(final ServiceContext context, final String mdId, final int categId) throws Exception {
-        Metadata metadata = getMetadataRepository().findOne(mdId);
-
-        if (metadata == null) {
-            return;
-        }
-        boolean changed = false;
-        for (MetadataCategory category : metadata.getMetadataCategories()) {
-            if (category.getId() == categId) {
-                changed = true;
-                metadata.getMetadataCategories().remove(category);
-                break;
-            }
-        }
-
-        if (changed) {
-            getMetadataRepository().save(metadata);
-            if (getSvnManager() != null) {
-                getSvnManager().setHistory(mdId + "", context);
-            }
-        }
+        metadataCategory.unsetCategory(context, mdId, categId);
     }
 
-    /**
-     *
-     * @param mdId
-     * @return
-     * @throws Exception
-     */
+    @Deprecated
     public Collection<MetadataCategory> getCategories(final String mdId) throws Exception {
-        Metadata metadata = getMetadataRepository().findOne(mdId);
-        if (metadata == null) {
-            throw new IllegalArgumentException("No metadata found with id: " + mdId);
-        }
-
-        return metadata.getMetadataCategories();
+        return metadataCategory.getCategories(mdId);
     }
 
-    /**
-     * Update metadata record (not template) using update-fixed-info.xsl
-     *
-     * @param uuid            If the metadata is a new record (not yet saved), provide the uuid for
-     *                        that record
-     * @param updateDatestamp FIXME ? updateDatestamp is not used when running XSL transformation
-     */
-    public Element updateFixedInfo(String schema, Optional<Integer> metadataId, String uuid, Element md, String parentUuid, UpdateDatestamp updateDatestamp, ServiceContext context) throws Exception {
-        boolean autoFixing = getSettingManager().getValueAsBool(Settings.SYSTEM_AUTOFIXING_ENABLE, true);
-        if (autoFixing) {
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                Log.debug(Geonet.DATA_MANAGER, "Autofixing is enabled, trying update-fixed-info (updateDatestamp: " + updateDatestamp.name() + ")");
-            }
-
-            Metadata metadata = null;
-            if (metadataId.isPresent()) {
-                metadata = getMetadataRepository().findOne(metadataId.get());
-                boolean isTemplate = metadata != null && metadata.getDataInfo().getType() != MetadataType.METADATA;
-
-                // don't process templates
-                if (isTemplate) {
-                    if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                        Log.debug(Geonet.DATA_MANAGER, "Not applying update-fixed-info for a template");
-                    }
-                    return md;
-                }
-            }
-
-            String currentUuid = metadata != null ? metadata.getUuid() : null;
-            String id = metadata != null ? metadata.getId() + "" : null;
-            uuid = uuid == null ? currentUuid : uuid;
-
-            //--- setup environment
-            Element env = new Element("env");
-            env.addContent(new Element("id").setText(id));
-            env.addContent(new Element("uuid").setText(uuid));
-
-            final ThesaurusManager thesaurusManager = getApplicationContext().getBean(ThesaurusManager.class);
-            env.addContent(thesaurusManager.buildResultfromThTable(context));
-
-            Element schemaLoc = new Element("schemaLocation");
-            schemaLoc.setAttribute(getSchemaManager().getSchemaLocation(schema, context));
-            env.addContent(schemaLoc);
-
-            if (updateDatestamp == UpdateDatestamp.YES) {
-                env.addContent(new Element("changeDate").setText(new ISODate().toString()));
-            }
-            if (parentUuid != null) {
-                env.addContent(new Element("parentUuid").setText(parentUuid));
-            }
-            if (metadataId.isPresent()) {
-                String metadataIdString = String.valueOf(metadataId.get());
-                final Path resourceDir = Lib.resource.getDir(context, Params.Access.PRIVATE, metadataIdString);
-                env.addContent(new Element("datadir").setText(resourceDir.toString()));
-            }
-
-						// add user information to env if user is authenticated (should be)
-            Element elUser = new Element("user");
-            UserSession usrSess = context.getUserSession();
-            if (usrSess.isAuthenticated()) {
-              String myUserId  = usrSess.getUserId();
-              User user = getApplicationContext().getBean(UserRepository.class).findOne(myUserId);
-        			if (user != null) {
-								Element elUserDetails = new Element("details");
-            		elUserDetails.addContent(new Element("surname").setText(user.getSurname()));
-            		elUserDetails.addContent(new Element("firstname").setText(user.getName()));
-            		elUserDetails.addContent(new Element("organisation").setText(user.getOrganisation()));
-                elUserDetails.addContent(new Element("username").setText(user.getUsername()));
-								elUser.addContent(elUserDetails);
-            		env.addContent(elUser);
-        			}
-            }
-
-            // add original metadata to result
-            Element result = new Element("root");
-            result.addContent(md);
-            // add 'environment' to result
-            env.addContent(new Element("siteURL").setText(getSettingManager().getSiteURL(context)));
-            env.addContent(new Element("node").setText(context.getNodeId()));
-
-            // Settings were defined as an XML starting with root named config
-            // Only second level elements are defined (under system).
-            List<?> config = getSettingManager().getAllAsXML(true).cloneContent();
-            for (Object c : config) {
-                Element settings = (Element) c;
-                env.addContent(settings);
-            }
-
-            result.addContent(env);
-            // apply update-fixed-info.xsl
-            Path styleSheet = getSchemaDir(schema).resolve(Geonet.File.UPDATE_FIXED_INFO);
-            result = Xml.transform(result, styleSheet);
-            return result;
-        } else {
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                Log.debug(Geonet.DATA_MANAGER, "Autofixing is disabled, not applying update-fixed-info");
-            }
-            return md;
-        }
+    @Deprecated
+    public Element updateFixedInfo(String schema, Optional<Integer> metadataId, String uuid, Element md, String parentUuid,
+            UpdateDatestamp updateDatestamp, ServiceContext context) throws Exception {
+        return metadataManager.updateFixedInfo(schema, metadataId, uuid, md, parentUuid, updateDatestamp, context);
     }
 
-    /**
-     * Updates all children of the selected parent. Some elements are protected in the children
-     * according to the stylesheet used in xml/schemas/[SCHEMA]/update-child-from-parent-info.xsl.
-     *
-     * Children MUST be editable and also in the same schema of the parent. If not, child is not
-     * updated.
-     *
-     * @param srvContext service context
-     * @param parentUuid parent uuid
-     * @param children   children
-     * @param params     parameters
-     */
-    public Set<String> updateChildren(ServiceContext srvContext, String parentUuid, String[] children, Map<String, Object> params) throws Exception {
-        String parentId = (String) params.get(Params.ID);
-        String parentSchema = (String) params.get(Params.SCHEMA);
-
-        // --- get parent metadata in read/only mode
-        boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = false;
-        Element parent = getMetadata(srvContext, parentId, forEditing, withValidationErrors, keepXlinkAttributes);
-
-        Element env = new Element("update");
-        env.addContent(new Element("parentUuid").setText(parentUuid));
-        env.addContent(new Element("siteURL").setText(getSettingManager().getSiteURL(srvContext)));
-        env.addContent(new Element("parent").addContent(parent));
-
-        // Set of untreated children (out of privileges, different schemas)
-        Set<String> untreatedChildSet = new HashSet<String>();
-
-        // only get iso19139 records
-        for (String childId : children) {
-
-            // Check privileges
-            if (!getAccessManager().canEdit(srvContext, childId)) {
-                untreatedChildSet.add(childId);
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                    Log.debug(Geonet.DATA_MANAGER, "Could not update child ("
-                        + childId + ") because of privileges.");
-                continue;
-            }
-
-            Element child = getMetadata(srvContext, childId, forEditing, withValidationErrors, keepXlinkAttributes);
-
-            String childSchema = child.getChild(Edit.RootChild.INFO,
-                Edit.NAMESPACE).getChildText(Edit.Info.Elem.SCHEMA);
-
-            // Check schema matching. CHECKME : this suppose that parent and
-            // child are in the same schema (even not profil different)
-            if (!childSchema.equals(parentSchema)) {
-                untreatedChildSet.add(childId);
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, "Could not update child ("
-                        + childId + ") because schema (" + childSchema
-                        + ") is different from the parent one (" + parentSchema
-                        + ").");
-                }
-                continue;
-            }
-
-            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-                Log.debug(Geonet.DATA_MANAGER, "Updating child (" + childId + ") ...");
-
-            // --- setup xml element to be processed by XSLT
-
-            Element rootEl = new Element("root");
-            Element childEl = new Element("child").addContent(child.detach());
-            rootEl.addContent(childEl);
-            rootEl.addContent(env.detach());
-
-            // --- do an XSL transformation
-
-            Path styleSheet = getSchemaDir(parentSchema).resolve(Geonet.File.UPDATE_CHILD_FROM_PARENT_INFO);
-            Element childForUpdate = Xml.transform(rootEl, styleSheet, params);
-
-            getXmlSerializer().update(childId, childForUpdate, new ISODate().toString(), true, null, srvContext);
-
-
-            // Notifies the metadata change to metatada notifier service
-            notifyMetadataChange(childForUpdate, childId);
-
-            rootEl = null;
-        }
-
-        return untreatedChildSet;
+    @Deprecated
+    public Set<String> updateChildren(ServiceContext srvContext, String parentUuid, String[] children, Map<String, Object> params)
+            throws Exception {
+        return metadataManager.updateChildren(srvContext, parentUuid, children, params);
     }
 
-    /**
-     * TODO : buildInfoElem contains similar portion of code with indexMetadata
-     */
-    private Element buildInfoElem(ServiceContext context, String id, String version) throws Exception {
-        Metadata metadata = getMetadataRepository().findOne(id);
-        final MetadataDataInfo dataInfo = metadata.getDataInfo();
-        String schema = dataInfo.getSchemaId();
-        String createDate = dataInfo.getCreateDate().getDateAndTime();
-        String changeDate = dataInfo.getChangeDate().getDateAndTime();
-        String source = metadata.getSourceInfo().getSourceId();
-        String isTemplate = dataInfo.getType().codeString;
-        String title = dataInfo.getTitle();
-        String uuid = metadata.getUuid();
-        String isHarvested = "" + Constants.toYN_EnabledChar(metadata.getHarvestInfo().isHarvested());
-        String harvestUuid = metadata.getHarvestInfo().getUuid();
-        String popularity = "" + dataInfo.getPopularity();
-        String rating = "" + dataInfo.getRating();
-        String owner = "" + metadata.getSourceInfo().getOwner();
-        String displayOrder = "" + dataInfo.getDisplayOrder();
-
-        Element info = new Element(Edit.RootChild.INFO, Edit.NAMESPACE);
-
-        addElement(info, Edit.Info.Elem.ID, id);
-        addElement(info, Edit.Info.Elem.SCHEMA, schema);
-        addElement(info, Edit.Info.Elem.CREATE_DATE, createDate);
-        addElement(info, Edit.Info.Elem.CHANGE_DATE, changeDate);
-        addElement(info, Edit.Info.Elem.IS_TEMPLATE, isTemplate);
-        addElement(info, Edit.Info.Elem.TITLE, title);
-        addElement(info, Edit.Info.Elem.SOURCE, source);
-        addElement(info, Edit.Info.Elem.UUID, uuid);
-        addElement(info, Edit.Info.Elem.IS_HARVESTED, isHarvested);
-        addElement(info, Edit.Info.Elem.POPULARITY, popularity);
-        addElement(info, Edit.Info.Elem.RATING, rating);
-        addElement(info, Edit.Info.Elem.DISPLAY_ORDER, displayOrder);
-
-        if (metadata.getHarvestInfo().isHarvested()) {
-            HarvestInfoProvider infoProvider = getApplicationContext().getBean(HarvestInfoProvider.class);
-            if (infoProvider != null) {
-                info.addContent(infoProvider.getHarvestInfo(harvestUuid, id, uuid));
-            }
-        }
-        if (version != null) {
-            addElement(info, Edit.Info.Elem.VERSION, version);
-        }
-
-        Map<String, Element> map = Maps.newHashMap();
-        map.put(id, info);
-        buildPrivilegesMetadataInfo(context, map);
-
-        // add owner name
-        User user = getApplicationContext().getBean(UserRepository.class).findOne(owner);
-        if (user != null) {
-            String ownerName = user.getName();
-            addElement(info, Edit.Info.Elem.OWNERNAME, ownerName);
-        }
-
-
-        for (MetadataCategory category : metadata.getMetadataCategories()) {
-            addElement(info, Edit.Info.Elem.CATEGORY, category.getName());
-        }
-
-        // add subtemplates
-        /* -- don't add as we need to investigate indexing for the fields
-           -- in the metadata table used here
-		List subList = getSubtemplates(dbms, schema);
-		if (subList != null) {
-			Element subs = new Element(Edit.Info.Elem.SUBTEMPLATES);
-			subs.addContent(subList);
-			info.addContent(subs);
-		}
-		*/
-
-
-        // Add validity information
-        List<MetadataValidation> validationInfo = getMetadataValidationRepository().findAllById_MetadataId(Integer.parseInt(id));
-        if (validationInfo == null || validationInfo.size() == 0) {
-            addElement(info, Edit.Info.Elem.VALID, "-1");
-        } else {
-            String isValid = "1";
-            for (Object elem : validationInfo) {
-                MetadataValidation vi = (MetadataValidation) elem;
-                String type = vi.getId().getValidationType();
-                if (!vi.isValid()) {
-                    isValid = "0";
-                }
-
-                String ratio = "xsd".equals(type) ? "" : vi.getNumFailures() + "/" + vi.getNumTests();
-
-                info.addContent(new Element(Edit.Info.Elem.VALID + "_details").
-                    addContent(new Element("type").setText(type)).
-                    addContent(new Element("status").setText(vi.isValid() ? "1" : "0").
-                        addContent(new Element("ratio").setText(ratio)))
-                );
-            }
-            addElement(info, Edit.Info.Elem.VALID, isValid);
-        }
-
-        // add baseUrl of this site (from settings)
-        String protocol = getSettingManager().getValue(Settings.SYSTEM_SERVER_PROTOCOL);
-        String host = getSettingManager().getValue(Settings.SYSTEM_SERVER_HOST);
-        String port = getSettingManager().getValue(Settings.SYSTEM_SERVER_PORT);
-        if (port.equals("80")) {
-            port = "";
-        } else {
-            port = ":" + port;
-        }
-        addElement(info, Edit.Info.Elem.BASEURL, protocol + "://" + host + port + baseURL);
-        addElement(info, Edit.Info.Elem.LOCSERV, "/srv/en");
-        return info;
-    }
-
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Static methods are for external modules like GAST to be able to use
-    //--- them.
-    //---
-    //---------------------------------------------------------------------------
-
-    /**
-     * Add privileges information about metadata record which depends on context and usually could
-     * not be stored in db or Lucene index because depending on the current user or current client
-     * IP address.
-     *
-     * @param mdIdToInfoMap a map from the metadata Id -> the info element to which the privilege
-     *                      information should be added.
-     */
+    @Deprecated
     @VisibleForTesting
-    void buildPrivilegesMetadataInfo(ServiceContext context, Map<String, Element> mdIdToInfoMap) throws Exception {
-        Collection<Integer> metadataIds = Collections2.transform(mdIdToInfoMap.keySet(), new Function<String, Integer>() {
-            @Nullable
-            @Override
-            public Integer apply(String input) {
-                return Integer.valueOf(input);
-            }
-        });
-        Specification<OperationAllowed> operationAllowedSpec = OperationAllowedSpecs.hasMetadataIdIn(metadataIds);
-
-        final Collection<Integer> allUserGroups = getAccessManager().getUserGroups(context.getUserSession(), context.getIpAddress(),
-            false);
-        final SetMultimap<Integer, ReservedOperation> operationsPerMetadata = loadOperationsAllowed(context, where(operationAllowedSpec).and(OperationAllowedSpecs.hasGroupIdIn(allUserGroups)));
-        final Set<Integer> visibleToAll = loadOperationsAllowed(context, where(operationAllowedSpec).and(OperationAllowedSpecs.isPublic(ReservedOperation.view))).keySet();
-        final Set<Integer> downloadableByGuest = loadOperationsAllowed(context, where(operationAllowedSpec).and(OperationAllowedSpecs.hasGroupId(ReservedGroup.guest.getId())).and(OperationAllowedSpecs.hasOperation(ReservedOperation.download))).keySet();
-        final Map<Integer, MetadataSourceInfo> allSourceInfo = getMetadataRepository().findAllSourceInfo(MetadataSpecs.hasMetadataIdIn
-            (metadataIds));
-
-        for (Map.Entry<String, Element> entry : mdIdToInfoMap.entrySet()) {
-            Element infoEl = entry.getValue();
-            final Integer mdId = Integer.valueOf(entry.getKey());
-            MetadataSourceInfo sourceInfo = allSourceInfo.get(mdId);
-            Set<ReservedOperation> operations = operationsPerMetadata.get(mdId);
-            if (operations == null) {
-                operations = Collections.emptySet();
-            }
-
-            boolean isOwner = getAccessManager().isOwner(context, sourceInfo);
-
-            if (isOwner) {
-                operations = Sets.newHashSet(Arrays.asList(ReservedOperation.values()));
-            }
-
-            if (isOwner || operations.contains(ReservedOperation.editing)) {
-                addElement(infoEl, Edit.Info.Elem.EDIT, "true");
-            }
-
-            if (isOwner) {
-                addElement(infoEl, Edit.Info.Elem.OWNER, "true");
-            }
-
-            addElement(infoEl, Edit.Info.Elem.IS_PUBLISHED_TO_ALL, visibleToAll.contains(mdId));
-            addElement(infoEl, ReservedOperation.view.name(), operations.contains(ReservedOperation.view));
-            addElement(infoEl, ReservedOperation.notify.name(), operations.contains(ReservedOperation.notify));
-            addElement(infoEl, ReservedOperation.download.name(), operations.contains(ReservedOperation.download));
-            addElement(infoEl, ReservedOperation.dynamic.name(), operations.contains(ReservedOperation.dynamic));
-            addElement(infoEl, ReservedOperation.featured.name(), operations.contains(ReservedOperation.featured));
-
-            if (!operations.contains(ReservedOperation.download)) {
-                addElement(infoEl, Edit.Info.Elem.GUEST_DOWNLOAD, downloadableByGuest.contains(mdId));
-            }
-        }
+    public void buildPrivilegesMetadataInfo(ServiceContext context, Map<String, Element> mdIdToInfoMap) throws Exception {
+        metadataManager.buildPrivilegesMetadataInfo(context, mdIdToInfoMap);
     }
 
-    private SetMultimap<Integer, ReservedOperation> loadOperationsAllowed(ServiceContext context, Specification<OperationAllowed>
-        operationAllowedSpec) {
-        final OperationAllowedRepository operationAllowedRepo = context.getBean(OperationAllowedRepository.class);
-        List<OperationAllowed> operationsAllowed = operationAllowedRepo.findAll(operationAllowedSpec);
-        SetMultimap<Integer, ReservedOperation> operationsPerMetadata = HashMultimap.create();
-        for (OperationAllowed allowed : operationsAllowed) {
-            final OperationAllowedId id = allowed.getId();
-            operationsPerMetadata.put(id.getMetadataId(), ReservedOperation.lookup(id.getOperationId()));
-        }
-        return operationsPerMetadata;
-    }
-
-    /**
-     *
-     * @param md
-     * @throws Exception
-     */
-    private void setNamespacePrefixUsingSchemas(String schema, Element md) throws Exception {
-        //--- if the metadata has no namespace or already has a namespace prefix
-        //--- then we must skip this phase
-        Namespace ns = md.getNamespace();
-        if (ns == Namespace.NO_NAMESPACE)
-            return;
-
-        MetadataSchema mds = getSchemaManager().getSchema(schema);
-
-        //--- get the namespaces and add prefixes to any that are
-        //--- default (ie. prefix is '') if namespace match one of the schema
-        ArrayList<Namespace> nsList = new ArrayList<Namespace>();
-        nsList.add(ns);
-        @SuppressWarnings("unchecked")
-        List<Namespace> additionalNamespaces = md.getAdditionalNamespaces();
-        nsList.addAll(additionalNamespaces);
-        for (Object aNsList : nsList) {
-            Namespace aNs = (Namespace) aNsList;
-            if (aNs.getPrefix().equals("")) { // found default namespace
-                String prefix = mds.getPrefix(aNs.getURI());
-                if (prefix == null) {
-                    Log.warning(Geonet.DATA_MANAGER, "Metadata record contains a default namespace " + aNs.getURI() + " (with no prefix) which does not match any " + schema + " schema's namespaces.");
-                }
-                ns = Namespace.getNamespace(prefix, aNs.getURI());
-                setNamespacePrefix(md, ns);
-                if (!md.getNamespace().equals(ns)) {
-                    md.removeNamespaceDeclaration(aNs);
-                    md.addNamespaceDeclaration(ns);
-                }
-            }
-        }
-    }
-
-    /**
-     *
-     * @param md
-     * @param metadataId
-     * @throws Exception
-     */
-
+    @Deprecated
     public void notifyMetadataChange(Element md, String metadataId) throws Exception {
-
-        final Metadata metadata = getMetadataRepository().findOne(metadataId);
-        if (metadata != null && metadata.getDataInfo().getType() == MetadataType.METADATA) {
-            MetadataSchema mds = getServiceContext().getBean(DataManager.class).getSchema(metadata.getDataInfo().getSchemaId());
-            Pair<String, Element> editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
-            XmlSerializer.removeFilteredElement(md, editXpathFilter, mds.getNamespaces());
-
-            String uuid = getMetadataUuid(metadataId);
-            getServiceContext().getBean(MetadataNotifierManager.class).updateMetadata(md, metadataId, uuid, getServiceContext());
-        }
+        metadataUtils.notifyMetadataChange(md, metadataId);
     }
 
+    @Deprecated
     public void flush() {
-        TransactionManager.runInTransaction("DataManager flush()", getApplicationContext(),
-            TransactionManager.TransactionRequirement.CREATE_ONLY_WHEN_NEEDED,
-            TransactionManager.CommitBehavior.ALWAYS_COMMIT, false, new TransactionTask<Object>() {
-                @Override
-                public Object doInTransaction(TransactionStatus transaction) throws Throwable {
-                    _entityManager.flush();
-                    return null;
-                }
-            });
-
+        metadataManager.flush();
     }
 
+    @Deprecated
     public void forceIndexChanges() throws IOException {
-        getSearchManager().forceIndexChanges();
+        metadataIndexer.forceIndexChanges();
     }
 
+    @Deprecated
     public int batchDeleteMetadataAndUpdateIndex(Specification<Metadata> specification) throws Exception {
-        final List<Integer> idsOfMetadataToDelete = getMetadataRepository().findAllIdsBy(specification);
-
-        for (Integer id : idsOfMetadataToDelete) {
-            //--- remove metadata directory for each record
-            final Path metadataDataDir = getApplicationContext().getBean(GeonetworkDataDirectory.class).getMetadataDataDir();
-            Path pb = Lib.resource.getMetadataDir(metadataDataDir, id + "");
-            IO.deleteFileOrDirectory(pb);
-        }
-
-        // Remove records from the index
-        getSearchManager().delete(Lists.transform(idsOfMetadataToDelete, new Function<Integer, String>() {
-            @Nullable
-            @Override
-            public String apply(@Nonnull Integer input) {
-                return input.toString();
-            }
-        }));
-
-        // Remove records from the database
-        getMetadataRepository().deleteAll(specification);
-
-        return idsOfMetadataToDelete.size();
+        return metadataIndexer.batchDeleteMetadataAndUpdateIndex(specification);
     }
 
-    protected MetadataRepository getMetadataRepository() {
-        return getBean(MetadataRepository.class);
-    }
-
-    private MetadataValidationRepository getMetadataValidationRepository() {
-        return getBean(MetadataValidationRepository.class);
-    }
-
-    private <T> T getBean(Class<T> requiredType) {
-        return getApplicationContext().getBean(requiredType);
-    }
-
-    private ISearchManager getSearchManager() {
-        return getBean(SearchManager.class);
-    }
-
+    @Deprecated
     public AccessManager getAccessManager() {
-        return getBean(AccessManager.class);
+        return accessManager;
     }
 
-    private SettingManager getSettingManager() {
-        return getBean(SettingManager.class);
-    }
-
-    private SchemaManager getSchemaManager() {
-        return getBean(SchemaManager.class);
-    }
-
-    protected XmlSerializer getXmlSerializer() {
-        return getBean(XmlSerializer.class);
-    }
-
-    protected SvnManager getSvnManager() {
-        return getBean(SvnManager.class);
-    }
-
-    protected ApplicationContext getApplicationContext() {
-        final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
-        return applicationContext == null ? _applicationContext : applicationContext;
-    }
-
-    @Override
-    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
-        this.applicationEventPublisher = applicationEventPublisher;
+    @Deprecated
+    public EditLib getEditLib() {
+        return metadataManager.getEditLib();
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
 /**
  * A runnable for indexing multiple metadata in a separate thread.
  */
-final class IndexMetadataTask implements Runnable {
+public final class IndexMetadataTask implements Runnable {
 
     private final ServiceContext _context;
     private final List<?> _metadataIds;
@@ -60,7 +60,7 @@ final class IndexMetadataTask implements Runnable {
      * @param metadataIds       the metadata ids to index (either integers or strings)
      * @param transactionStatus if non-null, wait for the transaction to complete before indexing
      */
-    IndexMetadataTask(@Nonnull ServiceContext context, @Nonnull List<?> metadataIds, Set<IndexMetadataTask> batchIndex,
+    public IndexMetadataTask(@Nonnull ServiceContext context, @Nonnull List<?> metadataIds, Set<IndexMetadataTask> batchIndex,
                       @Nullable TransactionStatus transactionStatus, @Nonnull AtomicInteger indexed) {
         this.indexed = indexed;
         this._transactionStatus = transactionStatus;

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataCategory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataCategory.java
@@ -1,0 +1,21 @@
+    package org.fao.geonet.kernel.datamanager;
+
+import java.util.Collection;
+
+import org.fao.geonet.domain.MetadataCategory;
+
+import jeeves.server.context.ServiceContext;
+
+public interface IMetadataCategory {
+        public void init(ServiceContext context, Boolean force) throws Exception;
+
+        boolean isCategorySet(String mdId, int categId) throws Exception;
+
+        void setCategory(ServiceContext context, String mdId, String categId) throws Exception;
+
+        void unsetCategory(ServiceContext context, String mdId, int categId) throws Exception;
+
+        Collection<MetadataCategory> getCategories(String mdId) throws Exception;
+}
+
+  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataIndexer.java
@@ -1,0 +1,43 @@
+    package org.fao.geonet.kernel.datamanager;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.List;
+
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.kernel.search.ISearchManager;
+import org.jdom.Element;
+import org.springframework.data.jpa.domain.Specification;
+
+import jeeves.server.context.ServiceContext;
+
+public interface IMetadataIndexer {
+
+        public void init(ServiceContext context, Boolean force) throws Exception;
+
+        void forceIndexChanges() throws IOException;
+
+        int batchDeleteMetadataAndUpdateIndex(Specification<Metadata> specification) throws Exception;
+
+        void rebuildIndexXLinkedMetadata(ServiceContext context) throws Exception;
+
+        void rebuildIndexForSelection(ServiceContext context, String bucket, boolean clearXlink) throws Exception;
+
+        void batchIndexInThreadPool(ServiceContext context, List<?> metadataIds);
+
+        boolean isIndexing();
+
+        void indexMetadata(List<String> metadataIds) throws Exception;
+
+        void indexMetadata(String metadataId, boolean forceRefreshReaders, ISearchManager searchManager) throws Exception;
+
+        void versionMetadata(ServiceContext context, String id, Element md) throws Exception;
+
+        void rescheduleOptimizer(Calendar beginAt, int interval) throws Exception;
+
+        void disableOptimizer() throws Exception;
+
+        void setMetadataUtils(IMetadataUtils metadataUtils);
+}
+
+  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
@@ -1,0 +1,60 @@
+    package org.fao.geonet.kernel.datamanager;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.kernel.EditLib;
+import org.fao.geonet.kernel.UpdateDatestamp;
+import org.jdom.Element;
+
+import com.google.common.base.Optional;
+
+import jeeves.server.context.ServiceContext;
+
+public interface IMetadataManager {
+
+        public void init(ServiceContext context, Boolean force) throws Exception;
+
+        void deleteMetadata(ServiceContext context, String metadataId) throws Exception;
+
+        void deleteMetadataGroup(ServiceContext context, String metadataId) throws Exception;
+
+        String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
+                String isTemplate, boolean fullRightsForGroup) throws Exception;
+
+        String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
+                String isTemplate, boolean fullRightsForGroup, String uuid) throws Exception;
+
+        String insertMetadata(ServiceContext context, String schema, Element metadataXml, String uuid, int owner, String groupOwner,
+                String source, String metadataType, String docType, String category, String createDate, String changeDate, boolean ufo,
+                boolean index) throws Exception;
+
+        Metadata insertMetadata(ServiceContext context, Metadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
+                boolean updateFixedInfo, UpdateDatestamp updateDatestamp, boolean fullRightsForGroup, boolean forceRefreshReaders)
+                throws Exception;
+
+        Element getMetadata(String id) throws Exception;
+
+        Element getMetadata(ServiceContext srvContext, String id, boolean forEditing, boolean withEditorValidationErrors,
+                boolean keepXlinkAttributes) throws Exception;
+
+        void updateMetadataOwner(int id, String owner, String groupOwner) throws Exception;
+
+        Metadata updateMetadata(ServiceContext context, String metadataId, Element md, boolean validate, boolean ufo, boolean index,
+                String lang, String changeDate, boolean updateDateStamp) throws Exception;
+
+        void buildPrivilegesMetadataInfo(ServiceContext context, Map<String, Element> mdIdToInfoMap) throws Exception;
+
+        Set<String> updateChildren(ServiceContext srvContext, String parentUuid, String[] children, Map<String, Object> params)
+                throws Exception;
+
+        Element updateFixedInfo(String schema, Optional<Integer> metadataId, String uuid, Element md, String parentUuid,
+                UpdateDatestamp updateDatestamp, ServiceContext context) throws Exception;
+
+        void flush();
+
+        EditLib getEditLib();
+}
+
+  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataOperations.java
@@ -1,0 +1,44 @@
+    package org.fao.geonet.kernel.datamanager;
+
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataStatus;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.repository.UserGroupRepository;
+
+import com.google.common.base.Optional;
+
+import jeeves.server.context.ServiceContext;
+
+public interface IMetadataOperations {
+
+        public void init(ServiceContext context, Boolean force) throws Exception;
+
+        void deleteMetadataOper(ServiceContext context, String metadataId, boolean skipAllReservedGroup) throws Exception;
+
+        void setOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception;
+
+        void setOperation(ServiceContext context, String mdId, String grpId, ReservedOperation op) throws Exception;
+
+        void copyDefaultPrivForGroup(ServiceContext context, String id, String groupId, boolean fullRightsForGroup) throws Exception;
+
+        void forceUnsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception;
+
+        void unsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception;
+
+        boolean setOperation(ServiceContext context, int mdId, int grpId, int opId) throws Exception;
+
+        Optional<OperationAllowed> getOperationAllowedToAdd(ServiceContext context, int mdId, int grpId, int opId);
+
+        void checkOperationPermission(ServiceContext context, int grpId, UserGroupRepository userGroupRepo);
+
+        void unsetOperation(ServiceContext context, String mdId, String grpId, ReservedOperation opId) throws Exception;
+
+        void unsetOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception;
+
+        boolean isUserMetadataOwner(int userId) throws Exception;
+
+        boolean existsUser(ServiceContext context, int id) throws Exception;
+}
+
+  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataSchemaUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataSchemaUtils.java
@@ -1,0 +1,32 @@
+    package org.fao.geonet.kernel.datamanager;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.fao.geonet.exceptions.NoSchemaMatchesException;
+import org.fao.geonet.exceptions.SchemaMatchConflictException;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.jdom.Element;
+
+import jeeves.server.context.ServiceContext;
+
+public interface IMetadataSchemaUtils {
+
+        public void init(ServiceContext context, Boolean force) throws Exception;
+
+        Path getSchemaDir(String name);
+
+        boolean existsSchema(String name);
+
+        Set<String> getSchemas();
+
+        MetadataSchema getSchema(String name);
+
+        String getMetadataSchema(String id) throws Exception;
+
+        String autodetectSchema(Element md) throws SchemaMatchConflictException, NoSchemaMatchesException;
+
+        String autodetectSchema(Element md, String defaultSchema) throws SchemaMatchConflictException, NoSchemaMatchesException;
+}
+
+  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
@@ -1,0 +1,25 @@
+    package org.fao.geonet.kernel.datamanager;
+
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataStatus;
+
+import jeeves.server.context.ServiceContext;
+
+public interface IMetadataStatus {
+
+        public void init(ServiceContext context, Boolean force) throws Exception;
+
+        boolean isUserMetadataStatus(int userId) throws Exception;
+
+        void activateWorkflowIfConfigured(ServiceContext context, String newId, String groupOwner) throws Exception;
+
+        MetadataStatus setStatusExt(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception;
+
+        MetadataStatus setStatus(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception;
+
+        String getCurrentStatus(int metadataId) throws Exception;
+
+        MetadataStatus getStatus(int metadataId) throws Exception;
+}
+
+  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -1,0 +1,86 @@
+    package org.fao.geonet.kernel.datamanager;
+
+import org.fao.geonet.domain.MetadataType;
+import org.jdom.Element;
+
+import com.google.common.base.Optional;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+
+public interface IMetadataUtils {
+
+        public void init(ServiceContext context, Boolean force) throws Exception;
+
+        void notifyMetadataChange(Element md, String metadataId) throws Exception;
+
+        String getMetadataUuid(String id) throws Exception;
+
+        void startEditingSession(ServiceContext context, String id) throws Exception;
+
+        void cancelEditingSession(ServiceContext context, String id) throws Exception;
+
+        void endEditingSession(String id, UserSession session);
+
+        Element enumerateTree(Element md) throws Exception;
+
+        String extractUUID(String schema, Element md) throws Exception;
+
+        String extractDateModified(String schema, Element md) throws Exception;
+
+        Element setUUID(String schema, String uuid, Element md) throws Exception;
+
+        Element extractSummary(Element md) throws Exception;
+
+        String getMetadataId(String uuid) throws Exception;
+
+        String getVersion(String id);
+
+        String getNewVersion(String id);
+
+        void setTemplateExt(int id, MetadataType metadataType) throws Exception;
+
+        void setTemplate(int id, MetadataType type, String title) throws Exception;
+
+        void setHarvestedExt(int id, String harvestUuid) throws Exception;
+
+        void setHarvested(int id, String harvestUuid) throws Exception;
+
+        void setHarvestedExt(int id, String harvestUuid, Optional<String> harvestUri) throws Exception;
+
+        void updateDisplayOrder(String id, String displayOrder) throws Exception;
+
+        void increasePopularity(ServiceContext srvContext, String id) throws Exception;
+
+        int rateMetadata(int metadataId, String ipAddress, int rating) throws Exception;
+
+        Element getMetadataNoInfo(ServiceContext srvContext, String id) throws Exception;
+
+        Element getElementByRef(Element md, String ref);
+
+        boolean existsMetadataUuid(String uuid) throws Exception;
+
+        boolean existsMetadata(int id) throws Exception;
+
+        Element getKeywords() throws Exception;
+
+        Element getThumbnails(ServiceContext context, String metadataId) throws Exception;
+
+        void setThumbnail(ServiceContext context, String id, boolean small, String file, boolean indexAfterChange) throws Exception;
+
+        void unsetThumbnail(ServiceContext context, String id, boolean small, boolean indexAfterChange) throws Exception;
+
+        void setDataCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction, String licensename,
+                String type) throws Exception;
+
+        void setCreativeCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction,
+                String licensename, String type) throws Exception;
+
+        void setMetadataManager(IMetadataManager metadataManager);
+
+        public String getMetadataTitle(String id) throws Exception;
+
+        public void setSubtemplateTypeAndTitleExt(int id, String title) throws Exception;
+}
+
+  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataValidator.java
@@ -1,0 +1,45 @@
+    package org.fao.geonet.kernel.datamanager;
+
+import java.util.List;
+
+import org.fao.geonet.domain.MetadataValidation;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.utils.Xml.ErrorHandler;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.Namespace;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+
+public interface IMetadataValidator {
+
+        public void init(ServiceContext context, Boolean force) throws Exception;
+
+        void validateMetadata(String schema, Element xml, ServiceContext context, String fileName) throws Exception;
+
+        void setNamespacePrefix(Element md);
+
+        void validate(String schema, Document doc) throws Exception;
+
+        void validate(String schema, Element md) throws Exception;
+
+        Element validateInfo(String schema, Element md, ErrorHandler eh) throws Exception;
+
+        Element doSchemaTronForEditor(String schema, Element md, String lang) throws Exception;
+
+        boolean doValidate(String schema, String metadataId, Document doc, String lang);
+
+        Pair<Element, String> doValidate(UserSession session, String schema, String metadataId, Element md, String lang, boolean forEditing)
+                throws Exception;
+
+        Element applyCustomSchematronRules(String schema, int metadataId, Element md, String lang, List<MetadataValidation> validations);
+
+        boolean validate(Element xml);
+
+        void setNamespacePrefix(Element md, Namespace ns);
+
+        void setMetadataManager(IMetadataManager metadataManager);
+}
+
+  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataCategory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataCategory.java
@@ -1,0 +1,138 @@
+package org.fao.geonet.kernel.datamanager.base;
+
+import java.util.Collection;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.kernel.SvnManager;
+import org.fao.geonet.kernel.datamanager.IMetadataCategory;
+import org.fao.geonet.repository.MetadataCategoryRepository;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.Updater;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import jeeves.server.context.ServiceContext;
+
+public class BaseMetadataCategory implements IMetadataCategory {
+
+    @Autowired
+    private MetadataRepository metadataRepository;
+    @Autowired(required=false)
+    private SvnManager svnManager;
+    @Autowired
+    private ApplicationContext _applicationContext;
+
+    public void init(ServiceContext context, Boolean force) throws Exception {
+//        this.metadataRepository = context.getBean(MetadataRepository.class);
+//        this.svnManager = context.getBean(SvnManager.class);
+    }
+
+    /**
+     * Adds a category to a metadata. Metadata is not reindexed.
+     */
+    @Override
+    public void setCategory(ServiceContext context, String mdId, String categId) throws Exception {
+        final MetadataCategoryRepository categoryRepository = getApplicationContext().getBean(MetadataCategoryRepository.class);
+
+        final MetadataCategory newCategory = categoryRepository.findOne(Integer.valueOf(categId));
+        final boolean[] changed = new boolean[1];
+        getMetadataRepository().update(Integer.valueOf(mdId), new Updater<Metadata>() {
+            @Override
+            public void apply(@Nonnull Metadata entity) {
+                changed[0] = !entity.getMetadataCategories().contains(newCategory);
+                entity.getMetadataCategories().add(newCategory);
+            }
+        });
+
+        if (changed[0]) {
+            if (getSvnManager() != null) {
+                getSvnManager().setHistory(mdId, context);
+            }
+        }
+    }
+
+    /**
+     *
+     * @param mdId
+     * @param categId
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public boolean isCategorySet(final String mdId, final int categId) throws Exception {
+        Set<MetadataCategory> categories = getMetadataRepository().findOne(mdId).getMetadataCategories();
+        for (MetadataCategory category : categories) {
+            if (category.getId() == categId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param mdId
+     * @param categId
+     * @throws Exception
+     */
+    @Override
+    public void unsetCategory(final ServiceContext context, final String mdId, final int categId) throws Exception {
+        Metadata metadata = getMetadataRepository().findOne(mdId);
+
+        if (metadata == null) {
+            return;
+        }
+        boolean changed = false;
+        for (MetadataCategory category : metadata.getMetadataCategories()) {
+            if (category.getId() == categId) {
+                changed = true;
+                metadata.getMetadataCategories().remove(category);
+                break;
+            }
+        }
+
+        if (changed) {
+            getMetadataRepository().save(metadata);
+            if (getSvnManager() != null) {
+                getSvnManager().setHistory(mdId + "", context);
+            }
+        }
+    }
+
+    /**
+     *
+     * @param mdId
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public Collection<MetadataCategory> getCategories(final String mdId) throws Exception {
+        Metadata metadata = getMetadataRepository().findOne(mdId);
+        if (metadata == null) {
+            throw new IllegalArgumentException("No metadata found with id: " + mdId);
+        }
+
+        return metadata.getMetadataCategories();
+    }
+
+    private SvnManager getSvnManager() {
+        return svnManager;
+
+    }
+
+    private MetadataRepository getMetadataRepository() {
+        return metadataRepository;
+
+    }
+
+    private ApplicationContext getApplicationContext() {
+        final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
+        return applicationContext == null ? _applicationContext : applicationContext;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataCategory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataCategory.java
@@ -5,7 +5,6 @@ import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.kernel.SvnManager;
@@ -14,8 +13,6 @@ import org.fao.geonet.repository.MetadataCategoryRepository;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.Updater;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ConfigurableApplicationContext;
 
 import jeeves.server.context.ServiceContext;
 
@@ -23,14 +20,15 @@ public class BaseMetadataCategory implements IMetadataCategory {
 
     @Autowired
     private MetadataRepository metadataRepository;
-    @Autowired(required=false)
+    @Autowired(required = false)
     private SvnManager svnManager;
     @Autowired
-    private ApplicationContext _applicationContext;
+    private MetadataCategoryRepository metadataCategoryRepository;
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-//        this.metadataRepository = context.getBean(MetadataRepository.class);
-//        this.svnManager = context.getBean(SvnManager.class);
+        this.metadataRepository = context.getBean(MetadataRepository.class);
+        this.svnManager = context.getBean(SvnManager.class);
+        this.metadataCategoryRepository = context.getBean(MetadataCategoryRepository.class);
     }
 
     /**
@@ -38,9 +36,8 @@ public class BaseMetadataCategory implements IMetadataCategory {
      */
     @Override
     public void setCategory(ServiceContext context, String mdId, String categId) throws Exception {
-        final MetadataCategoryRepository categoryRepository = getApplicationContext().getBean(MetadataCategoryRepository.class);
 
-        final MetadataCategory newCategory = categoryRepository.findOne(Integer.valueOf(categId));
+        final MetadataCategory newCategory = metadataCategoryRepository.findOne(Integer.valueOf(categId));
         final boolean[] changed = new boolean[1];
         getMetadataRepository().update(Integer.valueOf(mdId), new Updater<Metadata>() {
             @Override
@@ -129,10 +126,5 @@ public class BaseMetadataCategory implements IMetadataCategory {
     private MetadataRepository getMetadataRepository() {
         return metadataRepository;
 
-    }
-
-    private ApplicationContext getApplicationContext() {
-        final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
-        return applicationContext == null ? _applicationContext : applicationContext;
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -125,20 +125,20 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
     }
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-        // searchManager = context.getBean(SearchManager.class);
-        // geonetworkDataDirectory = context.getBean(GeonetworkDataDirectory.class);
-        // metadataRepository = context.getBean(MetadataRepository.class);
-        // statusRepository = context.getBean(MetadataStatusRepository.class);
-        // metadataUtils = context.getBean(IMetadataUtils.class);
-        // userRepository = context.getBean(UserRepository.class);
-        // operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
-        // groupRepository = context.getBean(GroupRepository.class);
-        // metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
-        // schemaManager = context.getBean(SchemaManager.class);
-        // svnManager = context.getBean(SvnManager.class);
-        // inspireAtomFeedRepository = context.getBean(InspireAtomFeedRepository.class);
-        // xmlSerializer = context.getBean(XmlSerializer.class);
-        // settingManager = context.getBean(SettingManager.class);
+         searchManager = context.getBean(SearchManager.class);
+         geonetworkDataDirectory = context.getBean(GeonetworkDataDirectory.class);
+         metadataRepository = context.getBean(MetadataRepository.class);
+         statusRepository = context.getBean(MetadataStatusRepository.class);
+         metadataUtils = context.getBean(IMetadataUtils.class);
+         userRepository = context.getBean(UserRepository.class);
+         operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
+         groupRepository = context.getBean(GroupRepository.class);
+         metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
+         schemaManager = context.getBean(SchemaManager.class);
+         svnManager = context.getBean(SvnManager.class);
+         inspireAtomFeedRepository = context.getBean(InspireAtomFeedRepository.class);
+         xmlSerializer = context.getBean(XmlSerializer.class);
+         settingManager = context.getBean(SettingManager.class);
 
         servContext = context;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -1,0 +1,582 @@
+package org.fao.geonet.kernel.datamanager.base;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.Vector;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Constants;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.InspireAtomFeed;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.domain.MetadataStatus;
+import org.fao.geonet.domain.MetadataStatusId_;
+import org.fao.geonet.domain.MetadataStatus_;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.MetadataValidation;
+import org.fao.geonet.domain.MetadataValidationStatus;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.OperationAllowedId;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.events.md.MetadataIndexCompleted;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.IndexMetadataTask;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.SelectionManager;
+import org.fao.geonet.kernel.SvnManager;
+import org.fao.geonet.kernel.XmlSerializer;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.search.ISearchManager;
+import org.fao.geonet.kernel.search.SearchManager;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.InspireAtomFeedRepository;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.MetadataStatusRepository;
+import org.fao.geonet.repository.MetadataValidationRepository;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.resources.Resources;
+import org.fao.geonet.util.ThreadUtils;
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Log;
+import org.jdom.Attribute;
+import org.jdom.Element;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.transaction.NoTransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import jeeves.xlink.Processor;
+
+public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPublisherAware {
+
+    private Lock indexLock = new ReentrantLock();
+
+    @Autowired
+    private SearchManager searchManager;
+    @Autowired
+    private GeonetworkDataDirectory geonetworkDataDirectory;
+    @Autowired
+    private MetadataRepository metadataRepository;
+    @Autowired
+    private MetadataStatusRepository statusRepository;
+
+    private IMetadataUtils metadataUtils;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private OperationAllowedRepository operationAllowedRepository;
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private MetadataValidationRepository metadataValidationRepository;
+    @Autowired
+    private SchemaManager schemaManager;
+    @Autowired(required = false)
+    private SvnManager svnManager;
+    @Autowired
+    private InspireAtomFeedRepository inspireAtomFeedRepository;
+    @Autowired(required = false)
+    private XmlSerializer xmlSerializer;
+    @Autowired
+    @Lazy
+    private SettingManager settingManager;
+
+    // FIXME remove when get rid of Jeeves
+    private ServiceContext servContext;
+
+    private ApplicationEventPublisher publisher;
+
+    public BaseMetadataIndexer() {
+        System.out.println("CREATING BASE METADATA INDEXER");
+    }
+
+    public void init(ServiceContext context, Boolean force) throws Exception {
+        // searchManager = context.getBean(SearchManager.class);
+        // geonetworkDataDirectory = context.getBean(GeonetworkDataDirectory.class);
+        // metadataRepository = context.getBean(MetadataRepository.class);
+        // statusRepository = context.getBean(MetadataStatusRepository.class);
+        // metadataUtils = context.getBean(IMetadataUtils.class);
+        // userRepository = context.getBean(UserRepository.class);
+        // operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
+        // groupRepository = context.getBean(GroupRepository.class);
+        // metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
+        // schemaManager = context.getBean(SchemaManager.class);
+        // svnManager = context.getBean(SvnManager.class);
+        // inspireAtomFeedRepository = context.getBean(InspireAtomFeedRepository.class);
+        // xmlSerializer = context.getBean(XmlSerializer.class);
+        // settingManager = context.getBean(SettingManager.class);
+
+        servContext = context;
+    }
+
+    @Override
+    public void setMetadataUtils(IMetadataUtils metadataUtils) {
+        this.metadataUtils = metadataUtils;
+    }
+
+    Set<String> waitForIndexing = new HashSet<String>();
+    Set<String> indexing = new HashSet<String>();
+    Set<IndexMetadataTask> batchIndex = new ConcurrentHashSet<IndexMetadataTask>();
+
+    @Override
+    public void forceIndexChanges() throws IOException {
+        searchManager.forceIndexChanges();
+    }
+
+    @Override
+    public int batchDeleteMetadataAndUpdateIndex(Specification<Metadata> specification) throws Exception {
+        final List<Integer> idsOfMetadataToDelete = metadataRepository.findAllIdsBy(specification);
+
+        for (Integer id : idsOfMetadataToDelete) {
+            // --- remove metadata directory for each record
+            final Path metadataDataDir = geonetworkDataDirectory.getMetadataDataDir();
+            Path pb = Lib.resource.getMetadataDir(metadataDataDir, id + "");
+            IO.deleteFileOrDirectory(pb);
+        }
+
+        // Remove records from the index
+        searchManager.delete(Lists.transform(idsOfMetadataToDelete, new Function<Integer, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nonnull Integer input) {
+                return input.toString();
+            }
+        }));
+
+        // Remove records from the database
+        metadataRepository.deleteAll(specification);
+
+        return idsOfMetadataToDelete.size();
+    }
+
+    @Override
+    /**
+     * Search for all records having XLinks (ie. indexed with _hasxlinks flag), clear the cache and reindex all records found.
+     */
+    public synchronized void rebuildIndexXLinkedMetadata(final ServiceContext context) throws Exception {
+
+        // get all metadata with XLinks
+        Set<Integer> toIndex = searchManager.getDocsWithXLinks();
+
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Will index " + toIndex.size() + " records with XLinks");
+        if (toIndex.size() > 0) {
+            // clean XLink Cache so that cache and index remain in sync
+            Processor.clearCache();
+
+            ArrayList<String> stringIds = new ArrayList<String>();
+            for (Integer id : toIndex) {
+                stringIds.add(id.toString());
+            }
+            // execute indexing operation
+            batchIndexInThreadPool(context, stringIds);
+        }
+    }
+
+    /**
+     * Reindex all records in current selection.
+     */
+    @Override
+    public synchronized void rebuildIndexForSelection(final ServiceContext context, String bucket, boolean clearXlink) throws Exception {
+
+        // get all metadata ids from selection
+        ArrayList<String> listOfIdsToIndex = new ArrayList<String>();
+        UserSession session = context.getUserSession();
+        SelectionManager sm = SelectionManager.getManager(session);
+
+        synchronized (sm.getSelection(bucket)) {
+            for (Iterator<String> iter = sm.getSelection(bucket).iterator(); iter.hasNext();) {
+                String uuid = (String) iter.next();
+                String id = metadataUtils.getMetadataId(uuid);
+                if (id != null) {
+                    listOfIdsToIndex.add(id);
+                }
+            }
+        }
+
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+            Log.debug(Geonet.DATA_MANAGER, "Will index " + listOfIdsToIndex.size() + " records from selection.");
+        }
+
+        if (listOfIdsToIndex.size() > 0) {
+            // clean XLink Cache so that cache and index remain in sync
+            if (clearXlink) {
+                Processor.clearCache();
+            }
+
+            // execute indexing operation
+            batchIndexInThreadPool(context, listOfIdsToIndex);
+        }
+    }
+
+    /**
+     * Index multiple metadata in a separate thread. Wait until the current transaction commits before starting threads (to make sure that
+     * all metadata are committed).
+     *
+     * @param context context object
+     * @param metadataIds the metadata ids to index
+     */
+    @Override
+    public void batchIndexInThreadPool(ServiceContext context, List<?> metadataIds) {
+
+        TransactionStatus transactionStatus = null;
+        try {
+            transactionStatus = TransactionAspectSupport.currentTransactionStatus();
+        } catch (NoTransactionException e) {
+            // not in a transaction so we can go ahead.
+        }
+        // split reindexing task according to number of processors we can assign
+        int threadCount = ThreadUtils.getNumberOfThreads();
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        int perThread;
+        if (metadataIds.size() < threadCount)
+            perThread = metadataIds.size();
+        else
+            perThread = metadataIds.size() / threadCount;
+        int index = 0;
+        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
+            Log.debug(Geonet.INDEX_ENGINE, "Indexing " + metadataIds.size() + " records.");
+            Log.debug(Geonet.INDEX_ENGINE, metadataIds.toString());
+        }
+        AtomicInteger numIndexedTracker = new AtomicInteger();
+        while (index < metadataIds.size()) {
+            int start = index;
+            int count = Math.min(perThread, metadataIds.size() - start);
+            int nbRecords = start + count;
+
+            if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
+                Log.debug(Geonet.INDEX_ENGINE, "Indexing records from " + start + " to " + nbRecords);
+            }
+
+            List<?> subList = metadataIds.subList(start, nbRecords);
+
+            if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
+                Log.debug(Geonet.INDEX_ENGINE, subList.toString());
+            }
+
+            // create threads to process this chunk of ids
+            Runnable worker = new IndexMetadataTask(context, subList, batchIndex, transactionStatus, numIndexedTracker);
+            executor.execute(worker);
+            index += count;
+        }
+
+        executor.shutdown();
+    }
+
+    @Override
+    public boolean isIndexing() {
+        indexLock.lock();
+        try {
+            return !indexing.isEmpty() || !batchIndex.isEmpty();
+        } finally {
+            indexLock.unlock();
+        }
+    }
+
+    @Override
+    public void indexMetadata(final List<String> metadataIds) throws Exception {
+        for (String metadataId : metadataIds) {
+            indexMetadata(metadataId, false, null);
+        }
+
+        searchManager.forceIndexChanges();
+    }
+
+    @Override
+    public void indexMetadata(final String metadataId, boolean forceRefreshReaders, ISearchManager searchManager) throws Exception {
+        indexLock.lock();
+        try {
+            if (waitForIndexing.contains(metadataId)) {
+                return;
+            }
+            while (indexing.contains(metadataId)) {
+                try {
+                    waitForIndexing.add(metadataId);
+                    // don't index the same metadata 2x
+                    wait(200);
+                } catch (InterruptedException e) {
+                    return;
+                } finally {
+                    waitForIndexing.remove(metadataId);
+                }
+            }
+            indexing.add(metadataId);
+        } finally {
+            indexLock.unlock();
+        }
+        Metadata fullMd;
+
+        try {
+            Vector<Element> moreFields = new Vector<Element>();
+            int id$ = Integer.parseInt(metadataId);
+
+            // get metadata, extracting and indexing any xlinks
+            Element md = getXmlSerializer().selectNoXLinkResolver(metadataId, true, false);
+            if (getXmlSerializer().resolveXLinks()) {
+                List<Attribute> xlinks = Processor.getXLinks(md);
+                if (xlinks.size() > 0) {
+                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.HASXLINKS, "1", true, true));
+                    StringBuilder sb = new StringBuilder();
+                    for (Attribute xlink : xlinks) {
+                        sb.append(xlink.getValue());
+                        sb.append(" ");
+                    }
+                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.XLINK, sb.toString(), true, true));
+                    Processor.detachXLink(md, getServiceContext());
+                } else {
+                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.HASXLINKS, "0", true, true));
+                }
+            } else {
+                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.HASXLINKS, "0", true, true));
+            }
+
+            fullMd = metadataRepository.findOne(id$);
+
+            final String schema = fullMd.getDataInfo().getSchemaId();
+            final String createDate = fullMd.getDataInfo().getCreateDate().getDateAndTime();
+            final String changeDate = fullMd.getDataInfo().getChangeDate().getDateAndTime();
+            final String source = fullMd.getSourceInfo().getSourceId();
+            final MetadataType metadataType = fullMd.getDataInfo().getType();
+            final String root = fullMd.getDataInfo().getRoot();
+            final String uuid = fullMd.getUuid();
+            final String extra = fullMd.getDataInfo().getExtra();
+            final String isHarvested = String.valueOf(Constants.toYN_EnabledChar(fullMd.getHarvestInfo().isHarvested()));
+            final String owner = String.valueOf(fullMd.getSourceInfo().getOwner());
+            final Integer groupOwner = fullMd.getSourceInfo().getGroupOwner();
+            final String popularity = String.valueOf(fullMd.getDataInfo().getPopularity());
+            final String rating = String.valueOf(fullMd.getDataInfo().getRating());
+            final String displayOrder = fullMd.getDataInfo().getDisplayOrder() == null ? null
+                    : String.valueOf(fullMd.getDataInfo().getDisplayOrder());
+
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                Log.debug(Geonet.DATA_MANAGER, "record schema (" + schema + ")"); // DEBUG
+                Log.debug(Geonet.DATA_MANAGER, "record createDate (" + createDate + ")"); // DEBUG
+            }
+
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.ROOT, root, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.SCHEMA, schema, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DATABASE_CREATE_DATE, createDate, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DATABASE_CHANGE_DATE, changeDate, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.SOURCE, source, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.IS_TEMPLATE, metadataType.codeString, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.UUID, uuid, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.IS_HARVESTED, isHarvested, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.OWNER, owner, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DUMMY, "0", false, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.POPULARITY, popularity, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.RATING, rating, true, true));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DISPLAY_ORDER, displayOrder, true, false));
+            moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.EXTRA, extra, false, true));
+
+            // If the metadata has an atom document, index related information
+            InspireAtomFeed feed = inspireAtomFeedRepository.findByMetadataId(id$);
+
+            if ((feed != null) && StringUtils.isNotEmpty(feed.getAtom())) {
+                moreFields.add(SearchManager.makeField("has_atom", "y", true, true));
+                moreFields.add(SearchManager.makeField("any", feed.getAtom(), false, true));
+            }
+
+            if (owner != null) {
+                User user = userRepository.findOne(fullMd.getSourceInfo().getOwner());
+                if (user != null) {
+                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.USERINFO,
+                            user.getUsername() + "|" + user.getSurname() + "|" + user.getName() + "|" + user.getProfile(), true, false));
+                }
+            }
+
+            String logoUUID = null;
+            if (groupOwner != null) {
+                final Group group = groupRepository.findOne(groupOwner);
+                if (group != null) {
+                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_OWNER, String.valueOf(groupOwner), true, true));
+                    final boolean preferGroup = settingManager.getValueAsBool(Settings.SYSTEM_PREFER_GROUP_LOGO, true);
+                    if (group.getWebsite() != null && !group.getWebsite().isEmpty() && preferGroup) {
+                        moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_WEBSITE, group.getWebsite(), true, false));
+                    }
+                    if (group.getLogo() != null && preferGroup) {
+                        logoUUID = group.getLogo();
+                    }
+                }
+            }
+
+            // Group logo are in the harvester folder and contains extension in file name
+            final Path harvesterLogosDir = Resources.locateHarvesterLogosDir(getServiceContext());
+            boolean added = false;
+            if (StringUtils.isNotEmpty(logoUUID)) {
+                final Path logoPath = harvesterLogosDir.resolve(logoUUID);
+                if (Files.exists(logoPath)) {
+                    added = true;
+                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.LOGO, "/images/harvesting/" + logoPath.getFileName(),
+                            true, false));
+                }
+            }
+
+            // If not available, use the local catalog logo
+            if (!added) {
+                logoUUID = source + ".png";
+                final Path logosDir = Resources.locateLogosDir(getServiceContext());
+                final Path logoPath = logosDir.resolve(logoUUID);
+                if (Files.exists(logoPath)) {
+                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.LOGO, "/images/logos/" + logoUUID, true, false));
+                }
+            }
+
+            // get privileges
+            List<OperationAllowed> operationsAllowed = operationAllowedRepository.findAllById_MetadataId(id$);
+
+            for (OperationAllowed operationAllowed : operationsAllowed) {
+                OperationAllowedId operationAllowedId = operationAllowed.getId();
+                int groupId = operationAllowedId.getGroupId();
+                int operationId = operationAllowedId.getOperationId();
+
+                moreFields
+                        .add(SearchManager.makeField(Geonet.IndexFieldNames.OP_PREFIX + operationId, String.valueOf(groupId), true, true));
+                if (operationId == ReservedOperation.view.getId()) {
+                    Group g = groupRepository.findOne(groupId);
+                    if (g != null) {
+                        moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.GROUP_PUBLISHED, g.getName(), true, true));
+                    }
+                }
+            }
+
+            for (MetadataCategory category : fullMd.getMetadataCategories()) {
+                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.CAT, category.getName(), true, true));
+            }
+
+            // get status
+            Sort statusSort = new Sort(Sort.Direction.DESC, MetadataStatus_.id.getName() + "." + MetadataStatusId_.changeDate.getName());
+            List<MetadataStatus> statuses = statusRepository.findAllById_MetadataId(id$, statusSort);
+            if (!statuses.isEmpty()) {
+                MetadataStatus stat = statuses.get(0);
+                String status = String.valueOf(stat.getId().getStatusId());
+                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.STATUS, status, true, true));
+                String statusChangeDate = stat.getId().getChangeDate().getDateAndTime();
+                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.STATUS_CHANGE_DATE, statusChangeDate, true, true));
+            }
+
+            // getValidationInfo
+            // -1 : not evaluated
+            // 0 : invalid
+            // 1 : valid
+            List<MetadataValidation> validationInfo = metadataValidationRepository.findAllById_MetadataId(id$);
+            if (validationInfo.isEmpty()) {
+                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.VALID, "-1", true, true));
+            } else {
+                String isValid = "1";
+                for (MetadataValidation vi : validationInfo) {
+                    String type = vi.getId().getValidationType();
+                    MetadataValidationStatus status = vi.getStatus();
+                    if (status == MetadataValidationStatus.INVALID && vi.isRequired()) {
+                        isValid = "0";
+                    }
+                    moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.VALID + "_" + type, status.getCode(), true, true));
+                }
+                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.VALID, isValid, true, true));
+            }
+
+            if (searchManager == null) {
+                searchManager = servContext.getBean(SearchManager.class);
+            }
+            
+            searchManager.index(schemaManager.getSchemaDir(schema), md, metadataId, moreFields, metadataType, root,
+                        forceRefreshReaders);
+            
+        } catch (Exception x) {
+            Log.error(Geonet.DATA_MANAGER,
+                    "The metadata document index with id=" + metadataId + " is corrupt/invalid - ignoring it. Error: " + x.getMessage(), x);
+            fullMd = null;
+        } finally {
+            indexLock.lock();
+            try {
+                indexing.remove(metadataId);
+            } finally {
+                indexLock.unlock();
+            }
+        }
+        if (fullMd != null) {
+            this.publisher.publishEvent(new MetadataIndexCompleted(fullMd));
+        }
+    }
+
+    private XmlSerializer getXmlSerializer() {
+        return xmlSerializer;
+    }
+
+    /**
+     *
+     * @param context
+     * @param id
+     * @param md
+     * @throws Exception
+     */
+    @Override
+    public void versionMetadata(ServiceContext context, String id, Element md) throws Exception {
+        if (svnManager != null) {
+            svnManager.createMetadataDir(id, context, md);
+        }
+    }
+
+    /**
+     *
+     * @param beginAt
+     * @param interval
+     * @throws Exception
+     */
+    @Override
+    public void rescheduleOptimizer(Calendar beginAt, int interval) throws Exception {
+        searchManager.rescheduleOptimizer(beginAt, interval);
+    }
+
+    /**
+     *
+     * @throws Exception
+     */
+    @Override
+    public void disableOptimizer() throws Exception {
+        searchManager.disableOptimizer();
+    }
+
+    private ServiceContext getServiceContext() {
+        ServiceContext context = ServiceContext.get();
+        return context == null ? servContext : context;
+    }
+
+    public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+        this.publisher = publisher;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -1,0 +1,1152 @@
+package org.fao.geonet.kernel.datamanager.base;
+
+import static org.springframework.data.jpa.domain.Specifications.where;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.Root;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.constants.Edit;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.Constants;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.domain.MetadataDataInfo;
+import org.fao.geonet.domain.MetadataDataInfo_;
+import org.fao.geonet.domain.MetadataFileUpload;
+import org.fao.geonet.domain.MetadataFileUpload_;
+import org.fao.geonet.domain.MetadataSourceInfo;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.MetadataValidation;
+import org.fao.geonet.domain.Metadata_;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.OperationAllowedId;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.domain.ReservedGroup;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.EditLib;
+import org.fao.geonet.kernel.HarvestInfoProvider;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.ThesaurusManager;
+import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.XmlSerializer;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataOperations;
+import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataValidator;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.search.LuceneSearcher;
+import org.fao.geonet.kernel.search.MetaSearcher;
+import org.fao.geonet.kernel.search.SearchManager;
+import org.fao.geonet.kernel.search.SearchParameter;
+import org.fao.geonet.kernel.search.SearcherType;
+import org.fao.geonet.kernel.search.index.IndexingList;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.notifier.MetadataNotifierManager;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.MetadataCategoryRepository;
+import org.fao.geonet.repository.MetadataFileUploadRepository;
+import org.fao.geonet.repository.MetadataRatingByIpRepository;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.MetadataStatusRepository;
+import org.fao.geonet.repository.MetadataValidationRepository;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.PathSpec;
+import org.fao.geonet.repository.SortUtils;
+import org.fao.geonet.repository.Updater;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.UserSavedSelectionRepository;
+import org.fao.geonet.repository.specification.MetadataFileUploadSpecs;
+import org.fao.geonet.repository.specification.MetadataSpecs;
+import org.fao.geonet.repository.specification.OperationAllowedSpecs;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.Namespace;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.transaction.TransactionStatus;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import jeeves.transaction.TransactionManager;
+import jeeves.transaction.TransactionTask;
+import jeeves.xlink.Processor;
+
+public class BaseMetadataManager implements IMetadataManager {
+
+    @Autowired
+    private IMetadataUtils metadataUtils;
+    @Autowired
+    private IMetadataIndexer metadataIndexer;
+    @Autowired
+    private IMetadataValidator metadataValidator;
+    @Autowired
+    private IMetadataOperations metadataOperations;
+    @Autowired
+    private IMetadataSchemaUtils metadataSchemaUtils;
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private MetadataStatusRepository metadataStatusRepository;
+    @Autowired
+    private MetadataValidationRepository metadataValidationRepository;
+    @Autowired
+    private MetadataRepository metadataRepository;
+    @Autowired
+    private SearchManager searchManager;
+
+    private EditLib editLib;
+    @Autowired
+    private MetadataRatingByIpRepository metadataRatingByIpRepository;
+    @Autowired
+    private MetadataFileUploadRepository metadataFileUploadRepository;
+    @Autowired(required = false)
+    private XmlSerializer xmlSerializer;
+    @Autowired
+    @Lazy
+    private SettingManager settingManager;
+    @Autowired
+    private MetadataCategoryRepository metadataCategoryRepository;
+    @Autowired(required = false)
+    private HarvestInfoProvider harvestInfoProvider;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SchemaManager schemaManager;
+    @Autowired
+    private ThesaurusManager thesaurusManager;
+    @Autowired
+    private AccessManager accessManager;
+    @Autowired
+    private UserSavedSelectionRepository userSavedSelectionRepository;
+
+    private static final int METADATA_BATCH_PAGE_SIZE = 100000;
+    private String baseURL;
+
+    @Autowired
+    private ApplicationContext _applicationContext;
+    @PersistenceContext
+    private EntityManager _entityManager;
+
+    @Override
+    public EditLib getEditLib() {
+        return editLib;
+    }
+
+    /**
+     * To avoid cyclic references on autowired
+     */
+    @PostConstruct
+    public void init() {
+        editLib = new EditLib(schemaManager);
+        metadataValidator.setMetadataManager(this);
+        metadataUtils.setMetadataManager(this);
+    }
+
+    public void init(ServiceContext context, Boolean force) throws Exception {
+        // metadataUtils = context.getBean(IMetadataUtils.class);
+        // metadataIndexer = context.getBean(IMetadataIndexer.class);
+        // metadataStatusRepository = context.getBean(MetadataStatusRepository.class);
+        // metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
+        // metadataRepository = context.getBean(MetadataRepository.class);
+        // metadataValidator = context.getBean(IMetadataValidator.class);
+        // metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
+        // searchManager = context.getBean(SearchManager.class);
+        // metadataRatingByIpRepository = context.getBean(MetadataRatingByIpRepository.class);
+        // metadataFileUploadRepository = context.getBean(MetadataFileUploadRepository.class);
+        // groupRepository = context.getBean(GroupRepository.class);
+        // xmlSerializer = context.getBean(XmlSerializer.class);
+        // settingManager = context.getBean(SettingManager.class);
+        // metadataCategoryRepository = context.getBean(MetadataCategoryRepository.class);
+        // harvestInfoProvider = context.getBean(HarvestInfoProvider.class);
+        // userRepository = context.getBean(UserRepository.class);
+        // schemaManager = context.getBean(SchemaManager.class);
+        // thesaurusManager = context.getBean(ThesaurusManager.class);
+        // accessManager = context.getBean(AccessManager.class);
+
+        // From DataManager:
+
+        // get lastchangedate of all metadata in index
+        Map<String, String> docs = getSearchManager().getDocsChangeDate();
+
+        // set up results HashMap for post processing of records to be indexed
+        ArrayList<String> toIndex = new ArrayList<String>();
+
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "INDEX CONTENT:");
+
+        Sort sortByMetadataChangeDate = SortUtils.createSort(Metadata_.dataInfo, MetadataDataInfo_.changeDate);
+        int currentPage = 0;
+        Page<Pair<Integer, ISODate>> results = metadataRepository
+                .findAllIdsAndChangeDates(new PageRequest(currentPage, METADATA_BATCH_PAGE_SIZE, sortByMetadataChangeDate));
+
+        // index all metadata in DBMS if needed
+        while (results.getNumberOfElements() > 0) {
+            for (Pair<Integer, ISODate> result : results) {
+
+                // get metadata
+                String id = String.valueOf(result.one());
+
+                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                    Log.debug(Geonet.DATA_MANAGER, "- record (" + id + ")");
+                }
+
+                String idxLastChange = docs.get(id);
+
+                // if metadata is not indexed index it
+                if (idxLastChange == null) {
+                    Log.debug(Geonet.DATA_MANAGER, "-  will be indexed");
+                    toIndex.add(id);
+
+                    // else, if indexed version is not the latest index it
+                } else {
+                    docs.remove(id);
+
+                    String lastChange = result.two().toString();
+
+                    if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                        Log.debug(Geonet.DATA_MANAGER, "- lastChange: " + lastChange);
+                    if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                        Log.debug(Geonet.DATA_MANAGER, "- idxLastChange: " + idxLastChange);
+
+                    // date in index contains 't', date in DBMS contains 'T'
+                    if (force || !idxLastChange.equalsIgnoreCase(lastChange)) {
+                        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                            Log.debug(Geonet.DATA_MANAGER, "-  will be indexed");
+                        toIndex.add(id);
+                    }
+                }
+            }
+
+            currentPage++;
+            results = metadataRepository
+                    .findAllIdsAndChangeDates(new PageRequest(currentPage, METADATA_BATCH_PAGE_SIZE, sortByMetadataChangeDate));
+        }
+
+        // if anything to index then schedule it to be done after servlet is
+        // up so that any links to local fragments are resolvable
+        if (toIndex.size() > 0) {
+            metadataIndexer.batchIndexInThreadPool(context, toIndex);
+        }
+
+        if (docs.size() > 0) { // anything left?
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                Log.debug(Geonet.DATA_MANAGER, "INDEX HAS RECORDS THAT ARE NOT IN DB:");
+            }
+        }
+
+        // remove from index metadata not in DBMS
+        for (String id : docs.keySet()) {
+            getSearchManager().delete(id);
+
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                Log.debug(Geonet.DATA_MANAGER, "- removed record (" + id + ") from index");
+            }
+        }
+    }
+
+    private SearchManager getSearchManager() {
+        return searchManager;
+    }
+
+    /**
+     * You should not use a direct flush. If you need to use this to properly run your code, you are missing something. Check the
+     * transaction annotations and try to comply to Spring/Hibernate
+     */
+    @Override
+    @Deprecated
+    public void flush() {
+        TransactionManager.runInTransaction("DataManager flush()", getApplicationContext(),
+                TransactionManager.TransactionRequirement.CREATE_ONLY_WHEN_NEEDED, TransactionManager.CommitBehavior.ALWAYS_COMMIT, false,
+                new TransactionTask<Object>() {
+                    @Override
+                    public Object doInTransaction(TransactionStatus transaction) throws Throwable {
+                        _entityManager.flush();
+                        return null;
+                    }
+                });
+
+    }
+
+    private ApplicationContext getApplicationContext() {
+        final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
+        return applicationContext == null ? _applicationContext : applicationContext;
+    }
+
+    private void deleteMetadataFromDB(ServiceContext context, String id) throws Exception {
+        // --- remove operations
+        metadataOperations.deleteMetadataOper(context, id, false);
+
+        int intId = Integer.parseInt(id);
+        metadataRatingByIpRepository.deleteAllById_MetadataId(intId);
+        metadataValidationRepository.deleteAllById_MetadataId(intId);
+        metadataStatusRepository.deleteAllById_MetadataId(intId);
+        userSavedSelectionRepository.deleteAllByUuid(metadataUtils.getMetadataUuid(id));
+
+        // Logical delete for metadata file uploads
+        PathSpec<MetadataFileUpload, String> deletedDatePathSpec = new PathSpec<MetadataFileUpload, String>() {
+            @Override
+            public javax.persistence.criteria.Path<String> getPath(Root<MetadataFileUpload> root) {
+                return root.get(MetadataFileUpload_.deletedDate);
+            }
+        };
+
+        metadataFileUploadRepository.createBatchUpdateQuery(deletedDatePathSpec, new ISODate().toString(),
+                MetadataFileUploadSpecs.isNotDeletedForMetadata(intId));
+
+        // --- remove metadata
+        getXmlSerializer().delete(id, context);
+    }
+
+    // --------------------------------------------------------------------------
+    // ---
+    // --- Metadata thumbnail API
+    // ---
+    // --------------------------------------------------------------------------
+
+    private XmlSerializer getXmlSerializer() {
+        return xmlSerializer;
+    }
+
+    /**
+     * Removes a metadata.
+     */
+    @Override
+    public synchronized void deleteMetadata(ServiceContext context, String metadataId) throws Exception {
+        String uuid = metadataUtils.getMetadataUuid(metadataId);
+        Metadata findOne = metadataRepository.findOne(metadataId);
+        if (findOne != null) {
+            boolean isMetadata = findOne.getDataInfo().getType() == MetadataType.METADATA;
+
+            deleteMetadataFromDB(context, metadataId);
+
+            // Notifies the metadata change to metatada notifier service
+            if (isMetadata) {
+                context.getBean(MetadataNotifierManager.class).deleteMetadata(metadataId, uuid, context);
+            }
+        }
+
+        // --- update search criteria
+        getSearchManager().delete(metadataId + "");
+        // _entityManager.flush();
+        // _entityManager.clear();
+    }
+
+    /**
+     *
+     * @param context
+     * @param metadataId
+     * @throws Exception
+     */
+    @Override
+    public synchronized void deleteMetadataGroup(ServiceContext context, String metadataId) throws Exception {
+        deleteMetadataFromDB(context, metadataId);
+        // --- update search criteria
+        getSearchManager().delete(metadataId + "");
+    }
+
+    /**
+     * Creates a new metadata duplicating an existing template creating a random uuid.
+     *
+     * @param isTemplate
+     * @param fullRightsForGroup
+     */
+    @Override
+    public String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
+            String isTemplate, boolean fullRightsForGroup) throws Exception {
+
+        return createMetadata(context, templateId, groupOwner, source, owner, parentUuid, isTemplate, fullRightsForGroup,
+                UUID.randomUUID().toString());
+    }
+
+    /**
+     * Creates a new metadata duplicating an existing template with an specified uuid.
+     *
+     * @param isTemplate
+     * @param fullRightsForGroup
+     */
+    @Override
+    public String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
+            String isTemplate, boolean fullRightsForGroup, String uuid) throws Exception {
+        Metadata templateMetadata = metadataRepository.findOne(templateId);
+        if (templateMetadata == null) {
+            throw new IllegalArgumentException("Template id not found : " + templateId);
+        }
+
+        String schema = templateMetadata.getDataInfo().getSchemaId();
+        String data = templateMetadata.getData();
+        Element xml = Xml.loadString(data, false);
+        if (templateMetadata.getDataInfo().getType() == MetadataType.METADATA) {
+            xml = updateFixedInfo(schema, Optional.<Integer> absent(), uuid, xml, parentUuid, UpdateDatestamp.NO, context);
+        }
+        final Metadata newMetadata = new Metadata().setUuid(uuid);
+        newMetadata.getDataInfo().setChangeDate(new ISODate()).setCreateDate(new ISODate()).setSchemaId(schema)
+                .setType(MetadataType.lookup(isTemplate));
+        newMetadata.getSourceInfo().setGroupOwner(Integer.valueOf(groupOwner)).setOwner(owner).setSourceId(source);
+
+        // If there is a default category for the group, use it:
+        Group group = groupRepository.findOne(Integer.valueOf(groupOwner));
+        if (group.getDefaultCategory() != null) {
+            newMetadata.getMetadataCategories().add(group.getDefaultCategory());
+        }
+        Collection<MetadataCategory> filteredCategories = Collections2.filter(templateMetadata.getMetadataCategories(),
+                new Predicate<MetadataCategory>() {
+                    @Override
+                    public boolean apply(@Nullable MetadataCategory input) {
+                        return input != null;
+                    }
+                });
+
+        newMetadata.getMetadataCategories().addAll(filteredCategories);
+
+        int finalId = insertMetadata(context, newMetadata, xml, false, true, true, UpdateDatestamp.YES, fullRightsForGroup, true).getId();
+
+        return String.valueOf(finalId);
+    }
+
+    /**
+     * Inserts a metadata into the database, optionally indexing it, and optionally applying automatic changes to it (update-fixed-info).
+     *
+     * @param context the context describing the user and service
+     * @param schema XSD this metadata conforms to
+     * @param metadataXml the metadata to store
+     * @param uuid unique id for this metadata
+     * @param owner user who owns this metadata
+     * @param groupOwner group this metadata belongs to
+     * @param source id of the origin of this metadata (harvesting source, etc.)
+     * @param metadataType whether this metadata is a template
+     * @param docType ?!
+     * @param category category of this metadata
+     * @param createDate date of creation
+     * @param changeDate date of modification
+     * @param ufo whether to apply automatic changes
+     * @param index whether to index this metadata
+     * @return id, as a string
+     * @throws Exception hmm
+     */
+    @Override
+    public String insertMetadata(ServiceContext context, String schema, Element metadataXml, String uuid, int owner, String groupOwner,
+            String source, String metadataType, String docType, String category, String createDate, String changeDate, boolean ufo,
+            boolean index) throws Exception {
+
+        boolean notifyChange = true;
+
+        if (source == null) {
+            source = settingManager.getSiteId();
+        }
+
+        if (StringUtils.isBlank(metadataType)) {
+            metadataType = MetadataType.METADATA.codeString;
+        }
+        final Metadata newMetadata = new Metadata().setUuid(uuid);
+        final ISODate isoChangeDate = changeDate != null ? new ISODate(changeDate) : new ISODate();
+        final ISODate isoCreateDate = createDate != null ? new ISODate(createDate) : new ISODate();
+        newMetadata.getDataInfo().setChangeDate(isoChangeDate).setCreateDate(isoCreateDate).setSchemaId(schema).setDoctype(docType)
+                .setRoot(metadataXml.getQualifiedName()).setType(MetadataType.lookup(metadataType));
+        newMetadata.getSourceInfo().setOwner(owner).setSourceId(source);
+        if (StringUtils.isNotEmpty(groupOwner)) {
+            newMetadata.getSourceInfo().setGroupOwner(Integer.valueOf(groupOwner));
+        }
+        if (StringUtils.isNotEmpty(category)) {
+            MetadataCategory metadataCategory = metadataCategoryRepository.findOneByName(category);
+            if (metadataCategory == null) {
+                throw new IllegalArgumentException("No category found with name: " + category);
+            }
+            newMetadata.getMetadataCategories().add(metadataCategory);
+        } else if (StringUtils.isNotEmpty(groupOwner)) {
+            // If the group has a default category, use it
+            Group group = groupRepository.findOne(Integer.valueOf(groupOwner));
+            if (group.getDefaultCategory() != null) {
+                newMetadata.getMetadataCategories().add(group.getDefaultCategory());
+            }
+        }
+
+        boolean fullRightsForGroup = false;
+
+        int finalId = insertMetadata(context, newMetadata, metadataXml, notifyChange, index, ufo, UpdateDatestamp.NO, fullRightsForGroup,
+                false).getId();
+
+        return String.valueOf(finalId);
+    }
+
+    @Override
+    public Metadata insertMetadata(ServiceContext context, Metadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
+            boolean updateFixedInfo, UpdateDatestamp updateDatestamp, boolean fullRightsForGroup, boolean forceRefreshReaders)
+            throws Exception {
+        final String schema = newMetadata.getDataInfo().getSchemaId();
+
+        // Check if the schema is allowed by settings
+        String mdImportSetting = settingManager.getValue(Settings.METADATA_IMPORT_RESTRICT);
+        if (mdImportSetting != null && !mdImportSetting.equals("")) {
+            if (!Arrays.asList(mdImportSetting.split(",")).contains(schema)) {
+                throw new IllegalArgumentException(schema + " is not permitted in the database as a non-harvested metadata.  "
+                        + "Apply a import stylesheet to convert file to allowed schemas");
+            }
+        }
+
+        // --- force namespace prefix for iso19139 metadata
+        setNamespacePrefixUsingSchemas(schema, metadataXml);
+
+        if (updateFixedInfo && newMetadata.getDataInfo().getType() == MetadataType.METADATA) {
+            String parentUuid = null;
+            metadataXml = updateFixedInfo(schema, Optional.<Integer> absent(), newMetadata.getUuid(), metadataXml, parentUuid,
+                    updateDatestamp, context);
+        }
+
+        // --- store metadata
+        final Metadata savedMetadata = getXmlSerializer().insert(newMetadata, metadataXml, context);
+
+        final String stringId = String.valueOf(savedMetadata.getId());
+        String groupId = null;
+        final Integer groupIdI = newMetadata.getSourceInfo().getGroupOwner();
+        if (groupIdI != null) {
+            groupId = String.valueOf(groupIdI);
+        }
+        metadataOperations.copyDefaultPrivForGroup(context, stringId, groupId, fullRightsForGroup);
+
+        if (index) {
+            metadataIndexer.indexMetadata(stringId, forceRefreshReaders, null);
+        }
+
+        if (notifyChange) {
+            // Notifies the metadata change to metatada notifier service
+            metadataUtils.notifyMetadataChange(metadataXml, stringId);
+        }
+        return savedMetadata;
+    }
+
+    /**
+     * Retrieves a metadata (in xml) given its id; adds editing information if requested and validation errors if requested.
+     *
+     * @param forEditing Add extra element to build metadocument {@link EditLib#expandElements(String, Element)}
+     * @param keepXlinkAttributes When XLinks are resolved in non edit mode, do not remove XLink attributes.
+     */
+    @Override
+    public Element getMetadata(ServiceContext srvContext, String id, boolean forEditing, boolean withEditorValidationErrors,
+            boolean keepXlinkAttributes) throws Exception {
+        boolean doXLinks = getXmlSerializer().resolveXLinks();
+        Element metadataXml = getXmlSerializer().selectNoXLinkResolver(id, false, forEditing);
+        if (metadataXml == null)
+            return null;
+
+        String version = null;
+
+        if (forEditing) { // copy in xlink'd fragments but leave xlink atts to editor
+            if (doXLinks)
+                Processor.processXLink(metadataXml, srvContext);
+            String schema = metadataSchemaUtils.getMetadataSchema(id);
+
+            // Inflate metadata
+            Path inflateStyleSheet = metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.INFLATE_METADATA);
+            if (Files.exists(inflateStyleSheet)) {
+                // --- setup environment
+                Element env = new Element("env");
+                env.addContent(new Element("lang").setText(srvContext.getLanguage()));
+
+                // add original metadata to result
+                Element result = new Element("root");
+                result.addContent(metadataXml);
+                result.addContent(env);
+
+                metadataXml = Xml.transform(result, inflateStyleSheet);
+            }
+
+            if (withEditorValidationErrors) {
+                version = metadataValidator
+                        .doValidate(srvContext.getUserSession(), schema, id, metadataXml, srvContext.getLanguage(), forEditing).two();
+            } else {
+                editLib.expandElements(schema, metadataXml);
+                version = editLib.getVersionForEditing(schema, id, metadataXml);
+            }
+        } else {
+            if (doXLinks) {
+                if (keepXlinkAttributes) {
+                    Processor.processXLink(metadataXml, srvContext);
+                } else {
+                    Processor.detachXLink(metadataXml, srvContext);
+                }
+            }
+        }
+
+        metadataXml.addNamespaceDeclaration(Edit.NAMESPACE);
+        Element info = buildInfoElem(srvContext, id, version);
+        metadataXml.addContent(info);
+
+        metadataXml.detach();
+        return metadataXml;
+    }
+
+    /**
+     * Retrieves a metadata (in xml) given its id. Use this method when you must retrieve a metadata in the same transaction.
+     */
+    @Override
+    public Element getMetadata(String id) throws Exception {
+        Element md = getXmlSerializer().selectNoXLinkResolver(id, false, false);
+        if (md == null)
+            return null;
+        md.detach();
+        return md;
+    }
+
+    /**
+     * For update of owner info.
+     */
+    @Override
+    public synchronized void updateMetadataOwner(final int id, final String owner, final String groupOwner) throws Exception {
+        metadataRepository.update(id, new Updater<Metadata>() {
+            @Override
+            public void apply(@Nonnull Metadata entity) {
+                entity.getSourceInfo().setGroupOwner(Integer.valueOf(groupOwner));
+                entity.getSourceInfo().setOwner(Integer.valueOf(owner));
+            }
+        });
+    }
+
+    /**
+     * Updates a metadata record. Deletes validation report currently in session (if any). If user asks for validation the validation report
+     * will be (re-)created then.
+     *
+     * @return metadata if the that was updated
+     */
+    @Override
+    public synchronized Metadata updateMetadata(final ServiceContext context, final String metadataId, final Element md,
+            final boolean validate, final boolean ufo, final boolean index, final String lang, final String changeDate,
+            final boolean updateDateStamp) throws Exception {
+        Element metadataXml = md;
+
+        // when invoked from harvesters, session is null?
+        UserSession session = context.getUserSession();
+        if (session != null) {
+            session.removeProperty(Geonet.Session.VALIDATION_REPORT + metadataId);
+        }
+        String schema = metadataSchemaUtils.getMetadataSchema(metadataId);
+        if (ufo) {
+            String parentUuid = null;
+            Integer intId = Integer.valueOf(metadataId);
+
+            final Metadata metadata = metadataRepository.findOne(metadataId);
+
+            String uuid = null;
+
+            if (schemaManager.getSchema(schema).isReadwriteUUID() && metadata.getDataInfo().getType() != MetadataType.SUB_TEMPLATE
+                    && metadata.getDataInfo().getType() != MetadataType.TEMPLATE_OF_SUB_TEMPLATE) {
+                uuid = metadataUtils.extractUUID(schema, metadataXml);
+            }
+
+            metadataXml = updateFixedInfo(schema, Optional.of(intId), uuid, metadataXml, parentUuid,
+                    (updateDateStamp ? UpdateDatestamp.YES : UpdateDatestamp.NO), context);
+        }
+
+        // --- force namespace prefix for iso19139 metadata
+        setNamespacePrefixUsingSchemas(schema, metadataXml);
+
+        // Notifies the metadata change to metatada notifier service
+        final Metadata metadata = metadataRepository.findOne(metadataId);
+
+        String uuid = null;
+        if (schemaManager.getSchema(schema).isReadwriteUUID() && metadata.getDataInfo().getType() != MetadataType.SUB_TEMPLATE
+                && metadata.getDataInfo().getType() != MetadataType.TEMPLATE_OF_SUB_TEMPLATE) {
+            uuid = metadataUtils.extractUUID(schema, metadataXml);
+        }
+
+        // --- write metadata to dbms
+        getXmlSerializer().update(metadataId, metadataXml, changeDate, updateDateStamp, uuid, context);
+        // Notifies the metadata change to metatada notifier service
+        metadataUtils.notifyMetadataChange(metadataXml, metadataId);
+
+        try {
+            // --- do the validation last - it throws exceptions
+            if (session != null && validate) {
+                metadataValidator.doValidate(session, schema, metadataId, metadataXml, lang, false);
+            }
+        } finally {
+            if (index) {
+                // --- update search criteria
+                metadataIndexer.indexMetadata(metadataId, true, null);
+            }
+        }
+
+        if (metadata.getDataInfo().getType() == MetadataType.SUB_TEMPLATE) {
+            if (!index) {
+                metadataIndexer.indexMetadata(metadataId, true, null);
+            }
+            MetaSearcher searcher = context.getBean(SearchManager.class).newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE);
+            Element parameters = new Element(Jeeves.Elem.REQUEST);
+            parameters.addContent(new Element(Geonet.IndexFieldNames.XLINK).addContent("*" + metadata.getUuid() + "*"));
+            parameters.addContent(new Element(Geonet.SearchResult.BUILD_SUMMARY).setText("false"));
+            parameters.addContent(new Element(SearchParameter.ISADMIN).addContent("true"));
+            parameters.addContent(new Element(SearchParameter.ISTEMPLATE).addContent("y or n"));
+            ServiceConfig config = new ServiceConfig();
+            searcher.search(context, parameters, config);
+            Map<Integer, Metadata> result = ((LuceneSearcher) searcher).getAllMdInfo(context, 500);
+            for (Integer id : result.keySet()) {
+                IndexingList list = context.getBean(IndexingList.class);
+                list.add(id);
+            }
+        }
+        // Return an up to date metadata record
+        return metadataRepository.findOne(metadataId);
+    }
+
+    /**
+     * TODO : buildInfoElem contains similar portion of code with indexMetadata
+     */
+    private Element buildInfoElem(ServiceContext context, String id, String version) throws Exception {
+        Metadata metadata = metadataRepository.findOne(id);
+        final MetadataDataInfo dataInfo = metadata.getDataInfo();
+        String schema = dataInfo.getSchemaId();
+        String createDate = dataInfo.getCreateDate().getDateAndTime();
+        String changeDate = dataInfo.getChangeDate().getDateAndTime();
+        String source = metadata.getSourceInfo().getSourceId();
+        String isTemplate = dataInfo.getType().codeString;
+        String title = dataInfo.getTitle();
+        String uuid = metadata.getUuid();
+        String isHarvested = "" + Constants.toYN_EnabledChar(metadata.getHarvestInfo().isHarvested());
+        String harvestUuid = metadata.getHarvestInfo().getUuid();
+        String popularity = "" + dataInfo.getPopularity();
+        String rating = "" + dataInfo.getRating();
+        String owner = "" + metadata.getSourceInfo().getOwner();
+        String displayOrder = "" + dataInfo.getDisplayOrder();
+
+        Element info = new Element(Edit.RootChild.INFO, Edit.NAMESPACE);
+
+        addElement(info, Edit.Info.Elem.ID, id);
+        addElement(info, Edit.Info.Elem.SCHEMA, schema);
+        addElement(info, Edit.Info.Elem.CREATE_DATE, createDate);
+        addElement(info, Edit.Info.Elem.CHANGE_DATE, changeDate);
+        addElement(info, Edit.Info.Elem.IS_TEMPLATE, isTemplate);
+        addElement(info, Edit.Info.Elem.TITLE, title);
+        addElement(info, Edit.Info.Elem.SOURCE, source);
+        addElement(info, Edit.Info.Elem.UUID, uuid);
+        addElement(info, Edit.Info.Elem.IS_HARVESTED, isHarvested);
+        addElement(info, Edit.Info.Elem.POPULARITY, popularity);
+        addElement(info, Edit.Info.Elem.RATING, rating);
+        addElement(info, Edit.Info.Elem.DISPLAY_ORDER, displayOrder);
+
+        if (metadata.getHarvestInfo().isHarvested()) {
+            if (harvestInfoProvider != null) {
+                info.addContent(harvestInfoProvider.getHarvestInfo(harvestUuid, id, uuid));
+            }
+        }
+        if (version != null) {
+            addElement(info, Edit.Info.Elem.VERSION, version);
+        }
+
+        Map<String, Element> map = Maps.newHashMap();
+        map.put(id, info);
+        buildPrivilegesMetadataInfo(context, map);
+
+        // add owner name
+        User user = userRepository.findOne(owner);
+        if (user != null) {
+            String ownerName = user.getName();
+            addElement(info, Edit.Info.Elem.OWNERNAME, ownerName);
+        }
+
+        for (MetadataCategory category : metadata.getMetadataCategories()) {
+            addElement(info, Edit.Info.Elem.CATEGORY, category.getName());
+        }
+
+        // add subtemplates
+        /*
+         * -- don't add as we need to investigate indexing for the fields -- in the metadata table used here List subList =
+         * getSubtemplates(dbms, schema); if (subList != null) { Element subs = new Element(Edit.Info.Elem.SUBTEMPLATES);
+         * subs.addContent(subList); info.addContent(subs); }
+         */
+
+        // Add validity information
+        List<MetadataValidation> validationInfo = metadataValidationRepository.findAllById_MetadataId(Integer.parseInt(id));
+        if (validationInfo == null || validationInfo.size() == 0) {
+            addElement(info, Edit.Info.Elem.VALID, "-1");
+        } else {
+            String isValid = "1";
+            for (Object elem : validationInfo) {
+                MetadataValidation vi = (MetadataValidation) elem;
+                String type = vi.getId().getValidationType();
+                if (!vi.isValid()) {
+                    isValid = "0";
+                }
+
+                String ratio = "xsd".equals(type) ? "" : vi.getNumFailures() + "/" + vi.getNumTests();
+
+                info.addContent(new Element(Edit.Info.Elem.VALID + "_details").addContent(new Element("type").setText(type)).addContent(
+                        new Element("status").setText(vi.isValid() ? "1" : "0").addContent(new Element("ratio").setText(ratio))));
+            }
+            addElement(info, Edit.Info.Elem.VALID, isValid);
+        }
+
+        // add baseUrl of this site (from settings)
+        String protocol = settingManager.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
+        String host = settingManager.getValue(Settings.SYSTEM_SERVER_HOST);
+        String port = settingManager.getValue(Settings.SYSTEM_SERVER_PORT);
+        if (port.equals("80")) {
+            port = "";
+        } else {
+            port = ":" + port;
+        }
+        addElement(info, Edit.Info.Elem.BASEURL, protocol + "://" + host + port + baseURL);
+        addElement(info, Edit.Info.Elem.LOCSERV, "/srv/en");
+        return info;
+    }
+
+    /**
+     * Update metadata record (not template) using update-fixed-info.xsl
+     *
+     * @param uuid If the metadata is a new record (not yet saved), provide the uuid for that record
+     * @param updateDatestamp updateDatestamp is not used when running XSL transformation
+     */
+    @Override
+    public Element updateFixedInfo(String schema, Optional<Integer> metadataId, String uuid, Element md, String parentUuid,
+            UpdateDatestamp updateDatestamp, ServiceContext context) throws Exception {
+        boolean autoFixing = settingManager.getValueAsBool(Settings.SYSTEM_AUTOFIXING_ENABLE, true);
+        if (autoFixing) {
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                Log.debug(Geonet.DATA_MANAGER,
+                        "Autofixing is enabled, trying update-fixed-info (updateDatestamp: " + updateDatestamp.name() + ")");
+            }
+
+            Metadata metadata = null;
+            if (metadataId.isPresent()) {
+                metadata = metadataRepository.findOne(metadataId.get());
+                boolean isTemplate = metadata != null && metadata.getDataInfo().getType() != MetadataType.METADATA;
+
+                // don't process templates
+                if (isTemplate) {
+                    if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                        Log.debug(Geonet.DATA_MANAGER, "Not applying update-fixed-info for a template");
+                    }
+                    return md;
+                }
+            }
+
+            String currentUuid = metadata != null ? metadata.getUuid() : null;
+            String id = metadata != null ? metadata.getId() + "" : null;
+            uuid = uuid == null ? currentUuid : uuid;
+
+            // --- setup environment
+            Element env = new Element("env");
+            env.addContent(new Element("id").setText(id));
+            env.addContent(new Element("uuid").setText(uuid));
+
+            env.addContent(thesaurusManager.buildResultfromThTable(context));
+
+            Element schemaLoc = new Element("schemaLocation");
+            schemaLoc.setAttribute(schemaManager.getSchemaLocation(schema, context));
+            env.addContent(schemaLoc);
+
+            if (updateDatestamp == UpdateDatestamp.YES) {
+                env.addContent(new Element("changeDate").setText(new ISODate().toString()));
+            }
+            if (parentUuid != null) {
+                env.addContent(new Element("parentUuid").setText(parentUuid));
+            }
+            if (metadataId.isPresent()) {
+                String metadataIdString = String.valueOf(metadataId.get());
+                final Path resourceDir = Lib.resource.getDir(context, Params.Access.PRIVATE, metadataIdString);
+                env.addContent(new Element("datadir").setText(resourceDir.toString()));
+            }
+
+            // add user information to env if user is authenticated (should be)
+            Element elUser = new Element("user");
+            UserSession usrSess = context.getUserSession();
+            if (usrSess.isAuthenticated()) {
+                String myUserId = usrSess.getUserId();
+                User user = getApplicationContext().getBean(UserRepository.class).findOne(myUserId);
+                if (user != null) {
+                    Element elUserDetails = new Element("details");
+                    elUserDetails.addContent(new Element("surname").setText(user.getSurname()));
+                    elUserDetails.addContent(new Element("firstname").setText(user.getName()));
+                    elUserDetails.addContent(new Element("organisation").setText(user.getOrganisation()));
+                    elUserDetails.addContent(new Element("username").setText(user.getUsername()));
+                    elUser.addContent(elUserDetails);
+                    env.addContent(elUser);
+                }
+            }
+
+            // add original metadata to result
+            Element result = new Element("root");
+            result.addContent(md);
+            // add 'environment' to result
+            env.addContent(new Element("siteURL").setText(settingManager.getSiteURL(context)));
+            env.addContent(new Element("node").setText(context.getNodeId()));
+            
+            // Settings were defined as an XML starting with root named config
+            // Only second level elements are defined (under system).
+            List<?> config = settingManager.getAllAsXML(true).cloneContent();
+            for (Object c : config) {
+                Element settings = (Element) c;
+                env.addContent(settings);
+            }
+
+            result.addContent(env);
+            // apply update-fixed-info.xsl
+            Path styleSheet = metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.UPDATE_FIXED_INFO);
+            result = Xml.transform(result, styleSheet);
+            return result;
+        } else {
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                Log.debug(Geonet.DATA_MANAGER, "Autofixing is disabled, not applying update-fixed-info");
+            }
+            return md;
+        }
+    }
+
+    /**
+     * Updates all children of the selected parent. Some elements are protected in the children according to the stylesheet used in
+     * xml/schemas/[SCHEMA]/update-child-from-parent-info.xsl.
+     *
+     * Children MUST be editable and also in the same schema of the parent. If not, child is not updated.
+     *
+     * @param srvContext service context
+     * @param parentUuid parent uuid
+     * @param children children
+     * @param params parameters
+     */
+    @Override
+    public Set<String> updateChildren(ServiceContext srvContext, String parentUuid, String[] children, Map<String, Object> params)
+            throws Exception {
+        String parentId = (String) params.get(Params.ID);
+        String parentSchema = (String) params.get(Params.SCHEMA);
+
+        // --- get parent metadata in read/only mode
+        boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = false;
+        Element parent = getMetadata(srvContext, parentId, forEditing, withValidationErrors, keepXlinkAttributes);
+
+        Element env = new Element("update");
+        env.addContent(new Element("parentUuid").setText(parentUuid));
+        env.addContent(new Element("siteURL").setText(settingManager.getSiteURL(srvContext)));
+        env.addContent(new Element("parent").addContent(parent));
+
+        // Set of untreated children (out of privileges, different schemas)
+        Set<String> untreatedChildSet = new HashSet<String>();
+
+        // only get iso19139 records
+        for (String childId : children) {
+
+            // Check privileges
+            if (!accessManager.canEdit(srvContext, childId)) {
+                untreatedChildSet.add(childId);
+                if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                    Log.debug(Geonet.DATA_MANAGER, "Could not update child (" + childId + ") because of privileges.");
+                continue;
+            }
+
+            Element child = getMetadata(srvContext, childId, forEditing, withValidationErrors, keepXlinkAttributes);
+
+            String childSchema = child.getChild(Edit.RootChild.INFO, Edit.NAMESPACE).getChildText(Edit.Info.Elem.SCHEMA);
+
+            // Check schema matching. CHECKME : this suppose that parent and
+            // child are in the same schema (even not profil different)
+            if (!childSchema.equals(parentSchema)) {
+                untreatedChildSet.add(childId);
+                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                    Log.debug(Geonet.DATA_MANAGER, "Could not update child (" + childId + ") because schema (" + childSchema
+                            + ") is different from the parent one (" + parentSchema + ").");
+                }
+                continue;
+            }
+
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                Log.debug(Geonet.DATA_MANAGER, "Updating child (" + childId + ") ...");
+
+            // --- setup xml element to be processed by XSLT
+
+            Element rootEl = new Element("root");
+            Element childEl = new Element("child").addContent(child.detach());
+            rootEl.addContent(childEl);
+            rootEl.addContent(env.detach());
+
+            // --- do an XSL transformation
+
+            Path styleSheet = metadataSchemaUtils.getSchemaDir(parentSchema).resolve(Geonet.File.UPDATE_CHILD_FROM_PARENT_INFO);
+            Element childForUpdate = Xml.transform(rootEl, styleSheet, params);
+
+            getXmlSerializer().update(childId, childForUpdate, new ISODate().toString(), true, null, srvContext);
+
+            // Notifies the metadata change to metatada notifier service
+            metadataUtils.notifyMetadataChange(childForUpdate, childId);
+
+            rootEl = null;
+        }
+
+        return untreatedChildSet;
+    }
+
+    // ---------------------------------------------------------------------------
+    // ---
+    // --- Static methods are for external modules like GAST to be able to use
+    // --- them.
+    // ---
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Add privileges information about metadata record which depends on context and usually could not be stored in db or Lucene index
+     * because depending on the current user or current client IP address.
+     *
+     * @param mdIdToInfoMap a map from the metadata Id -> the info element to which the privilege information should be added.
+     */
+    @VisibleForTesting
+    @Override
+    public void buildPrivilegesMetadataInfo(ServiceContext context, Map<String, Element> mdIdToInfoMap) throws Exception {
+        Collection<Integer> metadataIds = Collections2.transform(mdIdToInfoMap.keySet(), new Function<String, Integer>() {
+            @Nullable
+            @Override
+            public Integer apply(String input) {
+                return Integer.valueOf(input);
+            }
+        });
+        Specification<OperationAllowed> operationAllowedSpec = OperationAllowedSpecs.hasMetadataIdIn(metadataIds);
+
+        final Collection<Integer> allUserGroups = accessManager.getUserGroups(context.getUserSession(), context.getIpAddress(), false);
+        final SetMultimap<Integer, ReservedOperation> operationsPerMetadata = loadOperationsAllowed(context,
+                where(operationAllowedSpec).and(OperationAllowedSpecs.hasGroupIdIn(allUserGroups)));
+        final Set<Integer> visibleToAll = loadOperationsAllowed(context,
+                where(operationAllowedSpec).and(OperationAllowedSpecs.isPublic(ReservedOperation.view))).keySet();
+        final Set<Integer> downloadableByGuest = loadOperationsAllowed(context,
+                where(operationAllowedSpec).and(OperationAllowedSpecs.hasGroupId(ReservedGroup.guest.getId()))
+                        .and(OperationAllowedSpecs.hasOperation(ReservedOperation.download))).keySet();
+        final Map<Integer, MetadataSourceInfo> allSourceInfo = metadataRepository
+                .findAllSourceInfo(MetadataSpecs.hasMetadataIdIn(metadataIds));
+
+        for (Map.Entry<String, Element> entry : mdIdToInfoMap.entrySet()) {
+            Element infoEl = entry.getValue();
+            final Integer mdId = Integer.valueOf(entry.getKey());
+            MetadataSourceInfo sourceInfo = allSourceInfo.get(mdId);
+            Set<ReservedOperation> operations = operationsPerMetadata.get(mdId);
+            if (operations == null) {
+                operations = Collections.emptySet();
+            }
+
+            boolean isOwner = accessManager.isOwner(context, sourceInfo);
+
+            if (isOwner) {
+                operations = Sets.newHashSet(Arrays.asList(ReservedOperation.values()));
+            }
+
+            if (isOwner || operations.contains(ReservedOperation.editing)) {
+                addElement(infoEl, Edit.Info.Elem.EDIT, "true");
+            }
+
+            if (isOwner) {
+                addElement(infoEl, Edit.Info.Elem.OWNER, "true");
+            }
+
+            addElement(infoEl, Edit.Info.Elem.IS_PUBLISHED_TO_ALL, visibleToAll.contains(mdId));
+            addElement(infoEl, ReservedOperation.view.name(), operations.contains(ReservedOperation.view));
+            addElement(infoEl, ReservedOperation.notify.name(), operations.contains(ReservedOperation.notify));
+            addElement(infoEl, ReservedOperation.download.name(), operations.contains(ReservedOperation.download));
+            addElement(infoEl, ReservedOperation.dynamic.name(), operations.contains(ReservedOperation.dynamic));
+            addElement(infoEl, ReservedOperation.featured.name(), operations.contains(ReservedOperation.featured));
+
+            if (!operations.contains(ReservedOperation.download)) {
+                addElement(infoEl, Edit.Info.Elem.GUEST_DOWNLOAD, downloadableByGuest.contains(mdId));
+            }
+        }
+    }
+
+    private SetMultimap<Integer, ReservedOperation> loadOperationsAllowed(ServiceContext context,
+            Specification<OperationAllowed> operationAllowedSpec) {
+        final OperationAllowedRepository operationAllowedRepo = context.getBean(OperationAllowedRepository.class);
+        List<OperationAllowed> operationsAllowed = operationAllowedRepo.findAll(operationAllowedSpec);
+        SetMultimap<Integer, ReservedOperation> operationsPerMetadata = HashMultimap.create();
+        for (OperationAllowed allowed : operationsAllowed) {
+            final OperationAllowedId id = allowed.getId();
+            operationsPerMetadata.put(id.getMetadataId(), ReservedOperation.lookup(id.getOperationId()));
+        }
+        return operationsPerMetadata;
+    }
+
+    /**
+     *
+     * @param md
+     * @throws Exception
+     */
+    private void setNamespacePrefixUsingSchemas(String schema, Element md) throws Exception {
+        // --- if the metadata has no namespace or already has a namespace prefix
+        // --- then we must skip this phase
+        Namespace ns = md.getNamespace();
+        if (ns == Namespace.NO_NAMESPACE)
+            return;
+
+        MetadataSchema mds = schemaManager.getSchema(schema);
+
+        // --- get the namespaces and add prefixes to any that are
+        // --- default (ie. prefix is '') if namespace match one of the schema
+        ArrayList<Namespace> nsList = new ArrayList<Namespace>();
+        nsList.add(ns);
+        @SuppressWarnings("unchecked")
+        List<Namespace> additionalNamespaces = md.getAdditionalNamespaces();
+        nsList.addAll(additionalNamespaces);
+        for (Object aNsList : nsList) {
+            Namespace aNs = (Namespace) aNsList;
+            if (aNs.getPrefix().equals("")) { // found default namespace
+                String prefix = mds.getPrefix(aNs.getURI());
+                if (prefix == null) {
+                    Log.warning(Geonet.DATA_MANAGER, "Metadata record contains a default namespace " + aNs.getURI()
+                            + " (with no prefix) which does not match any " + schema + " schema's namespaces.");
+                }
+                ns = Namespace.getNamespace(prefix, aNs.getURI());
+                metadataValidator.setNamespacePrefix(md, ns);
+                if (!md.getNamespace().equals(ns)) {
+                    md.removeNamespaceDeclaration(aNs);
+                    md.addNamespaceDeclaration(ns);
+                }
+            }
+        }
+    }
+
+    /**
+     *
+     * @param root
+     * @param name
+     * @param value
+     */
+    private static void addElement(Element root, String name, Object value) {
+        root.addContent(new Element(name).setText(value == null ? "" : value.toString()));
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -189,25 +189,29 @@ public class BaseMetadataManager implements IMetadataManager {
     }
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-        // metadataUtils = context.getBean(IMetadataUtils.class);
-        // metadataIndexer = context.getBean(IMetadataIndexer.class);
-        // metadataStatusRepository = context.getBean(MetadataStatusRepository.class);
-        // metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
-        // metadataRepository = context.getBean(MetadataRepository.class);
-        // metadataValidator = context.getBean(IMetadataValidator.class);
-        // metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
-        // searchManager = context.getBean(SearchManager.class);
-        // metadataRatingByIpRepository = context.getBean(MetadataRatingByIpRepository.class);
-        // metadataFileUploadRepository = context.getBean(MetadataFileUploadRepository.class);
-        // groupRepository = context.getBean(GroupRepository.class);
-        // xmlSerializer = context.getBean(XmlSerializer.class);
-        // settingManager = context.getBean(SettingManager.class);
-        // metadataCategoryRepository = context.getBean(MetadataCategoryRepository.class);
-        // harvestInfoProvider = context.getBean(HarvestInfoProvider.class);
-        // userRepository = context.getBean(UserRepository.class);
-        // schemaManager = context.getBean(SchemaManager.class);
-        // thesaurusManager = context.getBean(ThesaurusManager.class);
-        // accessManager = context.getBean(AccessManager.class);
+        metadataUtils = context.getBean(IMetadataUtils.class);
+        metadataIndexer = context.getBean(IMetadataIndexer.class);
+        metadataStatusRepository = context.getBean(MetadataStatusRepository.class);
+        metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
+        metadataRepository = context.getBean(MetadataRepository.class);
+        metadataValidator = context.getBean(IMetadataValidator.class);
+        metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
+        searchManager = context.getBean(SearchManager.class);
+        metadataRatingByIpRepository = context.getBean(MetadataRatingByIpRepository.class);
+        metadataFileUploadRepository = context.getBean(MetadataFileUploadRepository.class);
+        groupRepository = context.getBean(GroupRepository.class);
+        xmlSerializer = context.getBean(XmlSerializer.class);
+        settingManager = context.getBean(SettingManager.class);
+        metadataCategoryRepository = context.getBean(MetadataCategoryRepository.class);
+        try {
+            harvestInfoProvider = context.getBean(HarvestInfoProvider.class);
+        } catch (Exception e) {
+            // If it doesn't exist, that's fine
+        }
+        userRepository = context.getBean(UserRepository.class);
+        schemaManager = context.getBean(SchemaManager.class);
+        thesaurusManager = context.getBean(ThesaurusManager.class);
+        accessManager = context.getBean(AccessManager.class);
 
         // From DataManager:
 
@@ -914,7 +918,7 @@ public class BaseMetadataManager implements IMetadataManager {
             // add 'environment' to result
             env.addContent(new Element("siteURL").setText(settingManager.getSiteURL(context)));
             env.addContent(new Element("node").setText(context.getNodeId()));
-            
+
             // Settings were defined as an XML starting with root named config
             // Only second level elements are defined (under system).
             List<?> config = settingManager.getAllAsXML(true).cloneContent();

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
@@ -1,0 +1,278 @@
+package org.fao.geonet.kernel.datamanager.base;
+
+import static org.springframework.data.jpa.domain.Specifications.where;
+
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.OperationAllowedId;
+import org.fao.geonet.domain.OperationAllowedId_;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.ReservedGroup;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.domain.UserGroupId;
+import org.fao.geonet.exceptions.ServiceNotAllowedEx;
+import org.fao.geonet.kernel.SvnManager;
+import org.fao.geonet.kernel.datamanager.IMetadataOperations;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.UserGroupRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.specification.MetadataSpecs;
+import org.fao.geonet.repository.specification.UserGroupSpecs;
+import org.fao.geonet.repository.specification.UserSpecs;
+import org.fao.geonet.utils.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.jpa.domain.Specification;
+
+import com.google.common.base.Optional;
+
+import jeeves.server.context.ServiceContext;
+
+public class BaseMetadataOperations implements IMetadataOperations {
+
+    @Autowired
+    private MetadataRepository metadataRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private OperationAllowedRepository opAllowedRepo;
+    @Autowired
+    private UserGroupRepository userGroupRepo;
+    @Autowired
+    @Lazy
+    private SettingManager settingManager;
+    @Autowired(required=false)
+    private SvnManager svnManager;
+
+    public void init(ServiceContext context, Boolean force) throws Exception {
+//        userRepository = context.getBean(UserRepository.class);
+//        metadataRepository = context.getBean(MetadataRepository.class);
+//        opAllowedRepo = context.getBean(OperationAllowedRepository.class);
+//        userGroupRepo = context.getBean(UserGroupRepository.class);
+//        settingManager = context.getBean(SettingManager.class);
+//        svnManager = context.getBean(SvnManager.class);
+    }
+
+    /**
+     * Removes all operations stored for a metadata.
+     */
+    @Override
+    public void deleteMetadataOper(ServiceContext context, String metadataId, boolean skipAllReservedGroup) throws Exception {
+        OperationAllowedRepository operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
+
+        if (skipAllReservedGroup) {
+            int[] exclude = new int[] { ReservedGroup.all.getId(), ReservedGroup.intranet.getId(), ReservedGroup.guest.getId() };
+            operationAllowedRepository.deleteAllByMetadataIdExceptGroupId(Integer.parseInt(metadataId), exclude);
+        } else {
+            operationAllowedRepository.deleteAllByIdAttribute(OperationAllowedId_.metadataId, Integer.parseInt(metadataId));
+        }
+    }
+
+    /**
+     * Adds a permission to a group. Metadata is not reindexed.
+     */
+    @Override
+    public void setOperation(ServiceContext context, String mdId, String grpId, ReservedOperation op) throws Exception {
+        setOperation(context, Integer.parseInt(mdId), Integer.parseInt(grpId), op.getId());
+    }
+
+    /**
+     * Adds a permission to a group. Metadata is not reindexed.
+     */
+    @Override
+    public void setOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception {
+        setOperation(context, Integer.parseInt(mdId), Integer.parseInt(grpId), Integer.valueOf(opId));
+    }
+
+    /**
+     * Set metadata privileges.
+     *
+     * Administrator can set operation for any groups.
+     *
+     * For reserved group (ie. Internet, Intranet & Guest), user MUST be reviewer of one group. For other group, if "Only set privileges to
+     * user's groups" is set in catalog configuration user MUST be a member of the group.
+     *
+     * @param mdId The metadata identifier
+     * @param grpId The group identifier
+     * @param opId The operation identifier
+     * @return true if the operation was set.
+     */
+    @Override
+    public boolean setOperation(ServiceContext context, int mdId, int grpId, int opId) throws Exception {
+        Optional<OperationAllowed> opAllowed = getOperationAllowedToAdd(context, mdId, grpId, opId);
+
+        // Set operation
+        if (opAllowed.isPresent()) {
+            opAllowedRepo.save(opAllowed.get());
+            svnManager.setHistory(mdId + "", context);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check that the operation has not been added and if not that it can be added.
+     * <ul>
+     * <li>If the operation can be added then an non-empty optional is return.</li>
+     * <li>If it has already been added the return empty optional</li>
+     * <li>If it is not permitted to be added throw exception.</li>
+     * </ul>
+     */
+    @Override
+    public Optional<OperationAllowed> getOperationAllowedToAdd(final ServiceContext context, final int mdId, final int grpId,
+            final int opId) {
+        final OperationAllowed operationAllowed = opAllowedRepo.findOneById_GroupIdAndId_MetadataIdAndId_OperationId(grpId, mdId, opId);
+
+        if (operationAllowed == null) {
+            checkOperationPermission(context, grpId, userGroupRepo);
+        }
+
+        if (operationAllowed == null) {
+            return Optional.of(new OperationAllowed(new OperationAllowedId().setGroupId(grpId).setMetadataId(mdId).setOperationId(opId)));
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    @Override
+    public void checkOperationPermission(ServiceContext context, int grpId, UserGroupRepository userGroupRepo) {
+        // Check user privileges
+        // Session may not be defined when a harvester is running
+        if (context.getUserSession() != null) {
+            Profile userProfile = context.getUserSession().getProfile();
+            if (!(userProfile == Profile.Administrator || userProfile == Profile.UserAdmin)) {
+                int userId = context.getUserSession().getUserIdAsInt();
+                // Reserved groups
+                if (ReservedGroup.isReserved(grpId)) {
+
+                    Specification<UserGroup> hasUserIdAndProfile = where(UserGroupSpecs.hasProfile(Profile.Reviewer))
+                            .and(UserGroupSpecs.hasUserId(userId));
+                    List<Integer> groupIds = userGroupRepo.findGroupIds(hasUserIdAndProfile);
+
+                    if (groupIds.isEmpty()) {
+                        throw new ServiceNotAllowedEx(
+                                "User can't set operation for group " + grpId + " because the user in not a " + "Reviewer of any group.");
+                    }
+                } else {
+                    String userGroupsOnly = settingManager.getValue(Settings.SYSTEM_METADATAPRIVS_USERGROUPONLY);
+                    if (userGroupsOnly.equals("true")) {
+                        // If user is member of the group, user can set operation
+
+                        if (userGroupRepo.exists(new UserGroupId().setGroupId(grpId).setUserId(userId))) {
+                            throw new ServiceNotAllowedEx(
+                                    "User can't set operation for group " + grpId + " because the user in not" + " member of this group.");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     *
+     * @param context
+     * @param mdId
+     * @param grpId
+     * @param opId
+     * @throws Exception
+     */
+    @Override
+    public void unsetOperation(ServiceContext context, String mdId, String grpId, ReservedOperation opId) throws Exception {
+        unsetOperation(context, Integer.parseInt(mdId), Integer.parseInt(grpId), opId.getId());
+    }
+
+    /**
+     *
+     * @param context
+     * @param mdId
+     * @param grpId
+     * @param opId
+     * @throws Exception
+     */
+    @Override
+    public void unsetOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception {
+        unsetOperation(context, Integer.parseInt(mdId), Integer.parseInt(grpId), Integer.valueOf(opId));
+    }
+
+    // --------------------------------------------------------------------------
+    // ---
+    // --- Check User Id to avoid foreign key problems
+    // ---
+    // --------------------------------------------------------------------------
+
+    /**
+     * @param mdId metadata id
+     * @param groupId group id
+     * @param operId operation id
+     */
+    @Override
+    public void unsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception {
+        checkOperationPermission(context, groupId, context.getBean(UserGroupRepository.class));
+        forceUnsetOperation(context, mdId, groupId, operId);
+    }
+
+    /**
+     * Unset operation without checking if user privileges allows the operation. This may be useful when a user is an editor and internal
+     * operations needs to update privilages for reserved group. eg. {@link org.fao.geonet.kernel.metadata.DefaultStatusActions}
+     */
+    @Override
+    public void forceUnsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception {
+        OperationAllowedId id = new OperationAllowedId().setGroupId(groupId).setMetadataId(mdId).setOperationId(operId);
+        final OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
+        if (repository.exists(id)) {
+            repository.delete(id);
+            if (svnManager != null) {
+                svnManager.setHistory(mdId + "", context);
+            }
+        }
+    }
+
+    /**
+     * Sets VIEW and NOTIFY privileges for a metadata to a group.
+     *
+     * @param context service context
+     * @param id metadata id
+     * @param groupId group id
+     * @param fullRightsForGroup 
+     * @throws Exception hmmm
+     */
+    @Override
+    public void copyDefaultPrivForGroup(ServiceContext context, String id, String groupId, boolean fullRightsForGroup) throws Exception {
+        if (StringUtils.isBlank(groupId)) {
+            Log.info(Geonet.DATA_MANAGER, "Attempt to set default privileges for metadata " + id + " to an empty groupid");
+            return;
+        }
+        // --- store access operations for group
+
+        setOperation(context, id, groupId, ReservedOperation.view);
+        setOperation(context, id, groupId, ReservedOperation.notify);
+        //
+        // Restrictive: new and inserted records should not be editable,
+        // their resources can't be downloaded and any interactive maps can't be
+        // displayed by users in the same group
+        if (fullRightsForGroup) {
+            setOperation(context, id, groupId, ReservedOperation.editing);
+            setOperation(context, id, groupId, ReservedOperation.download);
+            setOperation(context, id, groupId, ReservedOperation.dynamic);
+        }
+        // Ultimately this should be configurable elsewhere
+    }
+
+    @Override
+    public boolean isUserMetadataOwner(int userId) throws Exception {
+        return metadataRepository.count(MetadataSpecs.isOwnedByUser(userId)) > 0;
+    }
+
+    @Override
+    public boolean existsUser(ServiceContext context, int id) throws Exception {
+        return userRepository.count(where(UserSpecs.hasUserId(id))) > 0;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
@@ -52,12 +52,12 @@ public class BaseMetadataOperations implements IMetadataOperations {
     private SvnManager svnManager;
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-//        userRepository = context.getBean(UserRepository.class);
-//        metadataRepository = context.getBean(MetadataRepository.class);
-//        opAllowedRepo = context.getBean(OperationAllowedRepository.class);
-//        userGroupRepo = context.getBean(UserGroupRepository.class);
-//        settingManager = context.getBean(SettingManager.class);
-//        svnManager = context.getBean(SvnManager.class);
+        userRepository = context.getBean(UserRepository.class);
+        metadataRepository = context.getBean(MetadataRepository.class);
+        opAllowedRepo = context.getBean(OperationAllowedRepository.class);
+        userGroupRepo = context.getBean(UserGroupRepository.class);
+        settingManager = context.getBean(SettingManager.class);
+        svnManager = context.getBean(SvnManager.class);
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
@@ -28,8 +28,8 @@ public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
     private MetadataRepository metadataRepository;
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-//        schemaManager = context.getBean(SchemaManager.class);
-//        metadataRepository = context.getBean(MetadataRepository.class);
+        schemaManager = context.getBean(SchemaManager.class);
+        metadataRepository = context.getBean(MetadataRepository.class);
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
@@ -1,0 +1,122 @@
+package org.fao.geonet.kernel.datamanager.base;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+import javax.annotation.CheckForNull;
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.exceptions.NoSchemaMatchesException;
+import org.fao.geonet.exceptions.SchemaMatchConflictException;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.utils.Log;
+import org.jdom.Element;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import jeeves.server.context.ServiceContext;
+
+public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
+
+    @Autowired
+    private SchemaManager schemaManager;
+
+    @Autowired
+    private MetadataRepository metadataRepository;
+
+    public void init(ServiceContext context, Boolean force) throws Exception {
+//        schemaManager = context.getBean(SchemaManager.class);
+//        metadataRepository = context.getBean(MetadataRepository.class);
+    }
+
+    /**
+     *
+     * @param name
+     * @return
+     */
+    @Override
+    public MetadataSchema getSchema(String name) {
+        return schemaManager.getSchema(name);
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Override
+    public Set<String> getSchemas() {
+        return schemaManager.getSchemas();
+    }
+
+    /**
+     *
+     * @param name
+     * @return
+     */
+    @Override
+    public boolean existsSchema(String name) {
+        return schemaManager.existsSchema(name);
+    }
+
+    /**
+     *
+     * @param name
+     * @return
+     */
+    @Override
+    public Path getSchemaDir(String name) {
+        return schemaManager.getSchemaDir(name);
+    }
+
+    /**
+     * TODO javadoc.
+     */
+    @Override
+    public String getMetadataSchema(String id) throws Exception {
+        Metadata md = metadataRepository.findOne(id);
+
+        if (md == null) {
+            throw new IllegalArgumentException("Metadata not found for id : " + id);
+        } else {
+            // get metadata
+            return md.getDataInfo().getSchemaId();
+        }
+    }
+
+
+    /**
+     * Checks autodetect elements in installed schemas to determine whether the metadata record belongs to that schema. Use this method when
+     * you want the default schema from the geonetwork config to be returned when no other match can be found.
+     *
+     * @param md Record to checked against schemas
+     */
+    @Override
+    public @CheckForNull String autodetectSchema(Element md) throws SchemaMatchConflictException, NoSchemaMatchesException {
+        return autodetectSchema(md, schemaManager.getDefaultSchema());
+    }
+
+    /**
+     * Checks autodetect elements in installed schemas to determine whether the metadata record belongs to that schema. Use this method when
+     * you want to set the default schema to be returned when no other match can be found.
+     *
+     * @param md Record to checked against schemas
+     * @param defaultSchema Schema to be assigned when no other schema matches
+     */
+    @Override
+    public @CheckForNull String autodetectSchema(Element md, String defaultSchema)
+            throws SchemaMatchConflictException, NoSchemaMatchesException {
+
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER,
+                    "Autodetect schema for metadata with :\n * root element:'" + md.getQualifiedName() + "'\n * with namespace:'"
+                            + md.getNamespace() + "\n * with additional namespaces:" + md.getAdditionalNamespaces().toString());
+        String schema = schemaManager.autodetectSchema(md, defaultSchema);
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Schema detected was " + schema);
+        return schema;
+    }
+    
+}

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
@@ -1,0 +1,151 @@
+package org.fao.geonet.kernel.datamanager.base;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataStatus;
+import org.fao.geonet.domain.MetadataStatusId;
+import org.fao.geonet.domain.MetadataStatusId_;
+import org.fao.geonet.domain.MetadataStatus_;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.datamanager.IMetadataStatus;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.MetadataStatusRepository;
+import org.fao.geonet.repository.SortUtils;
+import org.fao.geonet.repository.StatusValueRepository;
+import org.fao.geonet.repository.specification.MetadataStatusSpecs;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Sort;
+
+import jeeves.server.context.ServiceContext;
+
+public class BaseMetadataStatus implements IMetadataStatus {
+
+    @Autowired
+    private MetadataStatusRepository metadataStatusRepository;
+    @Autowired
+    private IMetadataIndexer metadataIndexer;
+    @Autowired
+    private StatusValueRepository statusValueRepository;
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    @Lazy
+    private SettingManager settingManager;
+
+    public void init(ServiceContext context, Boolean force) throws Exception {
+//        metadataStatusRepository = context.getBean(MetadataStatusRepository.class);
+//        metadataIndexer = context.getBean(IMetadataIndexer.class);
+//        statusValueRepository = context.getBean(StatusValueRepository.class);
+//        groupRepository = context.getBean(GroupRepository.class);
+//        settingManager = context.getBean(SettingManager.class);
+    }
+
+    @Override
+    public boolean isUserMetadataStatus(int userId) throws Exception {
+        return metadataStatusRepository.count(MetadataStatusSpecs.hasUserId(userId)) > 0;
+    }
+
+    /**
+     * Return all status records for the metadata id - current status is the first child due to sort by DESC on changeDate
+     */
+    @Override
+    public MetadataStatus getStatus(int metadataId) throws Exception {
+        String sortField = SortUtils.createPath(MetadataStatus_.id, MetadataStatusId_.changeDate);
+        List<MetadataStatus> status = metadataStatusRepository.findAllById_MetadataId(metadataId, new Sort(Sort.Direction.DESC, sortField));
+        if (status.isEmpty()) {
+            return null;
+        } else {
+            return status.get(0);
+        }
+    }
+
+    /**
+     * Return status of metadata id.
+     */
+    @Override
+    public String getCurrentStatus(int metadataId) throws Exception {
+        MetadataStatus status = getStatus(metadataId);
+        if (status == null) {
+            return Params.Status.UNKNOWN;
+        }
+
+        return String.valueOf(status.getId().getStatusId());
+    }
+
+    // --------------------------------------------------------------------------
+    // ---
+    // --- Categories API
+    // ---
+    // --------------------------------------------------------------------------
+
+    /**
+     * Set status of metadata id and reindex metadata id afterwards.
+     *
+     * @return the saved status entity object
+     */
+    @Override
+    public MetadataStatus setStatus(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception {
+        MetadataStatus statusObject = setStatusExt(context, id, status, changeDate, changeMessage);
+        metadataIndexer.indexMetadata(Integer.toString(id), true, null);
+        return statusObject;
+    }
+
+    /**
+     * Set status of metadata id and do not reindex metadata id afterwards.
+     *
+     * @return the saved status entity object
+     */
+    @Override
+    public MetadataStatus setStatusExt(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage)
+            throws Exception {
+
+        MetadataStatus metatatStatus = new MetadataStatus();
+        metatatStatus.setChangeMessage(changeMessage);
+        metatatStatus.setStatusValue(statusValueRepository.findOne(status));
+        int userId = context.getUserSession().getUserIdAsInt();
+        MetadataStatusId mdStatusId = new MetadataStatusId().setStatusId(status).setMetadataId(id).setChangeDate(changeDate)
+                .setUserId(userId);
+        mdStatusId.setChangeDate(changeDate);
+
+        metatatStatus.setId(mdStatusId);
+
+        return metadataStatusRepository.save(metatatStatus);
+    }
+
+    /**
+     * If groupOwner match regular expression defined in setting metadata/workflow/draftWhenInGroup, then set status to draft to enable
+     * workflow.
+     */
+    @Override
+    public void activateWorkflowIfConfigured(ServiceContext context, String newId, String groupOwner) throws Exception {
+        if (StringUtils.isEmpty(groupOwner)) {
+            return;
+        }
+        String groupMatchingRegex = settingManager.getValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP);
+        if (!StringUtils.isEmpty(groupMatchingRegex)) {
+            final Group group = groupRepository.findOne(Integer.valueOf(groupOwner));
+            String groupName = "";
+            if (group != null) {
+                groupName = group.getName();
+            }
+
+            final Pattern pattern = Pattern.compile(groupMatchingRegex);
+            final Matcher matcher = pattern.matcher(groupName);
+            if (matcher.find()) {
+                setStatus(context, Integer.valueOf(newId), Integer.valueOf(Params.Status.DRAFT), new ISODate(),
+                        String.format("Workflow automatically enabled for record in group %s. Record status is set to %s.", groupName,
+                                Params.Status.DRAFT));
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
@@ -42,11 +42,11 @@ public class BaseMetadataStatus implements IMetadataStatus {
     private SettingManager settingManager;
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-//        metadataStatusRepository = context.getBean(MetadataStatusRepository.class);
-//        metadataIndexer = context.getBean(IMetadataIndexer.class);
-//        statusValueRepository = context.getBean(StatusValueRepository.class);
-//        groupRepository = context.getBean(GroupRepository.class);
-//        settingManager = context.getBean(SettingManager.class);
+        metadataStatusRepository = context.getBean(MetadataStatusRepository.class);
+        metadataIndexer = context.getBean(IMetadataIndexer.class);
+        statusValueRepository = context.getBean(StatusValueRepository.class);
+        groupRepository = context.getBean(GroupRepository.class);
+        settingManager = context.getBean(SettingManager.class);
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -86,16 +86,16 @@ public class BaseMetadataUtils implements IMetadataUtils {
     }
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-        // metadataRepository = context.getBean(MetadataRepository.class);
-        // metadataNotifierManager = context.getBean(MetadataNotifierManager.class);
-        servContext = context;
-        // schemaManager = context.getBean(SchemaManager.class);
-        // searchManager = context.getBean(SearchManager.class);
-        // metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
-        // metadataIndexer = context.getBean(IMetadataIndexer.class);
-        // ratingByIpRepository = context.getBean(MetadataRatingByIpRepository.class);
-        // settingManager = context.getBean(SettingManager.class);
-        // xmlSerializer = context.getBean(XmlSerializer.class);
+         metadataRepository = context.getBean(MetadataRepository.class);
+         metadataNotifierManager = context.getBean(MetadataNotifierManager.class);
+         servContext = context;
+         schemaManager = context.getBean(SchemaManager.class);
+         searchManager = context.getBean(SearchManager.class);
+         metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
+         metadataIndexer = context.getBean(IMetadataIndexer.class);
+         ratingByIpRepository = context.getBean(MetadataRatingByIpRepository.class);
+         settingManager = context.getBean(SettingManager.class);
+         xmlSerializer = context.getBean(XmlSerializer.class);
 
         final GeonetworkDataDirectory dataDirectory = context.getBean(GeonetworkDataDirectory.class);
         stylePath = dataDirectory.resolveWebResource(Geonet.Path.STYLESHEETS);

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -1,0 +1,786 @@
+package org.fao.geonet.kernel.datamanager.base;
+
+import static org.fao.geonet.repository.specification.MetadataSpecs.hasMetadataUuid;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
+
+import org.fao.geonet.NodeInfo;
+import org.fao.geonet.constants.Edit;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataDataInfo;
+import org.fao.geonet.domain.MetadataHarvestInfo;
+import org.fao.geonet.domain.MetadataRatingByIp;
+import org.fao.geonet.domain.MetadataRatingByIpId;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.XmlSerializer;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.search.SearchManager;
+import org.fao.geonet.kernel.search.index.IndexingList;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.notifier.MetadataNotifierManager;
+import org.fao.geonet.repository.MetadataRatingByIpRepository;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.Updater;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.Namespace;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+import com.google.common.base.Optional;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+
+public class BaseMetadataUtils implements IMetadataUtils {
+    @Autowired
+    private MetadataRepository metadataRepository;
+
+    @Autowired
+    private MetadataNotifierManager metadataNotifierManager;
+
+    // FIXME Remove when get rid of Jeeves
+    private ServiceContext servContext;
+    @Autowired
+    private IMetadataSchemaUtils metadataSchemaUtils;
+    @Autowired
+    private IMetadataIndexer metadataIndexer;
+    @Autowired
+    private SchemaManager schemaManager;
+    @Autowired
+    private MetadataRatingByIpRepository ratingByIpRepository;
+    @Autowired
+    @Lazy
+    private SettingManager settingManager;
+    @Autowired
+    private SearchManager searchManager;
+    @Autowired(required = false)
+    private XmlSerializer xmlSerializer;
+
+    private Path stylePath;
+
+    private IMetadataManager metadataManager;
+
+    @Override
+    public void setMetadataManager(IMetadataManager metadataManager) {
+        this.metadataManager = metadataManager;
+    }
+
+    public void init(ServiceContext context, Boolean force) throws Exception {
+        // metadataRepository = context.getBean(MetadataRepository.class);
+        // metadataNotifierManager = context.getBean(MetadataNotifierManager.class);
+        servContext = context;
+        // schemaManager = context.getBean(SchemaManager.class);
+        // searchManager = context.getBean(SearchManager.class);
+        // metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
+        // metadataIndexer = context.getBean(IMetadataIndexer.class);
+        // ratingByIpRepository = context.getBean(MetadataRatingByIpRepository.class);
+        // settingManager = context.getBean(SettingManager.class);
+        // xmlSerializer = context.getBean(XmlSerializer.class);
+
+        final GeonetworkDataDirectory dataDirectory = context.getBean(GeonetworkDataDirectory.class);
+        stylePath = dataDirectory.resolveWebResource(Geonet.Path.STYLESHEETS);
+    }
+
+    /**
+     * Needed to avoid circular dependency injection
+     */
+    @PostConstruct
+    public void init() {
+        this.metadataIndexer.setMetadataUtils(this);
+    }
+
+    /**
+     *
+     * @param md
+     * @param metadataId
+     * @throws Exception
+     */
+    @Override
+    public void notifyMetadataChange(Element md, String metadataId) throws Exception {
+
+        final Metadata metadata = metadataRepository.findOne(metadataId);
+        if (metadata != null && metadata.getDataInfo().getType() == MetadataType.METADATA) {
+            MetadataSchema mds = schemaManager.getSchema(metadata.getDataInfo().getSchemaId());
+            Pair<String, Element> editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
+            XmlSerializer.removeFilteredElement(md, editXpathFilter, mds.getNamespaces());
+
+            String uuid = getMetadataUuid(metadataId);
+            metadataNotifierManager.updateMetadata(md, metadataId, uuid, getServiceContext());
+        }
+    }
+
+    /**
+     *
+     * @param id
+     * @return
+     * @throws Exception
+     */
+    public @Nullable @Override String getMetadataUuid(@Nonnull String id) throws Exception {
+        Metadata metadata = metadataRepository.findOne(id);
+
+        if (metadata == null)
+            return null;
+
+        return metadata.getUuid();
+    }
+
+    protected ServiceContext getServiceContext() {
+        ServiceContext context = ServiceContext.get();
+        return context == null ? servContext : context;
+    }
+
+    /**
+     * Start an editing session. This will record the original metadata record in the session under the
+     * {@link org.fao.geonet.constants.Geonet.Session#METADATA_BEFORE_ANY_CHANGES} + id session property.
+     *
+     * The record contains geonet:info element.
+     *
+     * Note: Only the metadata record is stored in session. If the editing session upload new documents or thumbnails, those documents will
+     * not be cancelled. This needs improvements.
+     */
+    @Override
+    public void startEditingSession(ServiceContext context, String id) throws Exception {
+        if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
+            Log.debug(Geonet.EDITOR_SESSION, "Editing session starts for record " + id);
+        }
+
+        boolean keepXlinkAttributes = true;
+        boolean forEditing = false;
+        boolean withValidationErrors = false;
+        Element metadataBeforeAnyChanges = context.getBean(IMetadataManager.class).getMetadata(context, id, forEditing,
+                withValidationErrors, keepXlinkAttributes);
+        context.getUserSession().setProperty(Geonet.Session.METADATA_BEFORE_ANY_CHANGES + id, metadataBeforeAnyChanges);
+    }
+
+    /**
+     * Rollback to the record in the state it was when the editing session started (See
+     * {@link #startEditingSession(ServiceContext, String)}).
+     */
+    @Override
+    public void cancelEditingSession(ServiceContext context, String id) throws Exception {
+        UserSession session = context.getUserSession();
+        Element metadataBeforeAnyChanges = (Element) session.getProperty(Geonet.Session.METADATA_BEFORE_ANY_CHANGES + id);
+
+        if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
+            Log.debug(Geonet.EDITOR_SESSION,
+                    "Editing session end. Cancel changes. Restore record " + id + ". Replace by original record which was: ");
+        }
+
+        if (metadataBeforeAnyChanges != null) {
+            if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
+                Log.debug(Geonet.EDITOR_SESSION, " > restoring record: ");
+                Log.debug(Geonet.EDITOR_SESSION, Xml.getString(metadataBeforeAnyChanges));
+            }
+            Element info = metadataBeforeAnyChanges.getChild(Edit.RootChild.INFO, Edit.NAMESPACE);
+            boolean validate = false;
+            boolean ufo = false;
+            boolean index = true;
+            metadataBeforeAnyChanges.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);
+            context.getBean(IMetadataManager.class).updateMetadata(context, id, metadataBeforeAnyChanges, validate, ufo, index,
+                    context.getLanguage(), info.getChildText(Edit.Info.Elem.CHANGE_DATE), false);
+            endEditingSession(id, session);
+        } else {
+            if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
+                Log.debug(Geonet.EDITOR_SESSION,
+                        " > nothing to cancel for record " + id + ". Original record was null. Use starteditingsession to.");
+            }
+        }
+    }
+
+    /**
+     * Remove the original record stored in session.
+     */
+    @Override
+    public void endEditingSession(String id, UserSession session) {
+        if (Log.isDebugEnabled(Geonet.EDITOR_SESSION)) {
+            Log.debug(Geonet.EDITOR_SESSION, "Editing session end.");
+        }
+        session.removeProperty(Geonet.Session.METADATA_BEFORE_ANY_CHANGES + id);
+    }
+
+    /**
+     *
+     * @param md
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public Element enumerateTree(Element md) throws Exception {
+        metadataManager.getEditLib().enumerateTree(md);
+        return md;
+    }
+
+    /**
+     * Extract UUID from the metadata record using the schema XSL for UUID extraction)
+     */
+    @Override
+    public String extractUUID(String schema, Element md) throws Exception {
+        Path styleSheet = metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.EXTRACT_UUID);
+        String uuid = Xml.transform(md, styleSheet).getText().trim();
+
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Extracted UUID '" + uuid + "' for schema '" + schema + "'");
+
+        // --- needed to detach md from the document
+        md.detach();
+
+        return uuid;
+    }
+
+    /**
+     *
+     * @param schema
+     * @param md
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public String extractDateModified(String schema, Element md) throws Exception {
+        Path styleSheet = metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.EXTRACT_DATE_MODIFIED);
+        String dateMod = Xml.transform(md, styleSheet).getText().trim();
+
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Extracted Date Modified '" + dateMod + "' for schema '" + schema + "'");
+
+        // --- needed to detach md from the document
+        md.detach();
+
+        return dateMod;
+    }
+
+    /**
+     *
+     * @param schema
+     * @param uuid
+     * @param md
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public Element setUUID(String schema, String uuid, Element md) throws Exception {
+        // --- setup environment
+
+        Element env = new Element("env");
+        env.addContent(new Element("uuid").setText(uuid));
+
+        // --- setup root element
+
+        Element root = new Element("root");
+        root.addContent(md.detach());
+        root.addContent(env.detach());
+
+        // --- do an XSL transformation
+
+        Path styleSheet = metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.SET_UUID);
+
+        return Xml.transform(root, styleSheet);
+    }
+
+    /**
+     *
+     * @param md
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public Element extractSummary(Element md) throws Exception {
+        Path styleSheet = stylePath.resolve(Geonet.File.METADATA_BRIEF);
+        Element summary = Xml.transform(md, styleSheet);
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Extracted summary '\n" + Xml.getString(summary));
+
+        // --- needed to detach md from the document
+        md.detach();
+
+        return summary;
+    }
+
+    /**
+     *
+     * @param uuid
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public @Nullable String getMetadataId(@Nonnull String uuid) throws Exception {
+        final List<Integer> idList = metadataRepository.findAllIdsBy(hasMetadataUuid(uuid));
+        if (idList.isEmpty()) {
+            return null;
+        }
+        return String.valueOf(idList.get(0));
+    }
+
+    /**
+     *
+     * @param id
+     * @return
+     */
+    @Override
+    public String getVersion(String id) {
+        return metadataManager.getEditLib().getVersion(id);
+    }
+
+    /**
+     *
+     * @param id
+     * @return
+     */
+    @Override
+    public String getNewVersion(String id) {
+        return metadataManager.getEditLib().getNewVersion(id);
+    }
+
+    @Override
+    public void setTemplate(final int id, final MetadataType type, final String title) throws Exception {
+        setTemplateExt(id, type);
+        metadataIndexer.indexMetadata(Integer.toString(id), true, null);
+    }
+
+    @Override
+    public void setTemplateExt(final int id, final MetadataType metadataType) throws Exception {
+        metadataRepository.update(id, new Updater<Metadata>() {
+            @Override
+            public void apply(@Nonnull Metadata metadata) {
+                final MetadataDataInfo dataInfo = metadata.getDataInfo();
+                dataInfo.setType(metadataType);
+            }
+        });
+    }
+
+    @Override
+    public void setHarvested(int id, String harvestUuid) throws Exception {
+        setHarvestedExt(id, harvestUuid);
+        metadataIndexer.indexMetadata(Integer.toString(id), true, null);
+    }
+
+    /**
+     * Set metadata type to subtemplate and set the title. Only subtemplates need to persist the title as it is used to give a meaningful
+     * title for use when offering the subtemplate to users in the editor.
+     *
+     * @param id Metadata id to set to type subtemplate
+     * @param title Title of metadata of subtemplate/fragment
+     */
+    @Override
+    public void setSubtemplateTypeAndTitleExt(final int id, String title) throws Exception {
+        metadataRepository.update(id, new Updater<Metadata>() {
+            @Override
+            public void apply(@Nonnull Metadata metadata) {
+                final MetadataDataInfo dataInfo = metadata.getDataInfo();
+                dataInfo.setType(MetadataType.SUB_TEMPLATE);
+                if (title != null) {
+                    dataInfo.setTitle(title);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void setHarvestedExt(int id, String harvestUuid) throws Exception {
+        setHarvestedExt(id, harvestUuid, Optional.<String> absent());
+    }
+
+    @Override
+    public void setHarvestedExt(final int id, final String harvestUuid, final Optional<String> harvestUri) throws Exception {
+        metadataRepository.update(id, new Updater<Metadata>() {
+            @Override
+            public void apply(Metadata metadata) {
+                MetadataHarvestInfo harvestInfo = metadata.getHarvestInfo();
+                harvestInfo.setUuid(harvestUuid);
+                harvestInfo.setHarvested(harvestUuid != null);
+                harvestInfo.setUri(harvestUri.orNull());
+            }
+        });
+    }
+
+    /**
+     *
+     * @param id
+     * @param displayOrder
+     * @throws Exception
+     */
+    @Override
+    public void updateDisplayOrder(final String id, final String displayOrder) throws Exception {
+        metadataRepository.update(Integer.valueOf(id), new Updater<Metadata>() {
+            @Override
+            public void apply(Metadata entity) {
+                entity.getDataInfo().setDisplayOrder(Integer.parseInt(displayOrder));
+            }
+        });
+    }
+
+    /**
+     * @throws Exception hmm
+     */
+    @Override
+    public void increasePopularity(ServiceContext srvContext, String id) throws Exception {
+        // READONLYMODE
+        if (!srvContext.getBean(NodeInfo.class).isReadOnly()) {
+            // Update the popularity in database
+            int iId = Integer.parseInt(id);
+            metadataRepository.incrementPopularity(iId);
+
+            // And register the metadata to be indexed in the near future
+            final IndexingList list = srvContext.getBean(IndexingList.class);
+            list.add(iId);
+        } else {
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                Log.debug(Geonet.DATA_MANAGER, "GeoNetwork is operating in read-only mode. IncreasePopularity is skipped.");
+            }
+        }
+    }
+
+    /**
+     * Rates a metadata.
+     *
+     * @param ipAddress ipAddress IP address of the submitting client
+     * @param rating range should be 1..5
+     * @throws Exception hmm
+     */
+    @Override
+    public int rateMetadata(final int metadataId, final String ipAddress, final int rating) throws Exception {
+        MetadataRatingByIp ratingEntity = new MetadataRatingByIp();
+        ratingEntity.setRating(rating);
+        ratingEntity.setId(new MetadataRatingByIpId(metadataId, ipAddress));
+
+        ratingByIpRepository.save(ratingEntity);
+
+        //
+        // calculate new rating
+        //
+        final int newRating = ratingByIpRepository.averageRating(metadataId);
+
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Setting rating for id:" + metadataId + " --> rating is:" + newRating);
+
+        metadataRepository.update(metadataId, new Updater<Metadata>() {
+            @Override
+            public void apply(Metadata entity) {
+                entity.getDataInfo().setRating(newRating);
+            }
+        });
+
+        metadataIndexer.indexMetadata(Integer.toString(metadataId), true, null);
+
+        return rating;
+    }
+
+    /**
+     * Retrieves a metadata (in xml) given its id with no geonet:info.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public Element getMetadataNoInfo(ServiceContext srvContext, String id) throws Exception {
+        Element md = srvContext.getBean(IMetadataManager.class).getMetadata(srvContext, id, false, false, false);
+        md.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);
+
+        // Drop Geonet namespace declaration. It may be contained
+        // multiple times, so loop on all.
+        final List<Namespace> additionalNamespaces = new ArrayList<Namespace>(md.getAdditionalNamespaces());
+        for (Namespace n : additionalNamespaces) {
+            if (Edit.NAMESPACE.getURI().equals(n.getURI())) {
+                md.removeNamespaceDeclaration(Edit.NAMESPACE);
+            }
+        }
+        return md;
+    }
+
+    /**
+     * Retrieves a metadata element given it's ref.
+     */
+    @Override
+    public Element getElementByRef(Element md, String ref) {
+        return metadataManager.getEditLib().findElement(md, ref);
+    }
+
+    /**
+     * Returns true if the metadata exists in the database.
+     */
+    @Override
+    public boolean existsMetadata(int id) throws Exception {
+        return metadataRepository.exists(id);
+    }
+
+    /**
+     * Returns true if the metadata uuid exists in the database.
+     */
+    @Override
+    public boolean existsMetadataUuid(String uuid) throws Exception {
+        return !metadataRepository.findAllIdsBy(hasMetadataUuid(uuid)).isEmpty();
+    }
+
+    /**
+     * Returns all the keywords in the system.
+     */
+    @Override
+    public Element getKeywords() throws Exception {
+        // TODO ES
+        // Collection<String> keywords = getSearchManager().getTerms("keyword");
+        Element el = new Element("keywords");
+
+//        for (Object keyword : keywords) {
+//            el.addContent(new Element("keyword").setText((String) keyword));
+//        }
+        return el;
+    }
+
+    /**
+     *
+     * @param metadataId
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public Element getThumbnails(ServiceContext context, String metadataId) throws Exception {
+        Element md = getXmlSerializer().select(context, metadataId);
+
+        if (md == null)
+            return null;
+
+        md.detach();
+
+        String schema = metadataSchemaUtils.getMetadataSchema(metadataId);
+
+        // --- do an XSL transformation
+        Path styleSheet = metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.EXTRACT_THUMBNAILS);
+
+        Element result = Xml.transform(md, styleSheet);
+        result.addContent(new Element("id").setText(metadataId));
+
+        return result;
+    }
+
+    /**
+     *
+     * @param context
+     * @param id
+     * @param small
+     * @param file
+     * @throws Exception
+     */
+    @Override
+    public void setThumbnail(ServiceContext context, String id, boolean small, String file, boolean indexAfterChange) throws Exception {
+        int pos = file.lastIndexOf('.');
+        String ext = (pos == -1) ? "???" : file.substring(pos + 1);
+
+        Element env = new Element("env");
+        env.addContent(new Element("file").setText(file));
+        env.addContent(new Element("ext").setText(ext));
+
+        String host = getSettingManager().getValue(Settings.SYSTEM_SERVER_HOST);
+        String port = getSettingManager().getValue(Settings.SYSTEM_SERVER_PORT);
+        String baseUrl = context.getBaseUrl();
+
+        env.addContent(new Element("host").setText(host));
+        env.addContent(new Element("port").setText(port));
+        env.addContent(new Element("baseUrl").setText(baseUrl));
+        // TODO: Remove host, port, baseUrl and simplify the
+        // URL created in the XSLT. Keeping it for the time
+        // as many profiles depend on it.
+        env.addContent(new Element("url").setText(getSettingManager().getSiteURL(context)));
+
+        manageThumbnail(context, id, small, env, Geonet.File.SET_THUMBNAIL, indexAfterChange);
+    }
+
+    /**
+     *
+     * @param context
+     * @param id
+     * @param small
+     * @throws Exception
+     */
+    @Override
+    public void unsetThumbnail(ServiceContext context, String id, boolean small, boolean indexAfterChange) throws Exception {
+        Element env = new Element("env");
+
+        manageThumbnail(context, id, small, env, Geonet.File.UNSET_THUMBNAIL, indexAfterChange);
+    }
+
+    /**
+     *
+     * @param context
+     * @param id
+     * @param small
+     * @param env
+     * @param styleSheet
+     * @param indexAfterChange
+     * @throws Exception
+     */
+    private void manageThumbnail(ServiceContext context, String id, boolean small, Element env, String styleSheet, boolean indexAfterChange)
+            throws Exception {
+        boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = true;
+        Element md = context.getBean(IMetadataManager.class).getMetadata(context, id, forEditing, withValidationErrors,
+                keepXlinkAttributes);
+
+        if (md == null)
+            return;
+
+        md.detach();
+
+        String schema = metadataSchemaUtils.getMetadataSchema(id);
+
+        // --- setup environment
+        String type = small ? "thumbnail" : "large_thumbnail";
+        env.addContent(new Element("type").setText(type));
+        transformMd(context, id, md, env, schema, styleSheet, indexAfterChange);
+    }
+
+    /**
+     *
+     * @param context
+     * @param metadataId
+     * @param md
+     * @param env
+     * @param schema
+     * @param styleSheet
+     * @param indexAfterChange
+     * @throws Exception
+     */
+    private void transformMd(ServiceContext context, String metadataId, Element md, Element env, String schema, String styleSheet,
+            boolean indexAfterChange) throws Exception {
+
+        if (env.getChild("host") == null) {
+            String host = getSettingManager().getValue(Settings.SYSTEM_SERVER_HOST);
+            String port = getSettingManager().getValue(Settings.SYSTEM_SERVER_PORT);
+            env.addContent(new Element("host").setText(host));
+            env.addContent(new Element("port").setText(port));
+        }
+
+        // --- setup root element
+        Element root = new Element("root");
+        root.addContent(md);
+        root.addContent(env);
+
+        // --- do an XSL transformation
+        Path styleSheetPath = metadataSchemaUtils.getSchemaDir(schema).resolve(styleSheet);
+
+        md = Xml.transform(root, styleSheetPath);
+        String changeDate = null;
+        String uuid = null;
+        if (schemaManager.getSchema(schema).isReadwriteUUID()) {
+            uuid = extractUUID(schema, md);
+        }
+
+        getXmlSerializer().update(metadataId, md, changeDate, true, uuid, context);
+
+        if (indexAfterChange) {
+            // Notifies the metadata change to metatada notifier service
+            notifyMetadataChange(md, metadataId);
+
+            // --- update search criteria
+            metadataIndexer.indexMetadata(metadataId, true, null);
+        }
+    }
+
+    /**
+     *
+     * @param context
+     * @param id
+     * @param licenseurl
+     * @param imageurl
+     * @param jurisdiction
+     * @param licensename
+     * @param type
+     * @throws Exception
+     */
+    @Override
+    public void setDataCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction,
+            String licensename, String type) throws Exception {
+        Element env = prepareCommonsEnv(licenseurl, imageurl, jurisdiction, licensename, type);
+        manageCommons(context, id, env, Geonet.File.SET_DATACOMMONS);
+    }
+
+    private Element prepareCommonsEnv(String licenseurl, String imageurl, String jurisdiction, String licensename, String type) {
+        Element env = new Element("env");
+        env.addContent(new Element("imageurl").setText(imageurl));
+        env.addContent(new Element("licenseurl").setText(licenseurl));
+        env.addContent(new Element("jurisdiction").setText(jurisdiction));
+        env.addContent(new Element("licensename").setText(licensename));
+        env.addContent(new Element("type").setText(type));
+        return env;
+    }
+
+    /**
+     *
+     * @param context
+     * @param id
+     * @param licenseurl
+     * @param imageurl
+     * @param jurisdiction
+     * @param licensename
+     * @param type
+     * @throws Exception
+     */
+    @Override
+    public void setCreativeCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction,
+            String licensename, String type) throws Exception {
+        Element env = prepareCommonsEnv(licenseurl, imageurl, jurisdiction, licensename, type);
+        manageCommons(context, id, env, Geonet.File.SET_CREATIVECOMMONS);
+    }
+
+    /**
+     * Extract the title field from the Metadata Repository. This is only valid for subtemplates as the title can be stored with the
+     * subtemplate (since subtemplates don't have a title) - metadata records don't store the title here as this is part of the metadata.
+     *
+     * @param id metadata id to retrieve
+     */
+    @Override
+    public String getMetadataTitle(String id) throws Exception {
+        Metadata md = metadataRepository.findOne(id);
+
+        if (md == null) {
+            throw new IllegalArgumentException("Metadata not found for id : " + id);
+        } else {
+            // get metadata title
+            return md.getDataInfo().getTitle();
+        }
+    }
+
+    /**
+     *
+     * @param context
+     * @param id
+     * @param env
+     * @param styleSheet
+     * @throws Exception
+     */
+    private void manageCommons(ServiceContext context, String id, Element env, String styleSheet) throws Exception {
+        Lib.resource.checkEditPrivilege(context, id);
+        Element md = getXmlSerializer().select(context, id);
+
+        if (md == null)
+            return;
+
+        md.detach();
+
+        String schema = metadataSchemaUtils.getMetadataSchema(id);
+        transformMd(context, id, md, env, schema, styleSheet, true);
+    }
+
+    private XmlSerializer getXmlSerializer() {
+        return xmlSerializer;
+    }
+
+    private SettingManager getSettingManager() {
+        return this.settingManager;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -19,6 +19,7 @@ import org.fao.geonet.exceptions.JeevesException;
 import org.fao.geonet.exceptions.SchematronValidationErrorEx;
 import org.fao.geonet.exceptions.XSDValidationErrorEx;
 import org.fao.geonet.kernel.SchematronValidator;
+import org.fao.geonet.kernel.ThesaurusManager;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
 import org.fao.geonet.kernel.schema.MetadataSchema;
@@ -56,10 +57,10 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
     }
     
     public void init(ServiceContext context, Boolean force) throws Exception {
-//        metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
-//        validationRepository = context.getBean(MetadataValidationRepository.class);
-//        schematronValidator = context.getBean(SchematronValidator.class);
-//        thesaurusDir = context.getBean(ThesaurusManager.class).getThesauriDirectory();
+        metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
+        validationRepository = context.getBean(MetadataValidationRepository.class);
+        schematronValidator = context.getBean(SchematronValidator.class);
+        thesaurusDir = context.getBean(ThesaurusManager.class).getThesauriDirectory();
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -1,0 +1,574 @@
+package org.fao.geonet.kernel.datamanager.base;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.constants.Edit;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Geonet.Namespaces;
+import org.fao.geonet.domain.MetadataValidation;
+import org.fao.geonet.domain.MetadataValidationId;
+import org.fao.geonet.domain.MetadataValidationStatus;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.exceptions.JeevesException;
+import org.fao.geonet.exceptions.SchematronValidationErrorEx;
+import org.fao.geonet.exceptions.XSDValidationErrorEx;
+import org.fao.geonet.kernel.SchematronValidator;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.repository.MetadataValidationRepository;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.fao.geonet.utils.Xml.ErrorHandler;
+import org.jdom.Attribute;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.Namespace;
+import org.jdom.filter.ElementFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+
+public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.IMetadataValidator {
+
+    @Autowired
+    private IMetadataSchemaUtils metadataSchemaUtils;
+
+    private Path thesaurusDir;
+    @Autowired
+    private SchematronValidator schematronValidator;
+    @Autowired
+    private MetadataValidationRepository validationRepository;
+    
+    private IMetadataManager metadataManager;
+
+    @Override
+    public void setMetadataManager(IMetadataManager metadataManager) {
+        this.metadataManager = metadataManager;
+    }
+    
+    public void init(ServiceContext context, Boolean force) throws Exception {
+//        metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
+//        validationRepository = context.getBean(MetadataValidationRepository.class);
+//        schematronValidator = context.getBean(SchematronValidator.class);
+//        thesaurusDir = context.getBean(ThesaurusManager.class).getThesauriDirectory();
+    }
+
+    /**
+     * Validates metadata against XSD and schematron files related to metadata schema throwing XSDValidationErrorEx if xsd errors or
+     * SchematronValidationErrorEx if schematron rules fails.
+     */
+    @Override
+    public void validateMetadata(String schema, Element xml, ServiceContext context, String fileName) throws Exception {
+        setNamespacePrefix(xml);
+        try {
+            validate(schema, xml);
+        } catch (XSDValidationErrorEx e) {
+            if (!fileName.equals(" ")) {
+                throw new XSDValidationErrorEx(e.getMessage() + "(in " + fileName + "): ", e.getObject());
+            } else {
+                throw new XSDValidationErrorEx(e.getMessage(), e.getObject());
+            }
+        }
+
+        // --- Now do the schematron validation on this file - if there are errors
+        // --- then we say what they are!
+        // --- Note we have to use uuid here instead of id because we don't have
+        // --- an id...
+
+        Element schemaTronXml = doSchemaTronForEditor(schema, xml, context.getLanguage());
+        xml.detach();
+        if (schemaTronXml != null && schemaTronXml.getContent().size() > 0) {
+            Element schemaTronReport = doSchemaTronForEditor(schema, xml, context.getLanguage());
+
+            List<Namespace> theNSs = new ArrayList<Namespace>();
+            theNSs.add(Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork"));
+            theNSs.add(Namespace.getNamespace("svrl", "http://purl.oclc.org/dsdl/svrl"));
+
+            Element failedAssert = Xml.selectElement(schemaTronReport, "geonet:report/svrl:schematron-output/svrl:failed-assert", theNSs);
+
+            Element failedSchematronVerification = Xml.selectElement(schemaTronReport, "geonet:report/geonet:schematronVerificationError",
+                    theNSs);
+
+            if ((failedAssert != null) || (failedSchematronVerification != null)) {
+                throw new SchematronValidationErrorEx(
+                        "Schematron errors detected for file " + fileName + " - " + Xml.getString(schemaTronReport) + " for more details",
+                        schemaTronReport);
+            }
+        }
+
+    }
+
+    /**
+     *
+     * @param md
+     */
+    @Override
+    public void setNamespacePrefix(final Element md) {
+        // --- if the metadata has no namespace or already has a namespace then
+        // --- we must skip this phase
+
+        Namespace ns = md.getNamespace();
+        if (ns != Namespace.NO_NAMESPACE && (md.getNamespacePrefix().equals(""))) {
+            // --- set prefix for iso19139 metadata
+
+            ns = Namespace.getNamespace("gmd", md.getNamespace().getURI());
+            setNamespacePrefix(md, ns);
+        }
+    }
+
+    /**
+     *
+     * @param md
+     * @param ns
+     */
+    @Override
+    public void setNamespacePrefix(final Element md, final Namespace ns) {
+        if (md.getNamespaceURI().equals(ns.getURI())) {
+            md.setNamespace(ns);
+        }
+
+        Attribute xsiType = md.getAttribute("type", Namespaces.XSI);
+        if (xsiType != null) {
+            String xsiTypeValue = xsiType.getValue();
+
+            if (StringUtils.isNotEmpty(xsiTypeValue) && !xsiTypeValue.contains(":")) {
+                xsiType.setValue(ns.getPrefix() + ":" + xsiType.getValue());
+            }
+        }
+
+        for (Object o : md.getChildren()) {
+            setNamespacePrefix((Element) o, ns);
+        }
+    }
+
+    /**
+     * Use this validate method for XML documents with dtd.
+     */
+    @Override
+    public void validate(String schema, Document doc) throws Exception {
+        Xml.validate(doc);
+    }
+
+    /**
+     * Use this validate method for XML documents with xsd validation.
+     */
+    @Override
+    public void validate(String schema, Element md) throws Exception {
+        String schemaLoc = md.getAttributeValue("schemaLocation", Namespaces.XSI);
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Extracted schemaLocation of " + schemaLoc);
+        if (schemaLoc == null)
+            schemaLoc = "";
+
+        if (schema == null) {
+            // must use schemaLocation
+            Xml.validate(md);
+        } else {
+            // if schemaLocation use that
+            if (!schemaLoc.equals("")) {
+                Xml.validate(md);
+                // otherwise use supplied schema name
+            } else {
+                Xml.validate(metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.SCHEMA), md);
+            }
+        }
+    }
+
+    @Override
+    public Element validateInfo(String schema, Element md, ErrorHandler eh) throws Exception {
+        String schemaLoc = md.getAttributeValue("schemaLocation", Namespaces.XSI);
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Extracted schemaLocation of " + schemaLoc);
+        if (schemaLoc == null)
+            schemaLoc = "";
+
+        if (schema == null) {
+            // must use schemaLocation
+            return Xml.validateInfo(md, eh);
+        } else {
+            // if schemaLocation use that
+            if (!schemaLoc.equals("")) {
+                return Xml.validateInfo(md, eh);
+                // otherwise use supplied schema name
+            } else {
+                return Xml.validateInfo(metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.SCHEMA), md, eh);
+            }
+        }
+    }
+
+    /**
+     * Creates XML schematron report.
+     */
+    @Override
+    public Element doSchemaTronForEditor(String schema, Element md, String lang) throws Exception {
+        // enumerate the metadata xml so that we can report any problems found
+        // by the schematron_xml script to the geonetwork editor
+        metadataManager.getEditLib().enumerateTree(md);
+
+        // get an xml version of the schematron errors and return for error display
+        Element schemaTronXmlReport = getSchemaTronXmlReport(schema, md, lang, null);
+
+        // remove editing info added by enumerateTree
+        metadataManager.getEditLib().removeEditingInfo(md);
+
+        return schemaTronXmlReport;
+    }
+
+    /**
+     * Valid the metadata record against its schema. For each error found, an xsderror attribute is added to the corresponding element
+     * trying to find the element based on the xpath return by the ErrorHandler.
+     */
+    private synchronized Element getXSDXmlReport(String schema, Element md) {
+        // NOTE: this method assumes that enumerateTree has NOT been run on the metadata
+        ErrorHandler errorHandler = new ErrorHandler();
+        errorHandler.setNs(Edit.NAMESPACE);
+        Element xsdErrors;
+
+        try {
+            xsdErrors = validateInfo(schema, md, errorHandler);
+        } catch (Exception e) {
+            xsdErrors = JeevesException.toElement(e);
+            return xsdErrors;
+        }
+
+        if (xsdErrors != null) {
+            MetadataSchema mds = metadataSchemaUtils.getSchema(schema);
+            List<Namespace> schemaNamespaces = mds.getSchemaNS();
+
+            // -- now get each xpath and evaluate it
+            // -- xsderrors/xsderror/{message,xpath}
+            @SuppressWarnings("unchecked")
+            List<Element> list = xsdErrors.getChildren();
+            for (Element elError : list) {
+                String xpath = elError.getChildText("xpath", Edit.NAMESPACE);
+                String message = elError.getChildText("message", Edit.NAMESPACE);
+                message = "\\n" + message;
+
+                // -- get the element from the xpath and add the error message to it
+                Element elem = null;
+                try {
+                    elem = Xml.selectElement(md, xpath, schemaNamespaces);
+                } catch (JDOMException je) {
+                    je.printStackTrace();
+                    Log.error(Geonet.DATA_MANAGER, "Attach xsderror message to xpath " + xpath + " failed: " + je.getMessage());
+                }
+                if (elem != null) {
+                    String existing = elem.getAttributeValue("xsderror", Edit.NAMESPACE);
+                    if (existing != null)
+                        message = existing + message;
+                    elem.setAttribute("xsderror", message, Edit.NAMESPACE);
+                } else {
+                    Log.warning(Geonet.DATA_MANAGER, "WARNING: evaluating XPath " + xpath
+                            + " against metadata failed - XSD validation message: " + message + " will NOT be shown by the editor");
+                }
+            }
+        }
+        return xsdErrors;
+    }
+
+    /**
+     * Creates XML schematron report for each set of rules defined in schema directory.
+     */
+    private Element getSchemaTronXmlReport(String schema, Element md, String lang, Map<String, Integer[]> valTypeAndStatus)
+            throws Exception {
+        // NOTE: this method assumes that you've run enumerateTree on the
+        // metadata
+
+        MetadataSchema metadataSchema = metadataSchemaUtils.getSchema(schema);
+        String[] rules = metadataSchema.getSchematronRules();
+
+        // Schematron report is composed of one or more report(s)
+        // for each set of rules.
+        Element schemaTronXmlOut = new Element("schematronerrors", Edit.NAMESPACE);
+        if (rules != null) {
+            for (String rule : rules) {
+                // -- create a report for current rules.
+                // Identified by a rule attribute set to shematron file name
+                if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                    Log.debug(Geonet.DATA_MANAGER, " - rule:" + rule);
+                String ruleId = rule.substring(0, rule.indexOf(".xsl"));
+                Element report = new Element("report", Edit.NAMESPACE);
+                report.setAttribute("rule", ruleId, Edit.NAMESPACE);
+
+                java.nio.file.Path schemaTronXmlXslt = metadataSchema.getSchemaDir().resolve("schematron").resolve(rule);
+                try {
+                    Map<String, Object> params = new HashMap<String, Object>();
+                    params.put("lang", lang);
+                    params.put("rule", rule);
+                    params.put("thesaurusDir", this.thesaurusDir);
+                    Element xmlReport = Xml.transform(md, schemaTronXmlXslt, params);
+                    if (xmlReport != null) {
+                        report.addContent(xmlReport);
+                        // add results to persitent validation information
+                        int firedRules = 0;
+                        Iterator<?> firedRulesElems = xmlReport.getDescendants(new ElementFilter("fired-rule", Namespaces.SVRL));
+                        while (firedRulesElems.hasNext()) {
+                            firedRulesElems.next();
+                            firedRules++;
+                        }
+                        int invalidRules = 0;
+                        Iterator<?> faileAssertElements = xmlReport.getDescendants(new ElementFilter("failed-assert", Namespaces.SVRL));
+                        while (faileAssertElements.hasNext()) {
+                            faileAssertElements.next();
+                            invalidRules++;
+                        }
+                        Integer[] results = { invalidRules != 0 ? 0 : 1, firedRules, invalidRules };
+                        if (valTypeAndStatus != null) {
+                            valTypeAndStatus.put(ruleId, results);
+                        }
+                    }
+                } catch (Exception e) {
+                    Log.error(Geonet.DATA_MANAGER, "WARNING: schematron xslt " + schemaTronXmlXslt + " failed");
+
+                    // If an error occurs that prevents to verify schematron rules, add to show in report
+                    Element errorReport = new Element("schematronVerificationError", Edit.NAMESPACE);
+                    errorReport.addContent("Schematron error ocurred, rules could not be verified: " + e.getMessage());
+                    report.addContent(errorReport);
+
+                    e.printStackTrace();
+                }
+
+                // -- append report to main XML report.
+                schemaTronXmlOut.addContent(report);
+            }
+        }
+        return schemaTronXmlOut;
+    }
+
+    /**
+     * Used by harvesters that need to validate metadata.
+     *
+     * @param schema name of the schema to validate against
+     * @param metadataId metadata id - used to record validation status
+     * @param doc metadata document as JDOM Document not JDOM Element
+     * @param lang Language from context
+     */
+    @Override
+    public boolean doValidate(String schema, String metadataId, Document doc, String lang) {
+        Integer intMetadataId = Integer.valueOf(metadataId);
+        List<MetadataValidation> validations = new ArrayList<>();
+        boolean valid = true;
+
+        if (doc.getDocType() != null) {
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                Log.debug(Geonet.DATA_MANAGER, "Validating against dtd " + doc.getDocType());
+
+            // if document has a doctype then validate using that (assuming that the
+            // dtd is either mapped locally or will be cached after first validate)
+            try {
+                Xml.validate(doc);
+                validations.add(new MetadataValidation().setId(new MetadataValidationId(intMetadataId, "dtd"))
+                        .setStatus(MetadataValidationStatus.VALID).setRequired(true).setNumTests(1).setNumFailures(0));
+                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                    Log.debug(Geonet.DATA_MANAGER, "Valid.");
+                }
+            } catch (Exception e) {
+                validations.add(new MetadataValidation().setId(new MetadataValidationId(intMetadataId, "dtd"))
+                        .setStatus(MetadataValidationStatus.INVALID).setRequired(true).setNumTests(1).setNumFailures(1));
+
+                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                    Log.debug(Geonet.DATA_MANAGER, "Invalid.", e);
+                }
+                valid = false;
+            }
+        } else {
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                Log.debug(Geonet.DATA_MANAGER, "Validating against XSD " + schema);
+            }
+            // do XSD validation
+            Element md = doc.getRootElement();
+            Element xsdErrors = getXSDXmlReport(schema, md);
+
+            int xsdErrorCount = 0;
+            if (xsdErrors != null && xsdErrors.getContent().size() > 0) {
+                xsdErrorCount = xsdErrors.getContent().size();
+            }
+            if (xsdErrorCount > 0) {
+                validations.add(new MetadataValidation().setId(new MetadataValidationId(intMetadataId, "xsd"))
+                        .setStatus(MetadataValidationStatus.INVALID).setRequired(true).setNumTests(xsdErrorCount)
+                        .setNumFailures(xsdErrorCount));
+                if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                    Log.debug(Geonet.DATA_MANAGER, "Invalid.");
+                valid = false;
+            } else {
+                validations.add(new MetadataValidation().setId(new MetadataValidationId(intMetadataId, "xsd"))
+                        .setStatus(MetadataValidationStatus.VALID).setRequired(true).setNumTests(1).setNumFailures(0));
+                if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                    Log.debug(Geonet.DATA_MANAGER, "Valid.");
+            }
+            try {
+                metadataManager.getEditLib().enumerateTree(md);
+                // Apply custom schematron rules
+                Element errors = applyCustomSchematronRules(schema, Integer.parseInt(metadataId), doc.getRootElement(), lang, validations);
+                valid = valid && errors == null;
+                metadataManager.getEditLib().removeEditingInfo(md);
+            } catch (Exception e) {
+                e.printStackTrace();
+                Log.error(Geonet.DATA_MANAGER, "Could not run schematron validation on metadata " + metadataId + ": " + e.getMessage());
+                valid = false;
+            }
+        }
+
+        // now save the validation status
+        try {
+            saveValidationStatus(intMetadataId, validations);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Log.error(Geonet.DATA_MANAGER, "Could not save validation status on metadata " + metadataId + ": " + e.getMessage());
+        }
+
+        return valid;
+    }
+
+    // --------------------------------------------------------------------------
+    // ---
+    // --- Metadata Delete API
+    // ---
+    // --------------------------------------------------------------------------
+
+    /**
+     * Used by the validate embedded service. The validation report is stored in the session.
+     *
+     */
+    @Override
+    public Pair<Element, String> doValidate(UserSession session, String schema, String metadataId, Element md, String lang,
+            boolean forEditing) throws Exception {
+        int intMetadataId = Integer.parseInt(metadataId);
+        String version = null;
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Creating validation report for record #" + metadataId + " [schema: " + schema + "].");
+
+        Element sessionReport = (Element) session.getProperty(Geonet.Session.VALIDATION_REPORT + metadataId);
+        if (sessionReport != null && !forEditing) {
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                Log.debug(Geonet.DATA_MANAGER, "  Validation report available in session.");
+            sessionReport.detach();
+            return Pair.read(sessionReport, version);
+        }
+
+        List<MetadataValidation> validations = new ArrayList<>();
+        Element errorReport = new Element("report", Edit.NAMESPACE);
+        errorReport.setAttribute("id", metadataId, Edit.NAMESPACE);
+
+        // -- get an XSD validation report and add results to the metadata
+        // -- as geonet:xsderror attributes on the affected elements
+        Element xsdErrors = getXSDXmlReport(schema, md);
+        int xsdErrorCount = 0;
+        if (xsdErrors != null) {
+            xsdErrorCount = xsdErrors.getContent().size();
+        }
+        if (xsdErrorCount > 0) {
+            errorReport.addContent(xsdErrors);
+            validations.add(new MetadataValidation().setId(new MetadataValidationId(intMetadataId, "xsd"))
+                    .setStatus(MetadataValidationStatus.INVALID).setRequired(true).setNumTests(xsdErrorCount)
+                    .setNumFailures(xsdErrorCount));
+
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
+                Log.debug(Geonet.DATA_MANAGER, "  - XSD error: " + Xml.getString(xsdErrors));
+            }
+        } else {
+            validations.add(new MetadataValidation().setId(new MetadataValidationId(intMetadataId, "xsd"))
+                    .setStatus(MetadataValidationStatus.VALID).setRequired(true).setNumTests(1).setNumFailures(0));
+
+            if (Log.isTraceEnabled(Geonet.DATA_MANAGER)) {
+                Log.trace(Geonet.DATA_MANAGER, "Valid.");
+            }
+        }
+
+        // ...then schematrons
+        // edit mode
+        Element error = null;
+        if (forEditing) {
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                Log.debug(Geonet.DATA_MANAGER, "  - Schematron in editing mode.");
+            // -- now expand the elements and add the geonet: elements
+            metadataManager.getEditLib().expandElements(schema, md);
+            version = metadataManager.getEditLib().getVersionForEditing(schema, metadataId, md);
+
+            // Apply custom schematron rules
+            error = applyCustomSchematronRules(schema, Integer.parseInt(metadataId), md, lang, validations);
+        } else {
+            try {
+                // enumerate the metadata xml so that we can report any problems found
+                // by the schematron_xml script to the geonetwork editor
+                metadataManager.getEditLib().enumerateTree(md);
+
+                // Apply custom schematron rules
+                error = applyCustomSchematronRules(schema, Integer.parseInt(metadataId), md, lang, validations);
+
+                // remove editing info added by enumerateTree
+                metadataManager.getEditLib().removeEditingInfo(md);
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                Log.error(Geonet.DATA_MANAGER, "Could not run schematron validation on metadata " + metadataId + ": " + e.getMessage());
+            }
+        }
+
+        if (error != null) {
+            errorReport.addContent(error);
+        }
+
+        // Save report in session (invalidate by next update) and db
+        try {
+            saveValidationStatus(intMetadataId, validations);
+        } catch (Exception e) {
+            Log.error(Geonet.DATA_MANAGER, "Could not save validation status on metadata " + metadataId + ": " + e.getMessage(), e);
+        }
+
+        return Pair.read(errorReport, version);
+    }
+
+    /**
+     * Creates XML schematron report for each set of rules defined in schema directory. This method assumes that you've run enumerateTree on
+     * the metadata
+     *
+     * Returns null if no error on validation.
+     */
+    @Override
+    public Element applyCustomSchematronRules(String schema, int metadataId, Element md, String lang,
+            List<MetadataValidation> validations) {
+        return schematronValidator.applyCustomSchematronRules(schema, metadataId, md, lang, validations);
+    }
+
+    /**
+     * Saves validation status information into the database for the current record.
+     *
+     * @param id the metadata record internal identifier
+     * @param validations the validation reports for each type of validation and schematron validation
+     */
+    private void saveValidationStatus(int id, List<MetadataValidation> validations) throws Exception {
+        validationRepository.deleteAllById_MetadataId(id);
+        validationRepository.save(validations);
+    }
+
+    /**
+     * Validates an xml document, using autodetectschema to determine how.
+     *
+     * @return true if metadata is valid
+     */
+    @Override
+    public boolean validate(Element xml) {
+        try {
+            String schema = metadataSchemaUtils.autodetectSchema(xml);
+            validate(schema, xml);
+            return true;
+        }
+        // XSD validation error(s)
+        catch (Exception x) {
+            // do not print stacktrace as this is 'normal' program flow
+            if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+                Log.debug(Geonet.DATA_MANAGER, "invalid metadata: " + x.getMessage(), x);
+            return false;
+        }
+    }
+}

--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -148,4 +148,14 @@
         class="org.fao.geonet.notifier.MetadataNotifierClient"
         lazy-init="true" scope="prototype"/>
 
+        
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataIndexer"/>
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataValidator"/>
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataOperations"/>
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataStatus"/>
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataSchemaUtils"/>
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataCategory"/>
+
 </beans>


### PR DESCRIPTION
Why?
 * This classes are more Spring friendly
 * It will create less chaos when merging and modifying the same file
 * Decoupling
 * Allow to override parts of DataManager with overriding beans (documentation in future PR)

This PR only split the DataManager (now deprecated) into smaller files. It does not change any code or behaviour.

You can still use DataManager, it will just redirect to the proper helper class. But for future coding, try to use the helper class directly (through the interface).