### PR TITLE
Add support to map attribution

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -104,8 +104,9 @@
               zoom: 2
             }),
             // show zoom control in editor maps only
-            controls: type !== this.EDITOR_MAP ? [] : [
-                new ol.control.Zoom()
+            controls: type !== this.EDITOR_MAP ? [new ol.control.Attribution()] : [
+                new ol.control.Zoom(),
+                new ol.control.Attribution()
               ]
           });
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -11,6 +11,13 @@
   width: 250px !important;
   height: 250px !important;
   margin: 5px;
+  .ol-attribution {
+    right: auto;
+    left: .5em;
+  }
+  .ol-attribution button {
+    float: left;
+  }
 }
 
 // map viewer
@@ -20,6 +27,13 @@
   bottom: 0px;
   left: 0px;
   right: 0px;
+  .ol-attribution {
+    right: auto;
+    left: .5em;
+  }
+  .ol-attribution button {
+    float: left;
+  }
 
   .panel-tools {
     .panel-heading {


### PR DESCRIPTION
Add expandable attribution control, in the bottom left corner of the map viewer and of the mini map.

Discussion [here](https://github.com/geonetwork/core-geonetwork/pull/2581).

