### PR TITLE
Fix keywords management when of 'place' type

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -418,6 +418,15 @@
       $scope.editKeyword = function(k) {
         $scope.keywordSelected = angular.copy(k);
         $scope.keywordSelected.oldId = $scope.keywordSelected.uri;
+
+        // create geo object (if not already there)
+        $scope.keywordSelected.geo = $scope.keywordSelected.geo || {
+          east: k.coordEast,
+          north: k.coordNorth,
+          south: k.coordSouth,
+          west: k.coordWest
+        };
+
         creatingKeyword = false;
         $('#keywordModal').modal();
         searchRelation($scope.keywordSelected);
@@ -442,10 +451,10 @@
         };
         if ($scope.isPlaceType()) {
           $scope.keywordSelected.geo = {
-            west: '',
-            south: '',
-            east: '',
-            north: ''
+            west: '0',
+            south: '0',
+            east: '0',
+            north: '0'
           };
         }
         $('#keywordModal').modal();
@@ -454,7 +463,7 @@
       /**
        * Build keyword POST body message
        */
-      buildKeyword = function(keywordObject) {
+      buildKeywordXML = function(keywordObject) {
         var geoxml = $scope.isPlaceType() ?
             '<west>' + keywordObject.geo.west + '</west>' +
             '<south>' + keywordObject.geo.south + '</south>' +
@@ -488,6 +497,7 @@
             (keywordObject.oldId || keywordObject.uri) + '</oldid>' +
             localizedValues +
             localizedDefinitions +
+            geoxml +
             '</request>';
 
         return xml;
@@ -499,7 +509,7 @@
       $scope.createKeyword = function() {
         $http.post(
             'thesaurus.keyword.add?_content_type=json',
-            buildKeyword($scope.keywordSelected),
+            buildKeywordXML($scope.keywordSelected),
             { headers: {'Content-type': 'application/xml'} }
         )
             .success(function(data) {
@@ -533,7 +543,7 @@
        */
       $scope.updateKeyword = function() {
         $http.post('thesaurus.keyword.update',
-            buildKeyword($scope.keywordSelected),
+            buildKeywordXML($scope.keywordSelected),
             { headers: {'Content-type': 'application/xml'} }
         )
             .success(function(data) {

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -450,14 +450,14 @@
 
             <!-- Only displayed for thesaurus of type place -->
             <fieldset data-ng-show="isPlaceType()">
-              <legend data-translate="">keywordCoordinates</legend>
-
+              <legend translate>keywordCoordinates</legend>
               <div data-ng-repeat="(key, value) in keywordSelected.geo track by $index">
-                <label class="control-label" data-translate="">{{key | translate}}</label>
-                <!-- TODO: use type="number" min="-180" max="180" but there is
-                        some issue in Angular - maybe https://github.com/angular/angular.js/issues/2144-->
-                <input name="{{key}}" class="form-control" type="text"
-                      data-ng-disabled="isExternal()" data-ng-model="keywordSelected.geo[key]"/>
+                <div class="input-group">
+                  <span class="input-group-addon width-33 text-right" translate>{{key}}</span>
+                  <input name="{{key}}" class="form-control" type="text"
+                        data-ng-disabled="isExternal()" data-ng-model="keywordSelected.geo[key]"/>
+                </div>
+                <br>
               </div>
             </fieldset>
 


### PR DESCRIPTION
Previously keywords with an extent could not be loaded or saved. This is fixed with this PR.

Also the template for the geo coords has been improved:
![image](https://user-images.githubusercontent.com/10629150/30641464-7c199078-9e07-11e7-987a-acc0a7d13141.png)
