### PR TITLE
XSLT Formatter and HTML mode improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1274,13 +1274,14 @@
     <es.url>http://${es.host}:${es.port}</es.url>
     <es.index.features>features</es.index.features>
     <es.index.records>records</es.index.records>
+    <es.index.searchlogs>searchlogs</es.index.searchlogs>
+
     <!-- to load spring configurations related to es and camel,
     you should use maven "es" profile (defined in web).
     Devs may note that normally (not in this case), many spring profiles can
     be defined at the same time: "active.profiles.spring" is overriden
     in web.xml. -->
     <es.spring.profile></es.spring.profile>
-    <es.index.searchlogs>searchlogs</es.index.searchlogs>
     <es.username></es.username>
     <es.password></es.password>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
@@ -217,7 +217,7 @@ public class Handlers {
                 tip = this.f.translate("noUuidInLink")
                 cls = 'text-muted'
             } else {
-                href = env.localizedUrl + 'md.viewer#/full_view/' + identifier
+                href = env.localizedUrl + 'display#/' + identifier + '/formatters/full_view/'
                 tip = href
             }
             def category = opName.trim().isEmpty() ? 'uncategorized' : opName

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/strings.xml
@@ -31,4 +31,9 @@
   <refDate>Reference date</refDate>
   <temporalRef>Temporal information</temporalRef>
   <constraintInfo>Access constraint information</constraintInfo>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/strings.xml
@@ -34,7 +34,7 @@
   <xml_iso19139>Desar aquestes metadades com un arxiu XML ISO19139</xml_iso19139>
   <xml_iso19139Tooai_dc>Desar aquestes metadades com un arxiu XML OAI Dublin Core
   </xml_iso19139Tooai_dc>
-  
+
   <!-- New strings added for the AngularJS editor -->
   <!-- View and tabs -->
   <advanced>Complet</advanced>
@@ -43,6 +43,11 @@
   <inspire>INSPIRE</inspire>
   <inspire_sds>SDS</inspire_sds>
 
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
   <resource>Recurs</resource>
   <xml>XML</xml>
   <metadata>Metadada</metadata>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/strings.xml
@@ -31,4 +31,9 @@
   <refDate>Reference date</refDate>
   <temporalRef>Temporal information</temporalRef>
   <constraintInfo>Access constraint information</constraintInfo>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/strings.xml
@@ -40,6 +40,11 @@
   <inspire>INSPIRE</inspire>
   <inspire_sds>SDS</inspire_sds>
 
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
   <keywordFrom>Trefwoord van </keywordFrom>
   <resource>Bron</resource>
   <xml>XML</xml>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
@@ -58,6 +58,16 @@
   <applicationSchemaInfo>Schema info</applicationSchemaInfo>
   <noThesaurusName>Keywords</noThesaurusName>
   <bboxesSection>Geographic coverage</bboxesSection>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
+  <linkToPortal>Access to the portal</linkToPortal>
+  <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
+  <citationProposal>Citation proposal</citationProposal>
+  <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>
+  <associatedResources>Associated resources</associatedResources>
 
   <!-- XSD error translation -->
   <invalidElement>Invalid element. Invalid content was found starting with element:</invalidElement>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/strings.xml
@@ -41,6 +41,11 @@
   <simple>Yksinkertainen</simple>
   <inspire>INSPIRE</inspire>
   <inspire_sds>INSPIRE-SDS</inspire_sds>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 
   <resource>Resurssi</resource>
   <xml>XML</xml>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
@@ -31,6 +31,13 @@
   <temporalRef>Référence(s) temporelle(s)</temporalRef>
   <refDate>Date(s) de référence</refDate>
   <constraintInfo>Contraintes d'accès et d'utilisation</constraintInfo>
+  <overviews>Aperçus</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Fourni par</providedBy>
+  <shareOnSocialSite>Partager</shareOnSocialSite>
+  <viewMode>Mode d'affichage</viewMode>
+  <linkToPortal>Lien vers le portal</linkToPortal>
+  <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
 
 
   <advanced>Complète</advanced>
@@ -52,6 +59,9 @@
   <applicationSchemaInfo>Extension</applicationSchemaInfo>
   <noThesaurusName>Mots clés</noThesaurusName>
   <bboxesSection>Zone géographique</bboxesSection>
+  <citationProposal>Proposition de citation</citationProposal>
+  <citationProposal-help>Cette proposition de citation a été générée automatiquement selon le format suggéré par DataCite. Nous vous invitons à vérifier dans les métadonnées si les auteurs n'ont pas imposé un format de citation spécifique.</citationProposal-help>
+  <associatedResources>Ressources associées</associatedResources>
 
   <keywordFrom>Mots clés - </keywordFrom>
   <!-- XSD error translation -->

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/strings.xml
@@ -41,6 +41,11 @@
   <simple>Simple</simple>
   <inspire>INSPIRE</inspire>
   <inspire_sds>SDS</inspire_sds>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 
   <resource>Resource</resource>
   <xml>XML</xml>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/strings.xml
@@ -42,6 +42,11 @@
   <inspire>INSPIRE</inspire>
   <resource>Risorsa</resource>
   <xml>XML</xml>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
   <metadata>Metadato</metadata>
   <identificationInfo>Identificazione</identificationInfo>
   <distributionInfo>Distribuzione</distributionInfo>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/strings.xml
@@ -31,4 +31,9 @@
   <refDate>Reference date</refDate>
   <temporalRef>Temporal information</temporalRef>
   <constraintInfo>Access constraint information</constraintInfo>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/strings.xml
@@ -32,4 +32,9 @@
   <temporalRef>Informacje o odniesieniu czasowym</temporalRef>
   <constraintInfo>Ograniczenia dostępu</constraintInfo>
   <xml_iso19139>Zapisz plik metadanych jako XML zgodny z ISO19139</xml_iso19139>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/strings.xml
@@ -31,4 +31,9 @@
   <refDate>Reference date</refDate>
   <temporalRef>Temporal information</temporalRef>
   <constraintInfo>Access constraint information</constraintInfo>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/strings.xml
@@ -42,6 +42,11 @@
   <simple>Simple</simple>
   <inspire>INSPIRE</inspire>
   <inspire_sds>SDS</inspire_sds>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 
   <resource>Recurso</resource>
   <xml>XML</xml>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/strings.xml
