### PR TITLE
Fix unwanted lang header overwrite in CORS interceptor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -54,7 +54,7 @@
               if (isGnUrl && gnLangs.current &&
                   !config.headers['Accept-Language']) {
                 config.headers['Accept-Language'] = gnLangs.current;
-              } else {
+              } else if (!config.headers['Accept-Language']) {
                 config.headers['Accept-Language'] = navigator.language;
               }
               // For HTTP url and those which


### PR DESCRIPTION
Without this, some requests (i.e. i18n API calls) would sometimes be redirected with an unwanted `Accept-Language` header.