### PR TITLE
[WIP] Add fallback values for multilingual subtemplate indexing

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
@@ -78,15 +78,23 @@
 
         <xsl:choose>
             <xsl:when test="$isMultilingual">
-                <xsl:variable name="org"
-                              select="normalize-space(gmd:organisationName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = $locale])"/>
+                <xsl:variable name="org">
+                  <xsl:choose>
+                    <xsl:when test="normalize-space(gmd:organisationName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = $locale]) != ''">
+                      <xsl:copy-of select="normalize-space(gmd:organisationName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = $locale])"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:copy-of select="normalize-space((gmd:organisationName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[./text()!=''])[1])"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </xsl:variable>
                 <xsl:variable name="name"
                               select="normalize-space(gmd:individualName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = $locale])"/>
                 <xsl:variable name="mail"
                               select="normalize-space(gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress[1]/gco:CharacterString)"/>
 
                 <Field name="_title"
-                       string="{if ($title != '') then $title 
+                       string="{if ($title != '') then $title
                                 else if ($name != '') then concat($org, ' (', $name, ')')
                                 else if ($mail != '') then concat($org, ' (', $mail, ')')
                                 else $org}"
@@ -108,7 +116,7 @@
                               select="normalize-space(gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress[1]/gco:CharacterString)"/>
 
               <Field name="_title"
-                       string="{if ($title != '') then $title 
+                       string="{if ($title != '') then $title
                                 else if ($name != '') then concat($org, ' (', $name, ')')
                                 else if ($mail != '') then concat($org, ' (', $mail, ')')
                                 else $org}"
@@ -130,7 +138,7 @@
     <!--Distribution information-->
     <xsl:template mode="index" match="gmd:MD_Distribution[count(ancestor::node()) =  1]">
         <Field name="_title"
-               string="{if ($title != '') then $title 
+               string="{if ($title != '') then $title
         else string-join(gmd:transferOptions/gmd:MD_DigitalTransferOptions/
         gmd:onLine/gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ', ')}"
                store="true" index="true"/>
@@ -156,9 +164,13 @@
         <xsl:when test="normalize-space(gmd:description) != ''">
           <xsl:choose>
             <xsl:when test="$isMultilingual">
+              <xsl:variable name="localizedDesc"
+                          select="gmd:description/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = $locale]"/>
+              <xsl:variable name="nonEmptyDesc"
+                          select="(gmd:description/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[./text()!=''])[1]"/>
               <Field name="_title"
-                     string="{if ($title != '') then $title else 
-                       gmd:description/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = $locale]}"
+                     string="{if ($title != '') then $title else if ($localizedDesc != '') then $localizedDesc
+                             else $nonEmptyDesc}"
                      store="true" index="true"/>
             </xsl:when>
             <xsl:otherwise>
@@ -170,7 +182,7 @@
         </xsl:when>
         <xsl:otherwise>
           <Field name="_title"
-                 string="{if ($title != '') then $title 
+                 string="{if ($title != '') then $title
                           else if (normalize-space(gmd:description/gco:CharacterString) != '')
                           then gmd:description/gco:CharacterString
                           else string-join(.//gco:Decimal, ', ')}"
@@ -185,7 +197,7 @@
 
     <xsl:template mode="index" match="gmd:DQ_DomainConsistency[count(ancestor::node()) =  1]">
         <Field name="_title"
-               string="{if ($title != '') then $title 
+               string="{if ($title != '') then $title
                         else gmd:result/*/gmd:specification/*/gmd:title/gco:CharacterString}"
                store="true" index="true"/>
 

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -193,7 +193,7 @@
                   <span data-ng-if="!user.canEditRecord(md)">{{md.title || md.defaultTitle}}</span>
                 </div>
 
-                <div class="entry-info" ng-if="!templatesShown()">
+                <div class="entry-info flex-row flex-align-center" ng-if="!templatesShown()">
                   <small class="text-muted" translate
                     translate-values="{ownerName: getOwnerName(md), updateDate: getChangeDate(md)}">
                     directoryEntryInfo


### PR DESCRIPTION
Previously, if a subtemplate did not have a value for the current lang, the title would appear empty:
![image](https://user-images.githubusercontent.com/10629150/32844564-0c08ba96-ca23-11e7-8b40-71cf15d2056e.png)

This commit adds a fallback value (any non-empty value available for this field in another language).