### PR TITLE
Accessibility for the Search page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/savedselections/partials/action.html
+++ b/web-ui/src/main/resources/catalog/components/common/savedselections/partials/action.html
@@ -7,24 +7,28 @@
           aria-haspopup="true"
           aria-expanded="false">
     <i class="fa fa-thumb-tack"></i>&nbsp;
+    <span class="sr-only" data-translate="">addToSelection</span>
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu" role="menu">
     <li class="dropdown-header"
         data-ng-show="canBeAdded()"
+        role="menuitem"
         data-translate="">addToSelection</li>
     <li data-ng-repeat="s in selections.list"
-        data-ng-show="canBeAdded(s)">
+        data-ng-show="canBeAdded(s)"
+        role="menuitem">
       <a data-ng-click="add(s)">
         {{s.label[lang] || (s.name | translate)}}
       </a>
     </li>
-
     <li class="dropdown-header"
         data-ng-show="canBeRemoved()"
+        role="menuitem"
         data-translate="">removeFromSelection</li>
     <li data-ng-repeat="s in selections.list"
-        data-ng-show="canBeRemoved(s)">
+        data-ng-show="canBeRemoved(s)"
+        role="menuitem">
       <a data-ng-click="remove(s)">
         {{s.label[lang] || (s.name | translate)}}
       </a>

--- a/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
+++ b/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
@@ -4,11 +4,13 @@
       <li data-ng-class="config.currentPage == 1 ? 'disabled' : ''">
         <a href="" data-ng-click="first()">
           <i class="fa fa-angle-double-left"></i>
+          <span class="sr-only" data-translate="">first</span>
         </a>
       </li>
       <li data-ng-class="config.currentPage == 1 ? 'disabled' : ''">
         <a href="" data-ng-click="previous()">
           <i class="fa fa-angle-left"></i>
+          <span class="sr-only" data-translate="">previous</span>
         </a>
       </li>
       <li class="btn-group">
@@ -41,11 +43,13 @@
       <li data-ng-class="config.currentPage == config.pages ? 'disabled' : ''">
         <a href="" data-ng-click="next()">
           <i class="fa fa-angle-right"></i>
+          <span class="sr-only" data-translate="">next</span>
         </a>
       </li>
       <li data-ng-class="config.currentPage == config.pages ? 'disabled' : ''">
         <a href="" data-ng-click="last()">
           <i class="fa fa-angle-double-right"></i>
+          <span class="sr-only" data-translate="">last</span>
         </a>
       </li>
     </ul>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -8,18 +8,19 @@
          data-ng-class="getIcon()"></i>&nbsp;
       <span data-ng-show="searchResults.selectedCount > 0"
             class="badge">{{searchResults.selectedCount}}</span>
+      <span class="sr-only" data-translate="">clickToSelect</span>
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">
-      <li>
+      <li role="menuitem">
         <a href=""
            data-ng-click="selectAllInPage(true)"
            data-translate="">allInPage</a></li>
-      <li>
+      <li role="menuitem">
         <a href=""
            data-ng-click="selectAll()"
            data-translate="">all</a></li>
-      <li>
+      <li role="menuitem">
         <a href=""
            data-ng-click="unSelectAll()"
            data-translate="">none</a></li>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -3,6 +3,7 @@
     <td>
       <input data-gn-selection-md type="checkbox"
              data-ng-model="md['geonet:info'].selected"
+             aria-label="{{'clickToSelect' | translate}}"
              data-ng-change="change()"/>
     </td>
     <td>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/geocat.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/geocat.html
@@ -11,6 +11,7 @@
 
         <h4>
           <input gn-selection-md type="checkbox" ng-model="md['geonet:info'].selected"
+                 aria-label="{{'clickToSelect' | translate}}"
                  ng-change="change()"/>
           <span data-placement="right" gn-tooltip ng-if="md.type[0].indexOf('dataset')>=0"
                 class="fa fa-database" title="dataset"></span>
@@ -25,10 +26,14 @@
         </h4>
 
         <a class="pull-left" ng-if="md.groupWebsite" href="{{md.groupWebsite}}" target="_blank">
-          <img ng-src="../..{{md.logo}}" class="media-object"/>
+          <img ng-src="../..{{md.logo}}"
+               alt="{{'siteLogo' | translate}}"
+               class="media-object"/>
         </a>
-        <a class="pull-left" ng-if="!md.groupWebsite">
-          <img ng-src="../..{{md.logo}}" class="media-object"/>
+        <a class="pull-left" ng-if="!md.groupWebsite && md.logo">
+          <img ng-src="../..{{md.logo}}"
+               alt="{{'siteLogo' | translate}}"
+               class="media-object"/>
         </a>
 
         <p class="text-justify" dd-text-collapse dd-text-collapse-max-length="350"

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -9,16 +9,20 @@
     <div class="row">
       <input data-gn-selection-md type="checkbox"
              data-ng-model="md['geonet:info'].selected"
