### PR TITLE
Search page - filter tag for inspire themes thesaurus is not translated. Fixes #2869

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -131,7 +131,7 @@
              // Find label in dimension categories
              if (d.category) {
                var category = $.grep(d.category, function(cat, index) {
-                 return cat['@value'] === value;
+                 return cat['@value'] === decodeURIComponent(value);
                });
                if (category.length > 0) {
                  return category[0]['@label'];


### PR DESCRIPTION
See issue details in #2869

Tested the fix with other facets and look fine also, displaying the labels.

![facet-filter-inspire-themes-fix](https://user-images.githubusercontent.com/1695003/41291955-64243318-6e51-11e8-9175-d205bf55587c.png)
