### PR TITLE
Various UI search improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
@@ -23,9 +23,16 @@
            data-ng-change="updateParams(); triggerSearch()"
            autocomplete="false"/>
 
+    <!-- spinner while searching -->
+    <div ng-show="searching" class="list-group tt-dropdown-menu gn-autocomplete-list text-center">
+      <br />
+      <i class="fa fa-spinner fa-spin" />
+      <br /><br />
+    </div>
+
     <!-- The autocomplete list -->
     <div class="list-group tt-dropdown-menu gn-autocomplete-list"
-         data-ng-show="searchResults.records.length > 0">
+         data-ng-show="searchResults.records.length > 0 && !searching">
       <span class="tt-suggestions">
         <div class="tt-suggestion flex-row"
           data-ng-repeat="r in searchResults.records">

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -192,9 +192,8 @@
 
       var finalParams = angular.extend(params, hiddenParams);
       $scope.finalParams = finalParams;
-      gnSearchManagerService.gnSearch(finalParams).then(
+      gnSearchManagerService.gnSearch(finalParams, undefined, true).then(
           function(data) {
-            $scope.searching--;
             $scope.searchResults.records = [];
             for (var i = 0; i < data.metadata.length; i++) {
               $scope.searchResults.records.push(new Metadata(data.metadata[i]));
@@ -225,6 +224,8 @@
                   );
               paging.from = (paging.currentPage - 1) * paging.hitsPerPage + 1;
             }
+          }).finally(function() {
+            $scope.searching = 0;
           });
     };
 

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
@@ -188,11 +188,21 @@
         return defer.promise;
       };
 
+      // this will hold a promise when a search is triggered
+      // calling canceller.resolve() will cancel the search
+      var canceller;
+
       // TODO: remove search call to use params instead
       // of url and use gnSearch only (then rename it to search)
-      var gnSearch = function(params, error) {
+      var gnSearch = function(params, error, cancelPrevious) {
+        // cancel previous search if any
+        if (canceller && cancelPrevious) {
+          canceller.resolve();
+        }
+        canceller = $q.defer();
+
         var defer = $q.defer();
-        gnHttp.callService('search', params).
+        gnHttp.callService('search', params, { timeout: canceller.promise }).
             success(function(data, status) {
               defer.resolve(format(data));
             }).

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -90,6 +90,7 @@
       $scope.ownerGroup = null;
       $scope.defaultSearchObj = {
         selectionBucket: 'd101',
+        any: '',
         params: {
           _isTemplate: 's',
           any: '',
@@ -238,6 +239,7 @@
       $scope.getEntries = function(type) {
         if (type) {
           $scope.searchObj.params._root = type;
+          $scope.defaultSearchObj.params._root = type;
         }
         $scope.$broadcast('clearResults');
         $scope.$broadcast('search');
@@ -564,6 +566,12 @@
       };
       $scope.templatesShown = function() {
         return $scope.searchObj.params._isTemplate === 't';
+      };
+
+      // Append * for like search
+      $scope.updateParams = function() {
+        $scope.searchObj.params.any =
+        '*' + $scope.searchObj.any + '*';
       };
 
       init();

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -100,15 +100,15 @@
 
             <div class="pos-relative">
               <input class="form-control filter-text" type="search"
-                ng-change="triggerSearch()"
-                ng-model="searchObj.params.any"
+                ng-change="updateParams(); triggerSearch()"
+                ng-model="searchObj.any"
                 ng-model-options="modelOptions"
                 placeholder="{{'filter' | translate}}" autofocus=""/>
             </div>
             &nbsp;
 
             <button type="button"
-                    data-ng-click="resetSearch(defaultSearchObj.params);"
+                    data-ng-click="resetSearch(defaultSearchObj.params); searchObj.any = ''"
                     title="{{'ClearTitle' | translate}}"
                     class="btn btn-link">
               <i class="fa fa-times"></i>
@@ -494,8 +494,7 @@
     </div>
 
     <div class="col-sm-12 col-lg-4"
-      ng-if="::gnConfig[gnConfig.key.isXLinkEnabled]"
-      ng-show="currentEditorAction === 'editEntry'">
+      ng-if="gnConfig[gnConfig.key.isXLinkEnabled] && activeEntry && currentEditorAction === 'editEntry'">
       <div class="panel-default panel">
         <div class="panel-heading">
           <span translate>directoryEntryAssociatedMetadata</span>


### PR DESCRIPTION
* The method `SearchManagerService.gnSearch` now cancels any previous request before making a new one; this means that there cannot be race conditions with search results anymore. This removes the need for the "search counter" login in `SearchFormDirective`, which is now also adjusted (should still be backwards compatible with everything).

* Add a spinner when searching directory entries in `gn-directory-entry-selector`:
![image](https://user-images.githubusercontent.com/10629150/32955358-02f3fe22-cbb6-11e7-8681-c04400192ef4.png)

* Title search in directory management UI is now more flexible (wildcards added) and the reset button keeps the current type:
![image](https://user-images.githubusercontent.com/10629150/32955512-773fb5b4-cbb6-11e7-971e-07d74896101e.png)
