### PR TITLE
Refactor to allow different database types of metadata

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
@@ -23,12 +23,21 @@
 
 package org.fao.geonet.kernel;
 
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasMetadataId;
+import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasOperation;
+import static org.springframework.data.jpa.domain.Specifications.where;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
 
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataSourceInfo;
 import org.fao.geonet.domain.Operation;
@@ -57,16 +66,8 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.Specifications;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.StringTokenizer;
-
-import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasMetadataId;
-import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasOperation;
-import static org.springframework.data.jpa.domain.Specifications.where;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Handles the access to a metadata depending on the metadata/group.
@@ -255,7 +256,7 @@ public class AccessManager {
     public boolean isOwner(final ServiceContext context, final String id) throws Exception {
 
         //--- retrieve metadata info
-        Metadata info = context.getBean(MetadataRepository.class).findOne(id);
+        IMetadata info = context.getBean(MetadataRepository.class).findOne(id);
 
         if (info == null)
             return false;
@@ -347,7 +348,7 @@ public class AccessManager {
      * @param metadataId the id of the metadata
      */
     public boolean isVisibleToAll(final String metadataId) throws Exception {
-        Metadata metadata = ApplicationContextHolder.get().getBean(MetadataRepository.class).findOne(metadataId);
+        IMetadata metadata = ApplicationContextHolder.get().getBean(MetadataRepository.class).findOne(metadataId);
         if (metadata == null) {
             return false;
         } else {
@@ -396,7 +397,7 @@ public class AccessManager {
      * @param group    the group to check
      * @param opId     the id of the operation to check for
      */
-    public boolean hasPermission(final Metadata metadata, final Group group, final int opId) {
+    public boolean hasPermission(final IMetadata metadata, final Group group, final int opId) {
         OperationAllowedRepository opAllowedRepository = ApplicationContextHolder.get().getBean(OperationAllowedRepository.class);
         return opAllowedRepository.findOneById_GroupIdAndId_MetadataIdAndId_OperationId(group.getId(), metadata.getId(), opId) != null;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -41,6 +41,7 @@ import javax.annotation.Nullable;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
@@ -401,7 +402,7 @@ public class DataManager {
     }
 
     @Deprecated
-    public Metadata insertMetadata(ServiceContext context, Metadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
+    public IMetadata insertMetadata(ServiceContext context, IMetadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
             boolean updateFixedInfo, UpdateDatestamp updateDatestamp, boolean fullRightsForGroup, boolean forceRefreshReaders)
             throws Exception {
         return metadataManager.insertMetadata(context, newMetadata, metadataXml, notifyChange, index, updateFixedInfo, updateDatestamp,
@@ -450,7 +451,7 @@ public class DataManager {
     }
 
     @Deprecated
-    public synchronized Metadata updateMetadata(final ServiceContext context, final String metadataId, final Element md,
+    public synchronized IMetadata updateMetadata(final ServiceContext context, final String metadataId, final Element md,
             final boolean validate, final boolean ufo, final boolean index, final String lang, final String changeDate,
             final boolean updateDateStamp) throws Exception {
         return metadataManager.updateMetadata(context, metadataId, md, validate, ufo, index, lang, changeDate, updateDateStamp);

--- a/core/src/main/java/org/fao/geonet/kernel/SvnManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SvnManager.java
@@ -23,10 +23,21 @@
 
 package org.fao.geonet.kernel;
 
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-import jeeves.transaction.AfterCommitTransactionListener;
-import jeeves.transaction.BeforeRollbackTransactionListener;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.sql.Connection;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
@@ -34,7 +45,7 @@ import org.fao.geonet.Constants;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.Group;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.domain.MetadataStatus;
 import org.fao.geonet.domain.Operation;
@@ -72,21 +83,10 @@ import org.tmatesoft.svn.core.io.SVNRepository;
 import org.tmatesoft.svn.core.io.SVNRepositoryFactory;
 import org.tmatesoft.svn.core.wc.SVNWCUtil;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.sql.Connection;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
-import javax.annotation.Nonnull;
-import javax.sql.DataSource;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import jeeves.transaction.AfterCommitTransactionListener;
+import jeeves.transaction.BeforeRollbackTransactionListener;
 
 public class SvnManager implements AfterCommitTransactionListener, BeforeRollbackTransactionListener {
     private static String username = "geonetwork";
@@ -689,7 +689,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
         // get owner from the database
         Set<Integer> ids = new HashSet<Integer>();
         ids.add(Integer.valueOf(id));
-        Metadata metadata = this.context.getBean(MetadataRepository.class).findOne(id);
+        IMetadata metadata = this.context.getBean(MetadataRepository.class).findOne(id);
         User user = this.context.getBean(UserRepository.class).findOne(metadata.getSourceInfo().getOwner());
         // Backwards compatibility.  Format the metadata as XML in same format as previous versions.
         Element xml = new Element("results").addContent(

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -22,31 +22,7 @@
 
 package org.fao.geonet.kernel;
 
-import com.google.common.collect.Maps;
-
-import org.fao.geonet.Util;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Constants;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.ThesaurusActivation;
-import org.fao.geonet.kernel.oaipmh.Lib;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.languages.IsoLanguagesMapper;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.ThesaurusActivationRepository;
-import org.fao.geonet.utils.IO;
-import org.fao.geonet.utils.Log;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.openrdf.sesame.Sesame;
-import org.openrdf.sesame.config.ConfigurationException;
-import org.openrdf.sesame.config.RepositoryConfig;
-import org.openrdf.sesame.config.SailConfig;
-import org.openrdf.sesame.constants.RDFFormat;
-import org.openrdf.sesame.repository.local.LocalRepository;
-import org.openrdf.sesame.repository.local.LocalService;
+import static com.google.common.io.Files.getNameWithoutExtension;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -65,10 +41,34 @@ import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.fao.geonet.Util;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Constants;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ThesaurusActivation;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.oaipmh.Lib;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.languages.IsoLanguagesMapper;
+import org.fao.geonet.repository.ThesaurusActivationRepository;
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.openrdf.sesame.Sesame;
+import org.openrdf.sesame.config.ConfigurationException;
+import org.openrdf.sesame.config.RepositoryConfig;
+import org.openrdf.sesame.config.SailConfig;
+import org.openrdf.sesame.constants.RDFFormat;
+import org.openrdf.sesame.repository.local.LocalRepository;
+import org.openrdf.sesame.repository.local.LocalService;
+
+import com.google.common.collect.Maps;
+
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
-
-import static com.google.common.io.Files.getNameWithoutExtension;
 
 
 public class ThesaurusManager implements ThesaurusFinder {
@@ -214,7 +214,7 @@ public class ThesaurusManager implements ThesaurusFinder {
      * @param os   OutputStream to write rdf to from XSLT conversion
      */
     private void getRegisterMetadataAsRdf(String uuid, OutputStream os, ServiceContext context) throws Exception {
-        Metadata mdInfo = context.getBean(MetadataRepository.class).findOneByUuid(uuid);
+        IMetadata mdInfo = context.getBean(IMetadataUtils.class).findOneByUuid(uuid);
         Integer id = mdInfo.getId();
         final DataManager dataManager = context.getBean(DataManager.class);
         Element md = dataManager.getMetadata("" + id);

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializerDb.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializerDb.java
@@ -25,11 +25,11 @@ package org.fao.geonet.kernel;
 
 import java.sql.SQLException;
 
+import org.fao.geonet.domain.IMetadata;
+import org.jdom.Element;
+
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
-
-import org.fao.geonet.domain.Metadata;
-import org.jdom.Element;
 
 /**
  * This class is responsible of reading and writing xml on the database. It works on tables like
@@ -64,7 +64,7 @@ public class XmlSerializerDb extends XmlSerializer {
      * @param context     a service context
      * @return the saved metadata
      */
-    public Metadata insert(final Metadata newMetadata, final Element dataXml, ServiceContext context) throws SQLException {
+    public IMetadata insert(final IMetadata newMetadata, final Element dataXml, ServiceContext context) throws SQLException {
         return insertDb(newMetadata, dataXml, context);
 
     }

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializerSvn.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializerSvn.java
@@ -23,16 +23,16 @@
 
 package org.fao.geonet.kernel;
 
-import jeeves.server.context.ServiceContext;
-import jeeves.xlink.Processor;
+import java.sql.SQLException;
 
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
-import java.sql.SQLException;
+import jeeves.server.context.ServiceContext;
+import jeeves.xlink.Processor;
 
 /**
  * This class is responsible for reading and writing metadata extras from the database and xml from
@@ -80,7 +80,7 @@ public class XmlSerializerSvn extends XmlSerializer {
      * @param context     a service context
      * @return the saved metadata
      */
-    public Metadata insert(final Metadata newMetadata, final Element dataXml, ServiceContext context) throws SQLException {
+    public IMetadata insert(final IMetadata newMetadata, final Element dataXml, ServiceContext context) throws SQLException {
         return insertDb(newMetadata, dataXml, context);
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataCategory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataCategory.java
@@ -1,4 +1,4 @@
-    package org.fao.geonet.kernel.datamanager;
+package org.fao.geonet.kernel.datamanager;
 
 import java.util.Collection;
 
@@ -6,16 +6,59 @@ import org.fao.geonet.domain.MetadataCategory;
 
 import jeeves.server.context.ServiceContext;
 
+/**
+ * Interface to handle categories of records.
+ * 
+ * @author delawen
+ *
+ */
 public interface IMetadataCategory {
-        public void init(ServiceContext context, Boolean force) throws Exception;
 
-        boolean isCategorySet(String mdId, int categId) throws Exception;
+    /**
+     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
+     * 
+     * @param context
+     * @param force
+     * @throws Exception
+     */
+    public void init(ServiceContext context, Boolean force) throws Exception;
 
-        void setCategory(ServiceContext context, String mdId, String categId) throws Exception;
+    /**
+     * Given a record id and a category id, returns if the record has that category assigned.
+     * 
+     * @param mdId
+     * @param categId
+     * @return
+     * @throws Exception
+     */
+    boolean isCategorySet(String mdId, int categId) throws Exception;
 
-        void unsetCategory(ServiceContext context, String mdId, int categId) throws Exception;
+    /**
+     * Given a record id and a category id, assign that category to the previous record
+     * 
+     * @param context
+     * @param mdId
+     * @param categId
+     * @throws Exception
+     */
+    void setCategory(ServiceContext context, String mdId, String categId) throws Exception;
 
-        Collection<MetadataCategory> getCategories(String mdId) throws Exception;
+    /**
+     * Given a record id and a category id, unassign that category from the previous record
+     * 
+     * @param context
+     * @param mdId
+     * @param categId
+     * @throws Exception
+     */
+    void unsetCategory(ServiceContext context, String mdId, int categId) throws Exception;
+
+    /**
+     * Given a record id, return the list of categories associated to that record
+     * 
+     * @param mdId
+     * @return
+     * @throws Exception
+     */
+    Collection<MetadataCategory> getCategories(String mdId) throws Exception;
 }
-
-  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataIndexer.java
@@ -1,43 +1,129 @@
-    package org.fao.geonet.kernel.datamanager;
+package org.fao.geonet.kernel.datamanager;
 
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.List;
 
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.search.ISearchManager;
 import org.jdom.Element;
 import org.springframework.data.jpa.domain.Specification;
 
 import jeeves.server.context.ServiceContext;
 
+/**
+ * Interface to handle all indexing operations
+ * 
+ * @author delawen
+ *
+ */
 public interface IMetadataIndexer {
 
-        public void init(ServiceContext context, Boolean force) throws Exception;
+    /**
+     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
+     * 
+     * @param context
+     * @param force
+     * @throws Exception
+     */
+    public void init(ServiceContext context, Boolean force) throws Exception;
 
-        void forceIndexChanges() throws IOException;
+    /**
+     * Force the index to wait until all changes are processed and the next reader obtained will get the latest data.
+     */
+    void forceIndexChanges() throws IOException;
 
-        int batchDeleteMetadataAndUpdateIndex(Specification<Metadata> specification) throws Exception;
+    /**
+     * Remove the records that matches the specification
+     * 
+     * @param specification
+     * @return
+     * @throws Exception
+     */
+    int batchDeleteMetadataAndUpdateIndex(Specification<? extends IMetadata> specification) throws Exception;
 
-        void rebuildIndexXLinkedMetadata(ServiceContext context) throws Exception;
+    /**
+     * Search for all records having XLinks (ie. indexed with _hasxlinks flag), clear the cache and reindex all records found.
+     */
+    void rebuildIndexXLinkedMetadata(ServiceContext context) throws Exception;
 
-        void rebuildIndexForSelection(ServiceContext context, String bucket, boolean clearXlink) throws Exception;
+    /**
+     * Reindex all records in current selection.
+     */
+    void rebuildIndexForSelection(ServiceContext context, String bucket, boolean clearXlink) throws Exception;
 
-        void batchIndexInThreadPool(ServiceContext context, List<?> metadataIds);
+    /**
+     * Index multiple metadata in a separate thread. Wait until the current transaction commits before starting threads (to make sure that
+     * all metadata are committed).
+     *
+     * @param context context object
+     * @param metadataIds the metadata ids to index
+     */
+    void batchIndexInThreadPool(ServiceContext context, List<?> metadataIds);
 
-        boolean isIndexing();
+    /**
+     * Is the platform currently indexing?
+     * 
+     * @return
+     */
+    boolean isIndexing();
 
-        void indexMetadata(List<String> metadataIds) throws Exception;
+    /**
+     * Index the list of records passed as parameter in order.
+     * 
+     * @param metadataIds
+     * @throws Exception
+     */
+    void indexMetadata(List<String> metadataIds) throws Exception;
 
-        void indexMetadata(String metadataId, boolean forceRefreshReaders, ISearchManager searchManager) throws Exception;
+    /**
+     * Index one record defined by metadataId
+     * 
+     * @param metadataId
+     * @param forceRefreshReaders
+     * @param searchManager
+     * @throws Exception
+     */
+    void indexMetadata(String metadataId, boolean forceRefreshReaders, ISearchManager searchManager) throws Exception;
 
-        void versionMetadata(ServiceContext context, String id, Element md) throws Exception;
+    /**
+     * Start record versioning
+     * 
+     * @param context
+     * @param id
+     * @param md
+     * @throws Exception
+     */
+    void versionMetadata(ServiceContext context, String id, Element md) throws Exception;
 
-        void rescheduleOptimizer(Calendar beginAt, int interval) throws Exception;
+    /**
+     * Reschedule the Index Optimizer Manager (Lucene)
+     * 
+     * @param beginAt
+     * @param interval
+     * @throws Exception
+     */
+    void rescheduleOptimizer(Calendar beginAt, int interval) throws Exception;
 
-        void disableOptimizer() throws Exception;
+    /**
+     * Disable the Index Optimizer (Lucene)
+     * 
+     * @throws Exception
+     */
+    void disableOptimizer() throws Exception;
 
-        void setMetadataUtils(IMetadataUtils metadataUtils);
+    /**
+     * Helper function to avoid loop circular dependencies
+     * 
+     * @param metadataUtils
+     */
+    void setMetadataUtils(IMetadataUtils metadataUtils);
+
+    /**
+     * Helper function to avoid loop circular dependencies
+     * 
+     * @param metadataUtils
+     */
+    void setMetadataManager(IMetadataManager baseMetadataManager);
+
 }
-
-  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
@@ -1,60 +1,240 @@
-    package org.fao.geonet.kernel.datamanager;
+package org.fao.geonet.kernel.datamanager;
 
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.kernel.EditLib;
 import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.repository.BatchUpdateQuery;
+import org.fao.geonet.repository.PathSpec;
+import org.fao.geonet.repository.Updater;
 import org.jdom.Element;
+import org.springframework.data.jpa.domain.Specification;
 
 import com.google.common.base.Optional;
 
 import jeeves.server.context.ServiceContext;
 
+/**
+ * Utility interface to handle record insertions, removals and updates
+ * 
+ * @author delawen
+ *
+ */
 public interface IMetadataManager {
 
-        public void init(ServiceContext context, Boolean force) throws Exception;
+    /**
+     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
+     * 
+     * @param context
+     * @param force
+     * @throws Exception
+     */
+    public void init(ServiceContext context, Boolean force) throws Exception;
 
-        void deleteMetadata(ServiceContext context, String metadataId) throws Exception;
+    /**
+     * Removes the record with the id metadataId
+     * 
+     * @param context
+     * @param metadataId
+     * @throws Exception
+     */
+    void deleteMetadata(ServiceContext context, String metadataId) throws Exception;
 
-        void deleteMetadataGroup(ServiceContext context, String metadataId) throws Exception;
+    /**
+     * Removes a record without notifying.
+     * 
+     * FIXME explain better why this and not {@link #deleteMetadata(ServiceContext, String)}
+     * 
+     * @param context
+     * @param metadataId
+     * @throws Exception
+     */
+    void deleteMetadataGroup(ServiceContext context, String metadataId) throws Exception;
 
-        String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
-                String isTemplate, boolean fullRightsForGroup) throws Exception;
+    /**
+     * Creates a new metadata duplicating an existing template creating a random uuid.
+     *
+     * @param isTemplate
+     * @param fullRightsForGroup
+     */
+    String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
+            String isTemplate, boolean fullRightsForGroup) throws Exception;
 
-        String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
-                String isTemplate, boolean fullRightsForGroup, String uuid) throws Exception;
+    /**
+     * Creates a new metadata duplicating an existing template with an specified uuid.
+     *
+     * @param isTemplate
+     * @param fullRightsForGroup
+     */
+    String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
+            String isTemplate, boolean fullRightsForGroup, String uuid) throws Exception;
 
-        String insertMetadata(ServiceContext context, String schema, Element metadataXml, String uuid, int owner, String groupOwner,
-                String source, String metadataType, String docType, String category, String createDate, String changeDate, boolean ufo,
-                boolean index) throws Exception;
+    /**
+     * Inserts a metadata into the database, optionally indexing it, and optionally applying automatic changes to it (update-fixed-info).
+     *
+     * @param context the context describing the user and service
+     * @param schema XSD this metadata conforms to
+     * @param metadataXml the metadata to store
+     * @param uuid unique id for this metadata
+     * @param owner user who owns this metadata
+     * @param groupOwner group this metadata belongs to
+     * @param source id of the origin of this metadata (harvesting source, etc.)
+     * @param metadataType whether this metadata is a template
+     * @param docType ?!
+     * @param category category of this metadata
+     * @param createDate date of creation
+     * @param changeDate date of modification
+     * @param ufo whether to apply automatic changes
+     * @param index whether to index this metadata
+     * @return id, as a string
+     * @throws Exception hmm
+     */
+    String insertMetadata(ServiceContext context, String schema, Element metadataXml, String uuid, int owner, String groupOwner,
+            String source, String metadataType, String docType, String category, String createDate, String changeDate, boolean ufo,
+            boolean index) throws Exception;
 
-        Metadata insertMetadata(ServiceContext context, Metadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
-                boolean updateFixedInfo, UpdateDatestamp updateDatestamp, boolean fullRightsForGroup, boolean forceRefreshReaders)
-                throws Exception;
+    /**
+     * /** Inserts a metadata into the database, optionally indexing it, and optionally applying automatic changes to it
+     * (update-fixed-info).
+     *
+     * @param context
+     * @param newMetadata
+     * @param metadataXml
+     * @param notifyChange
+     * @param index
+     * @param updateFixedInfo
+     * @param updateDatestamp
+     * @param fullRightsForGroup
+     * @param forceRefreshReaders
+     * @return
+     * @throws Exception
+     */
+    IMetadata insertMetadata(ServiceContext context, IMetadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
+            boolean updateFixedInfo, UpdateDatestamp updateDatestamp, boolean fullRightsForGroup, boolean forceRefreshReaders)
+            throws Exception;
 
-        Element getMetadata(String id) throws Exception;
+    /**
+     * Retrieves a metadata (in xml) given its id. Use this method when you must retrieve a metadata in the same transaction.
+     */
+    Element getMetadata(String id) throws Exception;
 
-        Element getMetadata(ServiceContext srvContext, String id, boolean forEditing, boolean withEditorValidationErrors,
-                boolean keepXlinkAttributes) throws Exception;
+    /**
+     * Retrieves a metadata (in xml) given its id; adds editing information if requested and validation errors if requested.
+     *
+     * @param forEditing Add extra element to build metadocument {@link EditLib#expandElements(String, Element)}
+     * @param keepXlinkAttributes When XLinks are resolved in non edit mode, do not remove XLink attributes.
+     */
+    Element getMetadata(ServiceContext srvContext, String id, boolean forEditing, boolean withEditorValidationErrors,
+            boolean keepXlinkAttributes) throws Exception;
 
-        void updateMetadataOwner(int id, String owner, String groupOwner) throws Exception;
+    /**
+     * Update of owner info.
+     */
+    void updateMetadataOwner(int id, String owner, String groupOwner) throws Exception;
 
-        Metadata updateMetadata(ServiceContext context, String metadataId, Element md, boolean validate, boolean ufo, boolean index,
-                String lang, String changeDate, boolean updateDateStamp) throws Exception;
+    /**
+     * Updates a metadata record. Deletes validation report currently in session (if any). If user asks for validation the validation report
+     * will be (re-)created then.
+     *
+     * @return metadata if the that was updated
+     */
+    IMetadata updateMetadata(ServiceContext context, String metadataId, Element md, boolean validate, boolean ufo, boolean index,
+            String lang, String changeDate, boolean updateDateStamp) throws Exception;
 
-        void buildPrivilegesMetadataInfo(ServiceContext context, Map<String, Element> mdIdToInfoMap) throws Exception;
+    /**
+     * Add privileges information about metadata record which depends on context and usually could not be stored in db or Lucene index
+     * because depending on the current user or current client IP address.
+     *
+     * @param mdIdToInfoMap a map from the metadata Id -> the info element to which the privilege information should be added.
+     */
+    void buildPrivilegesMetadataInfo(ServiceContext context, Map<String, Element> mdIdToInfoMap) throws Exception;
 
-        Set<String> updateChildren(ServiceContext srvContext, String parentUuid, String[] children, Map<String, Object> params)
-                throws Exception;
+    /**
+     * Updates all children of the selected parent. Some elements are protected in the children according to the stylesheet used in
+     * xml/schemas/[SCHEMA]/update-child-from-parent-info.xsl.
+     *
+     * Children MUST be editable and also in the same schema of the parent. If not, child is not updated.
+     *
+     * @param srvContext service context
+     * @param parentUuid parent uuid
+     * @param children children
+     * @param params parameters
+     */
+    Set<String> updateChildren(ServiceContext srvContext, String parentUuid, String[] children, Map<String, Object> params)
+            throws Exception;
 
-        Element updateFixedInfo(String schema, Optional<Integer> metadataId, String uuid, Element md, String parentUuid,
-                UpdateDatestamp updateDatestamp, ServiceContext context) throws Exception;
+    /**
+     * Update metadata record (not template) using update-fixed-info.xsl
+     *
+     * @param uuid If the metadata is a new record (not yet saved), provide the uuid for that record
+     * @param updateDatestamp updateDatestamp is not used when running XSL transformation
+     */
+    Element updateFixedInfo(String schema, Optional<Integer> metadataId, String uuid, Element md, String parentUuid,
+            UpdateDatestamp updateDatestamp, ServiceContext context) throws Exception;
 
-        void flush();
+    /**
+     * You should not use a direct flush. If you need to use this to properly run your code, you are missing something. Check the
+     * transaction annotations and try to comply to Spring/Hibernate
+     */
+    @Deprecated
+    void flush();
 
-        EditLib getEditLib();
+    /**
+     * Returns a helpful EditLib for other utility classes
+     * 
+     * @return
+     */
+    EditLib getEditLib();
+
+    /**
+     * Saves an IMetadata into the database. Useful to avoid using the MetadataRepository classes directly, who may not know how to handle
+     * IMetadata types
+     * 
+     * @param info
+     */
+    public IMetadata save(IMetadata info);
+
+    /**
+     * Load a record, modify it and save it again.
+     * <p>
+     * This method loads the domain object identified domain object, passes the domain object to the function and then saves the domain
+     * object passed to the function.
+     * </p>
+     *
+     * @param id the id of the domain object to load.
+     * @param updater the function that updates the domain object before saving.
+     * @return the saved domain object.
+     */
+    public IMetadata update(int id, @Nonnull Updater<? extends IMetadata> md);
+
+    /**
+     * Delete all records that matches the specification
+     * 
+     * @param specification
+     */
+    public void deleteAll(Specification<? extends IMetadata> specification);
+
+    /**
+     * Remove the record with the identifier id
+     * 
+     * @param id
+     */
+    public void delete(Integer id);
+
+    /**
+     * Create a {@link BatchUpdateQuery} object to allow for updating multiple objects in a single query.
+     *
+     * @param pathToUpdate the path of the attribute to update with the new value. More paths and values can be added to the
+     *            {@link BatchUpdateQuery} object after it is created.
+     * @param newValue the value to set on the attribute of all the affected entities
+     * @param spec a specification for controlling which entities will be affected by update.
+     * @param <V> The type of the attribute
+     * @return a {@link BatchUpdateQuery} object to allow for updating multiple objects in a single query.
+     */
+    public void createBatchUpdateQuery(PathSpec<Metadata, String> servicesPath, String newUuid, Specification<Metadata> harvested);
 }
-
-  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataOperations.java
@@ -1,7 +1,5 @@
-    package org.fao.geonet.kernel.datamanager;
+package org.fao.geonet.kernel.datamanager;
 
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.MetadataStatus;
 import org.fao.geonet.domain.OperationAllowed;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.repository.UserGroupRepository;
@@ -10,35 +8,146 @@ import com.google.common.base.Optional;
 
 import jeeves.server.context.ServiceContext;
 
+/**
+ * Interface for hanlding record privileges
+ * 
+ * @author delawen
+ *
+ */
 public interface IMetadataOperations {
 
-        public void init(ServiceContext context, Boolean force) throws Exception;
+    /**
+     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
+     * 
+     * @param context
+     * @param force
+     * @throws Exception
+     */
+    public void init(ServiceContext context, Boolean force) throws Exception;
 
-        void deleteMetadataOper(ServiceContext context, String metadataId, boolean skipAllReservedGroup) throws Exception;
+    /**
+     * Removes all operations stored for a metadata.
+     */
+    void deleteMetadataOper(ServiceContext context, String metadataId, boolean skipAllReservedGroup) throws Exception;
 
-        void setOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception;
+    /**
+     * Adds a permission to a group. Metadata is not reindexed.
+     */
+    void setOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception;
 
-        void setOperation(ServiceContext context, String mdId, String grpId, ReservedOperation op) throws Exception;
+    /**
+     * Adds a permission to a group. Metadata is not reindexed.
+     */
+    void setOperation(ServiceContext context, String mdId, String grpId, ReservedOperation op) throws Exception;
 
-        void copyDefaultPrivForGroup(ServiceContext context, String id, String groupId, boolean fullRightsForGroup) throws Exception;
+    /**
+     * Sets VIEW and NOTIFY privileges for a metadata to a group.
+     *
+     * @param context service context
+     * @param id metadata id
+     * @param groupId group id
+     * @param fullRightsForGroup
+     * @throws Exception hmmm
+     */
+    void copyDefaultPrivForGroup(ServiceContext context, String id, String groupId, boolean fullRightsForGroup) throws Exception;
 
-        void forceUnsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception;
+    /**
+     * Unset operation without checking if user privileges allows the operation. This may be useful when a user is an editor and internal
+     * operations needs to update privilages for reserved group. eg. {@link org.fao.geonet.kernel.metadata.DefaultStatusActions}
+     */
+    void forceUnsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception;
 
-        void unsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception;
+    /**
+     * Removes a privilege if the user calling this function have enough privileges.
+     * 
+     * This is the "safe" version of {@link #forceUnsetOperation(ServiceContext, int, int, int)}
+     * 
+     * @param context
+     * @param mdId
+     * @param groupId
+     * @param operId
+     * @throws Exception
+     */
+    void unsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception;
 
-        boolean setOperation(ServiceContext context, int mdId, int grpId, int opId) throws Exception;
+    /**
+     * Set metadata privileges.
+     *
+     * Administrator can set operation for any groups.
+     *
+     * For reserved group (ie. Internet, Intranet & Guest), user MUST be reviewer of one group. For other group, if "Only set privileges to
+     * user's groups" is set in catalog configuration user MUST be a member of the group.
+     *
+     * @param mdId The metadata identifier
+     * @param grpId The group identifier
+     * @param opId The operation identifier
+     * @return true if the operation was set.
+     */
+    boolean setOperation(ServiceContext context, int mdId, int grpId, int opId) throws Exception;
 
-        Optional<OperationAllowed> getOperationAllowedToAdd(ServiceContext context, int mdId, int grpId, int opId);
+    /**
+     * Check that the operation has not been added and if not that it can be added.
+     * <ul>
+     * <li>If the operation can be added then an non-empty optional is return.</li>
+     * <li>If it has already been added the return empty optional</li>
+     * <li>If it is not permitted to be added throw exception.</li>
+     * </ul>
+     */
+    Optional<OperationAllowed> getOperationAllowedToAdd(ServiceContext context, int mdId, int grpId, int opId);
 
-        void checkOperationPermission(ServiceContext context, int grpId, UserGroupRepository userGroupRepo);
+    /**
+     * Check if the user calling have privileges over a group
+     * 
+     * @param context
+     * @param grpId
+     * @param userGroupRepo
+     */
+    void checkOperationPermission(ServiceContext context, int grpId, UserGroupRepository userGroupRepo);
 
-        void unsetOperation(ServiceContext context, String mdId, String grpId, ReservedOperation opId) throws Exception;
+    /**
+     * 
+     * Removes a privilege if the user calling this function have enough privileges.
+     * 
+     * This is the "safe" version of {@link #forceUnsetOperation(ServiceContext, int, int, int)}
+     * 
+     * @param context
+     * @param mdId
+     * @param grpId
+     * @param opId
+     * @throws Exception
+     */
+    void unsetOperation(ServiceContext context, String mdId, String grpId, ReservedOperation opId) throws Exception;
 
-        void unsetOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception;
+    /**
+     * 
+     * Removes a privilege if the user calling this function have enough privileges.
+     * 
+     * This is the "safe" version of {@link #forceUnsetOperation(ServiceContext, int, int, int)}
+     * 
+     * @param context
+     * @param mdId
+     * @param grpId
+     * @param opId
+     * @throws Exception
+     */
+    void unsetOperation(ServiceContext context, String mdId, String grpId, String opId) throws Exception;
 
-        boolean isUserMetadataOwner(int userId) throws Exception;
+    /**
+     * Checks if a user owns metadata
+     * 
+     * @param userId
+     * @return
+     * @throws Exception
+     */
+    boolean isUserMetadataOwner(int userId) throws Exception;
 
-        boolean existsUser(ServiceContext context, int id) throws Exception;
+    /**
+     * Checks if a user exists
+     * 
+     * @param context
+     * @param id
+     * @return
+     * @throws Exception
+     */
+    boolean existsUser(ServiceContext context, int id) throws Exception;
 }
-
-  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataSchemaUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataSchemaUtils.java
@@ -1,4 +1,4 @@
-    package org.fao.geonet.kernel.datamanager;
+package org.fao.geonet.kernel.datamanager;
 
 import java.nio.file.Path;
 import java.util.Set;
@@ -10,23 +10,77 @@ import org.jdom.Element;
 
 import jeeves.server.context.ServiceContext;
 
+/**
+ * Utility interface for schemas
+ * 
+ * @author delawen
+ *
+ */
 public interface IMetadataSchemaUtils {
 
-        public void init(ServiceContext context, Boolean force) throws Exception;
+    /**
+     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
+     * 
+     * @param context
+     * @param force
+     * @throws Exception
+     */
+    public void init(ServiceContext context, Boolean force) throws Exception;
 
-        Path getSchemaDir(String name);
+    /**
+     * Returns the schema folder path
+     * 
+     * @param name
+     * @return
+     */
+    Path getSchemaDir(String name);
 
-        boolean existsSchema(String name);
+    /**
+     * Checks if a schema exists on the platform
+     * 
+     * @param name
+     * @return
+     */
+    boolean existsSchema(String name);
 
-        Set<String> getSchemas();
+    /**
+     * Returns the full list of schemas available on the platform
+     * 
+     * @return
+     */
+    Set<String> getSchemas();
 
-        MetadataSchema getSchema(String name);
+    /**
+     * Given a schema name, returns the schema
+     * 
+     * @param name
+     * @return
+     */
+    MetadataSchema getSchema(String name);
 
-        String getMetadataSchema(String id) throws Exception;
+    /**
+     * Given a record id, returns the name of the schema
+     * 
+     * @param id
+     * @return
+     * @throws Exception
+     */
+    String getMetadataSchema(String id) throws Exception;
 
-        String autodetectSchema(Element md) throws SchemaMatchConflictException, NoSchemaMatchesException;
+    /**
+     * Checks autodetect elements in installed schemas to determine whether the metadata record belongs to that schema. Use this method when
+     * you want the default schema from the geonetwork config to be returned when no other match can be found.
+     *
+     * @param md Record to checked against schemas
+     */
+    String autodetectSchema(Element md) throws SchemaMatchConflictException, NoSchemaMatchesException;
 
-        String autodetectSchema(Element md, String defaultSchema) throws SchemaMatchConflictException, NoSchemaMatchesException;
+    /**
+     * Checks autodetect elements in installed schemas to determine whether the metadata record belongs to that schema. Use this method when
+     * you want to set the default schema to be returned when no other match can be found.
+     *
+     * @param md Record to checked against schemas
+     * @param defaultSchema Schema to be assigned when no other schema matches
+     */
+    String autodetectSchema(Element md, String defaultSchema) throws SchemaMatchConflictException, NoSchemaMatchesException;
 }
-
-  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
@@ -1,25 +1,71 @@
-    package org.fao.geonet.kernel.datamanager;
+package org.fao.geonet.kernel.datamanager;
 
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.MetadataStatus;
 
 import jeeves.server.context.ServiceContext;
 
+/**
+ * Interface to handle all actions related to status of a record
+ * 
+ * @author delawen
+ *
+ */
 public interface IMetadataStatus {
 
-        public void init(ServiceContext context, Boolean force) throws Exception;
+    /**
+     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
+     * 
+     * @param context
+     * @param force
+     * @throws Exception
+     */
+    public void init(ServiceContext context, Boolean force) throws Exception;
 
-        boolean isUserMetadataStatus(int userId) throws Exception;
+    /**
+     * Returns if the user has at least one metadata status associated
+     * 
+     * @param userId
+     * @return
+     * @throws Exception
+     */
+    boolean isUserMetadataStatus(int userId) throws Exception;
 
-        void activateWorkflowIfConfigured(ServiceContext context, String newId, String groupOwner) throws Exception;
+    /**
+     * If groupOwner match regular expression defined in setting metadata/workflow/draftWhenInGroup, then set status to draft to enable
+     * workflow.
+     */
+    void activateWorkflowIfConfigured(ServiceContext context, String newId, String groupOwner) throws Exception;
 
-        MetadataStatus setStatusExt(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception;
+    /**
+     * Set status of metadata id and do not reindex metadata id afterwards.
+     *
+     * @return the saved status entity object
+     */
+    MetadataStatus setStatusExt(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception;
 
-        MetadataStatus setStatus(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception;
+    /**
+     * Set status of metadata id and reindex metadata id afterwards.
+     *
+     * @return the saved status entity object
+     */
+    MetadataStatus setStatus(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception;
 
-        String getCurrentStatus(int metadataId) throws Exception;
+    /**
+     * Given a metadata id, return the name of the status of the metadata
+     * 
+     * @param metadataId
+     * @return
+     * @throws Exception
+     */
+    String getCurrentStatus(int metadataId) throws Exception;
 
-        MetadataStatus getStatus(int metadataId) throws Exception;
+    /**
+     * Given a metadata id, return the status of the metadata
+     * 
+     * @param metadataId
+     * @return
+     * @throws Exception
+     */
+    MetadataStatus getStatus(int metadataId) throws Exception;
 }
-
-  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -1,86 +1,462 @@
-    package org.fao.geonet.kernel.datamanager;
+package org.fao.geonet.kernel.datamanager;
 
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.repository.SimpleMetadata;
+import org.fao.geonet.repository.reports.MetadataReportsQueries;
 import org.jdom.Element;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 
 import com.google.common.base.Optional;
 
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 
+/**
+ * Utility interface for records
+ * 
+ * @author delawen
+ *
+ */
 public interface IMetadataUtils {
 
-        public void init(ServiceContext context, Boolean force) throws Exception;
+    /**
+     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
+     * 
+     * @param context
+     * @param force
+     * @throws Exception
+     */
+    public void init(ServiceContext context, Boolean force) throws Exception;
 
-        void notifyMetadataChange(Element md, String metadataId) throws Exception;
+    /**
+     * Notify a metadata modification
+     * 
+     * @param md
+     * @param metadataId
+     * @throws Exception
+     */
+    void notifyMetadataChange(Element md, String metadataId) throws Exception;
 
-        String getMetadataUuid(String id) throws Exception;
+    /**
+     * Return the uuid of the record with the defined id
+     * 
+     * @param id
+     * @return
+     * @throws Exception
+     */
+    String getMetadataUuid(String id) throws Exception;
 
-        void startEditingSession(ServiceContext context, String id) throws Exception;
+    /**
+     * Start an editing session. This will record the original metadata record in the session under the
+     * {@link org.fao.geonet.constants.Geonet.Session#METADATA_BEFORE_ANY_CHANGES} + id session property.
+     *
+     * The record contains geonet:info element.
+     *
+     * Note: Only the metadata record is stored in session. If the editing session upload new documents or thumbnails, those documents will
+     * not be cancelled. This needs improvements.
+     */
+    void startEditingSession(ServiceContext context, String id) throws Exception;
 
-        void cancelEditingSession(ServiceContext context, String id) throws Exception;
+    /**
+     * Rollback to the record in the state it was when the editing session started (See
+     * {@link #startEditingSession(ServiceContext, String)}).
+     */
+    void cancelEditingSession(ServiceContext context, String id) throws Exception;
 
-        void endEditingSession(String id, UserSession session);
+    /**
+     * Remove the original record stored in session.
+     */
+    void endEditingSession(String id, UserSession session);
 
-        Element enumerateTree(Element md) throws Exception;
+    /**
+     * Does a pre-order visit enumerating each node.
+     */
+    Element enumerateTree(Element md) throws Exception;
 
-        String extractUUID(String schema, Element md) throws Exception;
+    /**
+     * Extract UUID from the metadata record using the schema XSL for UUID extraction)
+     */
+    String extractUUID(String schema, Element md) throws Exception;
 
-        String extractDateModified(String schema, Element md) throws Exception;
+    /**
+     * Extract the last editing date from the record
+     * 
+     * @param schema
+     * @param md
+     * @return
+     * @throws Exception
+     */
+    String extractDateModified(String schema, Element md) throws Exception;
 
-        Element setUUID(String schema, String uuid, Element md) throws Exception;
+    /**
+     * Modify the UUID of a record. Uses the proper XSL transformation from the schema
+     * 
+     * @param schema
+     * @param uuid
+     * @param md
+     * @return
+     * @throws Exception
+     */
+    Element setUUID(String schema, String uuid, Element md) throws Exception;
 
-        Element extractSummary(Element md) throws Exception;
+    /**
+     * Returns the summary of the md record
+     * 
+     * @param md
+     * @return
+     * @throws Exception
+     */
+    Element extractSummary(Element md) throws Exception;
 
-        String getMetadataId(String uuid) throws Exception;
+    /**
+     * Returns the identifier of the record with uuid uuid
+     * 
+     * @param uuid
+     * @return
+     * @throws Exception
+     */
+    String getMetadataId(String uuid) throws Exception;
 
-        String getVersion(String id);
+    /**
+     * Returns the version of the record with identifier id
+     * 
+     * @param id
+     * @return
+     */
+    String getVersion(String id);
 
-        String getNewVersion(String id);
+    /**
+     * 
+     * Returns the version of a metadata, incrementing it if necessary.
+     *
+     * @param id
+     * @return
+     */
+    String getNewVersion(String id);
 
-        void setTemplateExt(int id, MetadataType metadataType) throws Exception;
+    /**
+     * Mark a record as template (or not)
+     * 
+     * @param id
+     * @param metadataType
+     * @throws Exception
+     */
+    void setTemplateExt(int id, MetadataType metadataType) throws Exception;
 
-        void setTemplate(int id, MetadataType type, String title) throws Exception;
+    /**
+     * Mark a record as template (or not)
+     * 
+     * @param id
+     * @param metadataType
+     * @throws Exception
+     */
+    void setTemplate(int id, MetadataType type, String title) throws Exception;
 
-        void setHarvestedExt(int id, String harvestUuid) throws Exception;
+    /**
+     * Mark a record as harvested
+     * 
+     * @param id
+     * @param harvestUuid
+     * @throws Exception
+     */
+    void setHarvestedExt(int id, String harvestUuid) throws Exception;
 
-        void setHarvested(int id, String harvestUuid) throws Exception;
+    /**
+     * Mark a record as harvested
+     * 
+     * @param id
+     * @param harvestUuid
+     * @throws Exception
+     */
+    void setHarvested(int id, String harvestUuid) throws Exception;
 
-        void setHarvestedExt(int id, String harvestUuid, Optional<String> harvestUri) throws Exception;
+    /**
+     * Mark a record as harvested from the harvestUri
+     * 
+     * @param id
+     * @param harvestUuid
+     * @throws Exception
+     */
+    void setHarvestedExt(int id, String harvestUuid, Optional<String> harvestUri) throws Exception;
 
-        void updateDisplayOrder(String id, String displayOrder) throws Exception;
+    /**
+     * Set the display order. A hint for ordering templates when displayed in a list. May also be used when displaying sub-templates.
+     *
+     *
+     * @param id
+     * @param displayOrder
+     * @throws Exception
+     */
+    void updateDisplayOrder(String id, String displayOrder) throws Exception;
 
-        void increasePopularity(ServiceContext srvContext, String id) throws Exception;
+    /**
+     * Increases the popularity of the record defined by the id
+     * 
+     * @param srvContext
+     * @param id
+     * @throws Exception
+     */
+    void increasePopularity(ServiceContext srvContext, String id) throws Exception;
 
-        int rateMetadata(int metadataId, String ipAddress, int rating) throws Exception;
+    /**
+     * Rates a metadata.
+     *
+     * @param ipAddress ipAddress IP address of the submitting client
+     * @param rating range should be 1..5
+     * @throws Exception hmm
+     */
+    int rateMetadata(int metadataId, String ipAddress, int rating) throws Exception;
 
-        Element getMetadataNoInfo(ServiceContext srvContext, String id) throws Exception;
+    /**
+     * Retrieves a metadata (in xml) given its id with no geonet:info.
+     */
+    Element getMetadataNoInfo(ServiceContext srvContext, String id) throws Exception;
 
-        Element getElementByRef(Element md, String ref);
+    /**
+     * Retrieves a metadata element given it's ref.
+     */
+    Element getElementByRef(Element md, String ref);
 
-        boolean existsMetadataUuid(String uuid) throws Exception;
+    /**
+     * Returns true if the metadata uuid exists in the database.
+     */
+    boolean existsMetadataUuid(String uuid) throws Exception;
 
-        boolean existsMetadata(int id) throws Exception;
+    /**
+     * Returns true if the metadata exists in the database.
+     */
+    boolean existsMetadata(int id) throws Exception;
 
-        Element getKeywords() throws Exception;
+    /**
+     * Returns all the keywords in the system.
+     */
+    Element getKeywords() throws Exception;
 
-        Element getThumbnails(ServiceContext context, String metadataId) throws Exception;
+    /**
+     * Returns the thumbnails associated to the record with id metadataId
+     * 
+     * @param context
+     * @param metadataId
+     * @return
+     * @throws Exception
+     */
+    Element getThumbnails(ServiceContext context, String metadataId) throws Exception;
 
-        void setThumbnail(ServiceContext context, String id, boolean small, String file, boolean indexAfterChange) throws Exception;
+    /**
+     * Add thumbnail to the record defined with the id
+     * 
+     * @param context
+     * @param id
+     * @param small
+     * @param indexAfterChange
+     * @throws Exception
+     */
+    void setThumbnail(ServiceContext context, String id, boolean small, String file, boolean indexAfterChange) throws Exception;
 
-        void unsetThumbnail(ServiceContext context, String id, boolean small, boolean indexAfterChange) throws Exception;
+    /**
+     * Remove thumbnail from the record defined with the id
+     * 
+     * @param context
+     * @param id
+     * @param small
+     * @param indexAfterChange
+     * @throws Exception
+     */
+    void unsetThumbnail(ServiceContext context, String id, boolean small, boolean indexAfterChange) throws Exception;
 
-        void setDataCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction, String licensename,
-                String type) throws Exception;
+    /**
+     * Add data commons to the record defined with the id
+     * 
+     * @param context
+     * @param id
+     * @param small
+     * @param indexAfterChange
+     * @throws Exception
+     */
+    void setDataCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction, String licensename,
+            String type) throws Exception;
 
-        void setCreativeCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction,
-                String licensename, String type) throws Exception;
+    /**
+     * Add creative commons to the record defined with the id
+     * 
+     * @param context
+     * @param id
+     * @param small
+     * @param indexAfterChange
+     * @throws Exception
+     */
+    void setCreativeCommons(ServiceContext context, String id, String licenseurl, String imageurl, String jurisdiction, String licensename,
+            String type) throws Exception;
 
-        void setMetadataManager(IMetadataManager metadataManager);
+    /**
+     * Helper function to prevent loop dependency
+     * 
+     * @param metadataManager
+     */
+    void setMetadataManager(IMetadataManager metadataManager);
 
-        public String getMetadataTitle(String id) throws Exception;
+    /**
+     * Extract the title field from the Metadata Repository. This is only valid for subtemplates as the title can be stored with the
+     * subtemplate (since subtemplates don't have a title) - metadata records don't store the title here as this is part of the metadata.
+     *
+     * @param id metadata id to retrieve
+     */
+    public String getMetadataTitle(String id) throws Exception;
 
-        public void setSubtemplateTypeAndTitleExt(int id, String title) throws Exception;
+    /**
+     * Set metadata type to subtemplate and set the title. Only subtemplates need to persist the title as it is used to give a meaningful
+     * title for use when offering the subtemplate to users in the editor.
+     *
+     * @param id Metadata id to set to type subtemplate
+     * @param title Title of metadata of subtemplate/fragment
+     */
+    public void setSubtemplateTypeAndTitleExt(int id, String title) throws Exception;
+
+    /**
+     * Count how many records are associated to a user
+     * 
+     * @param ownedByUser
+     * @return
+     */
+    public long count(Specification<? extends IMetadata> ownedByUser);
+
+    /**
+     * Given an identifier, return the record associated to it
+     * 
+     * @param id
+     * @return
+     */
+    public IMetadata findOne(int id);
+
+    /**
+     * Find all the ids of the records that fits the specification
+     * 
+     * @param specs
+     * @return
+     */
+    List<Integer> findAllIdsBy(Specification<? extends IMetadata> specs);
+
+    /**
+     * Count the total number of records available on the platform
+     * 
+     * @return
+     */
+    public long count();
+
+    /**
+     * Find the record with the UUID uuid
+     * 
+     * @param firstMetadataId
+     * @return
+     */
+    public IMetadata findOneByUuid(String firstMetadataId);
+
+    /**
+     * Find the record that fits the specification
+     * 
+     * @param spec
+     * @return
+     */
+    public IMetadata findOne(Specification<Metadata> spec);
+
+    /**
+     * Find the record that fits the id
+     * 
+     * @param id
+     * @return
+     */
+    public IMetadata findOne(String id);
+
+    /**
+     * Find all metadata harvested by the identified harvester.
+     *
+     * @param uuid the uuid of the harvester
+     * @return all metadata harvested by the identified harvester.
+     */
+    @Nonnull
+    List<? extends IMetadata> findAllByHarvestInfo_Uuid(@Nonnull String uuid);
+
+    /**
+     * Find all the metadata with the identifiers
+     * 
+     * @see org.springframework.data.repository.CrudRepository#findAll(java.lang.Iterable)
+     * @param keySet
+     * @return
+     */
+    public Iterable<? extends IMetadata> findAll(Set<Integer> keySet);
+
+    /**
+     * Returns all entities matching the given {@link Specification}.
+     * 
+     * @param spec
+     * @return
+     */
+    public List<? extends IMetadata> findAll(Specification<? extends IMetadata> hasHarvesterUuid);
+
+    /**
+     * Load only the basic info for a metadata. Used in harvesters, mostly.
+     *
+     * @param harvestUuid
+     * @return
+     */
+    public List<SimpleMetadata> findAllSimple(String harvestUuid);
+
+    /**
+     * Check if a record with identifier iId exists
+     * 
+     * @param iId
+     * @return
+     */
+    public boolean exists(Integer iId);
+
+    /**
+     * Load all records that satisfy the criteria provided and convert each to XML of the form:
+     * 
+     * <pre>
+     *  &lt;entityName&gt;
+     *      &lt;property&gt;propertyValue&lt;/property&gt;
+     *      ...
+     *  &lt;/entityName&gt;
+     * </pre>
+     *
+     * @param sort the order to sort the results by
+     * @return all entities in XML.
+     */
+    @Nonnull
+    public Element findAllAsXml(Specification<? extends IMetadata> spec, Sort sortByChangeDateDesc);
+
+    /**
+     * Load all entities that satisfy the criteria provided and convert each to XML of the form:
+     * 
+     * <pre>
+     *  &lt;entityName&gt;
+     *      &lt;property&gt;propertyValue&lt;/property&gt;
+     *      ...
+     *  &lt;/entityName&gt;
+     * </pre>
+     *
+     * @param specification A specification of the criteria that must be satisfied for entity to be selected.
+     * @param pageable The paging/sorting strategy
+     * @return all entities in XML.
+     */
+    @Nonnull
+    Element findAllAsXml(@Nullable Specification<? extends IMetadata> specification, @Nullable Pageable pageable);
+
+    /**
+     * Return an object that contains functions for calculating several different statistical calculations (related to the metadata) based
+     * on the data in the database.
+     *
+     * @return an object for performing statistic calculation queries.
+     */
+    MetadataReportsQueries getMetadataReports();
 }
-
-  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataValidator.java
@@ -1,4 +1,4 @@
-    package org.fao.geonet.kernel.datamanager;
+package org.fao.geonet.kernel.datamanager;
 
 import java.util.List;
 
@@ -12,34 +12,107 @@ import org.jdom.Namespace;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 
+/**
+ * Interface to handle all operations related to validations of records
+ * 
+ * @author delawen
+ *
+ */
 public interface IMetadataValidator {
 
-        public void init(ServiceContext context, Boolean force) throws Exception;
+    /**
+     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
+     * 
+     * @param context
+     * @param force
+     * @throws Exception
+     */
+    public void init(ServiceContext context, Boolean force) throws Exception;
 
-        void validateMetadata(String schema, Element xml, ServiceContext context, String fileName) throws Exception;
+    /**
+     * Validates metadata against XSD and schematron files related to metadata schema throwing XSDValidationErrorEx if xsd errors or
+     * SchematronValidationErrorEx if schematron rules fails.
+     */
+    void validateMetadata(String schema, Element xml, ServiceContext context, String fileName) throws Exception;
 
-        void setNamespacePrefix(Element md);
+    /**
+     * 
+     * if the metadata has no namespace or already has a namespace then we must skip this phase
+     * 
+     * @param md
+     */
+    void setNamespacePrefix(Element md);
 
-        void validate(String schema, Document doc) throws Exception;
+    /**
+     * Use this validate method for XML documents with dtd.
+     */
+    void validate(String schema, Document doc) throws Exception;
 
-        void validate(String schema, Element md) throws Exception;
+    /**
+     * Use this validate method for XML documents with xsd validation.
+     */
+    void validate(String schema, Element md) throws Exception;
 
-        Element validateInfo(String schema, Element md, ErrorHandler eh) throws Exception;
+    /**
+     * Validates an xml document with respect to an xml schema described by .xsd file path using supplied error handler.
+     *
+     * @param schema
+     * @param md
+     * @param eh
+     * @return
+     * @throws Exception
+     */
+    Element validateInfo(String schema, Element md, ErrorHandler eh) throws Exception;
 
-        Element doSchemaTronForEditor(String schema, Element md, String lang) throws Exception;
+    /**
+     * Creates XML schematron report.
+     */
+    Element doSchemaTronForEditor(String schema, Element md, String lang) throws Exception;
 
-        boolean doValidate(String schema, String metadataId, Document doc, String lang);
+    /**
+     * Used by harvesters that need to validate metadata.
+     *
+     * @param schema name of the schema to validate against
+     * @param metadataId metadata id - used to record validation status
+     * @param doc metadata document as JDOM Document not JDOM Element
+     * @param lang Language from context
+     */
+    boolean doValidate(String schema, String metadataId, Document doc, String lang);
 
-        Pair<Element, String> doValidate(UserSession session, String schema, String metadataId, Element md, String lang, boolean forEditing)
-                throws Exception;
+    /**
+     * Used by the validate embedded service. The validation report is stored in the session.
+     *
+     */
+    Pair<Element, String> doValidate(UserSession session, String schema, String metadataId, Element md, String lang, boolean forEditing)
+            throws Exception;
 
-        Element applyCustomSchematronRules(String schema, int metadataId, Element md, String lang, List<MetadataValidation> validations);
+    /**
+     * Creates XML schematron report for each set of rules defined in schema directory. This method assumes that you've run enumerateTree on
+     * the metadata
+     *
+     * Returns null if no error on validation.
+     */
+    Element applyCustomSchematronRules(String schema, int metadataId, Element md, String lang, List<MetadataValidation> validations);
 
-        boolean validate(Element xml);
+    /**
+     * Validates an xml document, using autodetectschema to determine how.
+     *
+     * @return true if metadata is valid
+     */
+    boolean validate(Element xml);
 
-        void setNamespacePrefix(Element md, Namespace ns);
+    /**
+     * Adds the namespace to the element
+     * 
+     * @param md
+     * @param ns
+     */
+    void setNamespacePrefix(Element md, Namespace ns);
 
-        void setMetadataManager(IMetadataManager metadataManager);
+    /**
+     * Helper function to prevent loop on dependencies
+     * 
+     * @param metadataManager
+     */
+    void setMetadataManager(IMetadataManager metadataManager);
 }
-
-  

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataCategory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataCategory.java
@@ -5,10 +5,12 @@ import java.util.Set;
 
 import javax.annotation.Nonnull;
 
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.kernel.SvnManager;
 import org.fao.geonet.kernel.datamanager.IMetadataCategory;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.repository.MetadataCategoryRepository;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.Updater;
@@ -80,7 +82,7 @@ public class BaseMetadataCategory implements IMetadataCategory {
      */
     @Override
     public void unsetCategory(final ServiceContext context, final String mdId, final int categId) throws Exception {
-        Metadata metadata = getMetadataRepository().findOne(mdId);
+        IMetadata metadata = getMetadataRepository().findOne(mdId);
 
         if (metadata == null) {
             return;
@@ -95,7 +97,7 @@ public class BaseMetadataCategory implements IMetadataCategory {
         }
 
         if (changed) {
-            getMetadataRepository().save(metadata);
+            context.getBean(IMetadataManager.class).save(metadata);
             if (getSvnManager() != null) {
                 getSvnManager().setHistory(mdId + "", context);
             }
@@ -110,7 +112,7 @@ public class BaseMetadataCategory implements IMetadataCategory {
      */
     @Override
     public Collection<MetadataCategory> getCategories(final String mdId) throws Exception {
-        Metadata metadata = getMetadataRepository().findOne(mdId);
+        IMetadata metadata = getMetadataRepository().findOne(mdId);
         if (metadata == null) {
             throw new IllegalArgumentException("No metadata found with id: " + mdId);
         }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataCategory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataCategory.java
@@ -11,6 +11,7 @@ import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.kernel.SvnManager;
 import org.fao.geonet.kernel.datamanager.IMetadataCategory;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataCategoryRepository;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.Updater;
@@ -21,6 +22,8 @@ import jeeves.server.context.ServiceContext;
 public class BaseMetadataCategory implements IMetadataCategory {
 
     @Autowired
+    private IMetadataUtils metadataUtils;
+    @Autowired
     private MetadataRepository metadataRepository;
     @Autowired(required = false)
     private SvnManager svnManager;
@@ -28,7 +31,7 @@ public class BaseMetadataCategory implements IMetadataCategory {
     private MetadataCategoryRepository metadataCategoryRepository;
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-        this.metadataRepository = context.getBean(MetadataRepository.class);
+        this.metadataUtils = context.getBean(IMetadataUtils.class);
         this.svnManager = context.getBean(SvnManager.class);
         this.metadataCategoryRepository = context.getBean(MetadataCategoryRepository.class);
     }
@@ -65,7 +68,7 @@ public class BaseMetadataCategory implements IMetadataCategory {
      */
     @Override
     public boolean isCategorySet(final String mdId, final int categId) throws Exception {
-        Set<MetadataCategory> categories = getMetadataRepository().findOne(mdId).getMetadataCategories();
+        Set<MetadataCategory> categories = getMetadataUtils().findOne(mdId).getMetadataCategories();
         for (MetadataCategory category : categories) {
             if (category.getId() == categId) {
                 return true;
@@ -82,7 +85,7 @@ public class BaseMetadataCategory implements IMetadataCategory {
      */
     @Override
     public void unsetCategory(final ServiceContext context, final String mdId, final int categId) throws Exception {
-        IMetadata metadata = getMetadataRepository().findOne(mdId);
+        IMetadata metadata = getMetadataUtils().findOne(mdId);
 
         if (metadata == null) {
             return;
@@ -112,7 +115,7 @@ public class BaseMetadataCategory implements IMetadataCategory {
      */
     @Override
     public Collection<MetadataCategory> getCategories(final String mdId) throws Exception {
-        IMetadata metadata = getMetadataRepository().findOne(mdId);
+        IMetadata metadata = getMetadataUtils().findOne(mdId);
         if (metadata == null) {
             throw new IllegalArgumentException("No metadata found with id: " + mdId);
         }
@@ -120,13 +123,21 @@ public class BaseMetadataCategory implements IMetadataCategory {
         return metadata.getMetadataCategories();
     }
 
-    private SvnManager getSvnManager() {
+    protected SvnManager getSvnManager() {
         return svnManager;
 
     }
 
-    private MetadataRepository getMetadataRepository() {
-        return metadataRepository;
+    protected IMetadataUtils getMetadataUtils() {
+        return metadataUtils;
 
+    }
+    
+    protected MetadataCategoryRepository getMetadataCategoryRepository() {
+        return metadataCategoryRepository;
+    }
+    
+    protected MetadataRepository getMetadataRepository() {
+        return metadataRepository;
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -24,8 +24,8 @@ import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Constants;
 import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.InspireAtomFeed;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.domain.MetadataStatus;
 import org.fao.geonet.domain.MetadataStatusId_;
@@ -45,6 +45,7 @@ import org.fao.geonet.kernel.SelectionManager;
 import org.fao.geonet.kernel.SvnManager;
 import org.fao.geonet.kernel.XmlSerializer;
 import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.search.ISearchManager;
 import org.fao.geonet.kernel.search.SearchManager;
@@ -53,7 +54,6 @@ import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.InspireAtomFeedRepository;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.MetadataStatusRepository;
 import org.fao.geonet.repository.MetadataValidationRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
@@ -90,11 +90,10 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
     @Autowired
     private GeonetworkDataDirectory geonetworkDataDirectory;
     @Autowired
-    private MetadataRepository metadataRepository;
-    @Autowired
     private MetadataStatusRepository statusRepository;
 
     private IMetadataUtils metadataUtils;
+    private IMetadataManager metadataManager;
     @Autowired
     private UserRepository userRepository;
     @Autowired
@@ -121,24 +120,23 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
     private ApplicationEventPublisher publisher;
 
     public BaseMetadataIndexer() {
-        System.out.println("CREATING BASE METADATA INDEXER");
     }
 
     public void init(ServiceContext context, Boolean force) throws Exception {
-         searchManager = context.getBean(SearchManager.class);
-         geonetworkDataDirectory = context.getBean(GeonetworkDataDirectory.class);
-         metadataRepository = context.getBean(MetadataRepository.class);
-         statusRepository = context.getBean(MetadataStatusRepository.class);
-         metadataUtils = context.getBean(IMetadataUtils.class);
-         userRepository = context.getBean(UserRepository.class);
-         operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
-         groupRepository = context.getBean(GroupRepository.class);
-         metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
-         schemaManager = context.getBean(SchemaManager.class);
-         svnManager = context.getBean(SvnManager.class);
-         inspireAtomFeedRepository = context.getBean(InspireAtomFeedRepository.class);
-         xmlSerializer = context.getBean(XmlSerializer.class);
-         settingManager = context.getBean(SettingManager.class);
+        searchManager = context.getBean(SearchManager.class);
+        geonetworkDataDirectory = context.getBean(GeonetworkDataDirectory.class);
+        statusRepository = context.getBean(MetadataStatusRepository.class);
+        metadataUtils = context.getBean(IMetadataUtils.class);
+        metadataManager = context.getBean(IMetadataManager.class);
+        userRepository = context.getBean(UserRepository.class);
+        operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
+        groupRepository = context.getBean(GroupRepository.class);
+        metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
+        schemaManager = context.getBean(SchemaManager.class);
+        svnManager = context.getBean(SvnManager.class);
+        inspireAtomFeedRepository = context.getBean(InspireAtomFeedRepository.class);
+        xmlSerializer = context.getBean(XmlSerializer.class);
+        settingManager = context.getBean(SettingManager.class);
 
         servContext = context;
     }
@@ -146,6 +144,11 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
     @Override
     public void setMetadataUtils(IMetadataUtils metadataUtils) {
         this.metadataUtils = metadataUtils;
+    }
+
+    @Override
+    public void setMetadataManager(IMetadataManager metadataManager) {
+        this.metadataManager = metadataManager;
     }
 
     Set<String> waitForIndexing = new HashSet<String>();
@@ -158,8 +161,8 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
     }
 
     @Override
-    public int batchDeleteMetadataAndUpdateIndex(Specification<Metadata> specification) throws Exception {
-        final List<Integer> idsOfMetadataToDelete = metadataRepository.findAllIdsBy(specification);
+    public int batchDeleteMetadataAndUpdateIndex(Specification<? extends IMetadata> specification) throws Exception {
+        final List<Integer> idsOfMetadataToDelete = metadataUtils.findAllIdsBy(specification);
 
         for (Integer id : idsOfMetadataToDelete) {
             // --- remove metadata directory for each record
@@ -178,7 +181,7 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
         }));
 
         // Remove records from the database
-        metadataRepository.deleteAll(specification);
+        metadataManager.deleteAll(specification);
 
         return idsOfMetadataToDelete.size();
     }
@@ -339,7 +342,7 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
         } finally {
             indexLock.unlock();
         }
-        Metadata fullMd;
+        IMetadata fullMd;
 
         try {
             Vector<Element> moreFields = new Vector<Element>();
@@ -365,7 +368,7 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
                 moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.HASXLINKS, "0", true, true));
             }
 
-            fullMd = metadataRepository.findOne(id$);
+            fullMd = metadataUtils.findOne(id$);
 
             final String schema = fullMd.getDataInfo().getSchemaId();
             final String createDate = fullMd.getDataInfo().getCreateDate().getDateAndTime();
@@ -512,10 +515,9 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
             if (searchManager == null) {
                 searchManager = servContext.getBean(SearchManager.class);
             }
-            
-            searchManager.index(schemaManager.getSchemaDir(schema), md, metadataId, moreFields, metadataType, root,
-                        forceRefreshReaders);
-            
+
+            searchManager.index(schemaManager.getSchemaDir(schema), md, metadataId, moreFields, metadataType, root, forceRefreshReaders);
+
         } catch (Exception x) {
             Log.error(Geonet.DATA_MANAGER,
                     "The metadata document index with id=" + metadataId + " is corrupt/invalid - ignoring it. Error: " + x.getMessage(), x);

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -428,7 +428,8 @@ public class BaseMetadataManager implements IMetadataManager {
         if (templateMetadata.getDataInfo().getType() == MetadataType.METADATA) {
             xml = updateFixedInfo(schema, Optional.<Integer> absent(), uuid, xml, parentUuid, UpdateDatestamp.NO, context);
         }
-        final Metadata newMetadata = new Metadata().setUuid(uuid);
+        final Metadata newMetadata = new Metadata();
+        newMetadata.setUuid(uuid);
         newMetadata.getDataInfo().setChangeDate(new ISODate()).setCreateDate(new ISODate()).setSchemaId(schema)
                 .setType(MetadataType.lookup(isTemplate));
         newMetadata.getSourceInfo().setGroupOwner(Integer.valueOf(groupOwner)).setOwner(owner).setSourceId(source);
@@ -487,7 +488,8 @@ public class BaseMetadataManager implements IMetadataManager {
         if (StringUtils.isBlank(metadataType)) {
             metadataType = MetadataType.METADATA.codeString;
         }
-        final Metadata newMetadata = new Metadata().setUuid(uuid);
+        final Metadata newMetadata = new Metadata();
+        newMetadata.setUuid(uuid);
         final ISODate isoChangeDate = changeDate != null ? new ISODate(changeDate) : new ISODate();
         final ISODate isoCreateDate = createDate != null ? new ISODate(createDate) : new ISODate();
         newMetadata.getDataInfo().setChangeDate(isoChangeDate).setCreateDate(isoCreateDate).setSchemaId(schema).setDoctype(docType)

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -21,6 +21,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.Root;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Edit;
@@ -28,6 +29,7 @@ import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.Constants;
 import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
@@ -186,8 +188,10 @@ public class BaseMetadataManager implements IMetadataManager {
         editLib = new EditLib(schemaManager);
         metadataValidator.setMetadataManager(this);
         metadataUtils.setMetadataManager(this);
+        metadataIndexer.setMetadataManager(this);
     }
 
+    @SuppressWarnings("unchecked")
     public void init(ServiceContext context, Boolean force) throws Exception {
         metadataUtils = context.getBean(IMetadataUtils.class);
         metadataIndexer = context.getBean(IMetadataIndexer.class);
@@ -363,7 +367,7 @@ public class BaseMetadataManager implements IMetadataManager {
     @Override
     public synchronized void deleteMetadata(ServiceContext context, String metadataId) throws Exception {
         String uuid = metadataUtils.getMetadataUuid(metadataId);
-        Metadata findOne = metadataRepository.findOne(metadataId);
+        IMetadata findOne = metadataRepository.findOne(metadataId);
         if (findOne != null) {
             boolean isMetadata = findOne.getDataInfo().getType() == MetadataType.METADATA;
 
@@ -417,7 +421,7 @@ public class BaseMetadataManager implements IMetadataManager {
     @Override
     public String createMetadata(ServiceContext context, String templateId, String groupOwner, String source, int owner, String parentUuid,
             String isTemplate, boolean fullRightsForGroup, String uuid) throws Exception {
-        Metadata templateMetadata = metadataRepository.findOne(templateId);
+        IMetadata templateMetadata = metadataRepository.findOne(templateId);
         if (templateMetadata == null) {
             throw new IllegalArgumentException("Template id not found : " + templateId);
         }
@@ -521,7 +525,7 @@ public class BaseMetadataManager implements IMetadataManager {
     }
 
     @Override
-    public Metadata insertMetadata(ServiceContext context, Metadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
+    public IMetadata insertMetadata(ServiceContext context, IMetadata newMetadata, Element metadataXml, boolean notifyChange, boolean index,
             boolean updateFixedInfo, UpdateDatestamp updateDatestamp, boolean fullRightsForGroup, boolean forceRefreshReaders)
             throws Exception {
         final String schema = newMetadata.getDataInfo().getSchemaId();
@@ -545,7 +549,7 @@ public class BaseMetadataManager implements IMetadataManager {
         }
 
         // --- store metadata
-        final Metadata savedMetadata = getXmlSerializer().insert(newMetadata, metadataXml, context);
+        final IMetadata savedMetadata = getXmlSerializer().insert(newMetadata, metadataXml, context);
 
         final String stringId = String.valueOf(savedMetadata.getId());
         String groupId = null;
@@ -660,7 +664,7 @@ public class BaseMetadataManager implements IMetadataManager {
      * @return metadata if the that was updated
      */
     @Override
-    public synchronized Metadata updateMetadata(final ServiceContext context, final String metadataId, final Element md,
+    public synchronized IMetadata updateMetadata(final ServiceContext context, final String metadataId, final Element md,
             final boolean validate, final boolean ufo, final boolean index, final String lang, final String changeDate,
             final boolean updateDateStamp) throws Exception {
         Element metadataXml = md;
@@ -675,7 +679,7 @@ public class BaseMetadataManager implements IMetadataManager {
             String parentUuid = null;
             Integer intId = Integer.valueOf(metadataId);
 
-            final Metadata metadata = metadataRepository.findOne(metadataId);
+            final IMetadata metadata = metadataRepository.findOne(metadataId);
 
             String uuid = null;
 
@@ -692,7 +696,7 @@ public class BaseMetadataManager implements IMetadataManager {
         setNamespacePrefixUsingSchemas(schema, metadataXml);
 
         // Notifies the metadata change to metatada notifier service
-        final Metadata metadata = metadataRepository.findOne(metadataId);
+        final IMetadata metadata = metadataRepository.findOne(metadataId);
 
         String uuid = null;
         if (schemaManager.getSchema(schema).isReadwriteUUID() && metadata.getDataInfo().getType() != MetadataType.SUB_TEMPLATE
@@ -729,7 +733,7 @@ public class BaseMetadataManager implements IMetadataManager {
             parameters.addContent(new Element(SearchParameter.ISTEMPLATE).addContent("y or n"));
             ServiceConfig config = new ServiceConfig();
             searcher.search(context, parameters, config);
-            Map<Integer, Metadata> result = ((LuceneSearcher) searcher).getAllMdInfo(context, 500);
+            Map<Integer, IMetadata> result = ((LuceneSearcher) searcher).getAllMdInfo(context, 500);
             for (Integer id : result.keySet()) {
                 IndexingList list = context.getBean(IndexingList.class);
                 list.add(id);
@@ -740,16 +744,17 @@ public class BaseMetadataManager implements IMetadataManager {
     }
 
     /**
-     * TODO : buildInfoElem contains similar portion of code with indexMetadata
+     *  buildInfoElem contains similar portion of code with indexMetadata
      */
     private Element buildInfoElem(ServiceContext context, String id, String version) throws Exception {
-        Metadata metadata = metadataRepository.findOne(id);
+        IMetadata metadata = metadataRepository.findOne(id);
         final MetadataDataInfo dataInfo = metadata.getDataInfo();
         String schema = dataInfo.getSchemaId();
         String createDate = dataInfo.getCreateDate().getDateAndTime();
         String changeDate = dataInfo.getChangeDate().getDateAndTime();
         String source = metadata.getSourceInfo().getSourceId();
         String isTemplate = dataInfo.getType().codeString;
+        @SuppressWarnings("deprecation")
         String title = dataInfo.getTitle();
         String uuid = metadata.getUuid();
         String isHarvested = "" + Constants.toYN_EnabledChar(metadata.getHarvestInfo().isHarvested());
@@ -1154,5 +1159,41 @@ public class BaseMetadataManager implements IMetadataManager {
      */
     private static void addElement(Element root, String name, Object value) {
         root.addContent(new Element(name).setText(value == null ? "" : value.toString()));
+    }
+
+    @Override
+    public IMetadata save(IMetadata info) {
+        if (info instanceof Metadata) {
+            return metadataRepository.save((Metadata) info);
+        } else {
+            throw new NotImplementedException("Unknown IMetadata subtype: " + info.getClass().getName());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public IMetadata update(int id, @Nonnull Updater<? extends IMetadata> updater) {
+        return metadataRepository.update(id, (Updater<Metadata>) updater);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void deleteAll(Specification<? extends IMetadata> specs) {
+        try {
+            metadataRepository.deleteAll((Specification<Metadata>) specs);
+        } catch (Throwable t) {
+            //Maybe it is not a Specification<Metadata>
+        }
+        throw new NotImplementedException("Unknown IMetadata subtype: " + specs.getClass().getName());
+    }
+
+    @Override
+    public void delete(Integer id) {
+        metadataRepository.delete(id);
+    }
+
+    @Override
+    public void createBatchUpdateQuery(PathSpec<Metadata, String> servicesPath, String newUuid, Specification<Metadata> harvested) {
+        metadataRepository.createBatchUpdateQuery(servicesPath, newUuid, harvested);
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -191,7 +191,6 @@ public class BaseMetadataManager implements IMetadataManager {
         metadataIndexer.setMetadataManager(this);
     }
 
-    @SuppressWarnings("unchecked")
     public void init(ServiceContext context, Boolean force) throws Exception {
         metadataUtils = context.getBean(IMetadataUtils.class);
         metadataIndexer = context.getBean(IMetadataIndexer.class);
@@ -326,7 +325,7 @@ public class BaseMetadataManager implements IMetadataManager {
         return applicationContext == null ? _applicationContext : applicationContext;
     }
 
-    private void deleteMetadataFromDB(ServiceContext context, String id) throws Exception {
+    protected void deleteMetadataFromDB(ServiceContext context, String id) throws Exception {
         // --- remove operations
         metadataOperations.deleteMetadataOper(context, id, false);
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
@@ -17,9 +17,9 @@ import org.fao.geonet.domain.UserGroupId;
 import org.fao.geonet.exceptions.ServiceNotAllowedEx;
 import org.fao.geonet.kernel.SvnManager;
 import org.fao.geonet.kernel.datamanager.IMetadataOperations;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.UserRepository;
@@ -38,7 +38,7 @@ import jeeves.server.context.ServiceContext;
 public class BaseMetadataOperations implements IMetadataOperations {
 
     @Autowired
-    private MetadataRepository metadataRepository;
+    private IMetadataUtils metadataUtils;
     @Autowired
     private UserRepository userRepository;
     @Autowired
@@ -53,7 +53,7 @@ public class BaseMetadataOperations implements IMetadataOperations {
 
     public void init(ServiceContext context, Boolean force) throws Exception {
         userRepository = context.getBean(UserRepository.class);
-        metadataRepository = context.getBean(MetadataRepository.class);
+        metadataUtils = context.getBean(IMetadataUtils.class);
         opAllowedRepo = context.getBean(OperationAllowedRepository.class);
         userGroupRepo = context.getBean(UserGroupRepository.class);
         settingManager = context.getBean(SettingManager.class);
@@ -268,7 +268,7 @@ public class BaseMetadataOperations implements IMetadataOperations {
 
     @Override
     public boolean isUserMetadataOwner(int userId) throws Exception {
-        return metadataRepository.count(MetadataSpecs.isOwnedByUser(userId)) > 0;
+        return metadataUtils.count(MetadataSpecs.isOwnedByUser(userId)) > 0;
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import javax.annotation.CheckForNull;
 
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.exceptions.NoSchemaMatchesException;
 import org.fao.geonet.exceptions.SchemaMatchConflictException;
 import org.fao.geonet.kernel.SchemaManager;
@@ -76,7 +76,7 @@ public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
      */
     @Override
     public String getMetadataSchema(String id) throws Exception {
-        Metadata md = metadataRepository.findOne(id);
+        IMetadata md = metadataRepository.findOne(id);
 
         if (md == null) {
             throw new IllegalArgumentException("Metadata not found for id : " + id);
@@ -85,7 +85,6 @@ public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
             return md.getDataInfo().getSchemaId();
         }
     }
-
 
     /**
      * Checks autodetect elements in installed schemas to determine whether the metadata record belongs to that schema. Use this method when
@@ -118,5 +117,5 @@ public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
             Log.debug(Geonet.DATA_MANAGER, "Schema detected was " + schema);
         return schema;
     }
-    
+
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
@@ -11,8 +11,8 @@ import org.fao.geonet.exceptions.NoSchemaMatchesException;
 import org.fao.geonet.exceptions.SchemaMatchConflictException;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.schema.MetadataSchema;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,11 +25,11 @@ public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
     private SchemaManager schemaManager;
 
     @Autowired
-    private MetadataRepository metadataRepository;
+    private IMetadataUtils metadataUtils;
 
     public void init(ServiceContext context, Boolean force) throws Exception {
         schemaManager = context.getBean(SchemaManager.class);
-        metadataRepository = context.getBean(MetadataRepository.class);
+        metadataUtils = context.getBean(IMetadataUtils.class);
     }
 
     /**
@@ -76,7 +76,7 @@ public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
      */
     @Override
     public String getMetadataSchema(String id) throws Exception {
-        IMetadata md = metadataRepository.findOne(id);
+        IMetadata md = metadataUtils.findOne(id);
 
         if (md == null) {
             throw new IllegalArgumentException("Metadata not found for id : " + id);
@@ -117,5 +117,4 @@ public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
             Log.debug(Geonet.DATA_MANAGER, "Schema detected was " + schema);
         return schema;
     }
-
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -77,7 +77,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Autowired
     private SchemaManager schemaManager;
     @Autowired
-    private MetadataRatingByIpRepository ratingByIpRepository;
+    protected MetadataRatingByIpRepository ratingByIpRepository;
     @Autowired
     @Lazy
     private SettingManager settingManager;
@@ -127,7 +127,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Override
     public void notifyMetadataChange(Element md, String metadataId) throws Exception {
 
-        final IMetadata metadata = metadataRepository.findOne(metadataId);
+        final IMetadata metadata = findOne(metadataId);
         if (metadata != null && metadata.getDataInfo().getType() == MetadataType.METADATA) {
             MetadataSchema mds = schemaManager.getSchema(metadata.getDataInfo().getSchemaId());
             Pair<String, Element> editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
@@ -145,7 +145,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
      * @throws Exception
      */
     public @Nullable @Override String getMetadataUuid(@Nonnull String id) throws Exception {
-        IMetadata metadata = metadataRepository.findOne(id);
+        IMetadata metadata = findOne(id);
 
         if (metadata == null)
             return null;
@@ -343,7 +343,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Override
     public List<Integer> findAllIdsBy(Specification<? extends IMetadata> specs) {
         try {
-            return metadataRepository.findAllIdsBy((Specification<Metadata>) specs);
+            return findAllIdsBy((Specification<Metadata>) specs);
         } catch (Throwable t) {
             //Maybe it is not a Specification<Metadata>
         }
@@ -537,7 +537,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
      */
     @Override
     public boolean existsMetadata(int id) throws Exception {
-        return metadataRepository.exists(id);
+        return exists(id);
     }
 
     /**
@@ -545,7 +545,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
      */
     @Override
     public boolean existsMetadataUuid(String uuid) throws Exception {
-        return !metadataRepository.findAllIdsBy(hasMetadataUuid(uuid)).isEmpty();
+        return !findAllIdsBy(hasMetadataUuid(uuid)).isEmpty();
     }
 
     /**
@@ -765,7 +765,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
      */
     @Override
     public String getMetadataTitle(String id) throws Exception {
-        IMetadata md = metadataRepository.findOne(id);
+        IMetadata md = findOne(id);
 
         if (md == null) {
             throw new IllegalArgumentException("Metadata not found for id : " + id);
@@ -852,7 +852,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
 
     @SuppressWarnings("unchecked")
     @Override
-    public List<? extends Metadata> findAll(Specification<? extends IMetadata> specs) {
+    public List<? extends IMetadata> findAll(Specification<? extends IMetadata> specs) {
         try {
             return metadataRepository.findAll((Specification<Metadata>) specs);
         } catch (Throwable t) {
@@ -896,5 +896,13 @@ public class BaseMetadataUtils implements IMetadataUtils {
             //Maybe it is not a Specification<Metadata>
         }
         throw new NotImplementedException("Unknown IMetadata subtype: " + specs.getClass().getName());
+    }
+    
+    protected MetadataRepository getMetadataRepository() {
+        return metadataRepository;
+    }
+    
+    protected SchemaManager getSchemaManager() {
+        return schemaManager;
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
@@ -23,10 +23,16 @@
 
 package org.fao.geonet.kernel.mef;
 
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.DataManager;
@@ -37,11 +43,8 @@ import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
-import org.jdom.Namespace;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
+import jeeves.server.context.ServiceContext;
 
 /**
  * An extension point called to create files to export as part of the MEF export.
@@ -54,7 +57,7 @@ public class ExportFormat implements GeonetworkExtension {
      *
      * @param metadata the metadata to convert to files.
      */
-    public static Iterable<Pair<String, String>> getFormats(ServiceContext context, Metadata metadata) throws Exception {
+    public static Iterable<Pair<String, String>> getFormats(ServiceContext context, IMetadata metadata) throws Exception {
         String schema = metadata.getDataInfo().getSchemaId();
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
         DataManager dm = gc.getBean(DataManager.class);
@@ -93,7 +96,7 @@ public class ExportFormat implements GeonetworkExtension {
      *
      * @return ByteArrayInputStream
      */
-    public static String formatData(Metadata metadata, boolean transform, Path stylePath) throws Exception {
+    public static String formatData(IMetadata metadata, boolean transform, Path stylePath) throws Exception {
         String xmlData = metadata.getData();
 
         Element md = Xml.loadString(xmlData, false);

--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -23,11 +23,24 @@
 
 package org.fao.geonet.kernel.mef;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Maps;
+import static org.fao.geonet.domain.Localized.translationXmlToLangMap;
 
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.GeonetContext;
@@ -36,6 +49,7 @@ import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
@@ -69,24 +83,11 @@ import org.jdom.Element;
 import org.springframework.context.ApplicationContext;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 
-import javax.annotation.Nonnull;
-
-import static org.fao.geonet.domain.Localized.translationXmlToLangMap;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 public class Importer {
     @Deprecated
@@ -518,7 +519,7 @@ public class Importer {
         return metadataIdMap;
     }
 
-    public static void addCategoriesToMetadata(Metadata metadata, Element finalCategs, ServiceContext context) {
+    public static void addCategoriesToMetadata(IMetadata metadata, Element finalCategs, ServiceContext context) {
         if (finalCategs != null) {
             final MetadataCategoryRepository categoryRepository = context.getBean(MetadataCategoryRepository.class);
             for (Object cat : finalCategs.getChildren()) {

--- a/core/src/main/java/org/fao/geonet/kernel/mef/MEF2Exporter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/MEF2Exporter.java
@@ -23,7 +23,21 @@
 
 package org.fao.geonet.kernel.mef;
 
-import jeeves.server.context.ServiceContext;
+import static com.google.common.xml.XmlEscapers.xmlContentEscaper;
+import static org.fao.geonet.Constants.CHARSET;
+import static org.fao.geonet.constants.Geonet.IndexFieldNames.LOCALE;
+import static org.fao.geonet.constants.Geonet.IndexFieldNames.UUID;
+import static org.fao.geonet.kernel.mef.MEFConstants.FILE_INFO;
+import static org.fao.geonet.kernel.mef.MEFConstants.FILE_METADATA;
+import static org.fao.geonet.kernel.mef.MEFConstants.MD_DIR;
+import static org.fao.geonet.kernel.mef.MEFConstants.SCHEMA;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
@@ -37,6 +51,7 @@ import org.fao.geonet.Constants;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.ZipUtil;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataRelation;
 import org.fao.geonet.domain.MetadataType;
@@ -45,7 +60,6 @@ import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.mef.MEFLib.Format;
 import org.fao.geonet.kernel.mef.MEFLib.Version;
-import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.search.IndexAndTaxonomy;
 import org.fao.geonet.kernel.search.LuceneIndexField;
 import org.fao.geonet.kernel.search.NoFilterFilter;
@@ -56,19 +70,7 @@ import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-
-import static com.google.common.xml.XmlEscapers.xmlContentEscaper;
-import static org.fao.geonet.Constants.CHARSET;
-import static org.fao.geonet.constants.Geonet.IndexFieldNames.LOCALE;
-import static org.fao.geonet.constants.Geonet.IndexFieldNames.UUID;
-import static org.fao.geonet.kernel.mef.MEFConstants.FILE_INFO;
-import static org.fao.geonet.kernel.mef.MEFConstants.FILE_METADATA;
-import static org.fao.geonet.kernel.mef.MEFConstants.MD_DIR;
-import static org.fao.geonet.kernel.mef.MEFConstants.SCHEMA;
+import jeeves.server.context.ServiceContext;
 
 class MEF2Exporter {
     /**
@@ -219,9 +221,9 @@ class MEF2Exporter {
         final Path metadataRootDir = zipFs.getPath(uuid);
         Files.createDirectories(metadataRootDir);
 
-        Pair<Metadata, String> recordAndMetadataForExport =
+        Pair<IMetadata, String> recordAndMetadataForExport =
             MEFLib.retrieveMetadata(context, uuid, resolveXlink, removeXlinkAttribute);
-        Metadata record = recordAndMetadataForExport.one();
+        IMetadata record = recordAndMetadataForExport.one();
         String xmlDocumentAsString = recordAndMetadataForExport.two();
 
         String id = "" + record.getId();
@@ -247,7 +249,7 @@ class MEF2Exporter {
         // --- save Feature Catalog
         String ftUUID = getFeatureCatalogID(context, record.getId());
         if (!ftUUID.equals("")) {
-            Pair<Metadata, String> ftrecordAndMetadata = MEFLib.retrieveMetadata(context, ftUUID, resolveXlink, removeXlinkAttribute);
+            Pair<IMetadata, String> ftrecordAndMetadata = MEFLib.retrieveMetadata(context, ftUUID, resolveXlink, removeXlinkAttribute);
             Path featureMdDir = metadataRootDir.resolve(SCHEMA);
             Files.createDirectories(featureMdDir);
             Files.write(featureMdDir.resolve(FILE_METADATA), ftrecordAndMetadata.two().getBytes(CHARSET));

--- a/core/src/main/java/org/fao/geonet/kernel/mef/MEFExporter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/MEFExporter.java
@@ -23,12 +23,17 @@
 
 package org.fao.geonet.kernel.mef;
 
-import jeeves.server.context.ServiceContext;
+import static org.fao.geonet.kernel.mef.MEFConstants.FILE_INFO;
+import static org.fao.geonet.kernel.mef.MEFConstants.FILE_METADATA;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.fao.geonet.Constants;
 import org.fao.geonet.ZipUtil;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.domain.ReservedOperation;
@@ -38,12 +43,7 @@ import org.fao.geonet.lib.Lib;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static org.fao.geonet.kernel.mef.MEFConstants.FILE_INFO;
-import static org.fao.geonet.kernel.mef.MEFConstants.FILE_METADATA;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Export MEF file
@@ -60,9 +60,9 @@ class MEFExporter {
      */
     public static Path doExport(ServiceContext context, String uuid,
                                 Format format, boolean skipUUID, boolean resolveXlink, boolean removeXlinkAttribute) throws Exception {
-        Pair<Metadata, String> recordAndMetadata =
+        Pair<IMetadata, String> recordAndMetadata =
             MEFLib.retrieveMetadata(context, uuid, resolveXlink, removeXlinkAttribute);
-        Metadata record = recordAndMetadata.one();
+        IMetadata record = recordAndMetadata.one();
         String xmlDocumentAsString = recordAndMetadata.two();
 
         if (record.getDataInfo().getType() == MetadataType.SUB_TEMPLATE ||

--- a/core/src/main/java/org/fao/geonet/kernel/mef/MEFLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/MEFLib.java
@@ -23,33 +23,10 @@
 
 package org.fao.geonet.kernel.mef;
 
-import org.apache.commons.io.IOUtils;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.ZipUtil;
-import org.fao.geonet.constants.Edit;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Group;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataCategory;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.Operation;
-import org.fao.geonet.domain.OperationAllowed;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.exceptions.BadInputEx;
-import org.fao.geonet.exceptions.BadParameterEx;
-import org.fao.geonet.exceptions.MetadataNotFoundEx;
-import org.fao.geonet.kernel.AccessManager;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
-import org.fao.geonet.repository.OperationRepository;
-import org.fao.geonet.utils.BinaryFile;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Document;
-import org.jdom.Element;
+import static org.fao.geonet.kernel.mef.MEFConstants.DIR_PRIVATE;
+import static org.fao.geonet.kernel.mef.MEFConstants.DIR_PUBLIC;
+import static org.fao.geonet.kernel.mef.MEFConstants.FS;
+import static org.fao.geonet.kernel.mef.MEFConstants.VERSION;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,12 +50,35 @@ import java.util.zip.ZipOutputStream;
 
 import javax.annotation.Nonnull;
 
-import jeeves.server.context.ServiceContext;
+import org.apache.commons.io.IOUtils;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.ZipUtil;
+import org.fao.geonet.constants.Edit;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.Operation;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.exceptions.BadInputEx;
+import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.exceptions.MetadataNotFoundEx;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.OperationRepository;
+import org.fao.geonet.utils.BinaryFile;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Document;
+import org.jdom.Element;
 
-import static org.fao.geonet.kernel.mef.MEFConstants.DIR_PRIVATE;
-import static org.fao.geonet.kernel.mef.MEFConstants.DIR_PUBLIC;
-import static org.fao.geonet.kernel.mef.MEFConstants.FS;
-import static org.fao.geonet.kernel.mef.MEFConstants.VERSION;
+import jeeves.server.context.ServiceContext;
 
 
 /**
@@ -169,10 +169,10 @@ public class MEFLib {
      * @return A pair composed of the domain object metadata AND the record to be exported (includes
      * Xlink resolution and filters depending on user session).
      */
-    static Pair<Metadata, String> retrieveMetadata(ServiceContext context, String uuid, boolean resolveXlink, boolean removeXlinkAttribute)
+    static Pair<IMetadata, String> retrieveMetadata(ServiceContext context, String uuid, boolean resolveXlink, boolean removeXlinkAttribute)
         throws Exception {
 
-        final Metadata metadata = context.getBean(MetadataRepository.class).findOneByUuid(uuid);
+        final IMetadata metadata = context.getBean(IMetadataUtils.class).findOneByUuid(uuid);
 
         if (metadata == null) {
             throw new MetadataNotFoundEx("uuid=" + uuid);
@@ -259,7 +259,7 @@ public class MEFLib {
     /**
      * Build an info file.
      */
-    static String buildInfoFile(ServiceContext context, Metadata md,
+    static String buildInfoFile(ServiceContext context, IMetadata md,
                                 Format format, Path pubDir, Path priDir, boolean skipUUID)
         throws Exception {
         Element info = new Element("info");
@@ -280,7 +280,7 @@ public class MEFLib {
      *
      * @param skipUUID If true, do not add uuid, site identifier and site name.
      */
-    static Element buildInfoGeneral(Metadata md, Format format,
+    static Element buildInfoGeneral(IMetadata md, Format format,
                                     boolean skipUUID, ServiceContext context) {
         String id = String.valueOf(md.getId());
         String uuid = md.getUuid();
@@ -318,7 +318,7 @@ public class MEFLib {
     /**
      * Build category section of info file.
      */
-    static Element buildInfoCategories(Metadata md)
+    static Element buildInfoCategories(IMetadata md)
         throws SQLException {
         Element categ = new Element("categories");
 
@@ -338,7 +338,7 @@ public class MEFLib {
     /**
      * Build priviliges section of info file.
      */
-    static Element buildInfoPrivileges(ServiceContext context, Metadata md)
+    static Element buildInfoPrivileges(ServiceContext context, IMetadata md)
         throws Exception {
 
         int iId = md.getId();

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/GetRecord.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/GetRecord.java
@@ -23,19 +23,22 @@
 
 package org.fao.geonet.kernel.oaipmh.services;
 
-import jeeves.server.context.ServiceContext;
+import static org.fao.geonet.repository.specification.MetadataSpecs.hasMetadataUuid;
+
+import java.nio.file.Path;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.domain.MetadataDataInfo;
 import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.oaipmh.Lib;
 import org.fao.geonet.kernel.oaipmh.OaiPmhService;
 import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.Xml;
 import org.fao.oaipmh.exceptions.CannotDisseminateFormatException;
 import org.fao.oaipmh.exceptions.IdDoesNotExistException;
@@ -49,9 +52,7 @@ import org.jdom.Attribute;
 import org.jdom.Element;
 import org.springframework.data.jpa.domain.Specification;
 
-import java.nio.file.Path;
-
-import static org.fao.geonet.repository.specification.MetadataSpecs.hasMetadataUuid;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -62,7 +63,7 @@ public class GetRecord implements OaiPmhService {
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
         SchemaManager sm = gc.getBean(SchemaManager.class);
 
-        Metadata metadata = context.getBean(MetadataRepository.class).findOne(spec);
+        IMetadata metadata = context.getBean(IMetadataUtils.class).findOne(spec);
         if (metadata == null)
             throw new IdDoesNotExistException(spec.toString());
 

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/Identify.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/Identify.java
@@ -23,12 +23,8 @@
 
 package org.fao.geonet.kernel.oaipmh.services;
 
-import jeeves.constants.Jeeves;
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.kernel.oaipmh.OaiPmhService;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.repository.MetadataRepository;
@@ -38,9 +34,9 @@ import org.fao.oaipmh.responses.AbstractResponse;
 import org.fao.oaipmh.responses.IdentifyResponse;
 import org.fao.oaipmh.responses.IdentifyResponse.DeletedRecord;
 import org.fao.oaipmh.responses.IdentifyResponse.Granularity;
-import org.jdom.Element;
 
-import java.util.List;
+import jeeves.constants.Jeeves;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -74,7 +70,7 @@ public class Identify implements OaiPmhService {
     //---------------------------------------------------------------------------
 
     private ISODate getEarliestDS(ServiceContext context) throws Exception {
-        final Metadata oldestByChangeDate = context.getBean(MetadataRepository.class).findOneOldestByChangeDate();
+        final IMetadata oldestByChangeDate = context.getBean(MetadataRepository.class).findOneOldestByChangeDate();
 
         //--- if we don't have metadata, just return 'now'
         if (oldestByChangeDate == null)

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/ListIdentifiers.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/ListIdentifiers.java
@@ -23,26 +23,24 @@
 
 package org.fao.geonet.kernel.oaipmh.services;
 
-import java.util.List;
-
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.oaipmh.Lib;
 import org.fao.geonet.kernel.oaipmh.ResumptionTokenCache;
-import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.oaipmh.requests.ListIdentifiersRequest;
 import org.fao.oaipmh.requests.TokenListRequest;
 import org.fao.oaipmh.responses.Header;
 import org.fao.oaipmh.responses.ListIdentifiersResponse;
 import org.fao.oaipmh.responses.ListResponse;
 import org.fao.oaipmh.util.SearchResult;
+
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -92,12 +90,11 @@ public class ListIdentifiers extends AbstractTokenLister {
     //---
     //---------------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
     private Header buildHeader(ServiceContext context, int id, String prefix) throws Exception {
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
         SchemaManager sm = gc.getBean(SchemaManager.class);
 
-        final Metadata metadata = gc.getBean(MetadataRepository.class).findOne(id);
+        final IMetadata metadata = gc.getBean(IMetadataUtils.class).findOne(id);
 
         //--- maybe the metadata has been removed
 

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/ListMetadataFormats.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/ListMetadataFormats.java
@@ -23,14 +23,15 @@
 
 package org.fao.geonet.kernel.oaipmh.services;
 
-import jeeves.server.context.ServiceContext;
-import jeeves.server.overrides.ConfigurationOverrides;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.oaipmh.OaiPmhService;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.Xml;
 import org.fao.oaipmh.requests.AbstractRequest;
 import org.fao.oaipmh.requests.ListMetadataFormatsRequest;
@@ -42,9 +43,8 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import jeeves.server.context.ServiceContext;
+import jeeves.server.overrides.ConfigurationOverrides;
 
 //=============================================================================
 
@@ -76,7 +76,7 @@ public class ListMetadataFormats implements OaiPmhService {
 
         String uuid = req.getIdentifier();
         if (uuid != null) {
-            String schema = context.getBean(MetadataRepository.class).findOneByUuid(uuid).getDataInfo().getSchemaId();
+            String schema = context.getBean(IMetadataUtils.class).findOneByUuid(uuid).getDataInfo().getSchemaId();
             res.addFormat(getSchemaInfo(context, sm, schema));
         } else {
             for (String schema : sm.getSchemas())

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -83,6 +83,7 @@ import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataSourceInfo;
@@ -102,7 +103,6 @@ import org.fao.geonet.kernel.search.facet.ItemBuilder;
 import org.fao.geonet.kernel.search.facet.ItemConfig;
 import org.fao.geonet.kernel.search.facet.SummaryType;
 import org.fao.geonet.kernel.search.index.GeonetworkMultiReader;
-import org.fao.geonet.kernel.search.log.SearcherLogger;
 import org.fao.geonet.kernel.search.lucenequeries.DateRangeQuery;
 import org.fao.geonet.kernel.search.spatial.SpatialFilter;
 import org.fao.geonet.kernel.setting.SettingInfo;
@@ -116,7 +116,6 @@ import org.jdom.JDOMException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.WKTReader;
 
@@ -1749,9 +1748,9 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
     /**
      * <p> Gets all metadata info as a int Map in current searcher. </p>
      */
-    public Map<Integer, Metadata> getAllMdInfo(ServiceContext context, int maxHits) throws Exception {
+    public Map<Integer, IMetadata> getAllMdInfo(ServiceContext context, int maxHits) throws Exception {
 
-        Map<Integer, Metadata> response = new HashMap<Integer, Metadata>();
+        Map<Integer, IMetadata> response = new HashMap<Integer, IMetadata>();
         TopDocs tdocs = performQuery(context, 0, maxHits, false);
         IndexAndTaxonomy indexAndTaxonomy = _sm.getIndexReader(_language.presentationLanguage, _versionToken);
         _versionToken = indexAndTaxonomy.version;

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPSynchronizerJob.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPSynchronizerJob.java
@@ -43,9 +43,9 @@ import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.Language;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.UserGroupId_;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.LanguageRepository;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.UserRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
@@ -171,7 +171,7 @@ public class LDAPSynchronizerJob extends QuartzJobBean {
         // metadata
         final UserRepository userRepository = applicationContext.getBean(UserRepository.class);
         final UserGroupRepository userGroupRepository = applicationContext.getBean(UserGroupRepository.class);
-        final MetadataRepository metadataRepository = applicationContext.getBean(MetadataRepository.class);
+        final IMetadataUtils metadataRepository = applicationContext.getBean(IMetadataUtils.class);
         final Specifications<User> spec = Specifications.where(
             UserSpecs.hasAuthType(LDAPConstants.LDAP_FLAG)
         ).and(

--- a/core/src/test/java/org/fao/geonet/DataManagerWorksWithoutTransactionIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/DataManagerWorksWithoutTransactionIntegrationTest.java
@@ -23,11 +23,13 @@
 
 package org.fao.geonet;
 
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import static org.fao.geonet.constants.Geonet.Namespaces.GCO;
+import static org.fao.geonet.constants.Geonet.Namespaces.GMD;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.kernel.DataManager;
 import org.jdom.Element;
@@ -35,10 +37,8 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 
-import static org.fao.geonet.constants.Geonet.Namespaces.GCO;
-import static org.fao.geonet.constants.Geonet.Namespaces.GMD;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Test that the aspect defined work correctly.
@@ -54,30 +54,28 @@ public class DataManagerWorksWithoutTransactionIntegrationTest extends AbstractC
 
     @Test
     public void testDataManagerCutpoints() throws Exception {
-        TransactionlessTesting.get().run
-            (new TestTask() {
-                @Override
-                public void run() throws Exception {
-                    final ServiceContext serviceContext = createServiceContext();
-                    loginAsAdmin(serviceContext);
+        TransactionlessTesting.get().run(new TestTask() {
+            @Override
+            public void run() throws Exception {
+                final ServiceContext serviceContext = createServiceContext();
+                loginAsAdmin(serviceContext);
 
-                    final Element sampleMetadataXml = getSampleMetadataXml();
-                    final UserSession userSession = serviceContext.getUserSession();
-                    final int userIdAsInt = userSession.getUserIdAsInt();
-                    final String mdId = _dataManager.insertMetadata(serviceContext, "iso19139", sampleMetadataXml,
-                        "uuid" + _inc.incrementAndGet(), userIdAsInt, "2", "source",
-                        MetadataType.METADATA.codeString, null, "maps", new ISODate().getDateAndTime(),
-                        new ISODate().getDateAndTime(), false, false);
-                    Element newMd = new Element("MD_Metadata", GMD).addContent(new Element("fileIdentifier",
-                        GMD).addContent(new Element("CharacterString", GCO)));
+                final Element sampleMetadataXml = getSampleMetadataXml();
+                final UserSession userSession = serviceContext.getUserSession();
+                final int userIdAsInt = userSession.getUserIdAsInt();
+                final String mdId = _dataManager.insertMetadata(serviceContext, "iso19139", sampleMetadataXml,
+                        "uuid" + _inc.incrementAndGet(), userIdAsInt, "2", "source", MetadataType.METADATA.codeString, null, "maps",
+                        new ISODate().getDateAndTime(), new ISODate().getDateAndTime(), false, false);
+                Element newMd = new Element("MD_Metadata", GMD)
+                        .addContent(new Element("fileIdentifier", GMD).addContent(new Element("CharacterString", GCO)));
 
-                    Metadata updateMd = _dataManager.updateMetadata(serviceContext, mdId, newMd, false, false, false, "eng",
+                IMetadata updateMd = _dataManager.updateMetadata(serviceContext, mdId, newMd, false, false, false, "eng",
                         new ISODate().getDateAndTime(), false);
-                    assertNotNull(updateMd);
-                    final boolean hasNext = updateMd.getMetadataCategories().iterator().hasNext();
-                    assertTrue(hasNext);
-                }
-            });
+                assertNotNull(updateMd);
+                final boolean hasNext = updateMd.getMetadataCategories().iterator().hasNext();
+                assertTrue(hasNext);
+            }
+        });
 
     }
 

--- a/core/src/test/java/org/fao/geonet/kernel/DataManagerWorksWithoutTransactionIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/DataManagerWorksWithoutTransactionIntegrationTest.java
@@ -23,12 +23,16 @@
 
 package org.fao.geonet.kernel;
 
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import static org.fao.geonet.constants.Geonet.Namespaces.GCO;
+import static org.fao.geonet.constants.Geonet.Namespaces.GMD;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
 
 import org.fao.geonet.AbstractCoreIntegrationTest;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.repository.MetadataCategoryRepository;
 import org.fao.geonet.repository.MetadataRepository;
@@ -36,12 +40,8 @@ import org.jdom.Element;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.UUID;
-
-import static org.fao.geonet.constants.Geonet.Namespaces.GCO;
-import static org.fao.geonet.constants.Geonet.Namespaces.GMD;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Test that the aspect defined work correctly.
@@ -79,7 +79,7 @@ public class DataManagerWorksWithoutTransactionIntegrationTest extends AbstractC
                     Element newMd = new Element(sampleMetadataXml.getName(), sampleMetadataXml.getNamespace()).addContent(new Element("fileIdentifier",
                         GMD).addContent(new Element("CharacterString", GCO)));
 
-                    Metadata updateMd = dm.updateMetadata(serviceContext, mdId, newMd, false, false, false, "eng",
+                    IMetadata updateMd = dm.updateMetadata(serviceContext, mdId, newMd, false, false, false, "eng",
                         new ISODate().getDateAndTime(), false);
                     assertNotNull(updateMd);
                     final boolean hasNext = updateMd.getMetadataCategories().iterator().hasNext();

--- a/core/src/test/java/org/fao/geonet/kernel/LocalXLinksUpdateHaveToTriggerIndexationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/LocalXLinksUpdateHaveToTriggerIndexationTest.java
@@ -133,7 +133,8 @@ public class LocalXLinksUpdateHaveToTriggerIndexationTest extends AbstractIntegr
     private Metadata insertTemplateResourceInDb(Element element, MetadataType type) throws Exception {
         loginAsAdmin(context);
 
-        Metadata metadata = new Metadata()
+        Metadata metadata = new Metadata();
+        metadata
                 .setDataAndFixCR(element)
                 .setUuid(UUID.randomUUID().toString());
         metadata.getDataInfo()

--- a/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
@@ -23,9 +23,18 @@
 
 package org.fao.geonet.kernel;
 
-import com.google.common.collect.Maps;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import jeeves.server.context.ServiceContext;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.fao.geonet.AbstractCoreIntegrationTest;
@@ -33,8 +42,8 @@ import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.Pair;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.schema.MetadataSchema;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.jdom.Namespace;
@@ -44,18 +53,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.Maps;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import jeeves.server.context.ServiceContext;
 
 public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
     private static final String OWNER_ID = "1234";
@@ -72,7 +72,7 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
     @Autowired
     DataManager _dataManager;
     @Autowired
-    MetadataRepository _metadataRepo;
+    IMetadataManager metadataManager;
     @Autowired
     ConfigurableApplicationContext applicationContext;
     private int _mdId;
@@ -124,7 +124,7 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
     @Before
     public void addMetadata() {
         setSchemaFilters(true, true);
-        this._mdId = _metadataRepo.save(metadata).getId();
+        this._mdId = metadataManager.save(metadata).getId();
     }
 
     @Test

--- a/core/src/test/java/org/fao/geonet/kernel/mef/MEFLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/mef/MEFLibIntegrationTest.java
@@ -28,7 +28,7 @@ import jeeves.server.context.ServiceContext;
 import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.ZipUtil;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.IO;
@@ -65,7 +65,7 @@ public class MEFLibIntegrationTest extends AbstractCoreIntegrationTest {
 
         assertEquals(1, metadataIds.size());
 
-        final Metadata metadata = _metadataRepo.findOne(metadataIds.get(0));
+        final IMetadata metadata = _metadataRepo.findOne(metadataIds.get(0));
 
         assertNotNull(metadata);
         assertEquals(admin.getId(), metadata.getSourceInfo().getOwner().intValue());
@@ -85,7 +85,7 @@ public class MEFLibIntegrationTest extends AbstractCoreIntegrationTest {
 
         for (String metadataId : metadataIds) {
 
-            final Metadata metadata = _metadataRepo.findOne(metadataId);
+            final IMetadata metadata = _metadataRepo.findOne(metadataId);
 
             assertNotNull(metadata);
             assertEquals(admin.getId(), metadata.getSourceInfo().getOwner().intValue());

--- a/core/src/test/java/org/fao/geonet/kernel/search/LuceneSearcher_FastEqualsFast_OrderIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/LuceneSearcher_FastEqualsFast_OrderIntegrationTest.java
@@ -27,7 +27,7 @@ import jeeves.server.ServiceConfig;
 
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
@@ -65,7 +65,7 @@ public class LuceneSearcher_FastEqualsFast_OrderIntegrationTest extends Abstract
         String[] titles = new String[nodes.size()];
         for (int i = 0; i < titles.length; i++) {
             final String mdId = nodes.get(i).getText();
-            final Metadata md = _metadataRepository.findOne(mdId);
+            final IMetadata md = _metadataRepository.findOne(mdId);
             final Element xmlData = md.getXmlData(false);
             titles[i] = getTitlesFromMetadataElements(_serviceContext, request, new Element("record").addContent(xmlData))[0];
         }

--- a/domain/src/main/java/org/fao/geonet/domain/GeonetEntity.java
+++ b/domain/src/main/java/org/fao/geonet/domain/GeonetEntity.java
@@ -23,10 +23,7 @@
 
 package org.fao.geonet.domain;
 
-import org.jdom.Element;
-import org.springframework.beans.BeanWrapperImpl;
-
-import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -35,6 +32,9 @@ import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.persistence.Embeddable;
+
+import org.jdom.Element;
+import org.springframework.beans.InvalidPropertyException;
 
 /**
  * Contains common methods of all entities in Geonetwork.
@@ -48,37 +48,66 @@ public class GeonetEntity {
 
     private static Element asXml(Object obj, IdentityHashMap<Object, Void> alreadyEncoded, Set<String> exclude) {
         alreadyEncoded.put(obj, null);
-        Element record = new Element(RECORD_EL_NAME);
-        BeanWrapperImpl wrapper = new BeanWrapperImpl(obj);
+        Element record = new Element(RECORD_EL_NAME);     
 
-        for (PropertyDescriptor desc : wrapper.getPropertyDescriptors()) {
-            try {
-                if (desc.getReadMethod() != null && desc.getReadMethod().getDeclaringClass() == obj.getClass() &&
-                    !exclude.contains(desc.getName())) {
-                    final String descName = desc.getName();
-                    if (descName.equalsIgnoreCase("labelTranslations")) {
-                        Element labelEl = new Element(LABEL_EL_NAME);
-
-                        @SuppressWarnings("unchecked")
-                        Map<String, String> labels = (Map<String, String>) desc.getReadMethod().invoke(obj);
-
-                        if (labels != null) {
-                            for (Map.Entry<String, String> entry : labels.entrySet()) {
-                                labelEl.addContent(new Element(entry.getKey().toLowerCase()).setText(entry.getValue()));
+        Class<? extends Object> objclass = obj.getClass();
+        while(objclass != null) {
+            for(Method method : objclass.getDeclaredMethods()) { 
+                try {
+                    if(method.getName().startsWith("get") 
+                            && method.getGenericParameterTypes().length == 0) {
+                        if (method.getDeclaringClass() == objclass 
+                                && !exclude.contains(method.getName())) {
+                            final String descName = method.getName().substring(3);
+                            if (descName.equals("LabelTranslations")
+                                    && !objclass.equals(Localized.class)) {
+                                Element labelEl = new Element(LABEL_EL_NAME);
+        
+                                @SuppressWarnings("unchecked")
+                                Map<String, String> labels = (Map<String, String>) method.invoke(obj);
+        
+                                if (labels != null) {
+                                    for (Map.Entry<String, String> entry : labels.entrySet()) {
+                                        labelEl.addContent(new Element(entry.getKey().toLowerCase()).setText(entry.getValue()));
+                                    }
+                                }
+        
+                                record.addContent(labelEl);
+                            } else if (!(descName.endsWith("AsInt") 
+                                    || descName.endsWith("AsBool")
+                                    || descName.equals("LabelTranslations"))){
+                                final Object rawData = method.invoke(obj);
+                                if (rawData != null) {
+                                    final Element element = propertyToElement(alreadyEncoded, descName, rawData, exclude);
+                                    record.addContent(element);
+                                }
                             }
                         }
-
-                        record.addContent(labelEl);
-                    } else {
-                        final Object rawData = desc.getReadMethod().invoke(obj);
-                        if (rawData != null) {
-                            final Element element = propertyToElement(alreadyEncoded, descName, rawData, exclude);
-                            record.addContent(element);
+                    } else if(method.getName().startsWith("is")
+                            && method.getGenericParameterTypes().length == 0) {
+                        if (method.getDeclaringClass() == objclass 
+                                && !exclude.contains(method.getName())) {
+                            final String descName = method.getName().substring(2);
+                            if (!(descName.endsWith("AsInt") || descName.endsWith("AsBool"))){
+                                final Object rawData = method.invoke(obj);
+                                if (rawData != null) {
+                                    final Element element = propertyToElement(alreadyEncoded, descName, rawData, exclude);
+                                    record.addContent(element);
+                                }
+                            }
                         }
                     }
+                } catch (InvalidPropertyException e) {
+                    //just ignore it and get to the following property
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            }
+            objclass = objclass.getSuperclass();
+            if(objclass != null 
+                    && (objclass.equals(GeonetEntity.class) || objclass.equals(Object.class))) {
+                objclass = null;
             }
         }
         return record;

--- a/domain/src/main/java/org/fao/geonet/domain/IMetadata.java
+++ b/domain/src/main/java/org/fao/geonet/domain/IMetadata.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.domain;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Transient;
+
+import org.apache.lucene.document.Document;
+import org.fao.geonet.utils.Xml;
+import org.hibernate.annotations.Type;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.output.Format;
+import org.jdom.output.XMLOutputter;
+
+import com.vividsolutions.jts.util.Assert;
+
+/**
+ * An entity representing a metadata object in the database. 
+ * The xml, groups and operations are lazily loaded so 
+ * accessing then will need to be done in a thread that has a bound 
+ * EntityManager. 
+ * 
+ * Also they can trigger database access if they have not 
+ * been cached and therefore can cause slowdowns so they should 
+ * only be accessed in need.
+ *
+ * All classes/tables implemented will share by default the same
+ * sequence for the ID. So you can have different kinds of metadata
+ * (like original and draft versioning) and the id will be unique
+ * on all the tables at the same time.
+ *
+ * @author María Arias de Reyna
+ */
+@MappedSuperclass 
+public class IMetadata extends GeonetEntity {
+    static final String ID_SEQ_NAME = "metadata_id_seq";
+    public static final String METADATA_CATEG_JOIN_TABLE_NAME = "MetadataCateg";
+    public static final String METADATA_CATEG_JOIN_TABLE_CATEGORY_ID = "categoryId";
+    private int _id;
+    private String _uuid;
+    private String _data;
+    private MetadataDataInfo _dataInfo = new MetadataDataInfo();
+    private MetadataSourceInfo _sourceInfo = new MetadataSourceInfo();
+    private MetadataHarvestInfo _harvestInfo = new MetadataHarvestInfo();
+    protected Set<MetadataCategory> metadataCategories = new HashSet<MetadataCategory>();
+
+    /**
+     * Get the id of the metadata. This is a generated value and as such new instances should not have this set as it will simply be
+     * ignored
+     * and could result in reduced performance.
+     *
+     * @return the id of the metadata
+     */
+    @Id
+    @SequenceGenerator(name=Metadata.ID_SEQ_NAME, initialValue=100, allocationSize=1)
+    @GeneratedValue (strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
+    @Column(nullable = false)
+    public int getId() {
+        return _id;
+    }
+
+    /**
+     * Set the id of the metadata. This is a generated value and as such new instances should not have this set as it will simply be
+     * ignored
+     * and could result in reduced performance.
+     *
+     * @param _id the id of the metadata
+     * @return this entity object
+     */
+    public IMetadata setId(int _id) {
+        this._id = _id;
+        return this;
+    }
+
+    /**
+     * Get the uuid of the metadata. This is a required property and thus must not be null.
+     *
+     * @return the uuid of the metadata.
+     */
+    @Column(nullable = false, unique = true)
+    @Nonnull
+    public String getUuid() {
+        return _uuid;
+    }
+
+    /**
+     * Set the metadata uuid.
+     *
+     * @param uuid the new uuid of the metadata
+     * @return this eneity object
+     */
+    @Nonnull
+    public IMetadata setUuid(@Nonnull String uuid) {
+        Assert.isTrue(uuid != null, "Cannot have null uuid");
+        this._uuid = uuid;
+        return this;
+    }
+
+    /**
+     * Get the metadata data as a string (typically XML)
+     *
+     * @return the metadata data as a string.
+     */
+    @Column(nullable = false)
+    @Lob
+    @Basic(fetch = FetchType.LAZY)
+    @Type(type="org.hibernate.type.StringClobType") // this is a work around for postgres so postgres can correctly load clobs
+    public String getData() {
+        return _data;
+    }
+
+    /**
+     * Set the metadata data as a string (typically XML).
+     *
+     * Warning: Do not use it when the user is not authenticated.
+     *
+     * When using this method be sure that
+     * the data to be persisted are the complete metadata
+     * record. For example, if the current user in session
+     * is not authenticated and element filters are applied
+     * (eg. withheld), do not set the data with the response
+     * of {@link org.fao.geonet.kernel.DataManager#getMetadata}
+     * in such case as the original content may be altered.
+     *
+     * Use XmlSerializer instead in an authenticated session.
+     *
+     * @param data the data for this metadata record.
+     * @return this metadata entity.
+     */
+    public IMetadata setData(String data) {
+        this._data = data;
+        return this;
+    }
+
+    /**
+     * Set the data and convert all the end of line characters to be only a \n character.
+     *
+     * Warning: Do not use it when the user is not authenticated.
+     *
+     * Use XmlSerializer instead in an authenticated session.
+     *
+     * @param xml the data as XML.
+     * @return this entity.
+     */
+    public IMetadata setDataAndFixCR(Element xml) {
+        XMLOutputter outputter = new XMLOutputter(Format.getPrettyFormat());
+
+        String data = outputter.outputString(fixCR(xml));
+        setData(data);
+
+        return this;
+    }
+
+    private Element fixCR(Element xml) {
+        List<?> list = xml.getChildren();
+        if (list.size() == 0) {
+            String text = xml.getText();
+            xml.setText(replaceString(text, "\r\n", "\n"));
+        } else {
+            for (Object o : list) {
+                fixCR((Element) o);
+            }
+        }
+        return xml;
+    }
+
+    /**
+     * Parse the data as xml and return the data.
+     *
+     * @param validate if true validate the XML while parsing.
+     * @return the parsed metadata.
+     * @throws IOException
+     * @throws JDOMException
+     */
+    @Transient
+    public Element getXmlData(boolean validate) throws IOException, JDOMException {
+        return Xml.loadString(getData(), validate);
+    }
+
+    private static String replaceString(final String initialString, final String pattern, final String replacement) {
+        StringBuilder result = new StringBuilder();
+        String remainingString = initialString;
+        int i;
+
+        while ((i = remainingString.indexOf(pattern)) != -1) {
+            result.append(remainingString.substring(0, i));
+            result.append(replacement);
+            remainingString = remainingString.substring(i + pattern.length());
+        }
+
+        result.append(remainingString);
+        return result.toString();
+    }
+
+
+    /**
+     * Get the object representing metadata about the metadata (metadata creation date, etc...)
+     *
+     * @return the {@link MetadataDataInfo} for the metadata entity.
+     */
+    @Embedded
+    public MetadataDataInfo getDataInfo() {
+        return _dataInfo;
+    }
+
+    /**
+     * Set the {@link MetadataDataInfo}, the object representing metadata about the metadata (metadata creation date, etc...)
+     *
+     * @param dataInfo the new data info object
+     */
+    public void setDataInfo(MetadataDataInfo dataInfo) {
+        this._dataInfo = dataInfo;
+    }
+
+    /**
+     * Get the object containing the source information about the metadata entity.
+     *
+     * @return the object containing the source information about the metadata entity.
+     */
+    @Embedded
+    public MetadataSourceInfo getSourceInfo() {
+        return _sourceInfo;
+    }
+
+    /**
+     * Set the object containing the source information about the metadata entity.
+     *
+     * @param sourceInfo the object containing the source information about the metadata entity.
+     */
+    public void setSourceInfo(MetadataSourceInfo sourceInfo) {
+        this._sourceInfo = sourceInfo;
+    }
+
+    /**
+     * Get the object containing information about how and from where the metadata was harvested (and whether it was harvested.)
+     *
+     * @return the harvest info object
+     */
+    @Embedded
+    public MetadataHarvestInfo getHarvestInfo() {
+        return _harvestInfo;
+    }
+
+    /**
+     * Set the object containing information about how and from where the metadata was harvested (and whether it was harvested.)
+     *
+     * @param harvestInfo the harvest info object
+     */
+    public void setHarvestInfo(MetadataHarvestInfo harvestInfo) {
+        this._harvestInfo = harvestInfo;
+    }
+
+    protected static void transform(Document in, IMetadata out) {
+        out.setId(Integer.valueOf(in.get("_id")));
+        out.setUuid(in.get("_uuid"));
+
+        final MetadataDataInfo dataInfo = out.getDataInfo();
+        dataInfo.setSchemaId(in.get("_schema"));
+        String metadataType = in.get("_isTemplate");
+        if (metadataType != null) {
+            dataInfo.setType(MetadataType.lookup(metadataType));
+        }
+        dataInfo.setCreateDate(new ISODate(in.get("_createDate")));
+        dataInfo.setChangeDate(new ISODate(in.get("_changeDate")));
+        dataInfo.setRoot(in.get("_root"));
+        final String displayOrder = in.get("_displayOrder");
+        if (displayOrder != null) {
+            dataInfo.setDisplayOrder(Integer.valueOf(displayOrder));
+        }
+
+        String tmpIsHarvest = in.get("_isHarvested");
+        if (tmpIsHarvest != null) {
+            out.getHarvestInfo()
+                    .setHarvested(in.get("_isHarvested").equals("y"));
+
+        }
+        final MetadataSourceInfo sourceInfo = out.getSourceInfo();
+        sourceInfo.setSourceId(in.get("_source"));
+        final String owner = in.get("_owner");
+        if (owner != null) {
+            sourceInfo.setOwner(Integer.valueOf(owner));
+        }
+
+        final String groupOwner = in.get("_groupOwner");
+        if (groupOwner != null) {
+            sourceInfo.setGroupOwner(Integer.valueOf(groupOwner));
+        }
+    }
+}

--- a/domain/src/main/java/org/fao/geonet/domain/IMetadata.java
+++ b/domain/src/main/java/org/fao/geonet/domain/IMetadata.java
@@ -23,7 +23,6 @@
 package org.fao.geonet.domain;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -51,24 +50,19 @@ import org.jdom.output.XMLOutputter;
 import com.vividsolutions.jts.util.Assert;
 
 /**
- * An entity representing a metadata object in the database. 
- * The xml, groups and operations are lazily loaded so 
- * accessing then will need to be done in a thread that has a bound 
- * EntityManager. 
+ * An entity representing a metadata object in the database. The xml, groups and operations are lazily loaded so accessing then will need to
+ * be done in a thread that has a bound EntityManager.
  * 
- * Also they can trigger database access if they have not 
- * been cached and therefore can cause slowdowns so they should 
- * only be accessed in need.
+ * Also they can trigger database access if they have not been cached and therefore can cause slowdowns so they should only be accessed in
+ * need.
  *
- * All classes/tables implemented will share by default the same
- * sequence for the ID. So you can have different kinds of metadata
- * (like original and draft versioning) and the id will be unique
- * on all the tables at the same time.
+ * All classes/tables implemented will share by default the same sequence for the ID. So you can have different kinds of metadata (like
+ * original and draft versioning) and the id will be unique on all the tables at the same time.
  *
  * @author María Arias de Reyna
  */
-@MappedSuperclass 
-public class IMetadata extends GeonetEntity {
+@MappedSuperclass
+public abstract class IMetadata extends GeonetEntity {
     static final String ID_SEQ_NAME = "metadata_id_seq";
     public static final String METADATA_CATEG_JOIN_TABLE_NAME = "MetadataCateg";
     public static final String METADATA_CATEG_JOIN_TABLE_CATEGORY_ID = "categoryId";
@@ -78,26 +72,23 @@ public class IMetadata extends GeonetEntity {
     private MetadataDataInfo _dataInfo = new MetadataDataInfo();
     private MetadataSourceInfo _sourceInfo = new MetadataSourceInfo();
     private MetadataHarvestInfo _harvestInfo = new MetadataHarvestInfo();
-    protected Set<MetadataCategory> metadataCategories = new HashSet<MetadataCategory>();
 
     /**
-     * Get the id of the metadata. This is a generated value and as such new instances should not have this set as it will simply be
-     * ignored
+     * Get the id of the metadata. This is a generated value and as such new instances should not have this set as it will simply be ignored
      * and could result in reduced performance.
      *
      * @return the id of the metadata
      */
     @Id
-    @SequenceGenerator(name=Metadata.ID_SEQ_NAME, initialValue=100, allocationSize=1)
-    @GeneratedValue (strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
+    @SequenceGenerator(name = Metadata.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
     @Column(nullable = false)
     public int getId() {
         return _id;
     }
 
     /**
-     * Set the id of the metadata. This is a generated value and as such new instances should not have this set as it will simply be
-     * ignored
+     * Set the id of the metadata. This is a generated value and as such new instances should not have this set as it will simply be ignored
      * and could result in reduced performance.
      *
      * @param _id the id of the metadata
@@ -140,7 +131,7 @@ public class IMetadata extends GeonetEntity {
     @Column(nullable = false)
     @Lob
     @Basic(fetch = FetchType.LAZY)
-    @Type(type="org.hibernate.type.StringClobType") // this is a work around for postgres so postgres can correctly load clobs
+    @Type(type = "org.hibernate.type.StringClobType") // this is a work around for postgres so postgres can correctly load clobs
     public String getData() {
         return _data;
     }
@@ -150,13 +141,9 @@ public class IMetadata extends GeonetEntity {
      *
      * Warning: Do not use it when the user is not authenticated.
      *
-     * When using this method be sure that
-     * the data to be persisted are the complete metadata
-     * record. For example, if the current user in session
-     * is not authenticated and element filters are applied
-     * (eg. withheld), do not set the data with the response
-     * of {@link org.fao.geonet.kernel.DataManager#getMetadata}
-     * in such case as the original content may be altered.
+     * When using this method be sure that the data to be persisted are the complete metadata record. For example, if the current user in
+     * session is not authenticated and element filters are applied (eg. withheld), do not set the data with the response of
+     * {@link org.fao.geonet.kernel.DataManager#getMetadata} in such case as the original content may be altered.
      *
      * Use XmlSerializer instead in an authenticated session.
      *
@@ -227,7 +214,6 @@ public class IMetadata extends GeonetEntity {
         result.append(remainingString);
         return result.toString();
     }
-
 
     /**
      * Get the object representing metadata about the metadata (metadata creation date, etc...)
@@ -306,8 +292,7 @@ public class IMetadata extends GeonetEntity {
 
         String tmpIsHarvest = in.get("_isHarvested");
         if (tmpIsHarvest != null) {
-            out.getHarvestInfo()
-                    .setHarvested(in.get("_isHarvested").equals("y"));
+            out.getHarvestInfo().setHarvested(in.get("_isHarvested").equals("y"));
 
         }
         final MetadataSourceInfo sourceInfo = out.getSourceInfo();
@@ -322,4 +307,10 @@ public class IMetadata extends GeonetEntity {
             sourceInfo.setGroupOwner(Integer.valueOf(groupOwner));
         }
     }
+
+    @Transient
+    public abstract Set<MetadataCategory> getMetadataCategories();
+
+    public abstract void setMetadataCategories(@Nonnull Set<MetadataCategory> categories);
+
 }

--- a/domain/src/main/java/org/fao/geonet/domain/Metadata.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Metadata.java
@@ -23,362 +23,55 @@
 
 package org.fao.geonet.domain;
 
-import com.vividsolutions.jts.util.Assert;
-
-import org.apache.lucene.document.Document;
-import org.fao.geonet.entitylistener.MetadataEntityListenerManager;
-import org.fao.geonet.utils.Xml;
-import org.hibernate.annotations.Type;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
-
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
-import javax.persistence.Basic;
 import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
-import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
-import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import javax.persistence.Transient;
+
+import org.apache.lucene.document.Document;
+import org.fao.geonet.entitylistener.MetadataEntityListenerManager;
 
 /**
- * An entity representing a metadata object in the database. The xml, groups and operations are
- * lazily loaded so accessing then will need to be done in a thread that has a bound EntityManager.
- * Also they can trigger database access if they have not been cached and therefore can cause
- * slowdowns so they should only be accessed in need.
- *
+ * @See {@link IMetadata}
  * @author Jesse
  */
 @Entity
 @Table(name = Metadata.TABLENAME)
 @Access(AccessType.PROPERTY)
 @EntityListeners(MetadataEntityListenerManager.class)
-@SequenceGenerator(name = Metadata.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
-public class Metadata extends GeonetEntity {
+public class Metadata extends IMetadata {
     public static final String TABLENAME = "Metadata";
-    public static final String METADATA_CATEG_JOIN_TABLE_NAME = "MetadataCateg";
-    public static final String METADATA_CATEG_JOIN_TABLE_CATEGORY_ID = "categoryId";
-    static final String ID_SEQ_NAME = "metadata_id_seq";
-    private int _id;
-    private String _uuid;
-    private String _data;
-    private MetadataDataInfo _dataInfo = new MetadataDataInfo();
-    private MetadataSourceInfo _sourceInfo = new MetadataSourceInfo();
-    private MetadataHarvestInfo _harvestInfo = new MetadataHarvestInfo();
-    private Set<MetadataCategory> metadataCategories = new HashSet<MetadataCategory>();
 
-    // private List<MetadataStatus> _metadataStatus;
-    // private Set<Operation> operations = new HashSet<Operation>();
-    // private Set<Group> groups = new HashSet<Group>();
-
-    private static String replaceString(final String initialString, final String pattern, final String replacement) {
-        StringBuilder result = new StringBuilder();
-        String remainingString = initialString;
-        int i;
-
-        while ((i = remainingString.indexOf(pattern)) != -1) {
-            result.append(remainingString.substring(0, i));
-            result.append(replacement);
-            remainingString = remainingString.substring(i + pattern.length());
-        }
-
-        result.append(remainingString);
-        return result.toString();
+    public Metadata() {
+        super();
     }
-
+    
     public static Metadata createFromLuceneIndexDocument(Document doc) {
         Metadata metadata = new Metadata();
-        metadata.setId(Integer.valueOf(doc.get("_id")));
-        metadata.setUuid(doc.get("_uuid"));
-
-        final MetadataDataInfo dataInfo = metadata.getDataInfo();
-        dataInfo.setSchemaId(doc.get("_schema"));
-        String metadataType = doc.get("_isTemplate");
-        if (metadataType != null) {
-            dataInfo.setType(MetadataType.lookup(metadataType));
-        }
-        dataInfo.setCreateDate(new ISODate(doc.get("_createDate")));
-        dataInfo.setChangeDate(new ISODate(doc.get("_changeDate")));
-        dataInfo.setRoot(doc.get("_root"));
-        final String displayOrder = doc.get("_displayOrder");
-        if (displayOrder != null) {
-            dataInfo.setDisplayOrder(Integer.valueOf(displayOrder));
-        }
-
-        String tmpIsHarvest = doc.get("_isHarvested");
-        if (tmpIsHarvest != null) {
-            metadata.getHarvestInfo().setHarvested(doc.get("_isHarvested").equals("y"));
-
-        }
-        final MetadataSourceInfo sourceInfo = metadata.getSourceInfo();
-        sourceInfo.setSourceId(doc.get("_source"));
-        final String owner = doc.get("_owner");
-        if (owner != null) {
-            sourceInfo.setOwner(Integer.valueOf(owner));
-        }
-
-        final String groupOwner = doc.get("_groupOwner");
-        if (groupOwner != null) {
-            sourceInfo.setGroupOwner(Integer.valueOf(groupOwner));
-        }
+        transform(doc, metadata);
         return metadata;
     }
-
+    
     /**
-     * Get the id of the metadata. This is a generated value and as such new instances should not
-     * have this set as it will simply be ignored and could result in reduced performance.
-     *
-     * @return the id of the metadata
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
-    @Column(nullable = false)
-    public int getId() {
-        return _id;
-    }
-
-    /**
-     * Set the id of the metadata. This is a generated value and as such new instances should not
-     * have this set as it will simply be ignored and could result in reduced performance.
-     *
-     * @param _id the id of the metadata
-     * @return this entity object
-     */
-    public Metadata setId(int _id) {
-        this._id = _id;
-        return this;
-    }
-
-    /**
-     * Get the uuid of the metadata. This is a required property and thus must not be null.
-     *
-     * @return the uuid of the metadata.
-     */
-    @Column(nullable = false, unique = true)
-    @Nonnull
-    public String getUuid() {
-        return _uuid;
-    }
-
-    /**
-     * Set the metadata uuid.
-     *
-     * @param uuid the new uuid of the metadata
-     * @return this eneity object
-     */
-    @Nonnull
-    public Metadata setUuid(@Nonnull String uuid) {
-        Assert.isTrue(uuid != null, "Cannot have null uuid");
-        this._uuid = uuid;
-        return this;
-    }
-
-    /**
-     * Get the metadata data as a string (typically XML)
-     *
-     * @return the metadata data as a string.
-     */
-    @Column(nullable = false)
-    @Lob
-    @Basic(fetch = FetchType.LAZY)
-    @Type(type = "org.hibernate.type.StringClobType")
-    // this is a work around for postgres so postgres can correctly load clobs
-    public String getData() {
-        return _data;
-    }
-
-    /**
-     * Set the metadata data as a string (typically XML).
-     *
-     * Warning: Do not use it when the user is not authenticated.
-     *
-     * When using this method be sure that the data to be persisted are the complete metadata
-     * record. For example, if the current user in session is not authenticated and element filters
-     * are applied (eg. withheld), do not set the data with the response of {@link
-     * org.fao.geonet.kernel.DataManager#getMetadata} in such case as the original content may be
-     * altered.
-     *
-     * Use XmlSerializer instead in an authenticated session.
-     *
-     * @param data the data for this metadata record.
-     * @return this metadata entity.
-     */
-    public Metadata setData(String data) {
-        this._data = data;
-        return this;
-    }
-
-    /**
-     * Set the data and convert all the end of line characters to be only a \n character.
-     *
-     * Warning: Do not use it when the user is not authenticated.
-     *
-     * Use XmlSerializer instead in an authenticated session.
-     *
-     * @param xml the data as XML.
-     * @return this entity.
-     */
-    public Metadata setDataAndFixCR(Element xml) {
-        XMLOutputter outputter = new XMLOutputter(Format.getPrettyFormat());
-
-        String data = outputter.outputString(fixCR(xml));
-        setData(data);
-
-        return this;
-    }
-
-    private Element fixCR(Element xml) {
-        List<?> list = xml.getChildren();
-        if (list.size() == 0) {
-            String text = xml.getText();
-            xml.setText(replaceString(text, "\r\n", "\n"));
-        } else {
-            for (Object o : list) {
-                fixCR((Element) o);
-            }
-        }
-        return xml;
-    }
-
-    /**
-     * Parse the data as xml and return the data.
-     *
-     * @param validate if true validate the XML while parsing.
-     * @return the parsed metadata.
-     */
-    @Transient
-    public Element getXmlData(boolean validate) throws IOException, JDOMException {
-        return Xml.loadString(getData(), validate);
-    }
-
-    /**
-     * Get the object representing metadata about the metadata (metadata creation date, etc...)
-     *
-     * @return the {@link MetadataDataInfo} for the metadata entity.
-     */
-    @Embedded
-    public MetadataDataInfo getDataInfo() {
-        return _dataInfo;
-    }
-
-    /**
-     * Set the {@link MetadataDataInfo}, the object representing metadata about the metadata
-     * (metadata creation date, etc...)
-     *
-     * @param dataInfo the new data info object
-     */
-    public void setDataInfo(MetadataDataInfo dataInfo) {
-        this._dataInfo = dataInfo;
-    }
-
-    /**
-     * Get the object containing the source information about the metadata entity.
-     *
-     * @return the object containing the source information about the metadata entity.
-     */
-    @Embedded
-    public MetadataSourceInfo getSourceInfo() {
-        return _sourceInfo;
-    }
-
-    /**
-     * Set the object containing the source information about the metadata entity.
-     *
-     * @param sourceInfo the object containing the source information about the metadata entity.
-     */
-    public void setSourceInfo(MetadataSourceInfo sourceInfo) {
-        this._sourceInfo = sourceInfo;
-    }
-
-    /**
-     * Get the object containing information about how and from where the metadata was harvested
-     * (and whether it was harvested.)
-     *
-     * @return the harvest info object
-     */
-    @Embedded
-    public MetadataHarvestInfo getHarvestInfo() {
-        return _harvestInfo;
-    }
-
-    // /**
-    // * Get the read-only set of operations that are assocated with
-    // * this metadata. This is essentially a view onto operations allowed
-    // * and isn't automatically updated when operationsAllowed is updated
-    // */
-    // @ManyToMany(fetch = FetchType.LAZY)
-    // @JoinTable(name = "operationallowed", joinColumns = @JoinColumn(name = "operationid"), inverseJoinColumns = @JoinColumn(name =
-    // "metadataid"))
-    // @Nonnull
-    // public Set<Operation> getOperations() {
-    // return Collections.unmodifiableSet(operations);
-    // }
-    //
-    // /**
-    // * Get the read-only collection of groups that are assocated with
-    // * this metadata. This is essentially a view onto operations allowed
-    // * and isn't automatically updated when operationsAllowed is updated
-    // */
-    // @ManyToMany(fetch = FetchType.LAZY)
-    // @JoinTable(name = "operationallowed", joinColumns = @JoinColumn(name = "groupid"), inverseJoinColumns = @JoinColumn(name =
-    // "metadataid"))
-    // @Nonnull
-    // public Set<Group> getGroups() {
-    // return Collections.unmodifiableSet(groups);
-    // }
-    // /**
-    // * Get the read-only collection of groups that are assocated with
-    // * this metadata. This is essentially a view onto operations allowed
-    // * and isn't automatically updated when operationsAllowed is updated
-    // */
-    // @ManyToMany(fetch = FetchType.LAZY)
-    // @JoinTable(name = "operationallowed", joinColumns = @JoinColumn(name = "groupid"), inverseJoinColumns = @JoinColumn(name =
-    // "metadataid"))
-    // @Nonnull
-    // public Set<Group> getGroups() {
-    // return Collections.unmodifiableSet(groups);
-    // }
-
-    /**
-     * Set the object containing information about how and from where the metadata was harvested
-     * (and whether it was harvested.)
-     *
-     * @param harvestInfo the harvest info object
-     */
-    public void setHarvestInfo(MetadataHarvestInfo harvestInfo) {
-        this._harvestInfo = harvestInfo;
-    }
-
-    /**
-     * Get the set of metadata categories this metadata is part of.  This is lazily loaded and all
-     * operations are cascaded
+     * Get the set of metadata categories this metadata is part of.  This is lazily loaded and all operations are
+     * cascaded
      *
      * @return the metadata categories
      */
     @ManyToMany(cascade = {CascadeType.DETACH, CascadeType.REFRESH},
-        fetch = FetchType.EAGER)
+            fetch = FetchType.EAGER)
     @JoinTable(name = METADATA_CATEG_JOIN_TABLE_NAME,
-        joinColumns = @JoinColumn(name = "metadataId"),
-        inverseJoinColumns = @JoinColumn(name =
+            joinColumns = @JoinColumn(name = "metadataId"),
+            inverseJoinColumns = @JoinColumn(name =
             METADATA_CATEG_JOIN_TABLE_CATEGORY_ID))
     @Nonnull
     public Set<MetadataCategory> getMetadataCategories() {
@@ -387,6 +80,8 @@ public class Metadata extends GeonetEntity {
 
     /**
      * Set the metadata category
+     *
+     * @param categories
      */
     protected void setMetadataCategories(@Nonnull Set<MetadataCategory> categories) {
         this.metadataCategories = categories;

--- a/domain/src/main/java/org/fao/geonet/domain/Metadata.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Metadata.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.domain;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
@@ -50,29 +51,25 @@ import org.fao.geonet.entitylistener.MetadataEntityListenerManager;
 @EntityListeners(MetadataEntityListenerManager.class)
 public class Metadata extends IMetadata {
     public static final String TABLENAME = "Metadata";
+    private Set<MetadataCategory> metadataCategories = new HashSet<MetadataCategory>();
 
     public Metadata() {
         super();
     }
-    
+
     public static Metadata createFromLuceneIndexDocument(Document doc) {
         Metadata metadata = new Metadata();
         transform(doc, metadata);
         return metadata;
     }
-    
+
     /**
-     * Get the set of metadata categories this metadata is part of.  This is lazily loaded and all operations are
-     * cascaded
+     * Get the set of metadata categories this metadata is part of. This is lazily loaded and all operations are cascaded
      *
      * @return the metadata categories
      */
-    @ManyToMany(cascade = {CascadeType.DETACH, CascadeType.REFRESH},
-            fetch = FetchType.EAGER)
-    @JoinTable(name = METADATA_CATEG_JOIN_TABLE_NAME,
-            joinColumns = @JoinColumn(name = "metadataId"),
-            inverseJoinColumns = @JoinColumn(name =
-            METADATA_CATEG_JOIN_TABLE_CATEGORY_ID))
+    @ManyToMany(cascade = { CascadeType.DETACH, CascadeType.REFRESH }, fetch = FetchType.EAGER)
+    @JoinTable(name = METADATA_CATEG_JOIN_TABLE_NAME, joinColumns = @JoinColumn(name = "metadataId"), inverseJoinColumns = @JoinColumn(name = METADATA_CATEG_JOIN_TABLE_CATEGORY_ID))
     @Nonnull
     public Set<MetadataCategory> getMetadataCategories() {
         return metadataCategories;
@@ -83,7 +80,7 @@ public class Metadata extends IMetadata {
      *
      * @param categories
      */
-    protected void setMetadataCategories(@Nonnull Set<MetadataCategory> categories) {
+    public void setMetadataCategories(@Nonnull Set<MetadataCategory> categories) {
         this.metadataCategories = categories;
     }
 }

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataRelation.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataRelation.java
@@ -30,10 +30,10 @@ import javax.persistence.*;
 /**
  * Tables that links related metadata. <p> Object is its own entity so that it is easier to add
  * relations without having to load the related metadata. </p> <p> Note: It is important that both
- * Metadata are managed (have been saved or loaded from the MetadataRepository.) For example:
+ * Metadata are managed (have been saved or loaded from the database.) For example:
  * <pre><code>
- *      Metadata metadata1 = _metadataRepo.findOne(id);
- *      Metadata metadata2 = _metadataRepo.findOne(id2);
+ *      Metadata metadata1 = _metadataUtils.findOne(id);
+ *      Metadata metadata2 = _metadataUtils.findOne(id2);
  *      new MetadataRelation(metadata1, metadata2);
  *     </code></pre>
  * </p>

--- a/domain/src/main/java/org/fao/geonet/repository/MetadataRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataRepository.java
@@ -36,10 +36,12 @@ import javax.annotation.Nullable;
 
 /**
  * Data Access object for the {@link Metadata} entities.
+ * 
+ * The use of this class is discouraged, you should use IMetadataUtils or IMetadataManager instead.
  *
  * @author Jesse
  */
-public interface MetadataRepository extends GeonetRepository<Metadata, Integer>, MetadataRepositoryCustom,
+public interface MetadataRepository extends GeonetRepository<Metadata, Integer>, MetadataRepositoryCustom<Metadata>,
     JpaSpecificationExecutor<Metadata> {
     /**
      * Find one metadata by the metadata's uuid.

--- a/domain/src/main/java/org/fao/geonet/repository/MetadataRepositoryCustom.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataRepositoryCustom.java
@@ -23,27 +23,29 @@
 
 package org.fao.geonet.repository;
 
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataSourceInfo;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.repository.reports.MetadataReportsQueries;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataSourceInfo;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.repository.reports.MetadataReportsQueries;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.repository.NoRepositoryBean;
+
 /**
  * Custom (Non spring-data) Query methods for {@link Metadata} entities.
  *
  * @author Jesse
  */
-public interface MetadataRepositoryCustom {
+@NoRepositoryBean
+public interface MetadataRepositoryCustom<T extends IMetadata> {
 
     /**
      * Return an object that contains functions for calculating several different statistical
@@ -63,7 +65,7 @@ public interface MetadataRepositoryCustom {
      * @param id the id in string form instead of integer.
      */
     @Nullable
-    Metadata findOne(@Nonnull String id);
+    IMetadata findOne(@Nonnull String id);
 
     /**
      * Find the list of Metadata Ids and changes dates for the metadata. <p> When constructing sort
@@ -80,11 +82,11 @@ public interface MetadataRepositoryCustom {
     /**
      * Find all ids of metadata that match the specification.
      *
-     * @param spec the specification for identifying the metadata.
+     * @param specs the specification for identifying the metadata.
      * @return all ids
      */
     @Nonnull
-    List<Integer> findAllIdsBy(@Nonnull Specification<Metadata> spec);
+    List<Integer> findAllIdsBy(@Nonnull Specification<T> specs);
 
     /**
      * Find the metadata that has the oldest change date.
@@ -92,7 +94,7 @@ public interface MetadataRepositoryCustom {
      * @return the metadata with the oldest change date
      */
     @Nullable
-    Metadata findOneOldestByChangeDate();
+    IMetadata findOneOldestByChangeDate();
 
     /**
      * Load the source info objects for all the metadata selected by the spec.
@@ -100,7 +102,7 @@ public interface MetadataRepositoryCustom {
      * @param spec the specification identifying the metadata of interest
      * @return a map of metadataId -> SourceInfo
      */
-    Map<Integer, MetadataSourceInfo> findAllSourceInfo(Specification<Metadata> spec);
+    Map<Integer, MetadataSourceInfo> findAllSourceInfo(Specification<T> spec);
 
     /**
      * Load only the basic info for a metadata. Used in harvesters, mostly.

--- a/domain/src/main/java/org/fao/geonet/repository/MetadataRepositoryImpl.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataRepositoryImpl.java
@@ -37,6 +37,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.repository.NoRepositoryBean;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +62,8 @@ import javax.persistence.criteria.Root;
  *
  * @author Jesse
  */
-public class MetadataRepositoryImpl implements MetadataRepositoryCustom {
+@NoRepositoryBean
+public class MetadataRepositoryImpl implements MetadataRepositoryCustom<Metadata> {
 
     @PersistenceContext
     EntityManager _entityManager;

--- a/domain/src/main/java/org/fao/geonet/repository/reports/MetadataReportsQueries.java
+++ b/domain/src/main/java/org/fao/geonet/repository/reports/MetadataReportsQueries.java
@@ -57,7 +57,7 @@ public class MetadataReportsQueries {
      * Retrieves the metadata updated during a period of time. Optionally filters metadata in
      * groups.
      */
-    public List<Metadata> getUpdatedMetadata(ISODate dateFrom, ISODate dateTo, Set<Integer> groups) {
+    public List<? extends IMetadata> getUpdatedMetadata(ISODate dateFrom, ISODate dateTo, Set<Integer> groups) {
         final CriteriaBuilder cb = _entityManager.getCriteriaBuilder();
         final CriteriaQuery<Metadata> cbQuery = cb.createQuery(Metadata.class);
         final Root<Metadata> metadataRoot = cbQuery.from(Metadata.class);

--- a/domain/src/test/java/org/fao/geonet/repository/AbstractOperationsAllowedTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/AbstractOperationsAllowedTest.java
@@ -78,7 +78,8 @@ public abstract class AbstractOperationsAllowedTest extends AbstractSpringDataTe
     }
 
     private Metadata newMetadata(int id) {
-        Metadata newMd = new Metadata().setUuid("uuid" + id).setData("data" + id);
+        Metadata newMd = new Metadata();
+        newMd.setUuid("uuid" + id).setData("data" + id);
         newMd.getDataInfo().setSchemaId("schemaId" + id);
         newMd.getSourceInfo().setOwner(id).setSourceId("source" + id);
         return newMd;

--- a/domain/src/test/java/org/fao/geonet/repository/InspireAtomFeedRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/InspireAtomFeedRepositoryTest.java
@@ -153,7 +153,8 @@ public class InspireAtomFeedRepositoryTest extends AbstractSpringDataTest {
 
     private Metadata newMetadata() {
         int val = _incMetadata.incrementAndGet();
-        Metadata metadata = new Metadata().setUuid("uuid" + val).setData("metadata" + val);
+        Metadata metadata = new Metadata();
+        metadata.setUuid("uuid" + val).setData("metadata" + val);
         metadata.getDataInfo().setSchemaId("customSchema" + val);
         metadata.getSourceInfo().setSourceId("source" + val);
         metadata.getSourceInfo().setOwner(1);

--- a/domain/src/test/java/org/fao/geonet/repository/MetadataRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/MetadataRepositoryTest.java
@@ -74,7 +74,8 @@ public class MetadataRepositoryTest extends AbstractSpringDataTest {
      */
     public static Metadata newMetadata(AtomicInteger inc) {
         int val = inc.incrementAndGet();
-        Metadata metadata = new Metadata().setUuid("uuid" + val).setData("<md>metadata" + val + "</md>");
+        Metadata metadata = new Metadata();
+        metadata.setUuid("uuid" + val).setData("<md>metadata" + val + "</md>");
         metadata.getDataInfo().setSchemaId("customSchema" + val);
         metadata.getSourceInfo().setSourceId("source" + val).setOwner(1);
         metadata.getHarvestInfo().setUuid("huuid" + val);

--- a/domain/src/test/java/org/fao/geonet/repository/MetadataRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/MetadataRepositoryTest.java
@@ -23,6 +23,22 @@
 
 package org.fao.geonet.repository;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataDataInfo_;
@@ -38,21 +54,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.Specifications;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class MetadataRepositoryTest extends AbstractSpringDataTest {
 
@@ -142,8 +143,8 @@ public class MetadataRepositoryTest extends AbstractSpringDataTest {
     @Test
     public void testFindAllByHarvestInfo_Uuid() throws Exception {
 
-        Metadata metadata = _repo.save(newMetadata());
-        Metadata metadata2 = _repo.save(newMetadata());
+        IMetadata metadata = _repo.save(newMetadata());
+        IMetadata metadata2 = _repo.save(newMetadata());
         Metadata metadata3 = newMetadata();
         metadata3.getHarvestInfo().setUuid(metadata2.getHarvestInfo().getUuid());
         _repo.save(metadata3);
@@ -174,7 +175,7 @@ public class MetadataRepositoryTest extends AbstractSpringDataTest {
 
         assertEquals(2, _repo.count());
 
-        Metadata found = _repo.findOneOldestByChangeDate();
+        IMetadata found = _repo.findOneOldestByChangeDate();
         assertNotNull(found);
         assertSameContents(metadata1, found);
     }
@@ -182,9 +183,9 @@ public class MetadataRepositoryTest extends AbstractSpringDataTest {
     @Test
     public void testFindAllIdsAndChangeDates() throws Exception {
 
-        Metadata metadata = _repo.save(updateChangeDate(newMetadata(), "1990-12-13"));
-        Metadata metadata2 = _repo.save(updateChangeDate(newMetadata(), "1980-12-13"));
-        Metadata metadata3 = _repo.save(updateChangeDate(newMetadata(), "1995-12-13"));
+        IMetadata metadata = _repo.save(updateChangeDate(newMetadata(), "1990-12-13"));
+        IMetadata metadata2 = _repo.save(updateChangeDate(newMetadata(), "1980-12-13"));
+        IMetadata metadata3 = _repo.save(updateChangeDate(newMetadata(), "1995-12-13"));
 
         final Sort sortByIdAsc = new Sort(Sort.Direction.DESC, Metadata_.id.getName());
         PageRequest page1 = new PageRequest(0, 2, sortByIdAsc);

--- a/domain/src/test/java/org/fao/geonet/repository/report/ReportsQueriesTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/report/ReportsQueriesTest.java
@@ -95,7 +95,7 @@ public class ReportsQueriesTest extends AbstractSpringDataTest {
         ISODate dateFrom = new ISODate("2014-01-01T00:00:0");
         ISODate dateTo = new ISODate("2014-04-01T00:00:0");
         Set<Integer> groupsSet = new HashSet<Integer>();
-        List<Metadata> updatedMetadata = _metadataRepository.getMetadataReports().
+        List<? extends IMetadata> updatedMetadata = _metadataRepository.getMetadataReports().
             getUpdatedMetadata(dateFrom, dateTo, groupsSet);
 
         assertEquals(3, updatedMetadata.size());
@@ -160,7 +160,7 @@ public class ReportsQueriesTest extends AbstractSpringDataTest {
         ISODate dateFrom = new ISODate("2014-01-01T00:00:0");
         ISODate dateTo = new ISODate("2014-04-01T00:00:0");
 
-        List<Metadata> updatedMetadata = _metadataRepository.getMetadataReports().
+        List<? extends IMetadata> updatedMetadata = _metadataRepository.getMetadataReports().
             getUpdatedMetadata(dateFrom, dateTo, groupsSet);
 
         assertEquals(1, updatedMetadata.size());

--- a/domain/src/test/java/org/fao/geonet/repository/specification/MetadataValidationSpecsTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/specification/MetadataValidationSpecsTest.java
@@ -1,6 +1,13 @@
 package org.fao.geonet.repository.specification;
 
 
+import static org.fao.geonet.repository.specification.MetadataValidationSpecs.hasMetadataId;
+import static org.fao.geonet.repository.specification.MetadataValidationSpecs.isInvalidAndRequiredForMetadata;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataValidation;
 import org.fao.geonet.repository.AbstractSpringDataTest;
 import org.fao.geonet.repository.MetadataRepository;
@@ -8,12 +15,6 @@ import org.fao.geonet.repository.MetadataValidationRepository;
 import org.fao.geonet.repository.MetadataValidationRepositoryTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
-import static org.fao.geonet.repository.specification.MetadataValidationSpecs.hasMetadataId;
-import static org.fao.geonet.repository.specification.MetadataValidationSpecs.isInvalidAndRequiredForMetadata;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test class for {@link org.fao.geonet.repository.specification.MetadataValidationSpecs}.

--- a/events/src/main/java/org/fao/geonet/events/md/MetadataEvent.java
+++ b/events/src/main/java/org/fao/geonet/events/md/MetadataEvent.java
@@ -23,7 +23,7 @@
 
 package org.fao.geonet.events.md;
 
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.springframework.context.ApplicationEvent;
 
 /**
@@ -35,9 +35,9 @@ public abstract class MetadataEvent extends ApplicationEvent {
 
     private static final long serialVersionUID = 456874566246220509L;
 
-    private Metadata md;
+    private IMetadata md;
 
-    public MetadataEvent(Metadata md) {
+    public MetadataEvent(IMetadata md) {
         super(md);
         if (md == null) {
             throw new NullPointerException("Metadata cannot be null");
@@ -45,7 +45,7 @@ public abstract class MetadataEvent extends ApplicationEvent {
         this.md = md;
     }
 
-    public Metadata getMd() {
+    public IMetadata getMd() {
         return md;
     }
 

--- a/events/src/main/java/org/fao/geonet/events/md/MetadataIndexCompleted.java
+++ b/events/src/main/java/org/fao/geonet/events/md/MetadataIndexCompleted.java
@@ -26,7 +26,7 @@
  */
 package org.fao.geonet.events.md;
 
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 
 /**
  * Event launched when the indexation of a metadata record is finished
@@ -40,7 +40,7 @@ public class MetadataIndexCompleted extends MetadataEvent {
     /**
      * @param metadata
      */
-    public MetadataIndexCompleted(Metadata metadata) {
+    public MetadataIndexCompleted(IMetadata metadata) {
         super(metadata);
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
@@ -23,23 +23,23 @@
 
 package org.fao.geonet.kernel.harvest;
 
-import jeeves.server.context.ServiceContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.fao.geonet.Logger;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.harvest.harvester.AbstractHarvester;
 import org.fao.geonet.kernel.harvest.harvester.AbstractParams;
 import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
 import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
 import org.fao.geonet.kernel.harvest.harvester.Privileges;
 import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataRepository;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+import jeeves.server.context.ServiceContext;
 
 /**
  * This class helps {@link AbstractHarvester} instances to process all metadata collected on the
@@ -69,7 +69,7 @@ public abstract class BaseAligner {
      * @param saveMetadata
      * @throws Exception
      */
-    public void addCategories(Metadata metadata, Iterable<String> categories, CategoryMapper localCateg, ServiceContext context,
+    public void addCategories(IMetadata metadata, Iterable<String> categories, CategoryMapper localCateg, ServiceContext context,
                               Logger log, String serverCategory, boolean saveMetadata) {
 
         final MetadataCategoryRepository categoryRepository = context.getBean(MetadataCategoryRepository.class);
@@ -112,7 +112,7 @@ public abstract class BaseAligner {
             }
         }
         if (saveMetadata) {
-            context.getBean(MetadataRepository.class).save(metadata);
+            context.getBean(IMetadataManager.class).save(metadata);
         }
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -52,8 +52,8 @@ import org.fao.geonet.csw.common.exceptions.InvalidParameterValueEx;
 import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.HarvestHistory;
 import org.fao.geonet.domain.HarvestHistory_;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.Profile;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.exceptions.BadInputEx;
@@ -63,6 +63,7 @@ import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.MetadataIndexerProcessor;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.harvest.Common.OperResult;
 import org.fao.geonet.kernel.harvest.Common.Status;
 import org.fao.geonet.kernel.setting.HarvesterSettingsManager;
@@ -179,6 +180,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
     protected void setContext(ServiceContext context) {
         this.context = context;
         this.dataMan = context.getBean(DataManager.class);
+        this.metadataUtils = context.getBean(IMetadataUtils.class);
         this.settingMan = context.getBean(HarvesterSettingsManager.class);
     }
 
@@ -334,13 +336,13 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
 
                 doUnschedule();
 
-                final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+                final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
                 final SourceRepository sourceRepository = context.getBean(SourceRepository.class);
                 
-                final Specifications<Metadata> ownedByHarvester = Specifications.where(MetadataSpecs.hasHarvesterUuid(getParams().getUuid()));
+                final Specifications<? extends IMetadata> ownedByHarvester = Specifications.where(MetadataSpecs.hasHarvesterUuid(getParams().getUuid()));
                 Set<String> sources = new HashSet<String>();
                 for (Integer id : metadataRepository.findAllIdsBy(ownedByHarvester)) {
-                    sources.add(metadataRepository.findOne(id).getSourceInfo().getSourceId());
+                    sources.add(metadataUtils.findOne(id).getSourceInfo().getSourceId());
                     dataMan.deleteMetadata(context, "" + id);
                 }
                 
@@ -1181,6 +1183,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
     protected HarvesterSettingsManager settingMan;
 
     protected DataManager dataMan;
+    protected IMetadataUtils metadataUtils;
 
     protected AbstractParams params;
     protected T result;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/RecordInfo.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/RecordInfo.java
@@ -23,8 +23,8 @@
 
 package org.fao.geonet.kernel.harvest.harvester;
 
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.jdom.Element;
 
 //=============================================================================
@@ -88,7 +88,7 @@ public class RecordInfo {
         isTemplate = record.getChildText("istemplate");
         changeDate = record.getChildText("changedate");
     }
-    public RecordInfo(Metadata record) {
+    public RecordInfo(IMetadata record) {
         id = "" + record.getId();
         uuid = record.getUuid();
         isTemplate = record.getDataInfo().getType().codeString;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/UUIDMapper.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/UUIDMapper.java
@@ -26,7 +26,7 @@ package org.fao.geonet.kernel.harvest.harvester;
 import java.util.HashMap;
 import java.util.List;
 
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.SimpleMetadata;
 
 //=============================================================================
@@ -47,7 +47,7 @@ public class UUIDMapper {
     //---
     //--------------------------------------------------------------------------
 
-    public UUIDMapper(MetadataRepository repo, String harvestUuid) throws Exception {
+    public UUIDMapper(IMetadataUtils repo, String harvestUuid) throws Exception {
 
         final List<SimpleMetadata> all = repo.findAllSimple(harvestUuid);
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/UriMapper.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/UriMapper.java
@@ -23,15 +23,15 @@
 
 package org.fao.geonet.kernel.harvest.harvester;
 
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.specification.MetadataSpecs;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.repository.specification.MetadataSpecs;
+
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -50,10 +50,10 @@ public class UriMapper {
     //--------------------------------------------------------------------------
 
     public UriMapper(ServiceContext context, String harvestUuid) throws Exception {
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
-        final List<Metadata> metadataList = metadataRepository.findAll(MetadataSpecs.hasHarvesterUuid(harvestUuid));
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
+        final List<? extends IMetadata> metadataList = metadataRepository.findAll(MetadataSpecs.hasHarvesterUuid(harvestUuid));
 
-        for (Metadata record : metadataList) {
+        for (IMetadata record : metadataList) {
             String uri = record.getHarvestInfo().getUri();
 
             List<RecordInfo> records = hmUriRecords.get(uri);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
@@ -391,7 +391,8 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
             createDate = new ISODate();
         }
 
-        Metadata metadata = new Metadata().setUuid(uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(xml.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
@@ -22,13 +22,26 @@
 //==============================================================================
 package org.fao.geonet.kernel.harvest.harvester.arcsde;
 
-import jeeves.server.context.ServiceContext;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.Logger;
 import org.fao.geonet.arcgis.ArcSDEConnection;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -52,23 +65,11 @@ import org.fao.geonet.resources.Resources;
 import org.fao.geonet.utils.BinaryFile;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
-
-import com.google.common.collect.Sets;
 import org.jdom.Namespace;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import com.google.common.collect.Sets;
+
+import jeeves.server.context.ServiceContext;
 
 /**
  * Harvester from ArcSDE. Requires the propietary ESRI libraries containing their API. Since those
@@ -357,7 +358,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
             changeDate = new ISODate().toString();
         }
 
-        final Metadata metadata = dataMan.updateMetadata(context, id, xml, validate, ufo, index, language, changeDate,
+        final IMetadata metadata = dataMan.updateMetadata(context, id, xml, validate, ufo, index, language, changeDate,
             true);
 
         OperationAllowedRepository operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
@@ -391,7 +392,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
             createDate = new ISODate();
         }
 
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -281,7 +281,8 @@ public class Aligner extends BaseAligner {
         } else {
             ownerId = Integer.parseInt(params.getOwnerId());
         }
-        Metadata metadata = new Metadata().setUuid(ri.uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(ri.uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -23,37 +23,8 @@
 
 package org.fao.geonet.kernel.harvest.harvester.csw;
 
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.Logger;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.csw.common.CswOperation;
-import org.fao.geonet.csw.common.CswServer;
-import org.fao.geonet.csw.common.ElementSetName;
-import org.fao.geonet.csw.common.requests.GetRecordByIdRequest;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.OperationAllowedId_;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.exceptions.OperationAbortedEx;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.UpdateDatestamp;
-import org.fao.geonet.kernel.harvest.BaseAligner;
-import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
-import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
-import org.fao.geonet.kernel.harvest.harvester.HarvestError;
-import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
-import org.fao.geonet.kernel.harvest.harvester.HarvesterUtil;
-import org.fao.geonet.kernel.harvest.harvester.RecordInfo;
-import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
-import org.fao.geonet.kernel.search.LuceneSearcher;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Element;
-import org.jdom.xpath.XPath;
+import static org.fao.geonet.utils.AbstractHttpRequest.Method.GET;
+import static org.fao.geonet.utils.AbstractHttpRequest.Method.POST;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,8 +35,38 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.fao.geonet.utils.AbstractHttpRequest.Method.GET;
-import static org.fao.geonet.utils.AbstractHttpRequest.Method.POST;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Logger;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.csw.common.CswOperation;
+import org.fao.geonet.csw.common.CswServer;
+import org.fao.geonet.csw.common.ElementSetName;
+import org.fao.geonet.csw.common.requests.GetRecordByIdRequest;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.OperationAllowedId_;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.exceptions.OperationAbortedEx;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.harvest.BaseAligner;
+import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
+import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
+import org.fao.geonet.kernel.harvest.harvester.HarvestError;
+import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
+import org.fao.geonet.kernel.harvest.harvester.HarvesterUtil;
+import org.fao.geonet.kernel.harvest.harvester.RecordInfo;
+import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
+import org.fao.geonet.kernel.search.LuceneSearcher;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.xpath.XPath;
+
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -178,7 +179,7 @@ public class Aligner extends BaseAligner {
 
         localCateg = new CategoryMapper(context);
         localGroups = new GroupMapper(context);
-        localUuids = new UUIDMapper(context.getBean(MetadataRepository.class), params.getUuid());
+        localUuids = new UUIDMapper(context.getBean(IMetadataUtils.class), params.getUuid());
 
         dataMan.flush();
 
@@ -281,7 +282,7 @@ public class Aligner extends BaseAligner {
         } else {
             ownerId = Integer.parseInt(params.getOwnerId());
         }
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(ri.uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
@@ -348,7 +349,7 @@ public class Aligner extends BaseAligner {
                 boolean ufo = false;
                 boolean index = false;
                 String language = context.getLanguage();
-                final Metadata metadata = dataMan.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, true);
+                final IMetadata metadata = dataMan.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, true);
 
                 OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
                 repository.deleteAllByIdAttribute(OperationAllowedId_.metadataId, Integer.parseInt(id));

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
@@ -23,34 +23,6 @@
 
 package org.fao.geonet.kernel.harvest.harvester.fragment;
 
-import com.google.common.base.Optional;
-
-import jeeves.server.context.ServiceContext;
-import jeeves.xlink.Processor;
-
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.Logger;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataCategory;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.OperationAllowedId_;
-import org.fao.geonet.exceptions.BadXmlResponseEx;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.UpdateDatestamp;
-import org.fao.geonet.kernel.harvest.BaseAligner;
-import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
-import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
-import org.fao.geonet.kernel.harvest.harvester.Privileges;
-import org.fao.geonet.kernel.setting.SettingInfo;
-import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.Namespace;
-
 import java.sql.SQLException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -62,6 +34,35 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Logger;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.OperationAllowedId_;
+import org.fao.geonet.exceptions.BadXmlResponseEx;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.harvest.BaseAligner;
+import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
+import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
+import org.fao.geonet.kernel.harvest.harvester.Privileges;
+import org.fao.geonet.kernel.setting.SettingInfo;
+import org.fao.geonet.repository.MetadataCategoryRepository;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.Namespace;
+
+import com.google.common.base.Optional;
+
+import jeeves.server.context.ServiceContext;
+import jeeves.xlink.Processor;
 
 //=============================================================================
 
@@ -409,7 +410,7 @@ public class FragmentHarvester extends BaseAligner {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
@@ -599,8 +600,8 @@ public class FragmentHarvester extends BaseAligner {
 
         int iId = Integer.parseInt(id);
 
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
-        Metadata metadata = metadataRepository.findOne(iId);
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
+        IMetadata metadata = metadataRepository.findOne(iId);
         OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
         repository.deleteAllByIdAttribute(OperationAllowedId_.metadataId, iId);
 
@@ -639,7 +640,7 @@ public class FragmentHarvester extends BaseAligner {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(recUuid);
         metadata.getDataInfo().
             setSchemaId(params.outputSchema).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
@@ -409,7 +409,8 @@ public class FragmentHarvester extends BaseAligner {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata().setUuid(uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).
@@ -638,7 +639,8 @@ public class FragmentHarvester extends BaseAligner {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata().setUuid(recUuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(recUuid);
         metadata.getDataInfo().
             setSchemaId(params.outputSchema).
             setRoot(template.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
@@ -205,7 +205,8 @@ public class Aligner extends BaseAligner {
         // insert metadata
         //
         int userid = 1;
-        Metadata metadata = new Metadata().setUuid(ri.uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(ri.uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
@@ -23,17 +23,23 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geoPREST;
 
-import jeeves.server.context.ServiceContext;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.harvest.BaseAligner;
 import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
 import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
@@ -41,18 +47,13 @@ import org.fao.geonet.kernel.harvest.harvester.HarvestError;
 import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
 import org.fao.geonet.kernel.harvest.harvester.RecordInfo;
 import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.Xml;
 import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Element;
 
-import java.net.URL;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -129,7 +130,7 @@ public class Aligner extends BaseAligner {
 
         localCateg = new CategoryMapper(context);
         localGroups = new GroupMapper(context);
-        localUuids = new UUIDMapper(context.getBean(MetadataRepository.class), params.getUuid());
+        localUuids = new UUIDMapper(context.getBean(IMetadataUtils.class), params.getUuid());
 
         dataMan.flush();
 
@@ -205,7 +206,7 @@ public class Aligner extends BaseAligner {
         // insert metadata
         //
         int userid = 1;
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(ri.uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
@@ -263,7 +264,7 @@ public class Aligner extends BaseAligner {
                 boolean ufo = false;
                 boolean index = false;
                 String language = context.getLanguage();
-                final Metadata metadata = dataMan.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, false);
+                final IMetadata metadata = dataMan.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, false);
 
                 OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
                 repository.deleteAllByIdAttribute(OperationAllowedId_.metadataId, Integer.parseInt(id));

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -520,7 +520,8 @@ public class Aligner extends BaseAligner {
         // insert metadata
         // If MEF format is full, private file links needs to be updated
         boolean ufo = params.mefFormatFull;
-        Metadata metadata = new Metadata().setUuid(ri.uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(ri.uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -23,9 +23,27 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geonet;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -34,6 +52,8 @@ import org.fao.geonet.domain.Pair;
 import org.fao.geonet.exceptions.NoSchemaMatchesException;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.harvest.BaseAligner;
 import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
 import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
@@ -52,7 +72,6 @@ import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.utils.BinaryFile;
 import org.fao.geonet.utils.IO;
@@ -61,23 +80,6 @@ import org.fao.geonet.utils.Xml;
 import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Element;
 import org.jdom.JDOMException;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
@@ -196,7 +198,7 @@ public class Aligner extends BaseAligner {
 
         localCateg = new CategoryMapper(context);
         localGroups = new GroupMapper(context);
-        localUuids = new UUIDMapper(context.getBean(MetadataRepository.class), params.getUuid());
+        localUuids = new UUIDMapper(context.getBean(IMetadataUtils.class), params.getUuid());
 
         Pair<String, Map<String, Object>> filter =
             HarvesterUtil.parseXSLFilter(params.xslfilter, log);
@@ -520,7 +522,7 @@ public class Aligner extends BaseAligner {
         // insert metadata
         // If MEF format is full, private file links needs to be updated
         boolean ufo = params.mefFormatFull;
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(ri.uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
@@ -570,7 +572,7 @@ public class Aligner extends BaseAligner {
         } else {
             addPrivilegesFromGroupPolicy(id, info.getChild("privileges"));
         }
-        context.getBean(MetadataRepository.class).save(metadata);
+        context.getBean(IMetadataManager.class).save(metadata);
 
         dataMan.indexMetadata(id, Math.random() < 0.01, null);
         result.addedMetadata++;
@@ -768,8 +770,9 @@ public class Aligner extends BaseAligner {
             return;
         }
 
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
-        Metadata metadata;
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
+        final IMetadataManager metadataManager = context.getBean(IMetadataManager.class);
+        IMetadata metadata;
         if (!ri.isMoreRecentThan(date)) {
             if (log.isDebugEnabled())
                 log.debug("  - XML not changed for local metadata with uuid:" + ri.uuid);
@@ -832,7 +835,7 @@ public class Aligner extends BaseAligner {
             addPrivilegesFromGroupPolicy(id, info.getChild("privileges"));
         }
 
-        metadataRepository.save(metadata);
+        metadataManager.save(metadata);
 //        dataMan.flush();
 
         dataMan.indexMetadata(id, Math.random() < 0.01, null);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
@@ -226,7 +226,8 @@ public class Aligner {
         //
         //  insert metadata
         //
-        Metadata metadata = new Metadata().setUuid(remoteUuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(remoteUuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
@@ -23,37 +23,38 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geonet20;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
-
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.Logger;
-import org.fao.geonet.constants.Edit;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataCategory;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.UpdateDatestamp;
-import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
-import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
-import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
-import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.specification.MetadataCategorySpecs;
-import org.fao.geonet.utils.XmlRequest;
-import org.jdom.Element;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import org.fao.geonet.Logger;
+import org.fao.geonet.constants.Edit;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
+import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
+import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
+import org.fao.geonet.repository.MetadataCategoryRepository;
+import org.fao.geonet.repository.specification.MetadataCategorySpecs;
+import org.fao.geonet.utils.XmlRequest;
+import org.jdom.Element;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -137,7 +138,7 @@ public class Aligner {
         //-----------------------------------------------------------------------
         //--- retrieve local uuids for given site-id
 
-        localUuids = new UUIDMapper(context.getBean(MetadataRepository.class), siteId);
+        localUuids = new UUIDMapper(context.getBean(IMetadataUtils.class), siteId);
 
         //-----------------------------------------------------------------------
         //--- remove old metadata
@@ -226,7 +227,7 @@ public class Aligner {
         //
         //  insert metadata
         //
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(remoteUuid);
         metadata.getDataInfo().
             setSchemaId(schema).
@@ -262,7 +263,7 @@ public class Aligner {
     //---
     //--------------------------------------------------------------------------
 
-    private void addCategories(Metadata metadata, List<Element> categ) throws Exception {
+    private void addCategories(IMetadata metadata, List<Element> categ) throws Exception {
         final MetadataCategoryRepository categoryRepository = context.getBean(MetadataCategoryRepository.class);
         Collection<String> catNames = Lists.transform(categ, new Function<Element, String>() {
             @Nullable

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -22,12 +22,20 @@
 //==============================================================================
 package org.fao.geonet.kernel.harvest.harvester.localfilesystem;
 
-import com.google.common.collect.Lists;
-
-import jeeves.server.context.ServiceContext;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.Logger;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -49,18 +57,10 @@ import org.fao.geonet.resources.Resources;
 import org.fao.geonet.utils.IO;
 import org.jdom.Element;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Harvester for local filesystem.
@@ -181,7 +181,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 
         String language = context.getLanguage();
 
-        final Metadata metadata = dataMan.updateMetadata(context, id, xml, false, false, false, language, changeDate,
+        final IMetadata metadata = dataMan.updateMetadata(context, id, xml, false, false, false, language, changeDate,
             true);
 
         OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
@@ -218,7 +218,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -218,7 +218,8 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata().setUuid(uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(xml.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
@@ -23,35 +23,37 @@
 
 package org.fao.geonet.kernel.harvest.harvester.localfilesystem;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
-import jeeves.server.context.ServiceContext;
-
-import org.apache.commons.lang.time.DateUtils;
-import org.fao.geonet.Logger;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.harvest.BaseAligner;
-import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
-import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
-import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.lang.time.DateUtils;
+import org.fao.geonet.Logger;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.harvest.BaseAligner;
+import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
+import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
+import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+
+import com.google.common.collect.Sets;
+
+import jeeves.server.context.ServiceContext;
 
 /**
  * @author Jesse on 11/6/2014.
@@ -63,7 +65,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
     private final DataManager dataMan;
     private final LocalFilesystemHarvester harvester;
     private final HarvestResult result = new HarvestResult();
-    private final MetadataRepository repo;
+    private final IMetadataUtils repo;
     private final ServiceContext context;
     private final AtomicBoolean cancelMonitor;
     private final BaseAligner aligner;
@@ -92,7 +94,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
         this.params = params;
         this.dataMan = context.getBean(DataManager.class);
         this.harvester = harvester;
-        this.repo = context.getBean(MetadataRepository.class);
+        this.repo = context.getBean(IMetadataUtils.class);
         this.startTime = System.currentTimeMillis();
         log.debug(String.format("Start visiting files at %d.",
             this.startTime));
@@ -219,7 +221,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
                             if (params.checkFileLastModifiedForUpdate) {
                                 Date fileDate = new Date(Files.getLastModifiedTime(file).toMillis());
 
-                                final Metadata metadata = repo.findOne(id);
+                                final IMetadata metadata = repo.findOne(id);
                                 final ISODate modified;
                                 if (metadata != null && metadata.getDataInfo() != null) {
                                     modified = metadata.getDataInfo().getChangeDate();

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -365,7 +365,8 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata().setUuid(ri.id);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(ri.id);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -23,7 +23,16 @@
 
 package org.fao.geonet.kernel.harvest.harvester.oaipmh;
 
-import jeeves.server.context.ServiceContext;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.command.AbortExecutionException;
@@ -31,6 +40,7 @@ import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -39,10 +49,16 @@ import org.fao.geonet.domain.Pair;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.harvest.BaseAligner;
-import org.fao.geonet.kernel.harvest.harvester.*;
+import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
+import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
+import org.fao.geonet.kernel.harvest.harvester.HarvestError;
+import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
+import org.fao.geonet.kernel.harvest.harvester.HarvesterUtil;
+import org.fao.geonet.kernel.harvest.harvester.IHarvester;
+import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
 import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.Xml;
@@ -57,11 +73,7 @@ import org.fao.oaipmh.responses.ListIdentifiersResponse;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -276,7 +288,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
 
         localCateg = new CategoryMapper(context);
         localGroups = new GroupMapper(context);
-        localUuids = new UUIDMapper(context.getBean(MetadataRepository.class), params.getUuid());
+        localUuids = new UUIDMapper(context.getBean(IMetadataUtils.class), params.getUuid());
 
         Pair<String, Map<String, Object>> filter =
             HarvesterUtil.parseXSLFilter(params.xslfilter, log);
@@ -365,7 +377,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(ri.id);
         metadata.getDataInfo().
             setSchemaId(schema).
@@ -509,7 +521,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
             boolean ufo = false;
             boolean index = false;
             String language = context.getLanguage();
-            final Metadata metadata = dataMan.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate.toString(),
+            final IMetadata metadata = dataMan.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate.toString(),
                 true);
 
             //--- the administrator could change privileges and categories using the

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -398,7 +398,8 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata().setUuid(uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).
@@ -723,7 +724,8 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
             //  insert metadata
             //
             schema = dataMan.autodetectSchema(xml);
-            Metadata metadata = new Metadata().setUuid(reg.uuid);
+            Metadata metadata = new Metadata();
+            metadata.setUuid(reg.uuid);
             metadata.getDataInfo().
                 setSchemaId(schema).
                 setRoot(xml.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -23,49 +23,6 @@
 
 package org.fao.geonet.kernel.harvest.harvester.ogcwxs;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
-import jeeves.server.context.ServiceContext;
-
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.Logger;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataCategory;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.GeonetworkDataDirectory;
-import org.fao.geonet.kernel.SchemaManager;
-import org.fao.geonet.kernel.UpdateDatestamp;
-import org.fao.geonet.kernel.harvest.BaseAligner;
-import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
-import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
-import org.fao.geonet.kernel.harvest.harvester.HarvestError;
-import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
-import org.fao.geonet.kernel.harvest.harvester.IHarvester;
-import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.services.thumbnail.Set;
-import org.fao.geonet.util.Sha1Encoder;
-import org.fao.geonet.utils.BinaryFile;
-import org.fao.geonet.utils.GeonetHttpRequestFactory;
-import org.fao.geonet.utils.IO;
-import org.fao.geonet.utils.Xml;
-import org.fao.geonet.utils.XmlRequest;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.Namespace;
-import org.jdom.filter.ElementFilter;
-import org.jdom.xpath.XPath;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.client.ClientHttpResponse;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -83,6 +40,50 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Logger;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.harvest.BaseAligner;
+import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
+import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
+import org.fao.geonet.kernel.harvest.harvester.HarvestError;
+import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
+import org.fao.geonet.kernel.harvest.harvester.IHarvester;
+import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.repository.MetadataCategoryRepository;
+import org.fao.geonet.services.thumbnail.Set;
+import org.fao.geonet.util.Sha1Encoder;
+import org.fao.geonet.utils.BinaryFile;
+import org.fao.geonet.utils.GeonetHttpRequestFactory;
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Xml;
+import org.fao.geonet.utils.XmlRequest;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.Namespace;
+import org.jdom.filter.ElementFilter;
+import org.jdom.xpath.XPath;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import jeeves.server.context.ServiceContext;
 
 
 //=============================================================================
@@ -213,7 +214,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
         // Clean all before harvest : Remove/Add mechanism
         // If harvest failed (ie. if node unreachable), metadata will be removed, and
         // the node will not be referenced in the catalogue until next harvesting.
-        UUIDMapper localUuids = new UUIDMapper(context.getBean(MetadataRepository.class), params.getUuid());
+        UUIDMapper localUuids = new UUIDMapper(context.getBean(IMetadataUtils.class), params.getUuid());
 
 
         // Try to load capabilities document
@@ -398,7 +399,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
@@ -724,7 +725,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
             //  insert metadata
             //
             schema = dataMan.autodetectSchema(xml);
-            Metadata metadata = new Metadata();
+            IMetadata metadata = new Metadata();
             metadata.setUuid(reg.uuid);
             metadata.getDataInfo().
                 setSchemaId(schema).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
@@ -26,14 +26,32 @@
 
 package org.fao.geonet.kernel.harvest.harvester.thredds;
 
-import jeeves.server.context.ServiceContext;
-import jeeves.xlink.Processor;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.net.ssl.SSLHandshakeException;
 
 import org.apache.commons.io.IOUtils;
 import org.fao.geonet.Constants;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -63,6 +81,8 @@ import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
 
+import jeeves.server.context.ServiceContext;
+import jeeves.xlink.Processor;
 import thredds.catalog.InvAccess;
 import thredds.catalog.InvCatalogFactory;
 import thredds.catalog.InvCatalogImpl;
@@ -79,26 +99,6 @@ import ucar.nc2.dataset.NetcdfDatasetInfo;
 import ucar.nc2.ncml.NcMLWriter;
 import ucar.nc2.units.DateType;
 import ucar.unidata.util.StringUtil;
-
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.net.ssl.SSLHandshakeException;
 
 //=============================================================================
 
@@ -534,7 +534,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
@@ -534,7 +534,8 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
         //
         // insert metadata
         //
-        Metadata metadata = new Metadata().setUuid(uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -22,11 +22,15 @@
 //==============================================================================
 package org.fao.geonet.kernel.harvest.harvester.webdav;
 
-import jeeves.server.context.ServiceContext;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -49,10 +53,7 @@ import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -305,7 +306,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
                 date = rf.getChangeDate();
             }
         }
-        Metadata metadata = new Metadata();
+        IMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
@@ -469,7 +470,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
             boolean index = false;
             String language = context.getLanguage();
 
-            final Metadata metadata = dataMan.updateMetadata(context, record.id, md, validate, ufo, index, language,
+            final IMetadata metadata = dataMan.updateMetadata(context, record.id, md, validate, ufo, index, language,
                 date, false);
 
             //--- the administrator could change privileges and categories using the

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -305,7 +305,8 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
                 date = rf.getChangeDate();
             }
         }
-        Metadata metadata = new Metadata().setUuid(uuid);
+        Metadata metadata = new Metadata();
+        metadata.setUuid(uuid);
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
@@ -23,36 +23,6 @@
 
 package org.fao.geonet.kernel.harvest.harvester.wfsfeatures;
 
-import jeeves.server.context.ServiceContext;
-import jeeves.xlink.Processor;
-
-import org.apache.jcs.access.exception.CacheException;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.Logger;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.exceptions.BadParameterEx;
-import org.fao.geonet.exceptions.BadXmlResponseEx;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.SchemaManager;
-import org.fao.geonet.kernel.harvest.harvester.HarvestError;
-import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
-import org.fao.geonet.kernel.harvest.harvester.IHarvester;
-import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
-import org.fao.geonet.kernel.harvest.harvester.fragment.FragmentHarvester;
-import org.fao.geonet.kernel.harvest.harvester.fragment.FragmentHarvester.FragmentParams;
-import org.fao.geonet.kernel.harvest.harvester.fragment.FragmentHarvester.HarvestSummary;
-import org.fao.geonet.kernel.setting.SettingInfo;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.utils.GeonetHttpRequestFactory;
-import org.fao.geonet.utils.IO;
-import org.fao.geonet.utils.Xml;
-import org.fao.geonet.utils.XmlElementReader;
-import org.fao.geonet.utils.XmlRequest;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.Namespace;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -68,6 +38,36 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.xml.stream.FactoryConfigurationError;
+
+import org.apache.jcs.access.exception.CacheException;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Logger;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.exceptions.BadXmlResponseEx;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.harvest.harvester.HarvestError;
+import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
+import org.fao.geonet.kernel.harvest.harvester.IHarvester;
+import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
+import org.fao.geonet.kernel.harvest.harvester.fragment.FragmentHarvester;
+import org.fao.geonet.kernel.harvest.harvester.fragment.FragmentHarvester.FragmentParams;
+import org.fao.geonet.kernel.harvest.harvester.fragment.FragmentHarvester.HarvestSummary;
+import org.fao.geonet.kernel.setting.SettingInfo;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.GeonetHttpRequestFactory;
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Xml;
+import org.fao.geonet.utils.XmlElementReader;
+import org.fao.geonet.utils.XmlRequest;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.Namespace;
+
+import jeeves.server.context.ServiceContext;
+import jeeves.xlink.Processor;
 
 //=============================================================================
 
@@ -205,7 +205,7 @@ class Harvester implements IHarvester<HarvestResult> {
         log.info("Retrieving metadata fragments for : " + params.getName());
 
         //--- collect all existing metadata uuids before we update
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
         localUuids = new UUIDMapper(metadataRepository, params.getUuid());
 
         //--- parse the xml query from the string - TODO: default should be

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
@@ -23,33 +23,33 @@
 package org.fao.geonet.inspireatom.harvester;
 
 
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.Logger;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.kernel.search.SearchManager;
-import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.InspireAtomFeedRepository;
-import org.fao.geonet.repository.specification.InspireAtomFeedSpecs;
-import org.fao.geonet.repository.specification.MetadataSpecs;
-import org.fao.geonet.utils.Log;
-import org.apache.commons.lang.StringUtils;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.utils.Xml;
-import org.fao.geonet.inspireatom.util.InspireAtomUtil;
-import org.fao.geonet.domain.InspireAtomFeed;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.jdom.Element;
-import org.springframework.data.jpa.domain.Specifications;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Logger;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.InspireAtomFeed;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.inspireatom.util.InspireAtomUtil;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.search.SearchManager;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.repository.InspireAtomFeedRepository;
+import org.fao.geonet.repository.specification.InspireAtomFeedSpecs;
+import org.fao.geonet.repository.specification.MetadataSpecs;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.springframework.data.jpa.domain.Specifications;
+
+import jeeves.server.context.ServiceContext;
 
 /**
  * Class to harvest the Atom documents referenced in the iso19139 in the catalog.
@@ -89,7 +89,7 @@ public class InspireAtomHarvester {
         // Using index information, as type is only available in index and not in database.
         // If retrieved from database retrieves all iso19139 metadata and should apply for each result an xslt process
         // to identify if a service or dataset (slow process)
-        List<Metadata> iso19139Metadata = InspireAtomUtil.searchMetadataByType(ServiceContext.get(), searchManager, "service");
+        List<IMetadata> iso19139Metadata = InspireAtomUtil.searchMetadataByType(ServiceContext.get(), searchManager, "service");
         //List<Metadata> iso19139Metadata = metadataRepository.findAll(Specifications.where(MetadataSpecs.isType(MetadataType.METADATA)).and(MetadataSpecs.isIso19139Schema()));
 
         Element result = new Element("response");
@@ -148,8 +148,8 @@ public class InspireAtomHarvester {
         DataManager dataMan = context.getBean(DataManager.class);
         SettingManager sm = context.getBean(SettingManager.class);
 
-        final MetadataRepository metadataRepository = gc.getBean(MetadataRepository.class);
-        Metadata iso19139Metadata = metadataRepository.findOne(Specifications.where(MetadataSpecs.isType(MetadataType.METADATA)).and(MetadataSpecs.isIso19139Schema()));
+        final IMetadataUtils metadataUtils = gc.getBean(IMetadataUtils.class);
+        IMetadata iso19139Metadata = metadataUtils.findOne(Specifications.where(MetadataSpecs.isType(MetadataType.METADATA)).and(MetadataSpecs.isIso19139Schema()));
 
 
         Element result = new Element("response");
@@ -281,7 +281,7 @@ public class InspireAtomHarvester {
 
         final InspireAtomFeedRepository repository = gc.getBean(InspireAtomFeedRepository.class);
 
-        List<Metadata> iso19139Metadata = InspireAtomUtil.searchMetadataByType(ServiceContext.get(), gc.getBean(SearchManager.class), "dataset");
+        List<IMetadata> iso19139Metadata = InspireAtomUtil.searchMetadataByType(ServiceContext.get(), gc.getBean(SearchManager.class), "dataset");
         //List<Metadata> iso19139Metadata = metadataRepository.findAll(Specifications.where(MetadataSpecs.isType(MetadataType.METADATA)).and(MetadataSpecs.isIso19139Schema()));
 
         Map<String, String> metadataWithAtomFeeds =

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
@@ -30,14 +30,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
-
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.search.LuceneSearcher;
@@ -52,6 +48,10 @@ import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
+
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 
 /**
@@ -188,7 +188,7 @@ public class InspireAtomUtil {
 
 
     public static Map<String, String> retrieveServiceMetadataWithAtomFeeds(final DataManager dataManager,
-                                                                           final List<Metadata> iso19139Metadata,
+                                                                           final List<IMetadata> iso19139Metadata,
                                                                            final String atomProtocol)
         throws Exception {
 
@@ -196,18 +196,18 @@ public class InspireAtomUtil {
     }
 
     public static Map<String, String> retrieveServiceMetadataWithAtomFeed(final DataManager dataManager,
-                                                                          final Metadata iso19139Metadata,
+                                                                          final IMetadata iso19139Metadata,
                                                                           final String atomProtocol)
         throws Exception {
 
-        List<Metadata> iso19139MetadataList = new ArrayList<>();
+        List<IMetadata> iso19139MetadataList = new ArrayList<>();
         iso19139MetadataList.add(iso19139Metadata);
 
         return retrieveServiceMetadataWithAtomFeeds(dataManager, iso19139MetadataList, atomProtocol);
     }
 
     public static Map<String, String> retrieveDatasetMetadataWithAtomFeeds(final DataManager dataManager,
-                                                                           final List<Metadata> iso19139Metadata,
+                                                                           final List<IMetadata> iso19139Metadata,
                                                                            final String atomProtocol)
         throws Exception {
 
@@ -215,12 +215,12 @@ public class InspireAtomUtil {
     }
 
     private static Map<String, String> processAtomFeedsInternal(DataManager dataManager,
-                                                                List<Metadata> iso19139Metadata, String type,
+                                                                List<IMetadata> iso19139Metadata, String type,
                                                                 String atomProtocol) throws Exception {
 
         Map<String, String> metadataAtomFeeds = new HashMap<String, String>();
 
-        for (Metadata md : iso19139Metadata) {
+        for (IMetadata md : iso19139Metadata) {
             int id = md.getId();
             String schema = md.getDataInfo().getSchemaId();
             Element mdEl = null;
@@ -264,7 +264,7 @@ public class InspireAtomUtil {
         return atomFeed;
     }
 
-    public static List<Metadata> searchMetadataByType(ServiceContext context,
+    public static List<IMetadata> searchMetadataByType(ServiceContext context,
                                                       SearchManager searchMan,
                                                       String type) {
 
@@ -278,7 +278,7 @@ public class InspireAtomUtil {
             searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE);
             searcher.search(context, request, new ServiceConfig());
 
-            Map<Integer, Metadata> allMdInfo = ((LuceneSearcher) searcher).getAllMdInfo(context, searcher.getSize());
+            Map<Integer, IMetadata> allMdInfo = ((LuceneSearcher) searcher).getAllMdInfo(context, searcher.getSize());
             return new ArrayList<>(allMdInfo.values());
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
@@ -26,21 +26,13 @@ package org.fao.geonet.services.inspireatom;
 import java.util.HashMap;
 import java.util.Map;
 
-import javassist.NotFoundException;
-
 import javax.servlet.http.HttpServletRequest;
 
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
-import jeeves.server.dispatchers.ServiceManager;
-import jeeves.server.sources.http.ServletPathFinder;
-
 import org.apache.commons.lang.StringUtils;
-
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
 import org.fao.geonet.exceptions.ObjectNotFoundEx;
@@ -48,21 +40,19 @@ import org.fao.geonet.exceptions.OperationNotAllowedEx;
 import org.fao.geonet.exceptions.UnAuthorizedException;
 import org.fao.geonet.inspireatom.util.InspireAtomUtil;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.search.MetaSearcher;
 import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.kernel.search.SearcherType;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
-
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Text;
 import org.jdom.xpath.XPath;
-
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -72,6 +62,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.NativeWebRequest;
+
+import javassist.NotFoundException;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+import jeeves.server.dispatchers.ServiceManager;
+import jeeves.server.sources.http.ServletPathFinder;
 
 
 /**
@@ -147,7 +143,7 @@ public class AtomPredefinedFeed {
         SearchManager searchMan = context.getBean(SearchManager.class);
 
         // Search for the dataset identified by spIdentifier
-        Metadata datasetMd = null;
+        IMetadata datasetMd = null;
         Document dsLuceneSearchParams = createDefaultLuceneSearcherParams();
         dsLuceneSearchParams.getRootElement().addContent(new Element("identifier").setText(spIdentifier));
         dsLuceneSearchParams.getRootElement().addContent(new Element("type").setText("dataset"));
@@ -163,7 +159,7 @@ public class AtomPredefinedFeed {
             Text uuidTxt = (Text) xp.selectSingleNode(new Document(searchResult));
             String datasetMdUuid = uuidTxt.getText();
 
-            MetadataRepository repo = context.getBean(MetadataRepository.class);
+            IMetadataUtils repo = context.getBean(IMetadataUtils.class);
             datasetMd = repo.findOneByUuid(datasetMdUuid);
 
         } finally {

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -23,25 +23,8 @@
 
 package org.fao.geonet.api;
 
-import com.google.common.collect.Sets;
-
-import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.api.exception.ResourceNotFoundException;
-import org.fao.geonet.api.tools.i18n.LanguageUtils;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.kernel.AccessManager;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.SelectionManager;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.utils.GeonetHttpRequestFactory;
-import org.fao.geonet.utils.XmlRequest;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-
-import java.awt.*;
+import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -59,11 +42,29 @@ import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.api.exception.ResourceNotFoundException;
+import org.fao.geonet.api.tools.i18n.LanguageUtils;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SelectionManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.GeonetHttpRequestFactory;
+import org.fao.geonet.utils.XmlRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+
+import com.google.common.collect.Sets;
+
 import jeeves.constants.Jeeves;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.ServiceManager;
-import org.springframework.dao.InvalidDataAccessApiUsageException;
 
 /**
  * API utilities mainly to deal with parameters.
@@ -120,11 +121,11 @@ public class ApiUtils {
         }
         return id;
     }
-    public static Metadata getRecord(String uuidOrInternalId)
+    public static IMetadata getRecord(String uuidOrInternalId)
         throws Exception {
         ApplicationContext appContext = ApplicationContextHolder.get();
-        MetadataRepository metadataRepository = appContext.getBean(MetadataRepository.class);
-        Metadata metadata = metadataRepository.findOneByUuid(uuidOrInternalId);
+        IMetadataUtils metadataRepository = appContext.getBean(IMetadataUtils.class);
+        IMetadata metadata = metadataRepository.findOneByUuid(uuidOrInternalId);
         if (metadata == null) {
             try {
                 metadata = metadataRepository.findOne(uuidOrInternalId);
@@ -211,9 +212,9 @@ public class ApiUtils {
     /**
      * Check if the current user can edit this record.
      */
-    static public Metadata canEditRecord(String metadataUuid, HttpServletRequest request) throws Exception {
+    static public IMetadata canEditRecord(String metadataUuid, HttpServletRequest request) throws Exception {
         ApplicationContext appContext = ApplicationContextHolder.get();
-        Metadata metadata = getRecord(metadataUuid);
+        IMetadata metadata = getRecord(metadataUuid);
         AccessManager accessManager = appContext.getBean(AccessManager.class);
         if (!accessManager.canEdit(createServiceContext(request), String.valueOf(metadata.getId()))) {
             throw new SecurityException(String.format(
@@ -225,8 +226,8 @@ public class ApiUtils {
     /**
      * Check if the current user can view this record.
      */
-    public static Metadata canViewRecord(String metadataUuid, HttpServletRequest request) throws Exception {
-        Metadata metadata = getRecord(metadataUuid);
+    public static IMetadata canViewRecord(String metadataUuid, HttpServletRequest request) throws Exception {
+        IMetadata metadata = getRecord(metadataUuid);
         try {
             Lib.resource.checkPrivilege(createServiceContext(request), String.valueOf(metadata.getId()), ReservedOperation.view);
         } catch (Exception e) {

--- a/services/src/main/java/org/fao/geonet/api/processing/MetadataSearchAndReplace.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/MetadataSearchAndReplace.java
@@ -23,22 +23,6 @@
 
 package org.fao.geonet.api.processing;
 
-import org.apache.commons.lang.StringUtils;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.api.processing.report.MetadataReplacementProcessingReport;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataDataInfo;
-import org.fao.geonet.kernel.AccessManager;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.MetadataIndexerProcessor;
-import org.fao.geonet.kernel.SchemaManager;
-import org.fao.geonet.kernel.search.LuceneSearcher;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Element;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -46,6 +30,22 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.api.processing.report.MetadataReplacementProcessingReport;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataDataInfo;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.MetadataIndexerProcessor;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.search.LuceneSearcher;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
 
 import jeeves.server.context.ServiceContext;
 
@@ -152,7 +152,8 @@ public class MetadataSearchAndReplace extends MetadataIndexerProcessor {
 
         int iId = Integer.valueOf(id);
 
-        Metadata metadataEntity = context.getBean(MetadataRepository.class).findOne(iId);
+        IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
+        IMetadata metadataEntity = metadataRepository.findOne(iId);
         MetadataDataInfo info = metadataEntity.getDataInfo();
 
         // Get metadata title from the index

--- a/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
@@ -23,17 +23,25 @@
 
 package org.fao.geonet.api.processing;
 
-import io.swagger.annotations.*;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
+
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.api.processing.report.registry.IProcessingReportRegistry;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.services.metadata.BatchOpsMetadataReindexer;
 import org.jdom.Document;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,18 +56,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import springfox.documentation.annotations.ApiIgnore;
-
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
 
 @RequestMapping(value = {
     "/api/records",
@@ -124,9 +128,9 @@ public class ValidateApi {
 
             Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, userSession);
 
-            final MetadataRepository metadataRepository = applicationContext.getBean(MetadataRepository.class);
+            final IMetadataUtils metadataRepository = applicationContext.getBean(IMetadataUtils.class);
             for (String uuid : records) {
-                Metadata record = metadataRepository.findOneByUuid(uuid);
+                IMetadata record = metadataRepository.findOneByUuid(uuid);
                 if (record == null) {
                     report.incrementNullRecords();
                 } else if (!accessMan.canEdit(serviceContext, String.valueOf(record.getId()))) {

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
@@ -23,12 +23,21 @@
 
 package org.fao.geonet.api.processing;
 
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.transform.stream.StreamResult;
+
 import org.fao.geonet.api.processing.report.XsltMetadataProcessingReport;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.MetadataRepository;
@@ -37,15 +46,7 @@ import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
-import java.io.StringWriter;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
-
 import jeeves.server.context.ServiceContext;
-
-import javax.xml.transform.stream.StreamResult;
 
 /**
  * Created by francois on 23/05/16.
@@ -66,7 +67,7 @@ public class XslProcessUtils {
         AccessManager accessMan = context.getBean(AccessManager.class);
         DataManager dataMan = context.getBean(DataManager.class);
         SettingManager settingsMan = context.getBean(SettingManager.class);
-        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
 
         report.incrementProcessedRecords();
 
@@ -78,7 +79,7 @@ public class XslProcessUtils {
         }
 
         int iId = Integer.valueOf(id);
-        Metadata info = metadataRepository.findOne(id);
+        IMetadata info = metadataRepository.findOne(id);
 
 
         if (info == null) {
@@ -178,7 +179,7 @@ public class XslProcessUtils {
         AccessManager accessMan = context.getBean(AccessManager.class);
         DataManager dataMan = context.getBean(DataManager.class);
         SettingManager settingsMan = context.getBean(SettingManager.class);
-        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
 
         report.incrementProcessedRecords();
 
@@ -190,7 +191,7 @@ public class XslProcessUtils {
         }
 
         int iId = Integer.valueOf(id);
-        Metadata info = metadataRepository.findOne(id);
+        IMetadata info = metadataRepository.findOne(id);
 
 
         if (info == null) {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -39,7 +39,7 @@ import org.fao.geonet.api.records.model.related.RelatedItemType;
 import org.fao.geonet.api.records.model.related.RelatedResponse;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
@@ -216,7 +216,7 @@ public class MetadataApi implements ApplicationContextAware {
         throws Exception {
         ApplicationContext appContext = ApplicationContextHolder.get();
         DataManager dataManager = appContext.getBean(DataManager.class);
-        Metadata metadata;
+        IMetadata metadata;
         try {
             metadata = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (ResourceNotFoundException e) {
@@ -347,7 +347,7 @@ public class MetadataApi implements ApplicationContextAware {
         ApplicationContext appContext = ApplicationContextHolder.get();
         GeonetworkDataDirectory dataDirectory = appContext.getBean(GeonetworkDataDirectory.class);
 
-        Metadata metadata;
+        IMetadata metadata;
         try {
             metadata = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {
@@ -455,7 +455,7 @@ public class MetadataApi implements ApplicationContextAware {
         HttpServletRequest request) throws Exception {
 
 
-        Metadata md;
+        IMetadata md;
         try{
             md = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
@@ -23,9 +23,20 @@
 
 package org.fao.geonet.api.records;
 
-import io.swagger.annotations.*;
-import jeeves.server.context.ServiceContext;
-import jeeves.services.ReadWriteController;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
+import static org.fao.geonet.api.ApiParams.API_OP_NOTE_PROCESS;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.xml.transform.TransformerConfigurationException;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -37,6 +48,7 @@ import org.fao.geonet.api.processing.report.XsltMetadataProcessingReport;
 import org.fao.geonet.api.records.model.suggestion.SuggestionType;
 import org.fao.geonet.api.records.model.suggestion.SuggestionsType;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.DataManager;
@@ -51,18 +63,19 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.xml.transform.TransformerConfigurationException;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.fao.geonet.api.ApiParams.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import jeeves.server.context.ServiceContext;
+import jeeves.services.ReadWriteController;
 
 @RequestMapping(value = {
     "/api/records",
@@ -108,7 +121,7 @@ public class MetadataProcessApi {
         HttpServletRequest request
     )
         throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -187,7 +200,7 @@ public class MetadataProcessApi {
         HttpServletRequest request
     )
         throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         boolean save = request.getMethod().equals("POST");
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
@@ -235,7 +248,7 @@ public class MetadataProcessApi {
         HttpServletRequest request
     )
         throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         boolean save = true;
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
@@ -249,7 +262,7 @@ public class MetadataProcessApi {
     }
 
     private Element process(String process, HttpServletRequest request,
-                         Metadata metadata, boolean save, ServiceContext context,
+            IMetadata metadata, boolean save, ServiceContext context,
                          SettingManager sm, XsltMetadataProcessingReport report) throws Exception {
         Element processedMetadata;
         try {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
@@ -246,7 +246,8 @@ public class MetadataSampleApi {
                         //
                         // insert metadata
                         //
-                        Metadata metadata = new Metadata().setUuid(uuid);
+                        Metadata metadata = new Metadata();
+                        metadata.setUuid(uuid);
                         metadata.getDataInfo().
                             setSchemaId(schemaName).
                             setRoot(xml.getQualifiedName()).

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSavedQueryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSavedQueryApi.java
@@ -29,7 +29,7 @@ import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.NoResultsFoundException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.schema.SavedQuery;
@@ -85,7 +85,7 @@ public class MetadataSavedQueryApi {
         @PathVariable final String metadataUuid,
         HttpServletRequest request
     ) throws Exception {
-        Metadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         String schemaIdentifier = metadata.getDataInfo().getSchemaId();
         SchemaPlugin schemaPlugin = schemaManager.getSchema(schemaIdentifier).getSchemaPlugin();
         if (schemaPlugin == null) {
@@ -133,7 +133,7 @@ public class MetadataSavedQueryApi {
         @ApiParam(value = "The query parameters")
         @RequestBody(required = false) final HashMap<String, String> parameters) throws Exception {
 
-        Metadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
 
         String schemaIdentifier = metadata.getDataInfo().getSchemaId();
         SchemaPlugin schemaPlugin = schemaManager.getSchema(schemaIdentifier).getSchemaPlugin();

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
@@ -23,7 +23,15 @@
 
 package org.fao.geonet.api.records;
 
-import io.swagger.annotations.*;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
+import static org.fao.geonet.kernel.setting.Settings.SYSTEM_LOCALRATING_ENABLE;
+
+import java.net.URL;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -31,7 +39,7 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.exceptions.BadServerResponseEx;
 import org.fao.geonet.kernel.DataManager;
@@ -47,23 +55,21 @@ import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.net.URL;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import jeeves.server.context.ServiceContext;
 import jeeves.services.ReadWriteController;
-import springfox.documentation.annotations.ApiIgnore;
-
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
-import static org.fao.geonet.kernel.setting.Settings.SYSTEM_LOCALRATING_ENABLE;
 
 @RequestMapping(value = {
     "/api/records",
@@ -119,7 +125,7 @@ public class MetadataSocialApi {
         HttpServletRequest request
     )
         throws Exception {
-        Metadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -23,7 +23,17 @@
 
 package org.fao.geonet.api.records;
 
-import io.swagger.annotations.*;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -31,10 +41,12 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.processing.report.MetadataProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataCategoryRepository;
 import org.fao.geonet.repository.MetadataRepository;
 import org.springframework.context.ApplicationContext;
@@ -49,19 +61,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import jeeves.services.ReadWriteController;
 import springfox.documentation.annotations.ApiIgnore;
-
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 
 @RequestMapping(value = {
     "/api/records",
@@ -102,7 +108,7 @@ public class MetadataTagApi {
             String metadataUuid,
         HttpServletRequest request
     ) throws Exception {
-        Metadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         return metadata.getMetadataCategories();
     }
@@ -145,11 +151,11 @@ public class MetadataTagApi {
             boolean clear,
         HttpServletRequest request
     ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
 
         if (clear) {
-            appContext.getBean(MetadataRepository.class).update(
+            appContext.getBean(IMetadataManager.class).update(
                 metadata.getId(), entity -> entity.getMetadataCategories().clear());
         }
 
@@ -199,11 +205,11 @@ public class MetadataTagApi {
             Integer[] id,
         HttpServletRequest request
     ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
 
         if (id == null || id.length == 0) {
-            appContext.getBean(MetadataRepository.class).update(
+            appContext.getBean(IMetadataManager.class).update(
                 metadata.getId(), entity -> entity.getMetadataCategories().clear());
         }
 
@@ -278,11 +284,12 @@ public class MetadataTagApi {
             final DataManager dataMan = context.getBean(DataManager.class);
             final MetadataCategoryRepository categoryRepository = context.getBean(MetadataCategoryRepository.class);
             final AccessManager accessMan = context.getBean(AccessManager.class);
-            final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+            final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
+            final IMetadataManager metadataManager = context.getBean(IMetadataManager.class);
 
             List<String> listOfUpdatedRecords = new ArrayList<>();
             for (String uuid : records) {
-                Metadata info = metadataRepository.findOneByUuid(uuid);
+                IMetadata info = metadataRepository.findOneByUuid(uuid);
                 if (info == null) {
                     report.incrementNullRecords();
                 } else if (!accessMan.canEdit(
@@ -306,7 +313,7 @@ public class MetadataTagApi {
                                 ));
                             }
                         }
-                        metadataRepository.save(info);
+                        metadataManager.save(info);
                         report.incrementProcessedRecords();
                     }
                 }
@@ -370,11 +377,12 @@ public class MetadataTagApi {
             final DataManager dataMan = context.getBean(DataManager.class);
             final MetadataCategoryRepository categoryRepository = context.getBean(MetadataCategoryRepository.class);
             final AccessManager accessMan = context.getBean(AccessManager.class);
-            final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+            final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
+            final IMetadataManager metadataManager = context.getBean(IMetadataManager.class);
 
             List<String> listOfUpdatedRecords = new ArrayList<>();
             for (String uuid : records) {
-                Metadata info = metadataRepository.findOneByUuid(uuid);
+                IMetadata info = metadataRepository.findOneByUuid(uuid);
                 if (info == null) {
                     report.incrementNullRecords();
                 } else if (!accessMan.canEdit(
@@ -382,7 +390,7 @@ public class MetadataTagApi {
                     report.addNotEditableMetadataId(info.getId());
                 } else {
                     info.getMetadataCategories().clear();
-                    metadataRepository.save(info);
+                    metadataManager.save(info);
                     report.incrementProcessedRecords();
                 }
             }

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -23,39 +23,6 @@
 
 package org.fao.geonet.api.records;
 
-import com.google.common.base.Joiner;
-
-import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.Constants;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.api.ApiUtils;
-import org.fao.geonet.api.records.model.related.RelatedItemType;
-import org.fao.geonet.constants.Edit;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.SchemaManager;
-import org.fao.geonet.kernel.mef.MEFLib;
-import org.fao.geonet.kernel.schema.AssociatedResource;
-import org.fao.geonet.kernel.schema.AssociatedResourcesSchemaPlugin;
-import org.fao.geonet.kernel.schema.SchemaPlugin;
-import org.fao.geonet.kernel.search.MetaSearcher;
-import org.fao.geonet.kernel.search.SearchManager;
-import org.fao.geonet.kernel.search.SearcherType;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.services.metadata.Show;
-import org.fao.geonet.services.relations.Get;
-import org.fao.geonet.utils.BinaryFile;
-import org.fao.geonet.utils.IO;
-import org.fao.geonet.utils.Log;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Content;
-import org.jdom.Element;
-import org.springframework.context.ApplicationContext;
-
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
@@ -70,6 +37,36 @@ import java.util.List;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
+
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.Constants;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.records.model.related.RelatedItemType;
+import org.fao.geonet.constants.Edit;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.mef.MEFLib;
+import org.fao.geonet.kernel.schema.AssociatedResource;
+import org.fao.geonet.kernel.schema.AssociatedResourcesSchemaPlugin;
+import org.fao.geonet.kernel.schema.SchemaPlugin;
+import org.fao.geonet.kernel.search.MetaSearcher;
+import org.fao.geonet.kernel.search.SearchManager;
+import org.fao.geonet.kernel.search.SearcherType;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.services.metadata.Show;
+import org.fao.geonet.services.relations.Get;
+import org.fao.geonet.utils.BinaryFile;
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Log;
+import org.jdom.Content;
+import org.jdom.Element;
+import org.springframework.context.ApplicationContext;
+
+import com.google.common.base.Joiner;
 
 import jeeves.constants.Jeeves;
 import jeeves.server.ServiceConfig;
@@ -325,7 +322,7 @@ public class MetadataUtils {
         return content;
     }
 
-    public static void backupRecord(Metadata metadata, ServiceContext context) {
+    public static void backupRecord(IMetadata metadata, ServiceContext context) {
         Path outDir = Lib.resource.getRemovedDir(metadata.getId());
         Path outFile;
         try {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
@@ -39,7 +39,7 @@ import org.fao.geonet.api.records.editing.AjaxEditUtils;
 import org.fao.geonet.api.records.model.validation.Reports;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.domain.MetadataValidation;
 import org.fao.geonet.domain.MetadataValidationId;
@@ -143,7 +143,7 @@ public class MetadataValidateApi {
             HttpSession session
     )
         throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
         DataManager dataManager = appContext.getBean(DataManager.class);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataVersionningApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataVersionningApi.java
@@ -23,10 +23,15 @@
 
 package org.fao.geonet.api.records;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import jeeves.services.ReadWriteController;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
+
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -34,10 +39,10 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.processing.report.MetadataProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
@@ -45,17 +50,18 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import jeeves.services.ReadWriteController;
 import springfox.documentation.annotations.ApiIgnore;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
-import java.util.Set;
-
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 
 @RequestMapping(value = {
     "/api/records",
@@ -91,7 +97,7 @@ public class MetadataVersionningApi {
             String metadataUuid,
         HttpServletRequest request
     ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
 
         DataManager dataManager = appContext.getBean(DataManager.class);
@@ -143,10 +149,10 @@ public class MetadataVersionningApi {
             final ApplicationContext context = ApplicationContextHolder.get();
             final DataManager dataMan = context.getBean(DataManager.class);
             final AccessManager accessMan = context.getBean(AccessManager.class);
-            final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+            final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
 
             for (String uuid : records) {
-                Metadata metadata = metadataRepository.findOneByUuid(uuid);
+                IMetadata metadata = metadataRepository.findOneByUuid(uuid);
                 if (metadata == null) {
                     report.incrementNullRecords();
                 } else if (!accessMan.canEdit(

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -30,7 +30,7 @@ import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.metadata.StatusActions;
@@ -114,7 +114,7 @@ public class MetadataWorkflowApi {
         HttpServletRequest request
     )
         throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         ServiceContext context = ApiUtils.createServiceContext(request, locale.getISO3Language());

--- a/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
@@ -22,9 +22,13 @@
  */
 package org.fao.geonet.api.records.editing;
 
-import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
-import io.swagger.annotations.*;
+import javax.servlet.http.HttpServletRequest;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -32,18 +36,17 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.processing.report.IProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.api.records.model.BatchEditParameter;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.AddElemValue;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.EditLib;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.SelectionManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.repository.MetadataRepository;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -53,17 +56,22 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import com.google.common.collect.Sets;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import jeeves.server.context.ServiceContext;
 import jeeves.services.ReadWriteController;
-
-import javax.servlet.http.HttpServletRequest;
 
 @RequestMapping(value = {
     "/api/records",
@@ -157,9 +165,9 @@ public class BatchEditsApi implements ApplicationContextAware {
         report.setTotalRecords(setOfUuidsToEdit.size());
 
         String changeDate = null;
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
         for (String recordUuid : setOfUuidsToEdit) {
-            Metadata record = metadataRepository.findOneByUuid(recordUuid);
+            IMetadata record = metadataRepository.findOneByUuid(recordUuid);
             if (record == null) {
                 report.incrementNullRecords();
             } else if (!accessMan.isOwner(serviceContext, String.valueOf(record.getId()))) {

--- a/services/src/main/java/org/fao/geonet/api/records/editing/EditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/EditUtils.java
@@ -23,32 +23,39 @@
 
 package org.fao.geonet.api.records.editing;
 
-import com.google.common.collect.Lists;
-
-import org.fao.geonet.exceptions.BadParameterEx;
-
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.kernel.*;
-import org.fao.geonet.kernel.schema.MultilingualSchemaPlugin;
-import org.fao.geonet.kernel.schema.SchemaPlugin;
-import org.fao.geonet.utils.Log;
-import org.fao.geonet.Util;
-import org.fao.geonet.utils.Xml;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.constants.Edit;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.exceptions.ConcurrentUpdateEx;
-import org.fao.geonet.lib.Lib;
-import org.jdom.*;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
+import org.fao.geonet.constants.Edit;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.exceptions.ConcurrentUpdateEx;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.EditLib;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.XmlSerializer;
+import org.fao.geonet.kernel.schema.MultilingualSchemaPlugin;
+import org.fao.geonet.kernel.schema.SchemaPlugin;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Attribute;
+import org.jdom.Content;
+import org.jdom.Element;
+import org.jdom.Namespace;
+import org.jdom.Text;
+
+import com.google.common.collect.Lists;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 
 /**
@@ -168,7 +175,7 @@ class EditUtils {
         // update element and return status
         //
 
-        Metadata result = null;
+        IMetadata result = null;
         // whether to request automatic changes (update-fixed-info)
         boolean ufo = true;
         // whether to index on update

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -36,7 +36,7 @@ import org.fao.geonet.api.records.model.Direction;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.domain.ReservedGroup;
 import org.fao.geonet.domain.ReservedOperation;
@@ -141,7 +141,7 @@ public class MetadataEditingApi {
             Map<String,String> allRequestParams,
         HttpServletRequest request
         ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         boolean showValidationErrors = false;
         boolean starteditingsession = true;
@@ -238,7 +238,7 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
         ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
         AjaxEditUtils ajaxEditUtils = new AjaxEditUtils(context);
 //        ajaxEditUtils.preprocessUpdate(allRequestParams, context);
@@ -398,7 +398,7 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         DataManager dataMan = applicationContext.getBean(DataManager.class);
@@ -458,7 +458,7 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -537,7 +537,7 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 
         new AjaxEditUtils(context).swapElementEmbedded(
@@ -589,7 +589,7 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 
         String id = String.valueOf(metadata.getId());
@@ -634,7 +634,7 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
-        Metadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+        IMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 
         new AjaxEditUtils(context).deleteAttributeEmbedded(

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/AbstractFormatService.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/AbstractFormatService.java
@@ -23,26 +23,26 @@
 
 package org.fao.geonet.api.records.formatters;
 
-import org.apache.commons.lang.StringUtils;
-import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.exceptions.BadParameterEx;
-import org.fao.geonet.exceptions.ResourceNotFoundEx;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.GeonetworkDataDirectory;
-import org.fao.geonet.repository.MetadataRepository;
+import static org.fao.geonet.api.records.formatters.FormatterConstants.SCHEMA_PLUGIN_FORMATTER_DIR;
+import static org.fao.geonet.api.records.formatters.FormatterConstants.VIEW_GROOVY_FILENAME;
+import static org.fao.geonet.api.records.formatters.FormatterConstants.VIEW_XSL_FILENAME;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import jeeves.server.ServiceConfig;
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.exceptions.ResourceNotFoundEx;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.utils.FilePathChecker;
 
-import static org.fao.geonet.api.records.formatters.FormatterConstants.SCHEMA_PLUGIN_FORMATTER_DIR;
-import static org.fao.geonet.api.records.formatters.FormatterConstants.VIEW_GROOVY_FILENAME;
-import static org.fao.geonet.api.records.formatters.FormatterConstants.VIEW_XSL_FILENAME;
+import jeeves.server.ServiceConfig;
 
 /**
  * Common constants and methods for Metadata formatter classes
@@ -79,8 +79,8 @@ abstract class AbstractFormatService {
     public void init(Path appPath, ServiceConfig params) throws Exception {
     }
 
-    protected Metadata loadMetadata(MetadataRepository metadataRepository, int id) {
-        Metadata md = metadataRepository.findOne(id);
+    protected IMetadata loadMetadata(IMetadataUtils metadataUtils, int id) {
+        IMetadata md = metadataUtils.findOne(id);
 
         if (md == null) {
             throw new IllegalArgumentException("No metadata found. id = " + id);

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -23,10 +23,30 @@
 
 package org.fao.geonet.api.records.formatters;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.io.ByteStreams;
+import static com.google.common.io.Files.getNameWithoutExtension;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
+import static org.fao.geonet.api.records.formatters.FormatterConstants.SCHEMA_PLUGIN_FORMATTER_DIR;
+import static org.springframework.data.jpa.domain.Specifications.where;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.Callable;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -45,6 +65,7 @@ import org.fao.geonet.api.records.formatters.cache.Validator;
 import org.fao.geonet.api.records.formatters.groovy.ParamValue;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -56,11 +77,11 @@ import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.XmlSerializer;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.OperationAllowedSpecs;
 import org.fao.geonet.util.XslUtil;
@@ -95,25 +116,10 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.xhtmlrenderer.pdf.ITextRenderer;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
-import java.util.concurrent.Callable;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.io.ByteStreams;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -121,11 +127,6 @@ import io.swagger.annotations.ApiParam;
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.ServiceManager;
 import springfox.documentation.annotations.ApiIgnore;
-
-import static com.google.common.io.Files.getNameWithoutExtension;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
-import static org.fao.geonet.api.records.formatters.FormatterConstants.SCHEMA_PLUGIN_FORMATTER_DIR;
-import static org.springframework.data.jpa.domain.Specifications.where;
 
 /**
  * Allows a user to display a metadata with a particular formatters
@@ -270,7 +271,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
 
         final ServiceContext context = createServiceContext(locale.getISO3Language(),
             formatType, request.getNativeRequest(HttpServletRequest.class));
-        Metadata metadata = ApiUtils.canViewRecord(metadataUuid, servletRequest);
+        IMetadata metadata = ApiUtils.canViewRecord(metadataUuid, servletRequest);
 
         Boolean hideWithheld = true;
 //        final boolean hideWithheld = Boolean.TRUE.equals(hide_withheld) ||
@@ -560,9 +561,9 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
 
     @VisibleForTesting
     Pair<FormatterImpl, FormatterParams> loadMetadataAndCreateFormatterAndParams(ServiceContext context, Key key, final NativeWebRequest request) throws Exception {
-        final Pair<Element, Metadata> elementMetadataPair = getMetadata(context, key.mdId, key.hideWithheld);
+        final Pair<Element, IMetadata> elementMetadataPair = getMetadata(context, key.mdId, key.hideWithheld);
         Element metadata = elementMetadataPair.one();
-        Metadata metadataInfo = elementMetadataPair.two();
+        IMetadata metadataInfo = elementMetadataPair.two();
 
         return createFormatterAndParams(key.lang, key.formatType, key.formatterId, key.width, request, context, metadata, metadataInfo);
     }
@@ -578,7 +579,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
                                                                           NativeWebRequest request,
                                                                           ServiceContext context,
                                                                           Element metadata,
-                                                                          Metadata metadataInfo) throws Exception {
+                                                                          IMetadata metadataInfo) throws Exception {
         final String schema = metadataInfo.getDataInfo().getSchemaId();
         Path schemaDir = null;
         if (schema != null) {
@@ -643,10 +644,10 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         return isInSchemaPlugin;
     }
 
-    public Pair<Element, Metadata> getMetadata(ServiceContext context, int id,
+    public Pair<Element, IMetadata> getMetadata(ServiceContext context, int id,
                                                Boolean hide_withheld) throws Exception {
 
-        Metadata md = loadMetadata(context.getBean(MetadataRepository.class), id);
+        IMetadata md = loadMetadata(context.getBean(IMetadataUtils.class), id);
         Element metadata = context.getBean(XmlSerializer.class).removeHiddenElements(false, md, false);
 
 

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -365,7 +365,8 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             metadataEl = Xml.selectElement(metadataEl, mdPath, namespaces);
             metadataEl.detach();
         }
-        Metadata metadataInfo = new Metadata().setData(metadata).setId(1).setUuid("uuid");
+        Metadata metadataInfo = new Metadata();
+        metadataInfo.setData(metadata).setId(1).setUuid("uuid");
         metadataInfo.getDataInfo().setType(MetadataType.METADATA).setRoot(metadataEl.getQualifiedName()).setSchemaId(schema);
 
         Pair<FormatterImpl, FormatterParams> result = createFormatterAndParams(lang, formatType, xslid, width,

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterParams.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterParams.java
@@ -23,12 +23,12 @@
 
 package org.fao.geonet.api.records.formatters;
 
+import java.nio.file.Path;
+
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.jdom.Element;
 import org.springframework.web.context.request.WebRequest;
-
-import java.nio.file.Path;
 
 import jeeves.server.context.ServiceContext;
 
@@ -46,7 +46,7 @@ public class FormatterParams {
     public Path schemaDir;
     public ConfigFile config;
     public String url;
-    public Metadata metadataInfo;
+    public IMetadata metadataInfo;
     public FormatType formatType;
     public boolean formatterInSchemaPlugin;
     public FormatterWidth width;

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ListFormatters.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ListFormatters.java
@@ -23,19 +23,7 @@
 
 package org.fao.geonet.api.records.formatters;
 
-import com.google.common.collect.Lists;
-
-import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.kernel.GeonetworkDataDirectory;
-import org.fao.geonet.kernel.SchemaManager;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.utils.IO;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import static org.fao.geonet.api.records.formatters.FormatterConstants.SCHEMA_PLUGIN_FORMATTER_DIR;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -50,7 +38,19 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import static org.fao.geonet.api.records.formatters.FormatterConstants.SCHEMA_PLUGIN_FORMATTER_DIR;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.utils.IO;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.google.common.collect.Lists;
 
 /**
  * List all formatters
@@ -116,7 +116,7 @@ public class ListFormatters extends AbstractFormatService {
         final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         if (id != null || uuid != null) {
             try {
-                loadMetadata(applicationContext.getBean(MetadataRepository.class), Integer.parseInt(resolveId(id, uuid)));
+                loadMetadata(applicationContext.getBean(IMetadataUtils.class), Integer.parseInt(resolveId(id, uuid)));
             } catch (Throwable e) {
                 // its ok.  just can't use metadata
             }

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/groovy/EnvironmentImpl.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/groovy/EnvironmentImpl.java
@@ -40,7 +40,7 @@ import org.apache.lucene.search.TopFieldCollector;
 import org.fao.geonet.api.records.formatters.FormatType;
 import org.fao.geonet.api.records.formatters.FormatterParams;
 import org.fao.geonet.api.records.formatters.FormatterWidth;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.search.IndexAndTaxonomy;
 import org.fao.geonet.kernel.search.SearchManager;
@@ -71,7 +71,7 @@ public class EnvironmentImpl implements Environment {
     private final String resourceUrl;
     private final Multimap<String, ParamValue> params = ArrayListMultimap.create();
     private final FormatType formatType;
-    private final Metadata metadataInfo;
+    private final IMetadata metadataInfo;
     private final String locUrl;
     private final Element jdomMetadata;
     private final ServiceContext serviceContext;

--- a/services/src/main/java/org/fao/geonet/api/registries/CollectResults.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/CollectResults.java
@@ -22,14 +22,14 @@
 //==============================================================================
 package org.fao.geonet.api.registries;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
-
-import org.fao.geonet.domain.Metadata;
-import org.jdom.Element;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.fao.geonet.domain.IMetadata;
+import org.jdom.Element;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
 
 
 /**
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class CollectResults {
     boolean recordUpdated = false;
-    private Metadata record;
+    private IMetadata record;
     private Element updatedRecord;
     /**
      * Table composed of the entry identifier (extracted from the Element),
@@ -51,10 +51,9 @@ public class CollectResults {
     private Map<String, Integer> entryIdentifiers = new HashMap<>();
 
     public CollectResults() {
-        this.record = record;
     }
 
-    public CollectResults(Metadata record) {
+    public CollectResults(IMetadata record) {
         this.record = record;
     }
 
@@ -62,11 +61,11 @@ public class CollectResults {
         return recordUpdated;
     }
 
-    public Metadata getRecord() {
+    public IMetadata getRecord() {
         return record;
     }
 
-    public CollectResults setRecord(Metadata record) {
+    public CollectResults setRecord(IMetadata record) {
         this.record = record;
         return this;
     }

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryEntriesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryEntriesApi.java
@@ -23,21 +23,25 @@
 
 package org.fao.geonet.api.registries;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import io.swagger.annotations.*;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.schema.MultilingualSchemaPlugin;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.util.XslUtil;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Attribute;
@@ -48,16 +52,24 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import springfox.documentation.annotations.ApiIgnore;
 
-import javax.servlet.http.HttpServletRequest;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import jeeves.server.context.ServiceContext;
+import springfox.documentation.annotations.ApiIgnore;
 
 @EnableWebMvc
 @Service
@@ -137,8 +149,8 @@ public class DirectoryEntriesApi {
         )
         throws Exception {
         ApplicationContext applicationContext = ApplicationContextHolder.get();
-        final MetadataRepository metadataRepository = applicationContext.getBean(MetadataRepository.class);
-        final Metadata metadata = metadataRepository.findOneByUuid(uuid);
+        final IMetadataUtils metadataRepository = applicationContext.getBean(IMetadataUtils.class);
+        final IMetadata metadata = metadataRepository.findOneByUuid(uuid);
 
         if (metadata == null) {
             throw new ResourceNotFoundException(String.format(

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
@@ -1,19 +1,24 @@
 package org.fao.geonet.api.registries;
 
-import com.google.common.collect.Table;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataDataInfo;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.search.MetaSearcher;
 import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.kernel.search.SearcherType;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.services.subtemplate.Get;
 import org.fao.geonet.util.Sha1Encoder;
 import org.fao.geonet.util.XslUtil;
@@ -25,16 +30,12 @@ import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.jdom.Text;
 
-import java.util.*;
+import com.google.common.collect.Table;
 
 import jeeves.constants.Jeeves;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.XLink;
-
-import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GCO;
-import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GMD;
-import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.SRV;
 
 /**
  * Created by francois on 11/03/16.
@@ -52,11 +53,11 @@ public class DirectoryUtils {
                                    Integer groupOwner,
                                    boolean saveRecord) {
         DataManager dataManager = context.getBean(DataManager.class);
-        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
         Table<String, String, Element> entries = collectResults.getEntries();
         Iterator<String> entriesIterator =
             entries.rowKeySet().iterator();
-        Metadata record = collectResults.getRecord();
+        IMetadata record = collectResults.getRecord();
         boolean validate = false, index = false, ufo = false,
             notify = false, publicForGroup = true, refreshReaders = false;
 
@@ -67,9 +68,9 @@ public class DirectoryUtils {
             String uuid = uuidAndEntry.keySet().iterator().next();
             Element entry = uuidAndEntry.values().iterator().next();
 
-            Metadata dbSubTemplate = metadataRepository.findOneByUuid(uuid);
+            IMetadata dbSubTemplate = metadataRepository.findOneByUuid(uuid);
             if (dbSubTemplate == null) {
-                Metadata subtemplate = new Metadata();
+                IMetadata subtemplate = new Metadata();
                 subtemplate.setUuid(uuid);
                 subtemplate.getDataInfo().
                     setSchemaId(record.getDataInfo().getSchemaId()).
@@ -125,7 +126,7 @@ public class DirectoryUtils {
      * record, and the identifier match, only one is reported (the last one).
      */
     public static CollectResults collectEntries(ServiceContext context,
-                                                Metadata record,
+                                                IMetadata record,
                                                 String xpath,
                                                 String identifierXpath) throws Exception {
         return collectEntries(context, record, xpath, identifierXpath, null, false, false, null);
@@ -137,7 +138,7 @@ public class DirectoryUtils {
      * propertiesToCopy
      */
     public static CollectResults synchronizeEntries(ServiceContext context,
-                                                    Metadata record,
+                                                    IMetadata record,
                                                     String xpath,
                                                     String identifierXpath,
                                                     List<String> propertiesToCopy,
@@ -149,7 +150,7 @@ public class DirectoryUtils {
 
 
     private static CollectResults collectEntries(ServiceContext context,
-                                                 Metadata record,
+                                                 IMetadata record,
                                                  String xpath,
                                                  String identifierXpath,
                                                  List<String> propertiesToCopy,
@@ -159,7 +160,7 @@ public class DirectoryUtils {
         CollectResults collectResults = new CollectResults(record);
         Map<String, List<Namespace>> namespaceList = new HashMap<String, List<Namespace>>();
 
-        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
 
         if (Log.isDebugEnabled(LOGGER)) {
             Log.debug(LOGGER, String.format(
@@ -266,7 +267,7 @@ public class DirectoryUtils {
                     Element subTemplateElement = null;
                     // Search in DB by UUID matching entry UUID
                     if (StringUtils.isEmpty(searchIndexField)) {
-                        Metadata subTemplate = metadataRepository.findOneByUuid(uuid);
+                        IMetadata subTemplate = metadataRepository.findOneByUuid(uuid);
                         if (subTemplate != null) {
                             subTemplateElement = subTemplate.getXmlData(false);
                         }
@@ -287,7 +288,7 @@ public class DirectoryUtils {
                         parameters.put(searchIndexField, identifier);
                         String id = search(context, parameters);
                         if (id != null) {
-                            Metadata subTemplate = metadataRepository.findOne(id);
+                            IMetadata subTemplate = metadataRepository.findOne(id);
                             if (subTemplate != null) {
                                 uuid = subTemplate.getUuid();
                                 subTemplateElement = subTemplate.getXmlData(false);

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
@@ -69,7 +69,8 @@ public class DirectoryUtils {
 
             Metadata dbSubTemplate = metadataRepository.findOneByUuid(uuid);
             if (dbSubTemplate == null) {
-                Metadata subtemplate = new Metadata().setUuid(uuid);
+                Metadata subtemplate = new Metadata();
+                subtemplate.setUuid(uuid);
                 subtemplate.getDataInfo().
                     setSchemaId(record.getDataInfo().getSchemaId()).
                     setRoot(entry.getQualifiedName()).

--- a/services/src/main/java/org/fao/geonet/api/related/Related.java
+++ b/services/src/main/java/org/fao/geonet/api/related/Related.java
@@ -23,9 +23,14 @@
 
 package org.fao.geonet.api.related;
 
-import io.swagger.annotations.*;
-import jeeves.server.context.ServiceContext;
-import jeeves.services.ReadWriteController;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
@@ -34,7 +39,7 @@ import org.fao.geonet.api.records.MetadataUtils;
 import org.fao.geonet.api.records.model.related.RelatedItemType;
 import org.fao.geonet.api.records.model.related.RelatedResponse;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
@@ -45,14 +50,19 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import javax.servlet.http.HttpServletRequest;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import jeeves.server.context.ServiceContext;
+import jeeves.services.ReadWriteController;
 
 @RequestMapping(value = {
     "/api/related",
@@ -111,7 +121,7 @@ public class Related implements ApplicationContextAware {
         GeonetworkDataDirectory dataDirectory = context.getBean(GeonetworkDataDirectory.class);
         Path relatedXsl = dataDirectory.getWebappDir().resolve("xslt/services/metadata/relation.xsl");
 
-        Metadata md;
+        IMetadata md;
         Map<String, RelatedResponse> res = new HashMap<String, RelatedResponse>();
 
         for(String uuid : uuids) {

--- a/services/src/main/java/org/fao/geonet/api/reports/ReportInternalMetadata.java
+++ b/services/src/main/java/org/fao/geonet/api/reports/ReportInternalMetadata.java
@@ -1,22 +1,24 @@
 package org.fao.geonet.api.reports;
 
-import jeeves.server.context.ServiceContext;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.fao.geonet.domain.Group;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.domain.User;
-import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.UserRepository;
-import org.fao.geonet.repository.specification.OperationAllowedSpecs;
-
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.specification.OperationAllowedSpecs;
+
+import jeeves.server.context.ServiceContext;
 
 /**
  * Created by jose on 31/01/17.
@@ -54,9 +56,9 @@ public class ReportInternalMetadata implements IReport {
             csvFilePrinter = new CSVPrinter(writer, csvFileFormat);
 
             // Retrieve metadata
-            final MetadataRepository metadataRepository =
-                    context.getBean(MetadataRepository.class);
-            final List<Metadata> records =
+            final IMetadataUtils metadataRepository =
+                    context.getBean(IMetadataUtils.class);
+            final List<? extends IMetadata> records =
                     metadataRepository.getMetadataReports().
                             getInternalMetadata(
                                     reportFilter.getBeginDate(),
@@ -81,7 +83,7 @@ public class ReportInternalMetadata implements IReport {
                     context.getBean(GroupRepository.class).findAll();
 
             // Process the records
-            for (Metadata metadata : records) {
+            for (IMetadata metadata : records) {
                 String userOwnerUsername = "";
                 String userOwnerName = "";
                 String userOwnerSurname = "";

--- a/services/src/main/java/org/fao/geonet/api/reports/ReportUpdatedMetadata.java
+++ b/services/src/main/java/org/fao/geonet/api/reports/ReportUpdatedMetadata.java
@@ -1,21 +1,22 @@
 package org.fao.geonet.api.reports;
 
-import jeeves.server.context.ServiceContext;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.fao.geonet.domain.Group;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.User;
-import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.UserRepository;
-
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.UserRepository;
+
+import jeeves.server.context.ServiceContext;
 
 /**
  * Created by jose on 31/01/17.
@@ -53,9 +54,9 @@ public class ReportUpdatedMetadata implements IReport {
             csvFilePrinter = new CSVPrinter(writer, csvFileFormat);
 
             // Retrieve metadata
-            final MetadataRepository metadataRepository =
-                    context.getBean(MetadataRepository.class);
-            final List<Metadata> records =
+            final IMetadataUtils metadataRepository =
+                    context.getBean(IMetadataUtils.class);
+            final List<? extends IMetadata> records =
                     metadataRepository.getMetadataReports().
                             getUpdatedMetadata(
                                     reportFilter.getBeginDate(),
@@ -81,7 +82,7 @@ public class ReportUpdatedMetadata implements IReport {
                     context.getBean(GroupRepository.class).findAll();
 
             // Process the records
-            for (Metadata metadata : records) {
+            for (IMetadata metadata : records) {
                 String userOwnerUsername = "";
                 String userOwnerName = "";
                 String userOwnerSurname = "";

--- a/services/src/main/java/org/fao/geonet/api/selections/UserSelectionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/selections/UserSelectionsApi.java
@@ -22,26 +22,27 @@
  */
 package org.fao.geonet.api.selections;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Language;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.Selection;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.UserSavedSelection;
 import org.fao.geonet.domain.UserSavedSelectionId;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.LanguageRepository;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.SelectionRepository;
-import org.fao.geonet.repository.UserSavedSelectionRepository;
 import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.UserSavedSelectionRepository;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -55,12 +56,13 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import springfox.documentation.annotations.ApiIgnore;
 
-import javax.servlet.http.HttpSession;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import springfox.documentation.annotations.ApiIgnore;
 
 /**
  * Select a list of elements stored in session.
@@ -349,11 +351,10 @@ public class UserSelectionsApi {
         }
 
         UserSavedSelectionRepository umsRepository =  appContext.getBean(UserSavedSelectionRepository.class);
-        MetadataRepository mdRepository = appContext.getBean(MetadataRepository.class);
-        ArrayList<String> notFoundRecords = new ArrayList<>();
+        IMetadataUtils mdRepository = appContext.getBean(IMetadataUtils.class);
         for (String u : uuid) {
             // Check record exist
-            Metadata md = mdRepository.findOneByUuid(u);
+            IMetadata md = mdRepository.findOneByUuid(u);
             if (md != null) {
                 UserSavedSelection e = new UserSavedSelection(selection, user, u);
                 try {

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -23,38 +23,57 @@
 
 package org.fao.geonet.api.site;
 
-import io.swagger.annotations.*;
-import jeeves.component.ProfileManager;
-import jeeves.config.springutil.ServerBeanPropertyUpdater;
-import jeeves.server.JeevesProxyInfo;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import static org.apache.commons.fileupload.util.Streams.checkFileName;
+import static org.fao.geonet.api.ApiParams.API_CLASS_CATALOG_TAG;
+
+import java.awt.image.BufferedImage;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+import javax.persistence.criteria.Root;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.SystemInfo;
-import org.fao.geonet.Util;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.site.model.SettingSet;
 import org.fao.geonet.api.site.model.SettingsListResponse;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.*;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataSourceInfo_;
+import org.fao.geonet.domain.Metadata_;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.Setting;
+import org.fao.geonet.domain.SettingDataType;
+import org.fao.geonet.domain.Source;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.PathSpec;
 import org.fao.geonet.repository.SettingRepository;
 import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
-import org.fao.geonet.repository.PathSpec;
 import org.fao.geonet.resources.Resources;
 import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.IO;
@@ -67,24 +86,24 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import jeeves.component.ProfileManager;
+import jeeves.config.springutil.ServerBeanPropertyUpdater;
+import jeeves.server.JeevesProxyInfo;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 import springfox.documentation.annotations.ApiIgnore;
-
-import javax.imageio.ImageIO;
-import javax.persistence.criteria.Root;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import java.awt.image.BufferedImage;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-
-import static org.apache.commons.fileupload.util.Streams.checkFileName;
-import static org.fao.geonet.api.ApiParams.API_CLASS_CATALOG_TAG;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
 
 /**
  *
@@ -366,7 +385,7 @@ public class SiteApi {
         String newUuid = allRequestParams.get(Settings.SYSTEM_SITE_SITE_ID_PATH);
 
         if (newUuid != null && !currentUuid.equals(newUuid)) {
-            final MetadataRepository metadataRepository = applicationContext.getBean(MetadataRepository.class);
+            final IMetadataManager metadataRepository = applicationContext.getBean(IMetadataManager.class);
             final SourceRepository sourceRepository = applicationContext.getBean(SourceRepository.class);
             final Source source = sourceRepository.findOne(currentUuid);
             Source newSource = new Source(newUuid, source.getName(), source.getLabelTranslations(), source.isLocal());

--- a/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
@@ -23,15 +23,31 @@
 
 package org.fao.geonet.api.users.transfer;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasGroupId;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiUtils;
-import org.fao.geonet.domain.*;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.OperationAllowedId;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.domain.UserGroup;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.UserGroupRepository;
@@ -43,15 +59,17 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 import springfox.documentation.annotations.ApiIgnore;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import java.sql.SQLException;
-import java.util.*;
-
-import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasGroupId;
 
 @RequestMapping(value = {
     "/api/users",
@@ -84,11 +102,11 @@ public class TransferApi {
         UserSession us = ApiUtils.getUserSession(httpSession);
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         List<User> users = applicationContext.getBean(UserRepository.class).findAll();
-        MetadataRepository metadataRepository = applicationContext.getBean(MetadataRepository.class);
+        IMetadataUtils metadataRepository = applicationContext.getBean(IMetadataUtils.class);
 
         List<OwnerResponse> ownerList = new ArrayList<>();
         for (User u : users) {
-            List<Metadata> userRecords = metadataRepository.findAll(
+            List<? extends IMetadata> userRecords = metadataRepository.findAll(
                 MetadataSpecs.hasOwner(u.getId())
             );
             if (userRecords.size() > 0) {
@@ -165,7 +183,8 @@ public class TransferApi {
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
         DataManager dm = applicationContext.getBean(DataManager.class);
-        final MetadataRepository metadataRepository = applicationContext.getBean(MetadataRepository.class);
+        final IMetadataUtils metadataUtils = applicationContext.getBean(IMetadataUtils.class);
+        final IMetadataManager metadataManager = applicationContext.getBean(IMetadataManager.class);
 
         //--- transfer privileges (if case)
 
@@ -217,16 +236,16 @@ public class TransferApi {
         // assign the new owner and ownerGroup for the source
         // user records.
         final List<Integer> sourceUserRecords =
-            metadataRepository.findAllIdsBy(MetadataSpecs.hasOwner(transfer.getSourceUser()));
+                metadataUtils.findAllIdsBy(MetadataSpecs.hasOwner(transfer.getSourceUser()));
         metadata.addAll(sourceUserRecords);
 
         // Set owner for all records to be modified.
         for (Integer i : metadata) {
-            final Metadata metadata1 = metadataRepository.findOne(i);
+            final IMetadata metadata1 = metadataUtils.findOne(i);
             metadata1.getSourceInfo()
                 .setGroupOwner(transfer.getTargetGroup())
                 .setOwner(transfer.getTargetUser());
-            metadataRepository.save(metadata1);
+            metadataManager.save(metadata1);
         }
 
         dm.flush();

--- a/services/src/main/java/org/fao/geonet/guiservices/metadata/GetLatestUpdated.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/metadata/GetLatestUpdated.java
@@ -23,14 +23,12 @@
 
 package org.fao.geonet.guiservices.metadata;
 
-import jeeves.constants.Jeeves;
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Path;
+import java.util.Map;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.search.LuceneSearcher;
 import org.fao.geonet.kernel.search.MetaSearcher;
@@ -39,8 +37,10 @@ import org.fao.geonet.kernel.search.SearcherType;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
 
-import java.nio.file.Path;
-import java.util.Map;
+import jeeves.constants.Jeeves;
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -98,7 +98,7 @@ public class GetLatestUpdated implements Service {
             Log.info(Geonet.SEARCH_ENGINE, "Creating latest updates searcher");
             try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {
                 searcher.search(context, _request, _config);
-                Map<Integer, Metadata> allMdInfo = ((LuceneSearcher) searcher).getAllMdInfo(context, _maxItems);
+                Map<Integer, IMetadata> allMdInfo = ((LuceneSearcher) searcher).getAllMdInfo(context, _maxItems);
                 for (Integer id : allMdInfo.keySet()) {
                     try {
                         boolean forEditing = false;

--- a/services/src/main/java/org/fao/geonet/guiservices/metadata/GetRelated.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/metadata/GetRelated.java
@@ -23,45 +23,27 @@
 
 package org.fao.geonet.guiservices.metadata;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Sets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Set;
 
-import jeeves.constants.Jeeves;
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
-import jeeves.server.dispatchers.ServiceManager;
+import javax.servlet.http.HttpServletRequest;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Util;
-import org.fao.geonet.api.records.MetadataUtils;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.RelatedMetadata;
-import org.fao.geonet.kernel.SchemaManager;
-import org.fao.geonet.kernel.schema.AssociatedResource;
-import org.fao.geonet.kernel.schema.AssociatedResourcesSchemaPlugin;
-import org.fao.geonet.kernel.schema.SchemaPlugin;
-import org.fao.geonet.kernel.search.MetaSearcher;
-import org.fao.geonet.kernel.search.SearchManager;
-import org.fao.geonet.kernel.search.SearcherType;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.services.Utils;
-import org.fao.geonet.services.metadata.Show;
-import org.fao.geonet.services.relations.Get;
-import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
-import org.jdom.Content;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -73,13 +55,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Sets;
 
-import javax.servlet.http.HttpServletRequest;
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+import jeeves.server.dispatchers.ServiceManager;
 
 /**
  * Perform a search and return all children metadata record for current record.
@@ -175,11 +157,11 @@ public class GetRelated implements Service, RelatedMetadata {
         ConfigurableApplicationContext appContext = ApplicationContextHolder.get();
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
         GeonetworkDataDirectory dataDirectory = appContext.getBean(GeonetworkDataDirectory.class);
-        MetadataRepository metadataRepository = appContext.getBean(MetadataRepository.class);
+        IMetadataUtils metadataRepository = appContext.getBean(IMetadataUtils.class);
 
         final ServiceContext context = serviceManager.createServiceContext("xml.relation", lang, request);
 
-        Metadata md;
+        IMetadata md;
         if (id != null) {
             md = metadataRepository.findOne(id);
 

--- a/services/src/main/java/org/fao/geonet/guiservices/metadata/Sitemap.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/metadata/Sitemap.java
@@ -28,10 +28,7 @@
 package org.fao.geonet.guiservices.metadata;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.fao.geonet.Util;
 import org.fao.geonet.domain.ISODate;
@@ -41,8 +38,7 @@ import org.fao.geonet.domain.OperationAllowed;
 import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.exceptions.SitemapDocumentNotFoundEx;
-import org.fao.geonet.kernel.AccessManager;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.repository.specification.OperationAllowedSpecs;
@@ -100,8 +96,8 @@ public class Sitemap implements Service {
 
         OperationAllowedRepository operationAllowedRepository =
             context.getBean(OperationAllowedRepository.class);
-        MetadataRepository metadataRepository =
-            context.getBean(MetadataRepository.class);
+        IMetadataUtils metadataRepository =
+            context.getBean(IMetadataUtils.class);
 
         final List<Integer> list = operationAllowedRepository.findAllIds(spec,
             OperationAllowedId_.metadataId);

--- a/services/src/main/java/org/fao/geonet/guiservices/templates/AddDefault.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/templates/AddDefault.java
@@ -133,7 +133,8 @@ public class AddDefault implements Service {
                         //
                         // insert metadata
                         //
-                        Metadata metadata = new Metadata().setUuid(uuid);
+                        Metadata metadata = new Metadata();
+                        metadata.setUuid(uuid);
                         metadata.getDataInfo().
                             setSchemaId(schemaName).
                             setRoot(xml.getQualifiedName()).

--- a/services/src/main/java/org/fao/geonet/services/category/Remove.java
+++ b/services/src/main/java/org/fao/geonet/services/category/Remove.java
@@ -23,16 +23,13 @@
 
 package org.fao.geonet.services.category;
 
-import com.google.common.base.Functions;
-import com.google.common.collect.Lists;
-
-import jeeves.services.ReadWriteController;
+import java.util.List;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.MediaType;
@@ -41,7 +38,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.List;
+import com.google.common.base.Functions;
+import com.google.common.collect.Lists;
+
+import jeeves.services.ReadWriteController;
 
 /**
  * Removes a category from the system.
@@ -63,7 +63,7 @@ public class Remove {
 
         ConfigurableApplicationContext appContext = ApplicationContextHolder.get();
         MetadataCategoryRepository categoryRepository = appContext.getBean(MetadataCategoryRepository.class);
-        MetadataRepository metadataRepository = appContext.getBean(MetadataRepository.class);
+        IMetadataUtils metadataRepository = appContext.getBean(IMetadataUtils.class);
         DataManager dataManager = appContext.getBean(DataManager.class);
 
         final MetadataCategory category = categoryRepository.findOne(id);

--- a/services/src/main/java/org/fao/geonet/services/config/Set.java
+++ b/services/src/main/java/org/fao/geonet/services/config/Set.java
@@ -23,11 +23,11 @@
 
 package org.fao.geonet.services.config;
 
-import jeeves.config.springutil.ServerBeanPropertyUpdater;
-import jeeves.constants.Jeeves;
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Root;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.api.site.SiteApi;
@@ -37,20 +37,20 @@ import org.fao.geonet.domain.MetadataSourceInfo_;
 import org.fao.geonet.domain.Metadata_;
 import org.fao.geonet.domain.Source;
 import org.fao.geonet.exceptions.OperationAbortedEx;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.PathSpec;
 import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
-import org.fao.geonet.repository.PathSpec;
 import org.jdom.Element;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.persistence.criteria.Path;
-import javax.persistence.criteria.Root;
+import jeeves.config.springutil.ServerBeanPropertyUpdater;
+import jeeves.constants.Jeeves;
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -93,7 +93,7 @@ public class Set implements Service {
         String newUuid = values.get(Settings.SYSTEM_SITE_SITE_ID_PATH);
 
         if (newUuid != null && !currentUuid.equals(newUuid)) {
-            final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+            final IMetadataManager metadataRepository = context.getBean(IMetadataManager.class);
             final SourceRepository sourceRepository = context.getBean(SourceRepository.class);
             final Source source = sourceRepository.findOne(currentUuid);
             Source newSource = new Source(newUuid, source.getName(), source.getLabelTranslations(), source.isLocal());

--- a/services/src/main/java/org/fao/geonet/services/feedback/AddLimitations.java
+++ b/services/src/main/java/org/fao/geonet/services/feedback/AddLimitations.java
@@ -23,15 +23,17 @@
 
 package org.fao.geonet.services.feedback;
 
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
 
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.kernel.DataManager;
@@ -44,12 +46,10 @@ import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -103,7 +103,7 @@ public class AddLimitations implements Service {
         Lib.resource.checkPrivilege(context, id, ReservedOperation.download);
 
         //--- get metadata info
-        Metadata info = context.getBean(MetadataRepository.class).findOne(id);
+        IMetadata info = context.getBean(MetadataRepository.class).findOne(id);
 
         if (info == null)
             throw new IllegalArgumentException("Metadata not found --> " + id);

--- a/services/src/main/java/org/fao/geonet/services/feedback/Insert.java
+++ b/services/src/main/java/org/fao/geonet/services/feedback/Insert.java
@@ -31,10 +31,9 @@ import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.util.MailUtil;
 import org.jdom.Element;
 
@@ -96,7 +95,7 @@ public class Insert implements Service {
         if (metadataEmail != null) {
             //Check metadata email belongs to metadata
             //security!!
-            Metadata md = gc.getBean(MetadataRepository.class).findOneByUuid(uuid);
+            IMetadata md = gc.getBean(IMetadataUtils.class).findOneByUuid(uuid);
             if(md.getData().indexOf(metadataEmail) > 0) {
                 toAddress.add(metadataEmail);
             }

--- a/services/src/main/java/org/fao/geonet/services/metadata/BatchDelete.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/BatchDelete.java
@@ -23,32 +23,32 @@
 
 package org.fao.geonet.services.metadata;
 
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.SelectionManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.mef.MEFLib;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.IO;
+import org.jdom.Element;
+
 import com.google.common.collect.Sets;
 
 import jeeves.constants.Jeeves;
 import jeeves.server.ServiceConfig;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.Util;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.kernel.AccessManager;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.GeonetworkDataDirectory;
-import org.fao.geonet.kernel.SelectionManager;
-import org.fao.geonet.kernel.mef.MEFLib;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.utils.IO;
-import org.jdom.Element;
-
-import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Removes a metadata from the system.
@@ -89,13 +89,13 @@ public class BatchDelete extends BackupFileService {
             SelectionManager.updateSelection("metadata", session, clearSelectionParams, context);
         }
 
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
         for (String uuid : selection) {
             if (context.isDebugEnabled()) {
                 context.debug("Deleting metadata with uuid:" + uuid);
             }
 
-            Metadata info = metadataRepository.findOneByUuid(uuid);
+            IMetadata info = metadataRepository.findOneByUuid(uuid);
             if (info == null) {
                 notFound.add(uuid);
             } else if (!accessMan.isOwner(context, String.valueOf(info.getId()))) {

--- a/services/src/main/java/org/fao/geonet/services/metadata/BatchNewOwner.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/BatchNewOwner.java
@@ -23,25 +23,26 @@
 
 package org.fao.geonet.services.metadata;
 
-import com.google.common.base.Optional;
+import static org.fao.geonet.api.records.MetadataSharingApi.retrievePrivileges;
+import static org.fao.geonet.kernel.SelectionManager.SELECTION_METADATA;
 
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-import jeeves.server.dispatchers.ServiceManager;
-import jeeves.services.ReadWriteController;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Vector;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.xml.bind.annotation.XmlRootElement;
 
 import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.OperationAllowedId;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.SelectionManager;
 import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,21 +50,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.Vector;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.xml.bind.annotation.XmlRootElement;
-
-import static org.fao.geonet.api.records.MetadataSharingApi.retrievePrivileges;
-import static org.fao.geonet.kernel.SelectionManager.SELECTION_METADATA;
-import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasGroupId;
-import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasMetadataId;
-import static org.springframework.data.jpa.domain.Specifications.where;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import jeeves.server.dispatchers.ServiceManager;
+import jeeves.services.ReadWriteController;
 
 
 /**
@@ -123,7 +113,7 @@ public class BatchNewOwner {
             context.info("Attempting to set metadata owner on: " + id);
 
             //--- check existence and access
-            Metadata info = null;
+            IMetadata info = null;
             if (id != null) {
                 info = context.getBean(MetadataRepository.class).findOne(id);
             }

--- a/services/src/main/java/org/fao/geonet/services/metadata/BatchUpdatePrivileges.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/BatchUpdatePrivileges.java
@@ -23,24 +23,7 @@
 
 package org.fao.geonet.services.metadata;
 
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.Profile;
-import org.fao.geonet.domain.ReservedGroup;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.kernel.AccessManager;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.SelectionManager;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.services.NotInReadOnlyModeService;
-import org.jdom.Element;
+import static org.fao.geonet.kernel.SelectionManager.SELECTION_METADATA;
 
 import java.nio.file.Path;
 import java.util.HashSet;
@@ -49,7 +32,24 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import static org.fao.geonet.kernel.SelectionManager.SELECTION_METADATA;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.ReservedGroup;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SelectionManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.services.NotInReadOnlyModeService;
+import org.jdom.Element;
+
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Stores all operations allowed for a metadata.
@@ -91,7 +91,7 @@ public class BatchUpdatePrivileges extends NotInReadOnlyModeService {
 
                 //--- check access
 
-                Metadata info = context.getBean(MetadataRepository.class).findOneByUuid(uuid);
+                IMetadata info = context.getBean(IMetadataUtils.class).findOneByUuid(uuid);
                 if (info == null) {
                     notFound.add(uuid);
                 } else if (!accessMan.isOwner(context, String.valueOf(info.getId()))) {

--- a/services/src/main/java/org/fao/geonet/services/metadata/BatchUpdateStatus.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/BatchUpdateStatus.java
@@ -23,30 +23,29 @@
 
 package org.fao.geonet.services.metadata;
 
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.Util;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.SelectionManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.metadata.StatusActions;
 import org.fao.geonet.kernel.metadata.StatusActionsFactory;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.services.NotInReadOnlyModeService;
 import org.jdom.Element;
 
-import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Assigns status to metadata.
@@ -84,7 +83,7 @@ public class BatchUpdateStatus extends NotInReadOnlyModeService {
         Set<Integer> notFound = new HashSet<Integer>();
         Set<Integer> notOwner = new HashSet<Integer>();
 
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
         synchronized (sm.getSelection("metadata")) {
             for (Iterator<String> iter = sm.getSelection("metadata").iterator(); iter.hasNext(); ) {
                 String uuid = (String) iter.next();

--- a/services/src/main/java/org/fao/geonet/services/metadata/Convert.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Convert.java
@@ -23,16 +23,14 @@
 
 package org.fao.geonet.services.metadata;
 
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Path;
 
-import org.fao.geonet.Util;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.oaipmh.Lib;
@@ -41,7 +39,9 @@ import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.services.Utils;
 import org.jdom.Element;
 
-import java.nio.file.Path;
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -79,7 +79,7 @@ public class Convert implements Service {
         String styleSheet = Util.getParam(params, Params.STYLESHEET);
 
         //--- get metadata info and create an env that works with oai translators
-        final Metadata metadata = context.getBean(MetadataRepository.class).findOne(id);
+        final IMetadata metadata = context.getBean(MetadataRepository.class).findOne(id);
         Path schemaDir = sm.getSchemaDir(metadata.getDataInfo().getSchemaId());
         final String baseUrl = context.getBaseUrl();
         final ISODate changeDate = metadata.getDataInfo().getChangeDate();

--- a/services/src/main/java/org/fao/geonet/services/metadata/Delete.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Delete.java
@@ -23,15 +23,13 @@
 
 package org.fao.geonet.services.metadata;
 
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Path;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.exceptions.OperationNotAllowedEx;
 import org.fao.geonet.kernel.AccessManager;
@@ -44,7 +42,9 @@ import org.fao.geonet.services.Utils;
 import org.fao.geonet.utils.IO;
 import org.jdom.Element;
 
-import java.nio.file.Path;
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Removes a metadata from the system.
@@ -75,7 +75,7 @@ public class Delete extends BackupFileService {
         //-----------------------------------------------------------------------
         //--- check access
 
-        Metadata metadata = context.getBean(MetadataRepository.class).findOne(id);
+        IMetadata metadata = context.getBean(MetadataRepository.class).findOne(id);
 
         if (metadata == null)
             throw new IllegalArgumentException("Metadata with identifier " + id + " not found.");

--- a/services/src/main/java/org/fao/geonet/services/metadata/GetAdminOper.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/GetAdminOper.java
@@ -23,21 +23,24 @@
 
 package org.fao.geonet.services.metadata;
 
-import static org.springframework.data.jpa.domain.Specifications.*;
+import static org.springframework.data.jpa.domain.Specifications.where;
 
-import jeeves.constants.Jeeves;
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
 
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Operation;
 import org.fao.geonet.domain.OperationAllowed;
 import org.fao.geonet.domain.UserGroup;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
 import org.fao.geonet.kernel.AccessManager;
-import org.fao.geonet.repository.*;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.OperationRepository;
+import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.specification.OperationAllowedSpecs;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.fao.geonet.services.Utils;
@@ -45,9 +48,10 @@ import org.jdom.Element;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.Specifications;
 
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Set;
+import jeeves.constants.Jeeves;
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -79,7 +83,7 @@ public class GetAdminOper implements Service {
         //-----------------------------------------------------------------------
         //--- check access
 
-        Metadata info = context.getBean(MetadataRepository.class).findOne(metadataId);
+        IMetadata info = context.getBean(MetadataRepository.class).findOne(metadataId);
 
         if (info == null)
             throw new MetadataNotFoundEx(metadataId);

--- a/services/src/main/java/org/fao/geonet/services/metadata/GetCategories.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/GetCategories.java
@@ -23,23 +23,23 @@
 
 package org.fao.geonet.services.metadata;
 
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.repository.MetadataCategoryRepository;
+import org.fao.geonet.services.Utils;
+import org.jdom.Element;
+
 import jeeves.constants.Jeeves;
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataCategory;
-import org.fao.geonet.kernel.AccessManager;
-import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.services.Utils;
-import org.jdom.Element;
-
-import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.List;
 
 //=============================================================================
 
@@ -72,7 +72,7 @@ public class GetCategories implements Service {
         //--- check access
         int iLocalId = Integer.parseInt(id);
 
-        final Metadata metadata = context.getBean(MetadataRepository.class).findOne(iLocalId);
+        final IMetadata metadata = context.getBean(IMetadataUtils.class).findOne(iLocalId);
         if (metadata == null) {
             throw new IllegalArgumentException("Metadata not found --> " + id);
         }

--- a/services/src/main/java/org/fao/geonet/services/metadata/GetSuggestion.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/GetSuggestion.java
@@ -23,14 +23,16 @@
 
 package org.fao.geonet.services.metadata;
 
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -39,11 +41,9 @@ import org.fao.geonet.services.Utils;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Get suggestion for all metadata
@@ -97,7 +97,7 @@ public class GetSuggestion implements Service {
 
         // Retrieve metadata record
         String id = Utils.getIdentifierFromParameters(params, context);
-        Metadata mdInfo = gc.getBean(MetadataRepository.class).findOne(id);
+        IMetadata mdInfo = gc.getBean(MetadataRepository.class).findOne(id);
         boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = false;
         Element md = gc.getBean(DataManager.class).getMetadata(context, id, forEditing, withValidationErrors, keepXlinkAttributes);
 

--- a/services/src/main/java/org/fao/geonet/services/metadata/Rate.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Rate.java
@@ -23,11 +23,16 @@
 
 package org.fao.geonet.services.metadata;
 
+import static org.fao.geonet.kernel.setting.Settings.SYSTEM_LOCALRATING_ENABLE;
+
+import java.net.URL;
+import java.nio.file.Path;
+
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.exceptions.BadServerResponseEx;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
@@ -45,13 +50,8 @@ import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Element;
 
-import java.net.URL;
-import java.nio.file.Path;
-
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
-
-import static org.fao.geonet.kernel.setting.Settings.SYSTEM_LOCALRATING_ENABLE;
 
 /**
  * User rating of metadata. If the metadata was harvested using the 'GeoNetwork' protocol and the
@@ -135,7 +135,7 @@ public class Rate extends NotInReadOnlyModeService {
     //--------------------------------------------------------------------------
 
     private String getHarvestingUuid(ServiceContext context, String id) throws Exception {
-        final Metadata metadata = context.getBean(MetadataRepository.class).findOne(id);
+        final IMetadata metadata = context.getBean(MetadataRepository.class).findOne(id);
 
         //--- if we don't have any metadata, just return
 

--- a/services/src/main/java/org/fao/geonet/services/metadata/Show.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Show.java
@@ -23,26 +23,28 @@
 
 package org.fao.geonet.services.metadata;
 
-import jeeves.server.ServiceConfig;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Path;
 
-import org.fao.geonet.Util;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.utils.Xml;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
-import org.fao.geonet.kernel.*;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.XmlSerializer;
 import org.fao.geonet.lib.Lib;
+import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.services.Utils;
+import org.fao.geonet.utils.Xml;
 import org.jdom.Attribute;
 import org.jdom.Element;
 
-import java.nio.file.Path;
+import jeeves.server.ServiceConfig;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 //=============================================================================
 
@@ -149,7 +151,7 @@ public class Show extends ShowViewBaseService {
         // that is in the GeoNetwork schema identification and if there isn't one
         // of those then build one pointing to the XSD in GeoNetwork
 
-        Metadata info = context.getBean(MetadataRepository.class).findOne(id);
+        IMetadata info = context.getBean(MetadataRepository.class).findOne(id);
         Attribute schemaLocAtt = sm.getSchemaLocation(info.getDataInfo().getSchemaId(), context);
 
         if (schemaLocAtt != null) {

--- a/services/src/main/java/org/fao/geonet/services/metadata/Update.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Update.java
@@ -23,41 +23,40 @@
 
 package org.fao.geonet.services.metadata;
 
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.GeonetContext;
-
-import org.fao.geonet.Util;
-import org.fao.geonet.api.records.editing.AjaxEditUtils;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.ReservedGroup;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.metadata.StatusActions;
-import org.fao.geonet.kernel.metadata.StatusActionsFactory;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.MetadataValidationRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
-import org.fao.geonet.repository.specification.MetadataValidationSpecs;
-import org.fao.geonet.utils.Xml;
-import org.fao.geonet.services.NotInReadOnlyModeService;
-import org.fao.geonet.services.Utils;
-import org.jdom.Document;
-import org.jdom.Element;
-
-import java.nio.file.Path;
-
 import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasGroupId;
 import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasMetadataId;
 import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasOperation;
 import static org.springframework.data.jpa.domain.Specifications.where;
+
+import java.nio.file.Path;
+
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
+import org.fao.geonet.api.records.editing.AjaxEditUtils;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.domain.ReservedGroup;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.metadata.StatusActions;
+import org.fao.geonet.kernel.metadata.StatusActionsFactory;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.repository.MetadataValidationRepository;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.specification.MetadataValidationSpecs;
+import org.fao.geonet.services.NotInReadOnlyModeService;
+import org.fao.geonet.services.Utils;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Document;
+import org.jdom.Element;
+
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * For editing : update leaves information. Access is restricted.
@@ -156,8 +155,8 @@ public class Update extends NotInReadOnlyModeService {
 
 			// Save validation if the forceValidationOnMdSave is enabled
 			if (forceValidationOnMdSave && !showValidationErrors.equals("true")) {
-				final MetadataRepository metadataRepository = gc.getBean(MetadataRepository.class);
-				Metadata metadata = metadataRepository.findOne(id);
+				final IMetadataUtils metadataRepository = gc.getBean(IMetadataUtils.class);
+				IMetadata metadata = metadataRepository.findOne(id);
 
 				dataMan.doValidate(metadata.getDataInfo().getSchemaId(), metadata.getId() + "",
 						new Document(metadata.getXmlData(false)), context.getLanguage());

--- a/services/src/main/java/org/fao/geonet/services/metadata/UpdateAdminOper.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/UpdateAdminOper.java
@@ -23,21 +23,22 @@
 
 package org.fao.geonet.services.metadata;
 
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import org.fao.geonet.Util;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Profile;
 import org.fao.geonet.domain.ReservedGroup;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.MetadataValidationRepository;
@@ -47,10 +48,10 @@ import org.fao.geonet.services.Utils;
 import org.jdom.Document;
 import org.jdom.Element;
 
-import java.nio.file.Path;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 
 /**
@@ -97,7 +98,7 @@ public class UpdateAdminOper extends NotInReadOnlyModeService {
         //-----------------------------------------------------------------------
         //--- check access
 
-        Metadata info = context.getBean(MetadataRepository.class).findOne(id);
+		IMetadata info = context.getBean(MetadataRepository.class).findOne(id);
 
         if (info == null)
             throw new MetadataNotFoundEx(id);
@@ -187,14 +188,14 @@ public class UpdateAdminOper extends NotInReadOnlyModeService {
      * @throws Exception
      */
 	private boolean canPublishToAllGroup(ServiceContext context, DataManager dm, int mdId) throws Exception {
-		MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+	    IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
 		MetadataValidationRepository metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
 
 		boolean hasValidation =
 				(metadataValidationRepository.count(MetadataValidationSpecs.hasMetadataId(mdId)) > 0);
 
 		if (!hasValidation) {
-			Metadata metadata = metadataRepository.findOne(mdId);
+			IMetadata metadata = metadataUtils.findOne(mdId);
 
 			dm.doValidate(metadata.getDataInfo().getSchemaId(), mdId + "",
 					new Document(metadata.getXmlData(false)), context.getLanguage());

--- a/services/src/main/java/org/fao/geonet/services/metadata/UpdateGroupOwner.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/UpdateGroupOwner.java
@@ -24,25 +24,26 @@
 package org.fao.geonet.services.metadata;
 
 
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Path;
 
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Group;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.exceptions.OperationNotAllowedEx;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.services.NotInReadOnlyModeService;
 import org.fao.geonet.services.Utils;
 import org.jdom.Element;
 
-import java.nio.file.Path;
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Update the metadata group owner.
@@ -90,8 +91,9 @@ public class UpdateGroupOwner extends NotInReadOnlyModeService {
         }
 
         //--- Update groupOwner
-        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
-        Metadata metadata = metadataRepository.findOne(iLocalId);
+        IMetadataManager metadataRepository = context.getBean(IMetadataManager.class);
+        IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
+        IMetadata metadata = metadataUtils.findOne(iLocalId);
         metadata.getSourceInfo().setGroupOwner(iGroupOwner);
         metadataRepository.save(metadata);
 

--- a/services/src/main/java/org/fao/geonet/services/metadata/ValidationService.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/ValidationService.java
@@ -23,17 +23,18 @@
 
 package org.fao.geonet.services.metadata;
 
-import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
-import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.responses.StatusResponse;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.SelectionManager;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.jdom.Document;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -43,7 +44,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.*;
+import com.google.common.collect.Sets;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Validate metadata records.
@@ -119,9 +123,9 @@ public class ValidationService implements ApplicationContextAware {
         DataManager dataMan = context.getBean(DataManager.class);
         AccessManager accessMan = context.getBean(AccessManager.class);
 
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
         for (String uuid : setOfUuidsToValidate) {
-            Metadata record = metadataRepository.findOneByUuid(uuid);
+            IMetadata record = metadataRepository.findOneByUuid(uuid);
             if (record == null) {
                 this.report.get("notFoundRecords").add(record.getId());
             } else if (!accessMan.isOwner(serviceContext, String.valueOf(record.getId()))) {

--- a/services/src/main/java/org/fao/geonet/services/ownership/Transfer.java
+++ b/services/src/main/java/org/fao/geonet/services/ownership/Transfer.java
@@ -23,29 +23,34 @@
 
 package org.fao.geonet.services.ownership;
 
-import static org.fao.geonet.repository.specification.OperationAllowedSpecs.*;
+import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasGroupId;
 
-import com.google.common.base.Optional;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
 
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.Util;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.OperationAllowed;
 import org.fao.geonet.domain.OperationAllowedId;
 import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.services.NotInReadOnlyModeService;
 import org.jdom.Element;
 
-import java.nio.file.Path;
-import java.sql.SQLException;
-import java.util.*;
+import com.google.common.base.Optional;
+
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 /**
  *
@@ -76,7 +81,8 @@ public class Transfer extends NotInReadOnlyModeService {
 
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
         DataManager dm = gc.getBean(DataManager.class);
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
+        final IMetadataManager metadataManager = context.getBean(IMetadataManager.class);
 
         //--- transfer privileges (if case)
 
@@ -132,9 +138,9 @@ public class Transfer extends NotInReadOnlyModeService {
 
         // Set owner for all records to be modified.
         for (Integer i : metadata) {
-            final Metadata metadata1 = metadataRepository.findOne(i);
+            final IMetadata metadata1 = metadataRepository.findOne(i);
             metadata1.getSourceInfo().setGroupOwner(targetGrp).setOwner(targetUsr);
-            metadataRepository.save(metadata1);
+            metadataManager.save(metadata1);
         }
 
         dm.flush();

--- a/services/src/main/java/org/fao/geonet/services/region/MetadataRegionDAO.java
+++ b/services/src/main/java/org/fao/geonet/services/region/MetadataRegionDAO.java
@@ -23,24 +23,20 @@
 
 package org.fao.geonet.services.region;
 
+import java.util.Collection;
+import java.util.Collections;
+
+import org.fao.geonet.api.regions.metadata.MetadataRegionSearchRequest;
+import org.fao.geonet.kernel.region.RegionsDAO;
+import org.fao.geonet.kernel.region.Request;
+import org.geotools.gml3.GMLConfiguration;
+import org.geotools.xml.Parser;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 
 import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.region.RegionsDAO;
-import org.fao.geonet.kernel.region.Request;
-import org.fao.geonet.kernel.search.SearchManager;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.api.regions.metadata.MetadataRegionSearchRequest;
-import org.geotools.gml3.GMLConfiguration;
-import org.geotools.xml.Parser;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Collection;
-import java.util.Collections;
 
 /**
  * A Regions DAO that fetches geometries from a metadata.  The geometry ids are structured as
@@ -57,12 +53,6 @@ public class MetadataRegionDAO extends RegionsDAO {
     public static final String CATEGORY_NAME = "metadata";
     private final Parser parser = new Parser(new GMLConfiguration());
     private final GeometryFactory factory = new GeometryFactory();
-    @Autowired
-    private DataManager dataManager;
-    @Autowired
-    private SearchManager searchManager;
-    @Autowired
-    private MetadataRepository metadataRepository;
 
     @Override
     public Collection<String> getRegionCategoryIds(ServiceContext context) throws Exception {

--- a/services/src/main/java/org/fao/geonet/services/reports/ReportUpdatedMetadata.java
+++ b/services/src/main/java/org/fao/geonet/services/reports/ReportUpdatedMetadata.java
@@ -23,21 +23,25 @@
 
 package org.fao.geonet.services.reports;
 
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.fao.geonet.Util;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.jdom.Element;
+
 import jeeves.constants.Jeeves;
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.Util;
-import org.fao.geonet.domain.*;
-import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.UserRepository;
-import org.jdom.Element;
-
-
-import java.nio.file.Path;
-import java.util.*;
 
 /**
  * Service to return the updated metadata during a period.
@@ -82,14 +86,14 @@ public class ReportUpdatedMetadata implements Service {
         Set<Integer> groupList = ReportUtils.groupsForFilter(context, params);
 
         // Retrieve metadata
-        final List<Metadata> records = context.getBean(MetadataRepository.class).getMetadataReports().
+        final List<? extends IMetadata> records = context.getBean(IMetadataUtils.class).getMetadataReports().
             getUpdatedMetadata(beginDateIso, endDateIso, groupList);
 
         // Process metadata results for the report
         Element response = new Element(Jeeves.Elem.RESPONSE);
 
         // Process the records
-        for (Metadata metadata : records) {
+        for (IMetadata metadata : records) {
             User userOwner = context.getBean(UserRepository.class).findOne(metadata.getSourceInfo().getOwner());
             final Integer mdGroupOwner = metadata.getSourceInfo().getGroupOwner();
             String groupOwnerName = "";

--- a/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
@@ -23,36 +23,6 @@
 
 package org.fao.geonet.services.resources;
 
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.Util;
-import org.fao.geonet.utils.FilePathChecker;
-import org.fao.geonet.ZipUtil;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Group;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.OperationAllowed;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.domain.User;
-import org.fao.geonet.exceptions.BadParameterEx;
-import org.fao.geonet.exceptions.MetadataNotFoundEx;
-import org.fao.geonet.exceptions.ResourceNotFoundEx;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.mef.MEFLib;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
-import org.fao.geonet.repository.UserRepository;
-import org.fao.geonet.services.Utils;
-import org.fao.geonet.services.resources.handlers.IResourceDownloadHandler;
-import org.fao.geonet.util.MailSender;
-import org.fao.geonet.utils.BinaryFile;
-import org.fao.geonet.utils.IO;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Element;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -67,6 +37,35 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.Util;
+import org.fao.geonet.ZipUtil;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.OperationAllowed;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.exceptions.MetadataNotFoundEx;
+import org.fao.geonet.exceptions.ResourceNotFoundEx;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.mef.MEFLib;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.OperationAllowedRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.services.Utils;
+import org.fao.geonet.services.resources.handlers.IResourceDownloadHandler;
+import org.fao.geonet.util.MailSender;
+import org.fao.geonet.utils.BinaryFile;
+import org.fao.geonet.utils.FilePathChecker;
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
 
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
@@ -171,7 +170,7 @@ public class DownloadArchive implements Service {
         }
 
         //--- get metadata info
-        Metadata info = context.getBean(MetadataRepository.class).findOne(id);
+        IMetadata info = context.getBean(MetadataRepository.class).findOne(id);
 
         // set up zip output stream
         Path zFile = Files.createTempFile(username + "_" + info.getUuid(), ".zip");

--- a/services/src/main/java/org/fao/geonet/services/resources/Upload.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/Upload.java
@@ -23,21 +23,21 @@
 
 package org.fao.geonet.services.resources;
 
+import java.nio.file.Path;
+
+import org.fao.geonet.Util;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.services.Utils;
+import org.fao.geonet.services.resources.handlers.IResourceUploadHandler;
+import org.jdom.Element;
+
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
-
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.services.resources.handlers.IResourceUploadHandler;
-import org.fao.geonet.Util;
-import org.fao.geonet.constants.Params;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.services.Utils;
-import org.jdom.Element;
-
-import java.nio.file.Path;
 
 //=============================================================================
 
@@ -78,7 +78,7 @@ public class Upload implements Service {
             username = "unknown (this shouldn't happen?)";
 
 
-        final Metadata metadata = context.getBean(MetadataRepository.class).findOne(id);
+        final IMetadata metadata = context.getBean(MetadataRepository.class).findOne(id);
 
         String mdUuid = metadata.getUuid();
 

--- a/services/src/main/java/org/fao/geonet/services/subtemplate/Get.java
+++ b/services/src/main/java/org/fao/geonet/services/subtemplate/Get.java
@@ -22,32 +22,29 @@
 //==============================================================================
 package org.fao.geonet.services.subtemplate;
 
-import com.google.common.collect.Sets;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
-import com.google.common.collect.Lists;
-
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
-
+import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
-import org.fao.geonet.Util;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Attribute;
 import org.jdom.Element;
-
-import java.util.Iterator;
-
 import org.jdom.Namespace;
 
-import java.nio.file.Path;
-import java.util.Set;
-import java.util.List;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Retrieve sub template from metadata table
@@ -81,8 +78,8 @@ public class Get implements Service {
         String uuid = Util.getParam(params, Params.UUID);
 
         // Retrieve template
-        final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
-        final Metadata metadata = metadataRepository.findOneByUuid(uuid);
+        final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
+        final IMetadata metadata = metadataRepository.findOneByUuid(uuid);
 
         if (metadata == null) {
             Log.error(Geonet.DATA_MANAGER, String.format("Subtemplate '%s' not found. Check records related to this directory entry.", uuid));

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataApiTest.java
@@ -137,7 +137,8 @@ public class MetadataApiTest extends AbstractServiceIntegrationTest {
 
         String source = sourceRepository.findAll().get(0).getUuid();
         String schema = schemaManager.autodetectSchema(sampleMetadataXml);
-        final Metadata metadata = new Metadata().setDataAndFixCR(sampleMetadataXml).setUuid(uuid);
+        final Metadata metadata = new Metadata();
+        metadata.setDataAndFixCR(sampleMetadataXml).setUuid(uuid);
         metadata.getDataInfo().setRoot(sampleMetadataXml.getQualifiedName()).setSchemaId(schema).setType(MetadataType.METADATA);
         metadata.getDataInfo().setPopularity(1000);
         metadata.getSourceInfo().setOwner(1).setSourceId(source);

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataApiTest.java
@@ -22,52 +22,6 @@
  */
 package org.fao.geonet.api.records;
 
-import com.google.common.collect.Lists;
-import jeeves.server.context.ServiceContext;
-import org.fao.geonet.NodeInfo;
-import org.fao.geonet.api.ApiParams;
-import org.fao.geonet.api.records.model.related.RelatedItemType;
-import org.fao.geonet.constants.Params;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.SchemaManager;
-import org.fao.geonet.kernel.SpringLocalServiceInvoker;
-import org.fao.geonet.kernel.UpdateDatestamp;
-import org.fao.geonet.kernel.mef.MEFLibIntegrationTest;
-import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRelationRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.SourceRepository;
-import org.fao.geonet.services.AbstractServiceIntegrationTest;
-import org.fao.geonet.utils.Xml;
-import org.jdom.Element;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpSession;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-
-import javax.imageio.ImageIO;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V1_ACCEPT_TYPE;
 import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V2_ACCEPT_TYPE;
 import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GCO;
@@ -91,6 +45,55 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
 
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.imageio.ImageIO;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.fao.geonet.NodeInfo;
+import org.fao.geonet.api.ApiParams;
+import org.fao.geonet.api.records.model.related.RelatedItemType;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.SpringLocalServiceInvoker;
+import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.mef.MEFLibIntegrationTest;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.repository.SourceRepository;
+import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.google.common.collect.Lists;
+
+import jeeves.server.context.ServiceContext;
+
 
 /**
  * Tests for class {@link MetadataApi}.
@@ -110,15 +113,11 @@ public class MetadataApiTest extends AbstractServiceIntegrationTest {
     @PersistenceContext
     private EntityManager _entityManager;
 
-    @Autowired private MetadataRepository metadataRepository;
-    @Autowired
-    private MetadataRelationRepository metadataRelationRepository;
-
+    @Autowired private IMetadataUtils metadataRepository;
+    
     private String uuid;
     private int id;
-    private Metadata md;
-    private String childUuid;
-    private int childId;
+    private IMetadata md;
     private ServiceContext context;
 
 

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataValidateApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataValidateApiTest.java
@@ -184,7 +184,8 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
         URL resource = AbstractCoreIntegrationTest.class.getResource("kernel/sub-OnlineResource.xml");
         Element sampleMetadataXml = Xml.loadStream(resource.openStream());
 
-        Metadata metadata = new Metadata()
+        Metadata metadata = new Metadata();
+        metadata
                 .setDataAndFixCR(sampleMetadataXml)
                 .setUuid(UUID.randomUUID().toString());
         metadata.getDataInfo()

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataValidateApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataValidateApiTest.java
@@ -1,9 +1,21 @@
 package org.fao.geonet.api.records;
 
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
+import static junit.framework.Assert.assertEquals;
+import static org.fao.geonet.domain.MetadataValidationStatus.VALID;
+import static org.fao.geonet.kernel.UpdateDatestamp.NO;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URL;
+import java.util.List;
+import java.util.UUID;
+
 import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.domain.MetadataValidation;
@@ -28,18 +40,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.net.URL;
-import java.util.List;
-import java.util.UUID;
-
-import static junit.framework.Assert.assertEquals;
-import static org.fao.geonet.domain.MetadataValidationStatus.VALID;
-import static org.fao.geonet.kernel.UpdateDatestamp.NO;
-import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
     private static final int SUBTEMPLATE_TEST_OWNER = 42;
@@ -61,7 +63,7 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
 
     @Test
     public void subTemplateValidIsTrue() throws Exception {
-        Metadata subTemplate = subTemplateOnLineResourceDbInsert();
+        IMetadata subTemplate = subTemplateOnLineResourceDbInsert();
 
         MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
         MockHttpSession mockHttpSession = loginAsAdmin();
@@ -82,7 +84,7 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
 
     @Test
     public void subTemplateValidIsFalse() throws Exception {
-        Metadata subTemplate = subTemplateOnLineResourceDbInsert();
+        IMetadata subTemplate = subTemplateOnLineResourceDbInsert();
 
         MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
         MockHttpSession mockHttpSession = loginAsAdmin();
@@ -103,7 +105,7 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
 
     @Test
     public void subTemplateValidIsNotSet() throws Exception {
-        Metadata subTemplate = subTemplateOnLineResourceDbInsert();
+        IMetadata subTemplate = subTemplateOnLineResourceDbInsert();
 
         MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
         MockHttpSession mockHttpSession = loginAsAdmin();
@@ -123,7 +125,7 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
 
     @Test
     public void subTemplateValidIsTrueButNotLoggedAsAdmin() throws Exception {
-        Metadata subTemplate = subTemplateOnLineResourceDbInsert();
+        IMetadata subTemplate = subTemplateOnLineResourceDbInsert();
 
         MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
         MockHttpSession mockHttpSession = loginAsAnonymous();
@@ -144,7 +146,7 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
 
     @Test
     public void subTemplateValidSetButTemplate() throws Exception {
-        Metadata subTemplate = subTemplateOnLineResourceDbInsertAsMetadata();
+        IMetadata subTemplate = subTemplateOnLineResourceDbInsertAsMetadata();
 
         MockMvc toTest = MockMvcBuilders.webAppContextSetup(this.wac).build();
         MockHttpSession mockHttpSession = loginAsAdmin();
@@ -170,15 +172,15 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
         this.context = createServiceContext();
     }
 
-    private Metadata subTemplateOnLineResourceDbInsert() throws Exception {
+    private IMetadata subTemplateOnLineResourceDbInsert() throws Exception {
         return subTemplateOnLineResourceDbInsert(MetadataType.SUB_TEMPLATE);
     }
 
-    private Metadata subTemplateOnLineResourceDbInsertAsMetadata() throws Exception {
+    private IMetadata subTemplateOnLineResourceDbInsertAsMetadata() throws Exception {
         return subTemplateOnLineResourceDbInsert(MetadataType.METADATA);
     }
 
-    private Metadata subTemplateOnLineResourceDbInsert(MetadataType type) throws Exception {
+    private IMetadata subTemplateOnLineResourceDbInsert(MetadataType type) throws Exception {
         loginAsAdmin(context);
 
         URL resource = AbstractCoreIntegrationTest.class.getResource("kernel/sub-OnlineResource.xml");
@@ -199,7 +201,7 @@ public class MetadataValidateApiTest extends AbstractServiceIntegrationTest {
         metadata.getHarvestInfo()
                 .setHarvested(false);
 
-        Metadata dbInsertedMetadata = dataManager.insertMetadata(
+        IMetadata dbInsertedMetadata = dataManager.insertMetadata(
                 context,
                 metadata,
                 sampleMetadataXml,

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/FormatterApiIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/FormatterApiIntegrationTest.java
@@ -128,7 +128,8 @@ public class FormatterApiIntegrationTest extends AbstractServiceIntegrationTest 
 
         String source = sourceRepository.findAll().get(0).getUuid();
         this.schema = schemaManager.autodetectSchema(sampleMetadataXml);
-        final Metadata metadata = new Metadata().setDataAndFixCR(sampleMetadataXml).setUuid(uuid);
+        final Metadata metadata = new Metadata();
+        metadata.setDataAndFixCR(sampleMetadataXml).setUuid(uuid);
         metadata.getDataInfo().setRoot(sampleMetadataXml.getQualifiedName()).setSchemaId(this.schema).setType(MetadataType.METADATA);
         metadata.getSourceInfo().setOwner(1).setSourceId(source);
         metadata.getHarvestInfo().setHarvested(false);

--- a/services/src/test/java/org/fao/geonet/api/registries/ApiImportSpatialDirectoryEntriesTest.java
+++ b/services/src/test/java/org/fao/geonet/api/registries/ApiImportSpatialDirectoryEntriesTest.java
@@ -1,11 +1,21 @@
 package org.fao.geonet.api.registries;
 
-import org.apache.http.HttpRequest;
+import static org.fao.geonet.repository.specification.MetadataSpecs.isOwnedByUser;
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.kernel.SpringLocalServiceInvoker;
-import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,22 +23,12 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
 
-import javax.servlet.http.HttpSession;
-
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.InputStreamReader;
-import java.util.List;
-
-import static org.fao.geonet.repository.specification.MetadataSpecs.isOwnedByUser;
-import static org.junit.Assert.assertEquals;
-
 public class ApiImportSpatialDirectoryEntriesTest extends AbstractServiceIntegrationTest {
 
     public static final int USER_ID = 42;
 
     @Autowired
-    private MetadataRepository metadataRepo;
+    private IMetadataUtils metadataRepo;
 
     @Autowired
     private SpringLocalServiceInvoker invoker;
@@ -103,10 +103,10 @@ public class ApiImportSpatialDirectoryEntriesTest extends AbstractServiceIntegra
         assertEquals(200, response.getStatus());
         assertEquals(3, report.getNumberOfRecords());
 
-        List<Metadata> datas = metadataRepo.findAll(isOwnedByUser(USER_ID));
+        List<? extends IMetadata> datas = metadataRepo.findAll(isOwnedByUser(USER_ID));
         assertEquals(3, datas.size());
 
-        Metadata data = metadataRepo.findOneByUuid("111");
+        IMetadata data = metadataRepo.findOneByUuid("111");
         BufferedReader expectedBRForFirst = new BufferedReader(new InputStreamReader(getClass().getClassLoader().getResourceAsStream("org/fao/geonet/api/registries/" + expectedFileName)));
         BufferedReader BRForFirst = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data.getData().getBytes())));
 

--- a/services/src/test/java/org/fao/geonet/services/category/RemoveTest.java
+++ b/services/src/test/java/org/fao/geonet/services/category/RemoveTest.java
@@ -23,28 +23,31 @@
 
 package org.fao.geonet.services.category;
 
-import jeeves.server.context.ServiceContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import org.fao.geonet.domain.Metadata;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.fao.geonet.domain.IMetadata;
 import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.MetadataRepositoryTest;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import jeeves.server.context.ServiceContext;
 
 /**
  * Test for Category Remove service User: Jesse Date: 11/1/13 Time: 7:08 PM
  */
 public class RemoveTest extends AbstractServiceIntegrationTest {
     @Autowired
-    MetadataRepository _MetadataRepository;
+    IMetadataUtils metadataUtils;
+    @Autowired
+    IMetadataManager metadataManager;
     @Autowired
     MetadataCategoryRepository _categoryRepository;
     @Autowired
@@ -58,17 +61,17 @@ public class RemoveTest extends AbstractServiceIntegrationTest {
         final MetadataCategory category = _categoryRepository.findAll().get(0);
         assertEquals(beforeCount, _categoryRepository.count());
 
-        Metadata entity = MetadataRepositoryTest.newMetadata(inc);
+        IMetadata entity = MetadataRepositoryTest.newMetadata(inc);
         entity.getMetadataCategories().add(category);
-        entity = _MetadataRepository.save(entity);
+        entity = metadataManager.save(entity);
 
         ServiceContext context = createServiceContext();
         loginAsAdmin(context);
         remove.exec(category.getId());
 
         assertEquals(beforeCount - 1, _categoryRepository.count());
-        assertEquals(1, _MetadataRepository.count());
-        entity = _MetadataRepository.findOne(entity.getId());
+        assertEquals(1, metadataUtils.count());
+        entity = metadataUtils.findOne(entity.getId());
         assertTrue(entity.getMetadataCategories().isEmpty());
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/metadata/BatchDeleteTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/BatchDeleteTest.java
@@ -23,26 +23,25 @@
 
 package org.fao.geonet.services.metadata;
 
-import com.google.common.collect.Sets;
+import static org.junit.Assert.assertEquals;
 
-import jeeves.server.context.ServiceContext;
+import java.util.Set;
 
-import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.kernel.SelectionManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.mef.MEFLibIntegrationTest;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.Set;
+import com.google.common.collect.Sets;
 
-import static org.junit.Assert.assertEquals;
+import jeeves.server.context.ServiceContext;
 
 public class BatchDeleteTest extends AbstractServiceIntegrationTest {
 
     @Autowired
-    private MetadataRepository repository;
+    private IMetadataUtils repository;
 
     @Test
     public void testExec() throws Exception {

--- a/services/src/test/java/org/fao/geonet/services/metadata/BatchEditsServiceTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/BatchEditsServiceTest.java
@@ -22,17 +22,22 @@
  */
 package org.fao.geonet.services.metadata;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
+import static org.fao.geonet.constants.Geonet.Namespaces.GCO;
+import static org.fao.geonet.constants.Geonet.Namespaces.GMD;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import jeeves.server.context.ServiceContext;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.fao.geonet.api.records.model.BatchEditParameter;
 import org.fao.geonet.csw.common.util.Xml;
-import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.IMetadata;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.mef.MEFLibIntegrationTest;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.jdom.Element;
 import org.junit.Before;
@@ -44,16 +49,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 
-import static org.fao.geonet.constants.Geonet.Namespaces.GCO;
-import static org.fao.geonet.constants.Geonet.Namespaces.GMD;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import jeeves.server.context.ServiceContext;
 
 public class BatchEditsServiceTest extends AbstractServiceIntegrationTest {
 
@@ -65,7 +65,7 @@ public class BatchEditsServiceTest extends AbstractServiceIntegrationTest {
     private WebApplicationContext wac;
 
     @Autowired
-    private MetadataRepository repository;
+    private IMetadataUtils repository;
 
     private MockMvc mockMvc;
 
@@ -147,7 +147,7 @@ public class BatchEditsServiceTest extends AbstractServiceIntegrationTest {
                 .accept(MediaType.parseMediaType("application/json")))
                 .andExpect(status().is(201));
 
-        Metadata updatedRecord = repository.findOneByUuid(firstMetadataId);
+        IMetadata updatedRecord = repository.findOneByUuid(firstMetadataId);
         Element xml = Xml.loadString(updatedRecord.getData(), false);
 
         for (BatchEditParameter p : listOfupdates) {


### PR DESCRIPTION
Refactor Metadata object in the database. Now you can extend the Metadata object to have different types of metadata with more attributes. For example, you can have an unpublished copy of a record to work on it while the "real" published record remains intact (draft).

**This commit does not change anything related to behaviour**. It is just a **refactor** preparing for the draft feature, but can be reused for example if at some point we have different types of records that are completely different from metadata. Now we have an IMetadata interface that is the same for all types of records. But if some specific type of record need some tweaking (like having a parent field or having some special constraint), we can extend IMetadata and, while being compatible to work with the previous type of record, extend GN to be able to detect this new type of record and act accordingly.

Each type of record can be stored on different tables of the databases.

After this, using directly MetadataRepository is discouraged, you should use the IMetadataUtils or IMetadataManager for this, to make sure you handle all types of Metadata. In al the source code, we will try not to use MetadataRepository except when mandatory. The idea is to prevent direct access to the database DAOs so we can inject other types of metadata on the queries on a transparent way to the developer that just have to handle IMetadata.

Also, some boyscoutting adding comments to all the org.fao.geonet.kernel.datamanager.IMetadata* classes