### PR TITLE
Add a loading spinner while requesting related resources in the metadata view

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -29,11 +29,13 @@
 
   goog.require('gn_atom');
   goog.require('gn_relatedresources_service');
+  goog.require('gn_related_observer_directive');
   goog.require('gn_wms');
   goog.require('gn_wmts');
 
   var module = angular.module('gn_related_directive', [
-    'gn_relatedresources_service', 'gn_wms', 'gn_wmts', 'gn_atom'
+    'gn_relatedresources_service', 'gn_related_observer_directive', 'gn_wms', 
+    'gn_wmts', 'gn_atom'
   ]);
 
   /**
@@ -112,12 +114,29 @@
               user: '=',
               hasResults: '=?'
             },
+            require: '?^gnRelatedObserver',
             link: function(scope, element, attrs, controller) {
               var promise;
+              var elem = element[0];
+              element.on('$destroy', function() {
+                // Unregister the directive in the observer if it is defined
+                if (controller) {
+                  controller.unregisterGnRelated(elem);
+                }
+              });
+
+              if (controller) {
+                // Register the directive in the observer
+                controller.registerGnRelated(elem);
+              }
+
               scope.updateRelations = function() {
                 scope.relations = null;
                 if (scope.uuid) {
                   scope.relationFound = false;
+                  if (controller) {
+                    controller.startGnRelatedRequest(elem);
+                  }
                   (promise = gnRelatedService.get(
                      scope.uuid, scope.types)
                   ).then(function(data) {
@@ -146,7 +165,12 @@
                            scope.relations[idx] = value;
                          }
                        });
-                     });
+                       if (controller) {
+                          controller.finishRequest(elem, scope.relationFound);
+                        }
+                     } , function () {
+                        controller.finishRequest(elem, false);
+                    });
                 }
               };
 

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedObserverDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedObserverDirective.js
@@ -1,0 +1,75 @@
+/**
+ * Created by juanluisrp on 30/08/2016.
+ */
+(function () {
+  goog.provide('gn_related_observer_directive');
+
+  var module = angular.module('gn_related_observer_directive', []);
+
+
+  module.directive('gnRelatedObserver', [
+    function () {
+
+      function GnRelatedObserverController(scope, $rootScope) {
+        this.managedAnnotations = [];
+        this.currentRequests = [];
+        this.scope = scope.$parent;
+        this.scope.gnRelatedLoadFinished = true;
+        this.scope.relatedsFound = false;
+        this.rootScope = $rootScope;
+      }
+
+      GnRelatedObserverController.prototype.registerGnRelated = function(gnRelated) {
+        this.managedAnnotations.push(gnRelated);
+      };
+
+      GnRelatedObserverController.prototype.unregisterGnRelated = function(gnRelated) {
+        this.managedAnnotations = $.grep(this.managedAnnotations, function(elem) {
+          return elem != gnRelated;
+        })
+      };
+
+      GnRelatedObserverController.prototype.startGnRelatedRequest = function(gnRelated) {
+        if(this.scope.gnRelatedLoadFinished) {
+          this.scope.relatedsFound = false;
+        }
+        this.currentRequests.push(gnRelated);
+        this.scope.gnRelatedLoadFinished = false;
+      };
+
+      GnRelatedObserverController.prototype.finishRequest = function(gnRelatedElement, found) {
+        var index = $.inArray(gnRelatedElement, this.currentRequests);
+        if (index != -1) {
+          this.currentRequests.splice(index, 1);
+          if (found) {
+            this.scope.relatedsFound = true;
+          }
+        }
+        this.updateGnRelatedLoadFinished();
+      };
+
+      GnRelatedObserverController.prototype.updateGnRelatedLoadFinished = function() {
+        if (this.currentRequests.length == 0) {
+          this.scope.gnRelatedLoadFinished = true;
+          if (!this.scope.relatedsFound) {
+            this.rootScope.$broadcast('tabChangeRequested', 'general');
+          }
+        }
+      };
+
+
+
+      return {
+        restrict: 'A',
+        transclude: true,
+        templateUrl: '../../catalog/components/metadataactions/partials/relatedObserverTemplate.html',
+        scope: {},
+        controller: ['$scope', '$rootScope', GnRelatedObserverController],
+        controllerAs: 'observerController',
+        link: function(scope, element, attrs, controller) {
+
+        }
+      };
+    }
+  ]);
+})();

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedObserverTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedObserverTemplate.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<div data-ng-hide="$parent.gnRelatedLoadFinished">
+  <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
+  <span class="sr-only">Loading...</span>
+</div>
+<div data-ng-show="$parent.gnRelatedLoadFinished">
+  <div data-ng-transclude></div>
+</div>

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -30,11 +30,13 @@
   goog.require('gn_md_feedback');
   goog.require('gn_mdview_directive');
   goog.require('gn_mdview_service');
