### PR TITLE
decrease page size in sitemap pagination

### DIFF
--- a/services/src/main/java/org/fao/geonet/guiservices/metadata/Sitemap.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/metadata/Sitemap.java
@@ -66,7 +66,7 @@ public class Sitemap implements Service {
     private static final String FORMAT_HTML = "html";
 
     // Max. items in page defined in spec
-    private static final int MAX_ITEMS_PER_PAGE = 50000;
+    private static final int MAX_ITEMS_PER_PAGE = 2500;
 
     private int _maxItemsPage;
 


### PR DESCRIPTION
a 20000 records request (doesn't hang the system anymore) but still takes 20 seconds, we have tha pagination in place, so why not decrease it a bit...