### PR TITLE
Allow 'Accept: */*' header in '/api/records/{uuid}' request

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -133,7 +133,8 @@ public class MetadataApi implements ApplicationContextAware {
             "application/pdf",
             "application/zip",
             MEF_V1_ACCEPT_TYPE,
-            MEF_V2_ACCEPT_TYPE
+            MEF_V2_ACCEPT_TYPE,
+            MediaType.ALL_VALUE
         })
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Return the record."),
@@ -181,7 +182,7 @@ public class MetadataApi implements ApplicationContextAware {
             return "forward:" + (metadataUuid + "/formatters/zip");
         } else {
             // FIXME this else is never reached because any of the accepted medias match one of the previous if conditions.
-            response.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XHTML_XML_VALUE);
+            //response.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XHTML_XML_VALUE);
             //response.sendRedirect(metadataUuid + "/formatters/" + defaultFormatter);
             return "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
         }

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -178,9 +178,6 @@ public class MetadataApi implements ApplicationContextAware {
             || accept.contains(MEF_V2_ACCEPT_TYPE)) {
             return "forward:" + (metadataUuid + "/formatters/zip");
         } else {
-            // FIXME this else is never reached because any of the accepted medias match one of the previous if conditions.
-            //response.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XHTML_XML_VALUE);
-            //response.sendRedirect(metadataUuid + "/formatters/" + defaultFormatter);
             return "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
         }
     }

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -23,25 +23,14 @@
 
 package org.fao.geonet.api.records;
 
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
-import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V1_ACCEPT_TYPE;
-import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V2_ACCEPT_TYPE;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import jeeves.constants.Jeeves;
+import jeeves.server.context.ServiceContext;
+import jeeves.services.ReadWriteController;
 import org.apache.commons.io.FileUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
