### PR TITLE
Bug fix: better WFS handling (failed on some corner cases)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -815,21 +815,24 @@
                 }
               }
 
-              var vectorFormat = new ol.format.WFS();
 
-              if (getCapLayer.outputFormats) {
-                $.each(getCapLayer.outputFormats.format,
-                    function(f, output) {
-                      if (output.indexOf('json') > 0 ||
-                         output.indexOf('JSON') > 0) {
-                        vectorFormat = ol.format.JSONFeature(
-                           {srsName_: getCapLayer.defaultSRS});
-                      }
-                    });
+              var vectorFormat = null;
+              
+              if(getCapLayer.version == '1.0.0') {
+                vectorFormat = new ol.format.WFS( 
+                {
+                    gmlFormat : new ol.format.GML2({
+                        featureNS: getCapLayer.name.prefix,
+                        featureType: getCapLayer.name.localPart,
+                        srsName: map.getView().getProjection().getCode()
+                      }) 
+                  }
+               );
+              } else {
+                  //Default format
+                  var vectorFormat = new ol.format.WFS();
               }
-
-              //TODO different strategy depending on the format
-
+              
               var vectorSource = new ol.source.Vector({
                 format: vectorFormat,
                 loader: function(extent, resolution, projection) {
@@ -845,11 +848,23 @@
                       gnUrlUtils.toKeyValue({
                         service: 'WFS',
                         request: 'GetFeature',
-                        version: '1.1.0',
+                        version: getCapLayer.version,
                         srsName: map.getView().getProjection().getCode(),
                         bbox: extent.join(','),
                         typename: getCapLayer.name.prefix + ':' +
                                    getCapLayer.name.localPart}));
+                  
+                  //Fix, ArcGIS fails if there is a bbox:
+                  if(getCapLayer.version == '1.1.0') {
+                    urlGetFeature = gnUrlUtils.append(parts[0],
+                        gnUrlUtils.toKeyValue({
+                          service: 'WFS',
+                          request: 'GetFeature',
+                          version: getCapLayer.version,
+                          srsName: map.getView().getProjection().getCode(),
+                          typename: getCapLayer.name.prefix + ':' +
+                                     getCapLayer.name.localPart}));
+                  }
                   
 
                   
@@ -864,22 +879,8 @@
                     url: urlGetFeature
                   })
                       .done(function(response) {
-                        // TODO: Check WFS exception
                         vectorSource.addFeatures(vectorFormat.
                             readFeatures(response));
-
-                        var extent = ol.extent.createEmpty();
-                        var features = vectorSource.getFeatures();
-                        for (var i = 0; i < features.length; ++i) {
-                          var feature = features[i];
-                          var geometry = feature.getGeometry();
-                          if (!goog.isNull(geometry)) {
-                            ol.extent.extend(extent, geometry.getExtent());
-                          }
-                        }
-
-                        map.getView().fit(extent, map.getSize());
-
                       })
                       .then(function() {
                         this.loadingLayer = false;


### PR DESCRIPTION
Better handling of WFS: now we use on the query the version of WFS returned on the GetCapabilities and try to accomodate to each version details (GML version).

Also applying a fix  which is not asking for bounding box on WFS 1.1.0. That will return all features. Because ArcGIS is a mess. See below to get the detailed explanation:

Example of failing ArcGIS service:

If I don't use any bbox, it returns all features on WFS 1.1.0. So the layer has content:
http://sedsh127.sedsh.gov.uk/arcgis/services/ScotGov/ProtectedSites/MapServer/WFSServer?service=WFS&request=GetFeature&version=1.1.0&srsName=EPSG:27700&typename=PS:Cairngorms_National_Park

If I use the same bbox as in WFS 1.0.0:
In 1.0.0 works:
http://sedsh127.sedsh.gov.uk/arcgis/services/ScotGov/ProtectedSites/MapServer/WFSServer?service=WFS&request=GetFeature&version=1.0.0&srsName=EPSG:27700&bbox=194450,746300,404950,852900&typename=PS:Cairngorms_National_Park
In 1.1.0 doesn't work:
http://sedsh127.sedsh.gov.uk/arcgis/services/ScotGov/ProtectedSites/MapServer/WFSServer?service=WFS&request=GetFeature&version=1.1.0&srsName=EPSG:27700&bbox=194450,746300,404950,852900&typename=PS:Cairngorms_National_Park

As expected, because of the axis order change in WFS 1.1.0:
http://docs.geoserver.org/stable/en/user/services/wfs/basics.html#differences-between-wfs-versions

But if I change x and y order:
http://sedsh127.sedsh.gov.uk/arcgis/services/ScotGov/ProtectedSites/MapServer/WFSServer?service=WFS&request=GetFeature&version=1.1.0&srsName=EPSG:27700&bbox=746300,194450,852900,404950&typename=PS:Cairngorms_National_Park
Something is badly broken there.

Still doesn't work. And what is worse, comparing geometries, axis order is not changed. So, what's happening in ArcGIS server WFS 1.1.0? No idea.

_The fix may overload the browser if we have too many features. Which, by the way, would happen anyway, as the first thing the layer does is, precisely, zoom to max extent of the layer. So all features will be loaded anyway. This is a bug not introduced on this fix, but something to take care some day._