### PR TITLE
Accessibility for the Details/Result page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -28,7 +28,7 @@
       </div>
       <div data-ng-class="mainType === 'MDFCATS' ? 'col-xs-11' : 'col-xs-7 col-sm-7'" >
         <!-- WMS & WFS contains layer name in title -->
-        <h4 data-ng-if="((mainType === 'WMS' || mainType === 'WMSSERVICE' ||
+        <h3 data-ng-if="((mainType === 'WMS' || mainType === 'WMSSERVICE' ||
                           mainType === 'WMTS' || mainType === 'WMTSSERVICE' ||
                           mainType === 'WFS') &&
                         !isLayerProtocol(r)) &&
@@ -36,7 +36,7 @@
                       mainType !== 'LINKDOWNLOAD' &&
                       mainType !== 'LINK'">
           {{::(r.title | gnLocalized: lang) || (r.url | gnLocalized: lang)}}
-        </h4>
+        </h3>
         <!-- Display description if available -->
         <h4 data-ng-if="(mainType === 'WMS' || mainType === 'WMSSERVICE' ||
                        mainType === 'WMTS' || mainType === 'WMTSSERVICE' ||

--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
@@ -53,6 +53,7 @@
     <div class="col-md-8 gn-nopadding-left">
       <select class="form-control"
         data-ng-model="ftSelected"
+        aria-label="{{'wfsChooseFeatureTypeToDownload' | translate}}"
         data-ng-options="featType as featType.name.localPart for featType in capabilities.featureTypeList.featureType | orderBy: 'name.localPart' track by featType.name.key">
         <option value="">{{'wfsChooseFeatureTypeToDownload' | translate}}</option>
       </select>

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -28,6 +28,7 @@
                        data-ng-model="searchObj.params.any"
                        data-ng-model-options="modelOptions"
                        placeholder="{{'anyPlaceHolder' | translate}}"
+                       aria-label="{{'anyPlaceHolder' | translate}}"
                        data-typeahead="address for address in getAnySuggestions($viewValue)"
                        data-typeahead-loading="anyLoading" class="form-control"
                        data-typeahead-min-length="1">
@@ -35,6 +36,7 @@
                 <div class="input-group-btn">
                   <button type="button"
                           data-ng-click="triggerSearch()"
+                          title="{{'search' | translate}}"
                           class="btn btn-default">
                     <i class="fa fa-search"></i>
                   </button>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -130,7 +130,7 @@
           </span>
         </a>
         <ul class="dropdown-menu" role="menu">
-          <li>
+          <li role="menuitem">
             <a href="{{gnCfg.mods.signout.appUrl}}"
                 title="{{'signout' | translate}}">
               <i class="fa fa-sign-out"></i>&nbsp;
@@ -150,7 +150,7 @@
           {{'signIn' | translate}}
         </a>
         <ul class="dropdown-menu" role="menu">
-          <li>
+          <li role="menuitem">
             <form name="gnSigninForm" class="navbar-form flex-row"
               action="{{signInFormAction}}" method="post" role="form">
               <input type="hidden" name="_csrf" value="{{csrf}}"/>
@@ -180,6 +180,7 @@
               </div>
               <div class="flex-spacer"></div>
               <button type="submit" class="btn btn-primary btn-sm pull-right"
+                      aria-label="{{'signIn' | translate}}"
                       data-ng-disabled="!gnSigninForm.$valid">
                 <i class="fa fa-sign-in"/>
               </button>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -5,33 +5,37 @@
             title="{{'manageRecord' | translate}}"
             class="btn btn-default dropdown-toggle"
             data-toggle="dropdown"
+            aria-label="{{'manageRecord' | translate}}"
             aria-expanded="false">
       <i class="fa fa-cog"/>
       <span data-translate="" class="hidden-xs">manageRecord</span>
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">
-      <li><a data-ng-href=""
+      <li role="menuitem">
+        <a data-ng-href=""
              data-ng-if="user.canEditRecord(md) && user.isEditorOrMore()"
              data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())">
-        <i class="fa fa-key"></i>&nbsp;
-        <span data-translate="">privileges</span>
-      </a></li>
-      <li data-ng-if="md.isOwned() && user.isUserAdminOrMore()">
+          <i class="fa fa-key"></i>&nbsp;
+          <span data-translate="">privileges</span>
+        </a>
+      </li>
+      <li role="menuitem"
+          data-ng-if="md.isOwned() && user.isUserAdminOrMore()">
         <a data-ng-href=""
            data-ng-click="mdService.openTransferOwnership(md, null, getCatScope())">
           <i class="fa fa-user"></i>&nbsp;
           <span data-translate="">transferOwnership</span>
         </a></li>
