### PR TITLE
Navbar fixes

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1161,7 +1161,7 @@
             var targetPath =
               link.match(pathRE) ? link.match(pathRE)[1] : '';
             var isActive = currentService == targetService &&
-              (!targetPath || currentPath == targetPath);
+              (!targetPath || currentPath.indexOf(targetPath) > -1);
 
             if (isActive) {
               element.parent().addClass('active');

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -83,7 +83,7 @@
         <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu" role="menu">
           <li data-ng-repeat="t in userAdminMenu">
             <a data-gn-active-tb-item="admin.console{{t.route}}">
-              <i class="fa {{t.icon}}"/>&nbsp;<span data-translate="">{{t.name | translate}}</span>
+              <i class="fa fa-fw {{t.icon}}"/>&nbsp;<span data-translate="">{{t.name | translate}}</span>
             </a>
           </li>
         </ul>
@@ -137,7 +137,7 @@
         </ul>
       </li>
       <li class="dropdown dropdown-hover open signin-dropdown"
-        data-ng-show="!authenticated && service !== 'catalog.signin' && !shibbolethEnabled">
+        data-ng-show="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !shibbolethEnabled">
         <a href="{{gnCfg.mods.signin.appUrl | signInLink}}"
            title="{{'signIn'|translate}}"
            class="dropdown-toggle"

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -24,13 +24,13 @@
           font-size: 0.9em;
         }
       }
-      &.open > .dropdown-toggle {
+      &.open:not(.active) > .dropdown-toggle {
         background: none;
       }
       ul {
         display: none;
       }
-      &:hover ul, &:focus ul, &:active ul {
+      &:hover ul, & > a:focus + ul, & > a:active + ul {
         display: block;
       }
     }


### PR DESCRIPTION
* the inline login form does not appear on the new account page anymore (fixes #2207)
* dropdowns can now be opened with keyboard navigation (tab focus)
* fixed root menu items 'active' state