### PR TITLE
Restore schemaLocation attributes in iso19139 records served by CSW

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-brief.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-brief.xsl
@@ -113,10 +113,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Avoid insertion of schema location in the CSW
-  response - which is invalid. -->
-  <xsl:template match="@xsi:schemaLocation"/>
-
 </xsl:stylesheet>
 
 

--- a/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-full.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-full.xsl
@@ -52,7 +52,4 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Avoid insertion of schema location in the CSW
-  response - which is invalid. -->
-  <xsl:template match="@xsi:schemaLocation"/>
 </xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-summary.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/present/csw/gmd-summary.xsl
@@ -217,9 +217,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Avoid insertion of schema location in the CSW
-  response - which is invalid. -->
-  <xsl:template match="@xsi:schemaLocation"/>
 </xsl:stylesheet>
 
 


### PR DESCRIPTION
This PR simply reverts a change that was made to hide `xsi:schemaLocation` attributes in iso19139 records served by CSW.

The produced XML responses should not be invalid XML, see: https://www.w3.org/TR/xmlschema-1/#schema-loc (bullet point 4)

Fixes https://github.com/geonetwork/core-geonetwork/issues/2435