### PR TITLE
Toolbar improvements pt. 2 & search widgets improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/partials/sortByCombo.html
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/partials/sortByCombo.html
@@ -4,11 +4,10 @@
             class="btn btn-default dropdown-toggle"
             data-toggle="dropdown"
             aria-expanded="false">
-      <i class="fa fa-sort"/>&nbsp;
       <span data-translate=""
             data-translate-values="{field: '{{params.sortBy | translate}}'}"
-            class="hidden-xs">sortedBy</span>
-      <span class="caret"></span>
+            class="">sortedBy</span>
+      <i class="fa fa-sort"/>
     </button>
     <ul class="dropdown-menu" role="menu">
       <li data-ng-repeat="v in ::values"

--- a/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
+++ b/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
@@ -1,7 +1,6 @@
 <div>
-  <div class="gn-pager"
-       data-ng-show="config.pages > 1">
-    <ul class="pager gn-pager-start">
+  <div class="gn-pager">
+    <ul class="pagination">
       <li data-ng-class="config.currentPage == 1 ? 'disabled' : ''">
         <a href="" data-ng-click="first()">
           <i class="fa fa-angle-double-left"></i>
@@ -12,26 +11,23 @@
           <i class="fa fa-angle-left"></i>
         </a>
       </li>
-    </ul>
+      <li class="btn-group">
     <!-- A dropdown button to select the number of page
     and indicating the current page info -->
-    <span data-ng-hide="values && values.length > 1">
-    {{config.from}} - {{config.to}}
-    <em data-translate="">on</em>
-    {{config.resultsCount}}
-  </span>
-    <div class="btn-group"
-         data-ng-show="values && values.length > 1"
-         title="{{'chooseRecordsPerPage' | translate}}">
-      <button type="button"
-              class="btn btn-default dropdown-toggle"
-              data-toggle="dropdown"
-              aria-expanded="false">
-        {{config.from}} - {{config.to}}
-        <em data-translate="">on</em>
-        {{config.resultsCount}}
+      <a href class="dropdown-toggle"
+        data-toggle="dropdown"
+        aria-expanded="false">
+        <span ng-show="config.pages > 1">
+          {{config.from}} - {{config.to}}
+          <span translate>resultXonY</span>
+          {{config.resultsCount}}
+        </span>
+        <span ng-show="config.pages <= 1">
+          {{config.to}}
+          <span translate>results</span>
+        </span>
         <span class="caret"></span>
-      </button>
+      </a>
       <ul class="dropdown-menu" role="menu">
         <li role="presentation"
             class="dropdown-header" data-translate="">hitsPerPage
@@ -41,8 +37,7 @@
           <a data-ng-click="updateSearch(nb)">{{nb}}</a>
         </li>
       </ul>
-    </div>
-    <ul class="pager gn-pager-end">
+    </li>
       <li data-ng-class="config.currentPage == config.pages ? 'disabled' : ''">
         <a href="" data-ng-click="next()">
           <i class="fa fa-angle-right"></i>
@@ -54,11 +49,5 @@
         </a>
       </li>
     </ul>
-  </div>
-  <div class="gn-sort-by">
-    <div class="btn-group"
-         data-ng-show="config.pages == 1">
-      <button class="btn btn-default">{{config.to}}&nbsp;<span translate="">results</span></button>
-    </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -463,6 +463,9 @@
         }
       });
 
+      // login url for inline signin form in top toolbar
+      $scope.signInFormAction = '../../signin#' + $location.path();
+
       /**
        * Catalog facet summary providing
        * a global overview of the catalog content.

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -353,5 +353,6 @@
     "settings": "Settings",
     "tools": "Tools",
     "collapseAllFacetLabel": "Collapse",
-    "expandAllFacetLabel": "Expand"
+    "expandAllFacetLabel": "Expand",
+    "resultXonY": "on"
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -23,18 +23,8 @@ div[gn-transfer-ownership] * .list-group {
 }
 
 .gn-pager {
-  .pager {
+  .pagination {
     margin: 0;
-    text-align: left;
-    display: inline-block;
-    li > a {
-      padding: 2px 5px;
-      border-radius: 6px;
-      font-size: 120%;
-    }
-    em {
-      font-style: normal;
-    }
   }
 }
 

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -186,6 +186,14 @@ span.gn-facet-label:first-letter {
   text-transform: uppercase;
 }
 
+// fix sort-by combo case
+.gn-sort-by .btn.dropdown-toggle {
+  text-transform: lowercase;
+  &:first-letter {
+    text-transform: uppercase;
+  }
+}
+
 /* TODO: Deprecate due to change in gn-pager and gn-sort-by */
 [sortby-combo], [hitsperpage-combo] {
   display: inline-block;

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -107,13 +107,17 @@
 
     <ul data-ng-if="gnCfg.mods.signin.enabled"
         class="nav navbar-nav navbar-right">
-      <li data-ng-show="authenticated">
+      <li class="dropdown dropdown-hover" data-ng-show="authenticated">
         <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}"
