### PR TITLE
Clean web's schema_plugins in the maven clean phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.5</version>
+          <version>2.6.1</version>
         </plugin>
         <plugin>
           <groupId>net.alchim31.maven</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -532,7 +532,21 @@
 
   <build>
     <plugins>
-    
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>src/main/webapp/WEB-INF/data/config/schema_plugins</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+
       <!-- Generate a properties file with the commit hash to be displayed on the admin.console -->
 	    <plugin>
 	        <groupId>pl.project13.maven</groupId>
@@ -546,7 +560,7 @@
 	                </goals>
 	            </execution>
 	        </executions>
-	
+
 	        <configuration>
 	            <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
 	            <prefix>git</prefix>
@@ -582,7 +596,7 @@
 	                <forceLongFormat>false</forceLongFormat>
 	            </gitDescribe>
 	            <!-- @since 2.2.2 -->
-	            <!-- 
+	            <!--
 	                Since version **2.2.2** the maven-git-commit-id-plugin comes equipped with an additional validation utility which can be used to verify if your project properties are set as you would like to have them set.
 	                *Note*: This configuration will only be taken into account when the additional goal `validateRevision` is configured inside an execution.
 	            -->
@@ -592,9 +606,9 @@
 	                         A descriptive name that will be used to be able to identify the validation that does not match up (will be displayed in the error message).
 	                    -->
 	                    <name>validating project version</name>
-	                    <!-- 
+	                    <!--
 	                         the value that needs the validation
-	                         *Note* : In order to be able to validate the generated git-properties inside the pom itself you may need to set the configuration `<injectAllReactorProjects>true</injectAllReactorProjects>`. 
+	                         *Note* : In order to be able to validate the generated git-properties inside the pom itself you may need to set the configuration `<injectAllReactorProjects>true</injectAllReactorProjects>`.
 	                    -->
 	                    <value>${project.version}</value>
 	                    <!--
@@ -606,7 +620,7 @@
 	            </validationProperties>
 	            <validationShouldFailIfNoMatch>false</validationShouldFailIfNoMatch>
 	        </configuration>
-	
+
 	    </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -871,7 +885,7 @@
         <es.spring.profile>es</es.spring.profile>
       </properties>
     </profile>
-   
+
   </profiles>
 
   <properties>


### PR DESCRIPTION
Sometimes a file is deleted from a schema or even a full schema is removed from the project. In these cases the file/folder needs to be manually removed from `web/src/main/webapp/WEB-INF/data/config/schema_plugins`. 
To avoid errors caused by unexpected files in `schema_plugins` folder this commit configures the `maven-clean-plugin` in web project to empty this folder during the maven clean phase.