### PR TITLE
Fix spatial search not working with shapefile sometimes

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -69,7 +69,6 @@ public class GeonetworkDataDirectory {
     private Path webappDir;
     private Path systemDataDir;
     private Path luceneDir;
-    private Path spatialIndexPath;
     private Path configDir;
     private Path thesauriDir;
     private Path schemaPluginsDir;
@@ -291,8 +290,6 @@ public class GeonetworkDataDirectory {
         // Set subfolder data directory
         luceneDir = setDir(jeevesServlet, webappName, handlerConfig, luceneDir, ".lucene" + KEY_SUFFIX,
             Geonet.Config.LUCENE_DIR, "index");
-        spatialIndexPath = setDir(jeevesServlet, "", handlerConfig, spatialIndexPath, "spatial" + KEY_SUFFIX,
-            null, "spatialindex");
 
         configDir = setDir(jeevesServlet, webappName, handlerConfig, configDir, ".config" + KEY_SUFFIX,
             Geonet.Config.CONFIG_DIR, "config");
@@ -525,24 +522,6 @@ public class GeonetworkDataDirectory {
      */
     public void setLuceneDir(Path luceneDir) {
         this.luceneDir = luceneDir;
-    }
-
-    /**
-     * Get the directory to store the metadata spatial index. If the spatial index is to be stored
-     * locally this is the directory to use.
-     *
-     * @return the directory to store the metadata spatial index
-     */
-    public Path getSpatialIndexPath() {
-        return spatialIndexPath;
-    }
-
-    /**
-     * Set the directory to store the metadata spatial index. If the spatial index is to be stored
-     * locally this is the directory to use.
-     */
-    public void setSpatialIndexPath(Path spatialIndexPath) {
-        this.spatialIndexPath = spatialIndexPath;
     }
 
     /**

--- a/core/src/test/java/org/fao/geonet/kernel/AbstractGeonetworkDataDirectoryTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AbstractGeonetworkDataDirectoryTest.java
@@ -58,7 +58,6 @@ public abstract class AbstractGeonetworkDataDirectoryTest extends AbstractCoreIn
         dataDirectory.setSystemDataDir(null);
         dataDirectory.setConfigDir(null);
         dataDirectory.setLuceneDir(null);
-        dataDirectory.setSpatialIndexPath(null);
         dataDirectory.setMetadataDataDir(null);
         dataDirectory.setMetadataRevisionDir(null);
         dataDirectory.setResourcesDir(null);
@@ -81,7 +80,6 @@ public abstract class AbstractGeonetworkDataDirectoryTest extends AbstractCoreIn
         final Path expectedConfigDir = expectedDataDir.resolve("config");
         assertEquals(expectedConfigDir, dataDirectory.getConfigDir());
         assertEquals(expectedDataDir.resolve("index"), dataDirectory.getLuceneDir());
-        assertEquals(expectedDataDir.resolve("spatialindex"), dataDirectory.getSpatialIndexPath());
         assertEquals(expectedDataDir.resolve("data").resolve("metadata_data"), dataDirectory.getMetadataDataDir());
         assertEquals(expectedDataDir.resolve("data").resolve("metadata_subversion"), dataDirectory.getMetadataRevisionDir());
         final Path expectedResourcesDir = expectedDataDir.resolve("data").resolve("resources");

--- a/services/src/main/java/org/fao/geonet/api/site/SiteInformation.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteInformation.java
@@ -173,16 +173,10 @@ public class SiteInformation {
         final GeonetworkDataDirectory dataDirectory = context.getBean(GeonetworkDataDirectory.class);
         Path luceneDir = dataDirectory.getLuceneDir();
         indexProperties.put("index.path", luceneDir.toAbsolutePath().normalize().toString());
-        Path lDir = dataDirectory.getSpatialIndexPath();
         if (Files.exists(luceneDir)) {
             long size = ApiUtils.sizeOfDirectory(luceneDir);
             indexProperties.put("index.size", "" + size); // lucene + Shapefile
             // if exist
-        }
-
-        if (Files.exists(lDir)) {
-            long size = ApiUtils.sizeOfDirectory(lDir);
-            indexProperties.put("index.size.lucene", "" + size);
         }
         indexProperties.put("index.lucene.config", context.getBean(LuceneConfig.class).toString());
     }
@@ -239,6 +233,6 @@ public class SiteInformation {
 
         } catch (Exception ex) {
             ex.printStackTrace();
-        } 
+        }
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/config/GetInfo.java
+++ b/services/src/main/java/org/fao/geonet/services/config/GetInfo.java
@@ -155,17 +155,12 @@ public class GetInfo implements Service {
         final GeonetworkDataDirectory dataDirectory = context.getBean(GeonetworkDataDirectory.class);
         Path luceneDir = dataDirectory.getLuceneDir();
         indexProperties.put("index.path", luceneDir.toAbsolutePath().normalize().toString());
-        Path lDir = dataDirectory.getSpatialIndexPath();
         if (Files.exists(luceneDir)) {
             long size = sizeOfDirectory(luceneDir) / 1024;
             indexProperties.put("index.size", "" + size); // lucene + Shapefile
             // if exist
         }
 
-        if (Files.exists(lDir)) {
-            long size = sizeOfDirectory(lDir) / 1024;
-            indexProperties.put("index.size.lucene", "" + size);
-        }
         indexProperties.put("index.lucene.config", context.getBean(LuceneConfig.class).toString());
     }
 

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -642,6 +642,10 @@ public class Geonetwork implements ApplicationHandler {
             logger.info("Using shapefile " + file.getAbsolutePath());
         }
         ShapefileDataStore ids = new ShapefileDataStore(file.toURI().toURL());
+        // It looks like we're facing this issue
+        // https://osgeo-org.atlassian.net/browse/GEOT-5830
+        // And spatial search does not return any results.
+        ids.setFidIndexed(false);
         ids.setNamespaceURI("http://geonetwork.org");
         ids.setMemoryMapped(false);
         ids.setCharset(Charset.forName(Constants.ENCODING));


### PR DESCRIPTION
At some point, spatial searches are not working when using Shapefile for spatial index. It looks like search by FID is not working here https://github.com/geonetwork/core-geonetwork/blob/develop/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialFilter.java#L199-L200. Reading https://osgeo-org.atlassian.net/browse/GEOT-5830, it could be related to feature deletion. 

Disabling fix index file looks to solve the issue.

Anyone having this error could try this fix ?

This PR also remove the unused spatialindex folder created in the datadir. Shapefile is created in index folder with Lucene one.