### PR TITLE
Fix #2511 Nil Reason is hidden when added

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -458,6 +458,13 @@ public class MetadataEditingApi {
             required = false
         )
             String child,
+        @ApiParam(
+            value = "Should attributes be shown on the editor snippet?",
+            required = false)
+        @RequestParam(
+                defaultValue = "false"
+            )
+                boolean displayAttributes,
         @ApiIgnore
         @ApiParam(hidden = true)
         @RequestParam
@@ -537,6 +544,13 @@ public class MetadataEditingApi {
             required = true)
         @PathVariable
             Direction direction,
+        @ApiParam(
+            value = "Should attributes be shown on the editor snippet?",
+            required = false)
+        @RequestParam(
+                defaultValue = "false"
+            )
+                boolean displayAttributes,
         @ApiIgnore
         @ApiParam(hidden = true)
         @RequestParam
@@ -593,6 +607,13 @@ public class MetadataEditingApi {
             required = true)
         @RequestParam
             String parent,
+        @ApiParam(
+            value = "Should attributes be shown on the editor snippet?",
+            required = false)
+        @RequestParam(
+                defaultValue = "false"
+            )
+                boolean displayAttributes,
         HttpServletRequest request,
         @ApiIgnore
         @ApiParam(hidden = true)
@@ -638,6 +659,13 @@ public class MetadataEditingApi {
             required = true)
         @RequestParam
             String ref,
+        @ApiParam(
+            value = "Should attributes be shown on the editor snippet?",
+            required = false)
+        @RequestParam(
+                defaultValue = "false"
+            )
+                boolean displayAttributes,
         HttpServletRequest request,
         @ApiIgnore
         @ApiParam(hidden = true)

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -387,6 +387,7 @@
 
              var defer = $q.defer();
              $http.put(this.buildEditUrlPrefix('editor/elements') +
+             '&displayAttributes=' + gnCurrentEdit.displayAttributes + 
              '&ref=' + ref + '&name=' + name + attributeAction)
               .success(function(data) {
                // Append HTML snippet after current element - compile Angular
@@ -424,6 +425,7 @@
            insertRef, position) {
              var defer = $q.defer();
              $http.put(this.buildEditUrlPrefix('editor/elements') +
+             '&displayAttributes=' + gnCurrentEdit.displayAttributes + 
              '&ref=' + ref +
              '&name=' + parent +
              '&child=' + name).success(function(data) {
@@ -453,7 +455,9 @@
              // Call service to remove element from metadata record in session
              var defer = $q.defer();
              $http.delete('../api/records/' + gnCurrentEdit.id +
-             '/editor/elements?ref=' + ref + '&parent=' + parent)
+             '/editor/elements?ref=' + ref + 
+             '&displayAttributes=' + gnCurrentEdit.displayAttributes + 
+             '&parent=' + parent)
               .success(function(data) {
                // For a fieldset, domref is equal to ref.
                // For an input, it may be different because


### PR DESCRIPTION
The option to display attributes ("More details") was lost when doing ajax editing.