-      <li data-ng-if="user.canEditRecord(md) && user.isReviewerOrMore()"
+      <li role="menuitem"
+          data-ng-if="user.canEditRecord(md) && user.isReviewerOrMore()"
           data-ng-class="
             (md.isPublished() || (allowPublishInvalidMd() === true) ||
             (!md.isPublished() && (allowPublishInvalidMd() === false) &&
             (!md.hasValidation() || (md.hasValidation() && md.isValid())))) ? '' : 'disabled'"
           title="{{(!md.isPublished() ? (md.isValid() ? 'mdvalid' :
-                    (!md.hasValidation() ? 'mdnovalidation':
-                      (allowPublishInvalidMd() === false ? 'mdinvalidcantpublish' : 'mdinvalid'))) : '') | translate }}"
-      >
+            (!md.hasValidation() ? 'mdnovalidation':
+            (allowPublishInvalidMd() === false ? 'mdinvalidcantpublish' : 'mdinvalid'))) : '') | translate }}">
         <a data-ng-click="mdService.publish(md, undefined, undefined, getCatScope())">
           <i class="fa"
              data-ng-class="md.isPublished() ? 'fa-lock' : 'fa-unlock'"></i>&nbsp;
@@ -50,7 +54,8 @@
       </li>
       <!-- TODO: Some installation only allows status update
       based on current status. -->
-      <li data-ng-class="((allowPublishInvalidMd() === true) || 
+      <li role="menuitem"
+          data-ng-class="((allowPublishInvalidMd() === true) || 
             ((allowPublishInvalidMd() === false) &&
             (!md.hasValidation() || (md.hasValidation() && md.isValid())))) ? '' : 'disabled'">
         <a data-ng-href=""
@@ -60,26 +65,33 @@
           <i class="fa fa-bell"></i>&nbsp;
           <span data-translate="">updateStatus</span>
         </a></li>
-      <li><a data-ng-href=""
-             data-ng-if="user.canEditRecord(md) &&
-                                  !md.isWorkflowEnabled()"
-             data-ng-click="mdService.startWorkflow(md, getCatScope())">
-        <i class="fa fa-bell"></i>&nbsp;
-        <span data-translate="">enableWorkflow</span>
-      </a></li>
-      <li class="divider" data-ng-if="user.isConnected()"></li>
-      <li><a data-ng-href=""
-             data-ng-if="user.isEditorOrMore()"
-             data-ng-click="mdService.duplicate(md)">
-        <i class="fa fa-copy"></i>&nbsp;
-        <span data-translate="">duplicate</span>
-      </a></li>
-      <li><a data-ng-href=""
-             data-ng-if="user.isEditorOrMore()"
-             data-ng-click="mdService.createChild(md)">
-        <i class="fa fa-sitemap"></i>&nbsp;
-        <span data-translate="">createChild</span>
-      </a></li>
+      <li>
+        <a role="menuitem"
+           data-ng-href=""
+           data-ng-if="user.canEditRecord(md) &&
+             !md.isWorkflowEnabled()"
+           data-ng-click="mdService.startWorkflow(md, getCatScope())">
+          <i class="fa fa-bell"></i>&nbsp;
+          <span data-translate="">enableWorkflow</span>
+        </a>
+      </li>
+      <li role="menuitem" class="divider" data-ng-if="user.isConnected()"></li>
+      <li role="menuitem">
+        <a data-ng-href=""
+           data-ng-if="user.isEditorOrMore()"
+           data-ng-click="mdService.duplicate(md)">
+          <i class="fa fa-copy"></i>&nbsp;
+          <span data-translate="">duplicate</span>
+        </a>
+      </li>
+      <li role="menuitem">
+        <a data-ng-href=""
+           data-ng-if="user.isEditorOrMore()"
+           data-ng-click="mdService.createChild(md)">
+          <i class="fa fa-sitemap"></i>&nbsp;
+          <span data-translate="">createChild</span>
+        </a>
+      </li>
     </ul>
   </div>
   <div class="btn-group md-actions">
