### PR TITLE
Web Accessibility for the homepage

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/languageswitcher/LanguageSwitcherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/languageswitcher/LanguageSwitcherDirective.js
@@ -41,6 +41,7 @@
         },
         template:
             '<select class="form-control" ' +
+            ' aria-label=' + "{{'languageSwitcher'|translate}}" + '"' +
             ' data-ng-show="isHidden()" ' +
             ' data-ng-model="lang" ' +
             ' data-ng-options="key as langLabels[key] ' +

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -69,6 +69,7 @@
       <div class="gn-md-thumbnail"
             data-ng-class="{'gn-md-no-thumbnail': !md.getThumbnails().list[0].url}">
         <img class="gn-img-thumbnail"
+             alt="{{md.title}}"
              data-ng-src="{{md.getThumbnails().list[0].url}}"
              data-ng-if="md.getThumbnails().list[0].url"/>
 

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -69,7 +69,7 @@
       <div class="gn-md-thumbnail"
             data-ng-class="{'gn-md-no-thumbnail': !md.getThumbnails().list[0].url}">
         <img class="gn-img-thumbnail"
-             alt="{{md.title}}"
+             alt="{{md.title || md.defaultTitle}}"
              data-ng-src="{{md.getThumbnails().list[0].url}}"
              data-ng-if="md.getThumbnails().list[0].url"/>
 

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
@@ -10,6 +10,7 @@
            data-ng-click="loadMap(maps[0], md)">
         <div class="gn-md-thumbnail">
           <img class="gn-img-thumbnail"
+               alt="{{md.title}}"
                data-ng-src="{{md.getThumbnails().list[0].url}}"
                data-ng-if="md.getThumbnails().list[0].url"/>
         </div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
@@ -10,7 +10,7 @@
            data-ng-click="loadMap(maps[0], md)">
         <div class="gn-md-thumbnail">
           <img class="gn-img-thumbnail"
-               alt="{{md.title}}"
+               alt="{{md.title || md.defaultTitle}}"
                data-ng-src="{{md.getThumbnails().list[0].url}}"
                data-ng-if="md.getThumbnails().list[0].url"/>
         </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
@@ -1,7 +1,7 @@
 <div class="context">
   <fieldset>
     <form class="form-horizontal"
-          role="nav"
+          role="grid"
           data-ng-controller="gnsMapSearchController"
           data-ng-search-form=""
           data-runSearch="true">

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -114,7 +114,7 @@
       </h3>
     </div>
     <div class="panel-body">
-      <tabset id="info-tabset">
+      <tabset class="info-tabset">
 
         <tab heading="{{'addLayerFromMaps' | translate}}"
              active="addLayerTabs.maps">
@@ -279,7 +279,7 @@
       </h3>
     </div>
     <div class="panel-body">
-      <tabset id="info-tabset">
+      <tabset class="info-tabset">
         <tab heading="{{'wpsByUrl' | translate}}"
              active="wpsTabs.byUrl">
           <br/>

--- a/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
@@ -56,6 +56,7 @@
             <td>
               <div class="gn-md-thumbnail">
                 <img class="gn-img-thumbnail"
+                     alt="{{md.title}}"
                      data-ng-src="{{md.getThumbnails().list[0].url}}"
                      data-ng-if="md.getThumbnails().list[0].url"/>
               </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
@@ -56,7 +56,7 @@
             <td>
               <div class="gn-md-thumbnail">
                 <img class="gn-img-thumbnail"
-                     alt="{{md.title}}"
+                     alt="{{md.title || md.defaultTitle}}"
                      data-ng-src="{{md.getThumbnails().list[0].url}}"
                      data-ng-if="md.getThumbnails().list[0].url"/>
               </div>

--- a/web-ui/src/main/resources/catalog/lib/angular.ext/template/tabset.html
+++ b/web-ui/src/main/resources/catalog/lib/angular.ext/template/tabset.html
@@ -1,8 +1,10 @@
 <div>
   <ul class="nav nav-{{type || 'tabs'}}"
+      role="tablist"
       ng-class="{'nav-stacked': vertical, 'nav-justified': justified}" ng-transclude></ul>
   <div class="tab-content">
     <div class="tab-pane"
+         role="tabpanel"
          ng-repeat="tab in tabs"
          ng-class="{active: tab.active}"
          tab-content-transclude="tab">

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -390,5 +390,8 @@
     "resolveCaptcha": "Resolve the captcha",
     "resolutions": "Resolution",
     "loginTitle": "Sign in",
-    "loginText": "Sign in with your username and password to add and edit metadata."
+    "loginText": "Sign in with your username and password to add and edit metadata.",
+    "siteLogo": "Logo",
+    "languageSwitcher": "Language switcher",
+    "avatar": "Avatar"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_badge_categories.less
+++ b/web-ui/src/main/resources/catalog/style/gn_badge_categories.less
@@ -49,7 +49,7 @@
 		}
 	}
 }
