### PR TITLE
Fix transfer ownership message when no users available

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -422,6 +422,11 @@
                   }
                 });
                 scope.userGroups = uniqueUserGroups;
+                if(scope.userGroups && Object.keys(scope.userGroups).length>0) {
+                  scope.userGroupDefined = true;
+                } else {
+                  scope.userGroupDefined = false;
+                }
               });
 
           scope.save = function() {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-md-12">
+  <div class="col-md-12" data-ng-show="userGroupDefined">
     <select class="form-control"
             data-ng-model="selectedUserGroup"
             data-ng-options="g.userName group by g.groupName
@@ -8,7 +8,7 @@
     <br/>
   </div>
 
-  <div class="btn-toolbar col-md-12">
+  <div class="btn-toolbar col-md-12" data-ng-show="userGroupDefined">
     <button type="button"
             class="btn btn-primary pull-right"
             data-ng-class="selectedUserGroup ? '' : 'disabled'"
@@ -17,5 +17,9 @@
       <span data-translate=""
             class="ng-scope">Save</span>
     </button>
+  </div>
+
+  <div class="col-md-12" data-ng-hide="userGroupDefined">
+    <span data-translate="">noUsers</span>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -369,6 +369,7 @@
   "wpsErrorCodeReturned": "The server returned status code",
   "time" : "Time",
   "features": "feature(s)",
+  "noUsers": "No users",
   "downloadLayer": "Download data",
   "featureCount": "Feature count",
   "fbContact": "Contact",


### PR DESCRIPTION
Currently, when there are no users to transfer ownership an empty drop-down is shown. This change introduces a "No users" message in place of the empty drop-down. 