+             aria-label="{{'clickToSelect' | translate}}"
              data-ng-change="change()"/>
 
       <!--Source catalog Logo-->
       <a data-ng-if="md.groupWebsite"
-         href="{{md.groupWebsite}}" target="_blank">
+         href="{{md.groupWebsite}}"
+         target="_blank">
         <img data-ng-src="{{gnUrl}}..{{md.logo}}"
+             alt="{{'siteLogo' | translate}}"
              class="gn-source-logo"/>
       </a>
-      <img data-ng-if="!md.groupWebsite"
+      <img data-ng-if="!md.groupWebsite && md.logo"
            data-ng-src="{{gnUrl}}..{{md.logo}}"
+           alt="{{'siteLogo' | translate}}"
            class="gn-source-logo"/>
 
       <div class="gn-md-category"

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -8,15 +8,20 @@
       <div class="col-md-1">
         <!--Catalog or group Logo-->
         <a class="pull-left" ng-if="md.groupWebsite" href="{{md.groupWebsite}}" target="_blank">
-          <img ng-src="../..{{md.logo}}" class="media-object"/>
+          <img ng-src="../..{{md.logo}}"
+               alt="{{'siteLogo' | translate}}"
+               class="media-object"/>
         </a>
         <a class="pull-left" ng-if="!md.groupWebsite">
-          <img ng-src="../..{{md.logo}}" class="media-object"/>
+          <img ng-src="../..{{md.logo}}"
+               alt="{{'siteLogo' | translate}}"
+               class="media-object"/>
         </a>
       </div>
       <div class="col-md-9">
         <div class="gn-md-title">
           <input gn-selection-md type="checkbox" ng-model="md['geonet:info'].selected"
+                 aria-label="{{'clickToSelect' | translate}}"
                  ng-change="change()"/>
           <div class="pull-right gn-md-category"
                data-ng-class="md.category.length > 0 ||

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/titlewithselection.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/titlewithselection.html
@@ -2,6 +2,7 @@
   <li class="list-group-item" data-ng-repeat="md in searchResults.records">
     <input data-gn-selection-md type="checkbox"
            data-ng-model="md['geonet:info'].selected"
+           aria-label="{{'clickToSelect' | translate}}"
            data-ng-change="change()"/>
     <i class="fa text-muted" data-ng-class="'gn-recordtype-' + md.isTemplate"
        data-ng-show="user.isReviewerOrMore()"

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -395,5 +395,6 @@
     "loginText": "Sign in with your username and password to add and edit metadata.",
     "siteLogo": "Logo",
     "languageSwitcher": "Language switcher",
-    "avatar": "Avatar"
+    "avatar": "Avatar",
+    "first": "First"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -456,5 +456,6 @@
   "GUFdeleteConfirm": "Do you want to delete this comment?",
   "GUFrequired": "Required",
   "GUFtooLong": "Too long",
-  "GUFnotValidFormat": "Not a valid format"
+  "GUFnotValidFormat": "Not a valid format",
+  "clickToSelect": "Click to select or unselect"
 }

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -182,6 +182,7 @@
                   <input class="flex-no-shrink" type="checkbox"
                          data-gn-selection-md
                          data-ng-model="md['geonet:info'].selected"
+                         aria-label="{{clickToSelect | translate}}"
                          data-ng-change="change()"/>
 
                   <gn-md-type-widget metadata="md"></gn-md-type-widget>
@@ -276,6 +277,7 @@
 
                   <input data-gn-selection-md type="checkbox"
                          data-ng-model="md['geonet:info'].selected"
+                         aria-label="{{'clickToSelect' | translate}}"
                          data-ng-change="change()"/>
 
                   <gn-md-type-widget metadata="md"></gn-md-type-widget>

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -45,7 +45,7 @@
           />
         </title>
         <meta charset="utf-8"/>
-        <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
+        <meta name="viewport" content="initial-scale=1.0"/>
         <meta name="apple-mobile-web-app-capable" content="yes"/>
 
         <meta name="description" content=""/>

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -45,7 +45,7 @@
           />
         </title>
         <meta charset="utf-8"/>
-        <meta name="viewport" content="initial-scale=1.0"/>
+        <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
         <meta name="apple-mobile-web-app-capable" content="yes"/>
 
         <meta name="description" content=""/>


### PR DESCRIPTION
Several changes have been made to follow more closely the Web Accessibility standards and guidelines.

This PR focusses on the search page for a user who is not logged in. The colour scheme is not changed, so some colours still need more contrast.

This PR is builds on an earlier (and merged) PR (https://github.com/geonetwork/core-geonetwork/pull/2893).

Issues addressed in this PR for images (alt attribute), labels and ARIA attributes:
* Remove `user-scalable` form the meta tags
* Screenreader only labels for pagination
* New language items for screenreader only labels
* Add alt attribute for thumbnails
* Add roles to items in dropdown menus
* Add `aria-label` to checkboxes

Everything is tested with the Axe plugin: https://www.deque.com/axe/