### PR TITLE
Map on search is not using config from the admin

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextDirective.js
@@ -236,19 +236,22 @@
           // load context from url or from storage
           var key = 'owsContext_' +
               window.location.host + window.location.pathname;
-          var storage = gnViewerSettings.storage ?
-              window[gnViewerSettings.storage] : window.localStorage;
-          if (gnViewerSettings.owsContext) {
-            gnOwsContextService.loadContextFromUrl(gnViewerSettings.owsContext,
-                scope.map);
-          } else if (storage.getItem(key)) {
+
+          var storage = gnViewerSettings.mapConfig.storage ?
+              window[gnViewerSettings.mapConfig.storage] : window.localStorage;
+
+          if (gnViewerSettings.mapConfig.storage !== '' &&
+            storage.getItem(key)) {
             var c = storage.getItem(key);
             gnOwsContextService.loadContext(c, scope.map);
+          } else if (gnViewerSettings.owsContext) {
+            gnOwsContextService.loadContextFromUrl(gnViewerSettings.owsContext,
+              scope.map);
           } else if (gnViewerSettings.defaultContext) {
             gnOwsContextService.loadContextFromUrl(
-                gnViewerSettings.defaultContext,
-                scope.map,
-                gnViewerSettings.additionalMapLayers);
+              gnViewerSettings.defaultContext,
+              scope.map,
+              gnViewerSettings.additionalMapLayers);
           }
 
           // store the current context in local storage to reload it

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -547,8 +547,12 @@
        * @param {ol.Map} map object
        */
       this.saveToLocalStorage = function(map) {
-        var storage = gnViewerSettings.storage ?
-            window[gnViewerSettings.storage] : window.localStorage;
+        // Disable map storage.
+        if (gnViewerSettings.mapConfig.storage === '') {
+          return;
+        }
+        var storage = gnViewerSettings.mapConfig.storage ?
+            window[gnViewerSettings.mapConfig.storage] : window.localStorage;
         if (map.getSize()[0] == 0 || map.getSize()[1] == 0) {
           // don't save a map which has not been rendered yet
           return;

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -181,18 +181,14 @@
             'layers': []
           },
           'map-search': {
-            'context': '',
+            'context': '../../map/config-viewer.xml',
             'extent': [0, 0, 0, 0],
-            'layers': [
-              { type: 'osm' }
-            ]
+            'layers': []
           },
           'map-editor': {
-            'context': '',
+            'context': '../../map/config-viewer.xml',
             'extent': [0, 0, 0, 0],
-            'layers': [
-              { type: 'osm' }
-            ]
+            'layers': []
           }
         },
         'geocoder': 'https://secure.geonames.org/searchJSON',

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1122,7 +1122,7 @@
     "ui-listOfServices": "List of preferred OGC services",
     "ui-listOfServices-help": "If none defined, service metadata records are proposed to the users",
     "ui-storage": "User preference persistence",
-    "ui-storage-help": "sessionStorage or localStorage",
+    "ui-storage-help": "'' or 'sessionStorage' or 'localStorage'. An empty value means that the viewer map will not be saved when leaving the application and restored when coming back.",
     "ui-isExportMapAsImageEnabled": "Export map as image",
     "ui-isExportMapAsImageEnabled-help": "This requires CORS to be enabled on the WMS services used in the map application. If not sure, you should disable that option that may cause trouble displaying WMS layers.",
     "ui-is3DModeAllowed": "Allow 3D mode",

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -35,11 +35,11 @@
         'gnSearchSettings',
         'gnViewerSettings',
         'gnOwsContextService',
-        'gnMap',
+        'gnMap', 'gnMapsManager',
         'gnGlobalSettings',
         '$location',
         function(searchSettings, viewerSettings, gnOwsContextService,
-                 gnMap, gnGlobalSettings, $location) {
+                 gnMap, gnMapsManager, gnGlobalSettings, $location) {
 
           // Load the context defined in the configuration
           viewerSettings.defaultContext =
@@ -115,9 +115,6 @@
 
           };
 
-          // Object to store the current Map context
-          viewerSettings.storage = 'sessionStorage';
-
           // Start location. This is usually overriden
           // by context for large map and search records
           // extent for minimap
@@ -131,27 +128,7 @@
             view: new ol.View(mapsConfig)
           });
 
-          var searchMap = new ol.Map({
-            controls:[],
-            layers: [],
-            view: new ol.View(angular.extend({}, mapsConfig))
-          });
-
-          // initialize search map layers according to settings
-          // (default is OSM)
-          var searchMapLayers = viewerSettings.mapConfig.searchMapLayers;
-          if (!searchMapLayers || !searchMapLayers.length) {
-            searchMap.addLayer(new ol.layer.Tile({
-              source: new ol.source.OSM()
-            }));
-          } else {
-            searchMapLayers.forEach(function (layerInfo) {
-              gnMap.createLayerForType(layerInfo.type, {
-                name: layerInfo.name,
-                url: layerInfo.url
-              }, layerInfo.title, searchMap);
-            });
-          }
+          var searchMap = gnMapsManager.createMap(gnMapsManager.SEARCH_MAP);
 
           // Map protocols used to load layers/services in the map viewer
           searchSettings.mapProtocols = {


### PR DESCRIPTION
* Search map is using deprecated settings. Use mapsManager instead

![image](https://user-images.githubusercontent.com/1701393/33597161-c817f3ca-d99e-11e7-950b-6b8581d9aacb.png)

* viewerSettings.storage was duplicates of viewerSettings.mapConfig.storage with a hard coded value
* Default layers are always merged in custom config so it was not possible to turn off OSM when using context config. Use context configuration by default.
* Add possibility to set an empty map viewer state storage. This allows to forget what use to be in localStorage eg. in case some VIP complains about some OSM labels in wrong languages.
