### PR TITLE
Check for height and width when initializing a map view

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -121,10 +121,12 @@
           }.bind(this));
 
           var unWatchFn = $rootScope.$watch(function() {
-            return map.getTargetElement() &&
-              map.getTargetElement().offsetWidth;
-          }, function(width) {
-            if (width > 0) {
+            return map.getTargetElement() && Math.min(
+              map.getTargetElement().offsetWidth,
+              map.getTargetElement().offsetHeight
+            );
+          }, function(size) {
+            if (size > 0) {
               map.updateSize();
               defer.resolve();
               unWatchFn();


### PR DESCRIPTION
Minor fix following #2580 

In some cases, a map view would be initialized even though the map container has no height (since the wheck is only done on the width)