### PR TITLE
on admin-dashboard prevent to load undefined.html

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/AdminController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminController.js
@@ -340,6 +340,8 @@
             $scope.href = value.href;
           }
         });
+        //do not try to load undefined.html
+        if (!pageMenu||!pageMenu.folder||!$scope.type) return "";
         return tplFolder + pageMenu.folder + $scope.type + '.html';
       };
 


### PR DESCRIPTION
if warninghealthcheck is slow (or timeout) a file undefinedundefined.html is tried to be loaded, this fix prevents loading of the file, in the end the effect is the same: blank page while loading, would be better to add some spinner while loading