### PR TITLE
Fix multilingual fields cleared incorrectly in Add Online Resource dialog

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1324,9 +1324,8 @@
 
                     if (!scope.isEditing) {
                       resetForm();
+                      initMultilingualFields();
                     }
-
-                    initMultilingualFields();
 
                     if (newValue.sources && newValue.sources.metadataStore) {
                       scope.$broadcast('resetSearch',


### PR DESCRIPTION
Previously multilingual fields were cleared on first opening of the Add Online Resource dialog, even when there were existing values.