### PR TITLE
Add metadata type information in metadata relations service

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/model/related/RelatedMetadataItem.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/related/RelatedMetadataItem.java
@@ -40,7 +40,8 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "relatedMetadataItem", propOrder = {
-    "description"
+    "description",
+    "mdType"
 })
 @XmlSeeAlso({
     RelatedSiblingMetadataItem.class
@@ -49,6 +50,9 @@ public class RelatedMetadataItem
     extends RelatedItem {
     @XmlElement(required = true)
     protected RelatedMetadataItem.Description description;
+
+    @XmlElement(required = true)
+    protected String[] mdType;
 
     /**
      * Gets the value of the description property.
@@ -68,6 +72,23 @@ public class RelatedMetadataItem
         this.description = value;
     }
 
+    /**
+     * Gets the value of the mdType property.
+     *
+     * @return possible object is {@link String }
+     */
+    public String[] getMdType() {
+        return mdType;
+    }
+
+    /**
+     * Sets the value of the mdType property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    public void setMdType(String[] value) {
+        this.mdType = value;
+    }
 
     /**
      * <p>Java class for anonymous complex type.

--- a/web/src/main/webapp/xslt/services/metadata/relation.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/relation.xsl
@@ -93,6 +93,12 @@
               </value>
             </description>
 
+            <xsl:for-each select="$metadata/type">
+              <mdType>
+                <xsl:value-of select="."/>
+              </mdType>
+            </xsl:for-each>
+
             <xsl:if test="$type = 'siblings'">
               <associationType>
                 <xsl:value-of select="../@initiative"/>


### PR DESCRIPTION
This pull requests adds the metadata type information to the metadata relations response.

We need to improve the way to add additional metadata information to the metadata relations response as actually requires Java changes, but in any case the metadata type field seem quite relevant and it's used by some customers using the API from third party applications.