### PR TITLE
Give access to batch editing submenu to editors

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -59,14 +59,12 @@
             </a>
           </li>
           <li>
-            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/directory"
-               data-ng-if="user.isEditorOrMore()">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/directory">
               <i class="fa fa-fw fa-list-ul"/>&nbsp;<span data-translate="">directoryManager</span>
             </a>
           </li>
           <li>
-            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/batchedit"
-               data-ng-if="user.isReviewerOrMore()">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/batchedit">
               <i class="fa fa-fw fa-pencil"/>&nbsp;<span data-translate="">batchEditing</span>
             </a>
           </li>


### PR DESCRIPTION
This is a simple cosmetic fix as the editors already had access to the batch editing menu before, but not from the toolbar.
![image](https://user-images.githubusercontent.com/10629150/32331953-800a6064-bfe4-11e7-9ae8-3a12fe2d1e00.png)