### PR TITLE
Spatial search: Bbox filters

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -513,6 +513,8 @@ public final class Geonet {
             public static final String CROSSES = "crosses";
             public static final String TOUCHES = "touches";
             public static final String WITHIN = "within";
+            public static final String WITHIN_BBOX = "within_bbox";
+            public static final String OVERLAPS_BBOX = "overlaps_bbox";
         }
 
         /**

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -111,7 +111,6 @@ import org.fao.geonet.kernel.search.spatial.SpatialIndexWriter;
 import org.fao.geonet.kernel.search.spatial.TouchesFilter;
 import org.fao.geonet.kernel.search.spatial.WithinFilter;
 import org.fao.geonet.kernel.setting.SettingInfo;
-import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.geotools.data.DataStore;
 import org.geotools.data.DefaultTransaction;
@@ -125,6 +124,8 @@ import org.jdom.Element;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.capability.FilterCapabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -142,6 +143,12 @@ import jeeves.server.context.ServiceContext;
  * Indexes metadata using Lucene.
  */
 public class SearchManager implements ISearchManager {
+    private static Logger SE_LOGGER = LoggerFactory.getLogger(Geonet.SEARCH_ENGINE);
+    private static Logger LU_LOGGER = LoggerFactory.getLogger(Geonet.LUCENE);
+    private static Logger IE_LOGGER = LoggerFactory.getLogger(Geonet.INDEX_ENGINE);
+    private static Logger SP_LOGGER = LoggerFactory.getLogger(Geonet.SPATIAL);
+
+
     public static final String INDEXING_ERROR_FIELD = "_indexingError";
     private static final String INDEXING_ERROR_MSG = "_indexingErrorMsg";
     private static final String SEARCH_STYLESHEETS_DIR_PATH = "xml/search";
@@ -181,9 +188,7 @@ public class SearchManager implements ISearchManager {
      * @param ignoreChars characters that should be ignored.  For example ' or -.
      */
     private static Analyzer createGeoNetworkAnalyzer(final Set<String> stopwords, final char[] ignoreChars) {
-        if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE)) {
-            Log.debug(Geonet.SEARCH_ENGINE, "Creating GeoNetworkAnalyzer");
-        }
+        SE_LOGGER.debug("Creating GeoNetworkAnalyzer");
         return new GeoNetworkAnalyzer(stopwords, ignoreChars);
     }
 
@@ -222,19 +227,14 @@ public class SearchManager implements ISearchManager {
      *                     analayzer.
      */
     public static PerFieldAnalyzerWrapper getAnalyzer(String language, boolean forSearching) {
-        if (Log.isDebugEnabled(Geonet.LUCENE)) {
-            Log.debug(Geonet.LUCENE, "Get analyzer for searching: " + forSearching + " and language: " + language);
-        }
-
+        LU_LOGGER.debug("Get analyzer for searching: {} and language: {}", forSearching, language);
         Map<String, Analyzer> map = forSearching ? searchAnalyzerMap : analyzerMap;
 
         PerFieldAnalyzerWrapper analyzer = (PerFieldAnalyzerWrapper) map.get(language);
         if (analyzer != null) {
             return analyzer;
         } else {
-            if (Log.isDebugEnabled(Geonet.LUCENE)) {
-                Log.debug(Geonet.LUCENE, "Returning default analyzer.");
-            }
+            LU_LOGGER.debug( "Returning default analyzer.");
             return forSearching ? _searchAnalyzer : _analyzer;
         }
     }
@@ -243,42 +243,32 @@ public class SearchManager implements ISearchManager {
      * Returns a default- (hardcoded) configured PerFieldAnalyzerWrapper, creating it if necessary.
      */
     private static void initHardCodedAnalyzers(char[] ignoreChars) throws IOException {
-        if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE))
-            Log.debug(Geonet.SEARCH_ENGINE, "initializing hardcoded analyzers");
+        SE_LOGGER.debug("initializing hardcoded analyzers");
         // no default analyzer instantiated: create one
         if (_defaultAnalyzer == null) {
             // create hardcoded default PerFieldAnalyzerWrapper w/o stopwords
             _defaultAnalyzer = SearchManager.createHardCodedPerFieldAnalyzerWrapper(null, ignoreChars);
         }
         if (_stopwordsDir == null || !Files.isDirectory(_stopwordsDir)) {
-            Log.warning(Geonet.SEARCH_ENGINE, "Invalid stopwords directory " + _stopwordsDir +
-                ", not using any stopwords.");
+            SE_LOGGER.warn("Invalid stopwords directory {}, not using any stopwords.", _stopwordsDir);
         } else {
-            if (Log.isDebugEnabled(Geonet.LUCENE)) {
-                Log.debug(Geonet.LUCENE, "loading stopwords");
-            }
-
+            LU_LOGGER.debug("loading stopwords");
             try (DirectoryStream<Path> paths = Files.newDirectoryStream(_stopwordsDir)) {
                 for (Path stopwordsFile : paths) {
                     final String fileName = stopwordsFile.getFileName().toString();
                     String language = fileName.substring(0, fileName.indexOf('.'));
                     if (language.length() != 2) {
-                        Log.info(Geonet.LUCENE, "invalid iso 639-1 code for language: " + language);
+                        LU_LOGGER.info("invalid iso 639-1 code for language: {}", language);
                     }
                     // look up stopwords for that language
                     Set<String> stopwordsForLanguage = StopwordFileParser.parse(stopwordsFile.toAbsolutePath());
                     if (stopwordsForLanguage != null) {
-                        if (Log.isDebugEnabled(Geonet.LUCENE)) {
-                            Log.debug(Geonet.LUCENE, "loaded # " + stopwordsForLanguage.size() + " stopwords for language " + language);
-                        }
+                        LU_LOGGER.debug("loaded # {} stopwords for language {}", stopwordsForLanguage.size(), language);
                         Analyzer languageAnalyzer = SearchManager.createHardCodedPerFieldAnalyzerWrapper(stopwordsForLanguage, ignoreChars);
                         analyzerMap.put(language, languageAnalyzer);
                     } else {
-                        if (Log.isDebugEnabled(Geonet.LUCENE)) {
-                            Log.debug(Geonet.LUCENE, "failed to load any stopwords for language " + language);
-                        }
+                        LU_LOGGER.debug("failed to load any stopwords for language {}", language);
                     }
-
                 }
             }
         }
@@ -304,9 +294,6 @@ public class SearchManager implements ISearchManager {
         return field;
     }
 
-    /**
-     * TODO javadoc.
-     */
     private static Constructor<? extends SpatialFilter> constructor(Class<? extends SpatialFilter> clazz)
         throws SecurityException, NoSuchMethodException {
         return clazz.getConstructor(org.apache.lucene.search.Query.class, int.class, Geometry.class, Pair.class);
@@ -333,9 +320,7 @@ public class SearchManager implements ISearchManager {
         final char[] ignoreChars = settingInfo.getAnalyzerIgnoreChars();
         Analyzer analyzer = null;
         try {
-            if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE)) {
-                Log.debug(Geonet.SEARCH_ENGINE, "Creating analyzer defined in Lucene config:" + analyzerClassName);
-            }
+            SE_LOGGER.debug("Creating analyzer defined in Lucene config: {}", analyzerClassName);
             // GNA analyzer
             if (analyzerClassName.equals("org.fao.geonet.kernel.search.GeoNetworkAnalyzer")) {
                 analyzer = SearchManager.createGeoNetworkAnalyzer(stopwords, ignoreChars);
@@ -348,33 +333,31 @@ public class SearchManager implements ISearchManager {
                     Object[] inParamsArray = _luceneConfig.getAnalyzerParameter((field == null ? "" : field) + analyzerClassName);
 
                     try {
-                        if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE)) {
-                            Log.debug(Geonet.SEARCH_ENGINE, " Creating analyzer with parameter");
-                        }
+                        SE_LOGGER.debug(" Creating analyzer with parameter");
                         Constructor<? extends Analyzer> c = analyzerClass.getConstructor(clTypesArray);
                         analyzer = c.newInstance(inParamsArray);
                     } catch (Exception x) {
-                        Log.warning(Geonet.SEARCH_ENGINE, "   Failed to create analyzer with parameter: " + x.getMessage());
+                        SE_LOGGER.warn("   Failed to create analyzer with parameter: {}",x.getMessage());
                         x.printStackTrace();
                         // Try using a default constructor without parameter
-                        Log.warning(Geonet.SEARCH_ENGINE, "   Now trying without parameter");
+                        SE_LOGGER.warn("   Now trying without parameter");
                         analyzer = analyzerClass.newInstance();
                     }
                 } catch (Exception y) {
-                    Log.warning(Geonet.SEARCH_ENGINE, "Failed to create analyzer as specified in lucene config, default analyzer will " +
-                        "be used for field " + field + ". Exception message is: " + y.getMessage());
+                    SE_LOGGER.warn("Failed to create analyzer as specified in lucene config, default analyzer will " +
+                        "be used for field {}. Exception message is: {}", field, y.getMessage());
                     y.printStackTrace();
                     // abandon and continue with next field defined in lucene config
                 }
             }
         } catch (Exception z) {
-            Log.warning(Geonet.SEARCH_ENGINE, " Error on analyzer initialization: " + z.getMessage() + ". Check your Lucene " +
-                "configuration. Hardcoded default analyzer will be used for field " + field);
+            SE_LOGGER.warn(" Error on analyzer initialization: {}. Check your Lucene " +
+                "configuration. Hardcoded default analyzer will be used for field {}", z.getMessage(), field);
             z.printStackTrace();
         } finally {
             // creation of analyzer has failed, default to GeoNetworkAnalyzer
             if (analyzer == null) {
-                Log.warning(Geonet.SEARCH_ENGINE, "Creating analyzer has failed, defaulting to GeoNetworkAnalyzer");
+                SE_LOGGER.warn("Creating analyzer has failed, defaulting to GeoNetworkAnalyzer");
                 analyzer = SearchManager.createGeoNetworkAnalyzer(stopwords, ignoreChars);
             }
         }
