### PR TITLE
Editor / Topic category / + should not be displayed #2940.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -627,7 +627,7 @@
   <!-- Ignore the following topic categories-->
   <xsl:template mode="mode-iso19139"
                 match="gmd:topicCategory[
-                        preceding-sibling::*[1]/name() = name()]"
+                        preceding-sibling::*[1]/name() = name()]|gn:child[@name = 'topicCategory']"
                 priority="2100"/>
 
 


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/2940