### PR TITLE
Editor / Add permalink

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -72,7 +72,8 @@
   }]);
 
   module.factory('gnUtilityService',
-      ['gnPopup', '$translate', function(gnPopup, $translate) {
+      ['gnPopup', '$translate', '$location',
+        function(gnPopup, $translate, $location) {
         /**
        * Scroll page to element.
        */
@@ -85,6 +86,8 @@
           }
           $('body,html').animate({scrollTop: top},
            duration, easing);
+
+          $location.search('scrollTo', elementId);
         };
 
         /**

--- a/web-ui/src/main/resources/catalog/js/admin/AdminController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminController.js
@@ -263,6 +263,7 @@
           when('/settings', {
             templateUrl: tplFolder + 'page-layout.html',
             controller: 'GnSettingsController',
+            reloadOnSearch: false,
             resolve: {
               permission: function() {
                 authorizationService.$get[0]().check('Administrator');

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -68,9 +68,9 @@
    */
   module.controller('GnSystemSettingsController', [
     '$scope', '$http', '$rootScope', '$translate', '$location',
-    'gnUtilityService',
+    'gnUtilityService', '$timeout',
     function($scope, $http, $rootScope, $translate, $location,
-        gnUtilityService) {
+        gnUtilityService, $timeout) {
 
       $scope.settings = [];
       $scope.initalSettings = [];
@@ -161,6 +161,13 @@
                       'children': filterBySection($scope.settings, level2name)
                     });
                   }
+                }
+
+                var target = $location.search()['scrollTo'];
+                if (target) {
+                  $timeout(function () {
+                    gnUtilityService.scrollTo(target);
+                  }, 300);
                 }
               }
             }).error(function(data) {

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -64,13 +64,8 @@
       $routeProvider.
           when('/metadata/:id', {
             templateUrl: tplFolder + 'editor.html',
-            controller: 'GnEditorController'}).
-          when('/metadata/:id/tab/:tab', {
-            templateUrl: tplFolder + 'editor.html',
-            controller: 'GnEditorController'}).
-          when('/metadata/:id/tab/:tab/:displayAttributes', {
-            templateUrl: tplFolder + 'editor.html',
-            controller: 'GnEditorController'}).
+            controller: 'GnEditorController',
+            reloadOnSearch: false}).
           when('/create', {
             templateUrl: gnGlobalSettings.gnCfg.mods.editor.createPageTpl,
             controller: 'GnNewMetadataController'}).
@@ -230,10 +225,10 @@
                   id: $routeParams.id,
                   formId: '#gn-editor-' + $routeParams.id,
                   containerId: '#gn-editor-container-' + $routeParams.id,
-                  tab: $routeParams.tab || defaultTab,
-                  displayAttributes: $routeParams.displayAttributes === 'true',
-                  displayTooltips: $routeParams.displayTooltips === 'true',
-                  displayTooltipsMode: $routeParams.displayTooltipsMode || '',
+                  tab: $location.search()['tab'] || defaultTab,
+                  displayAttributes: $location.search()['displayAttributes'] === 'true',
+                  displayTooltips: $location.search()['displayTooltips'] === 'true',
+                  displayTooltipsMode: $location.search()['displayTooltipsMode'] || '',
                   compileScope: $scope,
                   formScope: $scope.$new(),
                   sessionStartTime: moment(),
@@ -261,8 +256,25 @@
                   editorFormUrl += '&displayTooltips=true';
                 }
 
+                if (gnCurrentEdit.displayTooltipsMode != '') {
+                  editorFormUrl += '&displayTooltipsMode='
+                    + gnCurrentEdit.displayTooltipsMode ;
+                }
+
                 gnEditor.load(editorFormUrl).then(function() {
                   // $scope.onFormLoad();
+                  // Once the editor form is loaded, then
+                  // user might have set a target element
+                  // to scroll to.
+                  var target = $location.search()['scrollTo'];
+                  if (target) {
+                    $timeout(function () {
+                      gnUtilityService.scrollTo(target);
+                    }, 300);
+                    // Delayed a bit, the time to the form
+                    // and all directives to be rendered which
+                    // may affect element positions.
+                  }
                 });
 
                 window.onbeforeunload = function() {
@@ -334,6 +346,8 @@
         // Disable form + indicator ?
         //        $($scope.formId + ' > fieldset').fadeOut(duration);
         $scope.save(true);
+
+        $location.search('tab', tabIdentifier);
       };
 
       /**


### PR DESCRIPTION
The editor permalink allows users to point to a specific section of the editor
and use it in emails or links in the application.

The permalink is structured as followed:

```
http://localhost:8080/geonetwork/srv/eng/catalog.edit
                     #/metadata/{metadataId}?
                           tab={tabIdentifier}&
                           scrollTo={elementSelector}&
                           displayAttributes=true&
                           displayTooltips=true&
                           displayTooltipsMode={icon|onhover}
```

The path part of the URL (after the # and before the ?) define
the identifier of the metadata record to edit with the **metadataId** parameter.

Then the search part of the URL define a set of parameters
to customize the editor:

* **tab**: One tab identifier defined in config-editor.xml (eg. identificationInfo, metadata, xml). Remember a view is composed of one or more tab. Point to a tab to define which view to open.
* **scrollTo**: A CSS element selector. Could be a form element id (eg. ```#gn-editor-142-2```), a class (eg. ```.gn-descriptiveKeywords```)
* **displayAttributes** (false by default): Define if the form should display field attributes
* **displayTooltips** (false by default): Define if tooltips are enabled by default
* **displayTooltipsMode**: Define how tooltips are displayed. Focus on the form field or click on icon