### PR TITLE
Excluding servlet-related dependencies (#1912)

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -346,6 +346,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -513,6 +519,31 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>wfsfeature-harvester</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api-2.5</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-servlet_3.0_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jsp-api-2.1</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
These jars should be provided by the servlet container.

Note: If Hadoop transitively requires jetty + jetty:jsp-api + servlet-api (in wfsfeature-harvester subproject), there is probably a good reason for this. I preferred to exclude the dependencies from the web/pom.xml instead of acting on each maven subprojects.

Note 2: some classes actually require the servlet-api jar, so I added it as a dependency, but keeping it away from the resulting artifact using the 'provided' scope.

Tests: compilation + runtime on web, no issue so far.