### PR TITLE
Bug fix: Prefer to use capabilities url instead of hand-hard-coded URL.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -883,7 +883,7 @@
                 }
               }
               
-              url = url || getCapLayer.url;
+              url = getCapLayer.url || url;
               if(getCapLayer.useProxy 
                   && url.indexOf(gnGlobalSettings.proxyUrl) != 0) {
                 url = gnGlobalSettings.proxyUrl + encodeURIComponent(url);


### PR DESCRIPTION
When the online resource defines a URL with extra parameters like getCapabilities, addToMap fails.

this is on the main map, if you click add-2-map from metadata and the wms url has http://.../wms?Request=getcapabilities