### PR TITLE
Sidebar classes

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -104,27 +104,28 @@
   </xsl:template>
 
   <xsl:template mode="getOverviews" match="gmd:MD_Metadata">
-    <h4>
-      <i class="fa fa-fw fa-image">&#160;</i>&#160;
-      <span>
-        <xsl:value-of select="$schemaStrings/overviews"/>
-      </span>
-    </h4>
+    <section class="gn-md-side-overview">
+      <h4>
+        <i class="fa fa-fw fa-image">&#160;</i>
+        <span>
+          <xsl:value-of select="$schemaStrings/overviews"/>
+        </span>
+      </h4>
 
-    <xsl:for-each select="gmd:identificationInfo/*/gmd:graphicOverview/*">
-      <img class="gn-img-thumbnail center-block"
-           src="{gmd:fileName/*}"/>
+      <xsl:for-each select="gmd:identificationInfo/*/gmd:graphicOverview/*">
+        <img class="gn-img-thumbnail center-block"
+             src="{gmd:fileName/*}"/>
 
-      <xsl:for-each select="gmd:fileDescription">
-        <div class="gn-img-thumbnail-caption">
-          <xsl:call-template name="localised">
-            <xsl:with-param name="langId" select="$langId"/>
-          </xsl:call-template>
-        </div>
+        <xsl:for-each select="gmd:fileDescription">
+          <div class="gn-img-thumbnail-caption">
+            <xsl:call-template name="localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </div>
+        </xsl:for-each>
+
       </xsl:for-each>
-      <br/>
-
-    </xsl:for-each>
+    </section>
   </xsl:template>
 
   <xsl:template mode="getMetadataHeader" match="gmd:MD_Metadata">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -7,6 +7,9 @@
     .gn-img-extent {
       width: 100%;
     }
