### PR TITLE
Workflow / Fix invalid links in email.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -242,7 +242,7 @@ public class DefaultStatusActions implements StatusActions {
         }
         // Fallback on a default value if statusMetadataDetails not resolved
         if (statusMetadataDetails == null) {
-            statusMetadataDetails = "* {{index:title}} ({{serverurl}}/catalog.search#/metadata/{{index:_uuid}})";
+            statusMetadataDetails = "* {{index:title}} ({{serverurl}}catalog.search#/metadata/{{index:_uuid}})";
         }
 
         ArrayList<String> fields = new ArrayList<String>();

--- a/services/src/main/resources/org/fao/geonet/api/Messages.properties
+++ b/services/src/main/resources/org/fao/geonet/api/Messages.properties
@@ -96,8 +96,8 @@ Metadata records affected by this change are the following: \n\
 %s \n\
  \n\
 Records are available from the following URL: \n\
-%scatalog.search#/search?_status=%s&amp;_statusChangeDate=%s \n\
-status_email_change_details=* {{index:title}} ({{serverurl}}/search?uuid={{index:_uuid}})
+%scatalog.search#/search?_status=%s&_statusChangeDate=%s
+status_email_change_details=* {{index:title}} ({{serverurl}}catalog.search#/metadata/{{index:_uuid}})
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
 user_watchlist_subject=%s / %d updates in your watch list since %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:title}}</a></li>

--- a/services/src/main/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/services/src/main/resources/org/fao/geonet/api/Messages_fre.properties
@@ -84,8 +84,8 @@ Fiches mises à jour : \n\
 %s \n\
  \n\
 Consulter les fiches mises à jour : \n\
-%scatalog.search#/search?_status=%s&amp;_statusChangeDate=%s \n\
-status_email_change_details=* {{index:title}} ({{serverurl}}/search?uuid={{index:_uuid}})
+%scatalog.search#/search?_status=%s&_statusChangeDate=%s
+status_email_change_details=* {{index:title}} ({{serverurl}}catalog.search#/metadata/{{index:_uuid}})
 api.groups.group_not_found=Le groupe avec l'identifiant ''{0}'' n'a pas été trouvé dans le catalogue.
 user_watchlist_subject=%s / %d mises à jour dans vos fiches surveillées %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:title}}</a></li>


### PR DESCRIPTION
A number of links are invalid in emails sent when changing the status of a record
![image](https://user-images.githubusercontent.com/1701393/42532095-20e13cf4-8486-11e8-8770-913f254f3438.png)

Contains "//" and invalid content at the end.