### PR TITLE
Urldecode fails sometimes in lucene search

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/UserQueryInput.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/UserQueryInput.java
@@ -23,19 +23,18 @@
 
 package org.fao.geonet.kernel.search;
 
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.constants.Geonet;
+import org.jdom.Element;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.commons.lang.StringUtils;
-import org.fao.geonet.constants.Geonet;
-import org.jdom.Element;
 
 /**
  * Search parameters that can be provided by a search client.
@@ -278,7 +277,13 @@ public class UserQueryInput {
         try {
             if (currentValues == null) {
                 Set<String> values = new LinkedHashSet<String>();
-                values.add(URLDecoder.decode(nodeValue, "UTF-8"));
+                String val = nodeValue;
+                try {
+                    val = URLDecoder.decode(nodeValue, "UTF-8");
+                } catch (IllegalArgumentException iea) {
+                    // keep val as the original nodeValue
+                }
+                values.add(val);
                 hash.put(nodeName, values);
             } else {
                 currentValues.add(URLDecoder.decode(nodeValue, "UTF-8"));

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -154,7 +154,6 @@
       var finalParams = angular.extend(params, hiddenParams);
       gnSearchManagerService.gnSearch(finalParams).then(
           function(data) {
-            $scope.searching--;
             $scope.searchResults.records = [];
             for (var i = 0; i < data.metadata.length; i++) {
               $scope.searchResults.records.push(new Metadata(data.metadata[i]));
@@ -186,7 +185,9 @@
                   );
               paging.from = (paging.currentPage - 1) * paging.hitsPerPage + 1;
             }
-          });
+          }).finally(function() {
+        $scope.searching--;
+      });
     };
 
 

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
@@ -219,6 +219,8 @@
           } else {
             defer.reject('No records to index');
           }
+        }, function(reason) {
+          defer.reject("error: " + reason);
         });
         return defer.promise;
       };


### PR DESCRIPTION
If `URLDecoder.decode` fails, for example an unknown escape sequence like `"%8"`, the original value is used as parameter.
Also add some error control to the JS function `gnSearch`.
