### PR TITLE
Improve privileges widget in directory UI

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/popup/PopupDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/popup/PopupDirective.js
@@ -50,6 +50,11 @@
               };
             }
             element.addClass('gn-popup modal fade');
+
+            // handle close callback
+            if (scope.options.closeCallback) {
+              element.on('hidden.bs.modal', scope.options.closeCallback);
+            }
           }
         };
       }

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -532,11 +532,15 @@
         $scope.activeEntry = e;
         $('#gn-share').modal('show');
       };
-      $scope.$on('PrivilegesUpdated', function() {
+      $scope.closePermissionsEdit = function() {
         // clear active entry if privileges were updated from the list
         if (!$scope.currentEditorAction) {
           $scope.activeEntry = null;
+          $scope.$apply();
         }
+      };
+      // close modal on privileges update
+      $scope.$on('PrivilegesUpdated', function() {
         $('#gn-share').modal('hide');
       });
 

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -159,8 +159,6 @@ input[type=text], input[type=number], select {
     padding: 0px;
 
     & > li {
-      display: flex;
-      flex-direction: column;
       @padding: 6px;
 
       & > *:not(:last-child) {
@@ -169,23 +167,6 @@ input[type=text], input[type=number], select {
 
       & > * > *:not(:last-child) {
         margin-right: @padding;
-      }
-
-      .entry-title {
-        display: flex;
-        flex-direction: row;
-
-        a {
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          min-width: 0px;
-        }
-
-        .badge {
-          flex-shrink: 0;
-          border-radius: 3px;
-        }
       }
 
       .entry-info {

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -173,17 +173,20 @@
 
             <div class="directory-entries-list col-xs-12"
               ng-show="!searching">
+
+              <!-- result item -->
               <li class="list-group-item clearfix"
                   data-ng-repeat="md in searchResults.records">
 
-                <div class="entry-title" ng-if="!templatesShown()">
-
-                  <input data-gn-selection-md type="checkbox"
+                <div class="flex-row" ng-if="!templatesShown()">
+                  <input class="flex-no-shrink" type="checkbox"
+                         data-gn-selection-md
                          data-ng-model="md['geonet:info'].selected"
                          data-ng-change="change()"/>
 
                   <gn-md-type-widget metadata="md"></gn-md-type-widget>
-                  <a href
+
+                  <a href class="text-ellipsis"
                      data-ng-if="user.canEditRecord(md)"
                      ng-click="startEditing(md)" title="{{md.title || md.defaultTitle}}">
                     {{md.title || md.defaultTitle}}</a>
@@ -305,6 +308,7 @@
                   </button>
                 </div>
               </li>
+              <!-- end result item -->
             </div>
 
             <div class="search-options-header"
@@ -503,10 +507,10 @@
     </div>
   </div>
 
-  <div gn-modal class="gn-share"
-       gn-popup-options="{title:'sharingSettings'}"
+  <div gn-modal class="gn-share gn-privileges-popup"
+       gn-popup-options="{title:'sharingSettings', closeCallback: closePermissionsEdit}"
        id="gn-share">
-    <div gn-share="activeEntry['geonet:info'].id"></div>
+    <div ng-if="activeEntry" gn-share="activeEntry['geonet:info'].id"></div>
   </div>
 
   <div gn-modal class="gn-confirm-delete"
@@ -514,7 +518,6 @@
        id="gn-confirm-delete">
     <p translate>confirmDeleteEntry</p>
   </div>
-
 </div>
 
 <div data-ng-include="'../../catalog/templates/info.html'">


### PR DESCRIPTION
Now the privileges widget is cleared when not displayed, which prevents some bugs & inconsistencies.
Also a slight improvement to the directory UI search results.

To do this I had to handle a `closeCallback` parameter on `gnModal`, which is pretty handy for this sort of case (ie doing something when the modal is closed by any means).

Note that this only applies to the privileges edition of a single record from the search results list.