### PR TITLE
Accessibility features and attributes for Login pages

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/new-account.html
+++ b/web-ui/src/main/resources/catalog/templates/new-account.html
@@ -1,7 +1,9 @@
-<div class="container" data-ng-controller="GnLoginController">
+<div class="container" data-ng-controller="GnLoginController" role="main">
   <div class="col-lg-6">
     <div class="panel panel-default">
-      <div class="panel-heading" data-translate="">needAnAccount</div>
+      <div class="panel-heading">
+        <h1 data-translate="">needAnAccount</h1>
+      </div>
       <div class="panel-body">
         <form class="form-horizontal" id="userinfo">
          <input type="hidden" name="_csrf" value="{{csrf}}"/>
@@ -9,6 +11,7 @@
             <label class="control-label col-lg-4" data-translate="">email</label>
             <div class="col-lg-8">
               <input type="email" name="email"
+                     aria-label="{{'email' | translate}}"
                      data-ng-model="userInfo.username"
                      autofocus="" class="form-control"/>
             </div>
@@ -18,6 +21,7 @@
             <label class="control-label col-lg-4" for="inputName" translate="">name</label>
             <div class="col-lg-8">
               <input type="text" class="form-control"
+                     aria-label="{{'name' | translate}}"
                      data-ng-model="userInfo.name"
                      id="inputName" name="name"/>
             </div>
@@ -27,6 +31,7 @@
             <label class="control-label col-lg-4" for="inputUsername" translate="">surname</label>
             <div class="col-lg-8">
               <input type="text" class="form-control"
+                     aria-label="{{'surname' | translate}}"
                      data-ng-model="userInfo.surname"
                      id="inputUsername" name="surname"/>
             </div>
@@ -36,6 +41,7 @@
             <label class="control-label col-lg-4" data-translate="">organisation</label>
             <div class="col-lg-8">
               <input type="text" name="org"
+                     aria-label="{{'organisation' | translate}}"
                      data-ng-model="userInfo.organisation"
                      class="form-control"/>
             </div>
@@ -50,6 +56,7 @@
               <label class="control-label col-lg-4" data-translate="">address</label>
               <div class="col-lg-8">
                 <input type="text" name="address"
+                       aria-label="{{'address' | translate}}"
                        data-ng-model="userInfo.address.address"
                        class="form-control"/>
               </div>
@@ -58,6 +65,7 @@
               <label class="control-label col-lg-4" data-translate="">zip</label>
               <div class="col-lg-8">
                 <input type="text" name="zip" class="form-control"
+                       aria-label="{{'zip' | translate}}"
                        data-ng-model="userInfo.address.zip"/>
               </div>
             </div>
@@ -65,6 +73,7 @@
               <label class="control-label col-lg-4" data-translate="">state</label>
               <div class="col-lg-8">
                 <input type="text" name="state" class="form-control"
+                       aria-label="{{'state' | translate}}"
                        data-ng-model="userInfo.address.state"/>
               </div>
             </div>
@@ -72,6 +81,7 @@
               <label class="control-label col-lg-4" data-translate="">city</label>
               <div class="col-lg-8">
                 <input type="text" name="city" class="form-control"
+                       aria-label="{{'city' | translate}}"
                        data-ng-model="userInfo.address.city"/>
               </div>
             </div>
@@ -80,7 +90,8 @@
                      data-ng-model="userInfo.address.country">country</label>
               <div class="col-lg-8">
                 <!-- TODO : Add country list -->
-                <input type="text" name="country" class="form-control"/>
+                <input type="text" name="country" class="form-control"
+                       aria-label="{{'country' | translate}}"/>
               </div>
             </div>
           </fieldset>
@@ -90,6 +101,7 @@
             <div class="col-lg-8">
               <select name="profile"
                       data-ng-model="userInfo.profile"
+                      aria-label="{{'requestedProfile' | translate}}"
                       class="form-control">
                 <option data-ng-repeat="p in profiles" value="{{p}}">{{p | translate}}</option>
               </select>

--- a/web-ui/src/main/resources/catalog/templates/new-password.html
+++ b/web-ui/src/main/resources/catalog/templates/new-password.html
@@ -1,7 +1,9 @@
-<div class="container" data-ng-controller="GnLoginController">
+<div class="container" data-ng-controller="GnLoginController" role="main">
   <div class="col-lg-6">
     <div class="panel panel-default">
