### PR TITLE
Begin refactoring OpenLayers map handling

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
@@ -99,4 +99,25 @@
         }
       };
     }]);
+
+  // used to edit an object as a JSON string
+  module.directive('gnJsonEdit', function() {
+    return {
+      restrict: 'A',
+      scope: {
+        value: '=gnJsonEdit'
+      },
+      link: function(scope, element, attrs) {
+        element.val(JSON.stringify(scope.value));
+        element.on('change', function() {
+          var newValue = $(this).val();
+          try {
+            angular.merge(scope.value, JSON.parse(newValue));
+          } catch (e) {
+            console.warn('Error parsing JSON: ', newValue);
+          }
+        });
+      }
+    };
+  });
 })();

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/mapconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/mapconfig.html
@@ -25,12 +25,12 @@
   <tr data-ng-repeat="layer in mCfg[key]['layers'] track by $index">
   <td>
     <input type="text" class="form-control"
-    data-ng-model="layer"/>
+      gn-json-edit="layer" />
   </td>
   <td>
     <a class="btn btn-link text-danger"
-    title="{{'remove' | translate}}"
-    data-ng-click="removeItem(mCfg[key]['layers'], $index)">
+      title="{{'remove' | translate}}"
+      data-ng-click="removeItem(mCfg[key]['layers'], $index)">
     <i class="fa fa-times text-danger"/>
     </a>
   </td>
@@ -39,7 +39,7 @@
   <td>
     <a class="btn btn-link"
     title="{{'add' | translate}}"
-    data-ng-click="addItem(mCfg[key]['layers'], '{type=osm}')">
+    data-ng-click="addItem(mCfg[key]['layers'], {type: 'osm'})">
     <i class="fa fa-plus"/>
     </a>
   </td>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/mapconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/mapconfig.html
@@ -1,0 +1,47 @@
+<label class="control-label" translate>mapConfigContext</label>
+<input type="text" class="form-control"
+  data-ng-model="mCfg[key]['context']"/>
+<label class="control-label" translate>mapConfigExtent</label>
+<div class="input-group">
+  <span class="input-group-addon">MinX</span>
+  <input type="number" step="any"
+      class="form-control"
+      data-ng-model="mCfg[key]['extent'][0]"/>
+  <span class="input-group-addon">MinY</span>
+  <input type="number" step="any"
+      class="form-control"
+      data-ng-model="mCfg[key]['extent'][1]"/>
+  <span class="input-group-addon">MaxX</span>
+  <input type="number" step="any"
+      class="form-control"
+      data-ng-model="mCfg[key]['extent'][2]"/>
+  <span class="input-group-addon">MaxY</span>
+  <input type="number" step="any"
+      class="form-control"
+      data-ng-model="mCfg[key]['extent'][3]"/>
+</div>
+<label class="control-label" translate>mapConfigLayers</label>
+<table class="table table-striped">
+  <tr data-ng-repeat="layer in mCfg[key]['layers'] track by $index">
+  <td>
+    <input type="text" class="form-control"
+    data-ng-model="layer"/>
+  </td>
+  <td>
+    <a class="btn btn-link text-danger"
+    title="{{'remove' | translate}}"
+    data-ng-click="removeItem(mCfg[key]['layers'], $index)">
+    <i class="fa fa-times text-danger"/>
+    </a>
+  </td>
+  </tr>
+  <tr>
+  <td>
+    <a class="btn btn-link"
+    title="{{'add' | translate}}"
+    data-ng-click="addItem(mCfg[key]['layers'], '{type=osm}')">
+    <i class="fa fa-plus"/>
+    </a>
+  </td>
+  </tr>
+</table>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -16,9 +16,15 @@
     <div class="col-sm-12"
          data-ng-repeat="(key, value) in mCfg"
          data-ng-switch="key">
+
+      <!-- DEPRECATED SETTINGS (hidden) -->
       <div data-ng-switch-when="enabled"></div>
       <div data-ng-switch-when="context"></div>
       <div data-ng-switch-when="layer"></div>
+      <div data-ng-switch-when="searchMapLayers"></div>
+      <div data-ng-switch-when="viewerMapLayers"></div>
+      <div data-ng-switch-when="mapExtent"></div>
+      <div data-ng-switch-when="mapBackgroundLayer"></div>
 
 
       <!-- arrays -->