@@ -87,36 +99,47 @@
             title="{{'downloadRecord' | translate}}"
             class="btn btn-default dropdown-toggle"
             data-toggle="dropdown"
+            aria-label="{{'download' | translate}}"
             aria-expanded="false">
       <i class="fa fa-download"/>
       <span data-translate="" class="hidden-xs">download</span>
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">
-      <li><a data-ng-href=""
-             data-ng-click="mdService.getPermalink(md)">
-        <i class="fa fa-link"/>&nbsp;
-        <span data-translate="">permalink</span>
-      </a></li>
-      <li><a data-ng-href=""
-             data-ng-click="mdService.metadataMEF(md.getUuid())">
-        <i class="fa fa-file-zip-o"></i>&nbsp;
-        <span data-translate="">exportMEF</span>
-      </a></li>
-      <li><a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xsl-view?root=div&output=pdf"
-             target="_blank">
-        <i class="fa fa-file-pdf-o"></i>&nbsp;
-        <span data-translate="">exportPDF</span>
-      </a></li>
-      <li><a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xml?attachment=true">
-        <i class="fa fa-file-code-o"></i>&nbsp;
-        <span data-translate="">exportXML</span>
-      </a></li>
-      <li><a data-ng-href=""
-             data-ng-click="mdService.metadataRDF(md.getUuid())">
-        <i class="fa fa-share-alt"></i>&nbsp;
-        <span data-translate="">exportRDF</span>
-      </a></li>
+      <li>
+        <a data-ng-href=""
+           data-ng-click="mdService.getPermalink(md)">
+          <i class="fa fa-link"/>&nbsp;
+          <span data-translate="">permalink</span>
+        </a>
+      </li>
+      <li role="menuitem">
+        <a data-ng-href=""
+           data-ng-click="mdService.metadataMEF(md.getUuid())">
+          <i class="fa fa-file-zip-o"></i>&nbsp;
+          <span data-translate="">exportMEF</span>
+        </a>
+      </li>
+      <li role="menuitem">
+        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xsl-view?root=div&output=pdf"
+           target="_blank">
+          <i class="fa fa-file-pdf-o"></i>&nbsp;
+          <span data-translate="">exportPDF</span>
+        </a>
+      </li>
+      <li role="menuitem">
+        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xml?attachment=true">
+          <i class="fa fa-file-code-o"></i>&nbsp;
+          <span data-translate="">exportXML</span>
+        </a>
+      </li>
+      <li role="menuitem">
+        <a data-ng-href=""
+           data-ng-click="mdService.metadataRDF(md.getUuid())">
+          <i class="fa fa-share-alt"></i>&nbsp;
+          <span data-translate="">exportRDF</span>
+        </a>
+      </li>
     </ul>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -15,6 +15,9 @@
     section {
       margin-bottom: 20px;
     }