+    section {
+      margin-bottom: 20px;
+    }
   }
   .view-header {
     border-bottom: 2px solid #e5e5e5;

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -387,7 +387,7 @@
       </div>
 
       <div class="col-md-4 gn-md-side">
-        <section data-ng-if="mdView.current.record.overviews.length > 0">
+        <section class="gn-md-side-overview" data-ng-if="mdView.current.record.overviews.length > 0">
           <h4>
             <i class="fa fa-fw fa-image"></i>
             <span data-translate="">overview</span>
@@ -404,10 +404,8 @@
             </div>
           </div>
         </section>
-        </br>
 
-
-        <section data-ng-if="mdView.current.record.geoBox.length > 0">
+        <section class="gn-md-side-extent" data-ng-if="mdView.current.record.geoBox.length > 0">
           <h4>
             <i class="fa fa-fw fa-map-marker"></i>
             <span data-translate="">extent</span>
@@ -424,9 +422,9 @@
           </p>
 
         </section>
-        </br>
 
-        <section data-ng-if="mdView.current.record.creationDate ||
+        <section class="gn-md-side-dates"
+                 data-ng-if="mdView.current.record.creationDate ||
                              mdView.current.record.publicationDate ||
                              mdView.current.record.revisionDate ||
                              mdView.current.record.tempExtentBegin ||
@@ -457,13 +455,12 @@
             <dt data-translate>tempExtentBegin</dt>
             <dd>
               <span data-gn-humanize-time="{{mdView.current.record.tempExtentBegin}}"/>
-              &nbsp;<i class="fa fa-forward"></i>&nbsp;
+              &nbsp;<i class="fa fa-fw fa-forward"></i>
               <span data-gn-humanize-time="{{mdView.current.record.tempExtentEnd}}"/>
             </dd>
           </dl>
           </p>
         </section>
-        </br>
 
         <!--<section data-ng-repeat="c in mdView.current.record.getAllContacts().resource track by $index">
           <h4>
@@ -497,8 +494,7 @@
           </div>
         </section></br>-->
 
-
-        <section>
+        <section class="gn-md-side-providedby">
           <h4>
             <i class="fa fa-fw fa-cog"></i>
             <span data-translate="">sourceCatalog</span>
@@ -506,11 +502,10 @@
           <img ng-src="{{gnUrl}}../images/logos/{{mdView.current.record.source}}.png"
                class="gn-source-logo"/>
         </section>
-        </br>
 
-        <section>
+        <section class="gn-md-side-calendar">
           <h4>
-            <i class="fa fa-calendar"></i>&nbsp;
+            <i class="fa fa-fw fa-calendar"></i>
             <span data-translate="">updatedOn</span>
           </h4>
           <p>
@@ -518,9 +513,8 @@
                   data-from-now=""></span>
           </p>
         </section>
-        </br>
 
-        <section>
+        <section class="gn-md-side-social">
           <h4>
             <i class="fa fa-fw fa-share-square-o"></i>
             <span data-translate="">shareOn</span>
@@ -554,11 +548,10 @@
             title="{{'permalink' | translate}}"
             class="btn btn-default"><i class="fa fa-fw fa-link"></i></a>
         </section>
-        </br>
 
-        <section>
+        <section class="gn-md-side-rating">
           <h4>
-            <i class="fa fa-fw"></i>
+            <i class="fa fa-fw fa-star-half-o"></i>
             <span data-translate="">rate</span>
           </h4>
           <div data-gn-metadata-rate="mdView.current.record"/>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -99,7 +99,7 @@
 
             <section class="gn-md-side-providedby">
               <h4>
-                <i class="fa fa-fw fa-cog"></i>
+                <i class="fa fa-fw fa-cog">&#160;</i>
                 <span><xsl:value-of select="$schemaStrings/providedBy"/></span>
               </h4>
               <img class="gn-source-logo"
@@ -108,34 +108,34 @@
 
             <section class="gn-md-side-social">
               <h4>
-                <i class="fa fa-fw fa-share-square-o"></i>
+                <i class="fa fa-fw fa-share-square-o">&#160;</i>
                 <span><xsl:value-of select="$schemaStrings/shareOnSocialSite"/></span>
               </h4>
               <a href="https://twitter.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-twitter"></i>
+                <i class="fa fa-fw fa-twitter">&#160;</i>
               </a>
               <a href="https://plus.google.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-google-plus"></i>
+                <i class="fa fa-fw fa-google-plus">&#160;</i>
               </a>
               <a href="https://www.facebook.com/sharer.php?u={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-facebook"></i>
+                <i class="fa fa-fw fa-facebook">&#160;</i>
               </a>
               <a href="http://www.linkedin.com/shareArticle?mini=true&amp;summary=Hydrological Basins in Africa (Sample record, please remove!)&amp;url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-linkedin"></i>
+                <i class="fa fa-fw fa-linkedin">&#160;</i>
               </a>
               <a href="mailto:?subject={$title}&amp;body={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-envelope-o"></i>
+                <i class="fa fa-fw fa-envelope-o">&#160;</i>
               </a>
             </section>
 
             <section class="gn-md-side-viewmode">
               <h4>
-                <i class="fa fa-fw fa-eye"></i>
+                <i class="fa fa-fw fa-eye">&#160;</i>
                 <span><xsl:value-of select="$schemaStrings/viewMode"/></span>
               </h4>
               <xsl:for-each select="$configuration/editor/views/view[not(@disabled)]">
@@ -175,7 +175,7 @@
                    href="{if ($portalLink != '')
                           then replace($portalLink, '\$\{uuid\}', $metadataUuid)
                           else concat($nodeUrl, $language, '/catalog.search#/metadata/', $metadataUuid)}">
-                  <i class="fa fa-fw fa-link"></i>
+                  <i class="fa fa-fw fa-link">&#160;</i>
                   <xsl:value-of select="$schemaStrings/linkToPortal"/>
                 </a>
                 <xsl:value-of select="$schemaStrings/linkToPortal-help"/>
@@ -184,7 +184,7 @@
 
             <section class="gn-md-side-associated">
               <h4>
-                <i class="fa fa-fw fa-link"></i>
+                <i class="fa fa-fw fa-link">&#160;</i>
                 <span><xsl:value-of select="$schemaStrings/associatedResources"/></span>
               </h4>
               <div gn-related="md"

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -94,54 +94,48 @@
                                    select="."/>
             </xsl:for-each>
           </div>
-          <div class="gn-md-side col-md-4">
+          <div class="gn-md-side gn-md-side-advanced col-md-4">
             <xsl:apply-templates mode="getOverviews" select="$metadata"/>
 
-            <br/>
-
-            <section>
+            <section class="gn-md-side-providedby">
               <h4>
-                <i class="fa fa-fw fa-cog">&#160;</i>&#160;
+                <i class="fa fa-fw fa-cog"></i>
                 <span><xsl:value-of select="$schemaStrings/providedBy"/></span>
               </h4>
               <img class="gn-source-logo"
-                   src="{$nodeUrl}../images/logos/{$source}.png">&#160;</img>
+                   src="{$nodeUrl}../images/logos/{$source}.png" />
             </section>
 
