### PR TITLE
Add support to map attribution

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -93,8 +93,9 @@
               zoom: 2
             }),
             // show zoom control in editor maps only
-            controls: type !== this.EDITOR_MAP ? [] : [
-              new ol.control.Zoom()
+            controls: type !== this.EDITOR_MAP ? [new ol.control.Attribution()] : [
+              new ol.control.Zoom(),
+              new ol.control.Attribution()
             ]
           });
 

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -124,7 +124,7 @@
           };
 
           var viewerMap = new ol.Map({
-            controls: [],
+            controls: [new ol.control.Attribution()],
             view: new ol.View(mapsConfig)
           });
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -11,6 +11,13 @@
   width: 250px !important;
   height: 250px !important;
   margin: 5px;
+  .ol-attribution {
+    right: auto;
+    left: .5em;
+  }
+  .ol-attribution button {
+    float: left;
+  }
 }
 
 // map viewer
@@ -20,6 +27,14 @@
   bottom: 0px;
   left: 0px;
   right: 0px;
+
+  .ol-attribution {
+    right: auto;
+    left: .5em;
+  }
+  .ol-attribution button {
+    float: left;
+  }
 
   .panel-tools {
     .panel-heading {


### PR DESCRIPTION
This PR addresses [this]( https://github.com/geonetwork/core-geonetwork/issues/2454) issue, and adds an expandable attribution control (hidden by default), in the bottom left corner of the map viewer and of the mini map (see screenshots).

It applies to OSM, as well to any other background map.

![attribution1](https://user-images.githubusercontent.com/1038897/36641003-45ee833e-1a29-11e8-8468-2ed64f0124f6.png)

![atrribution2](https://user-images.githubusercontent.com/1038897/36641004-4aa758d8-1a29-11e8-9c8e-6dca5e56f0b8.png)

![minimap](https://user-images.githubusercontent.com/1038897/36641007-4ee7d4b8-1a29-11e8-9995-dfdbdf1a786f.png)
