### PR TITLE
do not use session to store the forward url after login

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -165,9 +165,10 @@
     </property>
     <property name="authenticationSuccessHandler">
       <bean
-        class="org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler">
+        class="org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler">
         <property name="defaultTargetUrl" value="/"/>
         <property name="targetUrlParameter" value="redirectUrl"/>
+        <property name="useReferer" value="true" />
       </bean>
     </property>
     <property name="sessionAuthenticationStrategy">


### PR DESCRIPTION
forward param in session incidentally gets overwritten by failed image/thumbnail/ajax requests, solves #2379 