### PR TITLE
Return an error when CSW filter is invalid

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/OgcGenericFilters.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/OgcGenericFilters.java
@@ -30,6 +30,7 @@ import com.vividsolutions.jts.index.SpatialIndex;
 
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
+import org.apache.jcs.access.exception.InvalidArgumentException;
 import org.apache.lucene.search.Query;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
@@ -119,10 +120,13 @@ public class OgcGenericFilters {
         if (parser.getValidationErrors().size() > 0) {
             Log.error(Geonet.SEARCH_ENGINE, "Errors occurred when trying to parse a filter:");
             Log.error(Geonet.SEARCH_ENGINE, "----------------------------------------------");
+            StringBuilder sb = new StringBuilder(" Errors parsing filter:");
             for (Object error : parser.getValidationErrors()) {
                 Log.error(Geonet.SEARCH_ENGINE, error);
+                sb.append("\n" + error);
             }
-            Log.error(Geonet.SEARCH_ENGINE, "----------------------------------------------");
+            Log.error(Geonet.SEARCH_ENGINE, "----------------------------------------------");                                                                                                             
+            throw new InvalidArgumentException(sb.toString());  
         }
         if (!(parseResult instanceof Filter)) {
             return null;

--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/OgcGenericFilters.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/OgcGenericFilters.java
@@ -117,7 +117,8 @@ public class OgcGenericFilters {
             Log.debug(Geonet.SEARCH_ENGINE, "Parsing filter");
         Object parseResult = parser
             .parse(new StringReader(string));
-        if (parser.getValidationErrors().size() > 0) {
+        
+        if (parser.getValidationErrors().size() > 0 && filterExpr.getContentSize() > 0) {
             Log.error(Geonet.SEARCH_ENGINE, "Errors occurred when trying to parse a filter:");
             Log.error(Geonet.SEARCH_ENGINE, "----------------------------------------------");
             StringBuilder sb = new StringBuilder(" Errors parsing filter:");


### PR DESCRIPTION
Enhancement/bug fix: when CSW has a wrong filter, instead of returning error it applied a null filter. Now it returns an error.
Fixes #2897.