### PR TITLE
Add a confirmation dialog when saving&closing editor on an invalid MD

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportService.js
@@ -40,12 +40,9 @@
         errorCheck: function() {
           return this.get()
             .then(function(response) {
-              var rules = response.data.report;
-              var hasErrors = false;
-              rules.forEach(function(rule) {
-                hasErrors = hasErrors || !!rule.error;
+              return response.data.report.some(function(rule) {
+                return rule.error;
               });
-              return hasErrors;
             });
         }
       };

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportService.js
@@ -36,6 +36,17 @@
         get: function() {
           return $http.put(
               '../api/records/' + gnCurrentEdit.uuid + '/validate');
+        },
+        errorCheck: function() {
+          return this.get()
+            .then(function(response) {
+              var rules = response.data.report;
+              var hasErrors = false;
+              rules.forEach(function(rule) {
+                hasErrors = hasErrors || !!rule.error;
+              });
+              return hasErrors;
+            });
         }
       };
     }]);

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -361,5 +361,7 @@
     "inputGeometryHint": "Paste here a geometry in the selected format and projection system.",
     "inputGeometryReadOnlyHint": "This geometry is read-only.",
     "selectKeyword": "Add keywords",
-    "saveLinkToSibling": "Save link to other resource"
+    "saveLinkToSibling": "Save link to other resource",
+    "confirmCloseInvalidTitle": "Confirm editor close",
+    "confirmCloseInvalidMetadata": "The current metadata has been found to be invalid. Closing the editor will cause it to be unpublished (this can be changed in the application settings).<br><br>Are you sure you want to proceed?"
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -329,6 +329,10 @@ div.gn-scroll-spy {
     }
   }
 }
+.gn-save-invalid-modal {
+  max-width: none;
+  max-height: none;
+}
 img.thumb-small {
   max-width: 100%;
   max-height: 80px;

--- a/web-ui/src/main/resources/catalog/templates/editor/editor.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editor.html
@@ -80,5 +80,11 @@
        class="link-sibling-md"></div>
 </div>
 
+<div data-gn-modal="" class="gn-save-invalid-modal"
+     data-gn-popup-options="{title:'confirmCloseInvalidTitle', confirmCallback: confirmClose}"
+     id="confirm-editor-close">
+  <p translate>confirmCloseInvalidMetadata</p>
+</div>
+
 <div data-ng-include="'../../catalog/templates/info.html'">
 </div>


### PR DESCRIPTION
This dialog will only appear if the option to automatically unpublish invalid MD is set.

![image](https://user-images.githubusercontent.com/10629150/32789002-047f0ef6-c95b-11e7-8e43-25574b3bbf48.png)

This will trigger only when the user clicks "save & close". When the validation process is triggered, the validity status of the MD is updated client-side, which means that this dialog:
* will appear if the user starts editing a valid MD and make it invalid, but triggers the validation process manually,
* will NOT appear if the user breaks validity on a MD and do not trigger the validation process manually.

I could not find a better way to implement this, but am of course open to suggestions.