### PR TITLE
Fix error when printing WMTS layers using REST

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1602,6 +1602,9 @@
                 for (var i = 0; i < layer.ResourceURL.length; i++) {
                   urls.push(layer.ResourceURL[i].template);
                 }
+                if (layer.ResourceURL.length > 0) {
+                  url = encodeURI(layer.ResourceURL[0].template);
+                }
 
                 angular.extend(sourceConfig, {
                   urls: urls,

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
@@ -294,6 +294,7 @@
           var tileGrid = source.getTileGrid();
           var matrixSet = source.getMatrixSet();
           var matrixIds = new Array(tileGrid.getResolutions().length);
+          var layerUrl = layer.get('url');
           for (var z = 0; z < tileGrid.getResolutions().length; ++z) {
             var mSize = (ol.extent.getWidth(ol.proj.get('EPSG:3857').
                 getExtent()) /tileGrid.getTileSize()) /
@@ -307,12 +308,24 @@
                 };
           }
 
+          // workaround for Mapfish v2.1.2 with REST and matrixIds
+          if (matrixIds.length > 0) {
+            if (/{style}/ig.test(decodeURI(layerUrl))) {
+              layerUrl = encodeURI(decodeURI(layerUrl).replace(/{style}/ig, source.getStyle()));
+            }
+            if (/layer/ig.test(decodeURI(layerUrl))) {
+              layerUrl = encodeURI(decodeURI(layerUrl).replace(/{layer}/ig, source.getLayer()));
+            }
+          }
+
           angular.extend(enc, {
             type: 'WMTS',
-            baseURL: layer.get('url'),
+            baseURL: layerUrl,
             layer: source.getLayer(),
             version: source.getVersion(),
-            requestEncoding: 'KVP',
+            requestEncoding: source.getRequestEncoding() || 'KVP',
+            // Dimensions is not a mandatory parameter but it is required by Mapfish v2.1.2 if requestEncoding is REST
+            dimensions: [],
             format: source.getFormat(),
             style: source.getStyle(),
             matrixSet: matrixSet,


### PR DESCRIPTION
Since GN uses Mapfish-print v2.1.2 and it contains some bugs when printing a WMTS layer when REST is used this commit is a workaround that processes some parameters in the client side to allow Mapfish print the layer.
For example it needs a `dimensions` parameter, even when it should be optional. Another change is that Mapfish v2.1.2 doesn't replace the `{style}` and `{layer}` parameters in the URL, so we need to do that in the Javascript code.

Same fix than #2441 but ported to 3.4.x branch.