### PR TITLE
Remove minor version number from schema artifacts

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Version.java
+++ b/common/src/main/java/org/fao/geonet/utils/Version.java
@@ -1,0 +1,100 @@
+package org.fao.geonet.utils;
+
+public class Version implements Comparable<Version> {
+    private final int major, minor, micro;
+
+    /**
+     * Parses a version number removing extra "-*" element and returning an integer.
+     * "2.7.0-SNAPSHOT" is returned as 270.
+     *
+     * @param number The version number to parse
+     * @return The version number as an integer
+     */
+    public static Version parseVersionNumber(String number) throws Exception {
+        // Remove extra "-SNAPSHOT" info which may be in version number
+        int dashIdx = number.indexOf("-");
+        if (dashIdx != -1) {
+            number = number.substring(0, number.indexOf("-"));
+        }
+        switch (numDots(number)) {
+            case 0:
+                number += ".0.0";
+                break;
+            case 1:
+                number += ".0";
+                break;
+            default:
+                break;
+        }
+
+        final String[] parts = number.split("\\.");
+        String major = parts[0];
+        String minor = parts.length > 1 ? parts[1] : "0";
+        String micro = parts.length > 2 ? parts[2] : "0";
+        return new Version(major, minor, micro);
+    }
+
+    public Version(String major, String minor, String micro) {
+        this.major = Integer.parseInt(major);
+        this.minor = Integer.parseInt(minor);
+        this.micro = Integer.parseInt(micro);
+    }
+
+    public Version() {
+        this("0", "0", "0");
+    }
+
+    @Override
+    public int compareTo(Version o) {
+        if (major != o.major) {
+            return Integer.compare(major, o.major);
+        }
+        if (minor != o.minor) {
+            return Integer.compare(minor, o.minor);
+        }
+        if (micro != o.micro) {
+            return Integer.compare(micro, o.micro);
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Version version = (Version) o;
+
+        if (major != version.major) return false;
+        if (micro != version.micro) return false;
+        if (minor != version.minor) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = major;
+        result = 31 * result + minor;
+        result = 31 * result + micro;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return major + "." + minor + "." + micro;
+    }
+
+
+    private static int numDots(String number) {
+        int num = 0;
+
+        for (int i = 0; i < number.length(); i++) {
+            if (number.charAt(i) == '.') {
+                num++;
+            }
+        }
+
+        return num;
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -415,7 +415,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>schema-iso19139</artifactId>
-      <version>${project.version}</version>
+      <version>${gn.schemas.version}</version>
     </dependency>
     <dependency> <!-- dummy API for ARC SDE stuff -->
       <groupId>${project.groupId}</groupId>

--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -36,6 +36,7 @@ import jeeves.server.overrides.ConfigurationOverrides;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
+import org.fao.geonet.SystemInfo;
 import org.fao.geonet.ZipUtil;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Geonet.Namespaces;
@@ -227,6 +228,9 @@ public class SchemaManager {
                     }
                 }
             }
+
+            checkAppSupported(schemaPluginCatRoot);
+
             checkDependencies(schemaPluginCatRoot);
         }
 
