### PR TITLE
Fix for feature catalog return null when empty

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -191,9 +191,12 @@ public class MetadataUtils {
             if (listOfTypes.size() == 0 ||
                 listOfTypes.contains(RelatedItemType.fcats)) {
                 Set<String> listOfUUIDs = schemaPlugin.getAssociatedFeatureCatalogueUUIDs(md);
-                Element fcat = new Element("fcats");
+                Element fcat = null;
 
                 if (listOfUUIDs != null && listOfUUIDs.size() > 0) {
+
+                    fcat = new Element("fcats");
+
                     for (String fcat_uuid : listOfUUIDs) {
                         Element metadata = new Element("metadata");
                         Element response = new Element("response");


### PR DESCRIPTION
Angular code expects a null value instead of empty array when there are no feature catalogs associated with the record.