### PR TITLE
Groovy Formatter / allow showing a tab other than the Overview

### DIFF
--- a/web-ui/src/main/resources/catalog/js/GnFormatterLib.js
+++ b/web-ui/src/main/resources/catalog/js/GnFormatterLib.js
@@ -183,4 +183,13 @@
         });
   };
 
+  gnFormatter.toggleTab = function(tabElementId) {
+    tab = $('.view-outline [id="tab-' + tabElementId + '"] a[rel]');
+    if (tab.length > 0) {
+      tab.click();
+    } else {
+      console.warn('Invalid tab requested in URL: ' + tabElementId)
+    }
+  };
+
 })();

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/groovy/common/Handlers.groovy
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/groovy/common/Handlers.groovy
@@ -125,11 +125,19 @@ public class Handlers {
 
     def htmlOrXmlEnd = {
         def required = "";
+        def tabToggle = "";
+        def activeTab = env.param('tab').toString();
+
+        if (activeTab != 'Null Value') {
+            tabToggle = "gnFormatter.toggleTab('$activeTab');"
+        }
+
         if (!func.isPDFOutput()) {
             required = """
 <script type="text/javascript">
 //<![CDATA[
     gnFormatter.formatterOnComplete();
+    $tabToggle
 //]]>
 </script>"""
         }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/html/view-header.html
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/html/view-header.html
@@ -17,14 +17,17 @@
     <span class="title">{{title | escapeXmlContent}}</span>
   </h1>
   <ul fmt-if="!isPDF" class="view-outline nav nav-tabs">
-    <li fmt-if="addOverviewNavItem"><a href="" rel=".overview" fmt-translate="">overview</a></li>
-    <li fmt-if="associated">
+    <li fmt-if="addOverviewNavItem" id="tab-overview">
+      <a href="" rel=".overview" fmt-translate="">overview</a>
+    </li>
+    <li fmt-if="associated" id="tab-associated">
       <a href="" rel=".container > .associated"><span fmt-translate="">associated-link</span>&amp;nbsp;
         <i class="fa fa-circle-o-notch fa-spin associated-spinner"></i></a>
     </li>
-    <li fmt-if="addCompleteNavItem"><a fmt-translate="" href=""
-                                       rel=".container > .entry:not(.overview)">complete</a></li>
-    <li fmt-repeat="item in navBar" title="{{item.name | escapeXmlAttrs}}">
+    <li fmt-if="addCompleteNavItem" id="tab-complete">
+      <a fmt-translate="" href="" rel=".container > .entry:not(.overview)">complete</a>
+    </li>
+    <li fmt-repeat="item in navBar" title="{{item.name | escapeXmlAttrs}}" id="tab-{{item.rel}}">
       <a fmt-if="item.href" href="{{item.href | escapeXmlAttrs}}" target="_blank">{{item.abbrName |
         escapeXmlContent}}</a>
       <a fmt-if="item.rel" rel="{{item.rel | escapeXmlAttrs}}">{{item.abbrName |
@@ -34,7 +37,7 @@
       <a class="dropdown-toggle" data-toggle="dropdown" title="More information"><i
         class="fa fa-ellipsis-h"></i><b class="caret"></b></a>
       <ul class="dropdown-menu">
-        <li fmt-repeat="item in navBarOverflow">
+        <li fmt-repeat="item in navBarOverflow" id="tab-{{item.rel}}">
           <a fmt-if="item.href" href="{{item.href | escapeXmlAttrs}}" target="_blank">{{item.abbrName
             | escapeXmlContent}}</a>
           <a fmt-if="item.rel" rel="{{item.rel | escapeXmlAttrs}}">{{item.abbrName |


### PR DESCRIPTION
Previously the Groovy formatter would always show the Overview tab by default.

With this PR, by passing a `tab=...` argument to the formatter API, other tabs can be shown as well (useful for permalinks). For example:
```
http://localhost:8080/geonetwork/srv/api/records/c8f3043a-b7b0-468d-9470-274be47371e5/formatters/full_view?output=xml&tab=complete
```

Accepted values for all records are:
* `overview`: default behaviour
* `associated`: associated resources (will be empty if none found)
* `complete`: complete view
![image](https://user-images.githubusercontent.com/10629150/42204145-1d454544-7ea1-11e8-997e-a4b4872f09bd.png)


Other tabs depend on the record XML and may also be shown using their `rel` attribute, e. g.:
* `.gmd_identificationInfo`
* `.gmd_distributionInfo`
* `.gmd_identificationInfo`
* etc.
![image](https://user-images.githubusercontent.com/10629150/42204092-f2ed0e80-7ea0-11e8-95d6-531cd35661d0.png)
