### PR TITLE
Fix for #2473: content of privilege window runs out of panel

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/popup/PopupDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/popup/PopupDirective.js
@@ -105,7 +105,7 @@
             element.css({
               left: scope.options.x ||
                   $(document.body).width() / 2 - element.width() / 2,
-              top: scope.options.y || 89 //89 is the default size of the header
+              top: scope.options.y || 60 // 50 is the default size of the header + extra margin
             });
           };
 

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -666,10 +666,16 @@ button.active [role=tooltip] {
   }
 }
 .gn-privileges-popup {
+  position: fixed !important;
   max-width: 750px;
   .gn-popup-content {
-    height: 750px;
+    vertical-align: top;
     max-height: 750px;
+    .gn-share-grid {
+      tbody {
+        max-height: 45vh;
+      }
+    }
   }
 }
 .gn-popup-title {


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/2473

Heights are adjusted so the content of the panel is contained within the panel. The maximum height of the table body inside the privileges popup now depends on the height of the screen itself.

Another issue that came up was the position of the privileges popup, it was positioned absolute just beneath the top of the screen, therefore when you open the popup when scrolled down the popup opens out of sight. The popup now has a fixed position, so it opens always where you can see it.