### PR TITLE
Simplify metadataUuid management in mapService

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1234,7 +1234,6 @@
                   olL = $this.addWmsToMap(map, o);
                   
                   if(md && md['geonet:info']['uuid']) {
-                	  olL.set('MDuuid', md['geonet:info']['uuid']);
                     olL.set('metadataUuid', md['geonet:info']['uuid']);
                   }
 
@@ -1269,8 +1268,7 @@
                   var feedMdPromise = md ?
                     $q.resolve(md).then(function(md) {
                       olL.set('md', md);
-                      if(!angular.isUndefined(md['geonet:info']['uuid'])) {
-                    	  olL.set('MDuuid', md['geonet:info']['uuid']);
+                      if(olL && md && md['geonet:info']['uuid']) {
                         olL.set('metadataUuid', md['geonet:info']['uuid']);
                       }
                     }) : $this.feedLayerMd(olL);
@@ -1289,10 +1287,9 @@
               });
             } else {
             	var olL = getTheLayerFromMap(map, name, url);
-            	if(olL && md && md['geonet:info']['uuid']) {
-                olL.set('MDuuid', md['geonet:info']['uuid']);
-                olL.set('metadataUuid', md['geonet:info']['uuid']);
-              }
+                if(olL && md && md['geonet:info']['uuid']) {
+                  olL.set('metadataUuid', md['geonet:info']['uuid']);
+                }
             }
             return defer.promise;
           },

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1232,9 +1232,9 @@
                     o.version = version;
                   }
                   olL = $this.addWmsToMap(map, o);
-                  
-                  if(md && md.getUuid()) {
-                    olL.set('metadataUuid', md.getUuid());
+
+                  if(olL && md) {
+                    olL.set('md', md);
                   }
 
                   if (!angular.isArray(olL.get('errors'))) {
@@ -1268,9 +1268,6 @@
                   var feedMdPromise = md ?
                     $q.resolve(md).then(function(md) {
                       olL.set('md', md);
-                      if(olL && md && md.getUuid()) {
-                        olL.set('metadataUuid', md.getUuid());
-                      }
                     }) : $this.feedLayerMd(olL);
 
                   feedMdPromise.then(finishCreation);
@@ -1287,8 +1284,8 @@
               });
             } else {
             	var olL = getTheLayerFromMap(map, name, url);
-                if(olL && md && md.getUuid()) {
-                  olL.set('metadataUuid', md.getUuid());
+                if(olL && md) {
+                  olL.set('md', md);
                 }
             }
             return defer.promise;

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1233,8 +1233,8 @@
                   }
                   olL = $this.addWmsToMap(map, o);
                   
-                  if(md && md['geonet:info']['uuid']) {
-                    olL.set('metadataUuid', md['geonet:info']['uuid']);
+                  if(md && md.getUuid()) {
+                    olL.set('metadataUuid', md.getUuid());
                   }
 
                   if (!angular.isArray(olL.get('errors'))) {
@@ -1268,8 +1268,8 @@
                   var feedMdPromise = md ?
                     $q.resolve(md).then(function(md) {
                       olL.set('md', md);
-                      if(olL && md && md['geonet:info']['uuid']) {
-                        olL.set('metadataUuid', md['geonet:info']['uuid']);
+                      if(olL && md && md.getUuid()) {
+                        olL.set('metadataUuid', md.getUuid());
                       }
                     }) : $this.feedLayerMd(olL);
 
@@ -1287,8 +1287,8 @@
               });
             } else {
             	var olL = getTheLayerFromMap(map, name, url);
-                if(olL && md && md['geonet:info']['uuid']) {
-                  olL.set('metadataUuid', md['geonet:info']['uuid']);
+                if(olL && md && md.getUuid()) {
+                  olL.set('metadataUuid', md.getUuid());
                 }
             }
             return defer.promise;

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -83,10 +83,14 @@
     var layer = this.layer,
         map = this.map,
         coordinates = this.coordinates;
-    
-    var uuid = layer.get('MDuuid');
 
-   
+    var uuid;
+    if(layer.get('md')) {
+      uuid = layer.get('md').getUuid();
+    } else if(layer.get('metadataUuid')) {
+      uuid = layer.get('metadataUuid');
+    }
+
     var uri = layer.getSource().getGetFeatureInfoUrl(
         coordinates,
         map.getView().getResolution(),
@@ -129,7 +133,7 @@
 
         this.dictionary = null;
 
-        if(!angular.isUndefined(uuid)) {
+        if(uuid) {
           this.dictionary = this.$http.get('../api/records/'+uuid+'/featureCatalog?_content_type=json')
           .then(function(response) {
             if(response.data['decodeMap']!=null) {


### PR DESCRIPTION
This to remove a duplication of code introduced with these changes https://github.com/geonetwork/core-geonetwork/pull/2333

The metadataUUID is already available in the layer, so there is no need to extract it again from metadata record.