@@ -396,10 +379,8 @@ public class SearchManager implements ISearchManager {
         LuceneConfig luceneConfig = applicationContext.getBean(LuceneConfig.class);
 
         String defaultAnalyzerClass = luceneConfig.getDefaultAnalyzerClass();
-        if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE)) {
-            Log.debug(Geonet.SEARCH_ENGINE, "createAnalyzer start");
-            Log.debug(Geonet.SEARCH_ENGINE, "defaultAnalyzer defined in Lucene config: " + defaultAnalyzerClass);
-        }
+        SE_LOGGER.debug("createAnalyzer start");
+        SE_LOGGER.debug("defaultAnalyzer defined in Lucene config: {}", defaultAnalyzerClass);
         // there is no default analyzer defined in lucene config
 
         char[] ignoreChars = settingInfo.getAnalyzerIgnoreChars();
@@ -410,12 +391,9 @@ public class SearchManager implements ISearchManager {
             // there is an analyzer defined in lucene config
 
             if (_stopwordsDir == null || !Files.isDirectory(_stopwordsDir)) {
-                Log.warning(Geonet.SEARCH_ENGINE, "Invalid stopwords directory " + _stopwordsDir +
-                    ", not using any stopwords.");
+                SE_LOGGER.warn("Invalid stopwords directory {}, not using any stopwords.", _stopwordsDir);
             } else {
-                if (Log.isDebugEnabled(Geonet.LUCENE)) {
-                    Log.debug(Geonet.LUCENE, "Loading stopwords and creating per field anlayzer ...");
-                }
+                LU_LOGGER.debug("Loading stopwords and creating per field anlayzer ...");
 
                 // One per field analyzer is created for each stopword list available using GNA as default analyzer
                 // Configuration can't define different analyzer per language.
@@ -426,15 +404,12 @@ public class SearchManager implements ISearchManager {
                         String language = fileName.substring(0, fileName.indexOf('.'));
                         // TODO check for valid ISO 639-2 codes could be better than this
                         if (language.length() != 3) {
-                            Log.warning(Geonet.LUCENE, "Stopwords file with incorrect ISO 639-2 language as filename: " + language);
+                            LU_LOGGER.warn("Stopwords file with incorrect ISO 639-2 language as filename: {}", language);
                         }
                         // look up stopwords for that language
                         Set<String> stopwordsForLanguage = StopwordFileParser.parse(stopwordsFile.toAbsolutePath());
                         if (stopwordsForLanguage != null) {
-                            if (Log.isDebugEnabled(Geonet.LUCENE)) {
-                                Log.debug(Geonet.LUCENE, "Loaded # " + stopwordsForLanguage.size() + " stopwords for language " + language);
-
-                            }
+                            LU_LOGGER.debug("Loaded # {} stopwords for language {}", stopwordsForLanguage.size(), language);
 
                             // Configure per field analyzer and register them to language map of pfa
                             // ... for indexing
@@ -446,9 +421,7 @@ public class SearchManager implements ISearchManager {
                                 searchAnalyzerMap, language, stopwordsForLanguage);
 
                         } else {
-                            if (Log.isDebugEnabled(Geonet.LUCENE)) {
-                                Log.debug(Geonet.LUCENE, "Failed to load any stopwords for language " + language);
-                            }
+                            LU_LOGGER.debug("Failed to load any stopwords for language {}", language);
                         }
                     }
                 }
@@ -479,9 +452,8 @@ public class SearchManager implements ISearchManager {
         Set<String> stopwordsForLanguage) {
 
         // Create the default analyzer according to Lucene config
-        if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE)) {
-            Log.debug(Geonet.SEARCH_ENGINE, " Default analyzer class: " + defaultAnalyzerClass);
-        }
+
+        SE_LOGGER.debug(" Default analyzer class: {}", defaultAnalyzerClass);
         Analyzer defaultAnalyzer = createAnalyzerFromLuceneConfig(defaultAnalyzerClass, null, stopwordsForLanguage);
 
         Map<String, Analyzer> extraFieldAnalyzers = new HashMap<String, Analyzer>();
