### PR TITLE
Fix base layer dropdown cut with many layers present

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
@@ -56,7 +56,48 @@
             layers.insertAt(0, layer);
             return false;
           };
+
+          var dropdownMenuElement;
+          // Fix problems when the dropdown menu is bigger than the panel.
+          element.on('shown.bs.dropdown', function() {
+            var dropdownToggle = element.find('.baselayer');
+            var dropdownMenu = element.find('.dropdown-menu');
+            var top = dropdownToggle.offset().top + dropdownToggle.height() ;
+            var maxHeight = 600;
+            var width = dropdownToggle.width();
+            if (scope.dropup) {
+              maxHeight = dropdownToggle.offset().top;
+              top = dropdownToggle.offset().top - dropdownToggle.height() - dropdownMenu.height();
+            }
+            if (top <= 0) {
+              top = 0;
+            }
+            var left = dropdownToggle.offset().left ;
+            dropdownMenu.css({
+              'top': top + 'px',
+              'left': left + "px",
+              'max-height': maxHeight + 'px',
+              'width': width + 'px',
+              'display': 'block',
+              'overflow-y': 'auto',
+              'position': 'absolute'
+            });
+            dropdownMenuElement = dropdownMenu;
+            $('body').append(dropdownMenuElement.detach());
+          });
+
+          element.on('hidden.bs.dropdown', function() {
+            element.append(dropdownMenuElement.css({
+              position: false,
+              height: false,
+              left:false,
+              top: false,
+              display: ''
+            }).detach());
+          });
+
         }
+
       };
     }]);
 


### PR DESCRIPTION
Base layer dropdown menu is cut when there are many layers.

![image](https://user-images.githubusercontent.com/826920/35094806-b6500fd6-fc46-11e7-968e-21980f1bfa30.png)

This PR fix this using JS to move the dropdown outside the layer's panel HTML element and positioning it calculating a fixed position. Also add a vertical scroll bar if needed
![image](https://user-images.githubusercontent.com/826920/35095178-d5b3adf0-fc47-11e7-8a45-9e44bf9fb744.png)
