### PR TITLE
Editor table improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -645,6 +645,11 @@ form.gn-tab-xml {
       }
     }
   }
+  // no padding in column
+  .col-sm-9 {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 // search filter boxes

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1299,12 +1299,12 @@
         <xsl:variable name="elementToMoveRef"
                       select="if ($elementEditInfo) then $elementEditInfo/@ref else ''"/>
         <a
-          class="fa fa-angle-up {if ($elementEditInfo and $elementEditInfo/@up = 'true') then '' else 'invisible'}"
+          class="fa fa-angle-up {if ($elementEditInfo and $elementEditInfo/@up = 'true') then '' else 'hidden'}"
           data-gn-editor-control-move="{$elementToMoveRef}"
           data-domelement-to-move="{$domeElementToMoveRef}"
           data-direction="up" href="" tabindex="-1"></a>
         <a
-          class="fa fa-angle-down {if ($elementEditInfo and $elementEditInfo/@down = 'true') then '' else 'invisible'}"
+          class="fa fa-angle-down {if ($elementEditInfo and $elementEditInfo/@down = 'true') then '' else 'hidden'}"
           data-gn-editor-control-move="{$elementToMoveRef}"
           data-domelement-to-move="{$domeElementToMoveRef}"
           data-direction="down" href="" tabindex="-1"></a>


### PR DESCRIPTION
The padding for the column in tables in the editor (with class `gn-table`) is removed. The column labels and input elements are now aligned properly.

Replace class `invisible` with `hidden`. This last class doesn't take any whitespace in the UI and this reduces the whitespace below elements in the editor.

**Screenshot of old situation**

![gn-editor-table-old](https://user-images.githubusercontent.com/19608667/34831359-09a9c592-f6e7-11e7-86d0-aab28a64248d.png)

**Screenshot of new situation**

![gn-editor-table-new](https://user-images.githubusercontent.com/19608667/34831383-1ac79a84-f6e7-11e7-92d1-9594495f4042.png)
