### PR TITLE
Add cancel buttons

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -113,8 +113,9 @@ div[gn-transfer-ownership] * .list-group {
   .gn-editor-board {
     padding-top: 120px;
   }
-  .gn-editor-container, .gn-batch-editor, #gn-directory-container {
-    padding-top: 65px;
+  .gn-editor-container, .gn-batch-editor, #gn-directory-container,
+  #gn-new-metadata-container, #gn-import-container {
+    padding-top: 70px;
   }
 }
 

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -338,7 +338,10 @@
         <gn-md-type-widget metadata="activeEntry"></gn-md-type-widget>
         {{activeEntry.title || activeEntry.defaultTitle}}
         &nbsp;
-        <a href ng-click="closeEditor()">({{'close' | translate}})</a>
+        <a href class="btn btn-default" ng-click="closeEditor()">
+          <i class="fa fa-close"/>&nbsp;
+          <span data=translate="">cancel</span>
+        </a>
       </p>
 
       <p ng-show="!activeEntry" class="text-muted" translate>
@@ -349,7 +352,7 @@
 
   <!-- simple editor, used for importing XML-->
   <div class="row" ng-show="currentEditorAction != '' && !activeEntry">
-    <div class="col-md-12 col-lg-8">
+    <div class="col-md-12">
       <div class="panel-default panel entry-editor">
         <div class="panel-heading">
           <span translate class="entry-editor-title">
@@ -402,7 +405,7 @@
 
   <!-- full editor is only used for edition -->
   <div class="row" ng-show="currentEditorAction != '' && activeEntry">
-    <div class="col-sm-12 col-lg-8">
+    <div class="col-sm-12">
       <div class="panel-default panel entry-editor">
         <div class="panel-heading">
 

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -242,12 +242,17 @@
               </div>
             </div>
 
-
-            <button type="button" class="btn btn-primary pull-right"
-                    data-ng-click="importRecords('#gn-import')"
-                    title="{{'import' | translate}}">
-              <i class="fa fa-plus"/>&nbsp;<span data-translate="">importRecords</span>
-            </button>
+            <div class="pull-right">
+              <button type="button" class="btn btn-primary"
+                      data-ng-click="importRecords('#gn-import')"
+                      title="{{'import' | translate}}">
+                <i class="fa fa-plus"/>&nbsp;<span data-translate="">importRecords</span>
+              </button>
+              <a href="#/board" class="btn btn-default">
+                <i class="fa fa-close"/>&nbsp;
+                <span data-translate="">cancel</span>
+              </a>
+            </div>
           </form>
         </div>
       </div>

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
@@ -97,14 +97,14 @@
         </div>
       </div>
       <div class="btn-group">
-        <button type="button" class="btn btn-success btn-lg"
+        <button type="button" class="btn btn-success"
                 data-gn-click-and-spin="createNewMetadata()"
                 data-ng-class="{'disabled': (!activeType || !activeTpl || !ownerGroup || ((!generateUuid) && (!isMdIdentifierFilled())) )}">
           <i class="fa fa-plus"/>
           <span data-translate="">createMetadata</span>
         </button>
         <button type="button"
-                class="btn btn-success btn-lg dropdown-toggle"
+                class="btn btn-success dropdown-toggle"
                 data-ng-class="{'disabled': (!activeType || !activeTpl || !ownerGroup || ((!generateUuid) && (!isMdIdentifierFilled())) )}"
                 data-toggle="dropdown">
           <span class="caret"></span>&nbsp;
@@ -117,6 +117,10 @@
             createMetadataForGroup</a></li>
         </ul>
       </div>
+      <a href="#/board" class="btn btn-default">
+        <i class="fa fa-close"/>&nbsp;
+        <span data-translate="">cancel</span>
+      </a>
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
@@ -117,6 +117,10 @@
               createMetadataForGroup</a></li>
           </ul>
         </div>
+        <a href="#/board" class="btn btn-default">
+          <i class="fa fa-close"/>&nbsp;
+          <span data-translate="">cancel</span>
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Add `cancel` buttons to Import and New Metadata page. Make the look and label for the `cancel` the same for all pages (new, import, manage directory, batch edit).

**Look and label for `cancel` button**
![gn-cancel-button](https://user-images.githubusercontent.com/19608667/33062059-3e3e8afc-ce9e-11e7-8e52-6e211596866c.png)