+  goog.require('gn_related_observer_directive');
 
   var module = angular.module('gn_mdview', [
     'gn_mdview_service',
     'gn_mdview_directive',
-    'gn_md_feedback'
+    'gn_md_feedback',
+    'gn_related_observer_directive'
   ]);
 
   module.controller('GnMdViewController', [

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -111,18 +111,19 @@
              class="gn-status gn-status-mdview gn-status-{{mdView.current.record.status[0]}}">
           {{mdView.current.record.status_text[0]}}
         </div>
+        <div data-gn-related-observer>
+          <div data-gn-related="mdView.current.record"
+               data-user="user"
+               data-types="onlines"
+               data-has-results="hasRelations.onlines"
+               data-title="{{'downloadsAndResources' | translate}}">
+          </div>
 
-        <div data-gn-related="mdView.current.record"
-             data-user="user"
-             data-types="onlines"
-             data-has-results="hasRelations.onlines"
-             data-title="{{'downloadsAndResources' | translate}}">
-        </div>
-
-        <div data-gn-related="mdView.current.record"
-             data-user="user"
-             data-types="parent|children|services|datasets"
-             data-title="{{'associatedResources' | translate}}">
+          <div data-gn-related="mdView.current.record"
+               data-user="user"
+               data-types="parent|children|services|datasets"
+               data-title="{{'associatedResources' | translate}}">
+          </div>
         </div>
 
         <h2 data-translate="">aboutThisResource</h2>
@@ -313,35 +314,38 @@
           <tr>
             <th></th>
             <td>
-              <div data-gn-related="mdView.current.record"
-                   data-user="user"
-                   data-types="sources"
-                   data-has-results="hasRelations.sources"
-                   data-title="{{'sourceDatasets' | translate}}">
-              </div>
+              <div data-gn-related-observer>
+                <div data-gn-related="mdView.current.record"
+                     data-user="user"
+                     data-types="sources"
+                     data-has-results="hasRelations.sources"
+                     data-title="{{'sourceDatasets' | translate}}">
+                </div>
 
 
-              <div data-gn-related="mdView.current.record"
-                   data-user="user"
-                   data-types="hassources"
-                   data-has-results="hasRelations.hassources"
-                   data-title="{{'isSourceOfDatasets' | translate}}">
+                <div data-gn-related="mdView.current.record"
+                     data-user="user"
+                     data-types="hassources"
+                     data-has-results="hasRelations.hassources"
+                     data-title="{{'isSourceOfDatasets' | translate}}">
+                </div>
               </div>
             </td>
           </tr>
           </tbody>
         </table>
 
-
-        <div data-gn-related="mdView.current.record"
-             data-user="user"
-             data-types="fcats|related"
-             data-title="{{'featureCatalog' | translate}}">
-        </div>
-        <div data-gn-related="mdView.current.record"
-             data-user="user"
-             data-types="siblings|associated|related"
-             data-title="{{'siblings' | translate}}">
+        <div data-gn-related-observer>
+          <div data-gn-related="mdView.current.record"
+               data-user="user"
+               data-types="fcats|related"
+               data-title="{{'featureCatalog' | translate}}">
+          </div>
+          <div data-gn-related="mdView.current.record"
+               data-user="user"
+               data-types="siblings|associated|related"
+               data-title="{{'siblings' | translate}}">
+          </div>
         </div>
 
         <h2 data-translate="">metadataInformation</h2>


### PR DESCRIPTION
In the main metadata view, show a loading spinner while the requests to the related API are active. Hide it at the end and show the actual related elements if there are any.

Related load in progress:
![image](https://user-images.githubusercontent.com/826920/32617189-99cb4ece-c574-11e7-9959-ccd09290d198.png)

Related load finished:
![image](https://user-images.githubusercontent.com/826920/32617254-d05b4ad4-c574-11e7-93f9-df1480d664c1.png)

