### PR TITLE
Csw gn replace ignoring carriage return

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -81,11 +81,6 @@ public class EditLib {
     public static final String COLON_SEPARATOR = "COLON";
     public static final String MSG_ELEMENT_NOT_FOUND_AT_REF = "Element not found at ref = ";
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Constructor
-    //---
-    //--------------------------------------------------------------------------
     private SchemaManager scm;
 
     //--------------------------------------------------------------------------

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -626,16 +626,10 @@ public class EditLib {
                                         .equals(SpecialUpdateTags.DELETE)) {
                                         parent.removeContent(parent.indexOf(matchingNode));
                                     }
-                                } else {
-                                    // If no parent, we probably matched the
-                                    // root element. This is not allowed.
-                                    isUpdated = false;
                                 }
                             } else if (propNode instanceof Attribute) {
                                 Element parent = ((Attribute) propNode).getParent();
                                 parent.removeAttribute(((Attribute) propNode).getName());
-                            } else {
-                                isUpdated = false;
                             }
                         } else {
                             // Update element content with node
@@ -653,8 +647,6 @@ public class EditLib {
                                 ((Element) propNode).setText(value.getStringValue());
                             } else if (propNode instanceof Attribute && !isValueXml) {
                                 ((Attribute) propNode).setValue(value.getStringValue());
-                            } else {
-                                isUpdated = false;
                             }
                         }
                         isUpdated = true;

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -323,8 +323,7 @@ public class EditLib {
         }
     }
 
