### PR TITLE
Fix for add-resource panel content: #2685

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="row">
+  <div class="row gn-modal-content">
     <div class="col-md-6">
       <form id="gn-upload-onlinesrc"
             name="gnAddLink"

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -328,6 +328,11 @@ div.gn-scroll-spy {
       max-height: 76vh;
       overflow: auto;
       min-height: 500px;
+      .gn-modal-content {
+        // height of modal body - 2 * padding - height of button(s)
+        max-height: calc(~"76vh - 30px - 30px");
+        overflow: auto;
+      }
     }
   }
   .modal-dialog {


### PR DESCRIPTION
Set a max height for the content of a dialog body so it fits on small screens.

Add a new class to calculate the height of a div with the class `gn-modal-content`, the height is based on the max height of it's container: `modal-body`. Also `overflow: auto` is added to the class to get a scrollbar when needed.

Fix for: https://github.com/geonetwork/core-geonetwork/issues/2685