+    h2 {
+      font-size: 16px;
+    }
   }
   .view-header {
     border-bottom: 2px solid #e5e5e5;

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -42,6 +42,7 @@
     <div class="btn-group pull-right">
       <button type="button" class="btn btn-default dropdown-toggle"
               data-toggle="dropdown"
+              aria-label="{{'chooseAView' | translate}}"
               aria-expanded="false">
         <i class="fa fa-eye"></i>
         <span data-translate="" class="hidden-sm hidden-xs">chooseAView</span>
@@ -49,13 +50,14 @@
       </button>
       <ul class="dropdown-menu" role="menu">
         <!-- <li class="dropdown-header" data-translate="">chooseAView</li> -->
-        <li data-ng-class="currentFormatter == undefined ? 'disabled' : ''">
+        <li role="menuitem" data-ng-class="currentFormatter == undefined ? 'disabled' : ''">
           <a href="" data-ng-click="format()">
             <i class="fa fa-fw"></i>
             <span data-translate="">defaultView</span>
           </a>
         </li>
-        <li data-ng-repeat="f in formatter.list"
+        <li role="menuitem"
+            data-ng-repeat="f in formatter.list"
             data-ng-class="f === currentFormatter ? 'disabled' : ''">
           <a href="" data-ng-click="format(f)">
             <i class="fa fa-fw"></i>
@@ -73,7 +75,6 @@
        data-gn-click-and-spin="deleteRecord(mdView.current.record)"
        data-gn-confirm-click="{{'deleteRecordConfirm' | translate:mdView.current.record}}"
        title="{{'delete' | translate}}">
-
       <i class="fa fa-times"></i>
       <span data-translate="" class="hidden-sm hidden-xs">delete</span>
     </a>
@@ -98,7 +99,6 @@
         <h1>
           <i class="fa gn-icon-{{mdView.current.record.type[0]}}"/>
           {{mdView.current.record.title || mdView.current.record.defaultTitle}}
-
         </h1>
 
         <div class="alert alert-info"
@@ -393,10 +393,10 @@
 
       <div class="col-md-4 gn-md-side">
         <section class="gn-md-side-overview" data-ng-if="mdView.current.record.overviews.length > 0">
-          <h4>
+          <h2>
             <i class="fa fa-fw fa-image"></i>
             <span data-translate="">overview</span>
-          </h4>
+          </h2>
 
           <div data-ng-repeat="img in mdView.current.record.overviews">
             <img data-gn-img-modal="img"
@@ -431,10 +431,10 @@
         <div data-gn-md-feedback="mdView.current.record"></div>
 
         <section class="gn-md-side-extent" data-ng-if="mdView.current.record.geoBox.length > 0">
-          <h4>
+          <h2>
             <i class="fa fa-fw fa-map-marker"></i>
             <span data-translate="">extent</span>
-          </h4>
+          </h2>
           <p data-ng-if="mdView.current.record.geoDesc">
           <ul>
             <li data-ng-repeat="d in mdView.current.record.geoDesc">{{d}}</li>
@@ -443,6 +443,8 @@
           <!-- TODO: use map config -->
           <p data-ng-repeat="bbox in mdView.current.record.geoBox">
             <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
+                 alt="{{'extent' | translate}}"
+                 aria-label="{{'extent' | translate}}"
                  data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:3857&width=250&background=osm&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
           </p>
 
@@ -454,10 +456,10 @@
                              mdView.current.record.revisionDate ||
                              mdView.current.record.tempExtentBegin ||
                              mdView.current.record.tempExtentEnd">
-          <h4>
+          <h2>
             <i class="fa fa-fw fa-clock-o"></i>
             <span data-translate="">tempExtent</span>
-          </h4>
+          </h2>
 
           <p>
           <dl data-ng-show="mdView.current.record.creationDate.length > 0">
@@ -524,19 +526,20 @@
         </section></br>-->
 
         <section class="gn-md-side-providedby">
-          <h4>
+          <h2>
             <i class="fa fa-fw fa-cog"></i>
             <span data-translate="">sourceCatalog</span>
-          </h4>
+          </h2>
           <img ng-src="{{gnUrl}}../images/logos/{{mdView.current.record.source}}.png"
+               aria-label="{{'sourceCatalog' | translate}}"
                class="gn-source-logo"/>
         </section>
 
         <section class="gn-md-side-calendar">
-          <h4>
+          <h2>
             <i class="fa fa-fw fa-calendar"></i>
             <span data-translate="">updatedOn</span>
-          </h4>
+          </h2>
           <p>
             <span data-gn-humanize-time="{{mdView.current.record['geonet:info'].changeDate}}"
                   data-from-now=""></span>
@@ -544,10 +547,10 @@
         </section>
 
         <section class="gn-md-side-social">
-          <h4>
+          <h2>
             <i class="fa fa-fw fa-share-square-o"></i>
             <span data-translate="">shareOn</span>
-          </h4>
+          </h2>
           <a data-ng-href="https://twitter.com/share?url={{socialMediaLink | encodeURIComponent}}"
              title="{{'shareOnTwitter' | translate}}"
              target="_blank"
@@ -579,10 +582,10 @@
         </section>
 
         <section data-ng-show="isRatingEnabled" class="gn-md-side-rating">
-          <h4>
+          <h2>
             <i class="fa fa-fw"></i>
             <span data-translate="">rate</span>
-          </h4>
+          </h2>
           <div data-gn-metadata-rate="mdView.current.record"/>
         </section>
       </div>


### PR DESCRIPTION
Several changes have been made to follow more closely the Web Accessibility standards and guidelines.

This PR focusses on the detail/result page for a user who is not logged in. The colour scheme is not changed, so some colours still need more contrast.

Issues addressed in this PR for roles, labels and ARIA attributes:
- added role `menuitem` to dropdown menu items
- added `aria-label` to buttons
- headings in the right order (`<h3>` follows `<h2>` follows `<h1>`) 