### PR TITLE
Subtemplate / Set properly gco:CharacterString depending on requested…

### DIFF
--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -25,6 +25,7 @@ package org.fao.geonet.schema.iso19139;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.kernel.schema.*;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
@@ -51,7 +52,7 @@ public class ISO19139SchemaPlugin
     ISOPlugin {
     public static final String IDENTIFIER = "iso19139";
 
-    private static ImmutableSet<Namespace> allNamespaces;
+    public static ImmutableSet<Namespace> allNamespaces;
     private static Map<String, Namespace> allTypenames;
     private static Map<String, String> allExportFormats;
 
@@ -222,37 +223,70 @@ public class ISO19139SchemaPlugin
     }
 
     /**
-     * Remove all multingual aspect of an element. Keep the md language localized strings
+     * Remove all multilingual aspect of an element. Keep the md language localized strings
      * as default gco:CharacterString for the element.
      *
      * @param element
-     * @param mdLang Metadata lang encoded as #EN
+     * @param langs Metadata languages. The main language MUST be the first one.
      * @return
      * @throws JDOMException
      */
     @Override
-    public Element removeTranslationFromElement(Element element, String mdLang) throws JDOMException {
+    public Element removeTranslationFromElement(Element element, List<String> langs) throws JDOMException {
+        String mainLanguage = langs != null && langs.size() > 0 ? langs.get(0) : "#EN";
 
-        List<Element> multilangElement = (List<Element>)Xml.selectNodes(element, "*//gmd:PT_FreeText", Arrays.asList(GMD));
+        List<Element> nodesWithStrings = (List<Element>) Xml.selectNodes(element, "*//gmd:PT_FreeText", Arrays.asList(GMD));
 
-        for(Element el : multilangElement) {
-            String filterAttribute = "*//node()[@locale='" + mdLang + "']";
-            List<Element> localizedElement = (List<Element>)Xml.selectNodes(el, filterAttribute, Arrays.asList(GMD));
-            if(localizedElement.size() == 1) {
-                String mainLangString = localizedElement.get(0).getText();
-                Element mainCharacterString = ((Element)el.getParent()).getChild("CharacterString", GCO);
-                if (mainCharacterString != null) {
+        for(Element e : nodesWithStrings) {
+            // Retrieve or create the main language element
+            Element mainCharacterString = ((Element)e.getParent()).getChild("CharacterString", ISO19139Namespaces.GCO);
+            if (mainCharacterString == null) {
+                // create it if it does not exist
+                mainCharacterString = new Element("CharacterString", ISO19139Namespaces.GCO);
+                ((Element)e.getParent()).addContent(0, mainCharacterString);
+            }
+
+            // Retrieve the main language value if exist
+            List<Element> mainLangElement = (List<Element>) Xml.selectNodes(
+                e,
+                "*//gmd:LocalisedCharacterString[@locale='" + mainLanguage + "']",
+                Arrays.asList(ISO19139Namespaces.GMD));
+
+            // Set the main language value
+            if (mainLangElement.size() == 1) {
+                String mainLangString = mainLangElement.get(0).getText();
+
+                if (StringUtils.isNotEmpty(mainLangString)) {
                     mainCharacterString.setText(mainLangString);
                 } else {
-                    ((Element) el.getParent()).addContent(
-                        new Element("CharacterString", GCO).setText(mainLangString)
-                    );
+                    mainCharacterString.setAttribute("nilReason", "missing", ISO19139Namespaces.GCO);
                 }
+            } else if (StringUtils.isEmpty(mainCharacterString.getText())) {
+                mainCharacterString.setAttribute("nilReason", "missing", ISO19139Namespaces.GCO);
             }
-            el.detach();
         }
+
+        // Remove unused lang entries
+        List<Element> translationNodes = (List<Element>)Xml.selectNodes(element, "*//node()[@locale]");
+        for(Element el : translationNodes) {
+            // Remove all translations if there is no or only one language requested
+            if(langs.size() <= 1 ||
+                !langs.contains(el.getAttribute("locale").getValue())) {
+                Element parent = (Element)el.getParent();
+                parent.detach();
+            }
+        }
+
+        // Remove PT_FreeText which might be emptied by above processing
+        for(Element el : nodesWithStrings) {
+            if (el.getChildren().size() == 0) {
+                el.detach();
+            }
+        }
+
         return element;
     }
+
 
     @Override
     public String getBasicTypeCharacterStringName() {

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -258,11 +258,11 @@ public class ISO19139SchemaPlugin
 
                 if (StringUtils.isNotEmpty(mainLangString)) {
                     mainCharacterString.setText(mainLangString);
-                } else {
-                    mainCharacterString.setAttribute("nilReason", "missing", ISO19139Namespaces.GCO);
+                } else if (mainCharacterString.getAttribute("nilReason", ISO19139Namespaces.GCO) == null){
+                    ((Element)mainCharacterString.getParent()).setAttribute("nilReason", "missing", ISO19139Namespaces.GCO);
                 }
             } else if (StringUtils.isEmpty(mainCharacterString.getText())) {
-                mainCharacterString.setAttribute("nilReason", "missing", ISO19139Namespaces.GCO);
+                ((Element)mainCharacterString.getParent()).setAttribute("nilReason", "missing", ISO19139Namespaces.GCO);
             }
         }
 

--- a/schemas/iso19139/src/test/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPluginTest.java
+++ b/schemas/iso19139/src/test/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPluginTest.java
@@ -33,6 +33,7 @@ import javax.xml.transform.TransformerConfigurationException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -69,7 +70,7 @@ public class ISO19139SchemaPluginTest {
                 root.resolve("multilingual-contact.xml"));
 
         ISO19139SchemaPlugin plugin = new ISO19139SchemaPlugin();
-        plugin.removeTranslationFromElement(multilingualElement, "#EN");
+        plugin.removeTranslationFromElement(multilingualElement, Arrays.asList(new String[]{"#EN"}));
 
         String resultString = Xml.getString(multilingualElement);
 

--- a/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/MultilingualSchemaPlugin.java
+++ b/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/MultilingualSchemaPlugin.java
@@ -42,6 +42,6 @@ public interface MultilingualSchemaPlugin {
 
     public abstract void addTranslationToElement(Element element, String languageIdentifier, String value);
 
-    public abstract  Element removeTranslationFromElement(Element element, String mdLang) throws JDOMException;
+    public abstract  Element removeTranslationFromElement(Element element, List<String> mdLang) throws JDOMException;
 
 }

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryEntriesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryEntriesApi.java
@@ -54,6 +54,7 @@ import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpServletRequest;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -194,18 +195,17 @@ public class DirectoryEntriesApi {
                 }
             }
         }
-        // Remove all locazedString from the subtemplate for langs that are not in the metadata
-        if(langs.length > 1) {
-            DirectoryUtils.removeUnsedLangsEntry(tpl, langs);
+        // Multilingual record: Remove all localizedString from the subtemplate for langs that are not in the metadata and set the gco:CharacterString
+        // Monolingual record: Remove all localized strings and extract main gco:CharacterString
+        List<String> twoCharLangs = new ArrayList<String>();
+        for(String l : langs) {
+            twoCharLangs.add("#" + XslUtil.twoCharLangCode(l).toUpperCase());
         }
-        // Monolingual metadata: remove all localized strings and extract main characterString
-        else {
-            MultilingualSchemaPlugin plugin = (MultilingualSchemaPlugin)schemaManager.getSchema(schema).getSchemaPlugin();
-            if (plugin != null) {
-                plugin.removeTranslationFromElement(tpl, ("#" + XslUtil.twoCharLangCode(langs[0]).toUpperCase()));
-            }
+        MultilingualSchemaPlugin plugin = (MultilingualSchemaPlugin)schemaManager.getSchema(schema).getSchemaPlugin();
+        if (plugin != null) {
+            plugin.removeTranslationFromElement(tpl, twoCharLangs);
+        }
 
-        }
         if (transformation != null) {
             Element root = new Element("root");
             Element requestElt = new Element("request");

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryUtils.java
@@ -429,22 +429,4 @@ public class DirectoryUtils {
         }
         return null;
     }
-
-    public static Element removeUnsedLangsEntry(Element entry, final String[] langs) throws JDOMException {
-        List<Element> multilangElement = (List<Element>)Xml.selectNodes(entry, "*//node()[@locale]");
-
-        List<String> twoCharLangs = new ArrayList<String>();
-        for(String l : langs) {
-            twoCharLangs.add("#" + XslUtil.twoCharLangCode(l).toUpperCase());
-        }
-
-        for(Element el : multilangElement) {
-            if(!twoCharLangs.contains(el.getAttribute("locale").getValue())) {
-                Element parent = (Element)el.getParent();
-                parent.detach();
-            }
-        }
-        return entry;
-    }
-
 }


### PR DESCRIPTION
… language(s). If language does not exist in subtemplate, use gco:CharacterString with nilReason. If default value is null, set nilReason attribute. If more than one language requested, set gco:CharacterString with the main language.