### PR TITLE
Small improvements to WPS directive API

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -100,6 +100,8 @@
 
           scope.hideExecuteButton = !!scope.$eval(attrs.hideExecuteButton);
           scope.hideTitle = !!scope.$eval(attrs.hideTitle);
+          scope.cancelPrevious = attrs.cancelPrevious !== undefined ?
+            !!scope.$eval(attrs.cancelPrevious) : true;
 
           // this will hold pre-loaded process descriptions
           // keys are: '<processId>@<uri>'
@@ -179,7 +181,7 @@
 
             // query a description and build up the form
             gnWpsService.describeProcess(newLink.uri, newLink.processId, {
-              cancelPrevious: true
+              cancelPrevious: scope.cancelPrevious
             }).then(
                 function(response) {
                   scope.describeState = 'succeeded';

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -29,6 +29,10 @@
   var module = angular.module('gn_wps_directive', [
   ]);
 
+  function isFieldNotEmpty (value) {
+    return value !== undefined && value !== ''
+  }
+
   /**
    * @ngdoc directive
    * @name gn_viewer.directive:gnWpsProcessForm
@@ -212,7 +216,7 @@
                             }
 
                             if (wfsFilter && wfsFilterValues &&
-                            wfsFilterValues[wfsFilter]) {
+                              isFieldNotEmpty(wfsFilterValues[wfsFilter])) {
                               // take value at specific index, or all values
                               if (valueIndex >= 0) {
                                 wfsFilterValue =
@@ -227,12 +231,12 @@
 
                       // display field as overriden
                       scope.inputWfsOverride[inputName] =
-                      wfsFilterValue && wfsFilterValue.length > 0;
+                      isFieldNotEmpty(wfsFilterValue) && wfsFilterValue.length > 0;
 
                       // literal data (basic form input)
-                      if (input.literalData != undefined) {
+                      if (input.literalData !== undefined) {
                         // Default value (if not already there)
-                        if (input.literalData.defaultValue != undefined &&
+                        if (input.literalData.defaultValue !== undefined &&
                         defaultValue === undefined) {
                           defaultValue = input.literalData.defaultValue;
 
@@ -320,12 +324,13 @@
                         });
                       }
                       // apply default values if any
-                      else if (defaultValue) {
+                      else if (isFieldNotEmpty(defaultValue)) {
                         inputs = scope.getInputsByName(inputName);
                         var defaultValueArray = Array.isArray(defaultValue) ?
                         defaultValue : [defaultValue];
-                        for (var i = 0; i < inputs.length; i++) {
-                          if (!inputs[i].value && defaultValueArray[i]) {
+                        for(var i = 0; i < inputs.length; i++) {
+                          if (!isFieldNotEmpty(inputs[i].value) &&
+                          isFieldNotEmpty(defaultValueArray[i])) {
                             scope.setInputValueByName(inputName, i,
                             defaultValueArray[i]);
                           }
@@ -444,7 +449,7 @@
                   // count the number of non empty values
                   var valueCount = scope.getInputsByName(input.identifier.value)
                   .filter(function(input) {
-                    return input.value;
+                    return isFieldNotEmpty(input.value);
                   }).length;
 
                   // this will be used to show errors on the form

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -82,7 +82,8 @@
         scope: {
           map: '=',
           wpsLink: '=',
-          wfsLink: '='
+          wfsLink: '=',
+          describedCallback: '&'
         },
         templateUrl: function(elem, attrs) {
           return attrs.template ||
@@ -423,6 +424,11 @@
                     }
                     scope.loadedDescriptions[processKey] =
                     angular.extend({}, scope.processDescription);
+                  }
+
+                  // described callback
+                  if (scope.describedCallback) {
+                    scope.describedCallback();
                   }
                 },
                 function(response) {

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -64,8 +64,15 @@
    *    set up an application profile object for a WPS service
    * @directiveInfo {Object} wfsLink the WFS link object
    *  will be used to overload inputs based on active WFS feature filters
-   * @directiveInfo {boolean} hideExecuteButton if true,
-   *  the 'execute' button is hidden
+   * @directiveInfo {function} describedCallback will be called with no arg when
+   *  the describeProcess request has been done & processed; this means the form
+   *  is ready to use
+   * @directiveInfo {boolean} hideExecuteButton if true, the 'execute' button
+   *  will be hidden
+   * @directiveInfo {boolean} hideTitle if true, the form title will be hidden
+   * @directiveInfo {boolean} cancelPrevious if true, concurrent requests on WPS
+   *  endpoints will be allowed; this permits having several forms at the same
+   *  time in the UI
    */
   module.directive('gnWpsProcessForm', [
     'gnWpsService',

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -508,10 +508,7 @@
                     if (response.status.processSucceeded &&
                         gnWpsService.responseHasWmsService(response)) {
                       gnWpsService.extractWmsLayerFromResponse(
-                          response, scope.map, scope.wpsLink.layer, {
-                            exclude: /^OUTPUT_/i
-                          }
-                      );
+                          response, scope.map, scope.wpsLink.layer);
                     }
                   }
                 }

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -97,7 +97,8 @@
             mimeType: ''
           };
 
-          scope.hideExecuteButton = attrs.hideExecuteButton;
+          scope.hideExecuteButton = !!scope.$eval(attrs.hideExecuteButton);
+          scope.hideTitle = !!scope.$eval(attrs.hideTitle);
 
           // this will hold pre-loaded process descriptions
           // keys are: '<processId>@<uri>'

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -53,7 +53,15 @@
    *
    * @directiveInfo {Object} map
    * @directiveInfo {Object} wpsLink this object holds information on the WPS
