### PR TITLE
Minor fix to german iso19139 labels (protocols)

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2565,8 +2565,7 @@
       Locator)
     </description>
   </element>
-  <element name="gmd:protocol" context="gmd:CI_OnlineResource"
-           id="398" alias="protocol">
+  <element name="gmd:protocol" id="398.0" alias="protocol">
     <label>Protokoll</label>
     <help/>
     <condition/>


### PR DESCRIPTION
The codelist was not defined like the others, see:
https://github.com/geonetwork/core-geonetwork/blob/ee31c1aa388adcebfaf0c4fcb970351b4813eb8b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml#L2172-L2174