### PR TITLE
Fix permissions editor in directory management

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -109,7 +109,7 @@
           },
           {
             sortBy: 'changeDate',
-            sortOrder: 'reverse'
+            sortOrder: ''
           },
           {
             sortBy: '_valid',
@@ -512,9 +512,14 @@
         });
 
         $scope.gnCurrentEdit = gnCurrentEdit;
-        $scope.editorFormUrl = gnEditor
-            .buildEditUrlPrefix('editor') +
-            '&starteditingsession=yes&random=' + i++;
+        $scope.editorFormUrl = '';
+
+        // put this out of the flow to clear the form first
+        setTimeout(function() {
+          $scope.editorFormUrl = gnEditor
+              .buildEditUrlPrefix('editor') +
+              '&starteditingsession=yes&random=' + i++;
+        });
       };
 
       $scope.closeEditor = function(e) {
@@ -528,7 +533,10 @@
         $('#gn-share').modal('show');
       };
       $scope.$on('PrivilegesUpdated', function() {
-        $scope.activeEntry = null;
+        // clear active entry if privileges were updated from the list
+        if (!$scope.currentEditorAction) {
+          $scope.activeEntry = null;
+        }
         $('#gn-share').modal('hide');
       });
 

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -413,7 +413,7 @@
             </div>
 
             <button type="button" class="btn btn-default"
-                ng-click="startPermissionsEdit()"
+                ng-click="startPermissionsEdit(activeEntry)"
                 ng-disabled="activeEntry['geonet:info'].edit !== 'true'"
                 title="{{'directoryEntryPermissions' | translate}}">
               <i class="fa fa-key"/>&nbsp;


### PR DESCRIPTION
Previously, editing the permissions would close the current entry. Also the editor form was improved to not show the previous entry while a new one is loading.