### PR TITLE
Check for not supported map projections

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -463,6 +463,16 @@
            * @return {Object} defaultMapConfig mapconfig
            */
           getMapConfig: function() {
+
+            // Check for unsupported projections
+            // To avoid to break the search page and map
+            if(gnViewerSettings.mapConfig.projection && !ol.proj.get(gnViewerSettings.mapConfig.projection)) {
+              console.log('%c The map projection ' + gnViewerSettings.mapConfig.projection + ' is not supported.','color: #d00d00');
+              console.log('Now using default projection EPSG:3857.');
+              // Switching to default
+              gnViewerSettings.mapConfig.projection = 'EPSG:3857';
+            }
+
             return gnViewerSettings.mapConfig;
           },
 

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -467,7 +467,7 @@
             // Check for unsupported projections
             // To avoid to break the search page and map
             if(gnViewerSettings.mapConfig.projection && !ol.proj.get(gnViewerSettings.mapConfig.projection)) {
-              console.log('%c The map projection ' + gnViewerSettings.mapConfig.projection + ' is not supported.','color: #d00d00');
+              console.warn('The map projection ' + gnViewerSettings.mapConfig.projection + ' is not supported.');
               console.log('Now using default projection EPSG:3857.');
               // Switching to default
               gnViewerSettings.mapConfig.projection = 'EPSG:3857';


### PR DESCRIPTION
This check can avoid an unexpected behaviour that can compromise the stability of a GeoNetwork instance. The issue is described here https://github.com/geonetwork/core-geonetwork/issues/2569

This fix checks if a projection is supported before it breaks the system. If a projection is not supported a default one is used, and a warning is shown on the console together with a message that notifies the use of the default projection.