-           title="{{'userDetails' | translate}}"
-           class="hidden-xs">
+          title="{{'userDetails' | translate}}"
+          class="dropdown-toggle"
+          role="button" aria-expanded="false">
           <img class="img-circle"
-               data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=18"/>
-          {{user.name}} {{user.surname}} ({{user.profile | translate}})
+            data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=18"/>&nbsp;
+          <div class="gn-user-info">
+            {{user.name}} {{user.surname}}<br>
+            <span class="gn-user-role">{{user.profile | lowercase | translate}}</span>
+          </div>
           <span class="alert alert-danger ng-hide"
                 data-ng-show="session.remainingTime > 0 &&
                     session.remainingTime < session.alertInTitleWhen"
@@ -122,21 +126,52 @@
             sessionWillExpireIn
           </span>
         </a>
+        <ul class="dropdown-menu" role="menu">
+          <li>
+            <a href="{{gnCfg.mods.signout.appUrl}}"
+                title="{{'signout' | translate}}">
+              <i class="fa fa-sign-out"></i>&nbsp;
+              {{'signout' | translate}}
+            </a>
+          </li>
+        </ul>
       </li>
-      <li data-ng-show="authenticated">
-        <a href="{{gnCfg.mods.signout.appUrl}}"
-           title="{{'signout' | translate}}">
-          <i class="fa fa-sign-out"></i>&nbsp;
-          {{'signout' | translate}}
-        </a>
-      </li>
-      <li data-ng-show="!authenticated && service !== 'catalog.signin' && !shibbolethEnabled"">
+      <li class="dropdown dropdown-hover signin-dropdown"
+        data-ng-show="!authenticated && service !== 'catalog.signin' && !shibbolethEnabled">
         <a href="{{gnCfg.mods.signin.appUrl | signInLink}}"
            title="{{'signIn'|translate}}"
+           class="dropdown-toggle"
            data-ng-keypress="$event">
           <i class="fa fa-sign-in"/>&nbsp;
           {{'signIn' | translate}}
         </a>
+        <ul class="dropdown-menu" role="menu">
+          <li>
+            <form name="gnSigninForm" class="navbar-form flex-row"
+              action="{{signInFormAction}}" method="post" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+              <div class="form-group form-group-sm">
+                <label class="sr-only" for="inputUsername" data-translate="">username</label>
+                <input type="text" class="form-control" id="inputUsername" name="username" autofocus=""
+                  placeholder="{{'username' | translate}}" data-ng-model="signinUsername"
+                  required=""/>
+              </div>
+              <div class="flex-spacer"></div>
+              <div class="form-group form-group-sm">
+                <label class="sr-only"for="inputPassword" data-translate="">password</label>
+                  <input type="password" class="form-control" id="inputPassword" name="password"
+                    autocomplete="off"
+                    data-ng-model="signinPassword" placeholder="{{'password' | translate}}"
+                    required=""/>
+              </div>
+              <div class="flex-spacer"></div>
+              <button type="submit" class="btn btn-primary btn-sm pull-right"
+                      data-ng-disabled="!gnSigninForm.$valid">
+                <i class="fa fa-sign-in"/>
+              </button>
+            </form>
+          </li>
+        </ul>
       </li>
     </ul>
   </div>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -38,7 +38,7 @@
           <span data-gnv-layer-indicator=""/>
         </a>
       </li>
-      <li class="dropdown dropdown-hover" data-ng-if="gnCfg.mods.editor.enabled"
+      <li class="dropdown dropdown-hover open" data-ng-if="gnCfg.mods.editor.enabled"
           data-ng-show="authenticated && user.isEditorOrMore()">
         <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}"
            title="{{'editorBoard' | translate}}"
@@ -47,7 +47,7 @@
           <i class="fa fa-pencil"></i>
           <span class="hidden-sm" data-translate="">contribute</span>
         </a>
-        <ul class="dropdown-menu hidden-xs" role="menu">
+        <ul class="dropdown-menu" role="menu">
           <li>
             <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/create">
               <i class="fa fa-fw fa-plus"/>&nbsp;<span data-translate="">addRecord</span>
@@ -72,7 +72,7 @@
           </li>
         </ul>
       </li>
-      <li class="dropdown dropdown-hover" data-ng-show="user.isUserAdminOrMore()">
+      <li class="dropdown dropdown-hover open" data-ng-show="user.isUserAdminOrMore()">
         <a data-gn-active-tb-item="admin.console"
            title="{{'adminConsole' | translate}}"
            class="dropdown-toggle"
