### PR TITLE
Use gn-checkbox-with-nilreason angularjs directive for Conformity pass element in simple view when INSPIRE is enabled #2437

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -611,6 +611,17 @@
   -->
   <xsl:template match="gmd:extent[gmd:EX_Extent/not(*)]|srv:extent[gmd:EX_Extent/not(*)]"/>
 
+  <xsl:template match="gmd:pass[@gco:nilReason = 'unknown']">
+    <xsl:copy>
+      <xsl:copy-of select="@*[name()!='gco:nilReason']" />
+
+      <xsl:if test="not(gco:Boolean)">
+        <xsl:copy-of select="@*[name()='gco:nilReason']" />
+      </xsl:if>
+
+      <xsl:apply-templates select="node()" />
+    </xsl:copy>
+  </xsl:template>
 
   <!-- ================================================================= -->
   <!-- copy everything else as is -->

--- a/web-ui/src/main/resources/catalog/components/edit/checkboxwithnilreason/CheckboxWithNilReason.js
+++ b/web-ui/src/main/resources/catalog/components/edit/checkboxwithnilreason/CheckboxWithNilReason.js
@@ -40,6 +40,7 @@
            scope: {
              value: '@gnCheckboxWithNilreason',
              label: '@',
+             required: '@',
              elementName: '@',
              elementRef: '@',
              tagName: '@',

--- a/web-ui/src/main/resources/catalog/components/edit/checkboxwithnilreason/partials/checkboxwithnilreason.html
+++ b/web-ui/src/main/resources/catalog/components/edit/checkboxwithnilreason/partials/checkboxwithnilreason.html
@@ -1,17 +1,23 @@
 <div class="form-group gn-field">
-  <input type="hidden" class="form-control"
-         name="{{elementRef}}" value="{{xmlSnippet}}"/>
+  <label class="control-label col-sm-2"
+         data-ng-class="{'gn-required': required}"
+         data-ng-show="label !== undefined">{{label}}</label>
 
-  <label class="radio-inline">
-    <input type="radio" data-ng-model="status" value="unknown" name="radio{{key}}"/>
-    <span>{{radioLabels['unknown'] | translate}}</span>
-  </label>
-  <label class="radio-inline">
-    <input type="radio" data-ng-model="status" value="true" name="radio{{key}}"/>
-    <span>{{radioLabels['true'] | translate}}</span>
-  </label>
-  <label class="radio-inline">
-    <input type="radio" data-ng-model="status" value="false" name="radio{{key}}"/>
-    <span>{{radioLabels['false'] | translate}}</span>
-  </label>
+  <div class="col-sm-10">
+    <input type="hidden" class="form-control"
+           name="{{elementRef}}" value="{{xmlSnippet}}"/>
+
+    <label class="radio-inline">
+      <input type="radio" data-ng-model="status" value="unknown" name="radio{{key}}"/>
+      <span>{{radioLabels['unknown'] | translate}}</span>
+    </label>
+    <label class="radio-inline">
+      <input type="radio" data-ng-model="status" value="true" name="radio{{key}}"/>
+      <span>{{radioLabels['true'] | translate}}</span>
+    </label>
+    <label class="radio-inline">
+      <input type="radio" data-ng-model="status" value="false" name="radio{{key}}"/>
+      <span>{{radioLabels['false'] | translate}}</span>
+    </label>
+  </div>
 </div>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -65,6 +65,7 @@
 
     <!-- The AngularJS directive name eg. gn-field-duration -->
     <xsl:param name="directive" required="no" as="xs:string" select="''"/>
+    <xsl:param name="directiveAttributes" required="no" />
 
     <xsl:param name="hidden" required="no" as="xs:boolean" select="false()"/>
     <xsl:param name="editInfo" required="no"/>
@@ -145,6 +146,14 @@
               </xsl:when>
               <xsl:otherwise>
                 <xsl:attribute name="data-{$directive}" select="$value"/>
+
+                <xsl:if test="$directiveAttributes">
+                  <xsl:for-each select="$directiveAttributes/directiveAttributes/attr">
+                    <xsl:message><xsl:value-of select="@name" />: <xsl:value-of select="@value" /> </xsl:message>
+                    <xsl:attribute name="data-{@name}" select="@value" />
+                  </xsl:for-each>
+                </xsl:if>
+
               </xsl:otherwise>
             </xsl:choose>
 

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -149,7 +149,6 @@
 
                 <xsl:if test="$directiveAttributes">
                   <xsl:for-each select="$directiveAttributes/directiveAttributes/attr">
-                    <xsl:message><xsl:value-of select="@name" />: <xsl:value-of select="@value" /> </xsl:message>
                     <xsl:attribute name="data-{@name}" select="@value" />
                   </xsl:for-each>
                 </xsl:if>


### PR DESCRIPTION
This pull request allows in the Simple view, when INSPIRE setting is enabled, to edit the `gmd:pass` (Conformity) using the same AngularJs directive `gn-checkbox-with-nilreason` that is used in the INSPIRE view template for this element.  See details in #2437.

Additionally, has been extended also the xslt template `render-element` to pass directive attributes in this format:

```
 <directiveAttributes>
        <attr name="NAME1" value="VALUE1" />
        <attr name="NAME2" value="VALUE2" />
         ...
</directiveAttributes>
```
, previously only the directive name was provided.

Something to review is https://github.com/geonetwork/core-geonetwork/compare/3.4.x...josegar74:improvements/inspire-conformity-directive-simple-view?expand=1#diff-1a0a7bc96168e03d2bd8b32895099ecfR614. 

This change has been required as the backend code that replaces an element, receives the full xml snippet for `gmd:pass` in a parameter `_XID_replace` updates content and the existing attributes, but doesn't remove the attributes that already existed and not provided in the new snippet: https://github.com/geonetwork/core-geonetwork/blob/3.4.x/core/src/main/java/org/fao/geonet/kernel/EditLib.java#L358-L361, maybe something to fix in this code instead.