### PR TITLE
Improved WMTS support for restful

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1362,7 +1362,18 @@
                 matrixIds[z] = matrix.Identifier;
               }
 
-              var source;
+              var sourceConfig = {
+                layer: layer.Identifier,
+                matrixSet: matrixSet.Identifier,
+                format: layer.Format[0] || 'image/png',
+                projection: projection,
+                tileGrid: new ol.tilegrid.WMTS({
+                  origin: ol.extent.getTopLeft(projection.getExtent()),
+                  resolutions: resolutions,
+                  matrixIds: matrixIds
+                }),
+                style: style
+              };
 
               if (useRest) {
                 var urls = [];
@@ -1370,38 +1381,18 @@
                   urls.push(layer.ResourceURL[i].template);
                 }
 
-
-                source = new ol.source.WMTS({
+                angular.extend(sourceConfig, {
                   urls: urls,
-                  requestEncoding: 'REST',
-                  layer: layer.Identifier,
-                  matrixSet: matrixSet.Identifier,
-                  format: layer.Format[0] || 'image/png',
-                  projection: projection,
-                  tileGrid: new ol.tilegrid.WMTS({
-                    origin: ol.extent.getTopLeft(projection.getExtent()),
-                    resolutions: resolutions,
-                    matrixIds: matrixIds
-                  }),
-                  style: style
+                  requestEncoding: 'REST'
+                });
+              } else {
+                angular.extend(sourceConfig, {
+                  url: url
                 });
 
-              } else {
-                source = new ol.source.WMTS({
-                  url: url,
-                  layer: layer.Identifier,
-                  matrixSet: matrixSet.Identifier,
-                  format: layer.Format[0] || 'image/png',
-                  projection: projection,
-                  tileGrid: new ol.tilegrid.WMTS({
-                    origin: ol.extent.getTopLeft(projection.getExtent()),
-                    resolutions: resolutions,
-                    matrixIds: matrixIds
-                  }),
-                  style: style
-                });
               }
 
+              var source = new ol.source.WMTS(sourceConfig);
 
               var olLayer = new ol.layer.Tile({
                 extent: projection.getExtent(),

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1282,16 +1282,48 @@
               var url, urls = capabilities.operationsMetadata.GetTile.
                   DCP.HTTP.Get;
 
+              var useKvp = false;
+              var useRest = false;
+
               for (var i = 0; i < urls.length; i++) {
                 if (urls[i].Constraint[0].AllowedValues.Value[0].
                     toLowerCase() == 'kvp') {
                   url = urls[i].href;
+                  useKvp = true;
                   break;
+                }
+              }
+
+              if (!useKvp) {
+                for (var i = 0; i < urls.length; i++) {
+                  if (urls[i].Constraint[0].AllowedValues.Value[0].
+                      toLowerCase() == 'restful') {
+                    useRest = true;
+                    break;
+                  }
                 }
               }
 
               var urlCap = capabilities.operationsMetadata.GetCapabilities.
                   DCP.HTTP.Get[0].href;
+
+              var urlCapType = capabilities.operationsMetadata.GetCapabilities.
+                  DCP.HTTP.Get[0].
+                  Constraint[0].AllowedValues.Value[0].toLowerCase();
+
+              if (urlCapType == 'restful') {
+                if (urlCap.indexOf('/1.0.0/WMTSCapabilities.xml') == -1) {
+                  urlCap = urlCap + '/1.0.0/WMTSCapabilities.xml';
+                }
+              } else {
+                var parts = urlCap.split('?');
+
+                urlCap = gnUrlUtils.append(parts[0],
+                    gnUrlUtils.toKeyValue({
+                      service: 'WMTS',
+                      request: 'GetCapabilities',
+                      version: '1.0.0'}));
+              }
 
               var style = layer.Style[0].Identifier;
 
@@ -1330,19 +1362,46 @@
                 matrixIds[z] = matrix.Identifier;
               }
 
-              var source = new ol.source.WMTS({
-                url: url,
-                layer: layer.Identifier,
-                matrixSet: matrixSet.Identifier,
-                format: layer.Format[0] || 'image/png',
-                projection: projection,
-                tileGrid: new ol.tilegrid.WMTS({
-                  origin: ol.extent.getTopLeft(projection.getExtent()),
-                  resolutions: resolutions,
-                  matrixIds: matrixIds
-                }),
-                style: style
-              });
+              var source;
+
+              if (useRest) {
+                var urls = [];
+                for (var i = 0; i < layer.ResourceURL.length; i++) {
+                  urls.push(layer.ResourceURL[i].template);
+                }
+
+
+                source = new ol.source.WMTS({
+                  urls: urls,
+                  requestEncoding: 'REST',
+                  layer: layer.Identifier,
+                  matrixSet: matrixSet.Identifier,
+                  format: layer.Format[0] || 'image/png',
+                  projection: projection,
+                  tileGrid: new ol.tilegrid.WMTS({
+                    origin: ol.extent.getTopLeft(projection.getExtent()),
+                    resolutions: resolutions,
+                    matrixIds: matrixIds
+                  }),
+                  style: style
+                });
+
+              } else {
+                source = new ol.source.WMTS({
+                  url: url,
+                  layer: layer.Identifier,
+                  matrixSet: matrixSet.Identifier,
+                  format: layer.Format[0] || 'image/png',
+                  projection: projection,
+                  tileGrid: new ol.tilegrid.WMTS({
+                    origin: ol.extent.getTopLeft(projection.getExtent()),
+                    resolutions: resolutions,
+                    matrixIds: matrixIds
+                  }),
+                  style: style
+                });
+              }
+
 
               var olLayer = new ol.layer.Tile({
                 extent: projection.getExtent(),
@@ -1450,11 +1509,11 @@
                 });
               //ALEJO: tms support
               case 'tms':
-                return   new ol.layer.Tile({
-                    source: new ol.source.XYZ({
+                return new ol.layer.Tile({
+                  source: new ol.source.XYZ({
                         url: opt.url
-                    }),
-                    title: title ||  'TMS Layer'
+                  }),
+                  title: title ||  'TMS Layer'
                 });
               case 'bing_aerial':
                 return new ol.layer.Tile({


### PR DESCRIPTION
This pull requests adds support for WMTS services that only supports `RESTful` and not `KVP` like https://maps.wien.gv.at/basemap/1.0.0/WMTSCapabilities.xml

If the WMTS supports `KVP` is used to don't change the original functionality.

Also the spec seem doesn't require to have the full url to the capabilities document, but just the service endpoint. For example:

```
<ows:Operation name="GetCapabilities">
  <ows:DCP>
    <ows:HTTP>
      <ows:Get xlink:href="https://maps.wien.gv.at/basemap">
        <ows:Constraint name="GetEncoding">
          <ows:AllowedValues>
            <ows:Value>RESTful</ows:Value>
          </ows:AllowedValues>
        </ows:Constraint>
      </ows:Get>
```

The problem is that the feature used in GeoNetwork to save the context in the session needs the full url (in this example: https://maps.wien.gv.at/basemap/1.0.0/WMTSCapabilities.xml), otherwise the context created is invalid.

Added also code to manage about this.

Tested with this service https://maps.wien.gv.at/basemap/1.0.0/WMTSCapabilities.xml that only supports `RESTful` adding to the `context-viewer.xml` the following layer:

```
 <ows-context:Layer queryable="false"
                       name="{type=wmts,name=bmaporthofoto30cm,requestEncoding=REST}"
                       hidden="true" opacity="1" group="Background layers" requestEncoding="REST">
      <ows:Title xmlns:ows="http://www.opengis.net/ows">Geoland Basemap Orthofoto</ows:Title>
      <ows-context:Server service="urn:ogc:serviceType:WMTS">
        <ows-context:OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                    xlink:href="https://maps.wien.gv.at/basemap/1.0.0/WMTSCapabilities.xml"/>
      </ows-context:Server>
      <ows-context:StyleList/>
 </ows-context:Layer>
```