@@ -80,14 +80,14 @@
           <i class="fa fa-wrench"></i>
           <span class="hidden-sm" data-translate="">adminConsole</span>
         </a>
-        <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu hidden-xs" role="menu">
+        <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu" role="menu">
           <li data-ng-repeat="t in userAdminMenu">
             <a data-gn-active-tb-item="admin.console{{t.route}}">
               <i class="fa {{t.icon}}"/>&nbsp;<span data-translate="">{{t.name | translate}}</span>
             </a>
           </li>
         </ul>
-        <ul data-ng-if="user.isAdministrator()" class="dropdown-menu hidden-xs" role="menu">
+        <ul data-ng-if="user.isAdministrator()" class="dropdown-menu" role="menu">
           <li data-ng-repeat="t in adminMenu">
             <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}{{t.route}}">
               <i class="fa fa-fw {{t.icon}}"/>&nbsp;<span data-translate="">{{t.name | translate}}</span>
@@ -99,7 +99,7 @@
 
 
     <form class="navbar-form navbar-right" role="language">
-      <div class="form-group pull-right"
+      <div class="form-group"
            data-gn-language-switcher="lang"
            data-langs="langs"
            data-lang-labels="langLabels"/>
@@ -107,7 +107,7 @@
 
     <ul data-ng-if="gnCfg.mods.signin.enabled"
         class="nav navbar-nav navbar-right">
-      <li class="dropdown dropdown-hover" data-ng-show="authenticated">
+      <li class="dropdown dropdown-hover open" data-ng-show="authenticated">
         <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}"
           title="{{'userDetails' | translate}}"
           class="dropdown-toggle"
@@ -136,7 +136,7 @@
           </li>
         </ul>
       </li>
-      <li class="dropdown dropdown-hover signin-dropdown"
+      <li class="dropdown dropdown-hover open signin-dropdown"
         data-ng-show="!authenticated && service !== 'catalog.signin' && !shibbolethEnabled">
         <a href="{{gnCfg.mods.signin.appUrl | signInLink}}"
            title="{{'signIn'|translate}}"

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -16,7 +16,7 @@
           font-family: FontAwesome;
           content: "\f0d7";
           position: absolute;
-          bottom: -2px;
+          bottom: -5px;
           left: 50%;
           transform: translate(-50%, 0);
           font-size: 0.9em;
@@ -25,9 +25,21 @@
       ul {
         display: none;
       }
-      &:hover ul {
+      &:hover ul, &:focus ul, &:active ul {
         display: block;
       }
+    }
+  }
+
+  .gn-user-info {
+    display: inline-block;
+    vertical-align: middle;
+    margin: -6px 0px;
+    line-height: 1em;
+    .gn-user-role {
+      text-transform: uppercase;
+      opacity: 0.7;
+      font-size: 0.8em;
     }
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -22,6 +22,9 @@
           font-size: 0.9em;
         }
       }
+      &.open > .dropdown-toggle {
+        background: none;
+      }
       ul {
         display: none;
       }
