### PR TITLE
Metadata file store / Encode file name for URL.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -25,6 +25,7 @@
 
 package org.fao.geonet.api.records.attachments;
 
+import com.google.common.net.UrlEscapers;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.fao.geonet.ApplicationContextHolder;
@@ -124,7 +125,9 @@ public class FilesystemStore implements Store {
                  Files.newDirectoryStream(resourceTypeDir, filter)) {
             for (Path path : directoryStream) {
                 MetadataResource resource = new FilesystemStoreResource(
-                    metadataUuid + "/attachments/" + path.getFileName(),
+                    UrlEscapers.urlFragmentEscaper().escape(metadataUuid) +
+                       "/attachments/" +
+                       UrlEscapers.urlFragmentEscaper().escape(path.getFileName().toString()),
                     settingManager.getNodeURL() + "api/records/",
                     visibility,
                     Files.size(path));

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -13,7 +13,7 @@
         <a href=""
            title="{{'clickToAddResource' | translate}}"
            data-ng-click="setResource(r)">
-          {{r.id.split('/').splice(2).join('/')}}
+          {{r.id.split('/').splice(2).join('/') | decodeURIComponent}}
         </a>
       </td>
       <td>


### PR DESCRIPTION
If attachement's file name contains characters that need to be encoded in URL, they are not for now

![image](https://user-images.githubusercontent.com/1701393/36730276-23204b0e-1bc7-11e8-9794-f365a5bef831.png)

In the XML

![image](https://user-images.githubusercontent.com/1701393/36730317-4a728000-1bc7-11e8-94f4-1a6f94602b33.png)


Should be

![image](https://user-images.githubusercontent.com/1701393/36730331-562a8302-1bc7-11e8-9bac-c9bbd831804d.png)


Thinking of how to migrate existing records ... any suggestions welcomed.