### PR TITLE
Focus map loading in mapsManager

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1200,6 +1200,11 @@
             var defer = $q.defer();
             var $this = this;
 
+            try {
+              // Avoid double encoding
+              name = decodeURIComponent(escape(name));
+            } catch (e) {}
+
             if (!isLayerInMap(map, name, url)) {
               gnWmsQueue.add(url, name);
               gnOwsCapabilities.getWMSCapabilities(url).then(function(capObj) {
@@ -1228,9 +1233,10 @@
                   }
                   olL = $this.addWmsToMap(map, o);
                   
-                  if(!angular.isUndefined(md['geonet:info']['uuid'])) {
+                  if(md && md['geonet:info']['uuid']) {
                 	  olL.set('MDuuid', md['geonet:info']['uuid']);
-                  } 
+                    olL.set('metadataUuid', md['geonet:info']['uuid']);
+                  }
 
                   if (!angular.isArray(olL.get('errors'))) {
                     olL.set('errors', []);
@@ -1265,6 +1271,7 @@
                       olL.set('md', md);
                       if(!angular.isUndefined(md['geonet:info']['uuid'])) {
                     	  olL.set('MDuuid', md['geonet:info']['uuid']);
+                        olL.set('metadataUuid', md['geonet:info']['uuid']);
                       }
                     }) : $this.feedLayerMd(olL);
 
@@ -1282,13 +1289,10 @@
               });
             } else {
             	var olL = getTheLayerFromMap(map, name, url);
-            	
-            	  $q.resolve(md).then(function(md) {
-                      if(!angular.isUndefined(md['geonet:info']['uuid'])) {
-                  	    olL.set('MDuuid', md['geonet:info']['uuid']);
-                      }
-                    });
-            	
+            	if(olL && md && md['geonet:info']['uuid']) {
+                olL.set('MDuuid', md['geonet:info']['uuid']);
+                olL.set('metadataUuid', md['geonet:info']['uuid']);
+              }
             }
             return defer.promise;
           },

--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -133,15 +133,14 @@
           // config found: load context if any, and apply extent & layers
           // (this is done through a promise anyway)
           var mapReady;
+          var urlParams = $location.search();
           if (type == this.VIEWER_MAP) {
-            var params = $location.search();
-            var urlContext = params.owscontext || params.map;
+            var urlContext = urlParams.owscontext || urlParams.map;
             if(urlContext) {
-              urlContext = decodeURIComponent(urlContext); 
               mapReady = gnOwsContextService.loadContextFromUrl(
                 urlContext, map);
             } else {
-              var storage = gnViewerSettings.mapConfig.storage;
+              var storage = gnMap.getMapConfig().storage;
               if (storage) {
                 storage = window[storage];
                 var key = 'owsContext_' +
@@ -184,14 +183,13 @@
                   });
               });
             }