@@ -45,4 +48,5 @@
 }
 .navbar-form {
   border:none;
+  margin: 8px 0px;
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_pagination_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_pagination_default.less
@@ -2,26 +2,9 @@
 
 /* Pagination */
 .gn-pager {
-  /* Hide the first/last page button */
-  .gn-pager-start {
-    li:nth-child(1) {
-      display: none;
-    }
-  }
-  .gn-pager-end {
-    li:nth-child(2) {
-      display: none;
-    }
-  }
-
   /* Button on the right, current page info on the left */
   .btn-group {
     float: left;
-
-    /* Drop down to select hits is a simple link */
-    button {
-      .btn-link();
-    }
 
     /* Inline hits options */
     li {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -35,6 +35,7 @@
     .btn-link();
   }
 }
+
 .gn-search-page {
   clear: both;
   flex-grow: 1;

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -26,59 +26,72 @@
           </div>
         </div>
       </div>
-
     </div>
 
-    <div class="col-md-9"
-         data-gn-facet-dimension-list="searchResults.dimension"
-         data-params="searchObj.params"
-         data-facet-type="facetsSummaryType"
-         data-facet-list="facetConfig"
-         data-current-facets="currentFacets"
-         data-tab-field="facetTabField"></div>
+    <div class="col-md-9 container-fluid">
+      <div class="row">
+        <div class="col-xs-12 col-md-9"
+            data-gn-facet-dimension-list="searchResults.dimension"
+            data-params="searchObj.params"
+            data-facet-type="facetsSummaryType"
+            data-facet-list="facetConfig"
+            data-current-facets="currentFacets"
+            data-tab-field="facetTabField"></div>
 
-    <div class="col-md-3 relative"
-         data-ng-show="searchResults.records.length > 0">
-      <div data-gn-selection-widget=""
-           data-results="searchResults"></div>
+        <div class="col-xs-12 col-sm-6 col-sm-push-3 text-center"
+          data-ng-show="searchResults.records.length > 0">
+          <div class=""
+              data-gn-pagination="paginationInfo"
+              data-hits-values="searchObj.hitsperpageValues"
+              data-enable-hot-keys=""
+              data-enable-events=""></div>
+        </div>
+
+        <div class="col-xs-6 col-sm-4 col-sm-pull-6 col-lg-pull-6"
+          data-ng-show="searchResults.records.length > 0">
+          <div data-gn-selection-widget=""
+                data-results="searchResults"></div>
+        </div>
+
+        <div class="col-xs-6 col-sm-2"
+          data-ng-show="searchResults.records.length > 0">
+          <div class="pull-right"
+              data-sortby-combo=""
+              data-params="searchObj.params"
+              data-gn-sortby-values="searchObj.sortbyValues"></div>
+        </div>
     </div>
 
-    <div class="col-md-6"
-         data-ng-show="searchResults.records.length > 0">
+    <div class="row">
+      <div class="col-xs-12">
+        <span class="loading fa fa-spinner fa-spin"
+              data-ng-show="searching"></span>
 
-      <div class="pull-right"
-           data-sortby-combo=""
-           data-params="searchObj.params"
-           data-gn-sortby-values="searchObj.sortbyValues"></div>
-      <div class="pull-right"
-           data-gn-pagination="paginationInfo"
-           data-hits-values="searchObj.hitsperpageValues"
-           data-enable-hot-keys=""
-           data-enable-events=""></div>
-    </div>
+        <div class="alert alert-warning" role="alert"
+            ng-if="!searching && searchResults.count == 0">
+          <i class="fa fa-frown-o"></i>
+          <span data-translate="">zarooResult</span>
+        </div>
 
-    <div class="col-md-9">
-      <span class="loading fa fa-spinner fa-spin"
-            data-ng-show="searching"></span>
-
-      <div class="alert alert-warning" role="alert"
-           ng-if="!searching && searchResults.count == 0">
-        <i class="fa fa-frown-o"></i>
-        <span data-translate="">zarooResult</span>
+        <div data-ng-show="searchResults.records.length > 0"
+            data-gn-results-container=""
+            data-search-results="searchResults"
+            data-template-url="resultTemplate"
+            data-map="searchObj.searchMap"></div>
       </div>
-
-      <div data-ng-show="searchResults.records.length > 0"
-           data-gn-results-container=""
-           data-search-results="searchResults"
-           data-template-url="resultTemplate"
-           data-map="searchObj.searchMap"></div>
-
-      <div class=""
-           data-gn-pagination="paginationInfo"
-           data-hits-values="searchObj.hitsperpageValues"
-           data-enable-hot-keys=""></div>
-      <br/>
     </div>
+
+    <div class="row">
+      <div class="col-xs-12 text-center"
+      data-ng-show="searchResults.records.length > 0">
+        <div class=""
+              data-gn-pagination="paginationInfo"
+              data-hits-values="searchObj.hitsperpageValues"
+              data-enable-hot-keys=""
+              data-enable-events=""></div>
+      </div>
+    </div>
+    <br>
   </div>
 
   <div data-gn-map-field="searchObj.searchMap"


### PR DESCRIPTION
More UI improvements with this PR:
* The user info block in the toolbar is now more compact (this way, there should not be any overlapping in the toolbar anymore), with the signout link being in a dropdown
![image](https://user-images.githubusercontent.com/10629150/30851169-1d12f218-a2a8-11e7-88cd-416305d5b0eb.png)
* When logged out, an inline form is available in the toolbar to quickly login:
![image](https://user-images.githubusercontent.com/10629150/30851729-c20c42dc-a2a9-11e7-9778-18d3476aa264.png)
* The toolbar displays all its items properly when on mobile format:
![image](https://user-images.githubusercontent.com/10629150/30852085-ef6fc766-a2aa-11e7-882a-934b2f7f959b.png)
* The pagination & sort-by widgets have been slightly improved:
![image](https://user-images.githubusercontent.com/10629150/30851292-7c0ef58c-a2a8-11e7-992b-cc1c5bb74d3d.png)
* The general layout of the search results page have been slightly improved to better handle mobile formats & have better widgets placement:
![image](https://user-images.githubusercontent.com/10629150/30851345-a9b44df2-a2a8-11e7-9baa-4ce127f85f3e.png)
