### PR TITLE
Tests for user creation, group management, creation of metadata, editing

### DIFF
--- a/integration-test/src/main/java/env/BaseTest.java
+++ b/integration-test/src/main/java/env/BaseTest.java
@@ -17,6 +17,7 @@ public interface BaseTest {
     public static WebDriver driver = Env.CreateWebDriver(Env.getBrowserName());
     public static String endPointToTest = Env.getEndPointToTest();
     public static String adminPassword = Env.getAdminPassword();
+    public static String adminUser = Env.getAdminUser();
     public static WebDriverWait wait = new WebDriverWait(BaseTest.driver, 30);
 
     MiscMethods miscmethodObj = new MiscMethods();

--- a/integration-test/src/main/java/env/Env.java
+++ b/integration-test/src/main/java/env/Env.java
@@ -123,4 +123,8 @@ public class Env {
         return Env.prop.getProperty("adminPassword");
     }
 
+    public static String getAdminUser() {
+        return Env.prop.getProperty("adminUser");
+    }
+
 }

--- a/integration-test/src/test/java/stepDefintions/PredefinedStepDefinitions.java
+++ b/integration-test/src/test/java/stepDefintions/PredefinedStepDefinitions.java
@@ -196,6 +196,7 @@ public class PredefinedStepDefinitions implements BaseTest {
     @Then("^I enter \"([^\"]*)\" into input field having (.+) \"([^\"]*)\"$")
     public void enter_text(String text, String type, String accessName) throws Exception {
         text = text.replace("{adminPassword}", adminPassword);
+        text = text.replace("{adminUser}", adminUser);
         miscmethodObj.validateLocator(type);
         inputObj.enterText(type, text, accessName);
     }

--- a/integration-test/src/test/resources/features/002.create_new_user.feature
+++ b/integration-test/src/test/resources/features/002.create_new_user.feature
@@ -1,0 +1,29 @@
+Feature: GeoNetwork Create new user
+        As a user admin I should able to create new user.
+ 
+ Scenario: I login and create a new user
+        Given I navigate to "{endPointToTest}"
+	      And I click on element having css "li.signin-dropdown"
+        And I enter "{adminUser}" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "{adminPassword}" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait for 1 sec
+        And I navigate to "{endPointToTest}/srv/eng/admin.console#/organization"
+        And I click on element having id "gn-btn-user-add"
+        And I enter "etabeta" into input field having id "username"
+        And I enter "PassTest" into input field having id "gn-user-password"
+        And I enter "PassTest" into input field having id "gn-user-password2"
+        And I enter "Eta" into input field having name "name"
+        And I enter "Beta" into input field having name "surname"
+        And I enter "etabeta@email.com" into input field having name "email"
+        And I click on element having id "gn-btn-user-save"
+        And I hover over element having css ".gn-user-info"
+        And I click on element having css ".fa-sign-out"
+        And I navigate to "{endPointToTest}"
+	      And I click on element having css "li.signin-dropdown"
+        And I enter "etabeta" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "PassTest" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait for 1 sec
+        And I hover over element having css ".gn-user-info"
+        When I click on element having css ".fa-sign-out"

--- a/integration-test/src/test/resources/features/003.delete_new_user.feature
+++ b/integration-test/src/test/resources/features/003.delete_new_user.feature
@@ -1,12 +1,15 @@
-Feature: GeoNetwork Login
-        As a user I should able to login into GeoNetwork.
+Feature: GeoNetwork Create new user
+        As a user admin I should able to create new user.
  
- Scenario: I login with valid credential
+ Scenario: I login and create a new user
         Given I navigate to "{endPointToTest}"
         And I click on element having css "li.signin-dropdown"
         And I enter "{adminUser}" into input field having xpath "//*[@id='inputUsername']"
         And I enter "{adminPassword}" into input field having xpath "//*[@id='inputPassword']"
         And I click on element having css "form > button.btn-primary"
         And I wait for 1 sec
+        And I navigate to "{endPointToTest}/srv/eng/admin.console#/organization"
+        And I click on link having partial text "Eta Beta"
+        And I click on element having css "button.btn-danger"  
         And I hover over element having css ".gn-user-info"  
         When I click on element having css ".fa-sign-out"

--- a/integration-test/src/test/resources/features/004.create_advanced_users.feature
+++ b/integration-test/src/test/resources/features/004.create_advanced_users.feature
@@ -1,0 +1,67 @@
+Feature: Create (draft) editor
+        Setup environment to test draft feature
+ 
+ Scenario: Setup environment to test draft feature
+        Given I navigate to "{endPointToTest}"
+        # Login as admin
+	      When I click on element having css "li.signin-dropdown"
+        And I enter "{adminUser}" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "{adminPassword}" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait 1 seconds for element having css "div.search-over" to display
+        
+        # Add editor
+        Then I navigate to "{endPointToTest}/srv/eng/admin.console#/organization"
+        And I click on element having id "gn-btn-user-add"
+        And I enter "editortest" into input field having id "username"
+        And I enter "editorpass" into input field having id "gn-user-password"
+        And I enter "editorpass" into input field having id "gn-user-password2"
+        And I enter "Edi" into input field having name "name"
+        And I enter "Thor" into input field having name "surname"
+        And I enter "editortest@email.com" into input field having name "email"
+        And I click on element having css "div[data-gn-multiselect*='Editor'] option"
+        And I double click on element having css "div[data-gn-multiselect*='Editor'] option"
+        And I wait 3 seconds for element having css "select[data-ng-model='currentSelectionRight'] > option" to display
+        When I click on element having id "gn-btn-user-save"
+        And I wait 2 seconds for element having css "div.alert.gn-info" to display
+        
+        # Add editor 2
+        Then I navigate to "{endPointToTest}/srv/eng/admin.console#/organization"
+        And I click on element having id "gn-btn-user-add"
+        And I enter "editortest2" into input field having id "username"
+        And I enter "editorpass" into input field having id "gn-user-password"
+        And I enter "editorpass" into input field having id "gn-user-password2"
+        And I enter "Edi" into input field having name "name"
+        And I enter "Thor 2" into input field having name "surname"
+        And I enter "editortest@email.com" into input field having name "email"
+        And I click on element having css "div[data-gn-multiselect*='Editor'] option"
+        And I double click on element having css "div[data-gn-multiselect*='Editor'] option"
+        And I wait 3 seconds for element having css "select[data-ng-model='currentSelectionRight'] > option" to display
+        When I click on element having id "gn-btn-user-save"
+        And I wait 2 seconds for element having css "div.alert.gn-info" to display
+
+        # Add reviewer
+        And I click on element having id "gn-btn-user-add"
+        And I enter "reviewertest" into input field having id "username"
+        And I enter "editorpass" into input field having id "gn-user-password"
+        And I enter "editorpass" into input field having id "gn-user-password2"
+        And I enter "Revi" into input field having name "name"
+        And I enter "Ewer" into input field having name "surname"
+        And I enter "reviewer@email.com" into input field having name "email"
+        And I click on element having css "div[data-gn-multiselect*='Reviewer'] option"
+        And I double click on element having css "div[data-gn-multiselect*='Reviewer'] option"
+        And I wait 3 seconds for element having css "select[data-ng-model='currentSelectionRight'] > option" to display
+        When I click on element having id "gn-btn-user-save"
+        Then I wait 2 seconds for element having css "div.alert.gn-info" to display
+        
+        # Import templates, just in case
+        Given I navigate to "{endPointToTest}/srv/eng/admin.console#/metadata"
+        Then I click on element having css "div.list-group > li:nth-child(1) > h4 > i"
+        Then I click on element having css "button > i.gn-recordtype-y"
+        Then I wait 10 seconds for element having css "div.panel-success" to display
+        
+        # Logout admin
+        And I hover over element having css ".gn-user-info"
+        Then I wait 1 seconds for element having css "i.fa-sign-out" to display
+        And I click on element having css "a > i.fa-sign-out"
+	      Then I wait 5 seconds for element having css "li.signin-dropdown" to display

--- a/integration-test/src/test/resources/features/010.create_and_publish_metadata.feature
+++ b/integration-test/src/test/resources/features/010.create_and_publish_metadata.feature
@@ -1,0 +1,59 @@
+Feature: Create and publish record
+        An editor creates and publishes a record
+ 
+ Scenario: Editor creates and publishes a record
+        # Login as editor
+        When I navigate to "{endPointToTest}"
+        And I wait 10 seconds for element having css "li.signin-dropdown" to display
+	      Then I click on element having css "li.signin-dropdown"
+        And I enter "editortest" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "editorpass" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait 1 seconds for element having css "div.search-over" to display
+        
+        # Create new record
+        When I navigate to "{endPointToTest}/srv/eng/catalog.edit#/create"
+        Then I click on link having partial text "preferred"
+        And I wait 10 seconds for element having css "div.btn-group > button.btn-success" to display
+        Then I click on element having css "div.btn-group > button.btn-success"
+        And I wait 10 seconds for element having css "div.gn-title" to display
+        Then I clear input field having css "div.gn-title input"
+        Then I enter "Metadata" into input field having css "div.gn-title input"
+        Then I click on element having css "button.btn-default > i.fa-sign-out"
+        And I wait for 3 sec
+        
+        # Add privileges to group for edit
+        When I navigate to "{endPointToTest}/srv/eng/catalog.edit#/board"
+        Then I click on link having text "Metadata"
+        Then I click on element having css "div.gn-md-actions-btn i.fa-cog"
+        And I wait 3 seconds for element having css "i.fa-key" to display
+        Then I click on element having css "i.fa-key"
+        Then I click on element having xpath "//*[@id="opsForm"]/table/tbody/tr[4]/td[5]/input"
+        Then I click on element having css "div.gn-privileges-popup .fa-eraser"
+        Then I wait 3 seconds for element having css "div.alert-success" to display
+        
+        # Logout as editor
+        When I hover over element having css ".gn-user-info"  
+        Then I wait 1 seconds for element having css ".fa-sign-out" to display
+        Then I click on element having css ".fa-sign-out"
+        
+        # Login as reviewer
+	      When I click on element having css "li.signin-dropdown"
+        And I enter "reviewertest" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "editorpass" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait 1 seconds for element having css "div.search-over" to display
+        
+        # Publish record
+        When I navigate to "{endPointToTest}/srv/eng/catalog.edit#/board"
+        Then I click on link having text "Metadata"
+        Then I click on element having css "div.gn-md-actions-btn i.fa-cog"
+        And I wait 10 seconds for element having css "i.fa-unlock" to display
+        Then I click on element having css "i.fa-unlock"
+        And I wait 5 seconds for element having css "div.alert-success" to display
+        
+        # Logout editor
+        When I hover over element having css ".gn-user-info"  
+        Then I wait 1 seconds for element having css ".fa-sign-out" to display
+        Then I click on element having css ".fa-sign-out"
+	      Then I wait 10 seconds for element having css "li.signin-dropdown" to display

--- a/integration-test/src/test/resources/features/011.edit_created_metadata.feature
+++ b/integration-test/src/test/resources/features/011.edit_created_metadata.feature
@@ -1,0 +1,39 @@
+Feature: Create Draft
+        When trying to edit the published record, a draft is created
+ 
+ Scenario: When trying to edit the published record, a draft is created
+        Given I navigate to "{endPointToTest}"
+        # Login as editor
+        Then I wait 10 seconds for element having css "li.signin-dropdown" to display
+	      When I click on element having css "li.signin-dropdown"
+        And I enter "editortest" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "editorpass" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait 1 seconds for element having css "div.search-over" to display
+        
+        # Edit published record       
+        When I navigate to "{endPointToTest}/srv/eng/catalog.edit#/board"
+        Then I click on link having text "Metadata"
+        Then I click on element having css ".gn-md-edit-btn"
+        And I wait 10 seconds for element having css "div.gn-title" to display
+        Then I clear input field having css "div.gn-title input"
+        Then I enter "Draft" into input field having css "div.gn-title input"
+        Then I click on element having css "button.btn-primary > i.fa-save"
+        And I wait for 3 sec
+        
+        #Check metadata has been modified
+        When I navigate to "{endPointToTest}/srv/eng/catalog.search#/search"
+        Then I accept alert
+        Then I click on link having text "Draft"
+        And I wait 10 seconds for element having css "div.gn-md-view" to display
+                
+        # Logout as editor  
+        When I hover over element having css ".gn-user-info"  
+        Then I wait 1 seconds for element having css ".fa-sign-out" to display
+        Then I click on element having css ".fa-sign-out"
+	      Then I wait 10 seconds for element having css "li.signin-dropdown" to display
+        
+        # Check metadata view as anonymous
+        When I navigate to "{endPointToTest}/srv/eng/catalog.search#/search"
+        Then I click on link having text "Draft"
+        And I wait 10 seconds for element having css "div.gn-md-view" to display

--- a/integration-test/src/test/resources/features/012.edit_with_another_editor.feature
+++ b/integration-test/src/test/resources/features/012.edit_with_another_editor.feature
@@ -1,0 +1,39 @@
+Feature: Edit with second editor
+        When another editor tries to edit a published metadata, it uses the same draft
+ 
+ Scenario: When another editor tries to edit a published metadata, it uses the same draft
+        Given I navigate to "{endPointToTest}"
+        # Login as editor2
+        Then I wait 10 seconds for element having css "li.signin-dropdown" to display
+	      When I click on element having css "li.signin-dropdown"
+        And I enter "editortest2" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "editorpass" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait 1 seconds for element having css "div.search-over" to display
+        
+        # Edit published record       
+        When I navigate to "{endPointToTest}/srv/eng/catalog.edit#/board"
+        Then I click on link having text "Draft"
+        Then I click on element having css "a.gn-md-edit-btn"
+        And I wait 10 seconds for element having css "div.gn-title" to display
+        Then I clear input field having css "div.gn-title input"
+        Then I enter "Second Version" into input field having css "div.gn-title input"
+        Then I click on element having css "button.btn-primary > i.fa-save"
+        And I wait for 3 sec
+        
+        #Check metadata has been modified
+        When I navigate to "{endPointToTest}/srv/eng/catalog.search#/search"
+        Then I accept alert
+        Then I click on link having text "Second Version"
+        And I wait 10 seconds for element having css "div.gn-md-view" to display
+                
+        # Logout as second editor  
+        When I hover over element having css ".gn-user-info"  
+        Then I wait 1 seconds for element having css ".fa-sign-out" to display
+        Then I click on element having css ".fa-sign-out"
+	      Then I wait 10 seconds for element having css "li.signin-dropdown" to display
+        
+        # Check metadata view as anonymous
+        When I navigate to "{endPointToTest}/srv/eng/catalog.search#/search"
+        Then I click on link having text "Second Version"
+        And I wait 10 seconds for element having css "div.gn-md-view" to display

--- a/integration-test/src/test/resources/features/013.edit_and_publish_with_reviewer.feature
+++ b/integration-test/src/test/resources/features/013.edit_and_publish_with_reviewer.feature
@@ -1,0 +1,46 @@
+Feature: Edit with reviewer
+        When a reviewer tries to edit a published metadata, it uses the same draft
+ 
+ Scenario: When a reviewer tries to edit a published metadata, it uses the same draft
+        Given I navigate to "{endPointToTest}"
+        # Login as editor
+        Then I wait 10 seconds for element having css "li.signin-dropdown" to display
+	      When I click on element having css "li.signin-dropdown"
+        And I enter "reviewertest" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "editorpass" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait 1 seconds for element having css "div.search-over" to display
+        
+        # Edit published record       
+        When I navigate to "{endPointToTest}/srv/eng/catalog.edit#/board"
+        Then I click on link having text "Second Version"
+        Then I click on element having css "a.gn-md-edit-btn"
+        And I wait 10 seconds for element having css "div.gn-title" to display
+        Then I clear input field having css "div.gn-title input"
+        Then I enter "Third Version" into input field having css "div.gn-title input"
+        Then I click on element having css "button.btn-primary > i.fa-save"
+        And I wait for 3 sec
+        
+        #Check metadata has been modified
+        When I navigate to "{endPointToTest}/srv/eng/catalog.search#/search"
+        Then I accept alert
+        Then I click on link having text "Third Version"
+        And I wait 10 seconds for element having css "div.gn-md-view" to display
+        
+        # Unpublish record
+        When I navigate to "{endPointToTest}/srv/eng/catalog.edit#/board"
+        Then I click on link having text "Third Version"
+        Then I click on element having css "div.gn-md-actions-btn i.fa-cog"
+        And I wait 10 seconds for element having css "i.fa-lock" to display
+        Then I click on element having css "i.fa-lock"
+        And I wait 5 seconds for element having css "div.alert-success" to display
+                
+        # Logout as reviewer
+        When I hover over element having css ".gn-user-info"  
+        Then I wait 1 seconds for element having css ".fa-sign-out" to display
+        Then I click on element having css ".fa-sign-out"
+	      Then I wait 10 seconds for element having css "li.signin-dropdown" to display
+        
+        # Check metadata not viewed as anonymous
+        When I navigate to "{endPointToTest}/srv/eng/catalog.search#/search"
+        Then element having xpath "//*a[title='Third Version']" should not be present

--- a/integration-test/src/test/resources/features/998.cleanup.feature
+++ b/integration-test/src/test/resources/features/998.cleanup.feature
@@ -1,0 +1,36 @@
+Feature: Cleanup Draft Tests
+        Remove everything we created for the tests
+ 
+ Scenario: Remove everything we created for the tests
+        # Login as admin
+        Given I navigate to "{endPointToTest}"
+	      When I click on element having css "li.signin-dropdown"
+        And I enter "{adminUser}" into input field having xpath "//*[@id='inputUsername']"
+        And I enter "{adminPassword}" into input field having xpath "//*[@id='inputPassword']"
+        And I click on element having css "form > button.btn-primary"
+        And I wait 1 seconds for element having css "div.search-over" to display
+        
+        # Remove all records
+        When I navigate to "{endPointToTest}/srv/eng/catalog.edit#/board"
+        Then I click on element having css "div.gn-editor-board button.dropdown-toggle"
+        Then I click on element having xpath "//a[@data-ng-click='selectAll()']"
+        Then I click on element having css "div.gn-selection-actions"
+        Then I click on element having css "div.gn-selection-actions i.fa-times"
+        Then I accept alert
+        And I wait 3 seconds for element having css "div.alert-warning" to display
+        
+        # Remove editors
+        When I navigate to "{endPointToTest}/srv/eng/admin.console#/organization"
+        Then I click on link having partial text "Edi Thor"
+        Then I click on element having css "button.btn-danger"
+        And I wait for 1 sec
+        Then I click on link having partial text "Revi Ewer"
+        Then I click on element having css "button.btn-danger"
+        And I wait for 1 sec
+        Then I click on link having partial text "Edi Thor"
+        Then I click on element having css "button.btn-danger"
+        
+        # Logout   
+        When I hover over element having css ".gn-user-info"  
+        Then I wait 1 seconds for element having css ".fa-sign-out" to display
+        Then I click on element having css ".fa-sign-out"

--- a/integration-test/src/test/resources/features/999.exit.feature
+++ b/integration-test/src/test/resources/features/999.exit.feature
@@ -1,0 +1,7 @@
+Feature: GeoNetwork Exit
+        As a user at some point I will close the browser...
+ 
+ Scenario: Closing the browser
+        Given I navigate to "{endPointToTest}"
+        And I wait for 1 sec
+        Then I close browser

--- a/integration-test/src/test/resources/system.properties
+++ b/integration-test/src/test/resources/system.properties
@@ -1,2 +1,3 @@
-endPointToTest.url=http://localhost:8080/geonetwork/
+endPointToTest.url=http://localhost:8080/geonetwork
+adminUser=admin
 adminPassword=admin


### PR DESCRIPTION
On this commit I add some basic testing. The idea is to run this basic tests always before we do any release, to make sure there are no critical obvious bugs on the new release.

To run this, you have to run two separated maven commands:

On one hand you need to run a local GeoNetwork: **mvn jetty:run** on **web** folder.
On the other hand you need to run the tests: like **mvn test -Dwebdriver.chrome.driver=$path/chromedriver -Dbrowser=chrome** on **integration-tests** folder
See on the README.md of integration-tests folder to know more about running this tests.

It takes several minutes, be patient. 

The tests included here are:
 * Creation of users (with roles on groups)
 * Creation of metadata 
 * Import of templates
 * Check an editor of the same group can edit a metadata with privileges on that group
 * Check a reviewer of the same group can edit a metadata with privileges on that group
 * Check a reviewer can publish and unpublish
 * Check publish means anonymous users can see the record
 * Check unpublish hides the record from anonymous users
 * Cleanup of data used

I plan to extend this tests with more critical usecases.