### PR TITLE
Revert PR #2476

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -167,10 +167,9 @@
     </property>
     <property name="authenticationSuccessHandler">
       <bean
-        class="org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler">
+        class="org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler">
         <property name="defaultTargetUrl" value="/"/>
         <property name="targetUrlParameter" value="redirectUrl"/>
-        <property name="useReferer" value="true" />
       </bean>
     </property>
     <property name="sessionAuthenticationStrategy">


### PR DESCRIPTION
Revert PR #2476 since use referer keeps the user in the login page and doesn't redirect to the protected resource as stated in issue #2379.