-            if(type == this.VIEWER_MAP && $location.search()) {
-              var params = $location.search();
-              if (params.wmsurl && params.layername) {
-                gnMap.addWmsFromScratch(map, params.wmsurl,
-                  params.layername, true).
+            if(type == this.VIEWER_MAP) {
+              if (urlParams.wmsurl && urlParams.layername) {
+                gnMap.addWmsFromScratch(map, urlParams.wmsurl,
+                  urlParams.layername, true).
 
                 then(function(layer) {
-                  layer.set('group', params.layergroup);
+                  layer.set('group', urlParams.layergroup);
                   map.addLayer(layer);
                 });
               }

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerModule.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerModule.js
@@ -184,16 +184,6 @@
 
       var map = $scope.searchObj.viewerMap;
 
-      if (gnViewerSettings.wmsUrl && gnViewerSettings.layerName) {
-        gnMap.addWmsFromScratch(map, gnViewerSettings.wmsUrl,
-            gnViewerSettings.layerName, true).
-
-            then(function(layer) {
-              layer.set('group', gnViewerSettings.layerGroup);
-              map.addLayer(layer);
-            });
-      }
-
       // Display pop up on feature over
       var div = document.createElement('div');
       div.className = 'overlay';

--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
@@ -48,7 +48,9 @@
         link: function(scope, element, attrs) {
           scope.layers = gnViewerSettings.bgLayers;
           scope.dropup = angular.isDefined(attrs.dropup);
-          scope.map.getLayers().insertAt(0, scope.layers[0]);
+          if(scope.layers.indexOf(scope.map.getLayers().item(0)) < 0) {
+            scope.map.getLayers().insertAt(0, scope.layers[0]);
+          }
           scope.setBgLayer = function(layer) {
             layer.setVisible(true);
             var layers = scope.map.getLayers();

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextDirective.js
@@ -243,27 +243,6 @@
             $('#owc-file-input')[0].value = '';
           });
 
-          // load context from url or from storage
-          var key = 'owsContext_' +
-              window.location.host + window.location.pathname;
-
-          var storage = gnViewerSettings.mapConfig.storage ?
-              window[gnViewerSettings.mapConfig.storage] : window.localStorage;
-
-          if (gnViewerSettings.mapConfig.storage !== '' &&
-              storage.getItem(key)) {
-            var c = storage.getItem(key);
-            gnOwsContextService.loadContext(c, scope.map);
-          } else if (gnViewerSettings.owsContext) {
-            gnOwsContextService.loadContextFromUrl(gnViewerSettings.owsContext,
-                scope.map);
-          } else if (gnViewerSettings.defaultContext) {
-            gnOwsContextService.loadContextFromUrl(
-                gnViewerSettings.defaultContext,
-                scope.map,
-                gnViewerSettings.additionalMapLayers);
-          }
-
           // store the current context in local storage to reload it
           // automatically on next connexion
           $(window).on('unload', function() {

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -250,11 +250,11 @@
 
                   (function(idx, loadingLayer) {
                     p.then(function(layer) {
-                      bgLayers[idx - 1] = layer;
-
                       if (!layer) {
                         return;
                       }
+                      bgLayers[idx - 1] = layer;
+
                       layer.displayInLayerManager = false;
                       layer.background = true;
 

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -151,12 +151,15 @@
           map.setView(view);
         }
 
-        // $timeout used to avoid map no rendered (eg: null size)
-        $timeout(function() {
-          if (map.getSize()) {
+        var loadPromise = map.get('sizePromise');
+        if (loadPromise) {
+          loadPromise.then(function() {
             map.getView().fit(extent, map.getSize(), { nearest: true });
-          }
-        }, 0, false);
+          })
+        }
+        else {
+          console.warn('Map must be created by mapsManager');
+        }
 
         // load the resources & add additional layers if available
         var layers = context.resourceList.layer;

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -253,8 +253,8 @@
         angular.extend(gnSearchSettings, this.gnCfg.mods.search);
         this.isMapViewerEnabled = this.gnCfg.mods.map.enabled;
         gnViewerSettings.bingKey = this.gnCfg.mods.map.bingKey;
-        gnViewerSettings.owsContext = gnViewerSettings.owsContext ||
-            this.gnCfg.mods.map.context;
+        gnViewerSettings.defaultContext =
+          gnViewerSettings.mapConfig['map-viewer'].context;
         gnViewerSettings.geocoder = this.gnCfg.mods.geocoder;
       },
       getDefaultConfig: function() {

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -40,24 +40,10 @@
         function(searchSettings, viewerSettings, gnOwsContextService,
                  gnMap, gnMapsManager) {
 
-          // these layers will be added along the default context
-          // (transform settings to be usable by the OwsContextService)
-          var viewerMapLayers = viewerSettings.mapConfig.viewerMapLayers;
-          viewerSettings.additionalMapLayers =
-            viewerMapLayers && viewerMapLayers.map ?
-            viewerMapLayers.map(function (layer) {
-              return {
-                name: '{type=' + layer.type + ', name=' + layer.name + '}',
-                title: layer.title,
-                group: 'Background layers',
-                server: [{
-                  service: 'urn:ogc:serviceType:WMS',
-                  onlineResource: [{
-                    href: layer.url
-                  }]
-                }]
-              }
-            }) : [];
+          if(viewerSettings.mapConfig.viewerMapLayers) {
+            console.warn('[geonetwork] Use of "mapConfig.viewerMapLayers" is depecrated. ' +
+              'Please configure layer per map type.')
+          }
 
           // Keep one layer in the background
           // while the context is not yet loaded.

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -41,7 +41,7 @@
                  gnMap, gnMapsManager) {
 
           if(viewerSettings.mapConfig.viewerMapLayers) {
-            console.warn('[geonetwork] Use of "mapConfig.viewerMapLayers" is depecrated. ' +
+            console.warn('[geonetwork] Use of "mapConfig.viewerMapLayers" is deprecated. ' +
               'Please configure layer per map type.')
           }
 

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -115,20 +115,8 @@
 
           };
 
-          // Start location. This is usually overriden
-          // by context for large map and search records
-          // extent for minimap
-          var mapsConfig = viewerSettings.aoi || {
-            center: [280274.03240585705, 6053178.654789996],
-            zoom: 2
-          };
-
-          var viewerMap = new ol.Map({
-            controls: [],
-            view: new ol.View(mapsConfig)
-          });
-
           var searchMap = gnMapsManager.createMap(gnMapsManager.SEARCH_MAP);
+          var viewerMap = gnMapsManager.createMap(gnMapsManager.VIEWER_MAP);
 
           // Map protocols used to load layers/services in the map viewer
           searchSettings.mapProtocols = {

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -35,20 +35,14 @@
         'gnSearchSettings',
         'gnViewerSettings',
         'gnOwsContextService',
-        'gnMap', 'gnMapsManager',
-        'gnGlobalSettings',
-        '$location',
+        'gnMap',
+        'gnMapsManager',
         function(searchSettings, viewerSettings, gnOwsContextService,
-                 gnMap, gnMapsManager, gnGlobalSettings, $location) {
-
-          // Load the context defined in the configuration
-          viewerSettings.defaultContext =
-              (viewerSettings.mapConfig.map || '../../map/config-viewer.xml');
-          viewerSettings.owsContext = $location.search().map;
+                 gnMap, gnMapsManager) {
 
           // these layers will be added along the default context
           // (transform settings to be usable by the OwsContextService)
-          var viewerMapLayers = viewerSettings.mapConfig.viewerMapLayers
+          var viewerMapLayers = viewerSettings.mapConfig.viewerMapLayers;
           viewerSettings.additionalMapLayers =
             viewerMapLayers && viewerMapLayers.map ?
             viewerMapLayers.map(function (layer) {

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -306,24 +306,13 @@
           m.map.enabled ? '/map' : 'home'
         );
       }
-      $scope.activeTab = $location.path().
-          match(/^(\/[a-zA-Z0-9]*)($|\/.*)/)[1];
-
-      $scope.$on('$locationChangeSuccess', function(next, current) {
+      var setActiveTab = function() {
         $scope.activeTab = $location.path().
-            match(/^(\/[a-zA-Z0-9]*)($|\/.*)/)[1];
+        match(/^(\/[a-zA-Z0-9]*)($|\/.*)/)[1];
+      };
 
-        // resize viewer map for corresponding view
-        if (gnSearchLocation.isMap() && (!angular.isArray(
-            viewerMap.getSize()) || viewerMap.getSize().indexOf(0) >= 0)) {
-          setTimeout(function() {
-            var map = $location.search().map;
-            if (angular.isDefined(map)) {
-              $scope.resultviewFns.loadMap({url: map});
-            }
-          }, 0);
-        }
-      });
+      setActiveTab();
+      $scope.$on('$locationChangeSuccess', setActiveTab);
 
       angular.extend($scope.searchObj, {
         advancedMode: false,

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -313,34 +313,10 @@
         $scope.activeTab = $location.path().
             match(/^(\/[a-zA-Z0-9]*)($|\/.*)/)[1];
 
-        // resize search map for any views exluding viewer
-        if (!gnSearchLocation.isMap() && (!angular.isArray(
-            searchMap.getSize()) || searchMap.getSize()[0] < 0)) {
-          setTimeout(function() {
-            searchMap.updateSize();
-
-            // if an extent was obtained from a loaded context, apply it
-            if(searchMap.get('lastExtent')) {
-              searchMap.getView().fit(
-                searchMap.get('lastExtent'),
-                searchMap.getSize(), { nearest: true });
-            }
-          }, 0);
-        }
-
         // resize viewer map for corresponding view
         if (gnSearchLocation.isMap() && (!angular.isArray(
             viewerMap.getSize()) || viewerMap.getSize().indexOf(0) >= 0)) {
           setTimeout(function() {
-            viewerMap.updateSize();
-
-            // if an extent was obtained from a loaded context, apply it
-            if(viewerMap.get('lastExtent')) {
-              viewerMap.getView().fit(
-                viewerMap.get('lastExtent'),
-                viewerMap.getSize(), { nearest: true });
-            }
-
             var map = $location.search().map;
             if (angular.isDefined(map)) {
               $scope.resultviewFns.loadMap({url: map});

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -201,16 +201,8 @@
       <link rel="stylesheet" href="{$uiResourcesPath}lib/d3_timeseries/nv.d3.min.css"/>
       <script type="text/javascript">
         var module = angular.module('gn_search');
-        module.config(['gnViewerSettings', 'gnGlobalSettings',
-        function(gnViewerSettings, gnGlobalSettings) {
-        <xsl:if test="$owsContext">
-          gnViewerSettings.owsContext = '<xsl:value-of select="$owsContext"/>';
-        </xsl:if>
-        <xsl:if test="$wmsUrl and $layerName">
-          gnViewerSettings.wmsUrl = '<xsl:value-of select="$wmsUrl"/>';
-          gnViewerSettings.layerName = '<xsl:value-of select="$layerName"/>';
-          gnViewerSettings.layerGroup = '<xsl:value-of select="$layerGroup"/>';
-        </xsl:if>
+        module.config(['gnGlobalSettings',
+        function(gnGlobalSettings) {
         gnGlobalSettings.shibbolethEnabled = <xsl:value-of select="$shibbolethOn"/>;
         }]);
       </script>

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -59,10 +59,6 @@
 
   <xsl:variable name="searchView"
                 select="if (/root/request/view) then /root/request/view else if(util:getSettingValue('system/ui/defaultView')) then util:getSettingValue('system/ui/defaultView') else 'default'"></xsl:variable>
-  <xsl:variable name="owsContext" select="/root/request/owscontext"/>
-  <xsl:variable name="wmsUrl" select="/root/request/wmsurl"/>
-  <xsl:variable name="layerName" select="/root/request/layername"/>
-  <xsl:variable name="layerGroup" select="/root/request/layergroup"/>
   <xsl:variable name="angularModule"
                 select="if ($angularApp = 'gn_search') then concat('gn_search_', $searchView) else $angularApp"></xsl:variable>
 


### PR DESCRIPTION
Load `viewerMap` in `mapsManager` as it was done for `searchMap`.
Fix `mapsManager` issues and move the localStorage context loading in this service, from `OwsContextService`.

Add a map size load directive to tell when the map has an ok size to be fit.
This make `lastExtent` useless.
Make `baselayerDirective` more robust if the context has been loaded before directive.
Move url params `owscontext, layergroup, layername, wmsurl` to angular params