### PR TITLE
Fixes a NPE when override is set in WebDAV harvesters

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -99,7 +99,7 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
 
     //--------------------------------------------------------------------------
     private DataManager dataMan;
-    
+
     private MetadataRepository metadataRepository;
 
     //--------------------------------------------------------------------------
@@ -272,10 +272,9 @@ class Harvester extends BaseAligner implements IHarvester<HarvestResult> {
             result.datasetUuidExist++;
             switch(params.getOverrideUuid()){
             case OVERRIDE:
-                UriMapper localUris = new UriMapper(context, 
-                        metadataRepository.findOneByUuid(uuid).getHarvestInfo().getUuid());
-                List<RecordInfo> records = localUris.getRecords(rf.getPath());
-                updateMetadata(rf, records.get(0));
+                Metadata existingMetadata = metadataRepository.findOneByUuid(uuid);
+                RecordInfo existingRecordInfo = new RecordInfo(existingMetadata);
+                updateMetadata(rf, existingRecordInfo);
                 log.info("Overriding record with uuid " + uuid);
                 result.updatedMetadata++;
                 return;


### PR DESCRIPTION
If there is a record with the same UUID harvested by another harvester, a NullPointerException is
thrown when it is harvested again from a WebDAV harvester with the Override option set:

```
2018-03-07 13:24:02,220 INFO  [localwebdav] - Start of alignment for : localwebdav
2018-03-07 13:24:02,253 WARN  [geonetwork.resources] - Resource not found images/harvesting/blank.png, default resource returned: /images/harvesting/blank.png
2018-03-07 13:24:02,280 ERROR [localwebdav] - Raised exception while harvesting from : localwebdav (WebDavHarvester)
java.lang.NullPointerException
2018-03-07 13:24:02,280 ERROR [localwebdav] -  (C) Class   : NullPointerException
    at org.fao.geonet.kernel.harvest.harvester.webdav.Harvester.addMetadata(Harvester.java:276)
2018-03-07 13:24:02,280 ERROR [localwebdav] -  (C) Message : null
    at org.fao.geonet.kernel.harvest.harvester.webdav.Harvester.align(Harvester.java:221)
    at org.fao.geonet.kernel.harvest.harvester.webdav.Harvester.harvest(Harvester.java:172)
    at org.fao.geonet.kernel.harvest.harvester.webdav.WebDavHarvester.doHarvest(WebDavHarvester.java:118)
    at org.fao.geonet.kernel.harvest.harvester.AbstractHarvester$HarvestWithIndexProcessor.process(AbstractHarvester.java:650)
    at org.fao.geonet.kernel.harvest.harvester.AbstractHarvester.harvest(AbstractHarvester.java:722)
    at org.fao.geonet.kernel.harvest.harvester.HarvesterJob.execute(HarvesterJob.java:57)
    at org.quartz.core.JobRunShell.run(JobRunShell.java:213)
    at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:557)
```

This pull request fixes this error.