### PR TITLE
Editor / Bounding polygon improvements.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -206,7 +206,8 @@
             format = new ol.format.GML({
               featureNS: options.gmlFeatureNS ||
                   'http://mapserver.gis.umn.edu/mapserver',
-              featureType: options.gmlFeatureElement || 'features'
+              featureType: options.gmlFeatureElement || 'features',
+              srsName: options.crs
             });
 
             if (options.outputAsWFSFeaturesCollection) {
@@ -307,6 +308,7 @@
                 '<gml:feature xmlns:gml="http://www.opengis.net/gml">' +
                 '<geometry>' +
                 input + '</geometry></gml:feature></featureMembers>';
+
             var feature = format.readFeatures(fullXml, {
               dataProjection: options.crs,
               featureProjection: outputProjection


### PR DESCRIPTION
* Preserve polygon input projection
* Fix empty namespace on non WGS84 geometries

```
org.jdom.IllegalAddException: The namespace xmlns="" could not be added as a namespace to "Polygon": The namespace prefix "" collides with the element namespace prefix
```

* Remove unecessary metadocument cleanup
* Editor / Bounding polygon / Read the data projection #2261
* Editor / Bounding polygon / Polygon is converted to WGS84 whatever is the initial projection #2262