### PR TITLE
Ordering subtemplate fixes

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/CaseInsensitiveFieldComparatorSource.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/CaseInsensitiveFieldComparatorSource.java
@@ -130,15 +130,7 @@ public class CaseInsensitiveFieldComparatorSource extends FieldComparatorSource 
         @Override
         public int compareBottom(int doc) {
             final String val2 = readerValue(doc);
-            if (bottom == null) {
-                if (val2 == null) {
-                    return 0;
-                }
-                return -1;
-            } else if (val2 == null) {
-                return 1;
-            }
-            return bottom.compareTo(val2);
+            return doCompare(bottom, val2);
         }
 
         private String readerValue(int doc) {
@@ -163,9 +155,7 @@ public class CaseInsensitiveFieldComparatorSource extends FieldComparatorSource 
         @Override
         public void copy(int slot, int doc) {
             String val = readerValue(doc);
-            if (val != null) {
-                values[slot] = val;
-            }
+            values[slot] = val;
         }
 
         @Override

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -647,7 +647,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         elSummary.setAttribute("count", tfc.getTotalHits() + "");
         elSummary.setAttribute("type", "local");
         LOGGER.debug(" Get top docs from {} ... {} (total: {})", new Object[] {startHit, endHit, tfc.getTotalHits()});
-        TopDocs tdocs = tfc.topDocs(startHit, endHit);
+        TopDocs tdocs = tfc.topDocs(startHit, endHit - startHit);
 
         return Pair.read(tdocs, elSummary);
     }

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/CatalogSearcher.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/CatalogSearcher.java
@@ -580,7 +580,7 @@ public class CatalogSearcher implements MetadataRecordSelector {
 
 
         Pair<TopDocs, Element> searchResults = LuceneSearcher.doSearchAndMakeSummary(numHits, startPosition - 1,
-            maxRecords, _lang.presentationLanguage,
+            maxRecords + startPosition - 1, _lang.presentationLanguage,
             luceneConfig.getSummaryTypes().get(resultType.toString()), luceneConfig,
             reader, _query, wrapSpatialFilter(),
             _sort, taxonomyReader, buildSummary

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
@@ -62,6 +62,7 @@
                 </xsl:when>
                 <xsl:otherwise>
                     <Document locale="">
+                        <Field name="_docLocale" string="{$isoDocLangId}" store="true" index="true"/>
                         <xsl:apply-templates mode="index" select="$root">
                         </xsl:apply-templates>
                     </Document>


### PR DESCRIPTION
CaseInsensitiveFieldComparatorSource.java is used for example for sorting subtemplate before to display them in a paginated list. Bottom refer to the last element of the requested page.

In the case of subtemplate, element are first sorted on docLocale, then on _tilte (attempt on "_title|{searchLang}", then on "_title" if  "_title|{searchLang}" not defined).

If monolingual subtemplate, docLocale should also be defined, as for multilingual.