### PR TITLE
Make configurable in the admin settings a list with disabled harvester protocols

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
@@ -99,6 +99,7 @@ public class Settings {
     public static final String SYSTEM_OAI_CACHESIZE = "system/oai/cachesize";
     public static final String SYSTEM_INSPIRE_ENABLE_SEARCH_PANEL = "system/inspire/enableSearchPanel";
     public static final String SYSTEM_HARVESTER_ENABLE_EDITING = "system/harvester/enableEditing";
+    public static final String SYSTEM_HARVESTER_DISABLED_HARVESTER_TYPES = "system/harvester/disabledHarvesterTypes";
     public static final String SYSTEM_METADATAPRIVS_USERGROUPONLY = "system/metadataprivs/usergrouponly";
     public static final String SYSTEM_INSPIRE_ATOM_PROTOCOL = "system/inspire/atomProtocol";
     public static final String SYSTEM_HARVESTING_MAIL_RECIPIENT = "system/harvesting/mail/recipient";

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -213,7 +213,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
         }
 
         // TODO use a parameter in mask to avoid call again in base
-        // and use it for call settingMan.get
+        // and use it for call harvesterSettingsManager.get
         // don't forget to clean parameter when update or delete
 
         Profile profile = context.getUserSession().getProfile();

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -66,6 +66,7 @@ import org.fao.geonet.kernel.MetadataIndexerProcessor;
 import org.fao.geonet.kernel.harvest.Common.OperResult;
 import org.fao.geonet.kernel.harvest.Common.Status;
 import org.fao.geonet.kernel.setting.HarvesterSettingsManager;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.HarvestHistoryRepository;
 import org.fao.geonet.repository.MetadataRepository;
