### PR TITLE
Change the harvester logo in the harvester page doesn't update the harvester logo image in the metadata detail page #2752

### DIFF
--- a/core/src/main/java/org/fao/geonet/resources/Resources.java
+++ b/core/src/main/java/org/fao/geonet/resources/Resources.java
@@ -28,6 +28,7 @@ import com.google.common.io.Files;
 
 import jeeves.server.context.ServiceContext;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
@@ -446,7 +447,7 @@ public class Resources {
 
             String extension = Files.getFileExtension(src.getFileName().toString());
             des = Resources.locateLogosDir(context).resolve(destName + "." + extension);
-            IO.copyDirectoryOrFile(src, des, false);
+            FileUtils.copyFile(src.toFile(), des.toFile());
         } catch (IOException e) {
             // --- we ignore exceptions here, just log them
 


### PR DESCRIPTION
Use Apache IO commons `FileUtils` to copy the logo instead of custom handmade [IO](https://github.com/geonetwork/core-geonetwork/blob/3.4.x/common/src/main/java/org/fao/geonet/utils/IO.java) class and avoid the exception `java.nio.file.FileAlreadyExistsException` when a logo is changed in a harvester, for example.