-#chips-card {
+.chips-card {
 	padding-bottom: 10px;
 	padding-left: 0px;
 	padding-right: 0px;

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -99,7 +99,7 @@
     </ul>
 
 
-    <form class="navbar-form navbar-right" role="language">
+    <form class="navbar-form navbar-right" role="listbox">
       <div class="form-group"
            data-gn-language-switcher="lang"
            data-langs="langs"

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -18,6 +18,7 @@
       <li data-ng-if="gnCfg.mods.home.enabled">
         <a data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
           <img class="gn-logo"
+               alt="{{'siteLogo' | translate}}"
                data-ng-src="{{gnUrl}}../images/logos/{{info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
           <span class="hidden-sm hidden-md gn-name" 
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
@@ -114,6 +115,7 @@
           class="dropdown-toggle"
           role="button" aria-expanded="false">
           <img class="img-circle"
+            alt="{{'avatar' | translate}}"
             data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=18"/>&nbsp;
           <div class="gn-user-info">
             {{user.name}} {{user.surname}}<br>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -11,6 +11,7 @@
           <div class="top">
             <div class="gn-md-thumbnail">
               <img class="gn-img-thumbnail"
+                   alt="{{md.title}}"
                    data-ng-src="{{md.getThumbnails().list[0].url}}"
                    data-ng-if="md.getThumbnails().list[0].url"/>
             </div>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -11,7 +11,7 @@
           <div class="top">
             <div class="gn-md-thumbnail">
               <img class="gn-img-thumbnail"
-                   alt="{{md.title}}"
+                   alt="{{md.title || md.defaultTitle}}"
                    data-ng-src="{{md.getThumbnails().list[0].url}}"
                    data-ng-if="md.getThumbnails().list[0].url"/>
             </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
@@ -13,7 +13,7 @@
       margin-bottom: 0;
     }
   }