@@ -491,9 +463,7 @@ public class SearchManager implements ISearchManager {
         for (Entry<String, String> e : fieldAnalyzers.entrySet()) {
             String field = e.getKey();
             String aClassName = e.getValue();
-            if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE)) {
-                Log.debug(Geonet.SEARCH_ENGINE, " Add analyzer for field: " + field + "=" + aClassName);
-            }
+            SE_LOGGER.debug(" Add analyzer for field: {}={}", field, aClassName);
             Analyzer analyzer = createAnalyzerFromLuceneConfig(aClassName, field, stopwordsForLanguage);
             extraFieldAnalyzers.put(field, analyzer);
         }
@@ -509,9 +479,6 @@ public class SearchManager implements ISearchManager {
         return pfa;
     }
 
-    /**
-     * TODO javadoc.
-     */
     public void init(int maxWritesInTransaction) throws Exception {
         ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         GeonetworkDataDirectory geonetworkDataDirectory = applicationContext.getBean(GeonetworkDataDirectory.class);
@@ -565,9 +532,6 @@ public class SearchManager implements ISearchManager {
         return null;
     }
 
-    /**
-     * TODO javadoc.
-     */
     private void createDocumentBoost() {
         ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         LuceneConfig luceneConfig = applicationContext.getBean(LuceneConfig.class);
@@ -580,15 +544,14 @@ public class SearchManager implements ISearchManager {
                 Class<?>[] clTypesArray = luceneConfig.getDocumentBoostParameterClass();
                 Object[] inParamsArray = luceneConfig.getDocumentBoostParameter();
                 try {
-                    if (Log.isDebugEnabled(Geonet.SEARCH_ENGINE))
-                        Log.debug(Geonet.SEARCH_ENGINE, " Creating document boost object with parameter");
+                    SE_LOGGER.debug(" Creating document boost object with parameter");
                     Constructor<? extends DocumentBoosting> c = clazz.getConstructor(clTypesArray);
                     _documentBoostClass = c.newInstance(inParamsArray);
                 } catch (Exception x) {
-                    Log.warning(Geonet.SEARCH_ENGINE, "   Failed to create document boost object with parameter: " + x.getMessage());
+                    SE_LOGGER.warn("   Failed to create document boost object with parameter: {}", x.getMessage());
                     x.printStackTrace();
                     // Try using a default constructor without parameter
-                    Log.warning(Geonet.SEARCH_ENGINE, "   Now trying without parameter");
+                    SE_LOGGER.warn("   Now trying without parameter");
                     _documentBoostClass = clazz.newInstance();
                 }
             } catch (Exception e) {
@@ -605,25 +568,16 @@ public class SearchManager implements ISearchManager {
         createDocumentBoost();
     }
 
-    /**
-     * TODO javadoc.
-     */
     public synchronized void disableOptimizer() throws Exception {
-        Log.info(Geonet.INDEX_ENGINE, "Scheduling thread that optimizes lucene index is disabled");
+        IE_LOGGER.info("Scheduling thread that optimizes lucene index is disabled");
         _luceneOptimizerManager.cancel();
     }
 
-    /**
-     * TODO javadoc.
-     */
     public synchronized void rescheduleOptimizer(
         Calendar optimizerBeginAt, int optimizerInterval) throws Exception {
         _luceneOptimizerManager.reschedule(optimizerBeginAt, optimizerInterval);
     }
 
-    /**
-     * TODO javadoc.
-     */
     public MetaSearcher newSearcher(SearcherType type, String stylesheetName) throws Exception {
         ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         SchemaManager schemaManager = applicationContext.getBean(SchemaManager.class);
@@ -695,7 +649,7 @@ public class SearchManager implements ISearchManager {
             _spatial.writer().delete(id);
             _spatial.writer().index(schemaDir, id, metadata);
         } catch (Exception e) {
-            Log.error(Geonet.INDEX_ENGINE, "Failed to properly index geometry of metadata " + id + ". Error: " + e.getMessage(), e);
+            IE_LOGGER.error("Failed to properly index geometry of metadata {}. Error: {}", id, e.getMessage());
             moreFields.add(SearchManager.makeField(INDEXING_ERROR_FIELD, "1", true, true));
             moreFields.add(SearchManager.makeField(INDEXING_ERROR_MSG, "GNIDX-GEOWRITE||" + e.getMessage(), true, false));
         }
@@ -708,31 +662,26 @@ public class SearchManager implements ISearchManager {
         }
     }
 
-    /**
-     * TODO javadoc.
-     */
     public void deleteGroup(String fld, String txt) throws Exception {
         ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         LuceneIndexLanguageTracker tracker = applicationContext.getBean(LuceneIndexLanguageTracker.class);
 
         // possibly remove old document
-        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE))
-            Log.debug(Geonet.INDEX_ENGINE, "Deleting document ");
+        IE_LOGGER.debug("Deleting document ");
         tracker.deleteDocuments(new Term(fld, txt));
 
         _spatial.writer().delete(txt);
     }
 
     /**
-     * TODO javadoc.
-     *
      * @param root @return
      */
     private List<IndexInformation> buildIndexDocument(Path schemaDir, Element metadata, String id,
                                                       List<Element> moreFields, MetadataType metadataType,
                                                       String root) throws Exception {
-        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
-            Log.debug(Geonet.INDEX_ENGINE, "Metadata to index:\n" + Xml.getString(metadata));
+
+        if (IE_LOGGER.isDebugEnabled()) {
+            IE_LOGGER.debug("Metadata to index:\n{}", Xml.getString(metadata));
         }
         Path defaultLangStyleSheet = getIndexFieldsXsl(schemaDir, root, "");
         Path otherLocalesStyleSheet = getIndexFieldsXsl(schemaDir, root, "language-");
@@ -746,8 +695,8 @@ public class SearchManager implements ISearchManager {
             xmlDoc = getIndexFields(metadata, defaultLangStyleSheet, otherLocalesStyleSheet);
         }
 
-        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
-            Log.debug(Geonet.INDEX_ENGINE, "Indexing fields:\n" + Xml.getString(xmlDoc));
+        if (IE_LOGGER.isDebugEnabled()) {
+            IE_LOGGER.debug("Indexing fields:\n{}", Xml.getString(xmlDoc));
         }
 
         @SuppressWarnings(value = "unchecked")
@@ -767,8 +716,8 @@ public class SearchManager implements ISearchManager {
             String locale = getLocaleFromIndexDoc(doc);
             documents.add(newDocument(locale, doc, multilingualSortFields));
         }
-        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE))
-            Log.debug(Geonet.INDEX_ENGINE, "Lucene document:\n" + Xml.getString(xmlDoc));
+        if (IE_LOGGER.isDebugEnabled())
+            IE_LOGGER.debug("Lucene document:\n{}", Xml.getString(xmlDoc));
         return documents;
     }
 
