### PR TITLE
extend feedback button to remove styling and add option for a label

### DIFF
--- a/web-ui/src/main/resources/catalog/components/mdFeedback/GnmdFeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/mdFeedback/GnmdFeedbackDirective.js
@@ -37,6 +37,8 @@
               '../../catalog/components/mdFeedback/partials/mdFeedback.html',
               link: function postLink(scope, element, attrs) {
 
+                scope.showLabel = attrs.showLabel;
+
                 $(element).find('.modal').on('hidden.bs.modal', function() {
                   scope.$apply(function() {
                     scope.mdFeedbackOpen = false;

--- a/web-ui/src/main/resources/catalog/components/mdFeedback/partials/mdFeedback.html
+++ b/web-ui/src/main/resources/catalog/components/mdFeedback/partials/mdFeedback.html
@@ -1,10 +1,11 @@
-<div class="md-feedback pull-right"
+<div class="md-feedback"
      data-ng-show="isFeedbackEnabled"
      data-ng-controller="gnMdFeedbackController">
   <a href data-ng-click="toggle()"
      title="{{'fbFeedback' | translate}}"
-     class="btn btn-primary pull-right gn-md-feedback-btn">
+     class="gn-md-feedback-btn">
     <i class="fa fa-fw fa-comments-o"></i>
+    <span class="hidden-xs" data-ng-show="showLabel" data-translate="">{{showLabel}}</span>
   </a>
   <div class="modal fade">
     <div class="modal-dialog">


### PR DESCRIPTION
this feature adds the capability to add a label to the feedback button
also some btn pull-right styling removed imho this type of config should go on a template