### PR TITLE
Use standard properties for proxy

### DIFF
--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -1,12 +1,16 @@
 package org.fao.geonet.proxy;
 
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
+
+import javax.servlet.ServletConfig;
 
 /**
  * This is a class extending the real proxy to make sure we can tweak specifics like removing the CSRF token on requests
- * 
- * @author delawen
  *
+ * @author delawen
  */
 public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemplateProxyServlet {
 
@@ -17,9 +21,25 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
      * parent
      */
     static {
-        String[] headers = new String[] { "X-XSRF-TOKEN", "Access-Control-Allow-Origin", "Vary", "Access-Control-Allow-Credentials" };
+        String[] headers = new String[]{"X-XSRF-TOKEN", "Access-Control-Allow-Origin", "Vary", "Access-Control-Allow-Credentials"};
         for (String header : headers) {
             hopByHopHeaders.addHeader(new BasicHeader(header, null));
         }
+    }
+
+    /**
+     * Creates the HttpClient used to make the proxied requests. It configures the client to use system properties like
+     * <code>http.proxyHost</code> and <code>http.httpPort</code>.
+     *
+     * Called from {@link #init(ServletConfig)}.
+     *
+     * @param requestConfig the configuration used for the request made by the client.
+     */
+    @Override
+    protected HttpClient createHttpClient(RequestConfig requestConfig) {
+        return HttpClients.custom()
+            .setDefaultRequestConfig(requestConfig)
+            .useSystemProperties()
+            .build();
     }
 }


### PR DESCRIPTION
After the introduction of the new `ProxyServlet` it doesn't use the proxy gateway configured in the admin settings making impossible the connection to external websites in environments where a proxy is needed to access the external network.
This commit allows `ProxyServlet` to use the proxy configured by Java standard properties `http.proxyHost`, `http.ProxyPort`, etc.

Other GN's components like the harvesters comply with the settings from the admin console.