### PR TITLE
Fix for missing Styles on ESRI WMS requests

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -637,6 +637,12 @@
 
             var options = layerOptions || {};
 
+            // Workaround for ESRI
+            // where STYLES is a mandatory field
+            if(layerParams.STYLES==='') {
+              options.url += "STYLES=";
+            }
+
             var source, olLayer;
             if (gnViewerSettings.singleTileWMS) {
               var config = {
@@ -841,10 +847,6 @@
               if (requestedStyle) {
                 layerParam.STYLES = requestedStyle.Name;
               } else {
-                // STYLES is mandatory parameter.
-                // ESRI will complain on this.
-                // Even &STYLES&... return an error on ESRI.
-                // TODO: Fix or workaround
                 layerParam.STYLES = '';
               }
 


### PR DESCRIPTION
This fix is to add the mandatory field STYLES to requests to ESRI WMS services. When it's missing, it's set to empty.

https://github.com/geonetwork/core-geonetwork/issues/2409