-  #chips-card {
+  .chips-card {
     padding-bottom: 0px;
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -9,6 +9,7 @@
                data-ng-model="homeAnyField"
                data-ng-model-options="modelOptions"
                placeholder="{{'anyPlaceHolder' | translate}}"
+               aria-label="{{'anyPlaceHolder' | translate}}"
                data-ng-keyup="$event.keyCode == 13 && goToSearch(homeAnyField)"
                data-typeahead="address for address in getAnySuggestions($viewValue)"
                data-typeahead-loading="anyLoading"
@@ -18,6 +19,7 @@
              type="button"
              data-ng-href="#/search?any={{homeAnyField}}">
             <i class="fa fa-search"></i>
+            <span class="sr-only" data-translate="">search</span>
           </a>
         </span>
       </div>
@@ -88,6 +90,7 @@
           <div class="badge-result badge-result-topic clearfix">
             <a class="pull-left clearfix"
                title="{{facet['@label']}}"
+               role="link"
                data-ng-href="#/search?facet.q=topicCat%2F{{facet['@name']}}">
               <span class="badge-icon badge-result-topic pull-left">
                 <i class="fa fa-3x fa-table gn-icon gn-icon-{{facet['@name']}}"></i>
@@ -145,7 +148,7 @@
   </div>
   <div class="row gn-row-info" data-ng-show="searchInfo.count > 0">
     <div class="col-sm-12">
-      <tabset id="info-tabset">
+      <tabset class="info-tabset">
         <tab heading="{{'lastRecords' | translate}}"
              active="infoTabs.lastRecords.active"
              role="tab">

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -82,9 +82,9 @@
         <span id="chips-card" data-ng-repeat="(key, facet) in searchInfo.facet['topicCats']"
               class="col-xs-6 col-sm-4 col-lg-3" data-ng-show="browse === 'topics'"> -->
       <div class="row">
-        <span id="chips-card" data-ng-repeat="(key, facet) in searchInfo.facet['topicCats']"
+        <span data-ng-repeat="(key, facet) in searchInfo.facet['topicCats']"
               data-ng-show="browse === 'topics'"
-              class="col-xs-12 col-sm-6 col-md-4">
+              class="col-xs-12 col-sm-6 col-md-4 chips-card">
           <div class="badge-result badge-result-topic clearfix">
             <a class="pull-left clearfix"
                title="{{facet['@label']}}"
@@ -99,10 +99,9 @@
             <span class="badge pull-left">{{facet['@count']}}</span>
           </div>
         </span>
-        <span id="chips-card"
-              data-ng-repeat="(key, facet) in searchInfo.facet['inspireThemesURI'] track by $index"
+        <span data-ng-repeat="(key, facet) in searchInfo.facet['inspireThemesURI'] track by $index"
               data-ng-show="browse === 'inspire'"
-              class="col-xs-12 col-sm-6 col-md-4">
+              class="col-xs-12 col-sm-6 col-md-4 chips-card">
           <div class="badge-result badge-result-inspire clearfix">
             <a class="pull-left clearfix bg-iti-{{facet['@name'].slice(facet['@name'].lastIndexOf('/')+1)}}"
                title="{{facet['@label']}}"
@@ -124,9 +123,9 @@
         <span data-translate="">browseTypes</span>
       </h4>
       <div class="row">
-          <span id="chips-card" data-ng-repeat="(key, facet) in searchInfo.facet['types']"
+          <span data-ng-repeat="(key, facet) in searchInfo.facet['types']"
                 data-ng-show="facet['@label']"
-                class="col-xs-12 col-sm-6 col-md-12">
+                class="col-xs-12 col-sm-6 col-md-12 chips-card">
             <div class="badge-result badge-result-type pull-left">
               <a title="{{facet['@label']}}"
                  class="pull-left clearfix"

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -29,12 +29,12 @@
   </div>
 
   <form class="form-horizontal"
-        role="nav"
+        role="grid"
         data-ng-controller="gnsSearchTopEntriesController"
         data-ng-search-form=""
         data-runSearch="true"
         data-ng-show="searchResults.records.length > 0">
-    <div class="row gn-top-records">
+    <div class="row gn-top-records" role="row">
       <h4 data-translate="">topMaps</h4>
 
         <input type="hidden" name="_csrf" value="{{csrf}}"/>
@@ -147,9 +147,9 @@
     <div class="col-sm-12">
       <tabset id="info-tabset">
         <tab heading="{{'lastRecords' | translate}}"
-             active="infoTabs.lastRecords.active">
+             active="infoTabs.lastRecords.active"
+             role="tab">
           <form class="form-horizontal"
-                role="nav"
                 data-ng-controller="gnsSearchLatestController"
                 data-ng-search-form=""
                 data-runSearch="true"
@@ -160,9 +160,9 @@
           </form>
         </tab>
         <tab heading="{{'preferredRecords' | translate}}"
-             active="infoTabs.preferredRecords.active">
+             active="infoTabs.preferredRecords.active"
+             role="tab">
           <form class="form-horizontal"
-                role="nav"
                 data-ng-controller="gnsSearchPopularController"
                 data-ng-search-form=""
                 data-runSearch="true"
@@ -173,8 +173,9 @@
         </tab>
         <tab heading="{{'Comments' | translate}}"
              data-ng-if="isUserFeedbackEnabled"
-             active="infoTabs.commentsalt.active" >
-          <form class="form-horizontal" role="nav">
+             active="infoTabs.commentsalt.active"
+             role="tab">
+          <form class="form-horizontal">
             <div class="data-gn-userfeedbacklasthome"
                  data-nb-of-comments="10"></div>
           </form>

--- a/web-ui/src/main/resources/catalog/views/default/templates/index.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/index.html
@@ -6,6 +6,7 @@
 </div>
 
 <div class="gn-search-page"
+     role="main"
      data-ng-controller="GnSearchController">
   <cookiewarning></cookiewarning>
   <div class=""

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -12,6 +12,7 @@
                    id="gn-any-field"
                    data-ng-model="searchObj.params.any"
                    placeholder="{{'anyPlaceHolder' | translate}}"
+                   aria-label="{{'anyPlaceHolder' | translate}}"
                    data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
                    data-typeahead="address for address in getAnySuggestions($viewValue)"
                    data-typeahead-loading="anyLoading" class="form-control"
@@ -27,6 +28,7 @@
                       btn-checkbox-true="1"
                       btn-checkbox-false="0">
                 <i class="fa fa-ellipsis-v"></i>
+                <span class="sr-only" data-translate="">advanced</span>
               </button>
 
               <button type="button"
@@ -34,6 +36,7 @@
                       class="btn btn-primary btn-lg">
                 &nbsp;&nbsp;
                 <i class="fa fa-search"></i>
+                <span class="sr-only" data-translate="">search</span>
                 &nbsp;&nbsp;
               </button>
               <button type="button"
@@ -41,6 +44,7 @@
                       title="{{'ClearTitle' | translate}}"
                       class="btn btn-link btn-lg">
                 <i class="fa fa-times"></i>
+                <span class="sr-only" data-translate="">ClearTitle</span>
               </button>
             </div>
           </div>

--- a/web/src/main/webapp/xslt/skin/default/skin.xsl
+++ b/web/src/main/webapp/xslt/skin/default/skin.xsl
@@ -31,6 +31,7 @@
             <li>
               <a href="{/root/gui/nodeUrl}{$lang}/catalog.search#/home">
                 <img class="gn-logo"
+                     alt="{$i18n/siteLogo}"
                      src="{/root/gui/url}/images/logos/{$env//system/site/siteId}.png"></img>
                 <span class="hidden-xs">
                   <xsl:value-of select="$env//system/site/name"/>


### PR DESCRIPTION
Several changes have been made to follow more closely the Web Accessibility standards and guidelines.

This PR focusses on the homepage for a user who is not logged in. The colour scheme is not changed, so some colours still need more contrast.

Everything is tested with the Axe plugin: https://www.deque.com/axe/

Changes are made for images (alt attribute), labels and ARIA attributes for the search results:
* Screenreader only labels for search buttons
* Add aria label to the search buttons
* Add aria label to the language switcher
* Add Landmark role to the main content
* Remove duplicate ID's
* Alt text for the logo

Correct ARIA roles for the homepage:
* for tabs, tabpanels
* grid
* language switcher
