### PR TITLE
Improvements to editor map tools (bounding box & polygon)

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -236,6 +236,8 @@
                                   gmd:geographicIdentifier/gmd:MD_Identifier/gmd:code/(gmx:Anchor|gco:CharacterString)"/>
         <xsl:variable name="description"
                       select="../preceding-sibling::gmd:description/gco:CharacterString"/>
+        <xsl:variable name="readonly" select="ancestor-or-self::node()[@xlink:href] != ''"/>
+
         <div gn-draw-bbox=""
              data-hleft="{gmd:westBoundLongitude/gco:Decimal}"
              data-hright="{gmd:eastBoundLongitude/gco:Decimal}"
@@ -245,7 +247,8 @@
              data-hright-ref="_{gmd:eastBoundLongitude/gco:Decimal/gn:element/@ref}"
              data-hbottom-ref="_{gmd:southBoundLatitude/gco:Decimal/gn:element/@ref}"
              data-htop-ref="_{gmd:northBoundLatitude/gco:Decimal/gn:element/@ref}"
-             data-lang="lang">
+             data-lang="lang"
+             data-read-only="{$readonly}">
           <xsl:if test="$identifier and $isFlatMode">
             <xsl:attribute name="data-identifier"
                            select="$identifier"/>

--- a/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
@@ -67,6 +67,9 @@
              scope.mapId = 'map-drawbbox-' +
              mapRef.substring(1, mapRef.length);
 
+             // set read only
+             scope.readOnly = scope.$eval(attrs['readOnly']);
+
              var extentTpl = {
                'iso19139': '<gmd:EX_Extent ' +
                'xmlns:gmd="http://www.isotc211.org/2005/gmd" ' +
@@ -241,7 +244,7 @@
 
              // apply background layer from settings
              var bgLayer = gnMap.getMapConfig().mapBackgroundLayer;
-             if (bgLayer) {
+             if (bgLayer && bgLayer.type && bgLayer.url && bgLayer.layer) {
                map.getLayers().removeAt(0);
                gnMap.createLayerForType(bgLayer.type, {
                  name: bgLayer.layer,

--- a/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
@@ -7,7 +7,7 @@
     </div>
 
     <!--Draw Button-->
-    <div class="col-md-3">
+    <div class="col-md-3" ng-if="!readOnly">
       <button class="btn btn-warning"
               title="{{'clickToDrawABox' | translate}}"
               data-ng-click="drawMap()"
@@ -23,7 +23,8 @@
     <div class="col-sm-8 gn-value">
       <input class="form-control"
              data-ng-model="identifier"
-             name="{{identifierRef}}"/>
+             name="{{identifierRef}}"
+             ng-disabled="readOnly"/>
     </div>
     <div class="col-sm-1 gn-control">
       <a class="btn pull-right" data-ng-click="identifier = ''">
@@ -37,7 +38,8 @@
     <div class="col-sm-8 gn-value">
       <input class="form-control"
              data-ng-model="description"
-             name="{{descriptionRef}}"/>
+             name="{{descriptionRef}}"
+             ng-disabled="readOnly"/>
     </div>
     <div class="col-sm-1 gn-control">
       <a class="btn pull-right" data-ng-click="description = ''">
@@ -81,7 +83,8 @@
           <input
             data-ng-model="extent.form[3]" type="number"
             id="drawbbox-top" placeholder="{{'north' | translate}}"
-            data-ng-change="updateBbox(true)"/>
+            data-ng-change="updateBbox(true)"
+            ng-disabled="readOnly"/>
         </div>
       </td>
       <td>
@@ -92,7 +95,8 @@
         <div class="form-group">
           <input data-ng-model="extent.form[0]" type="number"
                  id="drawbbox-left" placeholder="{{'west' | translate}}"
-                 data-ng-change="updateBbox(true)"/>
+                 data-ng-change="updateBbox(true)"
+                 ng-disabled="readOnly"/>
         </div>
       </td>
       <td class="col-middle">
@@ -103,7 +107,8 @@
           <input
             data-ng-model="extent.form[2]"
             type="number" id="drawbbox-right"
-            placeholder="{{'east' | translate}}" data-ng-change="updateBbox(true)"/>
+            placeholder="{{'east' | translate}}" data-ng-change="updateBbox(true)"
+            ng-disabled="readOnly"/>
         </div>
       </td>
     </tr>
@@ -113,7 +118,8 @@
           <input
             data-ng-model="extent.form[1]" type="number"
             id="drawbbox-bottom" placeholder="{{'south' | translate}}"
-            data-ng-change="updateBbox(true)"/>
+            data-ng-change="updateBbox(true)"
+            ng-disabled="readOnly"/>
         </div>
       </td>
     </tr>

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -68,7 +68,7 @@
 
             // apply background layer from settings
             var bgLayer = gnMap.getMapConfig().mapBackgroundLayer;
-            if (bgLayer) {
+            if (bgLayer && bgLayer.type && bgLayer.url && bgLayer.layer) {
               scope.ctrl.map.getLayers().removeAt(0);
               gnMap.createLayerForType(bgLayer.type, {
                 name: bgLayer.layer,

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -71,7 +71,7 @@
         inputGeometryHint</small>
       <small class="text-muted"
         ng-show="ctrl.readOnly" translate>
-        inputGeometryRedOnlyHint</small>
+        inputGeometryReadOnlyHint</small>
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -7,20 +7,7 @@
 
 <!-- draw tool & select boxes -->
 <div class="row">
-  <div class="col-xs-6 col-md-6 form-inline">
-    <label class="text-muted control-label" translate>
-      selectFormatAndProjection</label>
-    <br />
-    <select class="form-control" ng-model="ctrl.currentFormat"
-      ng-options="format for format in ctrl.formats"
-      ng-change="ctrl.handleInputOptionsChange()">
-    </select>
-    <select class="form-control" ng-model="ctrl.currentProjection"
-      ng-options="proj.code as proj.label for proj in ctrl.projections"
-      ng-change="ctrl.handleInputOptionsChange()">
-    </select>
-  </div>
-  <div class="col-xs-6 col-md-6" ng-if="!ctrl.readOnly">
+  <div class="col-xs-12 col-sm-6 col-sm-push-6" ng-if="!ctrl.readOnly">
     <label class="text-muted control-label" translate>drawOnMap</label>
     <br />
     <div gi-btn-group>
@@ -43,6 +30,26 @@
         <span class="fa fa-pencil"></span>
         <span translate>modifyGeometry</span>
       </button>
+    </div>
+  </div>
+  <div class="col-xs-12 col-sm-6 col-sm-pull-6">
+    <label class="text-muted control-label" translate>
+      selectFormatAndProjection</label>
+    <br />
+    <div class="flex-row width-100">
+      <div class="flex-nogrow">
+        <select ng-model="ctrl.currentFormat"
+          ng-options="format for format in ctrl.formats"
+          ng-change="ctrl.handleInputOptionsChange()">
+        </select>
+      </div>
+      <div class="flex-spacer"></div>
+      <div class="flex-shrink">
+        <select ng-model="ctrl.currentProjection"
+          ng-options="proj.code as proj.label for proj in ctrl.projections"
+          ng-change="ctrl.handleInputOptionsChange()">
+        </select>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Improvements:
* better handle background layer setting (use OSM if none defined) - note: this is a temporary fix, a better handling of maps still need to be done
* implement a read-only mode for the bounding box editor, which is active when the extent is resolved through a xlink (and as such, not editable)