### PR TITLE
Fixes editor form fields disappearing below OL maps

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -92,10 +92,9 @@
               projection: gnMap.getMapConfig().projection,
               zoom: 2
             }),
-            // apply default controls if not in editor map
+            // show zoom control in editor maps only
             controls: type !== this.EDITOR_MAP ? [] : [
-              new ol.control.Zoom(),
-              new ol.control.Rotate()
+              new ol.control.Zoom()
             ]
           });
 


### PR DESCRIPTION
Following #2369 I've done a bit of research and it turns out that removing the `ol-rotate` control altogether seems to fix the problem. This can be done in the maps manager instead of simply hiding them with CSS (remember: *maps are managed by the maps manager now* :smile:).

@MichelGabriel  @josegar74 can you please confirm this fixes it?

This fix won't be applicable to 3.2.x. For this branch, the modification will have to be done here:
https://github.com/geonetwork/core-geonetwork/blob/2d1c12e45ef9ac772976cbce8aea15539b036309/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js#L209-L220
Adding `controls: [ new ol.control.Zoom() ]` should do the trick.