### PR TITLE
INSPIRE view - allow to add temporal extent element if missing, cleanup up it's parent when removing it, if doesn't contain any other child

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -1362,7 +1362,7 @@
 
           <action type="add" name="extent" or="extent" btnLabel="temporalRangeSection"
                   in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification"
-                  if="count(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement) = 0">>
+                  if="count(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement) = 0">
             <template>
               <snippet>
                 <gmd:extent>
@@ -1422,7 +1422,7 @@
 
           <action type="add" name="extent" or="extent" btnLabel="temporalRangeSection"
                   in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
-                  if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:extent/gmd:EX_Extent/gmd:temporalElement) = 0">>
+                  if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:extent/gmd:EX_Extent/gmd:temporalElement) = 0">
             <template>
               <snippet>
                 <srv:extent>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -1360,7 +1360,30 @@
               </template>
             </field>
 
-            <field name="temporalRangeSection" templateModeOnly="true" notDisplayedIfMissing="true"
+          <action type="add" name="extent" or="extent" btnLabel="temporalRangeSection"
+                  in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification"
+                  if="count(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement) = 0">>
+            <template>
+              <snippet>
+                <gmd:extent>
+                  <gmd:EX_Extent>
+                    <gmd:temporalElement>
+                      <gmd:EX_TemporalExtent>
+                        <gmd:extent>
+                          <gml:TimePeriod gml:id="">
+                            <gml:beginPosition/>
+                            <gml:endPosition/>
+                          </gml:TimePeriod>
+                        </gmd:extent>
+                      </gmd:EX_TemporalExtent>
+                    </gmd:temporalElement>
+                  </gmd:EX_Extent>
+                </gmd:extent>
+              </snippet>
+            </template>
+          </action>
+
+          <field name="temporalRangeSection" templateModeOnly="true" notDisplayedIfMissing="true"
                    xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:extent/gmd:EX_Extent/gmd:temporalElement"
                    if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0">
               <template>
@@ -1396,6 +1419,29 @@
                 </snippet>
               </template>
             </field>
+
+          <action type="add" name="extent" or="extent" btnLabel="temporalRangeSection"
+                  in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
+                  if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:extent/gmd:EX_Extent/gmd:temporalElement) = 0">>
+            <template>
+              <snippet>
+                <srv:extent>
+                  <gmd:EX_Extent>
+                    <gmd:temporalElement>
+                      <gmd:EX_TemporalExtent>
+                        <gmd:extent>
+                          <gml:TimePeriod gml:id="">
+                            <gml:beginPosition/>
+                            <gml:endPosition/>
+                          </gml:TimePeriod>
+                        </gmd:extent>
+                      </gmd:EX_TemporalExtent>
+                    </gmd:temporalElement>
+                  </gmd:EX_Extent>
+                </srv:extent>
+              </snippet>
+            </template>
+          </action>
 
           <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/
             gmd:date"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -604,6 +604,30 @@
   </xsl:template>
 
 
+  <!-- Remove geographic/temporal extent if doesn't contain child elements.
+       Used to clean up the element, for example when removing the the temporal extent
+       in the editor, to avoid an element like <gmd:extent><gmd:EX_Extent></gmd:EX_Extent></gmd:extent>,
+       that causes a validation error in schematron iso: [ISOFTDS19139:2005-TableA1-Row23] - Extent element required
+  -->
+  <xsl:template match="gmd:extent|srv:extent">
+    <xsl:choose>
+      <xsl:when test="gmd:EX_Extent">
+        <xsl:if test="count(gmd:EX_Extent/*) > 0">
+          <xsl:copy>
+            <xsl:apply-templates select="@*|node()" />
+          </xsl:copy>
+        </xsl:if>
+      </xsl:when>
+
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()" />
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
   <!-- ================================================================= -->
   <!-- copy everything else as is -->
 

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -609,23 +609,7 @@
        in the editor, to avoid an element like <gmd:extent><gmd:EX_Extent></gmd:EX_Extent></gmd:extent>,
        that causes a validation error in schematron iso: [ISOFTDS19139:2005-TableA1-Row23] - Extent element required
   -->
-  <xsl:template match="gmd:extent|srv:extent">
-    <xsl:choose>
-      <xsl:when test="gmd:EX_Extent">
-        <xsl:if test="count(gmd:EX_Extent/*) > 0">
-          <xsl:copy>
-            <xsl:apply-templates select="@*|node()" />
-          </xsl:copy>
-        </xsl:if>
-      </xsl:when>
-
-      <xsl:otherwise>
-        <xsl:copy>
-          <xsl:apply-templates select="@*|node()" />
-        </xsl:copy>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
+  <xsl:template match="gmd:extent[gmd:EX_Extent/not(*)]|srv:extent[gmd:EX_Extent/not(*)]"/>
 
 
   <!-- ================================================================= -->


### PR DESCRIPTION
Changes:

- Action to add the temporal extent in the INSPIRE view, if the element is missing.

- When deleting the element, remove the container element to avoid this empty element:

```
<gmd:extent>
<gmd:EX_Extent/>
</gmd:extent>
```

That causes in the schematron iso the following validation issue:

```
[ISOFTDS19139:2005-TableA1-Row23] - Extent element required
In extent section, one of the following elements need to be defined : description, geographicElement, temporalElement, verticalElement. 
count(description + geographicElement + temporalElement + verticalElement) > 0.
```