### PR TITLE
Margin for help button

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -53,7 +53,15 @@ div[gn-transfer-ownership] * .list-group {
   line-height: 1.33;
   border-radius: 35px;
 }
-
+// help button
+[data-gn-need-help] {
+  margin-top: 10px;
+}
+.panel-heading {
+  [data-gn-need-help] {
+    margin-top: 0;
+  }
+}
 
 
 /* An update to 3.2 could provide responsive class


### PR DESCRIPTION
Add an extra margin for the help button. The button was sometimes positioned directly below another element.

**Old situation**
![gn-old-help-button](https://user-images.githubusercontent.com/19608667/33669975-282be522-daa4-11e7-8d43-92960ca03953.png)

**New situation**
![gn-new-help-button](https://user-images.githubusercontent.com/19608667/33669969-2443fdbe-daa4-11e7-88ba-b1ec90b4b477.png)


