### PR TITLE
Revert breaking change on UI search service

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -192,8 +192,9 @@
 
       var finalParams = angular.extend(params, hiddenParams);
       $scope.finalParams = finalParams;
-      gnSearchManagerService.gnSearch(finalParams, undefined, true).then(
+      gnSearchManagerService.gnSearch(finalParams).then(
           function(data) {
+            $scope.searching--;
             $scope.searchResults.records = [];
             for (var i = 0; i < data.metadata.length; i++) {
               $scope.searchResults.records.push(new Metadata(data.metadata[i]));
@@ -224,8 +225,6 @@
                   );
               paging.from = (paging.currentPage - 1) * paging.hitsPerPage + 1;
             }
-          }).finally(function() {
-            $scope.searching = 0;
           });
     };
 

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
@@ -188,21 +188,11 @@
         return defer.promise;
       };
 
-      // this will hold a promise when a search is triggered
-      // calling canceller.resolve() will cancel the search
-      var canceller;
-
       // TODO: remove search call to use params instead
       // of url and use gnSearch only (then rename it to search)
-      var gnSearch = function(params, error, cancelPrevious) {
-        // cancel previous search if any
-        if (canceller && cancelPrevious) {
-          canceller.resolve();
-        }
-        canceller = $q.defer();
-
+      var gnSearch = function(params, error) {
         var defer = $q.defer();
-        gnHttp.callService('search', params, { timeout: canceller.promise }).
+        gnHttp.callService('search', params).
             success(function(data, status) {
               defer.resolve(format(data));
             }).


### PR DESCRIPTION
This restores the front page searches (latest/popular) as I've reverted a breaking (and unnecessary) change in #2340: search requests are not cancelled anymore.


Fixes #2347