### PR TITLE
Button to keep the validation panel on top in md editor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -42,6 +42,7 @@
             link: function(scope) {
               scope.showErrors = false;
               scope.showSuccess = false;
+              scope.alwaysOnTop = false;
               scope.gnCurrentEdit = gnCurrentEdit;
               scope.loading = false;
               scope.ruleTypes = [];
@@ -99,7 +100,6 @@
               scope.toggleShowSuccess = function() {
                 scope.showSuccess = !scope.showSuccess;
               };
-
               scope.getClass = function(type) {
                 if (scope.numberOfRules > 0) {
                   if (type === 'icon') {
@@ -113,6 +113,16 @@
                   return 'fa-check';
                 } else {
                   return '';
+                }
+              };
+
+              scope.toggleAlwaysOnTop = function() {
+                scope.alwaysOnTop = !scope.alwaysOnTop;
+                var element = angular.element( document.querySelector( '#gn-editor-validation-panel' ) );
+                if(scope.alwaysOnTop) {
+                  element.addClass('gn-fixed-scroll');
+                } else {
+                  element.removeClass('gn-fixed-scroll');
                 }
               };
 

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -1,8 +1,16 @@
-<div class="panel panel-default" data-ng-class="getClass()">
+<div id="gn-editor-validation-panel" class="panel panel-default" data-ng-class="getClass()">
   <div class="panel-heading"
        data-gn-slide-toggle="">
     <i class="fa" data-ng-class="getClass('icon')"></i>&nbsp;
     <span data-translate="">validationReport</span>
+    <button type="button" class="btn btn-default pull-right btn-xs"
+            data-ng-click="toggleAlwaysOnTop();$event.stopPropagation();"
+            data-toggle="tooltip"
+            data-placement="top"
+            title="{{'fixedOnTop' | translate}}">
+      <i class="fa fa-thumb-tack"/>
+    </button>
+    &nbsp;
     <button type="button" class="btn btn-default pull-right btn-xs"
             data-ng-click="load();$event.stopPropagation();"
             data-toggle="tooltip"

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -297,6 +297,7 @@
     "validate-inspire-help": "Check record against inspire validation rules",
     "validationReport": "Validation",
     "runValidation": "Run validation check",
+    "fixedOnTop": "Always on top",
     "whoCanAccess": "Who has access",
     "wmsServiceUrl": "Service URL",
     "xmlSnippet": "XML snippet",

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -840,6 +840,12 @@ gn-md-type-widget {
   }
 }
 
+.gn-fixed-scroll {
+  position:fixed;
+  top:60px;
+}
+
+
 
 gn-bounding-polygon {
   label {


### PR DESCRIPTION
In the metadata editor, can be useful to have fixed on top of the page the validation results box, to have the informations on screen while checking the metadata issues. https://github.com/geonetwork/core-geonetwork/issues/2560

This mode is activated/deactivated with a button on the top of the validation results panel

![1](https://user-images.githubusercontent.com/1323093/36260945-24a287f2-1263-11e8-883b-031a38477fa3.png)


