### PR TITLE
Make distinction between user search and internal queries made by the app

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/directoryassociatedmd/DirectoryAssociatedMdDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryassociatedmd/DirectoryAssociatedMdDirective.js
@@ -50,6 +50,7 @@
                 sortBy: 'title',
                 _xlink: '*'
               },
+              internal: true,
               sortbyValues: [
                 {
                   sortBy: 'title'

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -92,6 +92,7 @@
                 pre: function preLink(scope) {
                   scope.searchObj = {
                     any: '',
+                    internal: true,
                     params: {
                       _isTemplate: 's',
                       any: '',
@@ -333,6 +334,7 @@
              return {
                pre: function preLink(scope) {
                  scope.searchObj = {
+                   internal: true,
                    defaultParams: {
                      _isTemplate: 's',
                      any: '',

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -187,6 +187,7 @@
             link: {
               pre: function preLink(scope) {
                 scope.searchObj = {
+                  internal: true,
                   params: {}
                 };
                 scope.modelOptions =
@@ -776,6 +777,7 @@
                 scope.map = null;
 
                 scope.searchObj = {
+                  internal: true,
                   params: {
                     sortBy: 'title'
                   }
@@ -1437,6 +1439,7 @@
               return {
                 pre: function preLink(scope) {
                   scope.searchObj = {
+                    internal: true,
                     params: {}
                   };
                   scope.modelOptions =
@@ -1602,6 +1605,7 @@
               return {
                 pre: function preLink(scope) {
                   scope.searchObj = {
+                    internal: true,
                     any: '',
                     params: {}
                   };
@@ -1690,6 +1694,7 @@
                 pre: function preLink(scope) {
                   scope.ctrl = {};
                   scope.searchObj = {
+                    internal: true,
                     any: '',
                     defaultParams: {
                       any: '',

--- a/web-ui/src/main/resources/catalog/components/edit/recordfragmentselector/RecordFragmentSelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/recordfragmentselector/RecordFragmentSelector.js
@@ -54,6 +54,7 @@
                pre: function preLink(scope) {
                  scope.searchObj = {
                    any: '',
+                   internal: true,
                    params: {
                      any: '',
                      from: 1,

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -192,7 +192,9 @@
 
       var finalParams = angular.extend(params, hiddenParams);
       $scope.finalParams = finalParams;
-      gnSearchManagerService.gnSearch(finalParams).then(
+      gnSearchManagerService.gnSearch(
+                              finalParams, null,
+                              $scope.searchObj.internal).then(
           function(data) {
             $scope.searchResults.records = [];
             for (var i = 0; i < data.metadata.length; i++) {

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchManagerService.js
@@ -191,9 +191,10 @@
 
       // TODO: remove search call to use params instead
       // of url and use gnSearch only (then rename it to search)
-      var gnSearch = function(params, error) {
+      var gnSearch = function(params, error, internal) {
         var defer = $q.defer();
-        gnHttp.callService('search', params).
+        gnHttp.callService(internal ? 'internalSearch' : 'search',
+            params).
             success(function(data, status) {
               defer.resolve(format(data));
             }).

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -46,6 +46,7 @@
              gnSearchManagerService, gnUtilityService, $timeout) {
 
       $scope.searchObj = {
+        internal: true,
         params: {
           template: 'y or s or n',
           sortBy: 'title'

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -47,6 +47,7 @@
     function($scope, gnSearchSettings) {
       $scope.searchObj = {
         permalink: false,
+        internal: true,
         filters: gnSearchSettings.filters,
         params: {
           sortBy: 'popularity',
@@ -62,6 +63,7 @@
     function($scope, gnSearchSettings) {
       $scope.searchObj = {
         permalink: false,
+        internal: true,
         filters: gnSearchSettings.filters,
         params: {
           sortBy: 'changeDate',
@@ -79,6 +81,7 @@
         'search/resultsview/partials/viewtemplates/grid4maps.html';
       $scope.searchObj = {
         permalink: false,
+        internal: true,
         filters: {
           'type': 'interactiveMap'
         },


### PR DESCRIPTION

This is mainly to improve search statistics reports and have a more representative search service information.

![image](https://user-images.githubusercontent.com/1701393/35928811-60bf7e1a-0c2e-11e8-9574-e1d0d2d39755.png)

Currently "qi" which could be defined as internal search service is never used by the Angular app - as it was in the ExtJS app.