### PR TITLE
Inspire atom opensearch

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -110,6 +110,7 @@ public final class Geonet {
         public static final String UPDATE_FIXED_INFO = "update-fixed-info.xsl";
         public static final String UPDATE_CHILD_FROM_PARENT_INFO = "update-child-from-parent-info.xsl";
         public static final String EXTRACT_UUID = "extract-uuid.xsl";
+        public static final String EXTRACT_DEFAULT_LANGUAGE = "extract-default-language.xsl";
         public static final String EXTRACT_SKOS_FROM_ISO19135 = "xml_iso19135ToSKOS.xsl";
         public static final String EXTRACT_DATE_MODIFIED = "extract-date-modified.xsl";
         public static final String SET_UUID = "set-uuid.xsl";

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -289,6 +289,11 @@ public class DataManager {
     }
 
     @Deprecated
+    public String extractDefaultLanguage(String schema, Element md) throws Exception {
+        return metadataUtils.extractDefaultLanguage(schema, md);
+    }
+
+    @Deprecated
     public String extractDateModified(String schema, Element md) throws Exception {
         return metadataUtils.extractDateModified(schema, md);
     }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -26,6 +26,8 @@ public interface IMetadataUtils {
 
         String extractUUID(String schema, Element md) throws Exception;
 
+        String extractDefaultLanguage(String schema, Element md) throws Exception;
+
         String extractDateModified(String schema, Element md) throws Exception;
 
         Element setUUID(String schema, String uuid, Element md) throws Exception;
@@ -81,6 +83,7 @@ public interface IMetadataUtils {
         public String getMetadataTitle(String id) throws Exception;
 
         public void setSubtemplateTypeAndTitleExt(int id, String title) throws Exception;
+
 }
 
   

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -248,6 +248,23 @@ public class BaseMetadataUtils implements IMetadataUtils {
     }
 
     /**
+     * Extract metadata default language from the metadata record using the schema XSL for default language extraction)
+     */
+    @Override
+    public String extractDefaultLanguage(String schema, Element md) throws Exception {
+        Path styleSheet = metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.EXTRACT_DEFAULT_LANGUAGE);
+        String defaultLanguage = Xml.transform(md, styleSheet).getText().trim();
+
+        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
+            Log.debug(Geonet.DATA_MANAGER, "Extracted default language '" + defaultLanguage + "' for schema '" + schema + "'");
+
+        // --- needed to detach md from the document
+        md.detach();
+
+        return defaultLanguage;
+    }
+
+    /**
      *
      * @param schema
      * @param md

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
@@ -30,15 +30,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import jeeves.constants.Jeeves;
-import jeeves.server.ServiceConfig;
-import jeeves.server.context.ServiceContext;
-
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.exceptions.MetadataNotFoundEx;
+import org.fao.geonet.exceptions.ObjectNotFoundEx;
+import org.fao.geonet.exceptions.UnAuthorizedException;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.search.LuceneSearcher;
 import org.fao.geonet.kernel.search.MetaSearcher;
@@ -46,12 +45,20 @@ import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.kernel.search.SearcherType;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.lib.Lib;
+import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
+import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
+import org.jdom.Text;
+import org.jdom.xpath.XPath;
+
+import jeeves.constants.Jeeves;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
 
 
 /**
@@ -78,6 +85,24 @@ public class InspireAtomUtil {
 
     /** Xslt process to get the atom feed link from the metadata. **/
     private static final String TRANSFORM_MD_TO_ATOM_FEED = "inspire-atom-feed.xsl";
+
+    /** Xslt process to get the atom feed link from the metadata. **/
+    private static final String TRANSFORM_ATOM_TO_OPENSEARCHDESCRIPTION = "opensearchdescription.xsl";
+
+    /** The OpenSearchDescription filename to describe local atomfeeds. **/
+    public static final String LOCAL_OPENSEARCH_DESCRIPTION_FILE_NAME = "OpenSearchDescription.xml";
+
+    /** The opensearch url suffix to describe local atomfeeds. **/
+    public static final String LOCAL_OPENSEARCH_URL_SUFFIX = "opensearch";
+
+    /** The describe url suffix for service atom feeds. **/
+    public static final String LOCAL_DESCRIBE_SERVICE_URL_SUFFIX = "atom.predefined.service";
+
+    /** The describe url suffix for dataset atom feeds. **/
+    public static final String LOCAL_DESCRIBE_DATASET_URL_SUFFIX = "atom.predefined.dataset";
+
+    /** The download url suffix for download of dataset atom feeds. **/
+    public static final String LOCAL_DOWNLOAD_DATASET_URL_SUFFIX = "atom.predefined.download";
 
     /**
      * Issue an http request to retrieve the remote Atom feed document.
@@ -410,5 +435,271 @@ public class InspireAtomUtil {
                 .resolve("convert/ATOM/")
                 .resolve(TRANSFORM_MD_TO_ATOM_FEED);
     }
+
+    public static Element getDatasetFeed(final ServiceContext context, final String spIdentifier, final String spNamespace, final Map<String,Object> params) throws Exception {
+
+        ServiceConfig config = new ServiceConfig();
+        SearchManager searchMan = context.getBean(SearchManager.class);
+
+        // Search for the dataset identified by spIdentifier
+        Metadata datasetMd = null;
+        Document dsLuceneSearchParams = createDefaultLuceneSearcherParams();
+        dsLuceneSearchParams.getRootElement().addContent(new Element("identifier").setText(spIdentifier));
+        if (StringUtils.isNotBlank(spNamespace)) {
+            dsLuceneSearchParams.getRootElement().addContent(new Element("identifierNamespace").setText(spNamespace));
+        }
+        dsLuceneSearchParams.getRootElement().addContent(new Element("type").setText("dataset"));
+
+        try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE))
+        {
+            searcher.search(context, dsLuceneSearchParams.getRootElement(), config);
+            Element searchResult = searcher.present(context, dsLuceneSearchParams.getRootElement(), config);
+
+            XPath xp = XPath.newInstance("//response/metadata/geonet:info/uuid/text()");
+            xp.addNamespace("geonet", "http://www.fao.org/geonetwork");
+            if (searchResult.getContentSize()==0) {
+                if (StringUtils.isNotBlank(spNamespace)) {
+                    dsLuceneSearchParams.getRootElement().removeChild("identifierNamespace");
+                    searcher.search(context, dsLuceneSearchParams.getRootElement(), config);
+                    searchResult = searcher.present(context, dsLuceneSearchParams.getRootElement(), config);
+                }
+            }
+            if (searchResult.getContentSize()>0) {
+                Text uuidTxt = (Text) xp.selectSingleNode(new Document(searchResult));
+                String datasetMdUuid = uuidTxt.getText();
+
+                MetadataRepository repo = context.getBean(MetadataRepository.class);
+                datasetMd = repo.findOneByUuid(datasetMdUuid);
+            }
+
+        } finally {
+            if (datasetMd == null) {
+                throw new ObjectNotFoundEx("metadata " + spIdentifier + " not found");
+            }
+        }
+
+        // check user's rights
+        try {
+            Lib.resource.checkPrivilege(context, String.valueOf(datasetMd.getId()), ReservedOperation.view);
+        } catch (Exception e) {
+            // This does not return a 403 as expected Oo
+            throw new UnAuthorizedException("Access denied to metadata " +datasetMd.getUuid(), e);
+        }
+
+        String serviceMdUuid = null;
+        Document luceneParamSearch = createDefaultLuceneSearcherParams();
+        luceneParamSearch.getRootElement().addContent(new Element("operatesOn").setText(datasetMd.getUuid()));
+
+        try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {
+            searcher.search(context, luceneParamSearch.getRootElement(), config);
+            Element searchResult = searcher.present(context, luceneParamSearch.getRootElement(), config);
+
+            XPath xp = XPath.newInstance("//response/metadata/geonet:info/uuid/text()");
+            xp.addNamespace("geonet", "http://www.fao.org/geonetwork");
+
+            Text uuidTxt = (Text) xp.selectSingleNode(new Document(searchResult));
+            serviceMdUuid = uuidTxt.getText();
+        } finally {
+            if (serviceMdUuid == null) {
+                throw new ObjectNotFoundEx("No related service metadata found");
+            }
+        }
+
+        DataManager dm = context.getBean(DataManager.class);
+        SettingManager sm = context.getBean(SettingManager.class);
+
+        Element inputDoc = InspireAtomUtil.prepareDatasetFeedEltBeforeTransform(datasetMd.getXmlData(false), serviceMdUuid);
+
+        return InspireAtomUtil.convertDatasetMdToAtom("iso19139", inputDoc, dm, params);
+    }
+
+    private static Document createDefaultLuceneSearcherParams() {
+        Document luceneParamSearch = new Document(new Element("request").
+                addContent(new Element("from").setText("1")).
+                addContent(new Element("to").setText("1000")).
+                addContent(new Element("fast").setText("index")));
+
+        return luceneParamSearch;
+    }
+
+    public static Element prepareOpenSearchDescriptionEltBeforeTransform(final ServiceContext context, final Map<String, Object> params, final String fileIdentifier, final String schema, final Element serviceAtomFeed,
+            final DataManager dataManager) throws Exception {
+
+        List<String> keywords = retrieveKeywordsFromFileIdentifier(context, fileIdentifier);
+        Namespace ns = serviceAtomFeed.getNamespace();
+        Document doc = new Document(new Element("root"));
+        Element response = new Element("response");
+        doc.getRootElement().addContent(response);
+        response.addContent(new Element("fileId").setText(fileIdentifier));
+        response.addContent(new Element("title").setText(serviceAtomFeed.getChildText("title",ns)));
+        response.addContent(new Element("subtitle").setText(serviceAtomFeed.getChildText("subtitle",ns)));
+        response.addContent(new Element("lang").setText(context.getLanguage()));
+        Element serviceAuthor = serviceAtomFeed.getChild("author",ns); 
+        if (serviceAuthor!=null) {
+            response.addContent(new Element("authorName").setText(serviceAuthor.getChildText("name",ns)));
+            response.addContent(new Element("authorEmail").setText(serviceAuthor.getChildText("email",ns)));
+        }
+        response.addContent(new Element("url").setText(serviceAtomFeed.getChildText("id",ns)));
+        Element datasetsEl = new Element("datasets");
+        response.addContent(datasetsEl);
+        Namespace inspiredlsns = serviceAtomFeed.getNamespace("inspire_dls");
+        Iterator<Element> datasets = (serviceAtomFeed.getChildren("entry", ns)).iterator();
+        List<String> fileTypes = new ArrayList<String>();
+        while(datasets.hasNext()) {
+            Element dataset = datasets.next();
+            String datasetIdCode = dataset.getChildText("spatial_dataset_identifier_code", inspiredlsns);
+            String datasetIdNs = dataset.getChildText("spatial_dataset_identifier_namespace", inspiredlsns);
+
+            Element datasetAtomFeed = null;
+            try {
+                datasetAtomFeed = InspireAtomUtil.getDatasetFeed(context, datasetIdCode, datasetIdNs, params);
+            } catch(Exception e) {
+				Log.error(Geonet.ATOM, "No dataset metadata found with uuid:"
+						+ fileIdentifier);
+				continue;
+            }
+			Element datasetEl = buildDatasetInfo(datasetIdCode,datasetIdNs);
+			datasetsEl.addContent(datasetEl);
+			Element author = datasetAtomFeed.getChild("author",ns);
+			if (author!=null) {
+				String authorName = author.getChildText("name",ns);
+				if (StringUtils.isNotBlank(authorName)) {
+					datasetEl.addContent(new Element("authorName").setText(authorName));
+				}
+			}
+            Map<String, Integer> downloadsCountByCrs = new HashMap<String, Integer>();
+            Iterator<Element> entries = (datasetAtomFeed.getChildren("entry", ns)).iterator();
+            while(entries.hasNext()) {
+            	Element entry = entries.next();
+            	Element category = entry.getChild("category",ns);
+            	if (category!=null) {
+	            	String term = category.getAttributeValue("term");
+	                Integer count = downloadsCountByCrs.get(term);
+	                if (count == null) {
+	                	count = new Integer(0);
+	                }
+	                downloadsCountByCrs.put(term, count + 1);
+            	}
+            	Element link = entry.getChild("link", ns);
+            	if (link!=null) {
+            		String fileType = link.getAttributeValue("type");
+            		if (!fileTypes.contains(fileType)) {
+            			fileTypes.add(fileType);
+            		}
+            	}
+            }
+            entries = (datasetAtomFeed.getChildren("entry", ns)).iterator();
+            while(entries.hasNext()) {
+            	Element entry = entries.next();
+            	Element category = entry.getChild("category",ns);
+            	if (category!=null) {
+	            	String term = category.getAttributeValue("term");
+	                Integer count = downloadsCountByCrs.get(term);
+	                if (count != null) {
+	                    Element downloadEl = new Element("file");
+                    	Element link = entry.getChild("link", ns);
+                    	if (link!=null) {
+    	                    String title = link.getAttributeValue("title");
+    	                    if (title!=null) {
+        	                    int iPos = title.indexOf(" in  -");
+        	                    if (iPos>-1) {
+        	                    	title = title.substring(0,iPos);
+        	                    }
+    	                    }
+    	                    downloadEl.addContent(new Element("title").setText(title));
+                    	}
+                    	Element lang = new Element("lang");
+                    	if (link!=null) {
+                    		lang.setText(link.getAttributeValue("hreflang"));
+                    	} else {
+    	                    lang.setText(context.getLanguage());
+                    	}
+	                    downloadEl.addContent(lang);
+	                    downloadEl.addContent(new Element("url").setText(entry.getChildText("id",ns)));
+	                    if (count > 1) {
+	                        downloadEl.addContent(new Element("type").setText("application/atom+xml"));
+	                    } else {
+	                    	if (link!=null) {
+	                    		downloadEl.addContent(new Element("type").setText(link.getAttributeValue("type")));
+	                    	}
+	                    }
+	                    downloadEl.addContent(new Element("crs").setText(term));
+	                    downloadEl.addContent(new Element("crsCount").setText("" + count));
+	                    datasetEl.addContent(downloadEl);
+
+	                    // Remove from map to not process further downloads with same CRS,
+	                    // only 1 entry with type= is added in result
+	                    downloadsCountByCrs.remove(term);
+	                }
+            	}
+            }
+        }
+    	response.addContent(new Element("keywords").setText(StringUtils.join(keywords,' ')));
+        Element fileTypesEl = new Element("fileTypes");
+        for(String fileType : fileTypes) {
+        	fileTypesEl.addContent(new Element("fileType").setText(fileType));
+        }
+        response.addContent(fileTypesEl);
+        return doc.getRootElement();
+    }
+
+    public static Element convertServiceMdToOpenSearchDescription(final ServiceContext context, final Element md, final Map<String,Object> params) throws Exception {
+
+        Path styleSheet = getOpenSearchDesciptionXSLStylesheet(context);
+        return Xml.transform(md, styleSheet, params);
+    }
+
+    private static Path getOpenSearchDesciptionXSLStylesheet(final ServiceContext context) {
+        return context.getAppPath().resolve(Geonet.Path.XSLT_FOLDER)
+        		.resolve("services/inspire-atom/")
+                .resolve(TRANSFORM_ATOM_TO_OPENSEARCHDESCRIPTION);
+    }
+
+    /**
+     * Builds JDOM element for dataset information.
+     *
+     * @param identifier Dataset identifier.
+     * @param namespace  Dataset namespace.
+     */
+    private static Element buildDatasetInfo(final String identifier, final String namespace) {
+        Element datasetEl = new Element("dataset");
+
+        Element codeEl = new Element("code");
+        codeEl.setText(identifier);
+
+        Element namespaceEl = new Element("namespace");
+        namespaceEl.setText(namespace);
+
+        datasetEl.addContent(codeEl);
+        datasetEl.addContent(namespaceEl);
+
+        return datasetEl;
+    }
+
+	public static List<String> retrieveKeywordsFromFileIdentifier(ServiceContext context, String fileIdentifier) {
+		List<String> keywordsList = new ArrayList<String>();
+        Element request = new Element(Jeeves.Elem.REQUEST);
+        request.addContent(new Element("fileId").setText(fileIdentifier));
+        //request.addContent(new Element("has_atom").setText("y"));
+        request.addContent(new Element("fast").setText("true"));
+        SearchManager searchMan = context.getBean(SearchManager.class);
+        // perform the search and return the results read from the index
+
+        try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {
+            searcher.search(context, request, new ServiceConfig());
+
+            List<Element> keywordElems = ((LuceneSearcher) searcher).getSummary().getChild("summary").getChild("keywords").getChildren();
+            for (Element elem : keywordElems) {
+                String keyword = elem.getAttributeValue("name");
+                if (!keywordsList.contains(keyword)) {
+                    keywordsList.add(keyword);
+                }
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+
+        return keywordsList;
+	}
 }
 

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomSearch.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomSearch.java
@@ -100,7 +100,7 @@ public class AtomSearch implements Service {
             List<String> datasetIdentifiers = InspireAtomUtil.extractRelatedDatasetsIdentifiers(schema, md, dm);
 
             // Remove fileIdentifier from params
-            params.removeContent(1);
+            params.removeChild("fileIdentifier");
 
             // Add query filter
             String values = Joiner.on(" or ").join(datasetIdentifiers);

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/ATOM/inspire-atom-feed.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/ATOM/inspire-atom-feed.xsl
@@ -29,6 +29,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
     <xsl:param name="atomDescribeDatasetUrlSuffix" select="'describe'"/>
     <xsl:param name="nodeName" select="string('srv')" />
     <xsl:param name="searchTerms" select="''"/>
+    <xsl:param name="requestedLanguage" select="''"/>
     <xsl:param name="requestedCRS" select="''"/>
 
     <!-- parameters used in case of dataset feed generation -->
@@ -56,7 +57,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <xsl:variable name="titleNode" select="gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:title"/>
         <xsl:variable name="title">
             <xsl:apply-templates mode="get-translation" select="$titleNode">
-                <xsl:with-param name="lang" select="$guiLang"/>
+                <xsl:with-param name="lang" select="$requestedLanguage"/>
             </xsl:apply-templates>
         </xsl:variable>
 
@@ -70,7 +71,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <!-- REC 1: subtitle -->
         <subtitle>
             <xsl:apply-templates mode="get-translation" select="gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:abstract">
-                <xsl:with-param name="lang" select="$guiLang"/>
+                <xsl:with-param name="lang" select="$requestedLanguage"/>
             </xsl:apply-templates>
         </subtitle>
 
@@ -92,10 +93,10 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <!--
         <link rel="search" type="application/opensearchdescription+xml" hreflang="{java:twoCharLangCode($guiLang)}">
         -->
-        <link rel="search" type="application/opensearchdescription+xml" hreflang="{java:twoCharLangCode($guiLang)}">
+        <link rel="search" type="application/opensearchdescription+xml">
             <xsl:attribute name="title">
                 <xsl:call-template name="translated-description">
-                    <xsl:with-param name="lang" select="$guiLang"/>
+                    <xsl:with-param name="lang" select="$requestedLanguage"/>
                     <xsl:with-param name="type" select="1"/>
                 </xsl:call-template>
                 <xsl:value-of select="$title"/>
@@ -121,10 +122,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
                     </xsl:with-param>
                     <xsl:with-param name="lang" select="."/>
                     <xsl:with-param name="fileIdentifier" select="$fileIdentifier"/>
-                    <xsl:with-param name="rel">
-                        <xsl:if test="$guiLang=.">self</xsl:if>
-                        <xsl:if test="$guiLang!=.">alternate</xsl:if>
-                    </xsl:with-param>
+                    <xsl:with-param name="rel">alternate</xsl:with-param>
                 </xsl:call-template>
             </xsl:if>
         </xsl:for-each>
@@ -178,7 +176,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <xsl:variable name="datasetTitleNode" select="./gmd:identificationInfo[1]//gmd:citation[1]/gmd:CI_Citation/gmd:title"/>
         <xsl:variable name="datasetTitle">
             <xsl:apply-templates mode="get-translation" select="$datasetTitleNode">
-                <xsl:with-param name="lang" select="$guiLang"/>
+                <xsl:with-param name="lang" select="$requestedLanguage"/>
             </xsl:apply-templates>
         </xsl:variable>
         <xsl:variable name="identifierCode" select="./gmd:identificationInfo[1]//gmd:citation/gmd:CI_Citation/gmd:identifier[1]/gmd:MD_Identifier/gmd:code/gco:CharacterString|
@@ -235,7 +233,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <xsl:call-template name="atom-link">
             <xsl:with-param name="title">
                 <xsl:apply-templates mode="get-translation" select="$datasetTitleNode">
-                    <xsl:with-param name="lang" select="$guiLang"/>
+                    <xsl:with-param name="lang" select="$requestedLanguage"/>
                 </xsl:apply-templates>
             </xsl:with-param>
             <xsl:with-param name="lang" select="$guiLang"/>
@@ -266,7 +264,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <!-- REC 5: summary -->
         <summary>
             <xsl:apply-templates mode="get-translation" select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract">
-                <xsl:with-param name="lang" select="$guiLang"/>
+                <xsl:with-param name="lang" select="$requestedLanguage"/>
             </xsl:apply-templates>
         </summary>
 
@@ -309,7 +307,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <xsl:variable name="datasetTitleNode" select="./gmd:identificationInfo[1]//gmd:citation[1]/gmd:CI_Citation/gmd:title"/>
         <xsl:variable name="datasetTitle">
             <xsl:apply-templates mode="get-translation" select="$datasetTitleNode">
-                <xsl:with-param name="lang" select="$guiLang"/>
+                <xsl:with-param name="lang" select="$requestedLanguage"/>
             </xsl:apply-templates>
         </xsl:variable>
         <xsl:variable name="identifierCode" select="./gmd:identificationInfo[1]//gmd:citation/gmd:CI_Citation/gmd:identifier[1]/gmd:MD_Identifier/gmd:code/gco:CharacterString|
@@ -320,7 +318,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <!-- REQ 21: title -->
         <title>
             <xsl:call-template name="translated-description">
-                <xsl:with-param name="lang" select="$guiLang"/>
+                <xsl:with-param name="lang" select="$requestedLanguage"/>
                 <xsl:with-param name="type" select="3"/>
             </xsl:call-template>
             <xsl:value-of select="$datasetTitle"/>
@@ -329,11 +327,11 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <!-- REC 8: subtitle -->
         <subtitle>
             <xsl:call-template name="translated-description">
-                <xsl:with-param name="lang" select="$guiLang"/>
+                <xsl:with-param name="lang" select="$requestedLanguage"/>
                 <xsl:with-param name="type" select="3"/>
             </xsl:call-template>
             <xsl:apply-templates mode="get-translation" select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract">
-                <xsl:with-param name="lang" select="$guiLang"/>
+                <xsl:with-param name="lang" select="$requestedLanguage"/>
             </xsl:apply-templates>
         </subtitle>
         
@@ -358,7 +356,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
         <xsl:call-template name="atom-link">
             <xsl:with-param name="title">
                 <xsl:apply-templates mode="get-translation" select="$datasetTitleNode">
-                    <xsl:with-param name="lang" select="$guiLang"/>
+                    <xsl:with-param name="lang" select="$requestedLanguage"/>
                 </xsl:apply-templates>
             </xsl:with-param>
             <xsl:with-param name="lang" select="$guiLang"/>
@@ -378,7 +376,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
                     <xsl:with-param name="lang" select="."/>
                     <xsl:with-param name="identifier" select="$identifierCode"/>
                     <xsl:with-param name="codeSpace" select="$identifierCodeSpace"/>
-                    <xsl:with-param name="rel"><xsl:if test="$guiLang=.">self</xsl:if><xsl:if test="$guiLang!=.">alternate</xsl:if></xsl:with-param>
+                    <xsl:with-param name="rel">alternate</xsl:with-param>
                 </xsl:call-template>
             </xsl:if>
         </xsl:for-each>
@@ -534,7 +532,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
                           rel="alternate"
                           type="{$inspireMimeType}"
                           href="{gmd:linkage/gmd:URL}"
-                          hreflang="{java:twoCharLangCode($guiLang)}">
+                          hreflang="{java:twoCharLangCode($docLang)}">
 
                         <xsl:variable name="units" select="../../gmd:unitsOfDistribution/gco:CharacterString"/>
                         <xsl:variable name="length" select="../../gmd:transferSize/gco:Real"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-default-language.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-default-language.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                version="1.0">
+
+  <xsl:template match="gmd:MD_Metadata">
+    <language>
+      <xsl:value-of select="gmd:language/gmd:LanguageCode/@codeListValue"/>
+    </language>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -173,6 +173,10 @@
           <Field name="identifier" string="{string(.)}" store="true" index="true"/>
         </xsl:for-each>
 
+        <xsl:for-each select="gmd:identifier/gmd:RS_Identifier/gmd:codeSpace/gco:CharacterString">
+        <!-- For local atom feed services -->
+          <Field name="identifierNamespace" string="{string(.)}" store="true" index="true"/>
+        </xsl:for-each>
 
         <xsl:for-each select="gmd:title/gco:CharacterString">
           <Field name="title" string="{string(.)}" store="true" index="true"/>
@@ -658,6 +662,11 @@
       <xsl:for-each select="gmd:distributionFormat/gmd:MD_Format/gmd:name/gco:CharacterString">
         <Field name="format" string="{string(.)}" store="true" index="true"/>
       </xsl:for-each>
+
+      <!-- For local atom feed services -->
+      <xsl:if test="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue='download'])>0">
+        <Field name="has_atom" string="true" store="false" index="true"/>
+      </xsl:if>
 
       <!-- index online protocol -->
       <xsl:for-each select="gmd:transferOptions/gmd:MD_DigitalTransferOptions">

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -765,6 +765,11 @@
           </format>
         </xsl:for-each>
 
+        <!-- For local atom feed services -->
+        <xsl:if test="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue='download'])>0">
+          <Field name="has_atom" string="true" store="false" index="true"/>
+        </xsl:if>
+
         <xsl:for-each select="gmd:transferOptions/*/
                                 gmd:onLine/*[gmd:linkage/gmd:URL != '']">
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -765,11 +765,6 @@
           </format>
         </xsl:for-each>
 
-        <!-- For local atom feed services -->
-        <xsl:if test="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue='download'])>0">
-          <Field name="has_atom" string="true" store="false" index="true"/>
-        </xsl:if>
-
         <xsl:for-each select="gmd:transferOptions/*/
                                 gmd:onLine/*[gmd:linkage/gmd:URL != '']">
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -545,6 +545,11 @@
         <Field name="format" string="{string(.)}" store="true" index="true"/>
       </xsl:for-each>
 
+      <!-- For local atom feed services -->
+      <xsl:if test="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue='download'])>0">
+        <Field name="has_atom" string="true" store="false" index="true"/>
+      </xsl:if>
+
       <xsl:for-each select="gmd:transferOptions/gmd:MD_DigitalTransferOptions">
         <xsl:variable name="tPosition" select="position()"></xsl:variable>
         <xsl:for-each select="gmd:onLine/gmd:CI_OnlineResource[

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
@@ -989,6 +989,37 @@
   <element name="gmd:description" id="401.0" context="gmd:CI_OnlineResource">
     <label>Description</label>
     <description>Detailed text description of what the online resource is/does</description>
+        <helper>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3035">ETRS89 / LAEA Europe</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/31370">Belge 1972 / Belgian Lambert 72</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/4936">ETRS89-XYZ: 3D Cartesian in ETRS89</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/4937">ETRS89-GRS80h: 3D geodetic in ETRS89 on GRS80</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/4258">ETRS89-GRS802D: geodetic in ETRS89 on GRS80</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3035">ETRS89-LAEA2D: LAEA projection in ETRS89 on GRS80</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3034">ETRS89-LCC2D: LCC projection in ETRS89 on GRS80</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3038">ETRS89-TM26N2D: TM projection in ETRS89 on GRS80, zone 26N (30°W to 24°W)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3039">ETRS89-TM27N2D: TM projection in ETRS89 on GRS80, zone 27N (24°W to 18°W)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3040">ETRS89-TM28N: 2D TM projection in ETRS89 on GRS80, zone 28N (18°W to 12°W)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3041">ETRS89-TM29N: 2D TM projection in ETRS89 on GRS80, zone 29N (12°W to 6°W)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3042">ETRS89-TM30N: 2D TM projection in ETRS89 on GRS80, zone 30N (6°W to 0°)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3043">ETRS89-TM31N:  2D TM projection in ETRS89 on GRS80, zone 31N (0° to 6°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3044">ETRS89-TM32N: 2D TM projection in ETRS89 on GRS80, zone 32N (6°E to 12°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3045">ETRS89-TM33N: 2D TM projection in ETRS89 on GRS80, zone 33N (12°E to 18°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3046">ETRS89-TM34N: 2D TM projection in ETRS89 on GRS80, zone 34N (18°E to 24°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3047">ETRS89-TM35N: 2D TM projection in ETRS89 on GRS80, zone 35N (24°E to 30°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3048">ETRS89-TM36N: 2D TM projection in ETRS89 on GRS80, zone 36N (30°E to 36°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3049">ETRS89-TM37N: 2D TM projection in ETRS89 on GRS80, zone 37N (36°E to 42°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3050">ETRS89-TM38N: 2D TM projection in ETRS89 on GRS80, zone 38N (42°E to 48°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/3051">ETRS89-TM39N: 2D TM projection in ETRS89 on GRS80, zone 39N (48°E to 54°E)</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/5730">EVRS: Height in EVRS</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/7409">ETRS89-GRS80-EVRS: 3D compound: 2D geodetic in ETRS89 on GRS80, and EVRS height</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/2154">RGF93 / Lambert-93</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/32620">WGS 84 / UTM zone 20N</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/2972">RGFG95 / UTM zone 22N</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/2975">RGR92 / UTM zone 40S</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/4467">RGSPM06 / UTM zone 21N</option>
+            <option value="http://www.opengis.net/def/crs/EPSG/0/4471">RGM04 / UTM zone 38S</option>
+        </helper>
   </element>
   <element name="gmd:description" id="541.0" context="gmd:MD_CodeDomain">
     <label>Description</label>

--- a/web/src/main/webResources/WEB-INF/urlrewrite.xml
+++ b/web/src/main/webResources/WEB-INF/urlrewrite.xml
@@ -379,6 +379,21 @@
     <to type="forward">/srv/$1/atom.describe</to>
   </rule>
 
+  <rule>
+    <note>
+      INSPIRE Atom Predefined Service Describe
+    </note>
+    <from>^/(.*)/atom.predefined.service?(.*)$</from>
+    <to type="forward">/srv/atom/describe/service?$2</to>
+  </rule>
+
+  <rule>
+    <note>
+      INSPIRE Atom Predefined Dataset Describe
+    </note>
+    <from>^/(.*)/atom.predefined.dataset?(.*)$</from>
+    <to type="forward">/srv/atom/describe/dataset?$2</to>
+  </rule>
 
   <rule>
     <note>

--- a/web/src/main/webResources/WEB-INF/urlrewrite.xml
+++ b/web/src/main/webResources/WEB-INF/urlrewrite.xml
@@ -354,6 +354,17 @@
 
   <rule>
     <note>
+      INSPIRE HTML search
+    </note>
+    <from>^/(.*)/(.*)/opensearch/htmlsearch\?.*q=(.*)</from>
+<!--
+    <to type="forward">/$1/$2/catalog.search#/search?any=$3</to>
+-->
+    <to type="permanent-redirect">%{context-path}/$1/$2/catalog.search#/search?any=$3</to>
+  </rule>
+
+  <rule>
+    <note>
       INSPIRE Atom Describe (service)
     </note>
     <from>^/opensearch/(.*)/(.*)/describe?(.*)$</from>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -891,8 +891,11 @@
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.search!?.*"
                            access="permitAll"/>
 
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/opensearch/htmlsearch!?.*q=.*" access="permitAll"/>
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/opensearch/OpenSearchDescription.xml!?.*" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.predefined.service!?.*" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.predefined.dataset!?.*" access="permitAll"/>
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.predefined.download!?.*" access="permitAll"/>
 
         <!-- Metadata identifier templates -->
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/metadataIdentifierTemplates!?.*"

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -892,10 +892,12 @@
                            access="permitAll"/>
 
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/opensearch/htmlsearch!?.*q=.*" access="permitAll"/>
-        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/opensearch/OpenSearchDescription.xml!?.*" access="permitAll"/>
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/opensearch/OpenSearchDescription.xml!?.*" access="permitAll"/>
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/atom/describe/service!?.*" access="permitAll"/>
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/atom/describe/dataset!?.*" access="permitAll"/>
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/atom/download/dataset!?.*" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.predefined.service!?.*" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.predefined.dataset!?.*" access="permitAll"/>
-        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.predefined.download!?.*" access="permitAll"/>
 
         <!-- Metadata identifier templates -->
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/metadataIdentifierTemplates!?.*"

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
@@ -116,13 +116,11 @@
       <xsl:choose>
         <xsl:when test="string(fileId)">
           <Developer>
-            <xsl:value-of select="/authorName"/>
+            <xsl:value-of select="authorName"/>
           </Developer>
           <!-- TG Requirement 45 -->
-          <!-- Supported Languages, Default Language -->
-          <!--Languages supported by the service. The first language is the Default Language-->
-          <xsl:variable name="languages" select="distinct-values(//dataset/file/lang)"/>
-          <xsl:for-each select="$languages">
+          <!-- Languages supported by the service. The first language is the Default Language-->
+          <xsl:for-each select="languages/language">
             <Language>
               <xsl:value-of select="."/>
             </Language>

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
@@ -13,7 +13,7 @@
                 xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
                 exclude-result-prefixes="gmx xsl gmd gco srv java">
   <xsl:param name="nodeUrl" />
-  <xsl:param name="guiLang" select="string('eng')" />
+  <xsl:param name="requestedLanguage" select="string('eng')" />
   <xsl:param name="opensearchDescriptionFileName" select="'OpenSearchDescription.xml'"/>
   <xsl:param name="opensearchUrlSuffix" />
   <xsl:param name="atomDescribeServiceUrlSuffix" />
@@ -39,7 +39,7 @@
           <Url type="application/opensearchdescription+xml" rel="self">
             <xsl:attribute name="template">
               <xsl:value-of
-                select="concat($nodeUrl, $guiLang, '/', $opensearchUrlSuffix, '/', $opensearchDescriptionFileName, '?uuid=', fileId)"/>
+                select="concat($nodeUrl, $opensearchUrlSuffix, '/', $opensearchDescriptionFileName, '?uuid=', fileId)"/>
             </xsl:attribute>
           </Url>
         </xsl:when>
@@ -52,7 +52,7 @@
       <Url type="text/html" rel="results">
         <xsl:attribute name="template">
           <xsl:value-of
-            select="concat($nodeUrl, $guiLang, '/', $opensearchUrlSuffix, '/htmlsearch?q={searchTerms?}')"/>
+            select="concat($nodeUrl, $requestedLanguage, '/', $opensearchUrlSuffix, '/htmlsearch?q={searchTerms?}')"/>
         </xsl:attribute>
       </Url>
 
@@ -62,7 +62,7 @@
            Dataset-->
       <Url type="application/atom+xml" rel="describedby">
         <xsl:attribute name="template">
-          <xsl:value-of select="concat($nodeUrl, $guiLang, '/',$atomDescribeDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+          <xsl:value-of select="concat($nodeUrl, $atomDescribeDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;language={language?}&amp;q={searchTerms?}')"/>
         </xsl:attribute>
       </Url>
 
@@ -71,7 +71,7 @@
            to retrieve a Spatial Data Set-->
       <Url type="application/atom+xml" rel="results">
         <xsl:attribute name="template">
-          <xsl:value-of select="concat($nodeUrl, $guiLang, '/',$atomDescribeDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+          <xsl:value-of select="concat($nodeUrl, $atomDescribeDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
         </xsl:attribute>
       </Url>
       <xsl:for-each select="fileTypes/fileType">
@@ -87,7 +87,7 @@
         </xsl:variable>
         <Url type="{$inspireMimeType}" rel="results">
           <xsl:attribute name="template">
-            <xsl:value-of select="concat($nodeUrl, $guiLang, '/',$atomDownloadDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+            <xsl:value-of select="concat($nodeUrl, $atomDownloadDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
           </xsl:attribute>
         </Url>
       </xsl:for-each>

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
@@ -10,7 +10,6 @@
                 xmlns:gml="http://www.opengis.net/gml"
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"
-                xmlns:opensearchextensions="http://example.com/opensearchextensions/1.0/"
                 xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
                 exclude-result-prefixes="gmx xsl gmd gco srv java">
   <xsl:param name="nodeUrl" />
@@ -24,7 +23,7 @@
   <xsl:output method="xml" indent="no" encoding="utf-8"/>
 
   <xsl:template match="/root">
-    <OpenSearchDescription>
+    <OpenSearchDescription xsi:schemaLocation="http://a9.com/-/spec/opensearch/1.1/ http://inspire-geoportal.ec.europa.eu/schemas/inspire/atom/1.0/opensearch.xsd">
       <xsl:apply-templates mode="service" select="response"/>
     </OpenSearchDescription>
   </xsl:template>
@@ -34,15 +33,7 @@
       <xsl:choose>
         <xsl:when test="string(fileId)">
           <ShortName>INSPIRE Download</ShortName>
-          <LongName><xsl:value-of select="substring(title,1,48)"/></LongName>
           <Description><xsl:value-of select="title"/>: <xsl:value-of select="subtitle"/></Description>
-          <Tags>
-            <xsl:value-of select="substring(keywords,1,256)"/>
-          </Tags>
-          <Contact>
-            <xsl:value-of select="authorEmail" />
-          </Contact>
-
           <!-- TG Requirement 40 -->
           <!--URL of this document-->
           <Url type="application/opensearchdescription+xml" rel="self">
@@ -78,6 +69,11 @@
       <!-- TG Requirement 43 -->
       <!-- Get Spatial Data Set Operation request URL template to be used in order
            to retrieve a Spatial Data Set-->
+      <Url type="application/atom+xml" rel="results">
+        <xsl:attribute name="template">
+          <xsl:value-of select="concat($nodeUrl, $guiLang, '/',$atomDescribeDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+        </xsl:attribute>
+      </Url>
       <xsl:for-each select="fileTypes/fileType">
         <xsl:variable name="inspireMimeType">
           <xsl:choose>
@@ -91,11 +87,18 @@
         </xsl:variable>
         <Url type="{$inspireMimeType}" rel="results">
           <xsl:attribute name="template">
-            <xsl:value-of select="concat($nodeUrl, $guiLang, '/',$atomDownloadDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+            <xsl:value-of select="concat($nodeUrl, $guiLang, '/',$atomDownloadDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
           </xsl:attribute>
         </Url>
       </xsl:for-each>
 
+      <Contact>
+        <xsl:value-of select="authorEmail" />
+      </Contact>
+      <Tags>
+        <xsl:value-of select="substring(keywords,1,256)"/>
+      </Tags>
+      <LongName><xsl:value-of select="substring(title,1,48)"/></LongName>
       <!-- TG Requirement 44 -->
       <!-- List of available Spatial Dataset Identifiers -->
       <xsl:for-each select="datasets/dataset">
@@ -113,18 +116,12 @@
       <xsl:choose>
         <xsl:when test="string(fileId)">
           <Developer>
-            <xsl:value-of select="authorName"/>
+            <xsl:value-of select="/authorName"/>
           </Developer>
-          <xsl:variable name="datasetAuthors" select="distinct-values(//authorName)"/>
-          <xsl:for-each select="$datasetAuthors">
-            <Developer>
-              <xsl:value-of select="."/>
-            </Developer>
-          </xsl:for-each>
           <!-- TG Requirement 45 -->
           <!-- Supported Languages, Default Language -->
           <!--Languages supported by the service. The first language is the Default Language-->
-          <xsl:variable name="languages" select="distinct-values(//lang)"/>
+          <xsl:variable name="languages" select="distinct-values(//dataset/file/lang)"/>
           <xsl:for-each select="$languages">
             <Language>
               <xsl:value-of select="."/>

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:java="java:org.fao.geonet.util.XslUtil"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:georss="http://www.georss.org/georss"
+                xmlns:gml="http://www.opengis.net/gml"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"
+                xmlns:opensearchextensions="http://example.com/opensearchextensions/1.0/"
+                xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
+                exclude-result-prefixes="gmx xsl gmd gco srv java">
+  <xsl:param name="nodeUrl" />
+  <xsl:param name="guiLang" select="string('eng')" />
+  <xsl:param name="opensearchDescriptionFileName" select="'OpenSearchDescription.xml'"/>
+  <xsl:param name="opensearchUrlSuffix" />
+  <xsl:param name="atomDescribeServiceUrlSuffix" />
+  <xsl:param name="atomDescribeDatasetUrlSuffix" />
+  <xsl:param name="atomDownloadDatasetUrlSuffix" />
+  <xsl:param name="nodeName" />
+  <xsl:output method="xml" indent="no" encoding="utf-8"/>
+
+  <xsl:template match="/root">
+    <OpenSearchDescription>
+      <xsl:apply-templates mode="service" select="response"/>
+    </OpenSearchDescription>
+  </xsl:template>
+
+  <xsl:template mode="service" match="response">
+      <!--URL of this document-->
+      <xsl:choose>
+        <xsl:when test="string(fileId)">
+          <ShortName>INSPIRE Download</ShortName>
+          <LongName><xsl:value-of select="substring(title,1,48)"/></LongName>
+          <Description><xsl:value-of select="title"/>: <xsl:value-of select="subtitle"/></Description>
+          <Tags>
+            <xsl:value-of select="substring(keywords,1,256)"/>
+          </Tags>
+          <Contact>
+            <xsl:value-of select="authorEmail" />
+          </Contact>
+
+          <!-- TG Requirement 40 -->
+          <!--URL of this document-->
+          <Url type="application/opensearchdescription+xml" rel="self">
+            <xsl:attribute name="template">
+              <xsl:value-of
+                select="concat($nodeUrl, $guiLang, '/', $opensearchUrlSuffix, '/', $opensearchDescriptionFileName, '?uuid=', fileId)"/>
+            </xsl:attribute>
+          </Url>
+        </xsl:when>
+        <xsl:otherwise>
+        </xsl:otherwise>
+      </xsl:choose>
+
+      <!-- TG Requirement 41 -->
+      <!--Generic URL template for browser integration-->
+      <Url type="text/html" rel="results">
+        <xsl:attribute name="template">
+          <xsl:value-of
+            select="concat($nodeUrl, $guiLang, '/', $opensearchUrlSuffix, '/htmlsearch?q={searchTerms?}')"/>
+        </xsl:attribute>
+      </Url>
+
+      <!-- TG Requirement 42 -->
+      <!-- Describe Spatial Data Set Operation request URL template to be used in
+           order to retrieve the description of Spatial Object Types in a Spatial
+           Dataset-->
+      <Url type="application/atom+xml" rel="describedby">
+        <xsl:attribute name="template">
+          <xsl:value-of select="concat($nodeUrl, $guiLang, '/',$atomDescribeDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+        </xsl:attribute>
+      </Url>
+
+      <!-- TG Requirement 43 -->
+      <!-- Get Spatial Data Set Operation request URL template to be used in order
+           to retrieve a Spatial Data Set-->
+      <xsl:for-each select="fileTypes/fileType">
+        <xsl:variable name="inspireMimeType">
+          <xsl:choose>
+            <xsl:when test=".='multipart/x-zip'">
+              <xsl:value-of select="string('application/x-gmz')"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="."/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        <Url type="{$inspireMimeType}" rel="results">
+          <xsl:attribute name="template">
+            <xsl:value-of select="concat($nodeUrl, $guiLang, '/',$atomDownloadDatasetUrlSuffix,'?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code?}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace?}}&amp;crs={inspire_dls:crs?}&amp;language={language?}&amp;q={searchTerms?}')"/>
+          </xsl:attribute>
+        </Url>
+      </xsl:for-each>
+
+      <!-- TG Requirement 44 -->
+      <!-- List of available Spatial Dataset Identifiers -->
+      <xsl:for-each select="datasets/dataset">
+          <xsl:variable name="codeVal" select="code" />
+          <xsl:variable name="namespaceVal" select="namespace" />
+
+          <xsl:for-each select="file">
+              <Query role="example"
+                  inspire_dls:spatial_dataset_identifier_namespace="{$namespaceVal}"
+                  inspire_dls:spatial_dataset_identifier_code="{$codeVal}" inspire_dls:crs="{crs}" language="{lang}" title="{title}" count="{crsCount}"/>
+         </xsl:for-each>
+
+      </xsl:for-each>
+
+      <xsl:choose>
+        <xsl:when test="string(fileId)">
+          <Developer>
+            <xsl:value-of select="authorName"/>
+          </Developer>
+          <xsl:variable name="datasetAuthors" select="distinct-values(//authorName)"/>
+          <xsl:for-each select="$datasetAuthors">
+            <Developer>
+              <xsl:value-of select="."/>
+            </Developer>
+          </xsl:for-each>
+          <!-- TG Requirement 45 -->
+          <!-- Supported Languages, Default Language -->
+          <!--Languages supported by the service. The first language is the Default Language-->
+          <xsl:variable name="languages" select="distinct-values(//lang)"/>
+          <xsl:for-each select="$languages">
+            <Language>
+              <xsl:value-of select="."/>
+            </Language>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise/>
+      </xsl:choose>
+
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This pull request fixes the remaining issues on the INSPIRE ATOM/OpenSearch implementation that are documented in [PR1900] (https://github.com/geonetwork/core-geonetwork/pull/1900) and is built on my original work in [1743] (https://github.com/geonetwork/core-geonetwork/pull/1743). 

*The general principle for GeoNetwork is to provide an INSPIRE-conform ATOM/OpenSearch download service on the basis of the download service metadata record and dataset metadata records.*

A working example of the code can be found on https://pocinspire.gim.be/geonetwork/srv/eng/catalog.search#/metadata/e406ea0b-c4e5-4d02-a129-29dbb7c242b1

*Brief usage instructions*: The metadata records must contain a number of fields for GeoNetwork to be able to generate the correct ATOM feeds and OpenSearch description.

**Service metadata must contain next xml elements:**

- A _coupledResource_ element defining dataset GetSpatialDataset operation, identifier and scopedName for each dataset metadata containing a download link.
- A _containsOperation_ element defining service operation like GetOpenSearchDescription, GetServiceAtomFeed and dataset operationName like DescribeSpatialDataset, GetSpatialDataset with an _onLine_ element for each of these operations.  The last ones can be the template url's mentioned in the response of the OpenSearchDescription operation of the service.
- An _operatesOn_ element defining an identifier and the csw link for each linked dataset metadata.
- Finally two transferOptions elements defining the _onLine_ element for the GetOpenSearchDescription and GetServiceAtomFeed operations again.


**Dataset metadata must contain next xml elements:**

- A _referenceSystemInfo_ element defining the CRS, containing an EPSG string.
- One or more _transferOptions_ elements defining an _onLine_ element with the download url of the dataset, an _unitsOfDistribution_ element and a _transferSize_ element.
- Important is to mention the _CI_OnLineFunctionCode_ element with a codeListValue 'download' and an optional _description_ element to overwrite the default CRS mentioned in the _referenceSystemInfo_ element.
- A _descriptiveKeywords_ element defining one or more keywords from a thesaurus based on the INSPIRE featureconcept http://inspire.ec.europa.eu/featureconcept .
- A _DQ_ConformanceResult_ element defining the INSPIRE conformity for validation reasons.

### *List of changes and improvements*: 

Issue 1:
In the core\src\main\java\org\fao\geonet\kernel\datamanager\base\BaseMetadataIndexer.java source, the index field has_atom is only set to true if atom exists in database (remote atom).

Solution:
Modified the stylesheet for indexing metadata to set the has_atom field value to true if the dataset metadata contains a xpath like //FunctionCode/@codeListValue='download' for transferOptions elements.


Issue 2:
In the inspire-atom-feed.xsl, stylesheet the variable protocol and application profile is not used anymore

Solution:
Modified the stylesheet to look for the FunctionCode codeListValue and if equals to download, an entry element is added to the atom feed.

Issue 3:
In the inspire-atom-feed.xsl, the value of the applicationProfile variable was changed from INSPIRE-Download-Atom to ATOM

Solution:
Not used anymore, so this is not an issue anymore.

Issue 4:
In the inspire-atom-feed.xsl, the capabilities url was removed as related link with title 'Service implementing Direct Access operations'

Solution:
Added it again based on the REQ 16 (entry link to WFS implementation (only for hybrid implementations))

Issue 5:
In the inspire-atom-feed.xsl, the add-author template will generate a transformer error when there are more authors in the pointOfContact

Solution:
Added count function in the test attribute of the if and return the first author

Issue 6:
In the inspire-atom-feed.xsl, the RS_Identifier is used for the category of the dataset atom feed, but will generate a transformer error when there are more than one gmd:referenceSystemInfo elements.

Solution:
Added support for setting another CRS as mentioned in the RS_Identifier element, using the description element of a CI_OnlineResource element containing the download link.

Issue 7:
In the inspire-atom-feed.xsl, the describeBy (CSW) and Dataset ATOM feed link (self) missing in Dataset ATOM feed (this is not the case for the entry elements in Service ATOM feed, there it is ok)

Solution:
Added missing links and also the links for other languages, if defined in the metadata

Issue 8:
In the inspire-atom-feed.xsl, no CRS request parameter is used to show only the entries containing a download url for that requested CRS

Solution:
Added support for this

Issue 9:
In the inspire-atom-feed.xsl, the author is only shown ones in the dataset atom feed and not repeated in every download link

Solution:
Added support for this

Issue 10:
No UTF-8 support for downloading of ATOM feeds, downloads are broken when ATOM feeds contains special characters.

Solution:
Added support for this by changing AtomPredefinedFeed.java file.

Issue 11:
Validation errors on dataset and service ATOM feed, because the order of the xml elements is important when most of all are used.

Solution:
Reordered the inspire-atom-feed.xsl

Issue 12:
The web\src\main\webapp\xslt\services\inspire-atom\opensearch.xsl file is to dependent from xml inserted by the service

Solution:
New file web\src\main\webapp\xslt\services\inspire-atom\opensearchdescription.xsl used for generating the response of the GetOpenSearchDescription operation

**Improvements**

Fixing the issues above. 

- Fixing issues #1, #2, #3 and #6 of our inspire-atom-opensearch branche created to do this pull request
- Improving support for the use of language request parameter in dataset ATOM feed and service ATOM feed.
- Modified atom feed urls and added extract document language xsl file to get the default atom feed languages, but backwards compatability with the rest urls implemented by geosolutions.it.
- Include a reference to the INSPIRE Spatial Object Type in the dataset-level ATOM feed (but used keyword thesaurus not added to the project)

**To do**

- May be the file iso19119ToAtomFeed.xsl can be removed, because I could not found where this stylesheet is used, otherwise this must be reviewed based on changes in inspire-atom-feed.xsl or we must reuse the last one.
- In the inspire-atom-feed.xsl, the rights element contains the codeListValue and not the translated description of it.  Must this be changed?

*Acknowledgement*: The development of this functionality would not have been possible without the support of the Brussels Capital Region, the Luxembourg Cadastre (ACT Luxembourg), and the Vlaamse Overheid (MercatorNet Samenwerkingsverband).