### PR TITLE
Fix xmlsearch call user inputs 3.4.x

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -417,6 +417,18 @@ public final class Geonet {
         public static final String HITS_PER_PAGE = "hitsPerPage";
 
         /**
+         * Parameter name: {@value #MAX_RECORDS} - Number of maximum results returned by the search
+         * engine, given the from / to user provided parameters. Default is 100 results.
+         */
+        public static final String MAX_RECORDS = "maxRecords";
+
+        /**
+         * Parameter name: {@value #MAX_RECORDS} - Number of maximum results returned by the search
+         * engine, given the from / to user provided parameters. Default is 100 results.
+         */
+        public static final String ALLOW_UNBOUNDED_QUERIES = "allowUnboundedQueries";
+
+        /**
          * Parameter name: {@value #SIMILARITY} - Use the Lucene FuzzyQuery. Values range from 0.0
          * to 1.0 and defaults to 0.8
          */

--- a/core/src/main/java/org/fao/geonet/services/util/SearchDefaults.java
+++ b/core/src/main/java/org/fao/geonet/services/util/SearchDefaults.java
@@ -82,7 +82,7 @@ public class SearchDefaults {
             }
 
             // Add other elements send by the request
-            // It could be extra parameters handle by Lucene in lucene.xsl
+            // It could be extra parameters handled by Lucene in lucene.xsl
             // and not set by default
             @SuppressWarnings("unchecked")
             List<Element> otherEl = request.getChildren();

--- a/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
+++ b/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
@@ -95,19 +95,19 @@ public class XmlSearch implements Service {
             params.removeChildren("from");
             params.removeChildren("to");
             params.addContent(new Element("from").setText("1"));
-            params.addContent(new Element("to").setText(Integer.toString(this.maxRecordValue - 1)));
+            params.addContent(new Element("to").setText(Integer.toString(this.maxRecordValue)));
             boundariesSet = true;
         }
         // from undefined, to defined
         else if (fromUndefined && ! toUndefined) {
             params.removeChildren("from");
-            params.addContent(new Element("from").setText(Integer.toString(to - this.maxRecordValue + 1)));
+            params.addContent(new Element("from").setText(Integer.toString(to - this.maxRecordValue)));
             boundariesSet = true;
         }
         // from defined, to undefined
         else if (! fromUndefined && toUndefined) {
             params.removeChildren("to");
-            params.addContent(new Element("to").setText(Integer.toString(from + this.maxRecordValue - 1)));
+            params.addContent(new Element("to").setText(Integer.toString(from + this.maxRecordValue)));
             boundariesSet = true;
         }
         // from defined, to defined
@@ -115,7 +115,7 @@ public class XmlSearch implements Service {
             // if the range is unacceptable
             if ((to - from) > this.maxRecordValue) {
                 params.removeChildren("to");
-                params.addContent(new Element("to").setText(Integer.toString(from + this.maxRecordValue - 1)));
+                params.addContent(new Element("to").setText(Integer.toString(from + this.maxRecordValue)));
                 boundariesSet = true;
             }
         }

--- a/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
+++ b/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
@@ -102,11 +102,7 @@ public class XmlSearch implements Service {
         }
         // from undefined, to defined
         else if (fromUndefined && ! toUndefined) {
-            if (to - this.maxRecordValue > 0) {
-                params.addContent(new Element("from").setText(Integer.toString(to - this.maxRecordValue)));
-            } else {
-                params.addContent(new Element("from").setText("1"));
-            }
+            params.addContent(new Element("from").setText(Integer.toString(Math.max(1,to - this.maxRecordValue))));
             boundariesSet = true;
         }
         // from defined, to undefined

--- a/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
+++ b/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
@@ -50,7 +50,9 @@ import static org.fao.geonet.kernel.SelectionManager.SELECTION_METADATA;
 public class XmlSearch implements Service {
     private ServiceConfig _config;
     private String _searchFast; //true, false, index
+    // Initialized here for testing purposes
     private int maxRecordValue = 100;
+    private boolean allowUnboundedQueries = false;
 
     //--------------------------------------------------------------------------
     //---
@@ -61,6 +63,8 @@ public class XmlSearch implements Service {
     public void init(Path appPath, ServiceConfig config) throws Exception {
         _config = config;
         _searchFast = config.getValue(Geonet.SearchResult.FAST, "true");
+        maxRecordValue = Integer.parseInt(config.getValue(Geonet.SearchResult.MAX_RECORDS, "100"));
+        allowUnboundedQueries = Boolean.parseBoolean(config.getValue(Geonet.SearchResult.ALLOW_UNBOUNDED_QUERIES, "false"));
     }
 
     /**
@@ -137,7 +141,10 @@ public class XmlSearch implements Service {
         params.removeChild(SELECTION_BUCKET);
 
         // Sets the boundaries (from/to) if needed
-        boolean boundariesSet = setSafeBoundaries(params);
+        boolean boundariesSet = false;
+        if (! this.allowUnboundedQueries) {
+            setSafeBoundaries(params);
+        }
 
         Element elData = SearchDefaults.getDefaultSearch(context, params);
 

--- a/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
+++ b/services/src/main/java/org/fao/geonet/services/main/XmlSearch.java
@@ -92,21 +92,21 @@ public class XmlSearch implements Service {
 
         // from / to undefined
         if (fromUndefined && toUndefined) {
-            params.removeChildren("from");
-            params.removeChildren("to");
             params.addContent(new Element("from").setText("1"));
             params.addContent(new Element("to").setText(Integer.toString(this.maxRecordValue)));
             boundariesSet = true;
         }
         // from undefined, to defined
         else if (fromUndefined && ! toUndefined) {
-            params.removeChildren("from");
-            params.addContent(new Element("from").setText(Integer.toString(to - this.maxRecordValue)));
+            if (to - this.maxRecordValue > 0) {
+                params.addContent(new Element("from").setText(Integer.toString(to - this.maxRecordValue)));
+            } else {
+                params.addContent(new Element("from").setText("1"));
+            }
             boundariesSet = true;
         }
         // from defined, to undefined
         else if (! fromUndefined && toUndefined) {
-            params.removeChildren("to");
             params.addContent(new Element("to").setText(Integer.toString(from + this.maxRecordValue)));
             boundariesSet = true;
         }

--- a/services/src/test/java/org/fao/geonet/services/main/XmlSearchTest.java
+++ b/services/src/test/java/org/fao/geonet/services/main/XmlSearchTest.java
@@ -50,7 +50,7 @@ public class XmlSearchTest {
 
         assertTrue(ret);
         assertTrue(params.getChild("from").getText().equals("324"));
-        assertTrue(params.getChild("to").getText().equals(Integer.toString(324 + xs.getMaxRecordValue() - 1)));
+        assertTrue(params.getChild("to").getText().equals(Integer.toString(324 + xs.getMaxRecordValue())));
     }
     
     @Test
@@ -60,7 +60,7 @@ public class XmlSearchTest {
         
         assertTrue("expected modified passed params", ret);
         assertTrue(params.getChild("from").getText().equals("1"));
-        assertTrue(params.getChild("to").getText().equals(Integer.toString(xs.getMaxRecordValue() - 1)));        
+        assertTrue(params.getChild("to").getText().equals(Integer.toString(xs.getMaxRecordValue())));
     }
     
     @Test
@@ -71,7 +71,7 @@ public class XmlSearchTest {
         boolean ret = (boolean) ReflectionUtils.invokeMethod(setSafeBoundaries, xs, params);
         
         assertTrue("expected modified passed params", ret);
-        assertTrue(params.getChild("from").getText().equals(Integer.toString(150 - xs.getMaxRecordValue() + 1)));
+        assertTrue(params.getChild("from").getText().equals(Integer.toString(150 - xs.getMaxRecordValue())));
         assertTrue(params.getChild("to").getText().equals("150"));        
     }
     
@@ -84,6 +84,6 @@ public class XmlSearchTest {
         
         assertTrue("expected modified passed params", ret);
         assertTrue(params.getChild("from").getText().equals("42"));
-        assertTrue(params.getChild("to").getText().equals(Integer.toString(42 + xs.getMaxRecordValue() -1)));        
+        assertTrue(params.getChild("to").getText().equals(Integer.toString(42 + xs.getMaxRecordValue())));
     }
 }

--- a/services/src/test/java/org/fao/geonet/services/main/XmlSearchTest.java
+++ b/services/src/test/java/org/fao/geonet/services/main/XmlSearchTest.java
@@ -1,0 +1,89 @@
+package org.fao.geonet.services.main;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.jdom.Element;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.util.ReflectionUtils;
+
+public class XmlSearchTest {
+    XmlSearch xs = new XmlSearch();
+    Method setSafeBoundaries = null;
+    @Before
+    public void setUp() {
+        this.setSafeBoundaries = ReflectionUtils.findMethod(XmlSearch.class, "setSafeBoundaries", Element.class);
+        this.setSafeBoundaries.setAccessible(true);
+    }
+
+    @Test
+    public void testFromDefinedToDefined() {
+        Element params = new Element("request");
+        params.addContent(new Element("from").setText("1"))
+              .addContent(new Element("to").setText("99"));
+
+        boolean ret = (boolean) ReflectionUtils.invokeMethod(setSafeBoundaries, xs, params);
+        
+        // 1 to 99 should be acceptable, no modification of passed parameters
+        assertFalse(ret);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testFromDefinedToDefinedFromBiggerThanTo() {
+        Element params = new Element("request");
+        params.addContent(new Element("from").setText("99"))
+              .addContent(new Element("to").setText("1"));
+
+        ReflectionUtils.invokeMethod(setSafeBoundaries, xs, params);
+    }
+
+    @Test
+    public void testFromDefinedToDefinedOutOfRange() {
+        Element params = new Element("request");
+        params.addContent(new Element("from").setText("324"))
+              .addContent(new Element("to").setText(Integer.toString(324 + xs.getMaxRecordValue() + 55)));
+
+        boolean ret = (boolean) ReflectionUtils.invokeMethod(setSafeBoundaries, xs, params);
+
+        assertTrue(ret);
+        assertTrue(params.getChild("from").getText().equals("324"));
+        assertTrue(params.getChild("to").getText().equals(Integer.toString(324 + xs.getMaxRecordValue() - 1)));
+    }
+    
+    @Test
+    public void testFromUndefinedToUndefined() {
+        Element params = new Element("request");
+        boolean ret = (boolean) ReflectionUtils.invokeMethod(setSafeBoundaries, xs, params);
+        
+        assertTrue("expected modified passed params", ret);
+        assertTrue(params.getChild("from").getText().equals("1"));
+        assertTrue(params.getChild("to").getText().equals(Integer.toString(xs.getMaxRecordValue() - 1)));        
+    }
+    
+    @Test
+    public void testFromUndefinedToDefined() {
+        Element params = new Element("request");
+        params.addContent(new Element("to").setText("150"));
+
+        boolean ret = (boolean) ReflectionUtils.invokeMethod(setSafeBoundaries, xs, params);
+        
+        assertTrue("expected modified passed params", ret);
+        assertTrue(params.getChild("from").getText().equals(Integer.toString(150 - xs.getMaxRecordValue() + 1)));
+        assertTrue(params.getChild("to").getText().equals("150"));        
+    }
+    
+    @Test
+    public void testFromDefinedToUndefined() {
+        Element params = new Element("request");
+        params.addContent(new Element("from").setText("42"));
+
+        boolean ret = (boolean) ReflectionUtils.invokeMethod(setSafeBoundaries, xs, params);
+        
+        assertTrue("expected modified passed params", ret);
+        assertTrue(params.getChild("from").getText().equals("42"));
+        assertTrue(params.getChild("to").getText().equals(Integer.toString(42 + xs.getMaxRecordValue() -1)));        
+    }
+}

--- a/services/src/test/java/org/fao/geonet/services/main/XmlSearchTest.java
+++ b/services/src/test/java/org/fao/geonet/services/main/XmlSearchTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
 
+import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,20 @@ public class XmlSearchTest {
         assertTrue(params.getChild("from").getText().equals(Integer.toString(150 - xs.getMaxRecordValue())));
         assertTrue(params.getChild("to").getText().equals("150"));        
     }
-    
+
+    @Test
+    public void testFromUndefinedToDefinedButTooSmall() {
+        Element params = new Element("request");
+        int boundaryTo = xs.getMaxRecordValue() / 2;
+        params.addContent(new Element("to").setText(Integer.toString(boundaryTo)));
+
+        boolean ret = (boolean) ReflectionUtils.invokeMethod(setSafeBoundaries, xs, params);
+
+        assertTrue("expected modified passed params", ret);
+        assertTrue(params.getChild("from").getText().equals("1"));
+        assertTrue(params.getChild("to").getText().equals(Integer.toString(boundaryTo)));
+    }
+
     @Test
     public void testFromDefinedToUndefined() {
         Element params = new Element("request");

--- a/web/src/main/webapp/WEB-INF/config/config-service-search.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-service-search.xml
@@ -41,7 +41,11 @@
 
         // TODO : improve
         ]]></documentation>
-      <class name=".services.main.XmlSearch"/>
+      <class name=".services.main.XmlSearch">
+        <!-- Note: this parameter will affect the server's response,
+             the parameter client-side is not related to this one. -->
+        <param name="maxRecords" value="100" />
+      </class>
     </service>
 
     <service name="qi">
@@ -52,7 +56,9 @@
       application search in statistics.
       ]]>
       </documentation>
-      <class name=".services.main.XmlSearch"/>
+      <class name=".services.main.XmlSearch">
+        <param name="maxRecords" value="100" />
+      </class>
     </service>
 
     <service name="lang">


### PR DESCRIPTION
This PR insures that the provided combination of "from" / "to" parameters is acceptable. Currently, if none of these parameters is provided, the whole catalogue visible by the user is dumped as JSON.

On a huge catalogue (80k MDs), this can lead to the production of a JSON document of ~ 400MB. Querying the same service with such unbounded parameters in 4 simultaneous requests lead to a DoS / memory exhaustion, YMMV.

Tests: testsuite added for this particular case, runtime tested with the same 80k volumetry.