@@ -878,9 +827,6 @@ public class SearchManager implements ISearchManager {
     }
 
 
-    /**
-     * TODO javadoc.
-     */
     public Set<Integer> getDocsWithXLinks() throws Exception {
         IndexAndTaxonomy indexAndTaxonomy = getNewIndexReader(null);
 
@@ -899,10 +845,9 @@ public class SearchManager implements ISearchManager {
                 Document doc = idXLinkSelector.getDocument();
                 String id = doc.get(Geonet.IndexFieldNames.ID);
                 String hasxlinks = doc.get("_hasxlinks");
-                if (Log.isDebugEnabled(Geonet.INDEX_ENGINE))
-                    Log.debug(Geonet.INDEX_ENGINE, "Got id " + id + " : '" + hasxlinks + "'");
+                IE_LOGGER.debug("Got id {} : '{}'", id, hasxlinks);
                 if (id == null) {
-                    Log.error(Geonet.INDEX_ENGINE, "Document with no _id field skipped! Document is " + doc);
+                    IE_LOGGER.error("Document with no _id field skipped! Document is {}", doc);
                     continue;
                 }
                 if (hasxlinks.trim().equals("1")) {
@@ -944,9 +889,6 @@ public class SearchManager implements ISearchManager {
         }
     }
 
-    /**
-     * TODO javadoc.
-     */
     public Map<String, String> getDocsChangeDate() throws Exception {
         IndexAndTaxonomy indexAndTaxonomy = getNewIndexReader(null);
         try {
@@ -965,7 +907,7 @@ public class SearchManager implements ISearchManager {
                 Document doc = idChangeDateSelector.getDocument();
                 String id = doc.get(Geonet.IndexFieldNames.ID);
                 if (id == null) {
-                    Log.error(Geonet.INDEX_ENGINE, "Document with no _id field skipped! Document is " + doc);
+                    IE_LOGGER.error("Document with no _id field skipped! Document is {}", doc);
                     continue;
                 }
                 docs.put(id, doc.get("_changeDate"));
@@ -1146,9 +1088,8 @@ public class SearchManager implements ISearchManager {
      * @return XML element that contain exception informations.
      */
     private Element onGetIndexFieldsError(Exception e, Element xml) {
-        Log.error(Geonet.INDEX_ENGINE,
-                String.format("Indexing stylesheet contains errors: %s %n\t Marking the metadata as _indexingError=1 in index",
-                        e.getMessage()));
+        IE_LOGGER.error("Indexing stylesheet contains errors: {}\t Marking the metadata as _indexingError=1 in index",
+                        e.getMessage());
         Element xmlDoc = new Element("Document");
         SearchManager.addField(xmlDoc, INDEXING_ERROR_FIELD, "1", true, true);
         SearchManager.addField(xmlDoc, INDEXING_ERROR_MSG, "GNIDX-XSL||" + e.getMessage(), true, false);
@@ -1247,15 +1188,12 @@ public class SearchManager implements ISearchManager {
 
     // utilities
 
-    /**
-     * TODO javadoc.
-     */
     Element transform(String styleSheetName, Element xml) throws Exception {
         try {
             Path styleSheetPath = _stylesheetsDir.resolve(styleSheetName).toAbsolutePath();
             return Xml.transform(xml, styleSheetPath);
         } catch (Exception e) {
-            Log.error(Geonet.INDEX_ENGINE, "Search stylesheet contains errors : " + e.getMessage());
+            IE_LOGGER.error("Search stylesheet contains errors : {}", e.getMessage());
             throw e;
         }
     }
@@ -1268,7 +1206,7 @@ public class SearchManager implements ISearchManager {
     }
 
     public IndexAndTaxonomy getNewIndexReader(String preferredLang) throws IOException, InterruptedException {
-        Log.debug(Geonet.INDEX_ENGINE, "Ask for new reader");
+        IE_LOGGER.debug("Ask for new reader");
         return getIndexReader(preferredLang, -1L);
     }
 
@@ -1315,8 +1253,7 @@ public class SearchManager implements ISearchManager {
             }
             return true;
         } catch (Exception e) {
-            Log.error(Geonet.INDEX_ENGINE, "Exception while rebuilding lucene index, going to rebuild it: " +
-                e.getMessage(), e);
+            IE_LOGGER.error("Exception while rebuilding lucene index, going to rebuild it: {}", e.getMessage());
             return false;
         }
     }
@@ -1349,8 +1286,7 @@ public class SearchManager implements ISearchManager {
         if (_documentBoostClass != null) {
             Float f = (_documentBoostClass).getBoost(xml);
             if (f != null) {
-                if (Log.isDebugEnabled(Geonet.INDEX_ENGINE))
-                    Log.debug(Geonet.INDEX_ENGINE, "Boosting document with boost factor: " + f);
+                IE_LOGGER.debug("Boosting document with boost factor: {}", f);
                 documentBoost = f;
             }
         }
@@ -1389,8 +1325,7 @@ public class SearchManager implements ISearchManager {
 
                         doc.add(idxError);
                         doc.add(idxMsg);
-
-                        Log.warning(Geonet.INDEX_ENGINE, msg);
+                        IE_LOGGER.warn(msg);
                         // If an exception occur, the field is not added to the document
                         // and to the taxonomy
                         continue;
@@ -1409,8 +1344,7 @@ public class SearchManager implements ISearchManager {
                 if (bIndex && !f.fieldType().omitNorms()) {
                     Float boost = luceneConfig.getFieldBoost(name);
                     if (boost != null) {
-                        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE))
-                            Log.debug(Geonet.INDEX_ENGINE, "Boosting field: " + name + " with boost factor: " + boost + " x " + documentBoost);
+                        IE_LOGGER.debug("Boosting field: {} with boost factor: {} x {}", new Object[] {name, boost, documentBoost});
                         f.setBoost(documentBoost * boost);
                     } else if (documentBoost != 1) {
                         f.setBoost(documentBoost);
@@ -1419,9 +1353,7 @@ public class SearchManager implements ISearchManager {
                 doc.add(f);
 
                 for (Field fFacet : fFacets) {
-                    if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
-                        Log.debug(Geonet.INDEX_ENGINE, "Facet field: " + fFacet.toString());
-                    }
+                    IE_LOGGER.debug("Facet field: {}", fFacet.toString());
                     doc.add(fFacet);
                 }
             }
@@ -1476,8 +1408,7 @@ public class SearchManager implements ISearchManager {
 
         Field field;
         // TODO : reuse the numeric field for better performance
-        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE))
-            Log.debug(Geonet.INDEX_ENGINE, "Indexing numeric field: " + name + " with value: " + string);
+        IE_LOGGER.debug("Indexing numeric field: {} with value: {}", name, string);
         try {
             String paramType = fieldConfig.getType();
             if ("double".equals(paramType)) {
@@ -1499,7 +1430,8 @@ public class SearchManager implements ISearchManager {
             }
             return field;
         } catch (Exception e) {
-            Log.warning(Geonet.INDEX_ENGINE, "Failed to index numeric field: " + name + " with value: " + string + ", error is: " + e.getMessage());
+            IE_LOGGER.warn("Failed to index numeric field: {} with value: {}, error is: {}",
+                    new Object[]{name, string, e.getMessage()});
             throw e;
         }
     }
@@ -1522,7 +1454,7 @@ public class SearchManager implements ISearchManager {
             tracker.optimize();
             return true;
         } catch (Throwable e) {
-            Log.error(Geonet.INDEX_ENGINE, "Exception while optimizing lucene index: " + e.getMessage());
+            IE_LOGGER.error("Exception while optimizing lucene index: {}", e.getMessage());
             return false;
         }
     }
@@ -1614,9 +1546,6 @@ public class SearchManager implements ISearchManager {
         }
     }
 
-    /**
-     * TODO javadoc.
-     */
     public class Spatial {
         private static final long TIME_BETWEEN_SPATIAL_COMMITS_IN_SECONDS = 10;
         private final DataStore _datastore;
@@ -1649,8 +1578,6 @@ public class SearchManager implements ISearchManager {
         }
 
         /**
-         * TODO javadoc.
-         *
          * @param maxWritesInTransaction - Number of features to write to before commit - set 1 and
          *                               the transaction will be autocommit which results in faster
          *                               loading for some (all?) configurations and does not keep a
@@ -1680,9 +1607,6 @@ public class SearchManager implements ISearchManager {
             }
         }
 
-        /**
-         * TODO javadoc.
-         */
         private boolean createWriter(DataStore datastore) throws IOException {
             boolean rebuildIndex;
             try {
@@ -1694,12 +1618,11 @@ public class SearchManager implements ISearchManager {
                     throw new RuntimeException(e);
                 }
                 String exceptionString = Xml.getString(JeevesException.toElement(e));
-                Log.warning(Geonet.SPATIAL, "Failure to make _writer, maybe a problem but might also not be an issue:" +
-                    exceptionString);
+                SP_LOGGER.warn("Failure to make _writer, maybe a problem but might also not be an issue: {}", exceptionString);
                 try {
                     _writer.reset();
                 } catch (Exception e1) {
-                    Log.error(Geonet.SPATIAL, "Unable to call reset on Spatial writer: " + e1.getMessage());
+                    SP_LOGGER.error("Unable to call reset on Spatial writer: {}", e1.getMessage());
                     e1.printStackTrace();
                 }
                 rebuildIndex = true;
@@ -1715,16 +1638,13 @@ public class SearchManager implements ISearchManager {
             try {
                 _writer.close();
             } catch (IOException e) {
-                Log.error(Geonet.SPATIAL, "error closing spatial index: " + e.getMessage());
+                SP_LOGGER.error("error closing spatial index: {}", e.getMessage());
                 e.printStackTrace();
             } finally {
                 _lock.unlock();
             }
         }
 
-        /**
-         * TODO javadoc.
-         */
         public Filter filter(org.apache.lucene.search.Query query, int numHits, Element filterExpr, String filterVersion)
             throws Exception {
             _lock.lock();
@@ -1741,9 +1661,6 @@ public class SearchManager implements ISearchManager {
             }
         }
 
-        /**
-         * TODO javadoc.
-         */
         public SpatialFilter filter(org.apache.lucene.search.Query query, int numHits,
                                     Collection<Geometry> geom, Element request) throws Exception {
             _lock.lock();
@@ -1770,9 +1687,6 @@ public class SearchManager implements ISearchManager {
             }
         }
 
-        /**
-         * TODO javadoc.
-         */
         public SpatialIndexWriter writer() throws Exception {
             _lock.lock();
             try {
@@ -1790,9 +1704,6 @@ public class SearchManager implements ISearchManager {
             }
         }
 
-        /**
-         * TODO javadoc.
-         */
         private SpatialIndexWriter writerNoLocking() throws Exception {
             if (_writer == null) {
                 _writer = new SpatialIndexWriter(_datastore, _gmlParser, _transaction, _maxWritesInTransaction, _lock);
@@ -1800,9 +1711,6 @@ public class SearchManager implements ISearchManager {
             return _writer;
         }
 
-        /**
-         * TODO javadoc.
-         */
         private Parser getFilterParser(String filterVersion) {
             Configuration config;
             if (filterVersion.equals(FilterCapabilities.VERSION_100)) {
@@ -1835,9 +1743,6 @@ public class SearchManager implements ISearchManager {
             }
         }
 
-        /**
-         * TODO javadoc.
-         */
         private class Committer implements Runnable {
             private AtomicBoolean cancelled = new AtomicBoolean(false);
 
@@ -1853,7 +1758,7 @@ public class SearchManager implements ISearchManager {
                         _committerTask = null;
                     }
                 } catch (IOException e) {
-                    Log.error(Geonet.SPATIAL, "error writing spatial index " + e.getMessage());
+                    SP_LOGGER.error("error writing spatial index {}", e.getMessage());
                 } finally {
                     _lock.unlock();
                 }

--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/OverlapsBBoxFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/OverlapsBBoxFilter.java
@@ -1,0 +1,121 @@
+//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.search.spatial;
+
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.index.ItemVisitor;
+import com.vividsolutions.jts.index.SpatialIndex;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.AtomicReader;
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.OpenBitSet;
+import org.fao.geonet.domain.Pair;
+import org.geotools.data.FeatureSource;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class OverlapsBBoxFilter extends SpatialFilter {
+
+    private Set<String> intersected;
+
+    public OverlapsBBoxFilter(Query query, int numHits, Geometry geom, Pair<FeatureSource<SimpleFeatureType, SimpleFeature>, SpatialIndex> sourceAccessor) throws IOException {
+        super(query, numHits, geom, sourceAccessor);
+    }
+
+    public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
+        final OpenBitSet bits = new OpenBitSet(context.reader().maxDoc());
+        final Set<String> intersected = intersected();
+
+        if (intersected.isEmpty() || _hits >= _numHits) return bits;
+
+        new IndexSearcher(context.reader()).search(_query, new Collector() {
+            private int docBase;
+            private Document document;
+            private AtomicReader reader;
+
+            // ignore scorer
+            public void setScorer(Scorer scorer) {
+            }
+
+            // accept docs out of order (for a BitSet it doesn't matter)
+            public boolean acceptsDocsOutOfOrder() {
+                return true;
+            }
+
+            public void collect(int doc) {
+                doc = doc + docBase;
+                try {
+                    document = reader.document(doc, _fieldsToLoad);
+                    String key = document.get("_id");
+                    if (intersected.contains(key) && _hits < _numHits) {
+                        _hits++;
+                        bits.set(doc + docBase);
+
+                        }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void setNextReader(AtomicReaderContext context) throws IOException {
+                this.docBase = context.docBase;
+                this.reader = context.reader();
+            }
+        });
+        return bits;
+    }
+
+    protected synchronized Set<String> intersected() {
+        if (intersected == null) {
+            intersected = new HashSet<>();
+            SpatialIndex spatialIndex = sourceAccessor.two();
+            Envelope env = _geom.getEnvelopeInternal();
+
+            spatialIndex.query(env, new ItemVisitor() {
+                @Override
+                public void visitItem(Object o) {
+                    SpatialIndexWriter.Data data = (SpatialIndexWriter.Data) o;
+                    intersected.add(data.getMetadataId());
+                }
+            });
+        }
+        return intersected;
+    }
+
+    protected org.opengis.filter.Filter createFilter(FeatureSource<SimpleFeatureType, SimpleFeature> source) {
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialFilter.java
@@ -92,8 +92,8 @@ public abstract class SpatialFilter extends Filter {
     private org.opengis.filter.Filter _spatialFilter;
     private Map<String, FeatureId> _unrefinedMatches;
     private boolean warned = false;
-    private int _numHits;
-    private int _hits = 0;
+    protected int _numHits;
+    protected int _hits = 0;
 
     protected SpatialFilter(Query query, int numHits, Geometry geom, Pair<FeatureSource<SimpleFeatureType, SimpleFeature>, SpatialIndex> sourceAccessor) throws IOException {
         this._query = query;
@@ -106,7 +106,7 @@ public abstract class SpatialFilter extends Filter {
         // _index.query returns geometries that intersect with provided envelope. To use later a spatial filter that
         // provides geometries that don't intersect with the query envelope (_geom) should be used a full extent
         // envelope in this method, instead of the query envelope (_geom)
-        if (_spatialFilter.getClass().getName().equals("org.geotools.filter.spatial.DisjointImpl")) {
+        if (_spatialFilter!=null && _spatialFilter.getClass().getName().equals("org.geotools.filter.spatial.DisjointImpl")) {
             this._geom = WORLD_BOUNDS;
         }
     }
@@ -238,7 +238,7 @@ public abstract class SpatialFilter extends Filter {
                 for (int doc : docIndexLookup.get(feature.getIdentifier())) {
                     bits.set(doc);
                 }
-            };
+            }
         } catch (TopologyException e) {
             if (!warned) {
                 warned = true;
@@ -254,10 +254,10 @@ public abstract class SpatialFilter extends Filter {
     protected synchronized Map<String, FeatureId> unrefinedSpatialMatches() {
         if (_unrefinedMatches == null) {
             SpatialIndex spatialIndex = sourceAccessor.two();
-            List<Pair<FeatureId, String>> fids = spatialIndex.query(_geom.getEnvelopeInternal());
+            List<SpatialIndexWriter.Data> fids = spatialIndex.query(_geom.getEnvelopeInternal());
             _unrefinedMatches = new HashMap<>();
-            for (Pair<FeatureId, String> match : fids) {
-                _unrefinedMatches.put(match.two(), match.one());
+            for (SpatialIndexWriter.Data match : fids) {
+                _unrefinedMatches.put(match.getMetadataId(), match.getFeatureId());
             }
         }
         return _unrefinedMatches;

--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialFilter.java
@@ -24,13 +24,11 @@ package org.fao.geonet.kernel.search.spatial;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.TopologyException;
 import com.vividsolutions.jts.index.SpatialIndex;
-
 import org.apache.jcs.access.GroupCacheAccess;
 import org.apache.jcs.access.exception.CacheException;
 import org.apache.lucene.document.Document;
@@ -47,7 +45,6 @@ import org.apache.lucene.util.OpenBitSet;
 import org.fao.geonet.JeevesJCS;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
-import org.fao.geonet.utils.Log;
 import org.geotools.data.FeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.factory.GeoTools;
@@ -62,6 +59,8 @@ import org.opengis.filter.Id;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.identity.FeatureId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -75,15 +74,17 @@ import java.util.Set;
 import static org.fao.geonet.kernel.search.spatial.SpatialIndexWriter.SPATIAL_FILTER_JCS;
 
 public abstract class SpatialFilter extends Filter {
-    private static final Geometry WORLD_BOUNDS;
+    private static Logger LOGGER = LoggerFactory.getLogger(Geonet.SPATIAL);
     private static final int MAX_FIDS_PER_QUERY = 5000;
+
+    private static final Geometry WORLD_BOUNDS;
 
     static {
         GeometryFactory fac = new GeometryFactory();
         WORLD_BOUNDS = fac.toGeometry(new Envelope(-180, 180, -90, 90));
     }
 
-    protected final Geometry _geom;
+    protected Geometry _geom;
     protected final FilterFactory2 _filterFactory;
     protected final Set<String> _fieldsToLoad;
     protected Pair<FeatureSource<SimpleFeatureType, SimpleFeature>, SpatialIndex> sourceAccessor;
@@ -95,13 +96,19 @@ public abstract class SpatialFilter extends Filter {
     private int _hits = 0;
 
     protected SpatialFilter(Query query, int numHits, Geometry geom, Pair<FeatureSource<SimpleFeatureType, SimpleFeature>, SpatialIndex> sourceAccessor) throws IOException {
-        _query = query;
-        _geom = geom;
-        _numHits = numHits;
+        this._query = query;
+        this._numHits = numHits;
         this.sourceAccessor = sourceAccessor;
-        _filterFactory = CommonFactoryFinder.getFilterFactory2(GeoTools.getDefaultHints());
-
-        _fieldsToLoad = Collections.singleton("_id");
+        this._filterFactory = CommonFactoryFinder.getFilterFactory2(GeoTools.getDefaultHints());
+        this._fieldsToLoad = Collections.singleton("_id");
+        this._geom = geom;
+        this._spatialFilter = createFilter(sourceAccessor.one());
+        // _index.query returns geometries that intersect with provided envelope. To use later a spatial filter that
+        // provides geometries that don't intersect with the query envelope (_geom) should be used a full extent
+        // envelope in this method, instead of the query envelope (_geom)
+        if (_spatialFilter.getClass().getName().equals("org.geotools.filter.spatial.DisjointImpl")) {
+            this._geom = WORLD_BOUNDS;
+        }
     }
 
     protected SpatialFilter(Query query, int numHits, Envelope bounds, Pair<FeatureSource<SimpleFeatureType, SimpleFeature>, SpatialIndex> sourceAccessor) throws IOException {
@@ -163,25 +170,34 @@ public abstract class SpatialFilter extends Filter {
                 this.reader = context.reader();
             }
         });
+        JeevesJCS jcs = getJCSCache();
+        processCachedFeatures(jcs, matches, docIndexLookup, bits);
+        processNonCachedFeature(jcs, matches, docIndexLookup, bits);
+        return bits;
+    }
 
-        if (matches.isEmpty()) {
-            return bits;
-        } else {
-            return applySpatialFilter(matches, docIndexLookup, bits);
+    private void processCachedFeatures(GroupCacheAccess jcs, Set<FeatureId> matches, Multimap<FeatureId, Integer> docIndexLookup, OpenBitSet bits) {
+        for (java.util.Iterator<FeatureId> iter = matches.iterator(); iter.hasNext(); ) {
+            FeatureId id = iter.next();
+            Geometry geom = (Geometry) jcs.get(id.getID());
+            if (geom != null) {
+                iter.remove();
+                final SimpleFeatureBuilder simpleFeatureBuilder = new SimpleFeatureBuilder(this.sourceAccessor.one().getSchema());
+                simpleFeatureBuilder.set(this.sourceAccessor.one().getSchema().getGeometryDescriptor().getName(), geom);
+                final SimpleFeature simpleFeature = simpleFeatureBuilder.buildFeature(id.getID());
+                evaluateFeature(simpleFeature, bits, docIndexLookup);
+            }
         }
     }
 
-    private OpenBitSet applySpatialFilter(Set<FeatureId> matches, Multimap<FeatureId, Integer> docIndexLookup, OpenBitSet bits) throws IOException {
-
-        JeevesJCS jcs = getJCSCache();
-        processCachedFeatures(jcs, matches, docIndexLookup, bits);
-
+    private void processNonCachedFeature(JeevesJCS jcs, Set<FeatureId> matches, Multimap<FeatureId, Integer> docIndexLookup, OpenBitSet bits) throws IOException {
         while (!matches.isEmpty()) {
             Id fidFilter;
             if (matches.size() > MAX_FIDS_PER_QUERY) {
                 FeatureId[] subset = new FeatureId[MAX_FIDS_PER_QUERY];
                 int i = 0;
                 Iterator<FeatureId> iter = matches.iterator();
+
                 while (iter.hasNext() && i < MAX_FIDS_PER_QUERY) {
                     subset[i] = iter.next();
                     iter.remove();
@@ -206,11 +222,7 @@ public abstract class SpatialFilter extends Filter {
                     SimpleFeature feature = iterator.next();
                     FeatureId featureId = feature.getIdentifier();
                     jcs.put(featureId.getID(), feature.getDefaultGeometry());
-                    if (evaluateFeature(feature)) {
-                        for (int doc : docIndexLookup.get(featureId)) {
-                            bits.set(doc);
-                        }
-                    }
+                    evaluateFeature(feature, bits, docIndexLookup);
                 }
             } catch (CacheException e) {
                 throw new Error(e);
@@ -218,76 +230,31 @@ public abstract class SpatialFilter extends Filter {
                 iterator.close();
             }
         }
-        return bits;
     }
 
-    private boolean evaluateFeature(SimpleFeature feature) {
+    private void evaluateFeature(SimpleFeature feature, OpenBitSet bits, Multimap<FeatureId, Integer> docIndexLookup) {
         try {
-            return getFilter().evaluate(feature);
+            if (_spatialFilter.evaluate(feature)) {
+                for (int doc : docIndexLookup.get(feature.getIdentifier())) {
+                    bits.set(doc);
+                }
+            };
         } catch (TopologyException e) {
             if (!warned) {
                 warned = true;
-                Log.warning(Geonet.SPATIAL, e.getMessage() + " errors are occuring with filter: " + getFilter());
+                LOGGER.warn("{} errors are occuring with filter: {}", e.getMessage(), _spatialFilter);
             }
-            if (Log.isDebugEnabled(Geonet.SPATIAL))
-                Log.debug(Geonet.SPATIAL, e.getMessage() + ": occurred during a search: " + getFilter() + " on feature: " + feature.getDefaultGeometry());
-            return false;
+            LOGGER.debug(e.getMessage() + "{}: occurred during a search: {} on feature: {}", new Object[] {e.getMessage(), _spatialFilter,feature.getDefaultGeometry()});
         }
     }
-
-    private void processCachedFeatures(GroupCacheAccess jcs, Set<FeatureId> matches, Multimap<FeatureId, Integer> docIndexLookup, OpenBitSet bits) {
-        for (java.util.Iterator<FeatureId> iter = matches.iterator(); iter.hasNext(); ) {
-            FeatureId id = iter.next();
-            Geometry geom = (Geometry) jcs.get(id.getID());
-            if (geom != null) {
-                iter.remove();
-                final SimpleFeatureBuilder simpleFeatureBuilder = new SimpleFeatureBuilder(this.sourceAccessor.one().getSchema());
-                simpleFeatureBuilder.set(this.sourceAccessor.one().getSchema().getGeometryDescriptor().getName(), geom);
-                final SimpleFeature simpleFeature = simpleFeatureBuilder.buildFeature(id.getID());
-                if (evaluateFeature(simpleFeature)) {
-                    for (int doc : docIndexLookup.get(id)) {
-                        bits.set(doc);
-                    }
-                }
-            }
-        }
-    }
-
-    private synchronized org.opengis.filter.Filter getFilter() {
-        if (_spatialFilter == null) {
-            _spatialFilter = createFilter(sourceAccessor.one());
-        }
-
-        return _spatialFilter;
-    }
-
+    
     /**
      * Returns all the FeatureId and ID attributes based on the query against the spatial index
-     *
-     * @return all the FeatureId and ID attributes based on the query against the spatial index
      */
     protected synchronized Map<String, FeatureId> unrefinedSpatialMatches() {
         if (_unrefinedMatches == null) {
-            Geometry geom = null;
-
-            // _index.query returns geometries that intersect with provided envelope. To use later a spatial filter that
-            // provides geometries that don't intersect with the query envelope (_geom) should be used a full extent
-            // envelope in this method, instead of the query envelope (_geom)
-            if (getFilter().getClass().getName().equals("org.geotools.filter.spatial.DisjointImpl")) {
-                try {
-                    geom = WORLD_BOUNDS;
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                    return _unrefinedMatches;
-                }
-
-            } else {
-                geom = _geom;
-            }
-
             SpatialIndex spatialIndex = sourceAccessor.two();
-            @SuppressWarnings("unchecked")
-            List<Pair<FeatureId, String>> fids = spatialIndex.query(geom.getEnvelopeInternal());
+            List<Pair<FeatureId, String>> fids = spatialIndex.query(_geom.getEnvelopeInternal());
             _unrefinedMatches = new HashMap<>();
             for (Pair<FeatureId, String> match : fids) {
                 _unrefinedMatches.put(match.two(), match.one());
@@ -297,20 +264,16 @@ public abstract class SpatialFilter extends Filter {
     }
 
     protected org.opengis.filter.Filter createFilter(FeatureSource<SimpleFeatureType, SimpleFeature> source) {
-        String geomAttName = source.getSchema().getGeometryDescriptor()
-            .getLocalName();
+        String geomAttName = source.getSchema().getGeometryDescriptor().getLocalName();
         PropertyName geomPropertyName = _filterFactory.property(geomAttName);
-
         Literal geomExpression = _filterFactory.literal(_geom);
-        org.opengis.filter.Filter filter = createGeomFilter(_filterFactory,
-            geomPropertyName, geomExpression);
+        org.opengis.filter.Filter filter = createGeomFilter(_filterFactory, geomPropertyName, geomExpression);
         return filter;
     }
 
     public org.opengis.filter.Filter createGeomFilter(FilterFactory2 filterFactory,
                                                       PropertyName geomPropertyName, Literal geomExpression) {
-        throw new UnsupportedOperationException(
-            "createGeomFilter must be overridden ");
+        throw new UnsupportedOperationException("createGeomFilter must be overridden ");
     }
 
     public Query getQuery() {

--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/WithinBBoxFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/WithinBBoxFilter.java
@@ -1,0 +1,129 @@
+//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.search.spatial;
+
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.index.ItemVisitor;
+import com.vividsolutions.jts.index.SpatialIndex;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.AtomicReader;
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.OpenBitSet;
+import org.fao.geonet.domain.Pair;
+import org.geotools.data.FeatureSource;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class WithinBBoxFilter extends SpatialFilter {
+
+    private Map<String, AtomicInteger> enclosed;
+
+    public WithinBBoxFilter(Query query, int numHits, Geometry geom, Pair<FeatureSource<SimpleFeatureType, SimpleFeature>, SpatialIndex> sourceAccessor) throws IOException {
+        super(query, numHits, geom, sourceAccessor);
+    }
+
+    public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
+        final OpenBitSet bits = new OpenBitSet(context.reader().maxDoc());
+        final Map<String, AtomicInteger> enclosed = enclosed();
+
+        if (enclosed.isEmpty() || _hits >= _numHits) return bits;
+
+        new IndexSearcher(context.reader()).search(_query, new Collector() {
+            private int docBase;
+            private Document document;
+            private AtomicReader reader;
+
+            // ignore scorer
+            public void setScorer(Scorer scorer) {
+            }
+
+            // accept docs out of order (for a BitSet it doesn't matter)
+            public boolean acceptsDocsOutOfOrder() {
+                return true;
+            }
+
+            public void collect(int doc) {
+                doc = doc + docBase;
+                try {
+                    document = reader.document(doc, _fieldsToLoad);
+                    String key = document.get("_id");
+                    AtomicInteger notEnclosedBrotherCount = enclosed.get(key);
+                    if (notEnclosedBrotherCount != null && notEnclosedBrotherCount.get() == 0 && _hits < _numHits) {
+                        _hits++;
+                        bits.set(doc + docBase);
+
+                        }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void setNextReader(AtomicReaderContext context) throws IOException {
+                this.docBase = context.docBase;
+                this.reader = context.reader();
+            }
+        });
+        return bits;
+    }
+
+    protected synchronized Map<String, AtomicInteger> enclosed() {
+        if (enclosed == null) {
+            enclosed = new HashMap<String, AtomicInteger>();
+            SpatialIndex spatialIndex = sourceAccessor.two();
+            Envelope env = _geom.getEnvelopeInternal();
+
+            spatialIndex.query(env, new ItemVisitor() {
+                @Override
+                public void visitItem(Object o) {
+                    SpatialIndexWriter.Data data = (SpatialIndexWriter.Data) o;
+                    if (env.contains(data.getEnv())) {
+                        if (enclosed.containsKey(data.getMetadataId())) {
+                            enclosed.get(data.getMetadataId()).decrementAndGet();
+                        } else {
+                            enclosed.put(data.getMetadataId(), new AtomicInteger(data.getNumBrotherGeometries() - 1));
+                        }
+                    }
+                }
+            });
+        }
+        return enclosed;
+    }
+
+    protected org.opengis.filter.Filter createFilter(FeatureSource<SimpleFeatureType, SimpleFeature> source) {
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/fao/geonet/services/util/SearchDefaults.java
+++ b/core/src/main/java/org/fao/geonet/services/util/SearchDefaults.java
@@ -47,7 +47,7 @@ public class SearchDefaults {
      */
     private static String[][] DEFAULT_PARAMS = {
         {Geonet.SearchResult.RELATION,
-            Geonet.SearchResult.Relation.OVERLAPS},
+            Geonet.SearchResult.Relation.OVERLAPS_BBOX},
         {Geonet.SearchResult.EXTENDED, Geonet.Text.OFF},
         {Geonet.SearchResult.HITS_PER_PAGE, "10"},
         {Geonet.SearchResult.SIMILARITY, "1"},

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -353,6 +353,7 @@
   "fullyOutsideOf": "Fully outside of",
   "encloses": "Enclosing",
   "within": "Within",
+  "within_bbox": "Within",
   "transferOwnership": "Transfer Ownership",
   "selectNewOwner": "Select New Owner",
   "selectGroup": "Select Group",

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -357,7 +357,7 @@
         viewerMap: viewerMap,
         searchMap: searchMap,
         mapfieldOption: {
-          relations: ['within']
+          relations: ['within_bbox']
         },
         hitsperpageValues: gnSearchSettings.hitsperpageValues,
         filters: gnSearchSettings.filters,


### PR DESCRIPTION
The PR comes with refactorings which helped to better take measure of geonetwork spatial indexing mechanisms.

The purpose of this PR is to propose two spatial filters operating on bbox rather than on geometries, in order to earn ram and cpu at runtime:
- as spatial requests emanating form minimap are related to rectangular bounds, theses two filters are substitued to usual minimap geometrical ones.
- at search time, as features bbox are already stored in SRTTree (spatial index), these two filters don't rely on jcscahe.

In my opinion, replacing Data Pair by POJO helps a lot:
https://github.com/geonetwork/core-geonetwork/pull/2555/files#diff-431f31b5144d54b586f8eabcdda4567aL415.
                                     vs 
https://github.com/geonetwork/core-geonetwork/pull/2555/files#diff-431f31b5144d54b586f8eabcdda4567aR559

In this case, for a true multipolygon and within filter POJO help counting and checking that all its parts are enclosed within query bounds.