-   *  service to use: name, url and applicationProfile (optional)
+   *  service to use; expected keys are:
+   *  * `name`: required, process identifier
+   *  * `url`: required, process URL
+   *  * `labels`: optional, object holding a string for different languages (use
+   *     ISO3 language codes as returned by `$tanslate.use()`, see:
+   *     https://angular-translate.github.io/docs/#/api/pascalprecht.translate.$translate)
+   *  * `label`: optional, string
+   *  * `applicationProfile`: optional, refer to the documentation on how to
+   *    set up an application profile object for a WPS service
    * @directiveInfo {Object} wfsLink the WFS link object
    *  will be used to overload inputs based on active WFS feature filters
    * @directiveInfo {boolean} hideExecuteButton if true,
@@ -675,6 +683,10 @@
             var input = scope._getInputInfo(name);
             return input ? !!input.disabled : false;
           };
+
+          scope.getLabel = function() {
+            return gnWpsService.getProcessLabel(scope.wpsLink);
+          }
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -79,8 +79,9 @@
     'gnGlobalSettings',
     'gnMap',
     '$q',
+    '$translate',
     function($http, gnOwsCapabilities, gnUrlUtils, gnGlobalSettings,
-             gnMap, $q) {
+             gnMap, $q, $translate) {
 
       this.WMS_MIMETYPE_REGEX = /.*ogc-wms/;
 
@@ -446,6 +447,23 @@
           console.warn('Error extracting WMS layers from response: ', e);
         }
       };
+
+      /**
+       * Returns a label normalized for the process description
+       * Field used: `labels[currentLang]` or `label`
+       * IF no label found, return nothing
+       * @param {Object} wpsLink object holding the process link
+       */
+      this.getProcessLabel = function (wpsLink) {
+        var currentLang = $translate.use();
+        if (wpsLink.labels) {
+          return wpsLink.labels[currentLang];
+        } else if (wpsLink.label) {
+          return wpsLink.label;
+        } else {
+          return null;
+        }
+      }
     }
   ]);
 

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -425,10 +425,9 @@
        * @param {object} response excecuteProcess response object.
        * @param {ol.Map} map
        * @param {ol.layer.Base} parentLayer optional
-       * @param {object=} opt_options
        */
       this.extractWmsLayerFromResponse =
-          function(response, map, parentLayer, opt_options) {
+          function(response, map, parentLayer) {
 
         try {
           var ref = response.processOutputs.output[0].reference;
@@ -437,10 +436,7 @@
                 layers.forEach(function(l) {
                   l.set('fromWps', true);
                   l.set('wpsParent', parentLayer);
-                  if (opt_options &&
-                      !opt_options.exclude.test(l.get('label'))) {
-                    map.addLayer(l);
-                  }
+                  map.addLayer(l);
                 });
               });
         } catch (e) {

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -1,6 +1,6 @@
 <div>
   <div class="panel panel-default">
-    <h4 class="panel-heading" ng-if="describeState == 'succeeded'">
+    <h4 class="panel-heading" ng-if="describeState == 'succeeded' && !hideTitle">
       {{getLabel() || processDescription.title.value}}
       <span class="fa fa-info-circle" ng-if="::processDescription._abstract.value"
         title="{{::processDescription._abstract.value}}"></span>

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -1,7 +1,9 @@
 <div>
   <div class="panel panel-default">
     <h4 class="panel-heading" ng-if="describeState == 'succeeded'">
-      {{processDescription.title.value}}
+      {{getLabel() || processDescription.title.value}}
+      <span class="fa fa-info-circle" ng-if="::processDescription._abstract.value"
+        title="{{::processDescription._abstract.value}}"></span>
       <button type="button" class="btn btn-default close" data-ng-click="close()">
         &times;
       </button>

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -138,7 +138,7 @@
                 &nbsp;<span translate>wpsExecute</span>
               </button>
 
-              <div class="output-selection dropup">
+              <div class="output-selection dropup" ng-if="executeResponse.processOutputs.output.length > 0">
                 <button class="btn btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <span class="caret"></span>
                   &nbsp;<span translate>wpsSelectOutput</span>

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -47,8 +47,8 @@
               class="form-group">
 
               <!-- Input label & info -->
-              <span>
-                <label>{{::input.title.value}}</label>
+              <label>
+                <span>{{::input.title.value}}&nbsp;</span>
                 <span class="fa fa-info-circle" ng-if="::input._abstract.value"
                   title="{{::input._abstract.value}}"></span>
                 <small class="text-danger" ng-if="::input.minOccurs">
@@ -58,7 +58,7 @@
                 <small class="text-muted"
                   ng-if="inputWfsOverride[input.identifier.value]">
                   {{::'inputIsOverloaded' | translate}}</small>
-              </span>
+              </label>
 
               <!-- Basic form field (combo box or text field) -->
               <div ng-if="::input.literalData">

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -611,8 +611,9 @@ gn-wps-process-form {
     box-shadow: none;
 
     .panel-heading {
-      height: 2em;
-      line-height: 1.6em;
+      height: auto;
+      line-height: 1.2em;
+      padding: 6px 15px;
 
       .close {
         margin-right: -0.2em;


### PR DESCRIPTION
Some new options & improvements on the WPS form directive:
* `hide-title` and `cancel-previous` allows for finer tuning of the form behaviour (previously all previous requests to WPS endpoints would be cancelled when a new one was made)
* Some minor UI improvements
* Provided a callback for when the WPS process is described, i.e. the response to `DescribeProcess` has been received and correctly parsed