### PR TITLE
Geonames search when editing a record doesn't seem to be working. Fixes #2803

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -242,8 +242,8 @@
                           forEach(function(p) {
                             if (loc[p]) { props.push(loc[p]); }
                           });
-                      return loc.name + ((props.length == 0) ? '' :
-                          ' — <em>' + props.join(', ') + '</em>');
+                      return '<div>' + loc.name + ((props.length == 0) ? '' :
+                          ' — <em>' + props.join(', ') + '</em></div>');
                     }
                   }
 


### PR DESCRIPTION
When merged will cherry-pick to 3.4.x branch. Fixes #2803