### PR TITLE
Don't show recordNotFound message while the server query is still running

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -59,6 +59,7 @@
       initFromConfig();
 
       this.feedMd = function(index, md, records) {
+        gnMdViewObj.loadDetailsFinished = true;
         gnMdViewObj.records = records || gnMdViewObj.records;
         if (angular.isUndefined(md)) {
           md = gnMdViewObj.records[index];
@@ -125,17 +126,18 @@
        */
       this.initMdView = function() {
         var that = this;
-        var loadMdView = function(oldUrl, newUrl) {
+        var loadMdView = function() {
+          gnMdViewObj.loadDetailsFinished = false;
           var uuid = gnSearchLocation.getUuid();
           if (uuid) {
             if (!gnMdViewObj.current.record ||
-                gnMdViewObj.current.record.getUuid() != uuid) {
+                gnMdViewObj.current.record.getUuid() !== uuid) {
 
               // Check if the md is in current search
               if (angular.isArray(gnMdViewObj.records)) {
                 for (var i = 0; i < gnMdViewObj.records.length; i++) {
                   var md = gnMdViewObj.records[i];
-                  if (md.getUuid() == uuid) {
+                  if (md.getUuid() === uuid) {
                     that.feedMd(i, md, gnMdViewObj.records);
                     return;
                   }
@@ -143,6 +145,7 @@
               }
 
               // get a new search to pick the md
+              gnMdViewObj.current.record = null;
               gnSearchManagerService.gnSearch({
                 uuid: uuid,
                 _isTemplate: 'y or n',
@@ -152,11 +155,18 @@
                 if (data.metadata.length == 1) {
                   data.metadata[0] = new Metadata(data.metadata[0]);
                   that.feedMd(0, undefined, data.metadata);
+                } else {
+                  gnMdViewObj.loadDetailsFinished = true;
                 }
+              }, function(error) {
+                gnMdViewObj.loadDetailsFinished = true;
               });
+            } else {
+              gnMdViewObj.loadDetailsFinished = true;
             }
           }
           else {
+            gnMdViewObj.loadDetailsFinished = true;
             gnMdViewObj.current.record = null;
           }
         };

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -1,9 +1,13 @@
 <div data-ng-controller="GnMdViewController" class="container">
   <div class="alert alert-warning"
-       data-ng-hide="mdView.current.record"
+       data-ng-hide="!mdView.loadDetailsFinished || mdView.current.record"
        data-translate=""
        data-translate-values="{uuid: '{{recordIdentifierRequested | htmlToPlaintext}}', url: '{{url | encodeURIComponent}}'}">
     recordNotFound
+  </div>
+  <div class="row"
+       data-ng-show="!mdView.loadDetailsFinished">
+    <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
   </div>
 
   <div class="row gn-md-view"


### PR DESCRIPTION
When connections are slow and the user tries to access to the metadata details page a warning about the record not found is shown temporarily until the record is retrieved from the server.
![image](https://user-images.githubusercontent.com/826920/40847444-b30badaa-65bc-11e8-8d59-e125a760234e.png)

This PR shows a loading spinner instead of that message until the info has been received.
It also hide the previous record info if the user changes the uuid in the URL and it doesn't exists. Previously the old record was shown even the uuid was new.