### PR TITLE
Tabs in advanced view (renewed)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -74,6 +74,30 @@
           });
         });
       };
+     
+      // activate the tabs in the advanded metadata view
+      $scope.activateTabs = function() {
+      
+        // attach click to tab
+        $('.nav-tabs-advanced a').click(function (e) {
+          e.preventDefault();
+          $(this).tab('show');
+        });
+        // hide empty tab     
+        $('.nav-tabs-advanced a').each(function() {
+      
+          var tabLink = $(this).attr('href');
+      
+          if (tabLink) {
+            if ($(tabLink).length === 0) {
+              $(this).parent().hide();
+            }
+          }
+        });
+        // show the first tab
+        $('.nav-tabs-advanced a:first').tab('show');
+      };
+      
       $scope.format = function(f) {
         $scope.usingFormatter = f !== undefined;
         $scope.currentFormatter = f;
@@ -97,6 +121,9 @@
                   var content = $compile(snippet)($scope.compileScope);
 
                   $('#gn-metadata-display').append(content);
+
+                  // activate the tabs in the full view
+                  $scope.activateTabs();
                 });
           });
         }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -82,17 +82,20 @@
               <div gn-related="md"
                    data-user="user"
                    data-types="onlines">&#160;</div>
-
-              <!--<xsl:apply-templates mode="render-toc" select="$viewConfig"/>-->
             </header>
 
-
-            <xsl:for-each select="$viewConfig/*">
-              <xsl:sort select="@formatter-order"
-                        data-type="number"/>
-              <xsl:apply-templates mode="render-view"
-                                   select="."/>
-            </xsl:for-each>
+            <div>
+              <xsl:apply-templates mode="render-toc" select="$viewConfig"/>
+              <!-- Tab panes -->
+              <div class="tab-content">
+                <xsl:for-each select="$viewConfig/*">
+                  <xsl:sort select="@formatter-order"
+                            data-type="number"/>
+                  <xsl:apply-templates mode="render-view"
+                                       select="."/>
+                </xsl:for-each>
+              </div>
+            </div>
           </div>
           <div class="gn-md-side gn-md-side-advanced col-md-4">
             <xsl:apply-templates mode="getOverviews" select="$metadata"/>
@@ -211,14 +214,10 @@
     </div>
   </xsl:template>
 
-
-
-
   <!-- Render list of tabs in the current view -->
   <xsl:template mode="render-toc" match="view">
     <xsl:if test="count(tab) > 1">
-      <!-- TODO: Hide tabs which does not contains anything -->
-      <ul class="view-outline nav nav-pills">
+      <ul class="view-outline nav nav-tabs nav-tabs-advanced">
         <xsl:for-each select="tab">
           <li>
             <a href="#gn-tab-{@id}">
@@ -243,7 +242,7 @@
       <xsl:variable name="title"
                     select="gn-fn-render:get-schema-strings($schemaStrings, @id)"/>
 
-      <div id="gn-tab-{@id}">
+      <div id="gn-tab-{@id}" class="tab-pane">
         <xsl:if test="count(following-sibling::tab) > 0">
           <h1 class="view-header">
             <xsl:value-of select="$title"/>
@@ -269,15 +268,15 @@
   -->
   <xsl:template mode="render-view"
                 match="section[@xpath]">
-    <div id="gn-view-{generate-id()}">
-      <xsl:apply-templates mode="render-view" select="@xpath"/>&#160;
+    <div id="gn-view-{generate-id()}" class="gn-tab-content">
+      <xsl:apply-templates mode="render-view" select="@xpath"/>
     </div>
   </xsl:template>
 
 
   <xsl:template mode="render-view"
                 match="section[not(@xpath)]">
-    <div id="gn-section-{generate-id()}">
+    <div id="gn-section-{generate-id()}" class="gn-tab-content">
       <xsl:if test="@name">
         <xsl:variable name="title"
                       select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -74,6 +74,42 @@
           </div>
           <xsl:call-template name="footer"/>
         </div>
+
+        <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+        <script src="http://code.jquery.com/jquery-1.12.4.min.js"
+                integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+                crossorigin="anonymous">
+          &#160;
+        </script>
+      
+        <!-- Latest compiled and minified JavaScript -->
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" 
+                integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+                crossorigin="anonymous">
+          &#160;
+        </script>
+      
+        <script type="text/javascript">
+          // attach click to tab
+          $('.nav-tabs-advanced a').click(function (e) {
+            e.preventDefault();
+            $(this).tab('show');
+          });
+          // hide empty tab     
+          $('.nav-tabs-advanced a').each(function() {
+      
+            var tabLink = $(this).attr('href');
+      
+            if (tabLink) {
+              if ($(tabLink).length === 0) {
+                $(this).parent().hide();
+              }
+            }
+          });
+          // show the first tab
+          $('.nav-tabs-advanced a:first').tab('show');
+        </script>
+        <xsl:call-template name="css-load"/>
       </body>
     </html>
   </xsl:template>


### PR DESCRIPTION
The content in the advanced view was listed in a long list with different sections. These sections are now displayed as tabs.

When a tab is empty it is not displayed. A function is added to the controller (GnMdViewController) to activate the tabs and hide the tab header.

This PR is the same as https://github.com/geonetwork/core-geonetwork/pull/2367 but based on a more recent version of 3.4x. core. 

**Screenshot of the tabs in the advanced view**
![gn-tabs-in-advanced-view](https://user-images.githubusercontent.com/19608667/33608968-859df846-d9c6-11e7-9ec7-27b047f78984.png)
