### PR TITLE
Editor / When outputting 4326 geometry in GML, do not specify the CRS

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -207,7 +207,7 @@
               featureNS: options.gmlFeatureNS ||
                   'http://mapserver.gis.umn.edu/mapserver',
               featureType: options.gmlFeatureElement || 'features',
-              srsName: options.crs
+              srsName: options.crs !== 'EPSG:4326' ? options.crs : undefined
             });
 
             if (options.outputAsWFSFeaturesCollection) {


### PR DESCRIPTION
In the case of EPSG:4326, writing the CRS in the GML will cause the longitudes and latitudes to be inversed, which breaks things down the line.
Note: this is apparently normal behavior.