### PR TITLE
Use database setting for the map in simple record view

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/region/GetMap.java
+++ b/services/src/main/java/org/fao/geonet/services/region/GetMap.java
@@ -299,10 +299,18 @@ public class GetMap {
 
         Exception error = null;
         if (background != null) {
-
-            if (background.equalsIgnoreCase(SETTING_BACKGROUND) &&
-                settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND).startsWith("http://")) {
-                background = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
+            // 4 cases:
+            // * request param is 'settings' and db setting is a full url
+            // * request param is 'settings' and db setting is a named bg layer
+            // * request param is a named bg layer
+            // * request param is a full url
+            if (background.equalsIgnoreCase(SETTING_BACKGROUND)) {
+                String bgSetting = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
+                if (bgSetting.startsWith("http://") || bgSetting.startsWith("https://")) {
+                    background = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
+                } else if (this.regionGetMapBackgroundLayers.containsKey(bgSetting)) {
+                    background = this.regionGetMapBackgroundLayers.get(bgSetting);
+                }
             } else if (this.regionGetMapBackgroundLayers.containsKey(background)) {
                 background = this.regionGetMapBackgroundLayers.get(background);
             }

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -444,7 +444,7 @@
             <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
                  alt="{{'extent' | translate}}"
                  aria-label="{{'extent' | translate}}"
-                 data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:3857&width=250&background=osm&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
+                 data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:3857&width=250&background=settings&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
           </p>
 
         </section>


### PR DESCRIPTION
Fixes #2281 

Previously the GetMap API would not accept a named layer in the database setting (although it accepted one when given in the URL param `background`).