### PR TITLE
Avoids losing the filter after removing all CSW harvester's records

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
@@ -24,7 +24,6 @@
 package org.fao.geonet.kernel.harvest.harvester.csw;
 
 import jeeves.server.context.ServiceContext;
-
 import org.fao.geonet.Logger;
 import org.fao.geonet.domain.Source;
 import org.fao.geonet.exceptions.BadInputEx;
@@ -93,7 +92,6 @@ public class CswHarvester extends AbstractHarvester<HarvestResult> {
     }
 
     /**
-     *
      * @param id
      * @param node
      * @throws org.fao.geonet.exceptions.BadInputEx
@@ -132,8 +130,8 @@ public class CswHarvester extends AbstractHarvester<HarvestResult> {
     //---------------------------------------------------------------------------
 
     /**
-     *
-     * @param p
+     * Stores in the harvester settings table some values not managed by {@link AbstractHarvester}
+     * @param p the harvester parameters.
      * @param path
      * @param siteId
      * @param optionsId
@@ -156,7 +154,12 @@ public class CswHarvester extends AbstractHarvester<HarvestResult> {
         if (params.eltSearches != null) {
             for (Element element : params.eltSearches) {
                 if (!element.getName().startsWith("parser")) {
-                    settingMan.add("id:" + searchID, element.getName(), element.getText());
+                    Element value = element.getChild("value");
+                    if (value != null) {
+                        settingMan.add("id:" + searchID, element.getName(), value.getText());
+                    } else {
+                        settingMan.add("id:" + searchID, element.getName(), element.getText());
+                    }
                 }
             }
         }
@@ -169,7 +172,6 @@ public class CswHarvester extends AbstractHarvester<HarvestResult> {
     //---------------------------------------------------------------------------
 
     /**
-     *
      * @param log
      * @throws Exception
      */


### PR DESCRIPTION
When the harvester settings are retrieved from the database using the
HarvesterSettingManager it includes a <value> element inside the search
filters. With this commit this case is covered too when the settings are 
cloned to be preserved.

This change should be merged in 3.4.x and develop branches too.

Fixes #1780.