### PR TITLE
Fix for too long keywords in the advanced search form (#2918)

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -123,6 +123,16 @@
 
     }
   }
+  .bootstrap-tagsinput {
+    .tag {
+      white-space: normal;
+      display: inline-flex;
+      text-align: left;
+      line-height: 1.5em;
+      // float: left;
+      margin-bottom: 3px;
+    }
+  }
 }
 
 .gn-row-filters {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -129,7 +129,7 @@
       display: inline-flex;
       text-align: left;
       line-height: 1.5em;
-      // float: left;
+      font-weight: normal;
       margin-bottom: 3px;
     }
   }


### PR DESCRIPTION
Fix for issue: https://github.com/geonetwork/core-geonetwork/issues/2918

Keywords were breaking out of the searchbox. Now long keywords are displayed on more than one line.

![gn34-long-keywords](https://user-images.githubusercontent.com/19608667/42220511-75a37e3a-7ecf-11e8-8de9-6280b29ebce7.png)
