### PR TITLE
getLinksByType / Lower case comparaison to properly return links 

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -679,7 +679,8 @@
                 }
               }
               else {
-                if (linkInfo.protocol.indexOf(type) >= 0 &&
+                if (linkInfo.protocol.toLowerCase().indexOf(
+                  type.toLowerCase()) >= 0 &&
                     (!groupId || groupId == linkInfo.group)) {
                   ret.push(linkInfo);
                 }


### PR DESCRIPTION
eg. OGC:WMS or application/ogc-wms.

