### PR TITLE
try to avoid vm being rude at test times with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: java
 jdk:
   - oraclejdk8
 before_install:
+  - unset _JAVA_OPTIONS
   - export MAVEN_OPTS="-Xmx512M -XX:MaxPermSize=256M"


### PR DESCRIPTION
seems that _JAVA_OPTIONS overwrite surefire settings

wonder if this is the cause of randomly failing builds

(java.lang.RuntimeException: The forked VM terminated
 without properly saying goodbye. VM crash or System.exit called?)