### PR TITLE
Fix base layer dropdown cut with many layers present (using ngeo-popover)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
@@ -59,13 +59,9 @@
             return false;
           };
 
-          scope.dismissPopover = function() {
-            angular.element(element.find("[data-ngeo-popover]")[0]).scope().popoverCtrl.dismissPopover()
-          };
 
           scope.changeBackground = function (layer) {
             scope.setBgLayer(layer);
-            scope.dismissPopover();
           };
 
           scope.reset = function() {

--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
@@ -58,6 +58,16 @@
             layers.insertAt(0, layer);
             return false;
           };
+
+          scope.dismissPopover = function() {
+            angular.element(element.find("[data-ngeo-popover]")[0]).scope().popoverCtrl.dismissPopover()
+          };
+
+          scope.changeBackground = function (layer) {
+            scope.setBgLayer(layer);
+            scope.dismissPopover();
+          };
+
           scope.reset = function() {
             $rootScope.$broadcast('owsContextReseted');
             gnOwsContextService.loadContextFromUrl(

--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/partials/baselayerswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/partials/baselayerswitcher.html
@@ -1,23 +1,26 @@
 <div class="btn-group baselayer"
-     data-ng-class="dropup ? 'dropup' : ''"
+     data-ngeo-popover
+     data-ngeo-popover-placement="bottom"
      data-ng-show="layers.length > 1">
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-default dropdown-toggle" data-ngeo-popover-anchor>
     <span data-translate="">backgroundMap</span>&nbsp;{{map.getLayers().item(0).get('title')}} <span
     class="caret"></span>
   </button>
-  <ul class="dropdown-menu" role="menu">
-    <li ng-if="::layer" ng-repeat="layer in layers">
-      <a href="" ng-click="setBgLayer(layer)" ng-if="::!layer.get('loading')">
-        <span class="fa"
-              ng-class="(layer == map.getLayers().item(0)) ? 'fa-dot-circle-o' : 'fa-circle-o'"></span>
-        {{layer.get('title')}}
-      </a>
-      <a ng-if="::layer.get('loading')">
-        <span class="fa fa-spin fa-spinner"></span>
-      </a>
+  <div data-ngeo-popover-content class="gn-baselayer-switcher-content">
+    <ul class="gn-baselayer-switcher-menu" role="menu">
+      <li ng-if="::layer" ng-repeat="layer in layers">
+        <span ng-click="changeBackground(layer)" ng-if="::!layer.get('loading')">
+          <span class="fa"
+                ng-class="(layer == map.getLayers().item(0)) ? 'fa-dot-circle-o' : 'fa-circle-o'"></span>
+          {{layer.get('title')}}
+        </span>
+        <span ng-if="::layer.get('loading')">
+          <span class="fa fa-spin fa-spinner"></span>
+        </span>
+      <li>
+    </ul>
+  </div>
 
-    <li>
-  </ul>
 </div>
 <br/>
 <div>

--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/partials/baselayerswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/partials/baselayerswitcher.html
@@ -8,8 +8,8 @@
   </button>
   <div data-ngeo-popover-content class="gn-baselayer-switcher-content">
     <ul class="gn-baselayer-switcher-menu" role="menu">
-      <li ng-if="::layer" ng-repeat="layer in layers">
-        <span ng-click="changeBackground(layer)" ng-if="::!layer.get('loading')">
+      <li ng-if="::layer" ng-repeat="layer in layers" ng-click="changeBackground(layer);popoverCtrl.dismissPopover()">
+        <span ng-if="::!layer.get('loading')">
           <span class="fa"
                 ng-class="(layer == map.getLayers().item(0)) ? 'fa-dot-circle-o' : 'fa-circle-o'"></span>
           {{layer.get('title')}}

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -729,3 +729,14 @@ button.active [role=tooltip] {
     }
   }
 }
+
+.gn-baselayer-switcher-menu {
+  > li {
+    cursor: pointer !important;
+  }
+}
+
+.gn-baselayer-switcher-content {
+  overflow-y:auto;
+  max-height: 350px;
+}


### PR DESCRIPTION
This PR replaces #2488 but using ngeo-popover instead of customising the JS for the list's positioning.

If there are many base layers available the dropdown menu hide some of them. This commit changes the dropdown menu by a ngeo-popover component.

Original problem: 
![image](https://user-images.githubusercontent.com/826920/39912267-7753ee04-54fe-11e8-97c4-ec7bf464da6b.png)


Using `ngeo-popover`:

![image](https://user-images.githubusercontent.com/826920/39912799-2b77dc5a-5500-11e8-8015-879b1bb8439c.png)

