### PR TITLE
Edit buttons in a buttonbar

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -4,7 +4,11 @@
       <input data-gn-selection-md type="checkbox"
              data-ng-model="md['geonet:info'].selected"
              data-ng-change="change()"/>
+    </td>
+    <td>
       <gn-md-type-widget metadata="md"></gn-md-type-widget>
+    </td>
+    <td>
       <a href=""
          data-ng-show="md.isTemplate != 's'"
          data-ng-href="catalog.search#/metadata/{{md.getUuid()}}"
@@ -19,48 +23,43 @@
       </div>
     </td>
     <td>
-      <a class="btn btn-link"
-         data-ng-href=""
-         data-ng-if="user.canEditRecord(md) && user.isEditorOrMore()"
-         data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())"
-         title="{{'privileges' | translate}}">
-        <i class="fa text-muted"
-           data-ng-class="md.isPublished() ? 'fa-unlock' : 'fa-lock'"></i>
-      </a>
-    </td>
-    <td>
-      <!-- TODO: subtemplate link for editing is different -->
-      <a class="btn btn-link"
-         data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-         data-ng-href="#/metadata/{{md['geonet:info'].id}}"
-         title="{{'edit' | translate}}">
-        <i class="fa fa-pencil"></i>
-      </a>
-    </td>
-    <td>
-      <a class="btn btn-link"
-         data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-         data-gn-click-and-spin="deleteRecord(md)"
-         data-gn-confirm-click="{{'deleteRecordConfirm' | translate:md}}"
-         title="{{'delete' | translate}}">
-        <i class="fa fa-times text-danger"></i>
-      </a>
-    </td>
-    <td>
-      <a class="btn btn-link"
-         data-ng-show="md.isTemplate != 's'"
-         data-ng-href="#/create?from={{md['geonet:info'].id}}"
-         title="{{'duplicate' | translate}}">
-        <i class="fa fa-copy text-muted"></i>
-      </a>
-    </td>
-    <td>
-      <a class="btn btn-link"
-         data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-         data-ng-href="#/create?childOf={{md['geonet:info'].id}}"
-         title="{{'createChild' | translate}}">
-        <i class="fa fa-sitemap text-muted"></i>
-      </a>
+      <div class="btn-group pull-right">
+        <a class="btn btn-default"
+           data-ng-href=""
+           data-ng-if="user.canEditRecord(md) && user.isEditorOrMore()"
+           data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())"
+           title="{{'privileges' | translate}}">
+          <i class="fa text-muted"
+             data-ng-class="md.isPublished() ? 'fa-unlock' : 'fa-lock'"></i>
+        </a>
+        <!-- TODO: subtemplate link for editing is different -->
+        <a class="btn btn-default"
+           data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
+           data-ng-href="#/metadata/{{md['geonet:info'].id}}"
+           title="{{'edit' | translate}}">
+          <i class="fa fa-pencil"></i>
+        </a>
+        <a class="btn btn-default"
+           data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
+           data-gn-click-and-spin="deleteRecord(md)"
+           data-gn-confirm-click="{{'deleteRecordConfirm' | translate:md}}"
+           title="{{'delete' | translate}}">
+          <i class="fa fa-times text-danger"></i>
+        </a>
+        <a class="btn btn-default"
+           data-ng-class="user.canEditRecord(md) ? '' : 'btn-single'"
+           data-ng-show="md.isTemplate != 's'"
+           data-ng-href="#/create?from={{md['geonet:info'].id}}"
+           title="{{'duplicate' | translate}}">
+          <i class="fa fa-copy text-muted"></i>
+        </a>
+        <a class="btn btn-default"
+           data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
+           data-ng-href="#/create?childOf={{md['geonet:info'].id}}"
+           title="{{'createChild' | translate}}">
+          <i class="fa fa-sitemap text-muted"></i>
+        </a>
+      </div>
     </td>
   </tr>
 </table>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -47,17 +47,17 @@
           <i class="fa fa-times text-danger"></i>
         </a>
         <a class="btn btn-default"
+           data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
+           data-ng-href="#/create?childOf={{md['geonet:info'].id}}"
+           title="{{'createChild' | translate}}">
+          <i class="fa fa-sitemap text-muted"></i>
+        </a>
+        <a class="btn btn-default"
            data-ng-class="user.canEditRecord(md) ? '' : 'btn-single'"
            data-ng-show="md.isTemplate != 's'"
            data-ng-href="#/create?from={{md['geonet:info'].id}}"
            title="{{'duplicate' | translate}}">
           <i class="fa fa-copy text-muted"></i>
-        </a>
-        <a class="btn btn-default"
-           data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-           data-ng-href="#/create?childOf={{md['geonet:info'].id}}"
-           title="{{'createChild' | translate}}">
-          <i class="fa fa-sitemap text-muted"></i>
         </a>
       </div>
     </td>

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -93,7 +93,7 @@ div[gn-transfer-ownership] * .list-group {
   margin-bottom: 10px;
   border: 1px solid #e7e7e7;
   border-top: 0;
-  z-index: 1;
+  z-index: 5;
 }
 [ng-app="gn_editor"] {
   .gn-top-bar {

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -224,10 +224,12 @@ input[type=text], input[type=number], select {
 
 .gn-editor-board {
   .table.gn-results-editor td {
-    padding: 6px;
-
-    .gn-record-details {
-      padding-left: 38px;
+    padding: 6px 3px;
+    .btn-group {
+      margin-top: 3px;
+      .btn-single {
+        border-radius: 4px;
+      }
     }
   }
 }
@@ -772,7 +774,6 @@ gn-directory-associated-md {
 // md type widget (used only in editor for now)
 gn-md-type-widget {
   display: inline-block;
-
   & > div {
     border-radius: 1000px;
     width: 24px;
@@ -811,6 +812,14 @@ gn-md-type-widget {
     }
   }
 }
+.gn-editor-board {
+  .table.gn-results-editor td {
+    gn-md-type-widget {
+      margin-top: 5px;
+    }
+  }
+}
+
 
 gn-bounding-polygon {
   label {


### PR DESCRIPTION
On the contribute page the edit buttons on each row had their own table cell, they are now placed in a buttonbar. This is taking less space and allows longer titles.

The checkbox and the type widget now each have their own table cell, this makes it easier to align all the elements on that row.

**Screenshot of the buttonbar**
![gn-buttonbar-for-edit-buttons](https://user-images.githubusercontent.com/19608667/33172107-09a40422-d04f-11e7-84ca-da505e49b212.png)
 