### PR TITLE
Fix and adapt privileges for harvest

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/HarvesterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/HarvesterDirective.js
@@ -143,8 +143,8 @@
      * for metadata privileges. To be improved.
      */
   module.directive('gnHarvesterPrivileges',
-      ['$http', '$translate', '$rootScope',
-       function($http, $translate, $rootScope) {
+      ['$http', '$translate', '$rootScope', 'gnShareConstants',
+       function($http, $translate, $rootScope, gnShareConstants) {
 
          return {
            restrict: 'A',
@@ -171,22 +171,24 @@
              };
              var defaultPrivileges = [getPrivilege(1)];
 
-             scope.visibleTo = function(who) {
-               scope.custom = false;
-               scope.selectedPrivileges = {};
-               if (who == 'all') {
-                 scope.allGroup = false;
-                 scope.selectedPrivileges = {1: true};
-               } else if (who == 'none') {
-                 scope.allGroup = false;
-                 scope.selectedPrivileges = {1: false};
-               } else if (who == 'allGroup') {
-                 scope.allGroup = !scope.allGroup;
-                 angular.forEach(scope.groups, function(g) {
-                   scope.selectedPrivileges[g['@id']] = scope.allGroup;
-                 });
-               }
-             };
+             // deal with order by
+             scope.sorter = null
+             scope.setSorter = function(g) {
+               if (scope.sorter == 'name') return g.label ? g.label[scope.lang] : g.name;
+               else if (scope.sorter == 'checked') return scope.selectedPrivileges[g['@id']];
+               else return 0;
+             }
+
+             var internalGroups =  gnShareConstants.internalGroups;
+
+             scope.keepInternalGroups = function(g){
+               if (internalGroups.includes(parseInt(g['@id']))) return true;
+               else return false;
+             }
+             scope.removeInternalGroups = function(g){
+               if (internalGroups.includes(parseInt(g['@id']))) return false;
+               else return true;
+             }
              function loadGroups() {
                $http.get('info?_content_type=json&' +
                'type=groupsIncludingSystemGroups',

--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/privileges.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/privileges.html
@@ -1,36 +1,24 @@
 <fieldset>
   <legend data-translate="">harvestedRecordPrivileges</legend>
-  <span class="btn-group" data-toggle="buttons">
-      <label class="btn btn-primary" data-ng-click="visibleTo('all')" id="gn-harvester-visible-all">
-        <input type="radio" name="options"/>
-        <i class="fa fa-unlock"></i>
-        {{"visibleToAll"|translate}}
-      </label>
-      <label class="btn btn-primary" data-ng-click="visibleTo('none')"
-             id="gn-harvester-visible-none">
-        <input type="radio" name="options"/>
-        <i class="fa fa-lock"></i>
-        {{"visibleToNobody"|translate}}
-      </label>
-  </span>
   <ul class="list-group">
     <li class="list-group-item">
-      <div class="input-group">
-        <div class="input-group-btn">
-          <button class="btn btn-default" title="{{'SelectAllorNone'|translate}}">
-            <i class="fa"
-               data-ng-class="allGroup == true ? 'fa-check-square-o' : 'fa-square-o'"
-               data-ng-click="visibleTo('allGroup');">
-            </i>
-          </button>
-        </div>
+      <div>
         <input class="form-control" data-ng-model="groupSearch.$"
                placeholder="{{'filter' | translate}}"/>
       </div>
+      </tr>
     </li>
-    <li data-ng-repeat="g in groups | filter:groupSearch | orderBy:'name'" class="list-group-item">
-      <input type="checkbox" id="group-{{g.id}}" data-ng-model="selectedPrivileges[g.id]"/>
-      <label for="group-{{g.id}}">{{g.label[lang]|empty:g.name}}</label>
+    <li class="list-group-item">
+      <a href='' class="privilege-check-order" ng-click="sorter='checked'">{{'selected' | translate}} &#x2193;</a>
+      <a href='' ng-click="sorter='name'">{{'groups' | translate}} &#x2193;</a>
+    </li>
+    <li data-ng-repeat="g in groups" ng-if="keepInternalGroups(g)" class="list-group-item list-group-interne">
+      <input type="checkbox" id="int-group-{{g['@id']}}" data-ng-model="selectedPrivileges[g['@id']]"/>
+      <label for="group-{{g['@id']}}">{{g.label[lang]|empty:g.name}}</label>
+    </li>
+    <li data-ng-repeat="g in groups | filter:groupSearch | orderBy:setSorter" ng-if="removeInternalGroups(g)" class="list-group-item">
+      <input type="checkbox" id="group-{{g['@id']}}" data-ng-model="selectedPrivileges[g['@id']]"/>
+      <label for="group-{{g['@id']}}">{{g.label[lang]|empty:g.name}}</label>
     </li>
   </ul>
 </fieldset>

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -157,3 +157,15 @@ ul.pager {
     line-height: 1em;
   }
 }
+// harvester privileges
+
+.list-group-interne {
+  background-color: #d9edf7;
+}
+ul > li > a.privilege-check-order{
+  margin-right: 20px;
+}
+ul > li.list-group-item > input {
+  margin-right: 40px;
+  margin-left: 30px;
+}


### PR DESCRIPTION
This PR brings two changes:

- Prior to modifications, we were enable to check a single group. This is now fixed 
- Instead of having private/public buttons, we use the same mechanism as the one in metadata privileges attributions. 
