### PR TITLE
allow use of gnLocalized filter from gnRelatedService

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -351,15 +351,16 @@
   /**
    * Return the object value in requested lang or the first value.
    */
-  module.filter('gnLocalized', function() {
+  module.filter('gnLocalized', ['gnGlobalSettings', function(gnGlobalSettings) {
     return function(obj, lang) {
+    lang = lang || gnGlobalSettings.iso3lang;
       if (angular.isObject(obj)) {
         return obj[lang] ? obj[lang] : (obj[Object.keys(obj)[0]] || '');
       } else {
         return '';
       }
     };
-  });
+  }]);
 
   module.factory('gnRegionService', [
     '$q',


### PR DESCRIPTION
there are place where gnLocalized filter is called with no dom available, so with no scope available, so with no lang available, and in this case have to look for lang using what is set thru gn_locale services.