### PR TITLE
Add labels to buttons

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/needhelp/partials/needhelp.html
+++ b/web-ui/src/main/resources/catalog/components/common/needhelp/partials/needhelp.html
@@ -1,4 +1,4 @@
-<button type="button" class="btn btn-link" data-ng-click="showHelp();$event.stopPropagation();"
+<button type="button" class="btn btn-default btn-xs" data-ng-click="showHelp();$event.stopPropagation();"
         title="{{'needHelp' | translate}}">
   <i class="fa fa-question-circle"/>
   <span data-ng-hide="iconOnly">&nbsp;</span>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -3,11 +3,19 @@
     <i class="fa fa-link"></i><i class="icon-external-link"></i>&nbsp;
     <span
       data-translate="">associatedResources</span>
+
+    <div data-gn-need-help="user-guide/associating-resources/index.html"
+         data-icon-only="true"
+         class="pull-right"></div>
+  </div>
+  <div class="panel-body">
     <div class="btn-group"
          data-ng-if="readonly !== true">
       <button type="button"
-              class="btn btn-link dropdown-toggle fa fa-plus"
+              class="btn btn-default dropdown-toggle"
               data-toggle="dropdown">
+        <i class="fa fa-plus"></i>
+        <span data-translate="">add</span>      
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu pull-right" role="menu">
@@ -72,13 +80,6 @@
         </li>
       </ul>
     </div>
-
-
-    <div data-gn-need-help="user-guide/associating-resources/index.html"
-         data-icon-only="true"
-         class="pull-right"></div>
-  </div>
-  <div class="panel-body">
     <div class="gn-onlinesrc-panel">
 
       <!-- ******* Display Thumbnails ******* -->

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatacategoryupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatacategoryupdater.html
@@ -3,7 +3,9 @@
   <button type="button"
           class="btn btn-default dropdown-toggle"
           data-toggle="dropdown">
-    <i class="fa fa-tags"></i>&nbsp;<span class="caret"></span>&nbsp;
+    <i class="fa fa-tags"></i>
+    <span data-translate="" class="hidden-sm hidden-xs">listOfCategories</span>
+    <span class="caret"></span>
   </button>
   <ul class="dropdown-menu pull-right"
       role="menu">

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatagroupupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatagroupupdater.html
@@ -3,7 +3,7 @@
           class="btn btn-default dropdown-toggle"
           data-ng-mouseover="init()"
           data-toggle="dropdown">
-    <i class="fa fa-group"></i>&nbsp;<span class="caret"></span>&nbsp;
+    <i class="fa fa-group"></i>&nbsp;<span class="caret"></span>
   </button>
   <ul class="dropdown-menu pull-right"
       role="menu">

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -6,7 +6,8 @@
             class="btn btn-default dropdown-toggle"
             data-toggle="dropdown"
             aria-expanded="false">
-      <i class="fa fa-cog"/>&nbsp;
+      <i class="fa fa-cog"/>
+      <span data-translate="" class="hidden-xs">manageRecord</span>
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">
@@ -87,7 +88,8 @@
             class="btn btn-default dropdown-toggle"
             data-toggle="dropdown"
             aria-expanded="false">
-      <i class="fa fa-download"/>&nbsp;
+      <i class="fa fa-download"/>
+      <span data-translate="" class="hidden-xs">download</span>
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -39,11 +39,12 @@
       <button type="button" class="btn btn-default dropdown-toggle"
               data-toggle="dropdown"
               aria-expanded="false">
-        <i class="fa fa-eye"></i>&nbsp;
+        <i class="fa fa-eye"></i>
+        <span data-translate="" class="hidden-sm hidden-xs">chooseAView</span>
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
-        <li class="dropdown-header" data-translate="">chooseAView</li>
+        <!-- <li class="dropdown-header" data-translate="">chooseAView</li> -->
         <li data-ng-class="currentFormatter == undefined ? 'disabled' : ''">
           <a href="" data-ng-click="format()">
             <i class="fa fa-fw"></i>
@@ -77,6 +78,7 @@
        title="{{'delete' | translate}}">
 
       <i class="fa fa-times"></i>
+      <span data-translate="" class="hidden-sm hidden-xs">delete</span>
     </a>
 
     <a class="btn btn-primary gn-md-edit-btn pull-right"
@@ -84,6 +86,7 @@
        data-ng-href="catalog.edit#/metadata/{{mdView.current.record.getId()}}"
        title="{{'edit' | translate}}">
       <i class="fa fa-pencil"></i>
+      <span data-translate="" class="hidden-sm hidden-xs">edit</span>
     </a>
 
     <div class="gnMdfeedback"></div>


### PR DESCRIPTION
Add labels to buttons and make these labels responsive:
- on the editor buttonbar
- on the buttons in the metadata view
- on the `associated resources` button
- move the `associated resources` button to the panel body
- restyle the help button

**Screenshot of the labels in the metadata page**
![localhost_8080_geonetwork_srv_eng_catalog search laptop with mdpi screen](https://user-images.githubusercontent.com/19608667/33021898-a7291c80-ce03-11e7-8b17-1306a0934bb5.png)

**Screenshot of the label and help button in the editor page**
![localhost_8080_geonetwork_srv_eng_catalog edit laptop with mdpi screen](https://user-images.githubusercontent.com/19608667/33021948-ccf0d2be-ce03-11e7-9109-b66920c30d13.png)

