### PR TITLE
Add "available actions" facet to filter downloadable/viewable MD

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -708,10 +708,16 @@
 
           <xsl:if test="contains($protocol, 'WWW:DOWNLOAD')">
             <Field name="download" string="true" store="false" index="true"/>
+            <Field name="_mdActions" string="mdActions-download" store="false" index="true"/>
           </xsl:if>
 
           <xsl:if test="contains($protocol, 'OGC:WMS') or $wmsLinkNoProtocol">
             <Field name="dynamic" string="true" store="false" index="true"/>
+            <Field name="_mdActions" string="mdActions-view" store="false" index="true"/>
+          </xsl:if>
+
+          <xsl:if test="contains($protocol, 'OGC:WPS')">
+            <Field name="_mdActions" string="mdActions-process" store="false" index="true"/>
           </xsl:if>
 
           <!-- ignore WMS links without protocol (are indexed below with mimetype application/vnd.ogc.wms_xml) -->

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -596,11 +596,17 @@
           <xsl:if test="contains($protocol, 'WWW:DOWNLOAD') or contains($protocol, 'DB')
            or contains($protocol, 'FILE')  or contains($protocol, 'WFS')  or contains($protocol, 'WCS')  or contains($protocol, 'COPYFILE')">
             <Field name="download" string="true" store="false" index="true"/>
+            <Field name="_mdActions" string="mdActions-download" store="false" index="true"/>
           </xsl:if>
 
           <xsl:if test="contains($protocol, 'OGC:WMS') or contains($protocol, 'OGC:WMC') or contains($protocol, 'OGC:OWS')
                     or contains($protocol, 'OGC:OWS-C') or $wmsLinkNoProtocol">
             <Field name="dynamic" string="true" store="false" index="true"/>
+            <Field name="_mdActions" string="mdActions-view" store="false" index="true"/>
+          </xsl:if>
+
+          <xsl:if test="contains($protocol, 'OGC:WPS')">
+            <Field name="_mdActions" string="mdActions-process" store="false" index="true"/>
           </xsl:if>
 
           <!-- ignore WMS links without protocol (are indexed below with mimetype application/vnd.ogc.wms_xml) -->

--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-category.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-category.html
@@ -14,7 +14,7 @@
       <input type="checkbox"
             data-ng-checked="isInFilter(c)"
             data-ng-click="filter(c, $event)"/>&nbsp;
-      <span class="gn-facet-label">{{c['@label'] || c['@value']}}</span>&nbsp;
+      <span class="gn-facet-label">{{(c['@label'] | translate) || c['@value']}}</span>&nbsp;
       <span class="gn-facet-count">({{c['@count']}})</span>
     </label>
 

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -411,5 +411,9 @@
   "selection.indexing.count": "Indexing started for the {{count}} record(s) selected.",
   "selection.indexing.error": "Error during selection indexing.",
   "showLegend": "Show legend",
-  "hideLegend": "Hide legend"
+  "hideLegend": "Hide legend",
+  "mdActions": "Available actions",
+  "mdActions-view": "Viewable",
+  "mdActions-download": "Downloadable",
+  "mdActions-process": "Processable"
 }

--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -125,11 +125,13 @@
 
     <facet name="maintenanceAndUpdateFrequency" indexKey="cl_maintenanceAndUpdateFrequency"
            label="maintenanceAndUpdateFrequencies"/>
+    <facet name="mdActions" indexKey="_mdActions" label="mdActions"/>
   </facets>
 
   <summaryTypes>
     <summaryType name="details" format="DIMENSION">
       <item facet="type" translator="codelist:gmd:MD_ScopeCode"/>
+      <item facet="mdActions"/>
       <item facet="topicCat" translator="codelist:gmd:MD_TopicCategoryCode" max="20"/>
       <item facet="inspireThemeURI" sortBy="value" sortOrder="asc" max="35"
             translator="term:http://geonetwork-opensource.org/inspire-theme"/>


### PR DESCRIPTION
This PR adds a new facet, displayed by default after the "Resource Type" in the search results:
![image](https://user-images.githubusercontent.com/10629150/32658733-b500e468-c61b-11e7-88a1-0ec5ddef8569.png)

The facet is based on the presence of online resources of type `WMS`, `FILE` and `WPS`.

For now only "downloadable", "viewable" and "processable" values are handled, but I think it could be interesting to add a "filterable" value as well (i.e. possible to index & filter features from a WFS).

Only works for iso19139.

Please note: as there is no backend translator for these values, I had to modify the facets template to translate labels on the front end side.