### PR TITLE
Fix for category checkbox on Group page

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
@@ -151,10 +151,10 @@
 
             <div class="checkbox">
               <label>
-                <span data-translate="">enableAllowedCategories</span>
                 <input type="checkbox"
                        name="enableAllowedCategories"
                        data-ng-model="groupSelected.enableAllowedCategories"/>
+                <span data-translate="">enableAllowedCategories</span>
               </label>
             </div>
             <div>


### PR DESCRIPTION
Place the checkbox for the label, this fixes an error when displaying the checkbox.

**Old situation**
![gn-old-checkbox](https://user-images.githubusercontent.com/19608667/33654962-03c53440-da72-11e7-9404-5921dae4cbd4.png)

**New situation**
![gn-new-checkbox](https://user-images.githubusercontent.com/19608667/33654970-0c1968d2-da72-11e7-9c1f-7f304eb3da53.png)
 