### PR TITLE
Minor fixes to editor directives (thesaurus and directory entry selector)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
@@ -20,7 +20,8 @@
            data-ng-model="searchObj.params.any"
            data-ng-model-options="{debounce: 200}"
            ng-focus="triggerSearch()"
-           data-ng-change="triggerSearch()"/>
+           data-ng-change="triggerSearch()"
+           autocomplete="false"/>
 
     <!-- The autocomplete list -->
     <div class="list-group tt-dropdown-menu gn-autocomplete-list"

--- a/web-ui/src/main/resources/catalog/components/thesaurus/partials/thesaurusselector.html
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/partials/thesaurusselector.html
@@ -2,15 +2,14 @@
   <div class="btn-group">
     <button class="btn btn-default" type="button"
             data-gn-click-and-spin="add()"
-            data-ng-show="allowFreeTextKeywords"
-            data-ng-hide="selectorOnly">
+            data-ng-if="allowFreeTextKeywords && !selectorOnly">
       <i class="fa fa-plus gn-add"/>&nbsp;
       <span data-translate="">addKeywordNotFromThesaurus</span>
     </button>
     <div class="btn-group" data-ng-show="thesaurus.length > 0">
       <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
         <i class="fa fa-book"/>&nbsp;
-        <span data-ng-hide="selectorOnly"
+        <span data-ng-hide="!allowFreeTextKeywords || selectorOnly"
               data-translate="">addFromThesaurus</span>
         <span class="caret"/>
       </button>


### PR DESCRIPTION
Fixes:
* `gn-keyword-picker` now correctly handles the `allowFreeTextKeywords` attribute; if set to false, the user will not be able to add a new free-text keyword and the thesaurus button will be rendered without text:
![image](https://user-images.githubusercontent.com/10629150/30587277-ddec40aa-9d32-11e7-92b2-6016636b327f.png)
  Note: this attribute's value is currently set in the schema config, ie: https://github.com/geonetwork/core-geonetwork/blob/develop/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml#L180

* `gn-directory-entry-selector` now disables browser autocomplete on its input field, as it may collide with the autocompletion already existing