### PR TITLE
Go back to metadata view when closing to editor if coming from search

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -454,8 +454,16 @@
           // when the editor was not opened by a script.
         }
 
-        // Go to editor home
-        $location.path('');
+        var lastPage = document.referrer;
+        if(lastPage && /\/catalog\.search/.test(lastPage)) {
+          var debug = /(&|\?)debug/.test(window.location) ? '?debug' : '';
+          var url = lastPage.split('?')[0] + debug + '#/metadata/' +
+            gnCurrentEdit.uuid;
+          window.location = url;
+        }
+        else {
+          window.history.back();
+        }
       };
 
       $scope.cancel = function(refreshForm) {

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -454,16 +454,7 @@
           // when the editor was not opened by a script.
         }
 
-        var lastPage = document.referrer;
-        if(lastPage && /\/catalog\.search/.test(lastPage)) {
-          var debug = /(&|\?)debug/.test(window.location) ? '?debug' : '';
-          var url = lastPage.split('?')[0] + debug + '#/metadata/' +
-            gnCurrentEdit.uuid;
-          window.location = url;
-        }
-        else {
-          window.history.back();
-        }
+        window.history.back();
       };
 
       $scope.cancel = function(refreshForm) {


### PR DESCRIPTION
When closing the editor (save or cancel) try to go back from where we come.
If coming from search page, then go back to metadata view, else go back to editor board.