### PR TITLE
Remove whitespace in editor table and datepicker (replaces PR: #2475)

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
@@ -174,7 +174,7 @@
       <label class="col-sm-2 control-label">
         <xsl:value-of select="$labelConfig/label"/>
       </label>
-      <div class="col-sm-9 gn-value">
+      <div class="col-sm-9 gn-value nopadding-in-table">
         <div data-gn-date-picker="{gco:Date|gco:DateTime}"
              data-label=""
              data-element-name="{name(gco:Date|gco:DateTime)}"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -103,7 +103,7 @@
           (<xsl:value-of select="$labelMeasureType/label"/>)
         </xsl:if>
       </label>
-      <div class="col-sm-9 gn-value">
+      <div class="col-sm-9 gn-value nopadding-in-table">
         <xsl:variable name="elementRef"
                       select="gco:*/gn:element/@ref"/>
         <xsl:variable name="helper"

--- a/web-ui/src/main/resources/catalog/components/edit/datepicker/partials/datepicker.html
+++ b/web-ui/src/main/resources/catalog/components/edit/datepicker/partials/datepicker.html
@@ -1,7 +1,7 @@
-<div class="form-group gn-field"
+<div class="form-group gn-field gn-nopadding-top gn-nopadding-bottom"
      data-ng-class="{'has-error': !isValidDate, 'gn-required': required}">
   <label class="control-label col-sm-2" data-ng-if="label">{{label}}</label>
-  <div data-ng-class="label ? 'col-sm-9' : 'col-sm-12'">
+  <div data-ng-class="label ? 'col-sm-9' : 'col-sm-12'" class="gn-nopadding-left gn-nopadding-right">
     <!-- The hidden field with the value. -->
     <input type="hidden" class="form-control"
            name="{{elementRef}}" value="{{xmlSnippet}}"/>

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -656,6 +656,10 @@ form.gn-tab-xml {
       }
     }
   }
+  .nopadding-in-table {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 // search filter boxes

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -2,14 +2,14 @@
    which has to be applied for all apps
    (ie. admin, search, login, editor). */
 .gn-nopadding-top {
-  padding-top: 0;
+  padding-top: 0 !important;
 }
 .gn-nopadding-right {
-  padding-right: 0;
+  padding-right: 0 !important;
 }
 .gn-nopadding-bottom {
-  padding-bottom: 0;
+  padding-bottom: 0 !important;
 }
 .gn-nopadding-left {
-  padding-left: 0;
+  padding-left: 0 !important;
 }

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1325,12 +1325,12 @@
         <xsl:variable name="elementToMoveRef"
                       select="if ($elementEditInfo) then $elementEditInfo/@ref else ''"/>
         <a
-          class="fa fa-angle-up {if ($elementEditInfo and $elementEditInfo/@up = 'true') then '' else 'invisible'}"
+          class="fa fa-angle-up {if ($elementEditInfo and $elementEditInfo/@up = 'true') then '' else 'hidden'}"
           data-gn-editor-control-move="{$elementToMoveRef}"
           data-domelement-to-move="{$domeElementToMoveRef}"
           data-direction="up" href="" tabindex="-1"></a>
         <a
-          class="fa fa-angle-down {if ($elementEditInfo and $elementEditInfo/@down = 'true') then '' else 'invisible'}"
+          class="fa fa-angle-down {if ($elementEditInfo and $elementEditInfo/@down = 'true') then '' else 'hidden'}"
           data-gn-editor-control-move="{$elementToMoveRef}"
           data-domelement-to-move="{$domeElementToMoveRef}"
           data-direction="down" href="" tabindex="-1"></a>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -168,7 +168,7 @@
             <xsl:value-of select="$label/label"/>
           </label>
 
-          <div class="col-sm-9 gn-value">
+          <div class="col-sm-9 gn-value nopadding-in-table">
             <xsl:if test="$isMultilingual">
               <xsl:attribute name="data-gn-multilingual-field"
                              select="$metadataOtherLanguagesAsJson"/>


### PR DESCRIPTION
This is replacing PR: https://github.com/geonetwork/core-geonetwork/pull/2475

The padding for the column in tables in the editor (with class `gn-table`) is removed. The column labels and input elements are now aligned properly. This removal is done by adding classes that remove the padding (e.g. `.nopadding-in-table`)

**Screenshot of old situation**

![gn-editor-table-old](https://user-images.githubusercontent.com/19608667/34831359-09a9c592-f6e7-11e7-86d0-aab28a64248d.png)

**Screenshot of new situation**

![gn-editor-table-new](https://user-images.githubusercontent.com/19608667/34831383-1ac79a84-f6e7-11e7-92d1-9594495f4042.png)

Also padding is removed around datepickers.

**Screenshot of the old situation**
![gn-datepicker-old](https://user-images.githubusercontent.com/19608667/38562032-e304bdd2-3cd9-11e8-969c-4e1b20bf2a0a.png)

**New Situation**
![gn-datepicker-new](https://user-images.githubusercontent.com/19608667/38562053-edeac49e-3cd9-11e8-9f2a-74fd28c874d6.png)