-      <div class="panel-heading" data-translate="">updatePassword</div>
+      <div class="panel-heading">
+        <h1 data-translate="">updatePassword</h1>
+      </div>
       <div class="panel-body">
         <form class="form-horizontal" id="userinfo" name="gnUserEdit">
          <input type="hidden" name="_csrf" value="{{csrf}}"/>
@@ -12,7 +14,11 @@
           <div class="form-group">
             <label class="control-label col-lg-4" data-translate="">username</label>
             <div class="col-lg-8">
-              <input type="text" class="form-control" disabled="" data-ng-model="userToRemind"/>
+              <input type="text"
+                     class="form-control"
+                     disabled=""
+                     aria-label="{{'username' | translate}}"
+                     data-ng-model="userToRemind"/>
               <!-- Hidden field to be sent - the other one is disabled-->
               <input type="hidden" name="username" value="{{userToRemind}}"/>
             </div>
@@ -23,9 +29,15 @@
                data-ng-class="gnUserEdit.password.$valid != true ? 'has-error' : ''">
             <label class="control-label col-lg-4" data-translate="">password</label>
             <div class="col-lg-8">
-              <input type="password" id="gn-user-password" name="password"
-                     class="form-control" autocomplete="off" required="required"
-                     data-ng-minlength="6" data-ng-model="password"/>
+              <input type="password"
+                     id="gn-user-password"
+                     name="password"
+                     class="form-control"
+                     autocomplete="off"
+                     required="required"
+                     aria-label="{{'password' | translate}}"
+                     data-ng-minlength="6"
+                     data-ng-model="password"/>
             </div>
             <p class="help-block">
               <span class="error" ng-show="gnUserEdit.password.$error.minlength" data-translate=""
@@ -37,9 +49,12 @@
                         (passwordCheck !== password) ? 'has-error' : ''">
             <label class="control-label col-lg-4" data-translate="">passwordRepeat</label>
             <div class="col-lg-8">
-              <input type="password" id="gn-user-password2"
-                     name="password2" class="form-control"
+              <input type="password"
+                     id="gn-user-password2"
+                     name="password2"
+                     class="form-control"
                      autocomplete="off"
+                     aria-label="{{'passwordRepeat' | translate}}"
                      data-ng-model="passwordCheck"/>
             </div>
             <p class="help-block">

--- a/web-ui/src/main/resources/catalog/templates/signin.html
+++ b/web-ui/src/main/resources/catalog/templates/signin.html
@@ -1,4 +1,4 @@
-<div class="container" data-ng-controller="GnLoginController">
+<div class="container" data-ng-controller="GnLoginController" role="main">
   <div class="row">
     <div class="col-lg-12 col-md-12">
       <h1 data-translate="">loginTitle</h1>
@@ -99,6 +99,7 @@
                   <label class="control-label col-lg-3" data-translate="">username</label>
                   <div class="col-lg-8">
                     <input type="text" name="username" id="username"
+                           aria-label="{{'username' | translate}}"
                            data-ng-model="usernameToRemind"
                            data-ng-required="" class="form-control"/>
                   </div>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -100,7 +100,7 @@
     </ul>
 
 
-    <form class="navbar-form navbar-right" role="listbox">
+    <form class="navbar-form navbar-right">
       <div class="form-group"
            data-gn-language-switcher="lang"
            data-langs="langs"

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
@@ -2,3 +2,12 @@
 @import "gn_view.less";
 // variables for manipulating the theme
 @import "gn_variables_default.less"; // must be last
+
+.panel-default > .panel-heading {
+  h1 {
+    font-size: 14px;
+    padding: 0;
+    margin: 0;
+    font-weight: normal;
+  }
+}

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -86,6 +86,7 @@
             <!-- AngularJS application -->
             <xsl:if test="$angularApp != 'gn_search' and $angularApp != 'gn_viewer' and $angularApp != 'gn_formatter_viewer'">
               <div class="navbar navbar-default gn-top-bar"
+                   role="navigation"
                    data-ng-hide="layout.hideTopToolBar"
                    data-ng-include="'{$uiResourcesPath}templates/top-toolbar.html'"></div>
             </xsl:if>


### PR DESCRIPTION
Several changes have been made to follow more closely the Web Accessibility standards and guidelines.

This PR focusses on the **login** page, **new account** page, **reset password** page. The colour scheme is not changed, so some colours still need more contrast.

Issues addressed in this PR:
- added `aria-labels` for buttons and inputs
- main landmark added to each page
- add a main heading (`<h1>`)