@@ -430,109 +436,6 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
-      <div data-ng-switch-when="searchMapLayers">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
-          <tr data-ng-repeat="opt in mCfg[key] track by $index">
-            <td>
-              <div class="input-group">
-                <span class="input-group-addon">Type </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-layerType-{{$index}}"
-                       data-ng-model="opt.type"/>
-                <span class="input-group-addon">Name </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-layerName-{{$index}}"
-                       data-ng-model="opt.name"/>
-                <span class="input-group-addon">Title </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-layerTile-{{$index}}"
-                       data-ng-model="opt.title"/>
-                <span class="input-group-addon">Url </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-layerUrl-{{$index}}"
-                       data-ng-model="opt.url"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a class="btn btn-link"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], {'type': '', 'title': '', 'name': '', 'url': 'http://'})">
-                <i class="fa fa-plus"/>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <div data-ng-switch-when="viewerMapLayers">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
-          <tr data-ng-repeat="opt in mCfg[key] track by $index">
-            <td>
-              <div class="input-group">
-                <span class="input-group-addon">Type </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-layerType-{{$index}}"
-                       data-ng-model="opt.type"/>
-                <span class="input-group-addon">Name </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-layerName-{{$index}}"
-                       data-ng-model="opt.name"/>
-                <span class="input-group-addon">Title </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-layerTile-{{$index}}"
-                       data-ng-model="opt.title"/>
-                <span class="input-group-addon">Url </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-layerUrl-{{$index}}"
-                       data-ng-model="opt.url"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a class="btn btn-link"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], {'type': '', 'title': '', 'name': '', 'url': 'http://'})">
-                <i class="fa fa-plus"/>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-
       <!-- numbers -->
       <div data-ng-switch-when="paginationInfo">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
@@ -631,50 +534,30 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
-      <div data-ng-switch-when="mapExtent">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <div class="input-group">
-          <span class="input-group-addon">MinX</span>
-          <input type="number" step="any"
-                 class="form-control"
-                 data-ng-model="mCfg[key][0]"/>
-          <span class="input-group-addon">MinY</span>
-          <input type="number" step="any"
-                 class="form-control"
-                 data-ng-model="mCfg[key][1]"/>
-          <span class="input-group-addon">MaxX</span>
-          <input type="number" step="any"
-                 class="form-control"
-                 data-ng-model="mCfg[key][2]"/>
-          <span class="input-group-addon">MaxY</span>
-          <input type="number" step="any"
-                 class="form-control"
-                 data-ng-model="mCfg[key][3]"/>
-        </div>
+      <!-- map configs -->
+      <div data-ng-switch-when="map-viewer">
+        <h3>{{('ui-' + key) | translate}}</h3>
         <p class="help-block"
            data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
           {{('ui-' + key + '-help') | translate}} </p>
+        <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
+        </div>
       </div>
-
-      <div data-ng-switch-when="mapBackgroundLayer">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <div class="input-group">
-          <span class="input-group-addon">Type </span>
-          <input type="text"
-                 class="form-control"
-                 data-ng-model="mCfg[key].type"/>
-          <span class="input-group-addon">Layer </span>
-          <input type="text"
-                 class="form-control"
-                 data-ng-model="mCfg[key].layer"/>
-          <span class="input-group-addon">Url </span>
-          <input type="text"
-                 class="form-control"
-                 data-ng-model="mCfg[key].url"/>
-        </div>
+      <div data-ng-switch-when="map-search">
+        <h3>{{('ui-' + key) | translate}}</h3>
         <p class="help-block"
            data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
           {{('ui-' + key + '-help') | translate}} </p>
+        <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
+        </div>
+      </div>
+      <div data-ng-switch-when="map-editor">
+        <h3>{{('ui-' + key) | translate}}</h3>
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+        <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
+        </div>
       </div>
 
       <div data-ng-switch-default>