@@ -81,14 +70,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import jeeves.constants.Jeeves;
-import jeeves.server.context.ServiceContext;
-import jeeves.services.ReadWriteController;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
+import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V1_ACCEPT_TYPE;
+import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V2_ACCEPT_TYPE;
 
 @RequestMapping(value = {
     "/api/records",
@@ -174,11 +171,11 @@ public class MetadataApi implements ApplicationContextAware {
             || accept.contains("application/pdf")) {
             return "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
         } else if (accept.contains(MediaType.APPLICATION_XML_VALUE)
-                || accept.contains(MediaType.APPLICATION_JSON_VALUE)) {
+            || accept.contains(MediaType.APPLICATION_JSON_VALUE)) {
             return "forward:" + (metadataUuid + "/formatters/xml");
         } else if (accept.contains("application/zip")
-                || accept.contains(MEF_V1_ACCEPT_TYPE)
-                || accept.contains(MEF_V2_ACCEPT_TYPE)) {
+            || accept.contains(MEF_V1_ACCEPT_TYPE)
+            || accept.contains(MEF_V2_ACCEPT_TYPE)) {
             return "forward:" + (metadataUuid + "/formatters/zip");
         } else {
             // FIXME this else is never reached because any of the accepted medias match one of the previous if conditions.
@@ -248,8 +245,7 @@ public class MetadataApi implements ApplicationContextAware {
         } catch (ResourceNotFoundException e) {
             Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
             throw e;
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
@@ -272,9 +268,9 @@ public class MetadataApi implements ApplicationContextAware {
 
 
         boolean withValidationErrors = false, keepXlinkAttributes = false, forEditing = false;
-        Element xml  = withInfo ?
+        Element xml = withInfo ?
             dataManager.getMetadata(context,
-            metadata.getId() + "", forEditing, withValidationErrors, keepXlinkAttributes) :
+                metadata.getId() + "", forEditing, withValidationErrors, keepXlinkAttributes) :
             dataManager.getMetadataNoInfo(context, metadata.getId() + "");
 
         if (addSchemaLocation) {
@@ -296,7 +292,7 @@ public class MetadataApi implements ApplicationContextAware {
 
         boolean isJson = acceptHeader.contains(MediaType.APPLICATION_JSON_VALUE);
 
-        String mode = (attachment)?"attachment":"inline";
+        String mode = (attachment) ? "attachment" : "inline";
         response.setHeader("Content-Disposition", String.format(
             mode + "; filename=\"%s.%s\"",
             metadata.getUuid(),
@@ -486,7 +482,7 @@ public class MetadataApi implements ApplicationContextAware {
         HttpServletRequest request) throws Exception {
 
         Metadata md;
-        try{
+        try {
             md = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {
             Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
@@ -499,11 +495,11 @@ public class MetadataApi implements ApplicationContextAware {
         // At least for related metadata and keep XSL only for links
         final ServiceContext context = ApiUtils.createServiceContext(request);
         Element raw = new Element("root").addContent(Arrays.asList(
-                new Element("gui").addContent(Arrays.asList(
-                        new Element("language").setText(language),
-                        new Element("url").setText(context.getBaseUrl())
-        		)),
-        		MetadataUtils.getRelated(context, md.getId(), md.getUuid(), type, start, start + rows, true)
+            new Element("gui").addContent(Arrays.asList(
+                new Element("language").setText(language),
+                new Element("url").setText(context.getBaseUrl())
+            )),
+            MetadataUtils.getRelated(context, md.getId(), md.getUuid(), type, start, start + rows, true)
         ));
         GeonetworkDataDirectory dataDirectory = context.getBean(GeonetworkDataDirectory.class);
         Path relatedXsl = dataDirectory.getWebappDir().resolve("xslt/services/metadata/relation.xsl");
@@ -514,57 +510,57 @@ public class MetadataApi implements ApplicationContextAware {
     }
 
     @ApiOperation(
-            value = "Returns a map to decode attributes in a dataset (from the associated feature catalog)",
-            nickname = "getFeatureCatalog",
-            notes = "Retrieve related services, datasets, onlines, thumbnails, sources, ... " +
-                "to this records.<br/>" +
-                "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/associating-resources/index.html'>More info</a>")
-        @RequestMapping(value = "/{metadataUuid}/featureCatalog",
-            method = RequestMethod.GET,
-            produces = {
-                MediaType.APPLICATION_XML_VALUE,
-                MediaType.APPLICATION_JSON_VALUE
-            })
-        @ResponseStatus(HttpStatus.OK)
-        @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Return the associated resources."),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
+        value = "Returns a map to decode attributes in a dataset (from the associated feature catalog)",
+        nickname = "getFeatureCatalog",
+        notes = "Retrieve related services, datasets, onlines, thumbnails, sources, ... " +
+            "to this records.<br/>" +
+            "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/associating-resources/index.html'>More info</a>")
+    @RequestMapping(value = "/{metadataUuid}/featureCatalog",
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.APPLICATION_XML_VALUE,
+            MediaType.APPLICATION_JSON_VALUE
         })
-        @ResponseBody
-        public FeatureResponse getFeatureCatalog(
-            @ApiParam(
-                value = API_PARAM_RECORD_UUID,
-                required = true)
-            @PathVariable
-                String metadataUuid,
-            HttpServletRequest request) throws Exception {
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Return the associated resources."),
+        @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
+    })
+    @ResponseBody
+    public FeatureResponse getFeatureCatalog(
+        @ApiParam(
+            value = API_PARAM_RECORD_UUID,
+            required = true)
+        @PathVariable
+            String metadataUuid,
+        HttpServletRequest request) throws Exception {
 
-            RelatedItemType[] type = {RelatedItemType.fcats};
+        RelatedItemType[] type = {RelatedItemType.fcats};
 
-            FeatureResponse response = new FeatureResponse();
+        FeatureResponse response = new FeatureResponse();
 
-            Map<String, String[]> decodeMap = new HashMap<>();
+        Map<String, String[]> decodeMap = new HashMap<>();
 
-            RelatedResponse related = getRelated(metadataUuid, type, 0, 100, request);
+        RelatedResponse related = getRelated(metadataUuid, type, 0, 100, request);
 
-            if(related.getFcats()!=null) {
-                for (AttributeTable.Element element : related.getFcats().getItem().get(0).getFeatureType().getAttributeTable().getElement()) {
-                    if(element.getCode()!=null && !element.getCode().trim().equals("")) {
-                        if(!decodeMap.containsKey(element.getCode())) {
-                            String[] decodedValues = {element.getName(), element.getDefinition()};
-                            decodeMap.put(element.getCode(), decodedValues);
-                        }
-                    } else {
-                        if(!decodeMap.containsKey(element.getName())) {
-                            String[] decodedValues = {element.getName(), element.getDefinition()};
-                            decodeMap.put(element.getName(), decodedValues);
-                        }
+        if (related.getFcats() != null) {
+            for (AttributeTable.Element element : related.getFcats().getItem().get(0).getFeatureType().getAttributeTable().getElement()) {
+                if (element.getCode() != null && !element.getCode().trim().equals("")) {
+                    if (!decodeMap.containsKey(element.getCode())) {
+                        String[] decodedValues = {element.getName(), element.getDefinition()};
+                        decodeMap.put(element.getCode(), decodedValues);
+                    }
+                } else {
+                    if (!decodeMap.containsKey(element.getName())) {
+                        String[] decodedValues = {element.getName(), element.getDefinition()};
+                        decodeMap.put(element.getName(), decodedValues);
                     }
                 }
-            } else return response;
+            }
+        } else return response;
 
-            response.setDecodeMap(decodeMap);
+        response.setDecodeMap(decodeMap);
 
-            return response;
-        }
+        return response;
+    }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -27,7 +27,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import jeeves.server.context.ServiceContext;
+import jeeves.server.dispatchers.ServiceManager;
 import jeeves.xlink.Processor;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -95,7 +99,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.xhtmlrenderer.pdf.ITextRenderer;
+import springfox.documentation.annotations.ApiIgnore;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -112,17 +119,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
-
-import javax.print.attribute.standard.Media;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import jeeves.server.context.ServiceContext;
-import jeeves.server.dispatchers.ServiceManager;
-import springfox.documentation.annotations.ApiIgnore;
 
 import static com.google.common.io.Files.getNameWithoutExtension;
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
@@ -228,8 +224,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             String acceptHeader,
         @PathVariable(
             value = "formatterId"
-        )
-        final String formatterId,
+        ) final String formatterId,
         @ApiParam(
             value = API_PARAM_RECORD_UUID,
             required = true)
@@ -237,18 +232,15 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             String metadataUuid,
         @RequestParam(
             value = "width",
-            defaultValue = "_100")
-        final FormatterWidth width,
+            defaultValue = "_100") final FormatterWidth width,
         @RequestParam(
             value = "mdpath",
-            required = false)
-        final String mdPath,
+            required = false) final String mdPath,
         @RequestParam(
             value = "output",
             required = false)
-        FormatType formatType,
-        @ApiIgnore
-        final NativeWebRequest request,
+            FormatType formatType,
+        @ApiIgnore final NativeWebRequest request,
         final HttpServletRequest servletRequest) throws Exception {
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
@@ -264,7 +256,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         if (MediaType.ALL_VALUE.equals(acceptHeader)) {
             acceptHeader = MediaType.TEXT_HTML_VALUE;
         }
-        if(formatType == null) {
+        if (formatType == null) {
             formatType = FormatType.find(acceptHeader);
         }
         if (formatType == null) {

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -113,6 +113,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 
+import javax.print.attribute.standard.Media;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -207,7 +208,8 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         produces = {
             MediaType.TEXT_HTML_VALUE,
             MediaType.APPLICATION_XHTML_XML_VALUE,
-            "application/pdf"
+            "application/pdf",
+            MediaType.ALL_VALUE
             // TODO: PDF
         })
     @ApiOperation(
@@ -259,6 +261,9 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         // Force PDF ouutput when URL parameter is set.
         // This is useful when making GET link to PDF which
         // can not use headers.
+        if (MediaType.ALL_VALUE.equals(acceptHeader)) {
+            acceptHeader = MediaType.TEXT_HTML_VALUE;
+        }
         if(formatType == null) {
             formatType = FormatType.find(acceptHeader);
         }


### PR DESCRIPTION
When received 'Accept: \*/\*' header at `/api/records/{uuid}` or
`/api/records/{uuid}/formatters/xsl-view` return HTML instead of a 400 error.

Fixes #2567. 