@@ -99,20 +100,20 @@ import jeeves.server.context.ServiceContext;
 
 /**
  * Represents a harvester job. Used to launch harvester workers.
- * 
+ *
  * If you want to synchronize something here, use protected variable lock.
  * If not, we may not be able to even stop a frozen harvester.
- * 
+ *
  */
 public abstract class AbstractHarvester<T extends HarvestResult> {
 
     private static final String SCHEDULER_ID = "abstractHarvester";
     public static final String HARVESTER_GROUP_NAME = "HARVESTER_GROUP_NAME";
-    
+
     /**
      * Used to make sure we don't wait forever for any task
-     * 
-     * 
+     *
+     *
         try {
             if(lock.tryLock(SHORT_WAIT, TimeUnit.SECONDS)) {
                 //DO WORK
@@ -126,7 +127,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                 lock.unlock();
             }
         }
-        
+
      */
     protected final ReentrantLock lock = new ReentrantLock(false);
 
@@ -135,9 +136,9 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
      * short. If we cannot do it, just show an error and warn.
      */
     protected Integer SHORT_WAIT = 2;
-    
+
     /**
-     * Time to wait for important operations in seconds. 
+     * Time to wait for important operations in seconds.
      * Patience, but don't block forever.
      */
     protected Integer LONG_WAIT = 30;
@@ -179,7 +180,8 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
     protected void setContext(ServiceContext context) {
         this.context = context;
         this.dataMan = context.getBean(DataManager.class);
-        this.settingMan = context.getBean(HarvesterSettingsManager.class);
+        this.harvesterSettingsManager = context.getBean(HarvesterSettingsManager.class);
+        this.settingManager = context.getBean(SettingManager.class);
     }
 
     /**
@@ -336,17 +338,17 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
 
                 final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
                 final SourceRepository sourceRepository = context.getBean(SourceRepository.class);
-                
+
                 final Specifications<Metadata> ownedByHarvester = Specifications.where(MetadataSpecs.hasHarvesterUuid(getParams().getUuid()));
                 Set<String> sources = new HashSet<String>();
                 for (Integer id : metadataRepository.findAllIdsBy(ownedByHarvester)) {
                     sources.add(metadataRepository.findOne(id).getSourceInfo().getSourceId());
                     dataMan.deleteMetadata(context, "" + id);
                 }
-                
+
                 // Remove all sources related to the harvestUuid if they are not linked to any record anymore
                 for (String sourceUuid : sources) {
-                    Long ownedBySource = 
+                    Long ownedBySource =
                             metadataRepository.count(Specifications.where(MetadataSpecs.hasSource(sourceUuid)));
                     if (ownedBySource == 0 && !sourceUuid.equals(params.getUuid()) && sourceRepository.exists(sourceUuid)) {
                         removeIcon(sourceUuid);
@@ -381,7 +383,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                 if (status != Status.INACTIVE) {
                     return OperResult.ALREADY_ACTIVE;
                 }
-                settingMan.setValue("harvesting/id:" + id + "/options/status", Status.ACTIVE);
+                harvesterSettingsManager.setValue("harvesting/id:" + id + "/options/status", Status.ACTIVE);
 
                 status = Status.ACTIVE;
                 error = null;
@@ -399,7 +401,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                 lock.unlock();
             }
         }
-        return OperResult.ERROR;        
+        return OperResult.ERROR;
     }
 
     /**
@@ -415,14 +417,14 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
 
         JobKey jobKey = jobKey(getParams().getUuid(), HARVESTER_GROUP_NAME);
         if(getScheduler().checkExists(jobKey)) {
-            getScheduler().interrupt(jobKey);            
+            getScheduler().interrupt(jobKey);
         }
 
         try {
             if(lock.tryLock(LONG_WAIT, TimeUnit.SECONDS)) {
                 this.running = false;
-                
-                settingMan.setValue("harvesting/id:" + id + "/options/status", newStatus);
+
+                harvesterSettingsManager.setValue("harvesting/id:" + id + "/options/status", newStatus);
                 if (newStatus == Status.INACTIVE) {
                     if (this.status != Status.ACTIVE) {
                         return OperResult.ALREADY_INACTIVE;
@@ -434,7 +436,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                 return OperResult.OK;
             } else {
                 log.error("Harvester '" + this.getID() + "' looks deadlocked.");
-                
+
                 // Sometimes the harvester is frozen
                 // give some time, but if it does not finish properly...
                 // just kill it!!
@@ -442,7 +444,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                     @Override
                     public void run() {
                         super.run();
-                        
+
                         //Wait again for proper shutdown
                         try {
                             Thread.sleep(LONG_WAIT * 1000);
@@ -453,13 +455,13 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                         //Still running?
                         if(AbstractHarvester.this.running) {
                             //Then kill it!
-                            log.error("Forcefully stopping harvester '" + 
+                            log.error("Forcefully stopping harvester '" +
                                     AbstractHarvester.this.getID() + "'.");
-                            try {                
+                            try {
                                 AbstractHarvester.this.running = false;
-                                settingMan.setValue("harvesting/id:" + id + "/options/status", newStatus);
+                                harvesterSettingsManager.setValue("harvesting/id:" + id + "/options/status", newStatus);
                                 AbstractHarvester.this.status = newStatus;
-                                
+
                                 //Restart scheduling. Something went terribly wrong!
                                 doUnschedule();
                                 doSchedule();
@@ -477,7 +479,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                 lock.unlock();
             }
         }
-        return OperResult.ERROR;          
+        return OperResult.ERROR;
     }
 
     /**
@@ -507,7 +509,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                 lock.unlock();
             }
         }
-        return OperResult.ERROR;  
+        return OperResult.ERROR;
     }
 
     /**
@@ -559,7 +561,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                     //--- restart executor
                     error = null;
                     doSchedule();
-                }                
+                }
             } else {
                 log.error("Harvester '" + this.getID() + "' looks deadlocked.");
             }
@@ -660,13 +662,13 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
         if (log.isDebugEnabled()) {
             log.debug("AbstractHarvester login: ownerId = " + ownerId);
         }
-        
+
         UserRepository repository = this.context.getBean(UserRepository.class);
         User user = null;
         if (StringUtils.isNotEmpty(ownerId)) {
             user = repository.findOne(ownerId);
         }
-        
+
         // for harvesters created before owner was added to the harvester code,
         // or harvesters belonging to a user that no longer exists
         if (user == null || StringUtils.isEmpty(ownerId) || !this.dataMan.existsUser(this.context, Integer.parseInt(ownerId))) {
@@ -712,7 +714,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                         login();
 
                         //--- update lastRun
-                        settingMan.setValue("harvesting/id:" + id + "/info/lastRun", lastRun);
+                        harvesterSettingsManager.setValue("harvesting/id:" + id + "/info/lastRun", lastRun);
 
                         //--- proper harvesting
                         logger.info("Started harvesting from node : " + nodeName);
@@ -753,7 +755,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
                 } finally {
                     cancelMonitor.set(false);
                     running = false;
-                }    
+                }
             } else {
                 log.error("Harvester '" + this.getID() + "' looks deadlocked.");
                 log.error("Harvester '" + this.getID() + "' hasn't initiated.");
@@ -767,9 +769,9 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
             }
         }
 
-        return operResult;  
-        
-        
+        return operResult;
+
+
     }
 
     private void logHarvest(String logfile, Logger logger, String nodeName, String lastRun, long elapsedTime) {
@@ -860,7 +862,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
      * @return
      */
     public final String getType() {
-        // FIXME: context is null when removing record 
+        // FIXME: context is null when removing record
         // eg. http://localhost:8080/geonetwork/node1/eng/admin.harvester.clear@json?id=585
         final String[] types = context.getApplicationContext().getBeanNamesForType(getClass());
         return types[0];
@@ -955,53 +957,53 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
      * @throws SQLException
      */
     protected void storeNode(AbstractParams params, String path) throws SQLException {
-        String siteId = settingMan.add(path, "site", "");
-        String translations = settingMan.add(ID_PREFIX + siteId, AbstractParams.TRANSLATIONS, "");
-        String optionsId = settingMan.add(path, "options", "");
-        String infoId = settingMan.add(path, "info", "");
-        String contentId = settingMan.add(path, "content", "");
+        String siteId = harvesterSettingsManager.add(path, "site", "");
+        String translations = harvesterSettingsManager.add(ID_PREFIX + siteId, AbstractParams.TRANSLATIONS, "");
+        String optionsId = harvesterSettingsManager.add(path, "options", "");
+        String infoId = harvesterSettingsManager.add(path, "info", "");
+        String contentId = harvesterSettingsManager.add(path, "content", "");
 
         //--- setup site node ----------------------------------------
 
-        settingMan.add(ID_PREFIX + siteId, "name", params.getName());
+        harvesterSettingsManager.add(ID_PREFIX + siteId, "name", params.getName());
         for (Map.Entry<String, String> entry : params.getTranslations().entrySet()) {
-            settingMan.add(ID_PREFIX + translations, entry.getKey(), entry.getValue());
+            harvesterSettingsManager.add(ID_PREFIX + translations, entry.getKey(), entry.getValue());
         }
-        settingMan.add(ID_PREFIX + siteId, "uuid", params.getUuid());
+        harvesterSettingsManager.add(ID_PREFIX + siteId, "uuid", params.getUuid());
 
         /**
          * User who created or updated this node.
          */
-        settingMan.add(ID_PREFIX + siteId, "ownerId", params.getOwnerId());
+        harvesterSettingsManager.add(ID_PREFIX + siteId, "ownerId", params.getOwnerId());
         /**
          * User selected by user who created or updated this node.
          */
-        settingMan.add(ID_PREFIX + siteId, "ownerUser", params.getOwnerIdUser());
+        harvesterSettingsManager.add(ID_PREFIX + siteId, "ownerUser", params.getOwnerIdUser());
         /**
          * Group selected by user who created or updated this node.
          */
-        settingMan.add(ID_PREFIX + siteId, "ownerGroup", params.getOwnerIdGroup());
+        harvesterSettingsManager.add(ID_PREFIX + siteId, "ownerGroup", params.getOwnerIdGroup());
 
-        String useAccId = settingMan.add(ID_PREFIX + siteId, "useAccount", params.isUseAccount());
+        String useAccId = harvesterSettingsManager.add(ID_PREFIX + siteId, "useAccount", params.isUseAccount());
 
-        settingMan.add(ID_PREFIX + useAccId, "username", params.getUsername());
-        settingMan.add(ID_PREFIX + useAccId, "password", params.getPassword());
+        harvesterSettingsManager.add(ID_PREFIX + useAccId, "username", params.getUsername());
+        harvesterSettingsManager.add(ID_PREFIX + useAccId, "password", params.getPassword());
 
         //--- setup options node ---------------------------------------
 
-        settingMan.add(ID_PREFIX + optionsId, "every", params.getEvery());
-        settingMan.add(ID_PREFIX + optionsId, "oneRunOnly", params.isOneRunOnly());
-        settingMan.add(ID_PREFIX + optionsId, "overrideUUID", params.getOverrideUuid());
-        settingMan.add(ID_PREFIX + optionsId, "status", status);
+        harvesterSettingsManager.add(ID_PREFIX + optionsId, "every", params.getEvery());
+        harvesterSettingsManager.add(ID_PREFIX + optionsId, "oneRunOnly", params.isOneRunOnly());
+        harvesterSettingsManager.add(ID_PREFIX + optionsId, "overrideUUID", params.getOverrideUuid());
+        harvesterSettingsManager.add(ID_PREFIX + optionsId, "status", status);
 
         //--- setup content node ---------------------------------------
 
-        settingMan.add(ID_PREFIX + contentId, "importxslt", params.getImportXslt());
-        settingMan.add(ID_PREFIX + contentId, "validate", params.getValidate());
+        harvesterSettingsManager.add(ID_PREFIX + contentId, "importxslt", params.getImportXslt());
+        harvesterSettingsManager.add(ID_PREFIX + contentId, "validate", params.getValidate());
 
         //--- setup stats node ----------------------------------------
 
-        settingMan.add(ID_PREFIX + infoId, "lastRun", "");
+        harvesterSettingsManager.add(ID_PREFIX + infoId, "lastRun", "");
 
         //--- store privileges and categories ------------------------
 
@@ -1019,12 +1021,12 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
      * @throws SQLException
      */
     protected void storePrivileges(AbstractParams params, String path) throws SQLException {
-        String privId = settingMan.add(path, "privileges", "");
+        String privId = harvesterSettingsManager.add(path, "privileges", "");
 
         for (Privileges p : params.getPrivileges()) {
-            String groupId = settingMan.add(ID_PREFIX + privId, "group", p.getGroupId());
+            String groupId = harvesterSettingsManager.add(ID_PREFIX + privId, "group", p.getGroupId());
             for (int oper : p.getOperations()) {
-                settingMan.add(ID_PREFIX + groupId, "operation", oper);
+                harvesterSettingsManager.add(ID_PREFIX + groupId, "operation", oper);
             }
         }
     }
@@ -1037,10 +1039,10 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
      * @throws SQLException
      */
     protected void storeCategories(AbstractParams params, String path) throws SQLException {
-        String categId = settingMan.add(path, "categories", "");
+        String categId = harvesterSettingsManager.add(path, "categories", "");
 
         for (String id : params.getCategories()) {
-            settingMan.add(ID_PREFIX + categId, "category", id);
+            harvesterSettingsManager.add(ID_PREFIX + categId, "category", id);
         }
     }
 
@@ -1170,7 +1172,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
      */
     private List<HarvestError> errors = Collections.synchronizedList(new LinkedList<HarvestError>());
     private volatile boolean running = false;
-    
+
     /**
      * Should we cancel the harvester?
      */
@@ -1179,7 +1181,8 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
 
     protected ServiceContext context;
 
-    protected HarvesterSettingsManager settingMan;
+    protected HarvesterSettingsManager harvesterSettingsManager;
+    protected SettingManager settingManager;
 
     protected DataManager dataMan;
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvesterJob.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvesterJob.java
@@ -26,8 +26,14 @@ package org.fao.geonet.kernel.harvest.harvester;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.harvest.Common.OperResult;
 import org.fao.geonet.utils.Log;
-import org.quartz.*;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.InterruptableJob;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.UnableToInterruptJobException;
 import org.springframework.context.ConfigurableApplicationContext;
 
 /**
@@ -52,8 +58,14 @@ public class HarvesterJob implements Job, InterruptableJob {
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
+        if (harvester.isHarvesterTypeDisabled()) {
+            log.info("Cancelling harvester " + harvesterId + " execution because harvester type "
+                + harvester.getType() + " is disabled in the system settings");
+            context.setResult(OperResult.OK);
+            return;
+        }
         try {
-          _this = Thread.currentThread();
+            _this = Thread.currentThread();
             harvester.harvest();
         } catch (Throwable t) {
             throw new JobExecutionException(t, false);
@@ -79,16 +91,16 @@ public class HarvesterJob implements Job, InterruptableJob {
     @Override
     public void interrupt() throws UnableToInterruptJobException {
         harvester.cancelMonitor.set(true);
-        
+
         // Following the suggestion of InterruptableJob
         // Sometimes the harvester is frozen
         // give some time, but if it does not finish properly...
         // just kill it!!
-         new Thread(){
+        new Thread() {
             @Override
             public void run() {
                 super.run();
-                
+
                 //Wait for proper shutdown (a minute, more than enough!)
                 try {
                     Thread.sleep(60 * 1000);
@@ -97,12 +109,12 @@ public class HarvesterJob implements Job, InterruptableJob {
                 }
 
                 //Still running?
-                if(_this.isAlive()) {
+                if (_this.isAlive()) {
                     //Then kill it!
-                    log.error("Forcefully stopping harvester thread '" + 
-                            getHarvesterId() + "'.");
-                    try {                
-                       _this.interrupt();
+                    log.error("Forcefully stopping harvester thread '" +
+                        getHarvesterId() + "'.");
+                    try {
+                        _this.interrupt();
                     } catch (Throwable e) {
                         log.error(e);
                     }
@@ -110,8 +122,8 @@ public class HarvesterJob implements Job, InterruptableJob {
             }
         }.start();
     }
-    
+
     public Thread getThread() {
-      return _this;
+        return _this;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
@@ -95,15 +95,15 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
     protected void storeNodeExtra(AbstractParams params, String path, String siteId, String optionsId) throws SQLException {
         ArcSDEParams as = (ArcSDEParams) params;
         super.setParams(as);
-        settingMan.add("id:" + siteId, "icon", as.icon);
-        settingMan.add("id:" + siteId, "server", as.server);
-        settingMan.add("id:" + siteId, "port", as.port);
-        settingMan.add("id:" + siteId, "username", as.getUsername());
-        settingMan.add("id:" + siteId, "password", as.getPassword());
-        settingMan.add("id:" + siteId, "database", as.database);
-        settingMan.add("id:" + siteId, "version", as.version);
-        settingMan.add("id:" + siteId, "connectionType", as.connectionType);
-        settingMan.add("id:" + siteId, "databaseType", as.databaseType);
+        harvesterSettingsManager.add("id:" + siteId, "icon", as.icon);
+        harvesterSettingsManager.add("id:" + siteId, "server", as.server);
+        harvesterSettingsManager.add("id:" + siteId, "port", as.port);
+        harvesterSettingsManager.add("id:" + siteId, "username", as.getUsername());
+        harvesterSettingsManager.add("id:" + siteId, "password", as.getPassword());
+        harvesterSettingsManager.add("id:" + siteId, "database", as.database);
+        harvesterSettingsManager.add("id:" + siteId, "version", as.version);
+        harvesterSettingsManager.add("id:" + siteId, "connectionType", as.connectionType);
+        harvesterSettingsManager.add("id:" + siteId, "databaseType", as.databaseType);
     }
 
     @Override
@@ -129,7 +129,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
         storeNode(params, "id:" + id);
 
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -439,7 +439,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
@@ -81,7 +81,7 @@ public class CswHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
 
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -106,7 +106,7 @@ public class CswHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);
@@ -140,25 +140,25 @@ public class CswHarvester extends AbstractHarvester<HarvestResult> {
     protected void storeNodeExtra(AbstractParams p, String path, String siteId, String optionsId) throws SQLException {
         CswParams params = (CswParams) p;
 
-        settingMan.add("id:" + siteId, "capabUrl", params.capabUrl);
-        settingMan.add("id:" + siteId, "icon", params.icon);
-        settingMan.add("id:" + siteId, "rejectDuplicateResource", params.rejectDuplicateResource);
-        settingMan.add("id:" + siteId, "queryScope", params.queryScope);
-        settingMan.add("id:" + siteId, "hopCount", params.hopCount);
-        settingMan.add("id:" + siteId, "xslfilter", params.xslfilter);
-        settingMan.add("id:" + siteId, "outputSchema", params.outputSchema);
+        harvesterSettingsManager.add("id:" + siteId, "capabUrl", params.capabUrl);
+        harvesterSettingsManager.add("id:" + siteId, "icon", params.icon);
+        harvesterSettingsManager.add("id:" + siteId, "rejectDuplicateResource", params.rejectDuplicateResource);
+        harvesterSettingsManager.add("id:" + siteId, "queryScope", params.queryScope);
+        harvesterSettingsManager.add("id:" + siteId, "hopCount", params.hopCount);
+        harvesterSettingsManager.add("id:" + siteId, "xslfilter", params.xslfilter);
+        harvesterSettingsManager.add("id:" + siteId, "outputSchema", params.outputSchema);
 
         //--- store dynamic search nodes
-        String searchID = settingMan.add(path, "search", "");
+        String searchID = harvesterSettingsManager.add(path, "search", "");
 
         if (params.eltSearches != null) {
             for (Element element : params.eltSearches) {
                 if (!element.getName().startsWith("parser")) {
                     Element value = element.getChild("value");
                     if (value != null) {
-                        settingMan.add("id:" + searchID, element.getName(), value.getText());
+                        harvesterSettingsManager.add("id:" + searchID, element.getName(), value.getText());
                     } else {
-                        settingMan.add("id:" + searchID, element.getName(), element.getText());
+                        harvesterSettingsManager.add("id:" + searchID, element.getName(), element.getText());
                     }
                 }
             }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/GeoPRESTHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/GeoPRESTHarvester.java
@@ -79,7 +79,7 @@ public class GeoPRESTHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
 
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -99,7 +99,7 @@ public class GeoPRESTHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);
@@ -126,15 +126,15 @@ public class GeoPRESTHarvester extends AbstractHarvester<HarvestResult> {
                                   String siteId, String optionsId) throws SQLException {
         GeoPRESTParams params = (GeoPRESTParams) p;
 
-        settingMan.add("id:" + siteId, "baseUrl", params.baseUrl);
-        settingMan.add("id:" + siteId, "icon", params.icon);
+        harvesterSettingsManager.add("id:" + siteId, "baseUrl", params.baseUrl);
+        harvesterSettingsManager.add("id:" + siteId, "icon", params.icon);
 
         //--- store search nodes
 
         for (Search s : params.getSearches()) {
-            String searchID = settingMan.add(path, "search", "");
+            String searchID = harvesterSettingsManager.add(path, "search", "");
 
-            settingMan.add("id:" + searchID, "freeText", s.freeText);
+            harvesterSettingsManager.add("id:" + searchID, "freeText", s.freeText);
         }
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
@@ -77,7 +77,7 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
 
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), false);
@@ -97,7 +97,7 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);
@@ -124,37 +124,37 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult> {
         GeonetParams params = (GeonetParams) p;
         super.setParams(params);
 
-        settingMan.add("id:" + siteId, "host", params.host);
-        settingMan.add("id:" + siteId, "node", params.getNode());
-        settingMan.add("id:" + siteId, "useChangeDateForUpdate", params.useChangeDateForUpdate());
-        settingMan.add("id:" + siteId, "createRemoteCategory", params.createRemoteCategory);
-        settingMan.add("id:" + siteId, "mefFormatFull", params.mefFormatFull);
-        settingMan.add("id:" + siteId, "xslfilter", params.xslfilter);
+        harvesterSettingsManager.add("id:" + siteId, "host", params.host);
+        harvesterSettingsManager.add("id:" + siteId, "node", params.getNode());
+        harvesterSettingsManager.add("id:" + siteId, "useChangeDateForUpdate", params.useChangeDateForUpdate());
+        harvesterSettingsManager.add("id:" + siteId, "createRemoteCategory", params.createRemoteCategory);
+        harvesterSettingsManager.add("id:" + siteId, "mefFormatFull", params.mefFormatFull);
+        harvesterSettingsManager.add("id:" + siteId, "xslfilter", params.xslfilter);
 
         //--- store search nodes
 
         for (Search s : params.getSearches()) {
-            String searchID = settingMan.add(path, "search", "");
+            String searchID = harvesterSettingsManager.add(path, "search", "");
 
-            settingMan.add("id:" + searchID, "freeText", s.freeText);
-            settingMan.add("id:" + searchID, "title", s.title);
-            settingMan.add("id:" + searchID, "abstract", s.abstrac);
-            settingMan.add("id:" + searchID, "keywords", s.keywords);
-            settingMan.add("id:" + searchID, "digital", s.digital);
-            settingMan.add("id:" + searchID, "hardcopy", s.hardcopy);
-            settingMan.add("id:" + searchID, "sourceUuid", s.sourceUuid);
-            settingMan.add("id:" + searchID, "sourceName", s.sourceName);
-            settingMan.add("id:" + searchID, "anyField", s.anyField);
-            settingMan.add("id:" + searchID, "anyValue", s.anyValue);
+            harvesterSettingsManager.add("id:" + searchID, "freeText", s.freeText);
+            harvesterSettingsManager.add("id:" + searchID, "title", s.title);
+            harvesterSettingsManager.add("id:" + searchID, "abstract", s.abstrac);
+            harvesterSettingsManager.add("id:" + searchID, "keywords", s.keywords);
+            harvesterSettingsManager.add("id:" + searchID, "digital", s.digital);
+            harvesterSettingsManager.add("id:" + searchID, "hardcopy", s.hardcopy);
+            harvesterSettingsManager.add("id:" + searchID, "sourceUuid", s.sourceUuid);
+            harvesterSettingsManager.add("id:" + searchID, "sourceName", s.sourceName);
+            harvesterSettingsManager.add("id:" + searchID, "anyField", s.anyField);
+            harvesterSettingsManager.add("id:" + searchID, "anyValue", s.anyValue);
         }
 
         //--- store group mapping
 
         for (Group g : params.getGroupCopyPolicy()) {
-            String groupID = settingMan.add(path, "groupCopyPolicy", "");
+            String groupID = harvesterSettingsManager.add(path, "groupCopyPolicy", "");
 
-            settingMan.add("id:" + groupID, "name", g.name);
-            settingMan.add("id:" + groupID, "policy", g.policy);
+            harvesterSettingsManager.add("id:" + groupID, "name", g.name);
+            harvesterSettingsManager.add("id:" + groupID, "policy", g.policy);
         }
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Geonet20Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Geonet20Harvester.java
@@ -97,7 +97,7 @@ public class Geonet20Harvester extends AbstractHarvester {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
 
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -123,7 +123,7 @@ public class Geonet20Harvester extends AbstractHarvester {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);
@@ -150,20 +150,20 @@ public class Geonet20Harvester extends AbstractHarvester {
         GeonetParams params = (GeonetParams) p;
         super.setParams(params);
 
-        settingMan.add("id:" + siteId, "host", params.host);
+        harvesterSettingsManager.add("id:" + siteId, "host", params.host);
 
         //--- store search nodes
 
         for (Search s : params.getSearches()) {
-            String searchID = settingMan.add(path, "search", "");
+            String searchID = harvesterSettingsManager.add(path, "search", "");
 
-            settingMan.add("id:" + searchID, "freeText", s.freeText);
-            settingMan.add("id:" + searchID, "title", s.title);
-            settingMan.add("id:" + searchID, "abstract", s.abstrac);
-            settingMan.add("id:" + searchID, "keywords", s.keywords);
-            settingMan.add("id:" + searchID, "digital", s.digital);
-            settingMan.add("id:" + searchID, "hardcopy", s.hardcopy);
-            settingMan.add("id:" + searchID, "siteId", s.siteId);
+            harvesterSettingsManager.add("id:" + searchID, "freeText", s.freeText);
+            harvesterSettingsManager.add("id:" + searchID, "title", s.title);
+            harvesterSettingsManager.add("id:" + searchID, "abstract", s.abstrac);
+            harvesterSettingsManager.add("id:" + searchID, "keywords", s.keywords);
+            harvesterSettingsManager.add("id:" + searchID, "digital", s.digital);
+            harvesterSettingsManager.add("id:" + searchID, "hardcopy", s.hardcopy);
+            harvesterSettingsManager.add("id:" + searchID, "siteId", s.siteId);
         }
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -76,13 +76,13 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
         LocalFilesystemParams lp = (LocalFilesystemParams) params;
         super.setParams(lp);
 
-        settingMan.add("id:" + siteId, "icon", lp.icon);
-        settingMan.add("id:" + siteId, "recurse", lp.recurse);
-        settingMan.add("id:" + siteId, "directory", lp.directoryname);
-        settingMan.add("id:" + siteId, "recordType", lp.recordType);
-        settingMan.add("id:" + siteId, "nodelete", lp.nodelete);
-        settingMan.add("id:" + siteId, "checkFileLastModifiedForUpdate", lp.checkFileLastModifiedForUpdate);
-        settingMan.add("id:" + siteId, "beforeScript", lp.beforeScript);
+        harvesterSettingsManager.add("id:" + siteId, "icon", lp.icon);
+        harvesterSettingsManager.add("id:" + siteId, "recurse", lp.recurse);
+        harvesterSettingsManager.add("id:" + siteId, "directory", lp.directoryname);
+        harvesterSettingsManager.add("id:" + siteId, "recordType", lp.recordType);
+        harvesterSettingsManager.add("id:" + siteId, "nodelete", lp.nodelete);
+        harvesterSettingsManager.add("id:" + siteId, "checkFileLastModifiedForUpdate", lp.checkFileLastModifiedForUpdate);
+        harvesterSettingsManager.add("id:" + siteId, "beforeScript", lp.beforeScript);
     }
 
     @Override
@@ -96,7 +96,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
         storeNode(params, "id:" + id);
 
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -271,7 +271,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/OaiPmhHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/OaiPmhHarvester.java
@@ -80,7 +80,7 @@ public class OaiPmhHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
 
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -101,7 +101,7 @@ public class OaiPmhHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);
@@ -128,22 +128,22 @@ public class OaiPmhHarvester extends AbstractHarvester<HarvestResult> {
                                   String siteId, String optionsId) throws SQLException {
         OaiPmhParams params = (OaiPmhParams) p;
 
-        settingMan.add("id:" + siteId, "url", params.url);
-        settingMan.add("id:" + siteId, "icon", params.icon);
-        settingMan.add("id:" + siteId, "xslfilter", params.xslfilter);
+        harvesterSettingsManager.add("id:" + siteId, "url", params.url);
+        harvesterSettingsManager.add("id:" + siteId, "icon", params.icon);
+        harvesterSettingsManager.add("id:" + siteId, "xslfilter", params.xslfilter);
 
-        settingMan.add("id:" + optionsId, "validate", params.getValidate());
+        harvesterSettingsManager.add("id:" + optionsId, "validate", params.getValidate());
 
         //--- store search nodes
 
         for (Search s : params.getSearches()) {
-            String searchID = settingMan.add(path, "search", "");
+            String searchID = harvesterSettingsManager.add(path, "search", "");
 
-            settingMan.add("id:" + searchID, "from", s.from);
-            settingMan.add("id:" + searchID, "until", s.until);
-            settingMan.add("id:" + searchID, "set", s.set);
-            settingMan.add("id:" + searchID, "prefix", s.prefix);
-            settingMan.add("id:" + searchID, "stylesheet", s.stylesheet);
+            harvesterSettingsManager.add("id:" + searchID, "from", s.from);
+            harvesterSettingsManager.add("id:" + searchID, "until", s.until);
+            harvesterSettingsManager.add("id:" + searchID, "set", s.set);
+            harvesterSettingsManager.add("id:" + searchID, "prefix", s.prefix);
+            harvesterSettingsManager.add("id:" + searchID, "stylesheet", s.stylesheet);
         }
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/OgcWxSHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/OgcWxSHarvester.java
@@ -79,7 +79,7 @@ public class OgcWxSHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
 
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -100,7 +100,7 @@ public class OgcWxSHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);
@@ -127,16 +127,16 @@ public class OgcWxSHarvester extends AbstractHarvester<HarvestResult> {
         OgcWxSParams params = (OgcWxSParams) p;
         super.setParams(params);
 
-        settingMan.add("id:" + siteId, "url", params.url);
-        settingMan.add("id:" + siteId, "icon", params.icon);
-        settingMan.add("id:" + siteId, "ogctype", params.ogctype);
-        settingMan.add("id:" + optionsId, "lang", params.lang);
-        settingMan.add("id:" + optionsId, "topic", params.topic);
-        settingMan.add("id:" + optionsId, "createThumbnails", params.createThumbnails);
-        settingMan.add("id:" + optionsId, "useLayer", params.useLayer);
-        settingMan.add("id:" + optionsId, "useLayerMd", params.useLayerMd);
-        settingMan.add("id:" + optionsId, "datasetCategory", params.datasetCategory);
-        settingMan.add("id:" + optionsId, "outputSchema", params.outputSchema);
+        harvesterSettingsManager.add("id:" + siteId, "url", params.url);
+        harvesterSettingsManager.add("id:" + siteId, "icon", params.icon);
+        harvesterSettingsManager.add("id:" + siteId, "ogctype", params.ogctype);
+        harvesterSettingsManager.add("id:" + optionsId, "lang", params.lang);
+        harvesterSettingsManager.add("id:" + optionsId, "topic", params.topic);
+        harvesterSettingsManager.add("id:" + optionsId, "createThumbnails", params.createThumbnails);
+        harvesterSettingsManager.add("id:" + optionsId, "useLayer", params.useLayer);
+        harvesterSettingsManager.add("id:" + optionsId, "useLayerMd", params.useLayerMd);
+        harvesterSettingsManager.add("id:" + optionsId, "datasetCategory", params.datasetCategory);
+        harvesterSettingsManager.add("id:" + optionsId, "outputSchema", params.outputSchema);
     }
 
     //---------------------------------------------------------------------------

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/ThreddsHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/ThreddsHarvester.java
@@ -80,7 +80,7 @@ public class ThreddsHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
 
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -101,7 +101,7 @@ public class ThreddsHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);
@@ -129,31 +129,31 @@ public class ThreddsHarvester extends AbstractHarvester<HarvestResult> {
         ThreddsParams params = (ThreddsParams) p;
         super.setParams(params);
 
-        settingMan.add("id:" + siteId, "url", params.url);
-        settingMan.add("id:" + siteId, "icon", params.icon);
-        settingMan.add("id:" + optionsId, "lang", params.lang);
-        settingMan.add("id:" + optionsId, "topic", params.topic);
-        settingMan.add("id:" + optionsId, "createThumbnails", params.createThumbnails);
-        settingMan.add("id:" + optionsId, "createServiceMd", params.createServiceMd);
-        settingMan.add("id:" + optionsId, "createCollectionDatasetMd", params.createCollectionDatasetMd);
-        settingMan.add("id:" + optionsId, "createAtomicDatasetMd", params.createAtomicDatasetMd);
-        settingMan.add("id:" + optionsId, "ignoreHarvestOnCollections", params.ignoreHarvestOnCollections);
-        settingMan.add("id:" + optionsId, "collectionGeneration", params.collectionMetadataGeneration);
-        settingMan.add("id:" + optionsId, "collectionFragmentStylesheet", params.collectionFragmentStylesheet);
-        settingMan.add("id:" + optionsId, "collectionMetadataTemplate", params.collectionMetadataTemplate);
-        settingMan.add("id:" + optionsId, "createCollectionSubtemplates", params.createCollectionSubtemplates);
-        settingMan.add("id:" + optionsId, "outputSchemaOnCollectionsDIF", params.outputSchemaOnCollectionsDIF);
-        settingMan.add("id:" + optionsId, "outputSchemaOnCollectionsFragments", params.outputSchemaOnCollectionsFragments);
-        settingMan.add("id:" + optionsId, "ignoreHarvestOnAtomics", params.ignoreHarvestOnAtomics);
-        settingMan.add("id:" + optionsId, "atomicGeneration", params.atomicMetadataGeneration);
-        settingMan.add("id:" + optionsId, "modifiedOnly", params.modifiedOnly);
-        settingMan.add("id:" + optionsId, "atomicFragmentStylesheet", params.atomicFragmentStylesheet);
-        settingMan.add("id:" + optionsId, "atomicMetadataTemplate", params.atomicMetadataTemplate);
-        settingMan.add("id:" + optionsId, "createAtomicSubtemplates", params.createAtomicSubtemplates);
-        settingMan.add("id:" + optionsId, "outputSchemaOnAtomicsDIF", params.outputSchemaOnAtomicsDIF);
-        settingMan.add("id:" + optionsId, "outputSchemaOnAtomicsFragments", params.outputSchemaOnAtomicsFragments);
-        settingMan.add("id:" + optionsId, "createAtomicDatasetMd", params.createAtomicDatasetMd);
-        settingMan.add("id:" + optionsId, "datasetCategory", params.datasetCategory);
+        harvesterSettingsManager.add("id:" + siteId, "url", params.url);
+        harvesterSettingsManager.add("id:" + siteId, "icon", params.icon);
+        harvesterSettingsManager.add("id:" + optionsId, "lang", params.lang);
+        harvesterSettingsManager.add("id:" + optionsId, "topic", params.topic);
+        harvesterSettingsManager.add("id:" + optionsId, "createThumbnails", params.createThumbnails);
+        harvesterSettingsManager.add("id:" + optionsId, "createServiceMd", params.createServiceMd);
+        harvesterSettingsManager.add("id:" + optionsId, "createCollectionDatasetMd", params.createCollectionDatasetMd);
+        harvesterSettingsManager.add("id:" + optionsId, "createAtomicDatasetMd", params.createAtomicDatasetMd);
+        harvesterSettingsManager.add("id:" + optionsId, "ignoreHarvestOnCollections", params.ignoreHarvestOnCollections);
+        harvesterSettingsManager.add("id:" + optionsId, "collectionGeneration", params.collectionMetadataGeneration);
+        harvesterSettingsManager.add("id:" + optionsId, "collectionFragmentStylesheet", params.collectionFragmentStylesheet);
+        harvesterSettingsManager.add("id:" + optionsId, "collectionMetadataTemplate", params.collectionMetadataTemplate);
+        harvesterSettingsManager.add("id:" + optionsId, "createCollectionSubtemplates", params.createCollectionSubtemplates);
+        harvesterSettingsManager.add("id:" + optionsId, "outputSchemaOnCollectionsDIF", params.outputSchemaOnCollectionsDIF);
+        harvesterSettingsManager.add("id:" + optionsId, "outputSchemaOnCollectionsFragments", params.outputSchemaOnCollectionsFragments);
+        harvesterSettingsManager.add("id:" + optionsId, "ignoreHarvestOnAtomics", params.ignoreHarvestOnAtomics);
+        harvesterSettingsManager.add("id:" + optionsId, "atomicGeneration", params.atomicMetadataGeneration);
+        harvesterSettingsManager.add("id:" + optionsId, "modifiedOnly", params.modifiedOnly);
+        harvesterSettingsManager.add("id:" + optionsId, "atomicFragmentStylesheet", params.atomicFragmentStylesheet);
+        harvesterSettingsManager.add("id:" + optionsId, "atomicMetadataTemplate", params.atomicMetadataTemplate);
+        harvesterSettingsManager.add("id:" + optionsId, "createAtomicSubtemplates", params.createAtomicSubtemplates);
+        harvesterSettingsManager.add("id:" + optionsId, "outputSchemaOnAtomicsDIF", params.outputSchemaOnAtomicsDIF);
+        harvesterSettingsManager.add("id:" + optionsId, "outputSchemaOnAtomicsFragments", params.outputSchemaOnAtomicsFragments);
+        harvesterSettingsManager.add("id:" + optionsId, "createAtomicDatasetMd", params.createAtomicDatasetMd);
+        harvesterSettingsManager.add("id:" + optionsId, "datasetCategory", params.datasetCategory);
     }
 
     //---------------------------------------------------------------------------

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WebDavHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WebDavHarvester.java
@@ -68,7 +68,7 @@ public class WebDavHarvester extends AbstractHarvester<HarvestResult> {
         params.create(node);
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
         context.getBean(SourceRepository.class).save(source);
@@ -86,7 +86,7 @@ public class WebDavHarvester extends AbstractHarvester<HarvestResult> {
         //--- update variables
         copy.update(node);
         String path = "harvesting/id:" + id;
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
         //--- update database
         storeNode(copy, path);
         //--- we update a copy first because if there is an exception CswParams
@@ -103,11 +103,11 @@ public class WebDavHarvester extends AbstractHarvester<HarvestResult> {
     //---------------------------------------------------------------------------
     protected void storeNodeExtra(AbstractParams p, String path, String siteId, String optionsId) throws SQLException {
         WebDavParams params = (WebDavParams) p;
-        settingMan.add("id:" + siteId, "url", params.url);
-        settingMan.add("id:" + siteId, "icon", params.icon);
-        settingMan.add("id:" + optionsId, "validate", params.getValidate());
-        settingMan.add("id:" + optionsId, "recurse", params.recurse);
-        settingMan.add("id:" + optionsId, "subtype", params.subtype);
+        harvesterSettingsManager.add("id:" + siteId, "url", params.url);
+        harvesterSettingsManager.add("id:" + siteId, "icon", params.icon);
+        harvesterSettingsManager.add("id:" + optionsId, "validate", params.getValidate());
+        harvesterSettingsManager.add("id:" + optionsId, "recurse", params.recurse);
+        harvesterSettingsManager.add("id:" + optionsId, "subtype", params.subtype);
     }
 
     //---------------------------------------------------------------------------

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/WfsFeaturesHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/WfsFeaturesHarvester.java
@@ -80,7 +80,7 @@ public class WfsFeaturesHarvester extends AbstractHarvester<HarvestResult> {
         //--- force the creation of a new uuid
         params.setUuid(UUID.randomUUID().toString());
 
-        String id = settingMan.add("harvesting", "node", getType());
+        String id = harvesterSettingsManager.add("harvesting", "node", getType());
 
         storeNode(params, "id:" + id);
         Source source = new Source(params.getUuid(), params.getName(), params.getTranslations(), true);
@@ -101,7 +101,7 @@ public class WfsFeaturesHarvester extends AbstractHarvester<HarvestResult> {
 
         String path = "harvesting/id:" + id;
 
-        settingMan.removeChildren(path);
+        harvesterSettingsManager.removeChildren(path);
 
         //--- update database
         storeNode(copy, path);
@@ -127,16 +127,16 @@ public class WfsFeaturesHarvester extends AbstractHarvester<HarvestResult> {
                                   String siteId, String optionsId) throws SQLException {
         WfsFeaturesParams params = (WfsFeaturesParams) p;
 
-        settingMan.add("id:" + siteId, "url", params.url);
-        settingMan.add("id:" + siteId, "icon", params.icon);
-        settingMan.add("id:" + optionsId, "lang", params.lang);
-        settingMan.add("id:" + optionsId, "query", params.query);
-        settingMan.add("id:" + optionsId, "outputSchema", params.outputSchema);
-        settingMan.add("id:" + optionsId, "stylesheet", params.stylesheet);
-        settingMan.add("id:" + optionsId, "streamFeatures", params.streamFeatures);
-        settingMan.add("id:" + optionsId, "createSubtemplates", params.createSubtemplates);
-        settingMan.add("id:" + optionsId, "templateId", params.templateId);
-        settingMan.add("id:" + optionsId, "recordsCategory", params.recordsCategory);
+        harvesterSettingsManager.add("id:" + siteId, "url", params.url);
+        harvesterSettingsManager.add("id:" + siteId, "icon", params.icon);
+        harvesterSettingsManager.add("id:" + optionsId, "lang", params.lang);
+        harvesterSettingsManager.add("id:" + optionsId, "query", params.query);
+        harvesterSettingsManager.add("id:" + optionsId, "outputSchema", params.outputSchema);
+        harvesterSettingsManager.add("id:" + optionsId, "stylesheet", params.stylesheet);
+        harvesterSettingsManager.add("id:" + optionsId, "streamFeatures", params.streamFeatures);
+        harvesterSettingsManager.add("id:" + optionsId, "createSubtemplates", params.createSubtemplates);
+        harvesterSettingsManager.add("id:" + optionsId, "templateId", params.templateId);
+        harvesterSettingsManager.add("id:" + optionsId, "recordsCategory", params.recordsCategory);
     }
 
     //---------------------------------------------------------------------------

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -745,6 +745,8 @@
     "system/feedback/mailServer/ignoreSslCertificateErrors": "Ignore errors caused by the mail server's SSL certificate",
     "system/harvester": "Harvesters",
     "system/harvester/enableEditing": "Allow editing on harvested records",
+    "system/harvester/disabledHarvesterTypes": "Disabled harvester protocols",
+    "system/harvester/disabledHarvesterTypes-help": "Comma or space separated list of disabled harvested protocols. For example:  arcsde, csw, filesystem, geonetwork, geonetwork20, geoPREST, oaipmh, ogcwxs, thredds, wfsfeatures.",
     "system/harvesting": "Harvester",
     "system/harvesting/mail/enabled": "Activate harvester notification",
     "system/harvesting/mail/level1": "... on success",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -617,6 +617,9 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atomSchedule', '0 0 0/24 ? * *', 0, 7240, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atomProtocol', 'INSPIRE-ATOM', 0, 7250, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvester/enableEditing', 'false', 2, 9010, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvester/disabledHarvesterTypes', '', 0, 9011, 'n');
+
+
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/recipient', NULL, 0, 9020, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/template', '', 0, 9021, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvesting/mail/templateError', 'There was an error on the harvesting: $$errorMsg$$', 0, 9022, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v342/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v342/migrate-default.sql
@@ -7,4 +7,4 @@ UPDATE Settings SET name = 'system/localrating/enable', datatype = 0, value = 'b
 UPDATE Settings SET value='3.4.2' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 
-
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvester/disabledHarvesterTypes', '', 0, 9011, 'n');


### PR DESCRIPTION
This pull request adds a system settings to specify a list of disabled harvester protocols. 

![image](https://user-images.githubusercontent.com/826920/39351714-b4689bde-4a02-11e8-9fc9-511fa9925388.png)

* These harvester's protocols will not be returned by the get available protocols operation, so no new harvesters of these disabled types can be created.
* For the existing harvesters, if they are of one of the disabled types, they will not be shown in the harvester list in the admin console. 
* Also, if an existing harvester belong to a disabled type and it is scheduled it will return immediately  if it is launched by the scheduler.

This fixes issue #2607.