### PR TITLE
User Admins can transfer ownership of records outside of their groups). Fixes #2738

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
@@ -37,6 +37,7 @@ import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.UserRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
+import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -127,7 +128,14 @@ public class TransferApi {
         List<UserGroupsResponse> list = new ArrayList<>();
         if (myProfile == Profile.Administrator || myProfile == Profile.UserAdmin) {
             List<User> allAdmin = userRepository.findAllByProfile(Profile.Administrator);
-            List<UserGroup> userGroups = userGroupRepository.findAll();
+            List<UserGroup> userGroups;
+
+            if (myProfile == Profile.Administrator) {
+                userGroups = userGroupRepository.findAll();
+            } else {
+                userGroups  = userGroupRepository.findAll(UserGroupSpecs.hasUserId(session.getUserIdAsInt()));
+            }
+
             for (UserGroup ug : userGroups) {
                 list.add(
                     new UserGroupsResponse(ug.getUser(), ug.getGroup(), ug.getProfile().name())


### PR DESCRIPTION
Please check details in #2738, used to work differently in old versions. 

The change seem fine, but not sure if the current behaviour was added for any reason that I can be missing?