### PR TITLE
Fixes download action on related resources

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -206,7 +206,7 @@
 
           var openLink = function(record, link) {
             var url = $filter('gnLocalized')(record.url) || record.url;
-            if (url && (record.url.indexOf('\\') == 0 ||
+            if (url && (url.indexOf('\\') == 0 ||
                url.indexOf('http') == 0 ||
                url.indexOf('ftp') == 0)) {
               return window.open(url, '_blank');


### PR DESCRIPTION
Previously, clicking on the "Download" button would cause a JS error:
![image](https://user-images.githubusercontent.com/10629150/31880059-af66a0aa-b7df-11e7-89d1-2a6ab0888b4f.png)