### PR TITLE
Fix for edit buttons in the buttonbar on smaller screens

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -11,7 +11,7 @@
     <td>
 
       <div class="row">
-        <div class="col-lg-6 col-md-6">
+        <div class="col-lg-8 col-md-8">
           <a href=""
              data-ng-show="md.isTemplate != 's'"
              data-ng-href="catalog.search#/metadata/{{md.getUuid()}}"
@@ -32,7 +32,7 @@
                   data-ng-show="md.mdStatus">{{('status-' + md.mdStatus) | translate}}</span>
           </div>
         </div>
-        <div class="col-lg-6 col-md-6">
+        <div class="col-lg-4 col-md-4">
           <div class="btn-group pull-right1">
             <a class="btn btn-default"
                data-ng-href=""

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -9,63 +9,68 @@
       <gn-md-type-widget metadata="md"></gn-md-type-widget>
     </td>
     <td>
-      <a href=""
-         data-ng-show="md.isTemplate != 's'"
-         data-ng-href="catalog.search#/metadata/{{md.getUuid()}}"
-         title="{{md.abstract}}">{{md.title || md.defaultTitle}}</a>
-      <span data-ng-show="md.isTemplate == 's'">{{md.title || md.defaultTitle}}</span>
-      <br/>
-      <div class="gn-record-details text-muted">
-        <small><span data-translate="">owner</span>:</small>
-        <small>{{::md.getOwnername()}}</small>
-        &nbsp;
-        <small data-translate="">updatedOn</small>
-        <small class="text-muted"
-               data-gn-humanize-time="{{md['geonet:info'].changeDate}}"
-               data-from-now=""></small>
 
-        <span class="pull-right text-muted"
-              data-ng-class="{'text-success': md.mdStatus == 2, 'text-warning': md.mdStatus == 4}"
-              data-ng-show="md.mdStatus">{{('status-' + md.mdStatus) | translate}}</span>
-      </div>
-    </td>
-    <td>
-      <div class="btn-group pull-right">
-        <a class="btn btn-default"
-           data-ng-href=""
-           data-ng-if="user.canEditRecord(md) && user.isEditorOrMore()"
-           data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())"
-           title="{{'privileges' | translate}}">
-          <i class="fa text-muted"
-             data-ng-class="md.isPublished() ? 'fa-unlock' : 'fa-lock'"></i>
-        </a>
-        <!-- TODO: subtemplate link for editing is different -->
-        <a class="btn btn-default"
-           data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-           data-ng-href="#/metadata/{{md['geonet:info'].id}}"
-           title="{{'edit' | translate}}">
-          <i class="fa fa-pencil"></i>
-        </a>
-        <a class="btn btn-default"
-           data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-           data-gn-click-and-spin="deleteRecord(md)"
-           data-gn-confirm-click="{{'deleteRecordConfirm' | translate:md}}"
-           title="{{'delete' | translate}}">
-          <i class="fa fa-times text-danger"></i>
-        </a>
-        <a class="btn btn-default"
-           data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-           data-ng-href="#/create?childOf={{md['geonet:info'].id}}"
-           title="{{'createChild' | translate}}">
-          <i class="fa fa-sitemap text-muted"></i>
-        </a>
-        <a class="btn btn-default"
-           data-ng-class="user.canEditRecord(md) ? '' : 'btn-single'"
-           data-ng-show="md.isTemplate != 's'"
-           data-ng-href="#/create?from={{md['geonet:info'].id}}"
-           title="{{'duplicate' | translate}}">
-          <i class="fa fa-copy text-muted"></i>
-        </a>
+      <div class="row">
+        <div class="col-lg-6 col-md-6">
+          <a href=""
+             data-ng-show="md.isTemplate != 's'"
+             data-ng-href="catalog.search#/metadata/{{md.getUuid()}}"
+             title="{{md.abstract}}">{{md.title || md.defaultTitle}}</a>
+          <span data-ng-show="md.isTemplate == 's'">{{md.title || md.defaultTitle}}</span>
+          <br/>
+          <div class="gn-record-details text-muted">
+            <small><span data-translate="">owner</span>:</small>
+            <small>{{::md.getOwnername()}}</small>
+            &nbsp;
+            <small data-translate="">updatedOn</small>
+            <small class="text-muted"
+                   data-gn-humanize-time="{{md['geonet:info'].changeDate}}"
+                   data-from-now=""></small>
+
+            <span class="pull-right text-muted"
+                  data-ng-class="{'text-success': md.mdStatus == 2, 'text-warning': md.mdStatus == 4}"
+                  data-ng-show="md.mdStatus">{{('status-' + md.mdStatus) | translate}}</span>
+          </div>
+        </div>
+        <div class="col-lg-6 col-md-6">
+          <div class="btn-group pull-right1">
+            <a class="btn btn-default"
+               data-ng-href=""
+               data-ng-if="user.canEditRecord(md) && user.isEditorOrMore()"
+               data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())"
+               title="{{'privileges' | translate}}">
+              <i class="fa text-muted"
+                 data-ng-class="md.isPublished() ? 'fa-unlock' : 'fa-lock'"></i>
+            </a>
+            <!-- TODO: subtemplate link for editing is different -->
+            <a class="btn btn-default"
+               data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
+               data-ng-href="#/metadata/{{md['geonet:info'].id}}"
+               title="{{'edit' | translate}}">
+              <i class="fa fa-pencil"></i>
+            </a>
+            <a class="btn btn-default"
+               data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
+               data-gn-click-and-spin="deleteRecord(md)"
+               data-gn-confirm-click="{{'deleteRecordConfirm' | translate:md}}"
+               title="{{'delete' | translate}}">
+              <i class="fa fa-times text-danger"></i>
+            </a>
+            <a class="btn btn-default"
+               data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
+               data-ng-href="#/create?childOf={{md['geonet:info'].id}}"
+               title="{{'createChild' | translate}}">
+              <i class="fa fa-sitemap text-muted"></i>
+            </a>
+            <a class="btn btn-default"
+               data-ng-class="user.canEditRecord(md) ? '' : 'btn-single'"
+               data-ng-show="md.isTemplate != 's'"
+               data-ng-href="#/create?from={{md['geonet:info'].id}}"
+               title="{{'duplicate' | translate}}">
+              <i class="fa fa-copy text-muted"></i>
+            </a>
+          </div>
+        </div>
       </div>
     </td>
   </tr>

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -231,7 +231,7 @@ input[type=text], input[type=number], select {
         border-radius: 4px;
       }
     }
-    .col-lg-6, .col-md-6 {
+    .col-lg-8, .col-md-8, .col-lg-4, .col-md-4 {
       padding-left: 0;
       padding-right: 0;
     }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -231,6 +231,15 @@ input[type=text], input[type=number], select {
         border-radius: 4px;
       }
     }
+    .col-lg-6, .col-md-6 {
+      padding-left: 0;
+      padding-right: 0;
+    }
+    @media (min-width: @screen-md-min) {
+      .btn-group {
+        float: right;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Small fix for displaying the edit buttons correctly. The buttonbar with edit buttons on the contribute page is now made responsive for smaller screens.

**Screenshot of a small screen**
![gn-buttonbar-on-small-screen](https://user-images.githubusercontent.com/19608667/33604614-e8dca4e4-d9b6-11e7-99f2-1c6545fb21b1.png)

