### PR TITLE
Support for database external configuration

### DIFF
--- a/web/src/main/webResources/WEB-INF/external-configuration/README.md
+++ b/web/src/main/webResources/WEB-INF/external-configuration/README.md
@@ -1,4 +1,6 @@
-# How to setup
+# How to setup an external database configuration
+
+To setup an external folder check the **geonetwork.xml** file in this folder.
 
 ## geonetwork.xml 
 
@@ -8,12 +10,24 @@ Example file to add to **tomcat/conf/Catalina/localhost** to define a JNDI prope
 
 The external GeoNetwork node configuration folder must contain **ONLY** the node configuration xml files, like srv.xml, the default in single node instances and the one placed in this folder as example.
 
-## srv.xml
+## srv.xml (or another node file)
 
-Inside the node file example must be configured the relative path (relative in relation to this file) to the dataSource.xml
+In this file must be configured the relative path (relative to this file location) to **dataSource.xml**
+
+```
+
+  <!-- The relative path to db configuration file -->
+  <import resource="../db-confs/dataSource.xml"/>
+  
+```
 
 ## dataSource.xml
 
-For common parameters check [/web/src/main/webResources/WEB-INF/config-db/README.md](https://github.com/geonetwork/core-geonetwork/blob/3.4.x/web/src/main/webResources/WEB-INF/config-db/README.md).
+The configuration parameters to setup and configure a database connection.
 
 For database specific configuration uncomment the appropriate section and edit the contents.
+
+Parameters informations is available here [/web/src/main/webResources/WEB-INF/config-db/README.md](https://github.com/geonetwork/core-geonetwork/blob/3.4.x/web/src/main/webResources/WEB-INF/config-db/README.md).
+
+
+

--- a/web/src/main/webResources/WEB-INF/external-configuration/README.md
+++ b/web/src/main/webResources/WEB-INF/external-configuration/README.md
@@ -1,0 +1,19 @@
+# How to setup
+
+## geonetwork.xml 
+
+Example file to add to **tomcat/conf/Catalina/localhost** to define a JNDI property with the absolute path (the **path** attribute) of the **external GeoNetwork node configuration folder**. Generally, when the JNDI property **configNodeFolderLocation** is defined, the path associated is considered in place of **/WEB-INF/config-node** inside GeoNetwork war.
+
+## External GeoNetwork node configuration folder
+
+The external GeoNetwork node configuration folder must contain **ONLY** the node configuration xml files, like srv.xml, the default in single node instances and the one placed in this folder as example.
+
+## srv.xml
+
+Inside the node file example must be configured the relative path (relative in relation to this file) to the dataSource.xml
+
+## dataSource.xml
+
+For common parameters check [/web/src/main/webResources/WEB-INF/config-db/README.md](https://github.com/geonetwork/core-geonetwork/blob/3.4.x/web/src/main/webResources/WEB-INF/config-db/README.md).
+
+For database specific configuration uncomment the appropriate section and edit the contents.

--- a/web/src/main/webResources/WEB-INF/external-configuration/dataSource.xml
+++ b/web/src/main/webResources/WEB-INF/external-configuration/dataSource.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       default-lazy-init="true"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	">
+
+  <!-- H2 DATABASE -->
+  <!-- 
+  
+  <bean id="jdbcDataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
+    <property name="driverClassName" ref="jdbcDriverClassName"/>
+    <property name="Url" ref="jdbcURL"/>
+    <property name="username" value="www-data"/>
+    <property name="password" value="www-data"/>
+    <property name="removeAbandoned" value="true"/>
+    <property name="removeAbandonedTimeout" value="120"/>
+    <property name="logAbandoned" value="true"/>
+    <property name="maxActive" value="10"/>
+    <property name="maxIdle" value="10"/>
+    <property name="maxWait" value="200"/>
+    <property name="testOnBorrow" value="true"/>
+    <property name="timeBetweenEvictionRunsMillis" value="10000"/>
+    <property name="minEvictableIdleTimeMillis" value="1800000"/>
+    <property name="testWhileIdle" value="true"/>
+    <property name="numTestsPerEvictionRun" value="3"/>
+    <property name="poolPreparedStatements" value="true"/>
+    <property name="maxOpenPreparedStatements" value="1200"/>
+    <property name="validationQuery" value="SELECT 1"/>
+    <property name="defaultReadOnly" value="false"/>
+    <property name="defaultAutoCommit" value="false"/>
+    <property name="initialSize" value="30"/>
+  </bean>
+  
+  <bean id="jpaVendorAdapterDatabaseParam" class="java.lang.String">
+    <constructor-arg value="H2"/>
+  </bean>
+
+  <bean id="jdbcDriverClassName" class="java.lang.String">
+    <constructor-arg value="org.h2.Driver"/>
+  </bean>
+
+  <bean id="jdbcURL" class="java.lang.String">
+    <constructor-arg
+      value="jdbc:h2:geonetworkDB;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE"/>
+  </bean>
+  
+  -->
+
+  <!-- POSTGRES DATABASE -->
+  <!-- 
+  
+  <bean id="jdbcDataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
+    <property name="driverClassName" ref="jdbcDriverClassName"/>
+    <property name="Url" ref="jdbcURL"/>
+    <property name="username" value="postgres"/>
+    <property name="password" value="postgres"/>
+    <property name="removeAbandoned" value="true"/>
+    <property name="removeAbandonedTimeout" value="120"/>
+    <property name="logAbandoned" value="true"/>
+    <property name="maxActive" value="10"/>
+    <property name="maxIdle" value="10"/>
+    <property name="maxWait" value="200"/>
+    <property name="testOnBorrow" value="true"/>
+    <property name="timeBetweenEvictionRunsMillis" value="10000"/>
+    <property name="minEvictableIdleTimeMillis" value="1800000"/>
+    <property name="testWhileIdle" value="true"/>
+    <property name="numTestsPerEvictionRun" value="3"/>
+    <property name="poolPreparedStatements" value="true"/>
+    <property name="maxOpenPreparedStatements" value="1200"/>
+    <property name="validationQuery" value="SELECT 1"/>
+    <property name="defaultReadOnly" value="false"/>
+    <property name="defaultAutoCommit" value="false"/>
+    <property name="initialSize" value="30"/>
+  </bean>
+    
+  <bean id="jpaVendorAdapterDatabaseParam" class="java.lang.String">
+    <constructor-arg value="POSTGRESQL"/>
+  </bean>
+
+  <bean id="jdbcDriverClassName" class="java.lang.String">
+    <constructor-arg value="org.postgresql.Driver"/>
+  </bean>
+
+  <bean id="jdbcURL" class="java.lang.String">
+    <constructor-arg value="jdbc:postgresql://localhost:5432/postgres"/>
+  </bean>
+  
+  -->
+  
+  <!-- JNDI POSTGRES DATABASE -->
+  <!--
+   
+  <bean id="jdbcDataSource" class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName" value="java:comp/env/jdbc/geonetwork"/>
+    <property name="cache" value="true"/>
+    <property name="exposeAccessContext" value="false"/>
+  </bean>
+
+  <bean id="jpaVendorAdapterDatabaseParam" class="java.lang.String">
+    <constructor-arg value="POSTGRESQL"/>
+  </bean>
+  
+  -->
+ 
+</beans>

--- a/web/src/main/webResources/WEB-INF/external-configuration/geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/external-configuration/geonetwork.xml
@@ -13,6 +13,7 @@
   St, Fifth Floor, Boston, MA 02110-1301, USA ~ ~ Contact: Jeroen Ticheler 
   - FAO - Viale delle Terme di Caracalla 2, ~ Rome - Italy. email: geonetwork@osgeo.org -->
 <Context>
+  <!-- External folder location -->
   <Environment name="configNodeFolderLocation"
     value="/.../gn-conf" type="java.lang.String" override="false" />
 

--- a/web/src/main/webResources/WEB-INF/external-configuration/geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/external-configuration/geonetwork.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the ~ 
+  United Nations (FAO-UN), United Nations World Food Programme (WFP) ~ and 
+  United Nations Environment Programme (UNEP) ~ ~ This program is free software; 
+  you can redistribute it and/or modify ~ it under the terms of the GNU General 
+  Public License as published by ~ the Free Software Foundation; either version 
+  2 of the License, or (at ~ your option) any later version. ~ ~ This program 
+  is distributed in the hope that it will be useful, but ~ WITHOUT ANY WARRANTY; 
+  without even the implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU ~ General Public License for more details. ~ ~ You should 
+  have received a copy of the GNU General Public License ~ along with this 
+  program; if not, write to the Free Software ~ Foundation, Inc., 51 Franklin 
+  St, Fifth Floor, Boston, MA 02110-1301, USA ~ ~ Contact: Jeroen Ticheler 
+  - FAO - Viale delle Terme di Caracalla 2, ~ Rome - Italy. email: geonetwork@osgeo.org -->
+<Context>
+  <Environment name="configNodeFolderLocation"
+    value="/.../gn-conf" type="java.lang.String" override="false" />
+
+  <!-- Example of JNDI DataSource configuration -->
+  <!-- <Resource name="jdbc/geonetwork" auth="Container" type="javax.sql.DataSource" 
+    driverClassName="org.postgresql.Driver" url="jdbc:postgresql://localhost:5432/postgres" 
+    username="postgres" password="postgres" maxActive="20" maxIdle="10" maxWait="-1"/> -->
+</Context>

--- a/web/src/main/webResources/WEB-INF/external-configuration/srv.xml
+++ b/web/src/main/webResources/WEB-INF/external-configuration/srv.xml
@@ -27,10 +27,12 @@
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
-
+        
+  <!-- Required imports form GeoNetwork. Don't change or remove. -->
   <import resource="classpath*:config-spring-geonetwork.xml"/>
   <import resource="classpath*:config-db/database_migration.xml"/>
 
+  <!-- Current node infos -->
   <bean id="nodeInfo" class="org.fao.geonet.NodeInfo">
     <property name="id" value="srv"/>
     <property name="defaultNode" value="true"/>

--- a/web/src/main/webResources/WEB-INF/external-configuration/srv.xml
+++ b/web/src/main/webResources/WEB-INF/external-configuration/srv.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       default-lazy-init="true"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <import resource="classpath*:config-spring-geonetwork.xml"/>
+  <import resource="classpath*:config-db/database_migration.xml"/>
+
+  <bean id="nodeInfo" class="org.fao.geonet.NodeInfo">
+    <property name="id" value="srv"/>
+    <property name="defaultNode" value="true"/>
+  </bean>
+
+  <!-- The relative path to db configuration file -->
+  <import resource="../db-confs/dataSource.xml"/>
+</beans>


### PR DESCRIPTION
This is an alternative approach to configure a database connection outside of the GeoNetwork war file.
It requires to put the config-node content outside of GeoNetwork war using the steps described here:

https://github.com/PascalLike/core-geonetwork/blob/jndiDatabase/web/src/main/webResources/WEB-INF/external-configuration/README.md

**TEST MADE:**
_Jetty + H2
Tomcat + H2, Postgres, JNDI Postgres_

The change made affect only the JeevesContextLoaderListener.getNodeConfigurationFiles method, that now checks if an external folder is defined (JNDI): if not, it works as before. 