@@ -974,6 +978,7 @@ public class SchemaManager {
         extractMetadata(mds, xmlIdFile);
         mds.setReadwriteUUID(extractReadWriteUuid(xmlIdFile));
         mds.setOperationFilters(extractOperationFilters(xmlIdFile));
+
         Log.debug(Geonet.SCHEMA_MANAGER, "  UUID is read/write mode: " + mds.isReadwriteUUID());
 
         putSchemaInfo(
@@ -1315,6 +1320,44 @@ public class SchemaManager {
 
     }
 
+    private void checkAppSupported(Element schemaPluginCatRoot) throws Exception {
+        List<String> removes = new ArrayList<String>();
+
+        final SystemInfo systemInfo = ApplicationContextHolder.get().getBean(SystemInfo.class);
+
+        String version = systemInfo.getVersion();
+
+        // process each schema to see whether its dependencies are present
+        for (String schemaName : hmSchemas.keySet()) {
+            Schema schema = hmSchemas.get(schemaName);
+            String minorAppVersionSupported = schema.getMetadataSchema().getAppMinorVersionSupported();
+
+            if (version.compareTo(minorAppVersionSupported) < 0) {
+                Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaName + " requires min Geonetwork version: " + minorAppVersionSupported + ", current is: " + version + ". Skip load schema.");
+                removes.add(schemaName);
+                continue;
+            }
+
+            String majorAppVersionSupported = schema.getMetadataSchema().getAppMajorVersionSupported();
+            if (StringUtils.isNotEmpty(majorAppVersionSupported) &&
+                version.compareTo(majorAppVersionSupported) > 0) {
+                Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaName + " requires max Geonetwork version: " + majorAppVersionSupported + ", current is: " + version + ". Skip load schema.");
+                removes.add(schemaName);
+                continue;
+            }
+
+        }
+
+        // now remove any that failed the app version test
+        for (String removeSchema : removes) {
+            hmSchemas.remove(removeSchema);
+            deleteSchemaFromPluginCatalog(removeSchema, schemaPluginCatRoot);
+        }
+
+    }
+
+
+
     /**
      * Get list of schemas that depend on supplied schema name.
      *
@@ -1404,6 +1447,9 @@ public class SchemaManager {
         mds.setStandardUrl(root.getChildText("standardUrl", GEONET_SCHEMA_NS));
         mds.setTitles(getSchemaIdentMultilingualProperty(root, "title"));
         mds.setDescriptions(getSchemaIdentMultilingualProperty(root, "description"));
+
+        mds.setAppMinorVersionSupported(root.getChildText("appMinorVersionSupported", GEONET_SCHEMA_NS));
+        mds.setAppMajorVersionSupported(root.getChildText("appMajorVersionSupported", GEONET_SCHEMA_NS));
     }
 
     private Map<String, String> getSchemaIdentMultilingualProperty(Element root, String propName) {

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -91,6 +91,8 @@ public class MetadataSchema {
     private String schemaName;
     private Path schemaDir;
     private String standardUrl;
+    private String appMinorVersionSupported;
+    private String appMajorVersionSupported;
     private Map<String, String> titles = new HashMap<>();
     private Map<String, String> descriptions = new HashMap<>();
     private String primeNS;
@@ -572,6 +574,22 @@ public class MetadataSchema {
 
     public void setStandardUrl(String standardUrl) {
         this.standardUrl = standardUrl;
+    }
+
+    public String getAppMinorVersionSupported() {
+        return appMinorVersionSupported;
+    }
+
+    public void setAppMinorVersionSupported(String appMinorVersionSupported) {
+        this.appMinorVersionSupported = appMinorVersionSupported;
+    }
+
+    public String getAppMajorVersionSupported() {
+        return appMajorVersionSupported;
+    }
+
+    public void setAppMajorVersionSupported(String appMajorVersionSupported) {
+        this.appMajorVersionSupported = appMajorVersionSupported;
     }
 
     public Map<String, String> getTitles() {

--- a/pom.xml
+++ b/pom.xml
@@ -1338,5 +1338,6 @@
     <slf4j.version>1.7.7</slf4j.version>
     <xbean.version>3.18</xbean.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
+    <gn.schemas.version>3.4</gn.schemas.version>
   </properties>
 </project>

--- a/schemas-test/pom.xml
+++ b/schemas-test/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>schema-iso19139</artifactId>
-      <version>${project.version}</version>
+      <version>${gn.schemas.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/schemas/csw-record/pom.xml
+++ b/schemas/csw-record/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.4.3-SNAPSHOT</version>
+    <version>3.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>schema-csw-record</artifactId>

--- a/schemas/csw-record/src/main/plugin/csw-record/schema-ident.xml
+++ b/schemas/csw-record/src/main/plugin/csw-record/schema-ident.xml
@@ -28,6 +28,7 @@
   <name>csw-record</name>
   <id>e5f27024-dde2-11df-a18e-001c2346de4c</id>
   <version>2.0.2</version>
+  <appMinorVersionSupported>3.4.0</appMinorVersionSupported>
   <title xml:lang="en">Dublin core (for CSW only)</title>
   <schemaLocation>http://www.opengis.net/cat/csw/2.0.2
     http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd

--- a/schemas/dublin-core/pom.xml
+++ b/schemas/dublin-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.4.3-SNAPSHOT</version>
+    <version>3.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/schemas/dublin-core/src/main/plugin/dublin-core/schema-ident.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/schema-ident.xml
@@ -28,6 +28,7 @@
   <gns:name>dublin-core</gns:name>
   <gns:id>3785ae4c-dde3-11df-a813-001c2346de4c</gns:id>
   <gns:version>1.0</gns:version>
+  <gns:appMinorVersionSupported>3.4.0</gns:appMinorVersionSupported>
   <gns:title xml:lang="en">Dublin core</gns:title>
   <gns:description>The Dublin Core Metadata Element Set is a vocabulary of fifteen properties for
     use in resource description. The name "Dublin" is due to its origin at a 1995 invitational

--- a/schemas/iso19110/pom.xml
+++ b/schemas/iso19110/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.4.3-SNAPSHOT</version>
+    <version>3.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/schemas/iso19110/src/main/plugin/iso19110/schema-ident.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/schema-ident.xml
@@ -28,6 +28,7 @@
   <name>iso19110</name>
   <id>ae229ba0-dde3-11df-99ab-001c2346de4c</id>
   <version>1.0</version>
+  <appMinorVersionSupported>3.4.0</appMinorVersionSupported>
   <title xml:lang="en">Geographic information -- Methodology for feature cataloguing</title>
   <title xml:lang="fr">Information géographique -- Méthodologie de catalogage des entités</title>
   <standardUrl xml:lang="en">

--- a/schemas/iso19139/pom.xml
+++ b/schemas/iso19139/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.4.3-SNAPSHOT</version>
+    <version>3.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
@@ -28,6 +28,7 @@
   <name>iso19139</name>
   <id>3f95190a-dde4-11df-8626-001c2346de4c</id>
   <version>1.0</version>
+  <appMinorVersionSupported>3.4.0</appMinorVersionSupported>
   <title xml:lang="en">Geographic information -- Metadata</title>
   <title xml:lang="fr">Information géographique -- Métadonnées</title>
   <description xml:lang="en">

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -30,6 +30,9 @@
     <groupId>org.geonetwork-opensource</groupId>
     <version>3.4.3-SNAPSHOT</version>
   </parent>
+
+  <version>3.4</version>
+
   <modelVersion>4.0.0</modelVersion>
   <artifactId>schemas</artifactId>
   <name>GeoNetwork schema plugins</name>

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -51,6 +51,7 @@
   </modules>
   <properties>
     <rootProjectDir>../..</rootProjectDir>
+    <gn.project.version>3.4.3-SNAPSHOT</gn.project.version>
   </properties>
-  
+
 </project>

--- a/schemas/schema-core/pom.xml
+++ b/schemas/schema-core/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.4.3-SNAPSHOT</version>
+    <version>3.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>common</artifactId>
-      <version>${project.version}</version>
+      <version>${gn.project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -496,17 +496,17 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>schema-iso19139</artifactId>
-      <version>${project.version}</version>
+      <version>${gn.schemas.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>schema-iso19110</artifactId>
-      <version>${project.version}</version>
+      <version>${gn.schemas.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>schema-dublin-core</artifactId>
-      <version>${project.version}</version>
+      <version>${gn.schemas.version}</version>
     </dependency>
 
     <dependency>
@@ -531,9 +531,9 @@
 
 
   <build>
-  
+
     <plugins>
-    
+
       <!-- Generate a properties file with the commit hash to be displayed on the admin.console -->
 	    <plugin>
 	        <groupId>pl.project13.maven</groupId>
@@ -548,7 +548,7 @@
 	                </goals>
 	            </execution>
 	        </executions>
-	
+
 	        <configuration>
 	            <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
 	            <prefix>git</prefix>
@@ -589,7 +589,7 @@
 	                <forceLongFormat>false</forceLongFormat>
 	            </gitDescribe>
 	            <!-- @since 2.2.2 -->
-	            <!-- 
+	            <!--
 	                Since version **2.2.2** the maven-git-commit-id-plugin comes equipped with an additional validation utility which can be used to verify if your project properties are set as you would like to have them set.
 	                *Note*: This configuration will only be taken into account when the additional goal `validateRevision` is configured inside an execution.
 	            -->
@@ -599,9 +599,9 @@
 	                         A descriptive name that will be used to be able to identify the validation that does not match up (will be displayed in the error message).
 	                    -->
 	                    <name>validating project version</name>
-	                    <!-- 
+	                    <!--
 	                         the value that needs the validation
-	                         *Note* : In order to be able to validate the generated git-properties inside the pom itself you may need to set the configuration `<injectAllReactorProjects>true</injectAllReactorProjects>`. 
+	                         *Note* : In order to be able to validate the generated git-properties inside the pom itself you may need to set the configuration `<injectAllReactorProjects>true</injectAllReactorProjects>`.
 	                    -->
 	                    <value>${project.version}</value>
 	                    <!--
@@ -613,7 +613,7 @@
 	            </validationProperties>
 	            <validationShouldFailIfNoMatch>false</validationShouldFailIfNoMatch>
 	        </configuration>
-	
+
 	    </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -776,7 +776,7 @@
             catalog/lib/style/bootstrap/Gemfile*,
             catalog/lib/style/bootstrap/.*,
             catalog/lib/style/bootstrap/*.txt,
-            catalog/lib/style/bootstrap/*.md,            
+            catalog/lib/style/bootstrap/*.md,
             catalog/lib/bootstrap-table/*.json,
             catalog/lib/bootstrap-table/Gemfile*,
             catalog/lib/bootstrap-table/.*,

--- a/web/src/main/java/org/fao/geonet/DatabaseMigration.java
+++ b/web/src/main/java/org/fao/geonet/DatabaseMigration.java
@@ -35,6 +35,7 @@ import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.lib.DatabaseType;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Version;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -422,60 +423,5 @@ public class DatabaseMigration implements BeanPostProcessor {
 
     public void setInitAfter(String initAfter) {
         this.initAfter = initAfter;
-    }
-
-    public static class Version implements Comparable<Version> {
-        private final int major, minor, micro;
-
-        public Version(String major, String minor, String micro) {
-            this.major = Integer.parseInt(major);
-            this.minor = Integer.parseInt(minor);
-            this.micro = Integer.parseInt(micro);
-        }
-
-        public Version() {
-            this("0", "0", "0");
-        }
-
-        @Override
-        public int compareTo(Version o) {
-            if (major != o.major) {
-                return Integer.compare(major, o.major);
-            }
-            if (minor != o.minor) {
-                return Integer.compare(minor, o.minor);
-            }
-            if (micro != o.micro) {
-                return Integer.compare(micro, o.micro);
-            }
-            return 0;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Version version = (Version) o;
-
-            if (major != version.major) return false;
-            if (micro != version.micro) return false;
-            if (minor != version.minor) return false;
-
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = major;
-            result = 31 * result + minor;
-            result = 31 * result + micro;
-            return result;
-        }
-
-        @Override
-        public String toString() {
-            return major + "." + minor + "." + micro;
-        }
     }
 }

--- a/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
+++ b/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
@@ -76,6 +76,8 @@
       <xs:element name="name" type="xs:string" minOccurs="1"/>
       <xs:element name="id" type="xs:string" minOccurs="1"/>
       <xs:element name="version" type="xs:string" minOccurs="1"/>
+      <xs:element name="appMinorVersionSupported" type="xs:string" minOccurs="1"/>
+      <xs:element name="appMajorVersionSupported" type="xs:string" minOccurs="0"/>
       <xs:element name="title" type="gns:title" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="description" type="gns:description" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="standardUrl" type="gns:standardUrl" minOccurs="0" maxOccurs="unbounded"/>


### PR DESCRIPTION
Currently the metadata schemas use the same versioning for the maven `artifactId` as the other modules.

While this is ok for schemas bundled in GeoNetwork, it's hard to maintain for third party schemas for example from https://github.com/metadata101/ when adding them as submodules (you can add them as a copy in your project, but then you loose the advantages of submodules):

* You need to keep them aligned with the related latest branch in GeoNetwork: 3.4.1-SNAPSHOT, 3.4.2-SNAPSHOT, etc.

* Also means that when updated to the latest branch in GeoNetwork, the schemas can't be used easily in a previous releases for the same branch.

This pull request changes the `artifactId` number for schemas module, so for GeoNetwork 3.4.x branch we use for shemas the `artifactId` 3.4. In the future, when released GeoNetwork 3.6, the schemas in 3.6.x branch will use `artifactId` 3.6 and so on.

Also adds in the `schema-ident.xml` 2 new fields:

* **appMinorVersionSupported** (mandatory): Minor GeoNetwork version supported, example: 3.4.0.
* **appMajorVersionSupported** (optional): Major GeoNetwork version supported.


It will require to update external schemas (for example the ones in https://github.com/metadata101/) with `appMinorVersionSupported` field and the `artifactId` version number.