-    public void addXMLFragments(String schema, Element md, Map<String, String> xmlInputs) throws Exception, IOException,
-        JDOMException {
+    public void addXMLFragments(String schema, Element md, Map<String, String> xmlInputs) throws Exception {
         // Loop over each XML fragments to insert or replace
         HashMap<String, Element> nodeRefToElem = new HashMap<>();
         for (Map.Entry<String, String> entry : xmlInputs.entrySet()) {

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -1452,21 +1452,11 @@ public class EditLib {
     }
 
     private void insertFirst(Element md, Element child) {
-        Vector<Element> v = new Vector<Element>();
-        v.add(child);
-
-        @SuppressWarnings("unchecked")
-        List<Element> list = md.getChildren();
-
-        for (Element elem : list) {
-            v.add(elem);
-        }
-
-        //---
+        List<Element> list = new ArrayList(md.getChildren());
         md.removeContent();
-
-        for (Element aV : v) {
-            md.addContent(aV);
+        md.addContent(child);
+        for (Element elem : list) {
+            md.addContent(elem);
         }
     }
 
@@ -1484,25 +1474,15 @@ public class EditLib {
             v.add(el);
 
             if (equal(childName, childNS, el) && !added) {
-                if (i == list.size() - 1) {
+                if (i == list.size() - 1 || !equal(el, list.get(i + 1))) {
                     v.add(child);
                     added = true;
-                } else {
-                    Element elNext = list.get(i + 1);
-
-                    if (!equal(el, elNext)) {
-                        v.add(child);
-                        added = true;
-                    }
                 }
             }
         }
 
         md.removeContent();
-
-        for (Element aV : v) {
-            md.addContent(aV);
-        }
+        md.addContent(v);
     }
 
     private boolean equal(String childName, String childNS, Element el) {

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -209,14 +209,11 @@ public class EditLib {
     public Element addElement(MetadataSchema mdSchema, Element el, String qname) throws Exception {
         LOGGER_ADD_ELEMENT.debug("#### in addElement()");
         LOGGER_ADD_ELEMENT.debug("#### - parent = {}", el.getName());
-        LOGGER_ADD_ELEMENT.debug( "#### - child qname = {}", qname);
 
         String name = getUnqualifiedName(qname);
         String ns = getNamespace(qname, el, mdSchema);
         String prefix = getPrefix(qname);
-        String parentName = getParentNameFromChild(el);
 
-        LOGGER_ADD_ELEMENT.debug("#### - parent name for type retrieval = {}", parentName);
         LOGGER_ADD_ELEMENT.debug("#### - child name = {}", name);
         LOGGER_ADD_ELEMENT.debug("#### - child namespace = {}", ns);
         LOGGER_ADD_ELEMENT.debug("#### - child prefix = {}", prefix);
@@ -230,27 +227,7 @@ public class EditLib {
 
         Element child = new Element(name, prefix, ns);
 
-        String typeName = mdSchema.getElementType(el.getQualifiedName(), parentName);
-        LOGGER_ADD_ELEMENT.debug("#### - type name = {}", typeName);
-
-        MetadataType type = mdSchema.getTypeInfo(typeName);
-        LOGGER_ADD_ELEMENT.debug("#### - metadata type = {}", type);
-
-        // remove everything and then add all children to the element and assure a correct position for the
-        // new one: at the end of the others
-        el.removeContent();
-        for (String singleType: type.getAlElements()) {
-            List<Element> list = getChildren(el, singleType);
-
-            LOGGER_ADD_ELEMENT.debug("####   - child of type {}, list size = {}", singleType, list.size());
-            for (Element aChild : list) {
-                el.addContent(aChild);
-                LOGGER_ADD_ELEMENT.debug("####		- add child {}", aChild.toString());
-            }
-
-            if (qname.equals(singleType))
-                el.addContent(child);
-        }
+        addChildToParent(mdSchema, el, child, qname, false);
 
         //--- add mandatory sub-tags
         SchemaSuggestions mdSugg = scm.getSchemaSuggestions(mdSchema.getName());
@@ -282,6 +259,10 @@ public class EditLib {
             throw new IllegalStateException("EditLib : Error when loading XML fragment, " + e.getMessage());
         }
 
+        addChildToParent(mdSchema, targetElement, childToAdd, qname, removeExisting);
+    }
+
+    private void addChildToParent(MetadataSchema mdSchema, Element targetElement, Element childToAdd, String qname, boolean removeExisting) throws Exception {
         LOGGER_ADD_ELEMENT.debug( "#### - child qname = {}", qname);
 
         String parentName = getParentNameFromChild(targetElement);

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -1407,39 +1407,36 @@ public class EditLib {
     }
 
     public String getNamespace(String qname, Element md, MetadataSchema schema) {
-        // check the element first to see whether the namespace is
-        // declared locally
+        // check the element first to see whether the namespace is declared locally
         String result = checkNamespaces(qname, md);
-        if (result.equals("UNKNOWN")) {
+        if (!result.equals("UNKNOWN")) { return result;}
 
-            // find root element, where namespaces *must* be declared
-            Element root = md;
-            while (root.getParent() != null && root.getParent() instanceof Element)
-                root = (Element) root.getParent();
-            result = checkNamespaces(qname, root);
-
-            // finally if it isn't on the root element then check the list
-            // namespaces we collected as we parsed the schema
-            if (result.equals("UNKNOWN")) {
-                result = getNamespace(qname, schema);
-            }
+        // find root element, where namespaces *must* be declared
+        Element root = md;
+        while (root.getParent() != null && root.getParent() instanceof Element) {
+            root = (Element) root.getParent();
         }
-        return result;
+        result = checkNamespaces(qname, root);
+        if (!result.equals("UNKNOWN")) { return result;}
+
+        // finally if it isn't on the root element then check the list
+        // namespaces we collected as we parsed the schema
+        return getNamespace(qname, schema);
     }
 
-    public String getNamespace(String qname, MetadataSchema schema) {
+    private String getNamespace(String qname, MetadataSchema schema) {
         // check the list of namespaces we collected as we parsed the schema
-        String result;
         String prefix = getPrefix(qname);
         if (!prefix.equals("")) {
-            result = schema.getNS(prefix);
-            if (result == null) result = "UNKNOWN";
-        } else result = "UNKNOWN";
-        return result;
+            String result = schema.getNS(prefix);
+            if (result != null) {
+                return result;
+            }
+        }
+        return "UNKNOWN";
     }
 
-    public String checkNamespaces(String qname, Element md) {
-        // get prefix
+    private String checkNamespaces(String qname, Element md) {
         String prefix = getPrefix(qname);
 
         // loop on namespaces to fine the one corresponding to prefix

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -244,16 +244,16 @@ public class EditLib {
 
         Vector<Element> children = new Vector<Element>();
 
-        for (int i = 0; i < type.getElementCount(); i++) {
-            List<Element> list = getChildren(el, type.getElementAt(i));
+        for (String singleType: type.getAlElements()) {
+            List<Element> list = getChildren(el, singleType);
 
-            LOGGER_ADD_ELEMENT.debug("####   - child of type {}, list size = {}", type.getElementAt(i), list.size());
+            LOGGER_ADD_ELEMENT.debug("####   - child of type {}, list size = {}", singleType, list.size());
             for (Element aChild : list) {
                 children.add(aChild);
                 LOGGER_ADD_ELEMENT.debug("####		- add child {}", aChild.toString());
             }
 
-            if (qname.equals(type.getElementAt(i)))
+            if (qname.equals(singleType))
                 children.add(child);
         }
         //--- remove everything and then add all collected children to the element to assure a correct position for the
@@ -302,17 +302,17 @@ public class EditLib {
         // --- collect all children, adding the new one at the end of the others
         Vector<Element> children = new Vector<Element>();
 
-        for (int i = 0; i < type.getElementCount(); i++) {
+        for (String singleType: type.getAlElements()) {
             // Add existing children of all types
-            List<Element> list = getChildren(el, type.getElementAt(i));
-            if (qname.equals(type.getElementAt(i)) && removeExisting) {
+            List<Element> list = getChildren(el, singleType);
+            if (qname.equals(singleType) && removeExisting) {
                 // Remove all existing children of the type of element to add
             } else {
                 for (Element aList : list) {
                     children.add(aList);
                 }
             }
-            if (qname.equals(type.getElementAt(i)))
+            if (qname.equals(singleType))
                 children.add(fragElt);
         }
         // --- remove everything and then add all collected children to the element
@@ -1018,9 +1018,8 @@ public class EditLib {
         //-----------------------------------------------------------------------
         //--- handle attributes if mandatory or suggested
         //
-        for (int i = 0; i < type.getAttributeCount(); i++) {
-            MetadataAttribute attr = type.getAttributeAt(i);
-            LOGGER_FILL_ELEMENT.debug("####   - {} attribute = {}", i, attr.name);
+        for (MetadataAttribute attr: type.getAlAttribs()) {
+            LOGGER_FILL_ELEMENT.debug("####   - {} attribute = {}", attr.name);
             LOGGER_FILL_ELEMENT.debug("####     - required = {}", attr.required);
             LOGGER_FILL_ELEMENT.debug("####     - suggested = {}", sugg.isSuggested(elemName, attr.name));
 
@@ -1161,8 +1160,7 @@ public class EditLib {
         String chNS = getNamespace(chName, md, mdSchema);
         Element container = new Element(chUQname, chPrefix, chNS);
         MetadataType containerType = mdSchema.getTypeInfo(chName);
-        for (int k = 0; k < containerType.getElementCount(); k++) {
-            String elemName = containerType.getElementAt(k);
+        for (String elemName: containerType.getAlElements()) {
             LOGGER.debug("		-- Searching for child {}", elemName);
             List<Element> elems;
             if (elemName.contains(Edit.RootChild.GROUP) ||
@@ -1211,8 +1209,7 @@ public class EditLib {
         if (thisType.hasContainers) {
             Vector<Content> holder = new Vector<Content>();
 
-            for (int i = 0; i < thisType.getElementCount(); i++) {
-                String chName = thisType.getElementAt(i);
+            for (String chName: thisType.getAlElements()) {
                 if (chName.contains(Edit.RootChild.CHOICE) ||
                     chName.contains(Edit.RootChild.GROUP) ||
                     chName.contains(Edit.RootChild.SEQUENCE)) {
@@ -1705,8 +1702,7 @@ public class EditLib {
                     child.addContent(newElem);
                 } else {
                     action = "before"; // js adds new elements before this child
-                    for (int l = 0; l < type.getElementCount(); l++) {
-                        String chElem = type.getElementAt(l);
+                    for (String chElem :type.getAlElements()) {
                         if (chElem.contains(Edit.RootChild.CHOICE)) {
                             List<String> chElems = recurseOnNestedChoices(schema, chElem, parent);
 
@@ -1741,8 +1737,7 @@ public class EditLib {
         List<String> chElems = new ArrayList<String>();
         String elemType = schema.getElementType(chElem, parent);
         MetadataType type = schema.getTypeInfo(elemType);
-        for (int l = 0; l < type.getElementCount(); l++) {
-            String subChElem = type.getElementAt(l);
+        for (String subChElem: type.getAlElements()) {
             if (subChElem.contains(Edit.RootChild.CHOICE)) {
                 List<String> subChElems = recurseOnNestedChoices(schema, subChElem, chElem);
                 chElems.addAll(subChElems);
@@ -1771,8 +1766,7 @@ public class EditLib {
     }
 
     private void addAttribs(MetadataType type, Element md, MetadataSchema schema) {
-        for (int i = 0; i < type.getAttributeCount(); i++) {
-            MetadataAttribute attr = type.getAttributeAt(i);
+        for (MetadataAttribute attr: type.getAlAttribs()) {
 
             Element attribute = new Element(Edit.RootChild.ATTRIBUTE, Edit.NAMESPACE);
 

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -217,13 +217,7 @@ public class EditLib {
         LOGGER_ADD_ELEMENT.debug("#### - child name = {}", name);
         LOGGER_ADD_ELEMENT.debug("#### - child namespace = {}", ns);
         LOGGER_ADD_ELEMENT.debug("#### - child prefix = {}", prefix);
-
-        @SuppressWarnings("unchecked")
-        List<Element> childS = el.getChildren();
-        if (childS.size() > 0) {
-            Element elChildS = childS.get(0);
-            LOGGER_ADD_ELEMENT.debug("#### 	- parents first child = {}", elChildS.getName());
-        }
+        LOGGER_ADD_ELEMENT.debug("#### - parents first child = {}", el.getChildren().stream().findFirst().toString());
 
         Element child = new Element(name, prefix, ns);
 

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -69,6 +69,10 @@ import java.util.Vector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.fao.geonet.constants.Edit.ChildElem.Attr.NAME;
+import static org.fao.geonet.constants.Edit.ChildElem.Attr.NAMESPACE;
+import static org.fao.geonet.constants.Edit.RootChild.CHILD;
+
 public class EditLib {
     private static Logger LOGGER = LoggerFactory.getLogger(Geonet.EDITOR);
     private static Logger LOGGER_ADD_ELEMENT = LoggerFactory.getLogger(Geonet.EDITORADDELEMENT);
@@ -1529,9 +1533,9 @@ public class EditLib {
 
     private boolean equal(String childName, String childNS, Element el) {
         if (Edit.NAMESPACE.getURI().equals(el.getNamespaceURI())) {
-            return Edit.RootChild.CHILD.equals(el.getName())
-                && childName.equals(el.getAttributeValue(Edit.ChildElem.Attr.NAME))
-                && childNS.equals(el.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE));
+            return CHILD.equals(el.getName())
+                && childName.equals(el.getAttributeValue(NAME))
+                && childNS.equals(el.getAttributeValue(NAMESPACE));
         } else
             return childName.equals(el.getName()) && childNS.equals(el.getNamespaceURI());
     }
@@ -1542,35 +1546,26 @@ public class EditLib {
         String geonetNS = Edit.NAMESPACE.getURI();
 
         if (geonetNS.equals(elemNS1) && geonetNS.equals(elemNS2)) {
-            if (!Edit.RootChild.CHILD.equals(el1.getName()))
-                return false;
-
-            if (!Edit.RootChild.CHILD.equals(el2.getName()))
-                return false;
-
-            String name1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAME);
-            String name2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAME);
-
-            String ns1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
-            String ns2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
-
+            if (!CHILD.equals(el1.getName())) return false;
+            if (!CHILD.equals(el2.getName())) return false;
+            String name1 = el1.getAttributeValue(NAME);
+            String ns1 = el1.getAttributeValue(NAMESPACE);
+            String name2 = el2.getAttributeValue(NAME);
+            String ns2 = el2.getAttributeValue(NAMESPACE);
             return name1.equals(name2) && ns1.equals(ns2);
+
         } else if (geonetNS.equals(elemNS1) && ! geonetNS.equals(elemNS2)) {
-            if (!Edit.RootChild.CHILD.equals(el1.getName()))
-                return false;
-
-            String name1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAME);
-            String ns1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
-
+            if (!CHILD.equals(el1.getName())) return false;
+            String name1 = el1.getAttributeValue(NAME);
+            String ns1 = el1.getAttributeValue(NAMESPACE);
             return el2.getName().equals(name1) && el2.getNamespaceURI().equals(ns1);
+
         } else if (!geonetNS.equals(elemNS1) && geonetNS.equals(elemNS2)) {
-            if (!Edit.RootChild.CHILD.equals(el2.getName()))
-                return false;
-
-            String name2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAME);
-            String ns2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
-
+            if (!CHILD.equals(el2.getName())) return false;
+            String name2 = el2.getAttributeValue(NAME);
+            String ns2 = el2.getAttributeValue(NAMESPACE);
             return el1.getName().equals(name2) && el1.getNamespaceURI().equals(ns2);
+            
         } else { // if (!geonetNS.equals(elemNS1) && !geonetNS.equals(elemNS2)) {
             return el1.getName().equals(el2.getName()) && el1.getNamespaceURI().equals(el2.getNamespaceURI());
         }
@@ -1614,13 +1609,13 @@ public class EditLib {
      */
     private Element createElement(MetadataSchema schema, String parent, String qname, String childNS, int min, int max) throws Exception {
 
-        Element child = new Element(Edit.RootChild.CHILD, Edit.NAMESPACE);
+        Element child = new Element(CHILD, Edit.NAMESPACE);
         SchemaSuggestions mdSugg = scm.getSchemaSuggestions(schema.getName());
 
-        child.setAttribute(new Attribute(Edit.ChildElem.Attr.NAME, getUnqualifiedName(qname)));
+        child.setAttribute(new Attribute(NAME, getUnqualifiedName(qname)));
         child.setAttribute(new Attribute(Edit.ChildElem.Attr.PREFIX, getPrefix(qname)));
-        child.setAttribute(new Attribute(Edit.ChildElem.Attr.NAMESPACE, childNS));
-        child.setAttribute(new Attribute(Edit.ChildElem.Attr.UUID, Edit.RootChild.CHILD + "_" + qname + "_" + UUID.randomUUID().toString()));
+        child.setAttribute(new Attribute(NAMESPACE, childNS));
+        child.setAttribute(new Attribute(Edit.ChildElem.Attr.UUID, CHILD + "_" + qname + "_" + UUID.randomUUID().toString()));
         child.setAttribute(new Attribute(Edit.ChildElem.Attr.MIN, "" + min));
         child.setAttribute(new Attribute(Edit.ChildElem.Attr.MAX, "" + max));
 

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -612,7 +612,7 @@ public class EditLib {
                     // If a property is found,
                     // - handle deletion
                     // - Update text node or attributes
-                    if (propNode != null && !isCreateMode) {
+                    if (!isCreateMode) {
                         // And if magic tag is delete
                         // Delete a node
                         // <gn_delete/>

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -1539,50 +1539,40 @@ public class EditLib {
     private boolean equal(Element el1, Element el2) {
         String elemNS1 = el1.getNamespaceURI();
         String elemNS2 = el2.getNamespaceURI();
+        String geonetNS = Edit.NAMESPACE.getURI();
 
-        if (Edit.NAMESPACE.getURI().equals(elemNS1)) {
-            if (Edit.NAMESPACE.getURI().equals(elemNS2)) {
-                //--- both are geonet:child elements
+        if (geonetNS.equals(elemNS1) && geonetNS.equals(elemNS2)) {
+            if (!Edit.RootChild.CHILD.equals(el1.getName()))
+                return false;
 
-                if (!Edit.RootChild.CHILD.equals(el1.getName()))
-                    return false;
+            if (!Edit.RootChild.CHILD.equals(el2.getName()))
+                return false;
 
-                if (!Edit.RootChild.CHILD.equals(el2.getName()))
-                    return false;
+            String name1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAME);
+            String name2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAME);
 
-                String name1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAME);
-                String name2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAME);
+            String ns1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
+            String ns2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
 
-                String ns1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
-                String ns2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
+            return name1.equals(name2) && ns1.equals(ns2);
+        } else if (geonetNS.equals(elemNS1) && ! geonetNS.equals(elemNS2)) {
+            if (!Edit.RootChild.CHILD.equals(el1.getName()))
+                return false;
 
-                return name1.equals(name2) && ns1.equals(ns2);
-            } else {
-                //--- el1 is a geonet:child, el2 is not
+            String name1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAME);
+            String ns1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
 
-                if (!Edit.RootChild.CHILD.equals(el1.getName()))
-                    return false;
+            return el2.getName().equals(name1) && el2.getNamespaceURI().equals(ns1);
+        } else if (!geonetNS.equals(elemNS1) && geonetNS.equals(elemNS2)) {
+            if (!Edit.RootChild.CHILD.equals(el2.getName()))
+                return false;
 
-                String name1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAME);
-                String ns1 = el1.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
+            String name2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAME);
+            String ns2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
 
-                return el2.getName().equals(name1) && el2.getNamespaceURI().equals(ns1);
-            }
-        } else {
-            if (Edit.NAMESPACE.getURI().equals(elemNS2)) {
-                //--- el2 is a geonet:child, el1 is not
-
-                if (!Edit.RootChild.CHILD.equals(el2.getName()))
-                    return false;
-
-                String name2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAME);
-                String ns2 = el2.getAttributeValue(Edit.ChildElem.Attr.NAMESPACE);
-
-                return el1.getName().equals(name2) && el1.getNamespaceURI().equals(ns2);
-            } else {
-                //--- both not geonet:child elements
-                return el1.getName().equals(el2.getName()) && el1.getNamespaceURI().equals(el2.getNamespaceURI());
-            }
+            return el1.getName().equals(name2) && el1.getNamespaceURI().equals(ns2);
+        } else { // if (!geonetNS.equals(elemNS1) && !geonetNS.equals(elemNS2)) {
+            return el1.getName().equals(el2.getName()) && el1.getNamespaceURI().equals(el2.getNamespaceURI());
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -240,28 +240,20 @@ public class EditLib {
 
         LOGGER_ADD_ELEMENT.debug("#### - metadata type = {}", type);
 
-        //--- collect all children, adding the new one at the end of the others
-
-        Vector<Element> children = new Vector<Element>();
-
+        // remove everything and then add all children to the element and assure a correct position for the
+        // new one: at the end of the others
+        el.removeContent();
         for (String singleType: type.getAlElements()) {
             List<Element> list = getChildren(el, singleType);
 
             LOGGER_ADD_ELEMENT.debug("####   - child of type {}, list size = {}", singleType, list.size());
             for (Element aChild : list) {
-                children.add(aChild);
+                el.addContent(aChild);
                 LOGGER_ADD_ELEMENT.debug("####		- add child {}", aChild.toString());
             }
 
             if (qname.equals(singleType))
-                children.add(child);
-        }
-        //--- remove everything and then add all collected children to the element to assure a correct position for the
-        // new one
-
-        el.removeContent();
-        for (Element aChildren : children) {
-            el.addContent(aChildren);
+                el.addContent(child);
         }
 
         //--- add mandatory sub-tags
@@ -299,9 +291,9 @@ public class EditLib {
         String typeName = mdSchema.getElementType(el.getQualifiedName(), parentName);
         MetadataType type = mdSchema.getTypeInfo(typeName);
 
-        // --- collect all children, adding the new one at the end of the others
-        Vector<Element> children = new Vector<Element>();
-
+        // remove everything and then add all children to the element and assure a correct position for the
+        // new one: at the end of the others
+        el.removeContent();
         for (String singleType: type.getAlElements()) {
             // Add existing children of all types
             List<Element> list = getChildren(el, singleType);
@@ -309,17 +301,11 @@ public class EditLib {
                 // Remove all existing children of the type of element to add
             } else {
                 for (Element aList : list) {
-                    children.add(aList);
+                    el.addContent(aList);
                 }
             }
             if (qname.equals(singleType))
-                children.add(fragElt);
-        }
-        // --- remove everything and then add all collected children to the element
-        // --- to assure a correct position for the new one
-        el.removeContent();
-        for (Element aChildren : children) {
-            el.addContent(aChildren);
+                el.addContent(fragElt);
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -659,7 +659,7 @@ public class EditLib {
                         }
                     }
                 } else if (o instanceof Text) {
-                    propEl.setText(((Text) o).getText());
+                    propEl.addContent((Content)(new Text(((Text) o).getText())));
                 }
             }
         } else if (newValue.getName().equals(propEl.getName()) &&

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -511,9 +511,7 @@ public class EditLib {
 
             // If a property is not found in metadata,
             // or in create mode, create it...
-            if (
-                (nodeList.size() == 0 && createXpathNodeIfNotExist) ||
-                    isCreateMode) {
+            if ( (nodeList.isEmpty() && createXpathNodeIfNotExist) || isCreateMode) {
                 int indexOfRequiredPortion = -1;
                 // Extract the XPath for the element to match. For:
                 //  * Relative XPath (*//gmd:RS_Identifier)[2]/gmd:code/gco:CharacterString
@@ -1035,7 +1033,7 @@ public class EditLib {
                             !elemType.isOrType() ||                         // eg. gmd:EX_Extent
                             (elemType.isOrType() && (                       // eg. depends on schema-suggestions.xml
                                 childHasOneSuggestion ||                    //   expand the only one suggestion - TODO - this needs improvements
-                                    (childSuggestion.size() == 0 && elemType.getElementList().contains("gco:CharacterString")))
+                                    (childSuggestion.isEmpty() && elemType.getElementList().contains("gco:CharacterString")))
                                 //   expand element which have no suggestion
                                 // and have a gco:CharacterString substitute.
                                 // gco:CharacterString is the default.
@@ -1051,10 +1049,8 @@ public class EditLib {
                         // Add it to the element
                         element.addContent(child);
 
-                        if (childHasOnlyCharacterStringSuggestion &&
-                            isISOPlugin) {
-                            child.addContent(isoPlugin.createBasicTypeCharacterString()
-                            );
+                        if (childHasOnlyCharacterStringSuggestion && isISOPlugin) {
+                            child.addContent(isoPlugin.createBasicTypeCharacterString());
                         }
 
                         // Continue ....
@@ -1063,9 +1059,7 @@ public class EditLib {
                         // Logging some cases to avoid
                         if (LOGGER_FILL_ELEMENT.isDebugEnabled()) {
                             if (elemType.isOrType() && isISOPlugin) {
-                                if (elemType.getElementList().contains(
-                                    isoPlugin.getBasicTypeCharacterStringName())
-                                    && !childHasOneSuggestion) {
+                                if (elemType.getElementList().contains(isoPlugin.getBasicTypeCharacterStringName()) && !childHasOneSuggestion) {
                                     LOGGER_FILL_ELEMENT.debug("####   - (INNER) Requested expansion of an OR element having gco:CharacterString substitute and no suggestion: {}", element.getName());
                                 } else {
                                     LOGGER_FILL_ELEMENT.debug("####   - WARNING (INNER): requested expansion of an OR element : {}", childName);
@@ -1075,10 +1069,7 @@ public class EditLib {
                     }
                 }
             }
-        } else if (isISOPlugin &&
-            type.getElementList().contains(
-                isoPlugin.getBasicTypeCharacterStringName()) &&
-            !hasSuggestion) {
+        } else if (isISOPlugin && type.getElementList().contains(isoPlugin.getBasicTypeCharacterStringName()) && !hasSuggestion) {
             // expand element which have no suggestion
             // and have a gco:CharacterString substitute.
             // gco:CharacterString is the default.
@@ -1351,7 +1342,7 @@ public class EditLib {
             LOGGER_EXPAND_ELEMENT.debug("- namespace = {}", childNS);
 
             List<?> list = md.getChildren(childName, Namespace.getNamespace(childNS));
-            if (list.size() == 0 && !(type.isOrType())) {
+            if (list.isEmpty() && !(type.isOrType())) {
                 LOGGER_EXPAND_ELEMENT.debug("- no children of this type already present");
 
                 Element newElem = createElement(schema, elemName, childQName, childNS, type.getMinCardinAt(i), type.getMaxCardinAt(i));

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -297,9 +297,7 @@ public class EditLib {
         for (String singleType: type.getAlElements()) {
             // Add existing children of all types
             List<Element> list = getChildren(el, singleType);
-            if (qname.equals(singleType) && removeExisting) {
-                // Remove all existing children of the type of element to add
-            } else {
+            if (!qname.equals(singleType) || !removeExisting) {
                 for (Element aList : list) {
                     el.addContent(aList);
                 }

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -351,33 +351,34 @@ public class EditLib {
             }
 
 
-            if (xmlSnippetAsString != null && !xmlSnippetAsString.equals("")) {
-                String[] fragments = xmlSnippetAsString.split(XML_FRAGMENT_SEPARATOR);
-                for (String fragment : fragments) {
-                    if (nodeName != null) {
-                        LOGGER.debug("Add XML fragment; {} to element with ref: {}", fragment, nodeRef);
-                        addFragment(schema, el, nodeName, fragment, replaceExisting);
-                    } else {
-                        LOGGER.debug("Add XML fragment; {} to element with ref: {} replacing content.", fragment, nodeRef);
-                        // clean before update
-                        el.removeContent();
-                        fragment = addGmlNamespaceToFragment(fragment);
+            if (xmlSnippetAsString == null || xmlSnippetAsString.equals("")) {
+                continue;
+            }
+            String[] fragments = xmlSnippetAsString.split(XML_FRAGMENT_SEPARATOR);
+            for (String fragment : fragments) {
+                if (nodeName != null) {
+                    LOGGER.debug("Add XML fragment; {} to element with ref: {}", fragment, nodeRef);
+                    addFragment(schema, el, nodeName, fragment, replaceExisting);
+                } else {
+                    LOGGER.debug("Add XML fragment; {} to element with ref: {} replacing content.", fragment, nodeRef);
+                    // clean before update
+                    el.removeContent();
+                    fragment = addGmlNamespaceToFragment(fragment);
 
-                        // Add content
-                        Element node = Xml.loadString(fragment, false);
-                        if (replaceExisting) {
-                            @SuppressWarnings("unchecked")
-                            List<Element> children = node.getChildren();
-                            for (Element child: children) {
-                                el.addContent((Element) child.clone());
-                            }
-                            List<Attribute> attributes = node.getAttributes();
-                            for (Attribute a : attributes) {
-                                el.setAttribute((Attribute) a.clone());
-                            }
-                        } else {
-                            el.addContent(node);
+                    // Add content
+                    Element node = Xml.loadString(fragment, false);
+                    if (replaceExisting) {
+                        @SuppressWarnings("unchecked")
+                        List<Element> children = node.getChildren();
+                        for (Element child: children) {
+                            el.addContent((Element) child.clone());
                         }
+                        List<Attribute> attributes = node.getAttributes();
+                        for (Attribute a : attributes) {
+                            el.setAttribute((Attribute) a.clone());
+                        }
+                    } else {
+                        el.addContent(node);
                     }
                 }
             }

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -349,20 +349,13 @@ public class EditLib {
             // * X125_gmdCOLONkeywords_replace
             nodeRef = nodeConfig[0];
 
-            if (nodeConfig.length > 1 && nodeConfig[1] != null) {
-                if (nodeConfig[1].equals("replace")) {
-                    replaceExisting = true;
-                } else {
-                    nodeName = nodeConfig[1].replace(COLON_SEPARATOR, ":");
-                }
+            if (nodeConfig[nodeConfig.length-1].equals("replace")) {
+                replaceExisting = true;
             }
 
-            if (nodeConfig.length > 2 && nodeConfig[2] != null) {
-                if (nodeConfig[2].equals("replace")) {
-                    replaceExisting = true;
-                }
+            if (nodeConfig.length > 1) {
+                nodeName = nodeConfig[1].replace(COLON_SEPARATOR, ":");
             }
-
 
             // Get element to fill
             Element el = nodeRefToElem.get(nodeRef);

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -368,8 +368,8 @@ public class EditLib {
                         if (replaceExisting) {
                             @SuppressWarnings("unchecked")
                             List<Element> children = node.getChildren();
-                            for (int i = 0; i < children.size(); i++) {
-                                el.addContent((Element) children.get(i).clone());
+                            for (Element child: children) {
+                                el.addContent((Element) child.clone());
                             }
                             List<Attribute> attributes = node.getAttributes();
                             for (Attribute a : attributes) {

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -74,15 +74,16 @@ import static org.fao.geonet.constants.Edit.ChildElem.Attr.NAMESPACE;
 import static org.fao.geonet.constants.Edit.RootChild.CHILD;
 
 public class EditLib {
-    private static Logger LOGGER = LoggerFactory.getLogger(Geonet.EDITOR);
-    private static Logger LOGGER_ADD_ELEMENT = LoggerFactory.getLogger(Geonet.EDITORADDELEMENT);
-    private static Logger LOGGER_FILL_ELEMENT = LoggerFactory.getLogger(Geonet.EDITORFILLELEMENT);
-    private static Logger LOGGER_EXPAND_ELEMENT = LoggerFactory.getLogger(Geonet.EDITOREXPANDELEMENT);
-    private static final Joiner SLASH_STRING_JOINER = Joiner.on('/');
+    private static final Logger LOGGER = LoggerFactory.getLogger(Geonet.EDITOR);
+    private static final Logger LOGGER_ADD_ELEMENT = LoggerFactory.getLogger(Geonet.EDITORADDELEMENT);
+    private static final Logger LOGGER_FILL_ELEMENT = LoggerFactory.getLogger(Geonet.EDITORFILLELEMENT);
+    private static final Logger LOGGER_EXPAND_ELEMENT = LoggerFactory.getLogger(Geonet.EDITOREXPANDELEMENT);
 
     public static final String XML_FRAGMENT_SEPARATOR = "&&&";
     public static final String COLON_SEPARATOR = "COLON";
     public static final String MSG_ELEMENT_NOT_FOUND_AT_REF = "Element not found at ref = ";
+
+    private static final Joiner SLASH_STRING_JOINER = Joiner.on('/');
 
     private SchemaManager scm;
     private Hashtable<String, Integer> htVersions = new Hashtable<String, Integer>(1000);
@@ -1120,9 +1121,7 @@ public class EditLib {
         for (String elemName: containerType.getAlElements()) {
             LOGGER.debug("		-- Searching for child {}", elemName);
             List<Element> elems;
-            if (elemName.contains(Edit.RootChild.GROUP) ||
-                elemName.contains(Edit.RootChild.SEQUENCE) ||
-                elemName.contains(Edit.RootChild.CHOICE)) {
+            if (edit_CHOICE_GROUP_SEQUENCE_in(elemName)) {
                 elems = searchChildren(elemName, md, schema);
             } else {
                 elems = filterOnQname(md.getChildren(), elemName);
@@ -1167,9 +1166,7 @@ public class EditLib {
             Vector<Content> holder = new Vector<Content>();
 
             for (String chName: thisType.getAlElements()) {
-                if (chName.contains(Edit.RootChild.CHOICE) ||
-                    chName.contains(Edit.RootChild.GROUP) ||
-                    chName.contains(Edit.RootChild.SEQUENCE)) {
+                if (edit_CHOICE_GROUP_SEQUENCE_in(chName)) {
                     List<Element> elems = searchChildren(chName, md, schema);
                     if (elems.size() > 0) {
                         holder.addAll(elems);
@@ -1196,9 +1193,7 @@ public class EditLib {
         List<Element> chChilds = md.getChildren();
         for (Element chChild : chChilds) {
             String chName = chChild.getName();
-            if (chName.contains(Edit.RootChild.CHOICE) ||
-                chName.contains(Edit.RootChild.GROUP) ||
-                chName.contains(Edit.RootChild.SEQUENCE)) {
+            if (edit_CHOICE_GROUP_SEQUENCE_in(chName)) {
                 List<Object> moreChChilds = getContainerChildren(chChild);
                 result.addAll(moreChChilds);
             } else {
@@ -1221,9 +1216,7 @@ public class EditLib {
             if (obj instanceof Element) {
                 Element mdCh = (Element) obj;
                 String mdName = mdCh.getName();
-                if (mdName.contains(Edit.RootChild.CHOICE) ||
-                    mdName.contains(Edit.RootChild.GROUP) ||
-                    mdName.contains(Edit.RootChild.SEQUENCE)) {
+                if (edit_CHOICE_GROUP_SEQUENCE_in(mdName)) {
                     if (mdCh.getChildren().size() > 0) {
                         Vector<Object> chChilds = getContainerChildren(mdCh);
                         if (chChilds.size() > 0) {
@@ -1428,11 +1421,7 @@ public class EditLib {
             // finally if it isn't on the root element then check the list
             // namespaces we collected as we parsed the schema
             if (result.equals("UNKNOWN")) {
-                String prefix = getPrefix(qname);
-                if (!prefix.equals("")) {
-                    result = schema.getNS(prefix);
-                    if (result == null) result = "UNKNOWN";
-                } else result = "UNKNOWN";
+                result = getNamespace(qname, schema);
             }
         }
         return result;
@@ -1849,5 +1838,11 @@ public class EditLib {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("MD after editing infomation::\n{}", Xml.getString(md));
         }
+    }
+
+    private boolean edit_CHOICE_GROUP_SEQUENCE_in(String name) {
+        return name.contains(Edit.RootChild.CHOICE) ||
+            name.contains(Edit.RootChild.GROUP) ||
+            name.contains(Edit.RootChild.SEQUENCE);
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataType.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataType.java
@@ -145,6 +145,10 @@ public class MetadataType {
         return name;
     }
 
+    public List<String> getAlElements() {return alElements; }
+
+    public List<MetadataAttribute> getAlAttribs() {return alAttribs; }
+
     //---------------------------------------------------------------------------
     //---
     //--- Package protected API methods

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -703,7 +703,6 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
      * adding an attribute to the existing element does not work.
      */
     @Test
-    @Ignore
     public void testAddAttributeExistingElement() throws JDOMException, IOException {
         SchemaManager manager = _schemaManager;
         MetadataSchema schema = manager.getSchema("iso19139");
@@ -720,7 +719,7 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
         boolean a1 = el.addElementOrFragmentFromXpath(metadataElement, schema, charStringXpath, new AddElemValue(text), true);
         boolean a2 = el.addElementOrFragmentFromXpath(metadataElement, schema, attXPath, new AddElemValue(att), true);
 
-        assertEquals(2, a1 && a2);
+        assertEquals(true, a1 && a2);
 
         assertEqualsText(text, metadataElement, charStringXpath, GMD, GCO);
         assertEquals(att, Xml.selectString(metadataElement, attXPath, Arrays.asList(GMD, GCO)));

--- a/services/src/main/java/org/fao/geonet/api/records/editing/EditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/EditUtils.java
@@ -263,7 +263,7 @@ class EditUtils {
                 if (Log.isDebugEnabled(Geonet.EDITOR))
                     Log.debug(Geonet.EDITOR, "replacing XML content");
                 el.removeContent();
-                val = EditLib.addNamespaceToFragment(val);
+                val = EditLib.addGmlNamespaceToFragment(val);
                 el.addContent(Xml.loadString(val, false));
             } else {
                 @SuppressWarnings("unchecked")

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="row">
+  <div class="row gn-modal-content">
     <div class="col-md-6">
       <form id="gn-upload-onlinesrc"
             name="gnAddLink"

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -328,6 +328,11 @@ div.gn-scroll-spy {
       max-height: 76vh;
       overflow: auto;
       min-height: 500px;
+      .gn-modal-content {
+        // height of modal body - 2 * padding - height of button(s)
+        max-height: calc(~"76vh - 30px - 30px");
+        overflow: auto;
+      }
     }
   }
   .modal-dialog {


### PR DESCRIPTION
last commit (rebased on top, "do not want last text to override content") avoid csw

```xml
<gn_replace>
  <gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2018-11-01T00:00:00</gco:Date>
</gn_replace>
```
 to fail when 

```xml
<gn_replace><gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2018-11-T00:00:00</gco:Date></gn_replace>
```
works.

previous commits are opportunist refactorings.