@@ -41,11 +41,6 @@
   <simple>Simple</simple>
   <inspire>INSPIRE</inspire>
   <inspire_sds>SDS</inspire_sds>
-  <overviews>Overviews</overviews>
-  <metadataInXML>XML</metadataInXML>
-  <providedBy>Provided by</providedBy>
-  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
-  <viewMode>Views</viewMode>
 
   <keywordFrom>Keywords - </keywordFrom>
   <resource>Resource</resource>
@@ -63,6 +58,11 @@
   <applicationSchemaInfo>Schema info</applicationSchemaInfo>
   <noThesaurusName>Keywords</noThesaurusName>
   <bboxesSection>Geographic coverage</bboxesSection>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
 
   <!-- XSD error translation -->
   <invalidElement>Invalid element. Invalid content was found starting with element:</invalidElement>

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -264,15 +264,17 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         if (formatType == null) {
             formatType = FormatType.xml;
         }
-
-        final ServiceContext context = createServiceContext(locale.getISO3Language(),
-            formatType, request.getNativeRequest(HttpServletRequest.class));
+        final String language = LanguageUtils.locale2gnCode(locale.getISO3Language());
+        final ServiceContext context = createServiceContext(
+            language,
+            formatType,
+            request.getNativeRequest(HttpServletRequest.class));
         Metadata metadata = ApiUtils.canViewRecord(metadataUuid, servletRequest);
 
         Boolean hideWithheld = true;
 //        final boolean hideWithheld = Boolean.TRUE.equals(hide_withheld) ||
 //            !context.getBean(AccessManager.class).canEdit(context, resolvedId);
-        Key key = new Key(metadata.getId(), locale.getISO3Language(), formatType, formatterId, hideWithheld, width);
+        Key key = new Key(metadata.getId(), language, formatType, formatterId, hideWithheld, width);
         final boolean skipPopularityBool = false;
 
         ISODate changeDate = metadata.getDataInfo().getChangeDate();
