### PR TITLE
Missing content in metadata full view (ISO19110)

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -248,12 +248,10 @@
       <xsl:variable name="title"
                     select="gn-fn-render:get-schema-strings($schemaStrings, @id)"/>
 
-      <div id="gn-tab-{@id}" class="tab-pane">
-        <xsl:if test="count(following-sibling::tab) > 0">
-          <h1 class="view-header">
-            <xsl:value-of select="$title"/>
-          </h1>
-        </xsl:if>
+      <xsl:if test="count(following-sibling::tab) = 0">
+        <h1 class="view-header">
+          <xsl:value-of select="$title"/>
+        </h1>
         <xsl:choose>
           <xsl:when test="normalize-space($content) = ''">
             No information
@@ -262,7 +260,22 @@
             <xsl:copy-of select="$content"/>&#160;
           </xsl:otherwise>
         </xsl:choose>
-      </div>
+      </xsl:if>
+      <xsl:if test="count(following-sibling::tab) > 0">
+        <div id="gn-tab-{@id}" class="tab-pane">
+          <h1 class="view-header">
+            <xsl:value-of select="$title"/>
+          </h1>
+        <xsl:choose>
+          <xsl:when test="normalize-space($content) = ''">
+            No information
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="$content"/>&#160;
+          </xsl:otherwise>
+        </xsl:choose>
+        </div>
+      </xsl:if>
     </xsl:if>
   </xsl:template>
 


### PR DESCRIPTION
This fix a bug on full view of metadata ISO19110 (and in general on every metadata record containing no tabs) that shows nothing but the title.

With this fix the content is shown also if not in tabs.

https://github.com/geonetwork/core-geonetwork/issues/2562