### PR TITLE
Truncate a long GeoNetwork name

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -19,7 +19,9 @@
         <a data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
           <img class="gn-logo"
                data-ng-src="{{gnUrl}}../images/logos/{{info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
-          <span class="hidden-sm hidden-md">{{info['system/site/name']}}</span>
+          <span class="hidden-sm hidden-md gn-name" 
+                data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
+                title="{{info['system/site/name']}}">{{info['system/site/name']}}</span>
         </a>
       </li>
       <li data-ng-if="gnCfg.mods.search.enabled">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -15,4 +15,11 @@
       color: @gn-menubar-color-hover;
     }
   }
+  .gn-name.gn-truncate {
+    @media (min-width: @screen-lg-min) {
+      max-width: 230px;
+      display: inline-block;
+      .text-overflow();
+    }
+  }
 }


### PR DESCRIPTION
When you give your GeoNetwork a long name/title, and you are logged in, there is the possibility that the name and menu buttons do not fit and the admin menu is displayed on a new line (see screenshot)

![gn-long-title](https://user-images.githubusercontent.com/19608667/39120506-eab672e0-46ee-11e8-9537-8a770b719cba.png)
**A long title forces the admin menu on a new line**

This PR adds a (general) class to the name (`gn-name`) to make it more unique, and adds a class to the name (`gn-truncate`) when you are logged in. The less file will then truncate the text and add an overflow.

![gn-long-title-truncated](https://user-images.githubusercontent.com/19608667/39120725-8dbf0858-46ef-11e8-9a95-b771c531bef0.png)
**The truncated title**

This solution is not fool proof, you can use even longer titles or a very wide logo and then the problem will be back again, but it will cover most cases. 