--- a/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
@@ -37,7 +37,8 @@
       [
        'gnMap',
        'gnMapsManager',
-       function(gnMap, gnMapsManager) {
+       'ngeoDecorateInteraction',
+       function(gnMap, gnMapsManager, ngeoDecorateInteraction) {
          return {
            restrict: 'A',
            replace: true,
@@ -219,9 +220,19 @@
              });
              bboxLayer.setZIndex(100);
 
-             var map = gnMapsManager.createMap(gnMapsManager.EDITOR_MAP)
+             var map = gnMapsManager.createMap(gnMapsManager.EDITOR_MAP);
+             scope.map = map;
              map.addLayer(bboxLayer);
              element.data('map', map);
+
+             // initialize extent & bbox on map load
+             map.get('creationPromise').then(function () {
+               drawBbox();
+
+               if (gnMap.isValidExtent(scope.extent.map)) {
+                 map.getView().fit(scope.extent.map, map.getSize());
+               }
+             });
 
              var dragbox = new ol.interaction.DragBox({
                style: boxStyle,
@@ -248,8 +259,8 @@
              map.addInteraction(dragbox);
 
              /**
-            * Draw the map extent as a bbox onto the map.
-            */
+              * Draw the map extent as a bbox onto the map.
+              */
              var drawBbox = function() {
                var coordinates, geom;
 
@@ -274,39 +285,17 @@
              };
 
              /**
-            * When form is loaded
-            * - set map div
-            * - draw the feature with MD initial coordinates
-            * - fit map extent
-            */
-             scope.$watch('gnCurrentEdit.version', function(newValue) {
-               map.setTarget(scope.mapId);
-               drawBbox();
-
-               // apply extent from settings
-               var mapExtent = gnMap.getMapConfig().mapExtent;
-               if (mapExtent && ol.extent.getWidth(mapExtent) &&
-               ol.extent.getHeight(mapExtent)) {
-                  map.getView().fit(mapExtent, map.getSize());
-               }
-
-               if (gnMap.isValidExtent(scope.extent.map)) {
-                 map.getView().fit(scope.extent.map, map.getSize());
-               }
-             });
-
-             /**
-            * Switch mode (panning or drawing)
-            */
+              * Switch mode (panning or drawing)
+              */
              scope.drawMap = function() {
                scope.drawing = !scope.drawing;
              };
 
              /**
-            * Called on form input change.
-            * Set map and md extent from form reprojection, and draw
-            * the bbox from the map extent.
-            */
+              * Called on form input change.
+              * Set map and md extent from form reprojection, and draw
+              * the bbox from the map extent.
+              */
              scope.updateBbox = function() {
 
                reprojExtent('form', 'map');
@@ -317,10 +306,10 @@
              };
 
              /**
-            * Callback sent to gn-country-picker directive.
-            * Called on region selection from typeahead.
-            * Zoom to extent.
-            */
+              * Callback sent to gn-country-picker directive.
+              * Called on region selection from typeahead.
+              * Zoom to extent.
+              */
              scope.onRegionSelect = function(region) {
                // Manage regions service and geonames
                var bbox = region.bbox || region;

--- a/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
@@ -23,7 +23,6 @@
 
 (function() {
   goog.provide('gn_map_directive');
-  goog.require('gn_owscontext_service');
 
   var METRIC_DECIMALS = 4;
   var DEGREE_DECIMALS = 8;
@@ -32,15 +31,13 @@
     return proj == 'EPSG:4326' ? DEGREE_DECIMALS : METRIC_DECIMALS;
   };
 
-  angular.module('gn_map_directive',
-      ['gn_owscontext_service'])
-
+  angular.module('gn_map_directive', [])
       .directive(
       'gnDrawBbox',
       [
        'gnMap',
-       'gnOwsContextService',
-       function(gnMap, gnOwsContextService) {
+       'gnMapsManager',
+       function(gnMap, gnMapsManager) {
          return {
            restrict: 'A',
            replace: true,
@@ -222,35 +219,9 @@
              });
              bboxLayer.setZIndex(100);
 
-             var map = new ol.Map({
-               layers: [
-                 gnMap.getLayersFromConfig(),
-                 bboxLayer
-               ],
-               renderer: 'canvas',
-               view: new ol.View({
-                 center: [0, 0],
-                 projection: scope.projs.map,
-                 zoom: 2
-               })
-             });
+             var map = gnMapsManager.createMap(gnMapsManager.EDITOR_MAP)
+             map.addLayer(bboxLayer);
              element.data('map', map);
-
-             //Uses configuration from database
-             if (gnMap.getMapConfig().context) {
-               gnOwsContextService.
-               loadContextFromUrl(gnMap.getMapConfig().context, map);
-             }
-
-             // apply background layer from settings
-             var bgLayer = gnMap.getMapConfig().mapBackgroundLayer;
-             if (bgLayer && bgLayer.type && bgLayer.url && bgLayer.layer) {
-               map.getLayers().removeAt(0);
-               gnMap.createLayerForType(bgLayer.type, {
-                 name: bgLayer.layer,
-                 url: bgLayer.url
-               }, null, map);
-             }
 
              var dragbox = new ol.interaction.DragBox({
                style: boxStyle,

--- a/web-ui/src/main/resources/catalog/components/common/map/mapModule.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapModule.js
@@ -28,10 +28,12 @@
   goog.require('gn_map_directive');
   goog.require('gn_map_service');
   goog.require('gn_map_wmsqueue');
+  goog.require('gn_maps_manager');
 
   angular.module('gn_map', [
     'gn_map_service',
     'gn_map_directive',
-    'gn_map_wmsqueue'
+    'gn_map_wmsqueue',
+    'gn_maps_manager'
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -41,103 +41,106 @@
    * The `gnMapsManager` service is used to create maps throughout the
    * application in a standardized way.
    */
-  module.provider('gnMapsManager', function() {
-    this.$get = [
-      '$q',
-      'gnMap',
-      'gnOwsContextService',
-      function($q, gnMap, gnOwsContextService) {
-        return {
-          /**
-           * These are types used when creating a new map with createMap
-           * The keys are used in the UI config, so that config.map.<KEY>
-           * points to a description of the map context & layers.
-           */
-          VIEWER_MAP: 'viewer',
-          SEARCH_MAP: 'search',
-          EDITOR_MAP: 'editor',
+  module.service('gnMapsManager', [
+    '$q',
+    'gnMap',
+    'gnOwsContextService',
+    function($q, gnMap, gnOwsContextService) {
+      return {
+        /**
+         * These are types used when creating a new map with createMap
+         * The keys are used in the UI config, so that config.map.<KEY>
+         * points to a description of the map context & layers.
+         */
+        VIEWER_MAP: 'viewer',
+        SEARCH_MAP: 'search',
+        EDITOR_MAP: 'editor',
 
-          /**
-           * @ngdoc method
-           * @methodOf gn_map.service:gnMapsManager
-           * @name gnMap#createMap
-           *
-           * @description
-           * Creates a new map according to current UI config.
-           * The map will be created using a context (if specified) as well as
-           * layers above it and an extent.
-           * The corresponding map description must be an object like so:
-           * {
-           *   context: {string} optional, path to a XML file,
-           *   extent: {ol.Extent} optional map extent,
-           *   layers: {Array.<string>} optional layers array: each layer must
-           *     be described according to the standard notation used by
-           *     createLayerFromNotation
-           * }
-           * First, the context is applied, then (if defined) extent & layers
-           * TODO: This method must become the standardized way of creating maps
-           * throughout the application.
-           *
-           * @param {string} type of map: gnMapsManager.VIEWER_MAP, SEARCH_MAP
-           * or EDITOR_MAP
-           * 
-           * @return {ol.Map} map created with the correct parameters
-           */
-          createMap: function(type) {
-            var config = gnMap.getMapConfig()['map-' + type];
-            var map = new ol.Map({
-              layers: [],
-              view: new ol.View({
-                center: [0, 0],
-                projection: gnMap.getMapConfig().projection,
-                zoom: 2
-              })
-            });
+        /**
+         * @ngdoc method
+         * @methodOf gn_map.service:gnMapsManager
+         * @name gnMap#createMap
+         *
+         * @description
+         * Creates a new map according to current UI config.
+         * The map will be created using a context (if specified) as well as
+         * layers above it and an extent.
+         * The corresponding map description must be an object like so:
+         * {
+         *   context: {string} optional, path to a XML file,
+         *   extent: {ol.Extent} optional map extent,
+         *   layers: {Array.<Object>} optional layers array: each layer must
+         *     be an object compatible with createLayerFromProperties
+         * }
+         * First, the context is applied, then (if defined) extent & layers
+         * The creation promise is available on the map with
+         * map.get('creationPromise')
+         * TODO: This method must become the standardized way of creating maps
+         * throughout the application.
+         *
+         * @param {string} type of map: gnMapsManager.VIEWER_MAP, SEARCH_MAP
+         * or EDITOR_MAP
+         *
+         * @return {ol.Map} map created with the correct parameters
+         */
+        createMap: function(type) {
+          var config = gnMap.getMapConfig()['map-' + type];
+          var map = new ol.Map({
+            layers: [],
+            view: new ol.View({
+              center: [0, 0],
+              projection: gnMap.getMapConfig().projection,
+              zoom: 2
+            })
+          });
 
-            // no config found: return empty map
-            if (!config) {
-              console.warn('Map config not found for type \'' + type + '\'');
-              return map;
-            }
-
-            // config found: load context if any, and apply extent & layers
-            // (this is done through a promise anyway)
-            $q(function (resolve, reject) {
-              if (config.context) {
-                gnOwsContextService.loadContextFromUrl(config.context, map)
-                  .then(function () {
-                    resolve();
-                  });
-              } else {
-                resolve();
-              }
-            }).then(function () {
-              // do a render of the map
-              map.renderSync();
-              
-              // extent
-              if (config.extent && ol.extent.getWidth(config.extent) &&
-                ol.extent.getHeight(config.extent)) {
-                map.getView().fit(config.extent, map.getSize());
-              }
-
-              // layers
-              if (config.layers && config.layers.length) {
-                config.layers.forEach(function(layerNotation) {
-                  gnMap.createLayerFromNotation(layerNotation, null, map)
-                    .then(function(layer) {
-                      if (layer) {
-                        map.addLayer(layer);
-                      }
-                    })
-                });
-              }
-            });
-
+          // no config found: return empty map
+          if (!config) {
+            console.warn('Map config not found for type \'' + type + '\'');
             return map;
           }
-        };
-      }
-    ];
-  });
+
+          // config found: load context if any, and apply extent & layers
+          // (this is done through a promise anyway)
+          var promise = $q(function (resolve, reject) {
+            if (config.context) {
+              gnOwsContextService.loadContextFromUrl(config.context, map)
+                .then(function () {
+                  resolve();
+                });
+            } else {
+              // force async resolution
+              setTimeout(resolve, 0);
+            }
+          }).then(function () {
+            // do a render of the map
+            map.renderSync();
+
+            // extent
+            if (config.extent && ol.extent.getWidth(config.extent) &&
+              ol.extent.getHeight(config.extent) && map.getSize()) {
+              map.getView().fit(config.extent, map.getSize());
+            }
+
+            // layers
+            if (config.layers && config.layers.length) {
+              config.layers.forEach(function(layerInfo) {
+                gnMap.createLayerFromProperties(layerInfo, map)
+                  .then(function(layer) {
+                    if (layer) {
+                      map.addLayer(layer);
+                    }
+                  })
+              });
+            }
+          });
+
+          // save the promise on the map
+          map.set('creationPromise', promise);
+
+          return map;
+        }
+      };
+    }
+  ]);
 })();

--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_maps_manager');
+
+  goog.require('gn_ows');
+
+
+  var module = angular.module('gn_maps_manager', [
+    'gn_ows',
+    'ngeo'
+  ]);
+
+  /**
+   * @ngdoc service
+   * @kind function
+   * @name gn_map.service:gnMapsManager
+   *
+   * @description
+   * The `gnMapsManager` service is used to create maps throughout the
+   * application in a standardized way.
+   */
+  module.provider('gnMapsManager', function() {
+    this.$get = [
+      '$q',
+      'gnMap',
+      'gnOwsContextService',
+      function($q, gnMap, gnOwsContextService) {
+        return {
+          /**
+           * These are types used when creating a new map with createMap
+           * The keys are used in the UI config, so that config.map.<KEY>
+           * points to a description of the map context & layers.
+           */
+          VIEWER_MAP: 'viewer',
+          SEARCH_MAP: 'search',
+          EDITOR_MAP: 'editor',
+
+          /**
+           * @ngdoc method
+           * @methodOf gn_map.service:gnMapsManager
+           * @name gnMap#createMap
+           *
+           * @description
+           * Creates a new map according to current UI config.
+           * The map will be created using a context (if specified) as well as
+           * layers above it and an extent.
+           * The corresponding map description must be an object like so:
+           * {
+           *   context: {string} optional, path to a XML file,
+           *   extent: {ol.Extent} optional map extent,
+           *   layers: {Array.<string>} optional layers array: each layer must
+           *     be described according to the standard notation used by
+           *     createLayerFromNotation
+           * }
+           * First, the context is applied, then (if defined) extent & layers
+           * TODO: This method must become the standardized way of creating maps
+           * throughout the application.
+           *
+           * @param {string} type of map: gnMapsManager.VIEWER_MAP, SEARCH_MAP
+           * or EDITOR_MAP
+           * 
+           * @return {ol.Map} map created with the correct parameters
+           */
+          createMap: function(type) {
+            var config = gnMap.getMapConfig()['map-' + type];
+            var map = new ol.Map({
+              layers: [],
+              view: new ol.View({
+                center: [0, 0],
+                projection: gnMap.getMapConfig().projection,
+                zoom: 2
+              })
+            });
+
+            // no config found: return empty map
+            if (!config) {
+              console.warn('Map config not found for type \'' + type + '\'');
+              return map;
+            }
+
+            // config found: load context if any, and apply extent & layers
+            // (this is done through a promise anyway)
+            $q(function (resolve, reject) {
+              if (config.context) {
+                gnOwsContextService.loadContextFromUrl(config.context, map)
+                  .then(function () {
+                    resolve();
+                  });
+              } else {
+                resolve();
+              }
+            }).then(function () {
+              // do a render of the map
+              map.renderSync();
+              
+              // extent
+              if (config.extent && ol.extent.getWidth(config.extent) &&
+                ol.extent.getHeight(config.extent)) {
+                map.getView().fit(config.extent, map.getSize());
+              }
+
+              // layers
+              if (config.layers && config.layers.length) {
+                config.layers.forEach(function(layerNotation) {
+                  gnMap.createLayerFromNotation(layerNotation, null, map)
+                    .then(function(layer) {
+                      if (layer) {
+                        map.addLayer(layer);
+                      }
+                    })
+                });
+              }
+            });
+
+            return map;
+          }
+        };
+      }
+    ];
+  });
+})();

--- a/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
@@ -100,7 +100,7 @@
         </div>
       </td>
       <td class="col-middle">
-        <div id="{{mapId}}" class="map"></div>
+        <div ng-if="map" ngeo-map="map"></div>
       </td>
       <td class="col-right">
         <div class="form-group">

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -54,11 +54,6 @@
         },
         templateUrl: '../../catalog/components/edit/bounding/' +
             'partials/boundingpolygon.html',
-        link: {
-          post: function(scope, element) {
-            scope.ctrl.initValue();
-          }
-        },
         controllerAs: 'ctrl',
         bindToController: true,
         controller: [
@@ -84,6 +79,9 @@
 
             // init map
             ctrl.map = gnMapsManager.createMap(gnMapsManager.EDITOR_MAP);
+            ctrl.map.get('creationPromise').then(function () {
+              ctrl.initValue();
+            });
 
             // interactions with map
             var layer = gnGeometryService.getCommonLayer(ctrl.map);

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -56,26 +56,6 @@
             'partials/boundingpolygon.html',
         link: {
           post: function(scope, element) {
-            scope.ctrl.map.renderSync();
-
-            // apply extent from settings
-            var mapExtent = gnMap.getMapConfig().mapExtent;
-            if (mapExtent && ol.extent.getWidth(mapExtent) &&
-                ol.extent.getHeight(mapExtent)) {
-              scope.ctrl.map.getView().fit(mapExtent,
-                  scope.ctrl.map.getSize());
-            }
-
-            // apply background layer from settings
-            var bgLayer = gnMap.getMapConfig().mapBackgroundLayer;
-            if (bgLayer && bgLayer.type && bgLayer.url && bgLayer.layer) {
-              scope.ctrl.map.getLayers().removeAt(0);
-              gnMap.createLayerForType(bgLayer.type, {
-                name: bgLayer.layer,
-                url: bgLayer.url
-              }, null, scope.ctrl.map);
-            }
-
             scope.ctrl.initValue();
           }
         },
@@ -86,7 +66,7 @@
           '$attrs',
           '$http',
           'gnMap',
-          'gnOwsContextService',
+          'gnMapsManager',
           'ngeoDecorateInteraction',
           'gnGeometryService',
           function BoundingPolygonController(
@@ -94,7 +74,7 @@
               $attrs,
               $http,
               gnMap,
-              gnOwsContextService,
+              gnMapsManager,
               ngeoDecorateInteraction,
               gnGeometryService) {
             var ctrl = this;
@@ -103,16 +83,7 @@
             ctrl.readOnly = $scope.$eval($attrs['readOnly']);
 
             // init map
-            ctrl.map = new ol.Map({
-              layers: [
-                gnMap.getLayersFromConfig()
-              ],
-              view: new ol.View({
-                center: [0, 0],
-                projection: gnMap.getMapConfig().projection,
-                zoom: 2
-              })
-            });
+            ctrl.map = gnMapsManager.createMap(gnMapsManager.EDITOR_MAP);
 
             // interactions with map
             var layer = gnGeometryService.getCommonLayer(ctrl.map);

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -565,7 +565,7 @@
        *
        * @description
        * Create a WMS ol.Layer from context object
-       * !! DEPRECATED: use gnMap.createLayerFromNotation instead
+       * !! DEPRECATED: use gnMap.createLayerFromProperties instead
        *
        * @param {Object} layer layer
        * @param {ol.map} map map

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -328,7 +328,7 @@
         //        if (/^(f|ht)tps?:\/\//i.test(url)) {
         //          url = gnGlobalSettings.proxyUrl + encodeURIComponent(url);
         //        }
-        $http.get(url, {headers: {accept: 'application/xml'}})
+        return $http.get(url, {headers: {accept: 'application/xml'}})
             .then(function(r) {
               if (r.data === '') {
                 var msg = $translate.instant('emptyMapLoadError', {
@@ -565,6 +565,7 @@
        *
        * @description
        * Create a WMS ol.Layer from context object
+       * !! DEPRECATED: use gnMap.createLayerFromNotation instead
        *
        * @param {Object} layer layer
        * @param {ol.map} map map

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -166,19 +166,19 @@
           },
           'graticuleOgcService': {},
           'map-viewer': {
-            'content': '../../map/config-viewer.xml',
+            'context': '../../map/config-viewer.xml',
             'extent': [0, 0, 0, 0],
             'layers': []
           },
           'map-search': {
-            'content': '',
+            'context': '',
             'extent': [0, 0, 0, 0],
             'layers': [
               '{type=osm}'
             ]
           },
           'map-editor': {
-            'content': '',
+            'context': '',
             'extent': [0, 0, 0, 0],
             'layers': [
               '{type=osm}'

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -148,16 +148,11 @@
           'appUrl': '../../srv/{{lang}}/catalog.search#/map',
           'is3DModeAllowed': true,
           'isSaveMapInCatalogAllowed': true,
-          'bingKey':
-              'AnElW2Zqi4fI-9cYx1LHiQfokQ9GrNzcjOh_p_0hkO1yo78ba8zTLARcLBIf8H6D',
           'storage': 'sessionStorage',
-          'map': '../../map/config-viewer.xml',
           'listOfServices': {
             'wms': [],
             'wmts': []
           },
-          'useOSM': true,
-          'context': '',
           'projection': 'EPSG:3857',
           'projectionList': [{
             'code': 'EPSG:4326',
@@ -166,14 +161,29 @@
             'code': 'EPSG:3857',
             'label': 'Google mercator (EPSG:3857)'
           }],
-          'searchMapLayers': [],
-          'viewerMapLayers': [],
           'disabledTools': {
             'processes': true
           },
           'graticuleOgcService': {},
-          'mapExtent': [0, 0, 0, 0],
-          'mapBackgroundLayer': {}
+          'map-viewer': {
+            'content': '../../map/config-viewer.xml',
+            'extent': [0, 0, 0, 0],
+            'layers': []
+          },
+          'map-search': {
+            'content': '',
+            'extent': [0, 0, 0, 0],
+            'layers': [
+              '{type=osm}'
+            ]
+          },
+          'map-editor': {
+            'content': '',
+            'extent': [0, 0, 0, 0],
+            'layers': [
+              '{type=osm}'
+            ]
+          }
         },
         'geocoder': 'https://secure.geonames.org/searchJSON',
         'editor': {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -174,14 +174,14 @@
             'context': '',
             'extent': [0, 0, 0, 0],
             'layers': [
-              '{type=osm}'
+              { type: 'osm' }
             ]
           },
           'map-editor': {
             'context': '',
             'extent': [0, 0, 0, 0],
             'layers': [
-              '{type=osm}'
+              { type: 'osm' }
             ]
           }
         },

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1139,8 +1139,17 @@
     "allLanguage-help": "Display all languages",
     "oneLanguage": "One",
     "oneLanguage-help": "Choose one language to edit using the selector",
-    "ui-mapExtent": "Map Extent",
-    "ui-mapExtent-help": "Extent coordinates to use for maps other that viewer and search maps.",
-    "ui-mapBackgroundLayer": "Map Background Layer",
-    "ui-mapBackgroundLayer-help": "Define here the background layer to use for maps other that viewer and search maps."
+    "ui-mapExtent": "DEPRECATED! Map Extent",
+    "ui-mapExtent-help": "DEPRECATED! Extent coordinates to use for maps other that viewer and search maps.",
+    "ui-mapBackgroundLayer": "DEPRECATED! Map Background Layer",
+    "ui-mapBackgroundLayer-help": "DEPRECATED! Define here the background layer to use for maps other that viewer and search maps.",
+    "ui-map-viewer": "Viewer Map Configuration",
+    "ui-map-viewer-help": "This configuration is used for the viewer map. Every parameter is optional. The context is applied first, then the extent and layers.",
+    "ui-map-search": "Search Map Configuration",
+    "ui-map-search-help": "This configuration is used for the search map. Every parameter is optional. The context is applied first, then the extent and layers.",
+    "ui-map-editor": "Editor Maps Configuration",
+    "ui-map-editor-help": "This configuration is used for the editor maps (bounding box and geometry editor). Every parameter is optional. The context is applied first, then the extent and layers.",
+    "mapConfigContext": "Path to the context file (XML)",
+    "mapConfigExtent": "Extent, expressed in current projection",
+    "mapConfigLayers": "Layers, expressed in standard notation: {type=XXX,arg1=YYY,...} (types are: osm, bing_aerial, wmts, wms)"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1144,12 +1144,12 @@
     "ui-mapBackgroundLayer": "DEPRECATED! Map Background Layer",
     "ui-mapBackgroundLayer-help": "DEPRECATED! Define here the background layer to use for maps other that viewer and search maps.",
     "ui-map-viewer": "Viewer Map Configuration",
-    "ui-map-viewer-help": "This configuration is used for the viewer map. Every parameter is optional. The context is applied first, then the extent and layers.",
+    "ui-map-viewer-help": "This configuration is used for the viewer map. Every parameter is optional. The context is applied first, then the extent and layers. Supported types are: osm, bing_aerial, stamen, wmts, wms.",
     "ui-map-search": "Search Map Configuration",
-    "ui-map-search-help": "This configuration is used for the search map. Every parameter is optional. The context is applied first, then the extent and layers.",
+    "ui-map-search-help": "This configuration is used for the search map. Every parameter is optional. The context is applied first, then the extent and layers. Supported types are: osm, bing_aerial, stamen, wmts, wms.",
     "ui-map-editor": "Editor Maps Configuration",
-    "ui-map-editor-help": "This configuration is used for the editor maps (bounding box and geometry editor). Every parameter is optional. The context is applied first, then the extent and layers.",
+    "ui-map-editor-help": "This configuration is used for the editor maps (bounding box and geometry editor). Every parameter is optional. The context is applied first, then the extent and layers. Supported types are: osm, bing_aerial, stamen, wmts, wms.",
     "mapConfigContext": "Path to the context file (XML)",
     "mapConfigExtent": "Extent, expressed in current projection",
-    "mapConfigLayers": "Layers, expressed in standard notation: {type=XXX,arg1=YYY,...} (types are: osm, bing_aerial, wmts, wms)"
+    "mapConfigLayers": "Layer objects in JSON: {\"type\"=\"XXX\",\"arg1\":\"YYY\",...}"
 }


### PR DESCRIPTION
The goal of this PR is to begin standardizing the way OpenLayers maps are created & configured in the admin console.
Currently the way the search map, viewer map and editor maps are handled is completely different.

With this PR, every map creation should be done through the new `gnMapsManager` service, which takes one argument: the map type (`VIEWER_MAP`, `SEARCH_MAP` or `EDITOR_MAP`).
The map will be available right away but some layers may be added asynchronously, especially WMTS as they go through a `GetCapabilities` call.

This PR also introduces a standard *layer notation* which is already used in the saved contexts, but should now be used everywhere to describe a map layer. The notation is a string structured like so:
`{type=<TYPE>,arg1=<VALUE>,...}`

Valid examples are:
* OSM layer: `{type=osm}`
* Bing Aerial layer: `{type=bing_aerial,key=XXX}`
* Stamen layer: `{type=stamen}`
* Generic WMTS layer: `{type=wmts,url=http://.../wmts,name=layer_name}`

This notation is consumed by the `gnMap.createLayerFromNotation` new function, which should be used exclusively to create map layers.

This means that the following UI settings will eventually become deprecated:
* Bing key (should be an argument in the layer definition: `{type=bing,key=XYZ}`)
* Use OSM (a `{type=osm}` layer should be added instead)
* Default context (should be set in the corresponding map configuration)
* Additional viewer & search layers
They are still used in the application though, as this PR does not cover all the OpenLayers map usages.

Finally, a map configuration template has been added to the UI config:
![image](https://user-images.githubusercontent.com/10629150/30593523-1f997118-9d4b-11e7-880c-b797d4bc333b.png)