### PR TITLE
Fix $translate dependency injection in gnKmlImport directive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -185,7 +185,8 @@
   module.directive('gnKmlImport', [
     'ngeoDecorateLayer',
     'gnAlertService',
-    function(ngeoDecorateLayer, gnAlertService) {
+    '$translate',
+    function(ngeoDecorateLayer, gnAlertService, $translate) {
       return {
         restrict: 'A',
         replace: true,


### PR DESCRIPTION
Fixing $translate dependency injection in gnKmlImport directive. This fix makes possible to load correctly a layer over the map through a kmz file.