-            <br/>
-
-            <section>
+            <section class="gn-md-side-social">
               <h4>
-                <i class="fa fa-fw fa-share-square-o">&#160;</i>&#160;
+                <i class="fa fa-fw fa-share-square-o"></i>
                 <span><xsl:value-of select="$schemaStrings/shareOnSocialSite"/></span>
               </h4>
               <a href="https://twitter.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-twitter">&#160;</i>&#160;
+                <i class="fa fa-fw fa-twitter"></i>
               </a>
               <a href="https://plus.google.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-google-plus">&#160;</i>&#160;
+                <i class="fa fa-fw fa-google-plus"></i>
               </a>
               <a href="https://www.facebook.com/sharer.php?u={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-facebook">&#160;</i>&#160;
+                <i class="fa fa-fw fa-facebook"></i>
               </a>
               <a href="http://www.linkedin.com/shareArticle?mini=true&amp;summary=Hydrological Basins in Africa (Sample record, please remove!)&amp;url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-linkedin">&#160;</i>&#160;
+                <i class="fa fa-fw fa-linkedin"></i>
               </a>
               <a href="mailto:?subject={$title}&amp;body={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                  target="_blank" class="btn btn-default">
-                <i class="fa fa-fw fa-envelope-o">&#160;</i>&#160;
+                <i class="fa fa-fw fa-envelope-o"></i>
               </a>
             </section>
 
-            <br/>
-
-            <section>
+            <section class="gn-md-side-viewmode">
               <h4>
-                <i class="fa fa-fw fa-eye">&#160;</i>&#160;
+                <i class="fa fa-fw fa-eye"></i>
                 <span><xsl:value-of select="$schemaStrings/viewMode"/></span>
               </h4>
               <xsl:for-each select="$configuration/editor/views/view[not(@disabled)]">
@@ -166,32 +160,31 @@
               </xsl:for-each>
             </section>
 
-            <br/>
+            <section class="gn-md-side-access">
+              <div class="well text-center">
+                <span itemprop="identifier"
+                    itemscope="itemscope"
+                    itemtype="http://schema.org/identifier" 
+                    class="hidden">
+                  <xsl:value-of select="$metadataUuid"/>
+                </span>
+                <a itemprop="url"
+                   itemscope="itemscope"
+                   itemtype="http://schema.org/url" 
+                   class="btn btn-block btn-primary"
+                   href="{if ($portalLink != '')
+                          then replace($portalLink, '\$\{uuid\}', $metadataUuid)
+                          else concat($nodeUrl, $language, '/catalog.search#/metadata/', $metadataUuid)}">
+                  <i class="fa fa-fw fa-link"></i>
+                  <xsl:value-of select="$schemaStrings/linkToPortal"/>
+                </a>
+                <xsl:value-of select="$schemaStrings/linkToPortal-help"/>
+              </div>
+            </section>
 
-            <div class="well text-center">
-              <span itemprop="identifier"
-                  itemscope="itemscope"
-                  itemtype="http://schema.org/identifier" 
-                  class="hidden">
-                <xsl:value-of select="$metadataUuid"/>
-              </span>
-              <a itemprop="url"
-                 itemscope="itemscope"
-                 itemtype="http://schema.org/url" 
-                 class="btn btn-block btn-primary"
-                 href="{if ($portalLink != '')
-                        then replace($portalLink, '\$\{uuid\}', $metadataUuid)
-                        else concat($nodeUrl, $language, '/catalog.search#/metadata/', $metadataUuid)}">
-                <i class="fa fa-link">&#160;</i>
-                <xsl:value-of select="$schemaStrings/linkToPortal"/>
-              </a>
-              <xsl:value-of select="$schemaStrings/linkToPortal-help"/>
-            </div>
-
-
-            <section>
+            <section class="gn-md-side-associated">
               <h4>
-                <i class="fa fa-fw fa-link">&#160;</i>&#160;
+                <i class="fa fa-fw fa-link"></i>
                 <span><xsl:value-of select="$schemaStrings/associatedResources"/></span>
               </h4>
               <div gn-related="md"


### PR DESCRIPTION
Classes are added to the different blocks in the sidebar of the metadata page (recordView), both in default and advanced view. Classes are named after the purpose (and title) of the blocks.

These classes make it easier for identifying and manipulating a single block. The advanced sidebar has an extra class: `gn-md-side-advanced` to distinguish it from the default sidebar.

Some code cleanup has been done, <br>'s are replaced with a `margin-bottom` and non-breaking spaces have been replaced with the class `fa-fw` where possible.