### PR TITLE
set proj to 3857 if proj of context is unknown

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -122,6 +122,14 @@
         var ll = bbox.lowerCorner;
         var ur = bbox.upperCorner;
         var projection = bbox.crs;
+        
+        // -- check if projection is available in ol
+        if (!ol.proj.get(projection)){
+         console.warn('Projection '+ projection +' is not available, map will be projected in a spherical mercator projection');
+         projection='EPSG:3857';
+         ll=[-10026376,-15048966];
+         ur=[10026376,15048966];
+       }
 
         if (projection == 'EPSG:4326') {
           ll.reverse();


### PR DESCRIPTION
if ows context has a projection not known to ol, then throw a warning and set projection to epsg:3857, alternative would be to load projection on the fly from epsg.io