### PR TITLE
Fix for printing maps in EPSG:4326

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js
@@ -180,14 +180,14 @@
               resolution >= minResolution) {
             if (src instanceof ol.source.WMTS) {
               encLayer = $scope.encoders.layers['WMTS'].call(this,
-                  layer, layerConfig);
+                  layer, layerConfig, proj);
             } else if (src instanceof ol.source.OSM) {
               encLayer = $scope.encoders.layers['OSM'].call(this,
                   layer, layerConfig);
             } else if (src instanceof ol.source.ImageWMS ||
                 src instanceof ol.source.TileWMS) {
               encLayer = $scope.encoders.layers['WMS'].call(this,
-                  layer, layerConfig);
+                  layer, layerConfig, proj);
             } else if (layer instanceof ol.layer.Vector) {
               var features = [];
               src.forEachFeatureInExtent(ext, function(feat) {

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -222,7 +222,7 @@
           }
           if (layer instanceof ol.layer.Group) {
             var encs = gnPrint.encoders.layers['Group'].call(this,
-                layer, proj);
+              layer, proj);
             encLayers = encLayers.concat(encs);
           } else {
             var enc = encodeLayer(layer, proj);
@@ -297,7 +297,7 @@
             resolution >= minResolution) {
           if (src instanceof ol.source.WMTS) {
             encLayer = gnPrint.encoders.layers['WMTS'].call(this,
-                layer, layerConfig, $scope.map);
+                layer, layerConfig, proj);
           } else if (src instanceof ol.source.OSM) {
             encLayer = gnPrint.encoders.layers['OSM'].call(this,
                 layer, layerConfig);
@@ -307,7 +307,7 @@
           } else if (src instanceof ol.source.ImageWMS ||
               src instanceof ol.source.TileWMS) {
             encLayer = gnPrint.encoders.layers['WMS'].call(this,
-                layer, layerConfig, $scope.map);
+                layer, layerConfig, proj);
           } else if (src instanceof ol.source.Vector ||
               src instanceof ol.source.ImageVector) {
             if (src instanceof ol.source.ImageVector) {
@@ -321,7 +321,7 @@
             if (features && features.length > 0) {
               encLayer =
                   gnPrint.encoders.layers['Vector'].call(this,
-                      layer, features);
+                    layer, features);
             }
           }
         }

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
@@ -38,7 +38,7 @@
     var DPI = 72;
     var MM_PER_INCHES = 25.4;
     var UNITS_RATIO = 39.37;
-    var METERS_PER_DEGREE = 222638.98158654716;
+    var METERS_PER_DEGREE = 111319.49079327358;
 
     /**
      * Get the map coordinates of the center of the given print rectangle.
@@ -222,7 +222,7 @@
           });
           return enc;
         },
-        'WMS': function(layer, config) {
+        'WMS': function(layer, config, proj) {
           var enc = self.encoders.
               layers['Layer'].call(this, layer);
           var params = layer.getSource().getParams();
@@ -243,7 +243,7 @@
             customParams: {
               'EXCEPTIONS': 'XML',
               'TRANSPARENT': 'true',
-              'CRS': 'EPSG:3857',
+              'CRS': proj.getCode(),
               'TIME': params.TIME
             },
             singleTile: config.singleTile || false
@@ -286,7 +286,7 @@
           });
           return enc;
         },
-        'WMTS': function(layer, config) {
+        'WMTS': function(layer, config, proj) {
           // sextant specific
           var enc = self.encoders.layers['Layer'].
               call(this, layer);
@@ -296,8 +296,8 @@
           var matrixIds = new Array(tileGrid.getResolutions().length);
           var layerUrl = layer.get('url');
           for (var z = 0; z < tileGrid.getResolutions().length; ++z) {
-            var mSize = (ol.extent.getWidth(ol.proj.get('EPSG:3857').
-                getExtent()) /tileGrid.getTileSize()) /
+            var mSize = (ol.extent.getWidth(proj.getExtent()) /
+                tileGrid.getTileSize()) /
                 tileGrid.getResolutions()[z];
                 matrixIds[z] = {
                   identifier: tileGrid.getMatrixIds()[z],


### PR DESCRIPTION
Previously printing maps in 4326 would sometime fail because of an computation error in the `matrixSize` parameter sent to mapfish print.