### PR TITLE
Fixes postgres database type not supported in ArcSDE harvester.

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/arcsde.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/arcsde.html
@@ -54,7 +54,7 @@
       <select class="form-control" data-ng-model="harvesterSelected.site.databaseType"
               data-ng-disabled="harvesterSelected.site.connectionType != 'JDBC'">
         <option value="oracle">{{'arcsde-oracle' | translate}}</option>
-        <option value="postgres">{{'arcsde-postgres' | translate}}</option>
+        <option value="postgresql">{{'arcsde-postgres' | translate}}</option>
         <option value="sqlserver">{{'arcsde-sqlserver' | translate}}</option>
       </select>
       <p class="help-block" data-translate="">arcsde-connection-databaseHelp</p>


### PR DESCRIPTION
In a ArcSDE harvester when `postgres` connection type is selected the harvester
fails with an `ArcSDEConnectionType JDBC for database type postgres not supported`.

This commit fixes this exception (#2636).