### PR TITLE
Refactor JsonDatabaseMigration to make easier to implement future JSON setting migrations

### DIFF
--- a/web/src/main/java/org/fao/geonet/DatabaseMigration.java
+++ b/web/src/main/java/org/fao/geonet/DatabaseMigration.java
@@ -24,11 +24,8 @@
 package org.fao.geonet;
 
 import com.google.common.util.concurrent.Callables;
-
 import com.vividsolutions.jts.util.Assert;
-
 import jeeves.server.sources.http.ServletPathFinder;
-
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.setting.Settings;
@@ -42,6 +39,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.web.context.WebApplicationContext;
 
+import javax.servlet.ServletContext;
+import javax.sql.DataSource;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
@@ -50,13 +49,9 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-
-import javax.servlet.ServletContext;
-import javax.sql.DataSource;
 
 /**
  * Postprocessor that runs after the jdbcDataSource bean has been initialized and migrates the
@@ -74,7 +69,7 @@ public class DatabaseMigration implements BeanPostProcessor {
     @Autowired
     private ApplicationContext _applicationContext;
 
-    private Callable<LinkedHashMap<String, List<String>>> _migration;
+    private Callable<Map<String, List<String>>> _migration;
 
     private String initAfter;
 
@@ -134,11 +129,11 @@ public class DatabaseMigration implements BeanPostProcessor {
         return bean;
     }
 
-    public final void setMigration(final LinkedHashMap<String, List<String>> migration) {
+    public final void setMigration(final Map<String, List<String>> migration) {
         this._migration = Callables.returning(migration);
     }
 
-    public final void setMigrationLoader(final Callable<LinkedHashMap<String, List<String>>> migration) {
+    public final void setMigrationLoader(final Callable<Map<String, List<String>>> migration) {
         this._migration = migration;
     }
 
@@ -146,23 +141,15 @@ public class DatabaseMigration implements BeanPostProcessor {
                                  final String subVersion) throws Exception {
         _logger.info("  - Migration ...");
 
-        Connection conn = null;
-        Statement statement = null;
-        try {
-            conn = dataSource.getConnection();
-            statement = conn.createStatement();
+        try (Connection conn = dataSource.getConnection();
+             Statement statement = conn.createStatement()) {
+
             this.foundErrors = doMigration(webappVersion, subVersion, servletContext, path, conn, statement);
             conn.commit();
-        } finally {
-            try {
-                if (statement != null) {
-                    statement.close();
-                }
-            } finally {
-                if (conn != null) {
-                    conn.close();
-                }
-            }
+        } catch (Exception e) {
+            _logger.warning("  - Migration: Exception running migration for version: " + webappVersion + " subversion: "
+                + subVersion + ". " + e.getMessage());
+            throw e;
         }
     }
 
@@ -270,6 +257,7 @@ public class DatabaseMigration implements BeanPostProcessor {
 
     /**
      * Execute a Java database migration.
+     *
      * @param conn database connection.
      * @param file Java migration class name prefixed with JAVA_MIGRATION_PREFIX ("java:")
      * @return <code>true</code> if there is any error while executing the migration. <code>false</code> if there are no errors.
@@ -340,34 +328,24 @@ public class DatabaseMigration implements BeanPostProcessor {
     }
 
     private String newLookup(Statement statement, String key) throws SQLException {
-        ResultSet results = null;
-        try {
-            final String newGetVersion = "SELECT value FROM Settings WHERE name = '" + key + "'";
-            results = statement.executeQuery(newGetVersion);
+        final String newGetVersion = "SELECT value FROM Settings WHERE name = '" + key + "'";
+
+        try (ResultSet results = statement.executeQuery(newGetVersion)) {
             if (results.next()) {
                 return results.getString(1);
             }
             return null;
-        } finally {
-            if (results != null) {
-                results.close();
-            }
         }
     }
 
     private String oldLookup(Statement statement, int key) throws SQLException {
-        ResultSet results = null;
-        try {
-            final String newGetVersion = "SELECT value FROM Settings WHERE id = " + key;
-            results = statement.executeQuery(newGetVersion);
+        final String newGetVersion = "SELECT value FROM Settings WHERE id = " + key;
+
+        try (ResultSet results = statement.executeQuery(newGetVersion)) {
             if (results.next()) {
                 return results.getString(1);
             }
             return null;
-        } finally {
-            if (results != null) {
-                results.close();
-            }
         }
     }
 
@@ -414,7 +392,7 @@ public class DatabaseMigration implements BeanPostProcessor {
         return num;
     }
 
-    public LinkedHashMap<String, List<String>> getMigrationConfig() throws Exception {
+    public Map<String, List<String>> getMigrationConfig() throws Exception {
         return _migration.call();
     }
 

--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -204,12 +204,12 @@
     <entry key="3.4.2">
       <list>
         <value>WEB-INF/classes/setup/sql/migrate/v342/migrate-</value>
-        <value>java:v342.AdvancedSearchFormMigration</value>
       </list>
     </entry>
     <entry key="3.4.3">
       <list>
         <value>WEB-INF/classes/setup/sql/migrate/v343/migrate-</value>
+        <value>java:v343.AdvancedSearchFormMigration</value>
       </list>
     </entry>
   </util:map>

--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -42,7 +42,7 @@
   <util:map id="migrationMap"
             map-class="java.util.LinkedHashMap"
             key-type="java.lang.String"
-            value-type="java.lang.String">
+            value-type="java.util.List">
     <entry key="2.4.3">
       <list>
         <value>WEB-INF/classes/setup/sql/migrate/v243/migrate-</value>
@@ -154,7 +154,7 @@
   <util:map id="dataMigrationMap"
             map-class="java.util.LinkedHashMap"
             key-type="java.lang.String"
-            value-type="java.lang.String">
+            value-type="java.util.List">
     <entry key="3.0.3">
       <list>
         <value>WEB-INF/classes/setup/sql/migrate/v303/migrate-</value>

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v343/AdvancedSearchFormMigration.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v343/AdvancedSearchFormMigration.java
@@ -47,43 +47,21 @@ import java.util.Map;
 public class AdvancedSearchFormMigration extends JsonDatabaseMigration
     implements DatabaseMigrationTask {
 
+    private final String settingName = "ui/config";
+
     @Override
-    public void update(Connection connection) throws SQLException {
-        try (PreparedStatement statement = connection.prepareStatement(
-            "SELECT * FROM settings WHERE name='ui/config'")) {
-            ResultSet rs = statement.executeQuery();
-
-            if (rs.next()) {
-                String currentSettingJson = rs.getString("value");
-                Map<String, String> fieldsToUpdate = new HashMap<>(1);
-                fieldsToUpdate.put("/mods/search/advancedSearchTemplate",
-                    "\"../../catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html\"");
-
-                String newSettingJson = super.insertOrUpdateField(currentSettingJson, fieldsToUpdate);
-                try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE settings SET "
-                    + "value=? WHERE name='ui/config'")) {
-                    updateStatement.setString(1, newSettingJson);
-                    updateStatement.executeUpdate();
-                }
-            }
-        } catch (IOException e) {
-            Log.error(Geonet.GEONETWORK + ".databasemigration",
-                "Error in AdvancedSearchFormMigration. Cannot complete the "
-                    + "migration", e);
-            throw new DatabaseMigrationException(e);
-        }
-
+    protected Map<String, String> setUpNewSettingValues() {
+        Map<String, String> fieldsToUpdate = new HashMap<>(1);
+        fieldsToUpdate.put("/mods/search/advancedSearchTemplate",
+            "\"../../catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html\"");
+        return fieldsToUpdate;
     }
 
-    /**
-     * Given a JSON string and a map of fields to update/insert and their values return an updated JSON string.
-     *
-     * @param currentSettingJson the JSON string to modify.
-     * @param fieldsToUpdate     a {@link Map} with the fields to update. Keys are in the form of nested fields separated by
-     *                           slash ("/") and starting by slash. Values are in form of JSON strings. For example
-     *                           <code>"\"my new value\""</code>
-     * @return a JSON string with updated/inserted values.
-     */
+    @Override
+    protected String getSettingName() {
+        return settingName;
+    }
+
     @VisibleForTesting
     @Override
     protected String insertOrUpdateField(String currentSettingJson, Map<String, String> fieldsToUpdate) throws IOException {

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v343/AdvancedSearchFormMigration.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v343/AdvancedSearchFormMigration.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package v342;
+package v343;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;

--- a/web/src/test/java/v343/AdvancedSearchFormMigrationTest.java
+++ b/web/src/test/java/v343/AdvancedSearchFormMigrationTest.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package v342;
+package v343;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import v343.AdvancedSearchFormMigration;
 
 import java.io.IOException;
 import java.sql.Connection;


### PR DESCRIPTION
With this refactor the only things needed to implement a `JsonDatabaseMigration` is to define the setting name to update and the list of JSON paths to update/modify in the method `setUpNewSettingValues`.

This PR also moves `AdvancedSearchFormMigration` to version v3.4.3 since the PR #2547 was not included in v3.4.2 release.

Another fix in this PR is to use the right types for map values in `database-migration.xml`.