### PR TITLE
When closing editor redirect to a location defined by the opening link or fallback to use history.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -205,7 +205,9 @@
             if (tab) {
               path += '/tab/' + tab;
             }
-            $location.path(path).search('justcreated');
+            $location.path(path)
+              .search('justcreated')
+              .search('redirectUrl', 'catalog.edit');
           });
         },
 

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -45,7 +45,7 @@
             <!-- TODO: subtemplate link for editing is different -->
             <a class="btn btn-default"
                data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-               data-ng-href="#/metadata/{{md['geonet:info'].id}}"
+               data-ng-href="#/metadata/{{md['geonet:info'].id}}?redirectUrl=catalog.edit"
                title="{{'edit' | translate}}">
               <i class="fa fa-pencil"></i>
             </a>

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -130,6 +130,7 @@
       $scope.gnConfig = gnConfig;
       $scope.unsupportedSchema = false;
       $scope.gnOnlinesrc = gnOnlinesrc;
+      $scope.redirectUrl = null;
 
       /**
        * Animation duration for slide up/down
@@ -188,7 +189,7 @@
 
               // Get the schema configuration for the current record
               gnCurrentEdit.metadata = new Metadata(data.metadata[0]);
-
+              $scope.redirectUrl = $location.search()['redirectUrl'];
 
               if ($scope.metadataFound) {
 
@@ -448,14 +449,16 @@
         window.onbeforeunload = null;
 
         // if there is no history, attempt to close tab
-        if (window.history.length == 1) {
+        if ($scope.redirectUrl != null) {
+          window.location.replace($scope.redirectUrl);
+        } else if (window.history.length == 1) {
           window.close();
           // This last point may trigger
           // "Scripts may close only the windows that were opened by it."
           // when the editor was not opened by a script.
+        } else {
+          window.history.back();
         }
-
-        window.history.back();
       };
 
       $scope.cancel = function(refreshForm) {

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -282,7 +282,8 @@
               <!--id and uuid from single import-->
               <div data-ng-repeat="(key, value) in report.metadataInfos">
                 <span>{{value[0].message}}</span>
-                <a href='#/metadata/{{key}}' title="{{'edit' | translate}}">
+                <a href='#/metadata/{{key}}?redirectUrl=catalog.edit'
+                   title="{{'edit' | translate}}">
                   <i class='fa fa-pencil'></i>
                 </a>
               </div>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
@@ -2,7 +2,7 @@
 
   <a class="gn-md-edit-btn"
      data-ng-show="user.canEditRecord(md)"
-     data-ng-href="catalog.edit#/metadata/{{md['geonet:info'].id}}"
+     data-ng-href="catalog.edit#/metadata/{{md['geonet:info'].id}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{md['geonet:info'].uuid}}"
      title="{{'edit' | translate}}">
     <i class="fa fa-pencil"></i>
   </a>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -83,7 +83,7 @@
 
     <a class="btn btn-primary gn-md-edit-btn pull-right"
        data-ng-show="user.canEditRecord(mdView.current.record)"
-       data-ng-href="catalog.edit#/metadata/{{mdView.current.record.getId()}}"
+       data-ng-href="catalog.edit#/metadata/{{mdView.current.record.getId()}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.getUuid()}}"
        title="{{'edit' | translate}}">
       <i class="fa fa-pencil"></i>
       <span data-translate="" class="hidden-sm hidden-xs">edit</span>


### PR DESCRIPTION
Parameter set in:
* editor board results
* search results
* record view
* new record page
* import record page

This allows to even have third party apps opening the editor and come back to the app at the end.
Fix create a new record, click "save-close" return to create metadata screen #2361