### PR TITLE
Improve layout of attribute display in editor. Fix for: #2468

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -309,6 +309,14 @@ form.gn-editor {
   .form-group {
     margin-bottom: 0px;
   }
+  div.well {
+    .form-group {
+      margin-bottom: 10px;
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
 
   legend {
     margin-bottom: 10px;

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -316,6 +316,9 @@ form.gn-editor {
         margin-bottom: 0;
       }
     }
+    .btn + .form-group {
+      margin-top: 10px;
+    }
   }
 
   legend {

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1409,10 +1409,10 @@
     <xsl:param name="insertRef" select="''"/>
 
     <xsl:variable name="attributeLabel" select="gn-fn-metadata:getLabel($schema, @name, $labels)"/>
-    <button type="button" class="btn btn-link btn-xs"
+    <button type="button" class="btn btn-default btn-xs"
             data-gn-click-and-spin="add('{$ref}', '{@name}', '{$insertRef}', null, true)"
             title="{$attributeLabel/description}">
-      <i class="fa fa-plus"/>
+      <i class="fa fa-plus fa-fw"/>
       <xsl:value-of select="$attributeLabel/label"/>
     </button>
   </xsl:template>


### PR DESCRIPTION
Fix for: https://github.com/geonetwork/core-geonetwork/issues/2468

The `nil-reason` button has the class `btn-link`, this is causing it to not align with the other elements in the editor. This class is now replaced with `btn-default`.

The class `fa-fw` is added to the icon on the button to add some extra spacing between icon and label.

**Screenshot of the button after adding the `btn-default` class**

![gn-editor-improve-anchor](https://user-images.githubusercontent.com/19608667/34821322-9de57e14-f6c3-11e7-91a4-520f1baabed8.png)
