### PR TITLE
adds some social media annotations to metadata detail page

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -109,6 +109,10 @@
     <xsl:value-of select="gmd:hierarchyLevel/gmd:MD_ScopeCode/@codeListValue"/>
   </xsl:template>
 
+  <xsl:template mode="getMetadataThumbnail" match="gmd:MD_Metadata">
+    <xsl:value-of select="gmd:identificationInfo/*/gmd:graphicOverview[1]/gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString"/>
+  </xsl:template>
+
   <xsl:template mode="getOverviews" match="gmd:MD_Metadata">
     <section class="gn-md-side-overview">
       <h4>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -21,7 +21,7 @@
   <xsl:template mode="getMetadataTitle" match="*"/>
   <xsl:template mode="getMetadataAbstract" match="*"/>
   <xsl:template mode="getMetadataHierarchyLevel" match="*"/>
-  <xsl:template mode="getOverviews" match="*"/>
+  <xsl:template mode="getMetadataThumbnail" match="*"/>
   <xsl:template mode="getMetadataHeader" match="*"/>
   <!-- Those templates should be overriden in the schema plugin - end -->
 
@@ -43,6 +43,12 @@
           </xsl:with-param>
           <xsl:with-param name="description">
             <xsl:apply-templates mode="getMetadataAbstract" select="$metadata"/>
+          </xsl:with-param>
+          <xsl:with-param name="type">
+            <xsl:apply-templates mode="getMetadataHierarchyLevel" select="$metadata"/>
+          </xsl:with-param>
+          <xsl:with-param name="thumbnail">
+            <xsl:apply-templates mode="getMetadataThumbnail" select="$metadata"/>
           </xsl:with-param>
         </xsl:call-template>
       </xsl:otherwise>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -21,6 +21,7 @@
   <xsl:template mode="getMetadataTitle" match="*"/>
   <xsl:template mode="getMetadataAbstract" match="*"/>
   <xsl:template mode="getMetadataHierarchyLevel" match="*"/>
+  <xsl:template mode="getOverviews" match="*"/>
   <xsl:template mode="getMetadataThumbnail" match="*"/>
   <xsl:template mode="getMetadataHeader" match="*"/>
   <!-- Those templates should be overriden in the schema plugin - end -->

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -37,9 +37,14 @@
   <xsl:template name="render-html">
     <xsl:param name="content"/>
     <xsl:param name="title"
-               select="''"/>
+               select="/root/gui/systemConfig/settings/system/site/name"/>
     <xsl:param name="description"
-               select="''"/>
+               select="/root/gui/systemConfig/settings/strings/mainpage2"/>
+    <xsl:param name="thumbnail"
+               select="concat(/root/gui/url,'/images/logos/favicon.png')"/>
+    <xsl:param name="type"
+               select="'dataset'"/>
+
 
     <html>
       <head>
@@ -51,7 +56,20 @@
         <meta name="description" content="{normalize-space($description)}"/>
         <meta name="keywords" content=""/>
 
+        <meta property="og:title" content="{$title}" />
+        <meta property="og:description" content="{normalize-space($description)}" />
+        <meta property="og:site_name" content="{/root/gui/systemConfig/settings/system/site/name}" />
+        <meta property="og:image" content="{$thumbnail}" />
 
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:image" content="{$thumbnail}" />
+        <meta name="twitter:title" content="{$title}" />
+        <meta name="twitter:description" content="{normalize-space($description)}" />
+        <meta name="twitter:site" content="{/root/gui/systemConfig/settings/system/site/name}" />
+
+        <xsl:if test="/root/info/record/uuid">
+          <link rel="canonical" href="{$nodeUrl}api/records/{/root/info/record/uuid}" />
+        </xsl:if>
         <link rel="icon" sizes="16x16 32x32 48x48" type="image/png"
               href="{/root/gui/url}/images/logos/favicon.png"/>
         <link href="{$nodeUrl}eng/rss.search?sortBy=changeDate"
@@ -81,25 +99,25 @@
                 crossorigin="anonymous">
           &#160;
         </script>
-      
+
         <!-- Latest compiled and minified JavaScript -->
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" 
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
                 integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
                 crossorigin="anonymous">
           &#160;
         </script>
-      
+
         <script type="text/javascript">
           // attach click to tab
           $('.nav-tabs-advanced a').click(function (e) {
             e.preventDefault();
             $(this).tab('show');
           });
-          // hide empty tab     
+          // hide empty tab
           $('.nav-tabs-advanced a').each(function() {
-      
+
             var tabLink = $(this).attr('href');
-      
+
             if (tabLink) {
               if ($(tabLink).length === 0) {
                 $(this).parent().hide();
@@ -114,3 +132,5 @@
     </html>
   </xsl:template>
 </xsl:stylesheet>
+
+


### PR DESCRIPTION
adds some social media annotations + canonical link to metadata details page to optimise browsing and search experience, resolves #2653

todo: add to iso19115-1 the getMetadataThumbnail override, that returns a single thumbnail url