### PR TITLE
Support override label for iso19139 geographic bounding box

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -219,14 +219,27 @@
   <xsl:template mode="mode-iso19139" match="gmd:EX_GeographicBoundingBox" priority="2000">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="overrideLabel" select="$labels" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
 
+
+    <xsl:variable name="labelVal">
+      <xsl:choose>
+        <xsl:when test="$overrideLabel != ''">
+          <xsl:value-of select="$overrideLabel"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$labelConfig/label"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
     <xsl:call-template name="render-boxed-element">
       <xsl:with-param name="label"
-                      select="$labelConfig/label"/>
+                      select="$labelVal"/>
       <xsl:with-param name="editInfo" select="../gn:element"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="subTreeSnippet">


### PR DESCRIPTION
Similar to https://github.com/geonetwork/core-geonetwork/pull/2767, but for bbox. Apologies as noticed about this element after https://github.com/geonetwork/core-geonetwork/pull/2767 was merged.