### PR TITLE
Support override label for iso19139 date fields

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
@@ -61,10 +61,12 @@
   <xsl:template mode="mode-iso19139" match="*[gmd:CI_Date]" priority="2000">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="overrideLabel" select="''" required="no"/>
 
     <xsl:apply-templates mode="mode-iso19139" select="*/gmd:*">
       <xsl:with-param name="schema" select="$schema"/>
       <xsl:with-param name="labels" select="$labels"/>
+      <xsl:with-param name="overrideLabel" select="$overrideLabel" />
     </xsl:apply-templates>
   </xsl:template>
 
@@ -80,6 +82,7 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="listOfValues" select="$iso19139codelists" required="no"/>
+    <xsl:param name="overrideLabel" select="''" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
@@ -92,7 +95,14 @@
          id="gn-el-{$dateTypeElementRef}"
          data-gn-field-highlight="">
       <label class="col-sm-2 control-label">
-        <xsl:value-of select="$labelConfig/label"/>
+        <xsl:choose>
+          <xsl:when test="$overrideLabel != ''">
+            <xsl:value-of select="$overrideLabel"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$labelConfig/label"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </label>
       <div class="col-sm-3 gn-value">
         <xsl:variable name="codelist"
@@ -158,6 +168,7 @@
                 match="*[(gco:Date|gco:DateTime) and not(../gmd:dateType)]">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="overrideLabel" select="''" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
@@ -172,7 +183,14 @@
          id="gn-el-{$dateTypeElementRef}"
          data-gn-field-highlight="">
       <label class="col-sm-2 control-label">
-        <xsl:value-of select="$labelConfig/label"/>
+        <xsl:choose>
+          <xsl:when test="$overrideLabel != ''">
+            <xsl:value-of select="$overrideLabel"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$labelConfig/label"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </label>
       <div class="col-sm-9 gn-value nopadding-in-table">
         <div data-gn-date-picker="{gco:Date|gco:DateTime}"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -101,11 +101,13 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="refToDelete" required="no"/>
+    <xsl:param name="overrideLabel" required="no"/>
 
     <xsl:apply-templates mode="mode-iso19139" select="*|@*">
       <xsl:with-param name="schema" select="$schema"/>
       <xsl:with-param name="labels" select="$labels"/>
       <xsl:with-param name="refToDelete" select="$refToDelete"/>
+      <xsl:with-param name="overrideLabel" select="$overrideLabel"/>
     </xsl:apply-templates>
   </xsl:template>
 


### PR DESCRIPTION
This pull request allows to define a custom label element in `config-editor.xml` for a date field to override the one in `labels.xml`, like:

```
<field
    name="referenceDate"
    xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:date"/>
```

If `strings.xml` contains an element `<referenceDate>Reference Date</referenceDate>` will be shown that label.

This mechanism was already support for other elements. 
