### PR TITLE
Restore subtemplate editing

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -504,6 +504,7 @@
         angular.extend(gnCurrentEdit, {
           id: id,
           formId: '#gn-editor-' + id,
+          containerId: '#gn-editor-container-' + id,
           tab: 'simple',
           displayTooltips: false,
           compileScope: $scope,
@@ -512,13 +513,13 @@
         });
 
         $scope.gnCurrentEdit = gnCurrentEdit;
-        $scope.editorFormUrl = '';
 
-        // put this out of the flow to clear the form first
-        setTimeout(function() {
-          $scope.editorFormUrl = gnEditor
-              .buildEditUrlPrefix('editor') +
-              '&starteditingsession=yes&random=' + i++;
+        $scope.editorFormUrl = gnEditor
+            .buildEditUrlPrefix('editor') +
+            '&starteditingsession=yes&random=' + i++;
+
+        gnEditor.load($scope.editorFormUrl).then(function() {
+          // $scope.onFormLoad();
         });
       };
 

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -485,9 +485,9 @@
           </div>
         </div>
         <div class="panel-body">
-          <fieldset data-ng-disabled="activeEntry['geonet:info'].edit !== 'true'">
-            <div data-ng-include="editorFormUrl"
-                 data-onload="onFormLoad()"></div>
+          <fieldset ng-if="activeEntry"
+                    ng-disabled="activeEntry['geonet:info'].edit !== 'true'">
+            <div id="gn-editor-container-{{activeEntry['geonet:info'].id}}"></div>
           </fieldset>
         </div>
       </div>

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
@@ -68,7 +68,7 @@
   <xsl:template match="/">
 
     <xsl:variable name="hasSidePanel"
-                  select="exists($viewConfig/sidePanel)"/>
+                  select="exists($viewConfig/sidePanel) and $isTemplate != 's' and $isTemplate != 't'"/>
     <div id="gn-editor-container-{$metadataId}">
 
       <div class="col-md-{if ($hasSidePanel) then '8' else '12'}">


### PR DESCRIPTION
This adapts the subtemplate editor following https://github.com/geonetwork/core-geonetwork/pull/2298

Subtemplate saving and XML editing is functional again with this PR.