### PR TITLE
ISSUE 2379 - Applying a match filter to RequestCache

### DIFF
--- a/core/src/main/java/org/fao/geonet/web/GeoNetworkHttpSessionRequestCache.java
+++ b/core/src/main/java/org/fao/geonet/web/GeoNetworkHttpSessionRequestCache.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.web;
+
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.web.PortResolver;
+import org.springframework.security.web.PortResolverImpl;
+import org.springframework.security.web.savedrequest.DefaultSavedRequest;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * The Class GeoNetworkHttpSessionRequestCache extends the basic one HttpSessionRequestCache
+ * from Spring security to implement a filter on URLs to store in session
+ */
+public class GeoNetworkHttpSessionRequestCache extends HttpSessionRequestCache {
+
+    /** The Constant SAVED_REQUEST. */
+    static final String SAVED_REQUEST = "SPRING_SECURITY_SAVED_REQUEST";
+
+    /** The port resolver. */
+    private PortResolver portResolver = new PortResolverImpl();
+
+    /** The create session allowed. */
+    private boolean createSessionAllowed = true;
+
+    /** The allowed urls matcher. */
+    private RequestMatcher allowedUrlsMatcher;
+
+    /**
+     * Stores the current request, provided the configuration properties allow it.
+     *
+     * @param request the request
+     * @param response the response
+     */
+    @Override
+    public void saveRequest(HttpServletRequest request, HttpServletResponse response) {
+        // If the url match the pattern
+        if (allowedUrlsMatcher.matches(request)) {
+            DefaultSavedRequest savedRequest = new DefaultSavedRequest(request, portResolver);
+
+            if (createSessionAllowed || request.getSession(false) != null) {
+                // Store the HTTP request itself. Used by AbstractAuthenticationProcessingFilter
+                // for redirection after successful authentication (SEC-29)
+                request.getSession().setAttribute(SAVED_REQUEST, savedRequest);                
+            }
+        }
+    }
+
+    /**
+     * Sets the allowed urls patterns.
+     *
+     * @param allowedUrlsPatterns the new allowed urls patterns
+     */
+    public void setAllowedUrlsPatterns(Set<String> allowedUrlsPatterns) {
+        this.allowedUrlsMatcher =  new RegexRequestMatcher(String.join("|", allowedUrlsPatterns), null);
+    }
+
+    /**
+     * Sets the creates the session allowed.
+     *
+     * @param createSessionAllowed the new creates the session allowed
+     */
+    @Override
+    public void setCreateSessionAllowed(boolean createSessionAllowed) {
+        this.createSessionAllowed = createSessionAllowed;
+    }
+
+    /**
+     * Sets the port resolver.
+     *
+     * @param portResolver the new port resolver
+     */
+    @Override
+    public void setPortResolver(PortResolver portResolver) {
+        this.portResolver = portResolver;
+    }
+
+}

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -143,8 +143,16 @@
     <property name="allowSessionCreation" value="true"/>
   </bean>
 
-  <bean id="formLoginFilter"
-        class="org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter">
+  <bean class="org.fao.geonet.web.GeoNetworkHttpSessionRequestCache" id="requestCache">
+    <property name="allowedUrlsPatterns">
+      <set>
+        <value>/[a-zA-Z0-9_\-]+/[a-z]{2,3}/catalog.*</value>
+        <value>/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.console</value>
+      </set>
+    </property>
+  </bean>
+
+  <bean id="formLoginFilter" class="org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter">
     <property name="postOnly" value="true"/>
     <property name="usernameParameter" value="username"/>
     <property name="passwordParameter" value="password"/>
@@ -170,6 +178,7 @@
         class="org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler">
         <property name="defaultTargetUrl" value="/"/>
         <property name="targetUrlParameter" value="redirectUrl"/>
+        <property name="requestCache" ref="requestCache" />
       </bean>
     </property>
     <property name="sessionAuthenticationStrategy">
@@ -224,6 +233,7 @@
         class="org.springframework.security.web.access.ExceptionTranslationFilter">
     <constructor-arg index="0" ref="authenticationEntryPoint"/>
     <property name="accessDeniedHandler" ref="accessDeniedHandler"/>
+    <property name="requestCache" ref="requestCache" />
   </bean>
 
   <bean id="defaultAuthenticationEntryPoint"


### PR DESCRIPTION
The issue is described here https://github.com/geonetwork/core-geonetwork/issues/2379

![servicenotavailable](https://user-images.githubusercontent.com/1323093/36158249-29bcac1e-10dc-11e8-8364-e84e60a9f520.png)

It happens randomly after valid sign in process.

This happens because multiple requests are done by ajax calls to server and HttpSessionRequestCache (from spring security web) stores only the last request and then redirect to this url after successful login. 
This solution proposed here is to contain the problem by filtering the urls where the browser should not be redirect.
In this PR are considered valid the any .../catalog.*/... and .../admin.console/... but probably there are more.

This bug is really annoying, please let me know your thoughts.

