### PR TITLE
Align schema fields in CSW harvester: Fixes #2608

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -298,6 +298,7 @@
     "csw-outputSchemaOptions": "Typical Output Schemas",
     "csw-dublinCore": "Dublin Core",
     "csw-iso19139": "ISO 19139",
+    "csw-recommendedValues": "Recommended values",
     "currentCatalogLogo": "Current catalog logo",
     "customConfiguration": "Custom ...",
     "customizeElementSet": "Customize element set",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
@@ -102,13 +102,13 @@
           <input type="text" class="form-control gn-csw-criteria" id="csw-outputSchemaInput"
                  data-ng-model="harvesterSelected.site.outputSchema"/>
         </div>
-        <div class="col-lg-4 col-md-4 col-sm-4 hidden-xs gn-nopadding-left gn-nopadding-right">
+        <div class="col-lg-4 col-md-4 col-sm-4 hidden-xs gn-nopadding-right">
           <label class="control-label" data-translate="">csw-outputSchemaOptions</label>
           <select data-ng-model="harvesterSelected.site.outputSchema"
                   class="form-control gn-csw-criteria"
                   id="csw-outputSchemaOptionsSelect">
-            <option value="http://www.opengis.net/cat/csw/2.0.2" data-translate="">csw-dublinCore
-            </option>
+            <option value="" disabled="" data-translate="">csw-recommendedValues</option>
+            <option value="http://www.opengis.net/cat/csw/2.0.2" data-translate="">csw-dublinCore</option>
             <option value="http://www.isotc211.org/2005/gmd" data-translate="">csw-iso19139</option>
           </select>
         </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
@@ -96,19 +96,23 @@
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
     </div>
     <div>
-      <label class="control-label" data-translate="">csw-outputSchema</label>
-      <input type="text" class="form-control gn-csw-criteria" id="csw-outputSchemaInput"
-             data-ng-model="harvesterSelected.site.outputSchema"/>
-
-      <label class="control-label" data-translate="">csw-outputSchemaOptions</label>
-      <select data-ng-model="harvesterSelected.site.outputSchema"
-              class="form-control gn-csw-criteria"
-              id="csw-outputSchemaOptionsSelect">
-        <option value="http://www.opengis.net/cat/csw/2.0.2" data-translate="">csw-dublinCore
-        </option>
-        <option value="http://www.isotc211.org/2005/gmd" data-translate="">csw-iso19139</option>
-      </select>
-
+      <div class="row">
+        <div class="col-lg-8 col-md-8 col-sm-8 gn-nopadding-left gn-nopadding-right">
+          <label class="control-label" data-translate="">csw-outputSchema</label>
+          <input type="text" class="form-control gn-csw-criteria" id="csw-outputSchemaInput"
+                 data-ng-model="harvesterSelected.site.outputSchema"/>
+        </div>
+        <div class="col-lg-4 col-md-4 col-sm-4 hidden-xs gn-nopadding-left gn-nopadding-right">
+          <label class="control-label" data-translate="">csw-outputSchemaOptions</label>
+          <select data-ng-model="harvesterSelected.site.outputSchema"
+                  class="form-control gn-csw-criteria"
+                  id="csw-outputSchemaOptionsSelect">
+            <option value="http://www.opengis.net/cat/csw/2.0.2" data-translate="">csw-dublinCore
+            </option>
+            <option value="http://www.isotc211.org/2005/gmd" data-translate="">csw-iso19139</option>
+          </select>
+        </div>
+      </div>
       <p class="help-block" data-translate="">csw-outputSchemaHelp</p>
     </div>
   </fieldset>


### PR DESCRIPTION
The schema fields are now displayed beside each other to highlight that they are connected.

![gn-schema-fields](https://user-images.githubusercontent.com/19608667/38560025-eed3920a-3cd4-11e8-82d7-10aac72aec64.png)

Fixes: https://github.com/geonetwork/core-geonetwork/issues/2608