@@ -281,7 +283,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         if (changeDate != null) {
             final long changeDateAsTime = changeDate.toDate().getTime();
             long roundedChangeDate = changeDateAsTime / 1000 * 1000;
-            if (request.checkNotModified(locale.getLanguage(), roundedChangeDate) &&
+            if (request.checkNotModified(language, roundedChangeDate) &&
                 context.getBean(CacheConfig.class).allowCaching(key)) {
                 if (!skipPopularityBool) {
                     context.getBean(DataManager.class).increasePopularity(context, String.valueOf(metadata.getId()));
@@ -311,7 +313,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             if (!skipPopularityBool) {
                 context.getBean(DataManager.class).increasePopularity(context, String.valueOf(metadata.getId()));
             }
-            writeOutResponse(context, locale.getISO3Language(), request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
+            writeOutResponse(context, metadataUuid, locale.getISO3Language(), request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
         }
     }
 
@@ -371,7 +373,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         final String formattedMetadata = result.one().format(result.two());
         byte[] bytes = formattedMetadata.getBytes(Constants.CHARSET);
 
-        writeOutResponse(context, lang, request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
+        writeOutResponse(context, "", lang, request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
     }
 
     /**
@@ -477,13 +479,13 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
                 context.getBean(DataManager.class).increasePopularity(context, resolvedId);
             }
 
-            writeOutResponse(context, lang, request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
+            writeOutResponse(context, resolvedId, lang, request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
         }
     }
 
-    private void writeOutResponse(ServiceContext context, String lang, HttpServletResponse response, FormatType formatType, byte[] formattedMetadata) throws Exception {
+    private void writeOutResponse(ServiceContext context, String metadataUuid, String lang, HttpServletResponse response, FormatType formatType, byte[] formattedMetadata) throws Exception {
         response.setContentType(formatType.contentType);
-        String filename = "metadata." + formatType;
+        String filename = "metadata." + metadataUuid + formatType;
         response.addHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
         response.setStatus(HttpServletResponse.SC_OK);
         if (formatType == FormatType.pdf) {

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
@@ -71,11 +71,18 @@ public class XsltFormatter implements FormatterImpl {
         root.addContent(new Element("url").setText(fparams.url));
         // FIXME: This is a hack to mimic what Jeeves service are doing.
         // Some XSLT are used by both formatters and Jeeves and Spring MVC services
+        Element translations = new Element("translations");
         Element gui = new Element("gui");
         gui.addContent(new Element("url").setText(fparams.url + "../.."));
         gui.addContent(new Element("nodeUrl").setText(settingManager.getNodeURL()));
+        gui.addContent(new Element("language").setText(fparams.context.getLanguage()));
         gui.addContent(new Element("reqService").setText("md.format.html"));
+        Element env = new Element("systemConfig");
+        env.addContent(settingManager.getAllAsXML(true));
+        gui.addContent(env);
         root.addContent(gui);
+
+
 
         root.addContent(new Element("locUrl").setText(fparams.getLocUrl()));
 

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
@@ -69,7 +69,7 @@ public class LanguageUtils {
         Locale l = parseAcceptLanguage(locales);
         return locale2gnCode(l.getISO3Language());
     }
-    private String locale2gnCode (String code) {
+    static public String locale2gnCode (String code) {
         if (code.equals("fra")) {
             return "fre";
         } else {

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -237,6 +237,7 @@
           // Attach the md to the grid element scope
           if (!scope.md) {
             scope.$parent.md = md;
+            scope.md = md;
           }
           return url;
         });

--- a/web-ui/src/main/resources/catalog/js/GnFormatterLib.js
+++ b/web-ui/src/main/resources/catalog/js/GnFormatterLib.js
@@ -32,7 +32,6 @@
     e.preventDefault();
 
     var visible = $('#' + thisEl.attr('target')).toggle().is(':visible');
-    console.log();
     return visible;
   };
 

--- a/web-ui/src/main/resources/catalog/js/GnFormatterViewerModule.js
+++ b/web-ui/src/main/resources/catalog/js/GnFormatterViewerModule.js
@@ -49,11 +49,13 @@
   goog.require('gn_catalog_service');
   goog.require('gn_formatter_lib');
   goog.require('gn_mdactions_service');
+  goog.require('gn_related_directive');
   goog.require('gn_mdview');
   goog.require('gn_popup_directive');
   goog.require('gn_popup_service');
   goog.require('gn_search_default_directive');
   goog.require('gn_utility');
+  goog.require('gn_viewer');
 
 
 
@@ -65,9 +67,11 @@
     'ngRoute',
     'gn',
     'gn_alert',
+    'gn_related_directive',
     'gn_catalog_service',
     'gn_mdactions_service',
     'gn_utility',
+    'gn_viewer',
     'gn_mdview'
   ]);
 
@@ -79,8 +83,10 @@
   module.constant('gnSearchSettings', {});
 
   module.controller('GnFormatterViewer',
-      ['$scope', '$http', '$sce', '$routeParams', 'Metadata', 'gnMdFormatter',
-       function($scope, $http, $sce, $routeParams, Metadata, gnMdFormatter) {
+      ['$scope', '$http', '$sce', '$routeParams', '$location',
+        'Metadata', 'gnMdFormatter',
+       function($scope, $http, $sce, $routeParams, $location,
+                Metadata, gnMdFormatter) {
 
          var formatter = $routeParams.formatter;
          var mdId = $routeParams.mdId;
@@ -90,7 +96,7 @@
            $scope.loading = false;
          });
 
-         var url = '../api/records/' + mdId + '/formatters/' + formatter;
+         var url = '../api/records/' + $location.url();
 
          gnMdFormatter.load(mdId, '.formatter-container', $scope, url);
        }]);
@@ -98,7 +104,14 @@
   module.config(['$routeProvider', function($routeProvider) {
     var tpls = '../../catalog/templates/';
 
-    $routeProvider.when('/:formatter/:mdId', { templateUrl: tpls +
-          'formatter-viewer.html', controller: 'GnFormatterViewer'});
+    $routeProvider
+      .when(
+        '/:mdId/formatters/:formatter', {
+          templateUrl: tpls + 'formatter-viewer.html',
+          controller: 'GnFormatterViewer'})
+      .when(
+        '/:mdId', {
+          templateUrl: tpls + 'formatter-viewer.html',
+          controller: 'GnFormatterViewer'});
   }]);
 })();

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -710,11 +710,6 @@ input.ng-invalid {
   }
 }
 
-.gn-resource-info {
-  text-align: center;
-  border: 3px solid #bbb;
-}
-
 [data-rating] {
   color: #ffa500;
 }

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -9,7 +9,7 @@
   table tr th {
     width: 25%;
   }
-  
+
   .badge {
     word-break: break-all;
     white-space: normal;
@@ -63,9 +63,6 @@
   h1 {
     font-size: 18px;
   }
-
-  font-family: Arial @font-family-sans-serif;
-  font-size: 13px;
 
   .property {
     @media (min-width: @screen-sm-min) {
@@ -188,7 +185,6 @@
     }
     h3 {
       border: none;
-      padding-left: .65em;
       i {
         transform: rotate(0deg);
       }
@@ -197,13 +193,10 @@
       }
     }
     .offseted {
-      margin-left: @large-offset;
       padding-bottom: 1.5em;
     }
     dd, .offseted {
-      border-left: 1px solid @gray-light;
       padding-left: 1em;
-      background: @gray-lighter;
       dd {
         border: none;
         padding-left: 0;

--- a/web-ui/src/main/resources/catalog/templates/formatter-viewer.html
+++ b/web-ui/src/main/resources/catalog/templates/formatter-viewer.html
@@ -1,6 +1,7 @@
 <div class="container formatter-container">
   <div class="row">
-    <div class="gn-md-actions-btn pull-right btn-group md-actions" data-gn-md-actions-menu="md"/>
+    <div class="gn-md-actions-btn pull-right btn-group md-actions"
+         data-gn-md-actions-menu="md"/>
     <a class="btn btn-danger gn-md-delete-btn pull-right"
        data-ng-show="user.canEditRecord(md)"
        data-gn-click-and-spin="deleteRecord(md)"
@@ -16,5 +17,7 @@
       <i class="fa fa-pencil"></i>
     </a>
   </div>
-  <div data-ng-if="loading" class="gn-spinner"><i class="fa fa-spinner fa-spin fa-4x"></i></div>
+  <div data-ng-if="loading" class="gn-spinner">
+    <i class="fa fa-spinner fa-spin fa-2x"></i>
+  </div>
 </div>

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -133,6 +133,7 @@
 
   <util:list id="formattersToInitialize" value-type="java.lang.String">
     <value>full_view</value>
+    <value>xsl-view</value>
     <value>xml_view</value>
     <value>hierarchy_view</value>
   </util:list>

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -14,5 +14,6 @@ usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}
 es.url=${es.url}
 es.index.features=${es.index.features}
 es.index.records=${es.index.records}
+es.index.searchlogs=${es.index.searchlogs}
 
 jms.url=${jms.url}

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -731,8 +731,6 @@
 
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/catalog.search!?.*"
                            access="permitAll"/>
-        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/catalog.search.nojs!?.*"
-                           access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/catalog.signin!?.*"
                            access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/contact.us!?.*" access="permitAll"/>
@@ -778,7 +776,7 @@
                            access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.format.clear"
                            access="hasRole('Administrator')"/>
-        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.viewer(\?debug)?"
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/display(\?debug)?"
                            access="permitAll"/>
 
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/crs.search!?.*" access="permitAll"/>

--- a/web/src/main/webapp/WEB-INF/config/config-ui-metadata.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-ui-metadata.xml
@@ -47,7 +47,7 @@
       <error sheet="../xslt/common/error.xsl"/>
     </service>
 
-    <service name="md.viewer">
+    <service name="display">
       <documentation>View a metadata record using one of the formatters</documentation>
       <output sheet="../xslt/ui-metadata/view/formatter-viewer.xsl">
         <xml name="i18n" file="xml/i18n.xml"/>

--- a/web/src/main/webapp/WEB-INF/config/config-ui-search.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-ui-search.xml
@@ -30,15 +30,5 @@
         <xml name="i18n" file="xml/i18n.xml"/>
       </output>
     </service>
-
-    <service name="catalog.search.nojs">
-      <documentation>Provide search in degraded mode when Javascript is not available.
-      </documentation>
-      <class name=".services.main.XmlSearch"/>
-
-      <output sheet="../xslt/ui-search/search-nojs.xsl">
-        <xml name="i18n" file="xml/i18n.xml"/>
-      </output>
-    </service>
   </services>
 </geonet>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/groovy/common/Handlers.groovy
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/groovy/common/Handlers.groovy
@@ -256,7 +256,7 @@ public class Handlers {
         if (uuid.trim().isEmpty()) {
             return "javascript:alert('" + this.f.translate("noUuidInLink") + "');"
         } else {
-            return this.env.localizedUrl + "md.viewer#/full_view/" + URLEncoder.encode(uuid, "UTF-8")
+            return this.env.localizedUrl + "display#/" + URLEncoder.encode(uuid, "UTF-8") + "/formatters/full_view"
         }
     }
 

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -13,10 +13,13 @@
   <xsl:import href="render-functions.xsl"/>
   <xsl:import href="render-layout-fields.xsl"/>
 
+  <xsl:output method="html"/>
+
   <!-- Those templates should be overriden in the schema plugin - start -->
   <xsl:template mode="getMetadataTitle" match="undefined"/>
   <xsl:template mode="getMetadataAbstract" match="undefined"/>
   <xsl:template mode="getMetadataHierarchyLevel" match="undefined"/>
+  <xsl:template mode="getOverviews" match="undefined"/>
   <xsl:template mode="getMetadataHeader" match="undefined"/>
   <!-- Those templates should be overriden in the schema plugin - end -->
 
@@ -50,27 +53,144 @@
       <xsl:variable name="type">
         <xsl:apply-templates mode="getMetadataHierarchyLevel" select="$metadata"/>
       </xsl:variable>
+
+      <xsl:variable name="title">
+        <xsl:apply-templates mode="getMetadataTitle" select="$metadata"/>
+      </xsl:variable>
+
+
       <article id="gn-metadata-view-{$metadataId}"
+               class="gn-md-view gn-metadata-display"
                itemscope="itemscope"
                itemtype="{gn-fn-core:get-schema-org-class($type)}">
-        <header>
-          <h1>
-            <xsl:apply-templates mode="getMetadataTitle" select="$metadata"/>
-          </h1>
-          <!--<p><xsl:apply-templates mode="getMetadataAbstract" select="$metadata"/></p>-->
-          <!-- TODO : Add thumbnail to header -->
 
-          <xsl:apply-templates mode="getMetadataHeader" select="$metadata"/>
-          <!--<xsl:apply-templates mode="render-toc" select="$viewConfig"/>-->
-        </header>
 
-        <xsl:for-each select="$viewConfig/*">
-          <xsl:sort select="@formatter-order" 
-                    data-type="number"/>
-          <xsl:apply-templates mode="render-view"
-                               select="."/>
-        </xsl:for-each>
 
+        <div class="row">
+          <div class="col-md-8">
+
+            <header>
+              <h1>
+                <i class="fa gn-icon-{$type}">&#160;</i>
+                <xsl:value-of select="$title"/>
+              </h1>
+
+              <xsl:apply-templates mode="getMetadataHeader" select="$metadata"/>
+
+              <div gn-related="md"
+                   data-user="user"
+                   data-types="onlines"/>
+
+              <!--<xsl:apply-templates mode="render-toc" select="$viewConfig"/>-->
+            </header>
+
+
+            <xsl:for-each select="$viewConfig/*">
+              <xsl:sort select="@formatter-order"
+                        data-type="number"/>
+              <xsl:apply-templates mode="render-view"
+                                   select="."/>
+            </xsl:for-each>
+          </div>
+          <div class="gn-md-side col-md-4">
+            <xsl:apply-templates mode="getOverviews" select="$metadata"/>
+
+            <br/>
+
+            <section>
+              <h4>
+                <i class="fa fa-fw fa-cog">&#160;</i>&#160;
+                <span><xsl:value-of select="$schemaStrings/providedBy"/></span>
+              </h4>
+              <img class="gn-source-logo"
+                   src="{$nodeUrl}../images/logos/{$source}.png">&#160;</img>
+            </section>
+
+            <br/>
+
+            <section>
+              <h4>
+                <i class="fa fa-fw fa-share-square-o">&#160;</i>&#160;
+                <span><xsl:value-of select="$schemaStrings/shareOnSocialSite"/></span>
+              </h4>
+              <a href="https://twitter.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
+                 target="_blank" class="btn btn-default">
+                <i class="fa fa-fw fa-twitter">&#160;</i>&#160;
+              </a>
+              <a href="https://plus.google.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
+                 target="_blank" class="btn btn-default">
+                <i class="fa fa-fw fa-google-plus">&#160;</i>&#160;
+              </a>
+              <a href="https://www.facebook.com/sharer.php?u={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
+                 target="_blank" class="btn btn-default">
+                <i class="fa fa-fw fa-facebook">&#160;</i>&#160;
+              </a>
+              <a href="http://www.linkedin.com/shareArticle?mini=true&amp;summary=Hydrological Basins in Africa (Sample record, please remove!)&amp;url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
+                 target="_blank" class="btn btn-default">
+                <i class="fa fa-fw fa-linkedin">&#160;</i>&#160;
+              </a>
+              <a href="mailto:?subject={$title}&amp;body={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
+                 target="_blank" class="btn btn-default">
+                <i class="fa fa-fw fa-envelope-o">&#160;</i>&#160;
+              </a>
+            </section>
+
+            <br/>
+
+            <section>
+              <h4>
+                <i class="fa fa-fw fa-eye">&#160;</i>&#160;
+                <span><xsl:value-of select="$schemaStrings/viewMode"/></span>
+              </h4>
+              <xsl:for-each select="$configuration/editor/views/view[not(@disabled)]">
+                <ul>
+                  <li>
+                    <a>
+                      <xsl:attribute name="href">
+                        <xsl:choose>
+                          <xsl:when test="@name = 'xml'">
+                            <xsl:value-of select="concat($nodeUrl, 'api/records/', $metadataUuid, '/formatters/xml')"/>
+                          </xsl:when>
+                          <xsl:otherwise>
+                            <xsl:value-of select="concat($nodeUrl, 'api/records/', $metadataUuid, '/formatters/xsl-view?view=', @name, '&amp;portalLink=', $portalLink)"/>
+                          </xsl:otherwise>
+                        </xsl:choose>
+                      </xsl:attribute>
+                      <xsl:variable name="name" select="@name"/>
+                      <xsl:value-of select="$schemaStrings/*[name(.) = $name]"/>
+                    </a>
+                  </li>
+                </ul>
+              </xsl:for-each>
+            </section>
+
+            <br/>
+
+            <div class="well text-center">
+              <a class="btn btn-block btn-primary"
+                 href="{if ($portalLink != '')
+                        then replace($portalLink, '\$\{uuid\}', $metadataUuid)
+                        else concat($nodeUrl, $language, '/catalog.search#/metadata/', $metadataUuid)}">
+                <i class="fa fa-link">&#160;</i>
+                <xsl:value-of select="$schemaStrings/linkToPortal"/>
+              </a>
+              <xsl:value-of select="$schemaStrings/linkToPortal-help"/>
+            </div>
+
+
+            <section>
+              <h4>
+                <i class="fa fa-fw fa-link">&#160;</i>&#160;
+                <span><xsl:value-of select="$schemaStrings/associatedResources"/></span>
+              </h4>
+              <div gn-related="md"
+                   data-user="user"
+                   data-types="parent|children|services|datasets|hassources|sources|fcats|siblings|associated">
+                Not available
+              </div>
+            </section>
+          </div>
+        </div>
 
         <!--
         TODO: scrollspy or tabs on header ?
@@ -120,10 +240,19 @@
                     select="gn-fn-render:get-schema-strings($schemaStrings, @id)"/>
 
       <div id="gn-tab-{@id}">
-        <h3 class="view-header">
-          <xsl:value-of select="$title"/>
-        </h3>
-        <xsl:copy-of select="$content"/>
+        <xsl:if test="count(following-sibling::tab) > 0">
+          <h1 class="view-header">
+            <xsl:value-of select="$title"/>
+          </h1>
+        </xsl:if>
+        <xsl:choose>
+          <xsl:when test="normalize-space($content) = ''">
+            No information
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="$content"/>&#160;
+          </xsl:otherwise>
+        </xsl:choose>
       </div>
     </xsl:if>
   </xsl:template>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
@@ -3,17 +3,33 @@
                 version="2.0">
 
   <!-- All URL parameters could be available as params -->
+
+  <!-- Define the view to be rendered as defined in
+  the config-editor.xml file of the schema. -->
   <xsl:param name="view" select="'default'"/>
 
-  <!-- Formatter will render a full HTML page. If not set,
-  then it will render an HTML DIV only. -->
+  <!-- Choose the type of HTML to return:
+  * html render a full HTML page
+  * div render a div element to be embedded in an existing webpage. -->
   <xsl:param name="root" select="'html'"/>
+
+  <!-- Define the full portal link. By default, it will link
+  to the catalog.search main page of the catalog. To configure a custom
+  use {{uuid}} to be replaced by the record UUID.
+  eg. http://another.portal.org/${uuid}
+  -->
+  <xsl:param name="portalLink" select="''"/>
+
 
   <!-- TODO: schema is not part of the XML -->
   <xsl:variable name="schema"
                 select="/root/info/record/datainfo/schemaid"/>
+  <xsl:variable name="source"
+                select="/root/info/record/sourceinfo/sourceid"/>
   <xsl:variable name="metadataId"
                 select="/root/info/record/id"/>
+  <xsl:variable name="metadataUuid"
+                select="/root/info/record/uuid"/>
 
   <xsl:variable name="schemaCodelists">
     <null/>

--- a/web/src/main/webapp/loc/dut/xml/i18n.xml
+++ b/web/src/main/webapp/loc/dut/xml/i18n.xml
@@ -4,7 +4,7 @@
   <warning>Waarschuwing!</warning>
   <nojs>Javascript is niet beschikbaar. Activeer javascript of klik
     <a
-      href="catalog.search.nojs">hier
+      href="../search">hier
     </a>
     voor een versie zonder javascript.
   </nojs>

--- a/web/src/main/webapp/loc/eng/xml/i18n.xml
+++ b/web/src/main/webapp/loc/eng/xml/i18n.xml
@@ -5,7 +5,7 @@
   <addA>Add</addA>
   <nojs>Javascript is not enabled. Enable it or click
     <a
-      href="catalog.search.nojs">here to search
+      href="../search">here to search
     </a>
     in a degraded mode.
   </nojs>

--- a/web/src/main/webapp/loc/fre/xml/i18n.xml
+++ b/web/src/main/webapp/loc/fre/xml/i18n.xml
@@ -4,7 +4,7 @@
   <warning>Attention!</warning>
   <nojs>Javascript n'est pas actif dans votre navigateur. Activez le ou cliquez
     <a
-      href="catalog.search.nojs">ici pour rechercher des informations
+      href="../search">ici pour rechercher des informations
     </a>
     en mode dégradé.
   </nojs>

--- a/web/src/main/webapp/loc/ita/xml/i18n.xml
+++ b/web/src/main/webapp/loc/ita/xml/i18n.xml
@@ -5,7 +5,7 @@
   <addA>Aggiungi</addA>
   <nojs>Javascript non è attivo. Attiva JavaScript oppure
     <a
-      href="catalog.search.nojs">clicca qui
+      href="../search">clicca qui
     </a>
     per effettuare una ricerca in modalità minimale.
   </nojs>

--- a/web/src/main/webapp/loc/spa/xml/i18n.xml
+++ b/web/src/main/webapp/loc/spa/xml/i18n.xml
@@ -5,7 +5,7 @@
   <addA>Añadir</addA>
   <nojs>Javascript no habilitado. Habilítelo o vaya al
     <a
-      href="catalog.search.nojs">here to search
+      href="../search">here to search
     </a>
     modo degradado.
   </nojs>

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -129,6 +129,7 @@
 
         <xsl:if test="$angularApp = 'gn_search' or
                       $angularApp = 'gn_editor' or
+                      $angularApp = 'gn_formatter_viewer' or
                       $angularApp = 'gn_admin'">
           <script src="{$uiResourcesPath}lib/zip/zip.js"></script>
           <!-- Jsonix resources (OWS Context) -->

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -66,7 +66,7 @@
   <xsl:variable name="angularModule"
                 select="if ($angularApp = 'gn_search') then concat('gn_search_', $searchView) else $angularApp"></xsl:variable>
 
-  <xsl:variable name="shibbolethOn" 
+  <xsl:variable name="shibbolethOn"
                 select="util:existsBean('shibbolethConfiguration')"/>
 
   <!-- Define which JS module to load using Closure -->
@@ -82,10 +82,9 @@
     else if ($service = 'catalog.edit') then 'gn_editor'
     else if ($service = 'catalog.viewer') then 'gn_viewer'
     else if ($service = 'catalog.search'
-      or $service = 'catalog.search.nojs'
       or $service = 'search'
       or $service = 'md.format.html') then 'gn_search'
-    else if ($service = 'md.viewer') then 'gn_formatter_viewer'
+    else if ($service = 'display') then 'gn_formatter_viewer'
     else 'gn'"/>
 
   <xsl:variable name="customFilename" select="concat($angularApp, '_', $searchView)"></xsl:variable>
@@ -101,6 +100,9 @@
 
   <!-- URL for services - may not be defined FIXME or use fullURL instead -->
   <xsl:variable name="siteURL" select="/root/gui/siteURL"/>
+
+  <xsl:variable name="nodeUrl"
+                select="util:getSettingValue('nodeUrl')"/>
 
   <!-- URL for webapp root -->
   <xsl:variable name="baseURL" select="substring-before($siteURL,'/srv/')"/>

--- a/web/src/main/webapp/xslt/common/functions-core.xsl
+++ b/web/src/main/webapp/xslt/common/functions-core.xsl
@@ -56,7 +56,7 @@
   </xsl:function>
 
   <xsl:function name="gn-fn-core:translate" as="xs:string">
-    <xsl:param name="key" as="xs:string"/>
+    <xsl:param name="key" as="xs:string?"/>
     <xsl:param name="t" as="node()"/>
 
     <xsl:value-of select="if ($t/*[name() = $key]/text() != '')

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -25,11 +25,14 @@
                 version="2.0"
                 exclude-result-prefixes="#all">
 
-  <xsl:output omit-xml-declaration="yes" method="html" doctype-system="html" indent="yes"
-              encoding="UTF-8"/>
-
   <xsl:include href="../base-layout-cssjs-loader.xsl"/>
   <xsl:include href="../skin/default/skin.xsl"/>
+
+  <xsl:output omit-xml-declaration="yes"
+              method="html"
+              doctype-system="html"
+              indent="yes"
+              encoding="UTF-8"/>
 
   <xsl:template name="render-html">
     <xsl:param name="content"/>
@@ -51,11 +54,11 @@
 
         <link rel="icon" sizes="16x16 32x32 48x48" type="image/png"
               href="{/root/gui/url}/images/logos/favicon.png"/>
-        <link href="rss.search?sortBy=changeDate"
+        <link href="{$nodeUrl}eng/rss.search?sortBy=changeDate"
               rel="alternate"
               type="application/rss+xml"
               title="{$title}"/>
-        <link href="portal.opensearch"
+        <link href="{$nodeUrl}eng/portal.opensearch"
               rel="search"
               type="application/opensearchdescription+xml"
               title="{$title}"/>
@@ -66,7 +69,9 @@
       <body>
         <div class="gn-full">
           <xsl:call-template name="header"/>
-          <xsl:copy-of select="$content"/>
+          <div class="container">
+            <xsl:copy-of select="$content"/>
+          </div>
           <xsl:call-template name="footer"/>
         </div>
       </body>

--- a/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
+++ b/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
@@ -89,8 +89,8 @@
           </sitemap>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:variable name="vMid" select=
-            "floor(($pStart + $pEnd) div 2)"/>
+          <xsl:variable name="vMid"
+                        select="floor(($pStart + $pEnd) div 2)"/>
           <xsl:call-template name="displayIndexDocs">
             <xsl:with-param name="pStart" select="$pStart"/>
             <xsl:with-param name="pEnd" select="$vMid"/>
@@ -120,23 +120,10 @@
           <loc>
             <xsl:choose>
               <xsl:when test="$format='xml'">
-                <xsl:variable name="metadataUrlValue">
-                  <xsl:call-template name="metadataXmlDocUrl">
-                    <xsl:with-param name="schemaid" select="$schemaid"/>
-                    <xsl:with-param name="uuid" select="$uuid"/>
-                  </xsl:call-template>
-                </xsl:variable>
-                <xsl:value-of select="$env/system/server/protocol"/>://<xsl:value-of
-                select="$env/system/server/host"/>:<xsl:value-of
-                select="$env/system/server/port"/><xsl:value-of select="/root/gui/locService"/>/<xsl:value-of
-                select="$metadataUrlValue"/>
+                <xsl:value-of select="concat($nodeUrl, 'api/records/', $uuid, '/formatters/xml')"/>
               </xsl:when>
-
               <xsl:otherwise>
-                <xsl:value-of select="$env/system/server/protocol"/>://<xsl:value-of
-                select="$env/system/server/host"/>:<xsl:value-of
-                select="$env/system/server/port"/><xsl:value-of select="/root/gui/url"/>/?uuid=<xsl:value-of
-                select="$uuid"/>
+                <xsl:value-of select="concat($nodeUrl, 'api/records/', $uuid)"/>
               </xsl:otherwise>
             </xsl:choose>
           </loc>
@@ -162,10 +149,7 @@
           (RDF)
         </sc:datasetLabel>
         <xsl:for-each select="metadata/record">
-          <sc:dataDumpLocation><xsl:value-of select="$env/system/server/protocol"/>://<xsl:value-of
-            select="$env/system/server/host"/>:<xsl:value-of
-            select="$env/system/server/port"/><xsl:value-of select="/root/gui/url"/>/srv/eng/rdf.metadata.get?uuid=<xsl:value-of
-            select="uuid"/>
+          <sc:dataDumpLocation><xsl:value-of select="concat($nodeUrl, 'eng/rdf.metadata.get?uuid=', uuid)"/>
           </sc:dataDumpLocation>
         </xsl:for-each>
         <!--For 5 latests update:
@@ -179,26 +163,5 @@
         <changefreq>daily</changefreq>
       </sc:dataset>
     </urlset>
-  </xsl:template>
-
-
-  <xsl:template name="metadataXmlDocUrl">
-    <xsl:param name="schemaid"/>
-    <xsl:param name="uuid"/>
-
-    <xsl:choose>
-      <xsl:when test="$schemaid='dublin-core'">xml_dublin-core?uuid=<xsl:value-of select="$uuid"/>
-      </xsl:when>
-      <xsl:when test="$schemaid='fgdc-std'">xml_fgdc-std?uuid=<xsl:value-of select="$uuid"/>
-      </xsl:when>
-      <xsl:when test="$schemaid='iso19115'">xml_iso19115to19139?uuid=<xsl:value-of select="$uuid"/>
-      </xsl:when>
-      <xsl:when test="$schemaid='iso19110'">xml_iso19110?uuid=<xsl:value-of select="$uuid"/>
-      </xsl:when>
-      <xsl:when test="$schemaid='iso19139'">xml_iso19139?uuid=<xsl:value-of select="$uuid"/>
-      </xsl:when>
-      <xsl:otherwise>xml.metadata.get?uuid=<xsl:value-of select="$uuid"/>
-      </xsl:otherwise>
-    </xsl:choose>
   </xsl:template>
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/skin/default/skin.xsl
+++ b/web/src/main/webapp/xslt/skin/default/skin.xsl
@@ -8,53 +8,78 @@
                 exclude-result-prefixes="#all">
 
   <xsl:template name="header">
-    <div class="navbar-header">
-      <button type="button"
-              class="navbar-toggle collapsed"
-              data-toggle="collapse"
-              data-target="#navbar"
-              title="{$i18n/toggleNavigation}"
-              aria-expanded="false"
-              aria-controls="navbar">
-        <span class="sr-only">
-          <xsl:value-of select="$i18n/toggleNavigation"/>
-        </span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-    </div>
-    <div id="navbar" class="navbar-collapse collapse">
-      <ul class="nav navbar-nav">
-        <li>
-          <a href="{/root/gui/nodeUrl}{$lang}/catalog.search#/home">
-            <img class="gn-logo"
-                 src="{/root/gui/url}/images/logos/{$env/system/site/siteId}.png"></img>
-            <span class="hidden-xs">
-              <xsl:value-of select="$env/system/site/name"/>
+    <div class="navbar navbar-default gn-top-bar">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button"
+                  class="navbar-toggle collapsed"
+                  data-toggle="collapse"
+                  data-target="#navbar"
+                  title="{$i18n/toggleNavigation}"
+                  aria-expanded="false"
+                  aria-controls="navbar">
+            <span class="sr-only">
+              <xsl:value-of select="$i18n/toggleNavigation"/>
             </span>
-          </a>
-        </li>
-        <li>
-          <!-- TODO: Append query parameters ? -->
-          <a href="{/root/gui/nodeUrl}{$lang}/catalog.search#/search"
-             title="{$t/search}">
-            <i class="fa fa-search">&#160;</i>&#160;
-            <xsl:value-of select="$t/search"/>
-          </a>
-        </li>
-      </ul>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div>
+        <div id="navbar" class="navbar-collapse collapse">
+          <ul class="nav navbar-nav">
+            <li>
+              <a href="{/root/gui/nodeUrl}{$lang}/catalog.search#/home">
+                <img class="gn-logo"
+                     src="{/root/gui/url}/images/logos/{$env//system/site/siteId}.png"></img>
+                <span class="hidden-xs">
+                  <xsl:value-of select="$env//system/site/name"/>
+                </span>
+              </a>
+            </li>
+            <li>
+              <div style="padding-top: 4px;">
+                <form action="{$nodeUrl}search"
+                      class="form-inline">
+                  <div class="input-group gn-form-any">
+                    <input type="text"
+                           name="any"
+                           id="fldAny"
+                           placeholder="{$t/anyPlaceHolder}"
+                           value="{/root/request/any}"
+                           class="form-control"
+                           autofocus=""/>
+                    <div class="input-group-btn">
+                      <button type="submit"
+                              class="btn btn-primary">
+                        &#160;&#160;
+                        <i class="fa fa-search">&#160;</i>
+                        &#160;&#160;
+                      </button>
+                      <a href="{$nodeUrl}search"
+                         class="btn btn-link">
+                        <i class="fa fa-times">&#160;</i>
+                      </a>
+                    </div>
+                  </div>
+                  <input type="hidden" name="fast" value="index"/>
+                </form>
+              </div>
+            </li>
+          </ul>
 
 
-      <ul class="nav navbar-nav navbar-right">
-        <li>
-          <a href="{/root/gui/nodeUrl}{lang}/signin"
-             title="{$t/signIn}">
-            <i class="fa fa-sign-in">&#160;</i>&#160;
-            <xsl:value-of select="$t/signIn"/>
-          </a>
-        </li>
-      </ul>
+          <ul class="nav navbar-nav navbar-right">
+            <li>
+              <a href="{/root/gui/nodeUrl}{lang}/signin"
+                 title="{$t/signIn}">
+                <i class="fa fa-sign-in">&#160;</i>&#160;
+                <xsl:value-of select="$t/signIn"/>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
   </xsl:template>
 

--- a/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
+++ b/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
@@ -33,27 +33,27 @@
   <xsl:import href="../base-layout-nojs.xsl"/>
   <xsl:import href="../common/functions-core.xsl"/>
 
-
-
   <xsl:template mode="content" match="/">
 
     <xsl:variable name="count"
                   select="/root/search/response[1]/summary[1]/@count"/>
 
 
-    <div class="row" style="padding-bottom:20px">
-      <div class="col-md-3">&#160;
 
+    <div class="row">
+      <div class="col-md-3 gn-facet">
+
+        <div>
           <xsl:variable name="parameters"
                         select="/root/search/params/*[
-                                    name(.) != 'fast' and name(.) != 'resultType'
-                                  ]"/>
+                                  name(.) != 'fast' and name(.) != 'resultType'
+                                ]"/>
 
           <!-- If only one parameter set, the page provides a summary
           for this criteria. For contact, source catalog, an extra panel
           is added with some details about this resource. -->
           <xsl:if test="count($parameters) = 1">
-            <div class="gn-resource-info">
+            <div class="thumbnail text-center">
               <xsl:variable name="parameterName"
                             select="$parameters[1]/name()"/>
               <xsl:variable name="parameterLabel"
@@ -68,11 +68,11 @@
               <xsl:choose>
                 <xsl:when test="$parameterName = '_groupPublished'">
                   <img  class="gn-logo-lg"
-                        src="{/root/gui/url}/images/harvesting/{$parameterValue}.png"/>
+                        src="{nodeUrl}../images/harvesting/{$parameterValue}.png"/>
                 </xsl:when>
                 <xsl:when test="$parameterName = '_source'">
                   <img  class="gn-logo-lg"
-                        src="{/root/gui/url}/images/logos/{$parameterValue}.png"/>
+                        src="{nodeUrl}../images/logos/{$parameterValue}.png"/>
                 </xsl:when>
                 <xsl:when test="$parameterName = 'responsiblePartyEmail'">
                   <img src="//gravatar.com/avatar/{util:md5Hex($parameterValue)}?s=200"/>
@@ -99,42 +99,10 @@
               </h4>
             </div>
           </xsl:if>
-      </div>
-      <div class="col-md-9">
-        <div style="padding-top: 19px;">
-          <form action="{/root/gui/nodeUrl}search"
-                class="form-inline">
-            <div class="input-group gn-form-any">
-              <input type="text"
-                     name="any"
-                     id="fldAny"
-                     placeholder="{$t/anyPlaceHolder}"
-                     value="{/root/request/any}"
-                     class="form-control input-lg"
-                     autofocus=""/>
-              <div class="input-group-btn">
-                <button type="submit"
-                        class="btn btn-primary btn-lg">
-                  &#160;&#160;
-                  <i class="fa fa-search">&#160;</i>
-                  &#160;&#160;
-                </button>
-                <a href="{/root/gui/nodeUrl}search"
-                   class="btn btn-link btn-lg">
-                  <i class="fa fa-times">&#160;</i>
-                </a>
-              </div>
-            </div>
-            <input type="hidden" name="fast" value="index"/>
-          </form>
+          &#160;
         </div>
-      </div>
-    </div>
 
-
-    <xsl:if test="$count > 0">
-      <div class="row">
-        <div class="col-md-3 gn-facet">
+        <xsl:if test="$count > 0">
           <xsl:for-each select="/root/search/response[1]/summary">
             <xsl:for-each select="dimension[category]">
               <h4><xsl:value-of select="gn-fn-core:translate(@label, $t)"/></h4>
@@ -150,7 +118,7 @@
                                             else if ($field = 'maintenanceAndUpdateFrequency')
                                             then 'cl_maintenanceAndUpdateFrequency'
                                             else $field"/>
-                      <a href="{/root/gui/nodeUrl}search?{$luceneField}={@value}">
+                      <a href="{$nodeUrl}search?{$luceneField}={@value}">
                         <span class="gn-facet-label">
                         <xsl:value-of select="gn-fn-core:translate(@label, $t)"/>
                         </span>
@@ -164,7 +132,9 @@
               </ul>
             </xsl:for-each>
           </xsl:for-each>
-        </div>
+        </xsl:if>
+      </div>
+      <xsl:if test="$count > 0">
         <div class="col-md-9">
           <xsl:for-each select="/root/search/response[@from]">
 
@@ -178,7 +148,7 @@
                 <b>
                   <xsl:value-of select="@to"/>
                 </b>
-                <xsl:value-of select="$t/on"/>
+                /
                 <b>
                   <xsl:value-of select="$count"/>
                 </b>
@@ -189,14 +159,14 @@
               <xsl:for-each select="metadata">
                <li class="list-group-item gn-grid"
                    itemscope="itemscope"
-                   itemtype="{gn-fn-core:get-schema-org-class(type)}">
+                   itemtype="{gn-fn-core:get-schema-org-class(type[1])}">
                  <div class="row">
                    <xsl:if test="count(category) > 0">
                      <div class="gn-md-category">
                        <span><xsl:value-of select="$t/categories"/></span>
                        <xsl:for-each select="category">
                          <a title="{.}"
-                            href="{/root/gui/nodeUrl}search?_cat=maps">
+                            href="{$nodeUrl}search?_cat=maps">
                            <i class="fa">
                              <span class="fa gn-icon-{.}">&#160;</span>
                            </i>
@@ -208,10 +178,17 @@
 
                  <div class="row gn-md-title">
                    <h3 itemprop="name">
-                     <a href="{/root/gui/nodeUrl}api/records/{*[name()='geonet:info']/uuid}"
+                     <a href="{$nodeUrl}api/records/{*[name()='geonet:info']/uuid}"
                         itemprop="url">
                        <i class="fa gn-icon-{type}" title="{type}">&#160;</i>
-                       <xsl:value-of select="title|defaultTitle"/>
+                       <xsl:choose>
+                         <xsl:when test="title != ''">
+                           <xsl:value-of select="title"/>
+                         </xsl:when>
+                         <xsl:otherwise>
+                           <xsl:value-of select="defaultTitle"/>
+                         </xsl:otherwise>
+                       </xsl:choose>
                      </a>
                    </h3>
                  </div>
@@ -239,8 +216,8 @@
             </ul>
           </xsl:for-each>
         </div>
-      </div>
-    </xsl:if>
+      </xsl:if>
+    </div>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Main motivations for those changes:
* Better pure HTML mode working
* Better indexing by web crawler
* Easier formatter embedding in third party website in pure HTML mode or as a basic Angular app
* More consistent layout between all pages.


## HTML mode

* Improve schema.org tags
* Improve styling to be more consistent with the main app and the angular view
* Restore the capability to browse the catalog using the pure HTML mode ie. search and view records

![image](https://user-images.githubusercontent.com/1701393/31487189-32bdc892-af3a-11e7-9cec-5711361e275e.png)



## XSLT Formatter

* Enable possibility to switch from different views defined in config-editor.xml

![image](https://user-images.githubusercontent.com/1701393/31487196-3876e37c-af3a-11e7-820c-3aad5c4c5e19.png)


* Add a link to the portal (ie. the angular app by default but can be customized to point to another portal using portalLink URL parameter)

![image](https://user-images.githubusercontent.com/1701393/31487207-4067b412-af3a-11e7-8033-2fdf38f741c1.png)


* Properly render codelist values when used in template modes, dates when no angular loaded in formatter
* Add a citation proposal to make reference to a record (related to DataCite & DOIs)
* Formatter can now also be displayed with Angular enabled using http://localhost:8080/geonetwork/srv/fre/display#/435c454c-0d4b-41cf-a136-a1aba134d9ac/formatters/xsl-view?root=div. This allows to use angular directive in formatters.

Eg. HTML mode 

![image](https://user-images.githubusercontent.com/1701393/31487276-753d2be0-af3a-11e7-8e1f-7af6526dcef3.png)


Angular formatter viewer usage of humanize-time directive


![image](https://user-images.githubusercontent.com/1701393/31487362-abcc2f44-af3a-11e7-88b0-6af66f32ccfb.png)




* Fix local resolution in formatter API eg. french was mapped to fra instead of fre

## Sitemap

* Points to the API to return pure HTML page easier to index for web crawler

## API change

* ```md.viewer``` (not much used service?) is now called ```display```
* ```catalog.search.nojs``` was not working. HTML mode is now available on ```srv/search```



https://www.youtube.com/watch?v=OILC856SOk0