### PR TITLE
Fix error in gnRelated directive when the observer is missing

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -175,7 +175,9 @@
                           controller.finishRequest(elem, scope.relationFound);
                         }
                      } , function() {
+                      if (controller) {
                         controller.finishRequest(elem, false);
+                      }
                   });
                 }
               };


### PR DESCRIPTION
This prevents a JS error when `gn-related` is not encapsulated in a `gn-related-observer` controller.