### PR TITLE
Set sortby for resolution facet to value

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -151,7 +151,7 @@
       <item facet="status" translator="codelist:gmd:MD_ProgressCode"/>
       <item facet="serviceType"/>
       <item facet="denominator" sortBy="numValue" sortOrder="desc"/>
-      <item facet="resolution" sortBy="numValue" sortOrder="desc"/>
+      <item facet="resolution" sortBy="value" sortOrder="desc"/>
       <!--
       <item facet="region"
             translator="term:http://geonetwork-opensource.org/thesaurus/naturalearth-and-seavox"/>


### PR DESCRIPTION
Generally speaking resolution can be a string or a number, so setting the sortby to value rather than numvalue avoids lots of errors in the log files