### PR TITLE
Fix for #2484: Content of add online resource dropdown runs outside of the screen

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -18,7 +18,7 @@
         <span data-translate="">add</span>      
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu pull-right" role="menu">
+      <ul class="dropdown-menu" role="menu">
         <li data-ng-show="::isCategoryEnable('thumbnail') || isCategoryEnable('onlinesrc')">
           <a href=""
              data-ng-click="onlinesrcService.onOpenPopup('onlinesrc')">


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/2484

The dropdown menu was opening to the left, however when the block containing the dropdown is on the left side of the page, the dropdown 'falls' off the page.

When the class `pull-right` is removed the dropdown opens to the right, and is now accessible when the block containing the dropdown is on the left or right side of the page (even on smaller screens).