### PR TITLE
Improve iso19139 CSW brief & summary output

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-brief.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-brief.xsl
@@ -35,6 +35,13 @@
 
   <!-- =================================================================== -->
 
+  <!-- Convert ISO profile elements to their base type -->
+  <xsl:template match="*[@gco:isoType]">
+    <xsl:element name="{@gco:isoType}">
+      <xsl:apply-templates select="@*[name() != 'gco:isoType']|*"/>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']">
     <xsl:variable name="info" select="geonet:info"/>
     <xsl:element name="{if (@gco:isoType) then @gco:isoType else name()}">

--- a/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-summary.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-summary.xsl
@@ -36,6 +36,13 @@
 
   <!-- =================================================================== -->
 
+  <!-- Convert ISO profile elements to their base type -->
+  <xsl:template match="*[@gco:isoType]">
+    <xsl:element name="{@gco:isoType}">
+      <xsl:apply-templates select="@*[name() != 'gco:isoType']|*"/>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']">
     <xsl:variable name="info" select="geonet:info"/>
     <xsl:element name="{if (@gco:isoType) then @gco:isoType else name()}">


### PR DESCRIPTION
Conversion of an element to its base type indicated in the `gco:isoType` attribute was done in the `full` output, but not in `brief` or `summary`.

This should not change anything for the iso19139 schema, but will give a more consistent behaviour for other schemas derived from it. Also facilitates extending the stylesheet for other schemas.