### PR TITLE
Editor / Improve search in directory entry selector

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
@@ -17,10 +17,10 @@
     <input type="text" class="form-control"
            placeholder="{{('searchA' + templateType) | translate}}"
            data-ng-show="searchAction"
-           data-ng-model="searchObj.params.any"
+           data-ng-model="searchObj.any"
            data-ng-model-options="{debounce: 200}"
-           ng-focus="triggerSearch()"
-           data-ng-change="triggerSearch()"
+           ng-focus="updateParams(); triggerSearch()"
+           data-ng-change="updateParams(); triggerSearch()"
            autocomplete="false"/>
 
     <!-- The autocomplete list -->


### PR DESCRIPTION
Previously the string used to search directory entries did not contain wildcards, and as such was not really usable.