### PR TITLE
Avoid "user status" request caching in IE11

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -572,8 +572,10 @@
 
 
         // Retrieve user information if catalog is online
+        // append a random number to avoid caching in IE11
         var userLogin = catInfo.then(function(value) {
-          return $http.get('../api/me').
+          return $http.get('../api/me?_random=' +
+            Math.floor(Math.random() * 10000)).
               success(function(me, status) {
                 if (angular.isObject(me)) {
                   angular.extend($scope.user, me);


### PR DESCRIPTION
Previously, the user would always see the logged in status in the toolbar even after a log out.

This happens because IE11 does not take into account the "Expired" header in the response.