### PR TITLE
Fixes for INSPIRE Atom remote feeds validation issues

### DIFF
--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -635,8 +635,17 @@ public class ServiceManager {
                         req.getOutputStream().write(Xml.getJSON(response).getBytes(Constants.ENCODING));
                         req.endStream();
                     } else {
-                        req.beginStream("application/xml; charset=UTF-8", cache);
-                        req.write(response);
+                        if (response.getAttribute("redirect") != null) {
+                            HttpServiceRequest req2 = (HttpServiceRequest) req;
+                            req2.getHttpServletResponse().setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+                            req2.getHttpServletResponse().setHeader("Location", response.getAttribute("url").getValue());
+                            req2.getHttpServletResponse().setHeader("Content-type", response.getAttribute("mime-type").getValue());
+
+                        } else {
+                            req.beginStream("application/xml; charset=UTF-8", cache);
+                            req.write(response);
+
+                        }
                     }
                 }
             }

--- a/web/src/main/webResources/WEB-INF/urlrewrite.xml
+++ b/web/src/main/webResources/WEB-INF/urlrewrite.xml
@@ -338,6 +338,22 @@
 
   <rule>
     <note>
+      INSPIRE Atom search (html)
+    </note>
+    <from>^/opensearch/(.*)/(.*)/searchhtml?(.*)$</from>
+    <to type="forward">/srv/$1/atom.search.html?fileIdentifier=$2</to>
+  </rule>
+
+  <rule>
+    <note>
+      INSPIRE Atom search (html)
+    </note>
+    <from>^/opensearch/(.*)/searchhtml?(.*)$</from>
+    <to type="forward">/srv/$1/atom.search.html</to>
+  </rule>
+
+  <rule>
+    <note>
       INSPIRE Atom search
     </note>
     <from>^/opensearch/(.*)/(.*)/search?(.*)$</from>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -888,6 +888,8 @@
                            access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.search!?.*"
                            access="permitAll"/>
+        <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.search.html!?.*"
+                           access="permitAll"/>
 
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.predefined.service!?.*" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/atom.predefined.dataset!?.*" access="permitAll"/>

--- a/web/src/main/webapp/WEB-INF/config/config-service-inspireatom.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-service-inspireatom.xml
@@ -41,8 +41,11 @@
     </service>
 
     <!-- Describe -->
-    <service name="atom.describe">
+    <service name="atom.describe" >
       <class name="org.fao.geonet.services.inspireatom.AtomDescribe"/>
+
+      <output sheet="../xslt/services/inspire-atom/describe.xsl"
+              contentType="application/atom+xml"/>
     </service>
 
     <!-- GetData -->
@@ -53,6 +56,13 @@
     <!-- Search -->
     <service name="atom.search">
       <class name="org.fao.geonet.services.inspireatom.AtomSearch"/>
+    </service>
+
+    <!-- Search html -->
+    <service name="atom.search.html">
+      <class name="org.fao.geonet.services.inspireatom.AtomSearch"/>
+
+      <output sheet="../xslt/services/inspire-atom/search-results.xsl" />
     </service>
   </services>
 </geonet>

--- a/web/src/main/webapp/xslt/services/inspire-atom/describe.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/describe.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
   ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
@@ -23,15 +22,14 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:gco="http://www.isotc211.org/2005/gco"
-                xmlns:gmd="http://www.isotc211.org/2005/gmd"
-                version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:atom="http://www.w3.org/2005/Atom"
+                xmlns:georss="http://www.georss.org/georss"
+                xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
+                xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
+                exclude-result-prefixes="#all" version="1.0">
 
-  <xsl:template match="gmd:MD_Metadata">
-    <identifier>
-      <xsl:value-of
-        select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:code/gco:CharacterString"/>
-    </identifier>
+  <xsl:template match="/root">
+    <xsl:copy-of select="atom:feed" />
   </xsl:template>
-
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearch.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearch.xsl
@@ -24,9 +24,23 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
   <xsl:template match="/">
-    <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
-      xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
-      xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0">
+    <OpenSearchDescription xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
+                           xmlns="http://a9.com/-/spec/opensearch/1.1/">
+
+
+      <xsl:variable name="baseUrl">
+        <xsl:choose>
+          <xsl:when test="//server/port = 80">
+            <xsl:value-of select="concat(//server/protocol,'://',//server/host)" />
+          </xsl:when>
+          <xsl:when test="//server/port = 443">
+            <xsl:value-of select="concat(//server/protocol,'://',//server/host)" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(//server/protocol,'://',//server/host,':',//server/port)" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
 
       <!--URL of this document-->
       <xsl:choose>
@@ -41,7 +55,7 @@
           <Url type="application/opensearchdescription+xml" rel="self">
             <xsl:attribute name="template">
               <xsl:value-of
-                select="concat(//server/protocol,'://',//server/host,':',//server/port,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/OpenSearchDescription.xml')"/>
+                select="concat($baseUrl,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/OpenSearchDescription.xml')"/>
             </xsl:attribute>
           </Url>
 
@@ -49,7 +63,7 @@
           <Url type="application/atom+xml" rel="results">
             <xsl:attribute name="template">
               <xsl:value-of
-                select="concat(//server/protocol,'://',//server/host,':',//server/port,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/describe')"/>
+                select="concat($baseUrl,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/describe')"/>
             </xsl:attribute>
           </Url>
 
@@ -57,16 +71,14 @@
           <Url type="application/xml" rel="results">
             <xsl:attribute name="template">
               <xsl:value-of
-                select="concat(//server/protocol,'://',//server/host,':',//server/port,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/search?any={filter}')"/>
+                select="concat($baseUrl,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/search?any={filter}')"/>
             </xsl:attribute>
           </Url>
 
-          <!--Describe Spatial Data Set Operation request URL template to be used
-              in order to retrieve the Description of Spatial Object Types in a Spatial
-              Dataset-->
-          <Url type="application/atom+xml" rel="describedby">
+          <Url type="text/html" rel="results">
             <xsl:attribute name="template">
-              <xsl:value-of select="concat(//server/protocol,'://',//server/host,':',//server/port,/root/gui/url,'/opensearch/', /root/gui/language, '/describe?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code}&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace}&amp;language={language}')"/>
+              <xsl:value-of
+                select="concat($baseUrl,/root/gui/url,'/opensearch/', /root/gui/language, '/', /root/response/fileId,'/searchhtml?any={filter}')"/>
             </xsl:attribute>
           </Url>
         </xsl:when>
@@ -85,11 +97,31 @@
           <Url type="application/xml" rel="results">
             <xsl:attribute name="template">
               <xsl:value-of
-                select="concat(//server/protocol,'://',//server/host,':',//server/port,/root/gui/url,'/opensearch/', /root/gui/language, '/search?any={filter}')"/>
+                select="concat($baseUrl,/root/gui/url,'/opensearch/', /root/gui/language, '/search?any={filter}')"/>
             </xsl:attribute>
           </Url>
         </xsl:otherwise>
       </xsl:choose>
+
+
+      <Url type="application/atom+xml" rel="describedby">
+        <xsl:attribute name="template">
+          <xsl:value-of
+            select="concat($baseUrl,/root/gui/url,'/opensearch/', /root/gui/language, '/describe?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code}', '&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace}', '&amp;language={language}')"/>
+        </xsl:attribute>
+      </Url>
+
+
+      <Url rel="results">
+        <xsl:attribute name="type">
+          <xsl:value-of select="/root/response/datasets/dataset[1]/file[1]/type"/>
+        </xsl:attribute>
+
+        <xsl:attribute name="template">
+          <xsl:value-of
+            select="concat($baseUrl,/root/gui/url,'/opensearch/', /root/gui/language, '/download?spatial_dataset_identifier_code={inspire_dls:spatial_dataset_identifier_code}', '&amp;spatial_dataset_identifier_namespace={inspire_dls:spatial_dataset_identifier_namespace}&amp;crs={inspire_dls:crs}', '&amp;language={language}')"/>
+        </xsl:attribute>
+      </Url>
 
       <!-- Repeat the following for each data set, for each CRS of a dataset query example (regardless of the number of file formats -->
       <xsl:for-each select="/root/response/datasets/dataset">

--- a/web/src/main/webapp/xslt/services/inspire-atom/search-results.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/search-results.xsl
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:atom="http://www.w3.org/2005/Atom"
+                xmlns:georss="http://www.georss.org/georss"
+                xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
+                xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
+                exclude-result-prefixes="#all" version="1.0">
+
+  <xsl:output omit-xml-declaration="yes" method="html" doctype-system="html" indent="yes"
+              encoding="UTF-8"/>
+
+  <!-- Catalog settings -->
+  <xsl:variable name="env" select="/root/gui/systemConfig"/>
+
+  <xsl:template match="/root">
+    <html>
+      <head>
+        <head>
+          <title>
+            <xsl:value-of select="concat($env/system/site/name, ' - ', $env/system/site/organization)"
+            />
+          </title>
+          <meta charset="utf-8"/>
+          <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
+          <meta name="apple-mobile-web-app-capable" content="yes"/>
+
+          <meta name="description" content=""/>
+          <meta name="keywords" content=""/>
+
+
+          <link rel="icon" sizes="16x16 32x32 48x48" type="image/png"
+                href="../../images/logos/favicon.png"/>
+          <link href="rss.search?sortBy=changeDate" rel="alternate" type="application/rss+xml"
+                title="{concat($env/system/site/name, ' - ', $env/system/site/organization)}"/>
+          <link href="portal.opensearch" rel="search" type="application/opensearchdescription+xml"
+                title="{concat($env/system/site/name, ' - ', $env/system/site/organization)}"/>
+
+          <style>
+            html {
+              font-family: sans-serif;
+              font-size: 0.9em;
+            }
+
+            div.feed {
+              border: 1px solid #000;
+              margin: 5px;
+              background-color: #ededed;
+            }
+
+            .feed-title {
+              font-weight: bold;
+            }
+
+            .column-title {
+              float: left;
+              width: 15%;
+              font-weight: bold;
+            }
+
+            .column-content {
+              float: left;
+              width: 85%;
+            }
+
+            .row {
+              padding: 5px;
+            }
+
+            /* Clear floats after the columns */
+            .row:after {
+              content: "";
+              display: table;
+              clear: both;
+            }
+          </style>
+        </head>
+
+
+      </head>
+      <body>
+        <h1><xsl:value-of select="/root/gui/strings/atom/results/header" /></h1>
+
+        <xsl:if test="count(feeds/atom:feed) = 0">
+          <p><xsl:value-of select="/root/gui/strings/atom/results/noresults" /></p>
+        </xsl:if>
+
+
+        <xsl:for-each select="feeds/atom:feed">
+          <div class="feed">
+            <div class="row">
+              <div class="column-title">
+                <span><xsl:value-of select="/root/gui/strings/atom/results/title" /></span>
+              </div>
+              <div class="column-content">
+                <span class="feed-title"><xsl:value-of select="atom:title" /></span>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="column-title">
+                <span><xsl:value-of select="/root/gui/strings/atom/results/content" /></span>
+              </div>
+              <div class="column-content">
+                <span><xsl:value-of select="atom:content" /></span>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="column-title">
+                <span><xsl:value-of select="/root/gui/strings/atom/results/id" /></span>
+              </div>
+              <div class="column-content">
+                <xsl:choose>
+                  <xsl:when test="starts-with(atom:id, 'http')">
+                    <a href="{atom:id}"><xsl:value-of select="atom:id" /></a>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <span><xsl:value-of select="atom:id" /></span>
+                  </xsl:otherwise>
+                </xsl:choose>
+               </div>
+            </div>
+
+            <div class="row">
+              <div class="column-title">
+                <span><xsl:value-of select="/root/gui/strings/atom/results/rights" /></span>
+              </div>
+              <div class="column-content">
+                <span><xsl:value-of select="atom:rights" /></span>
+              </div>
+            </div>
+
+            <xsl:if test="atom:link[@rel='describedby']">
+              <div class="row">
+                <div class="column-title">
+                  <span><xsl:value-of select="/root/gui/strings/atom/results/describedby" /></span>
+                </div>
+                <div class="column-content">
+                  <a href="{atom:link[@rel='describedby']/@href}"><xsl:value-of select="atom:link[@rel='describedby']/@href" /></a>
+                </div>
+              </div>
+            </xsl:if>
+
+            <div class="row">
+              <div class="column-title">
+                <span><xsl:value-of select="/root/gui/strings/atom/results/author" /></span>
+              </div>
+              <div class="column-content">
+                <span><xsl:value-of select="atom:author/atom:name" />
+                  <xsl:if test="atom:author/atom:email">
+                  - <a href="{atom:author/atom:email}"><xsl:value-of select="atom:author/atom:email" /></a>
+                  </xsl:if>
+                </span>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="column-title">
+                <span><xsl:value-of select="/root/gui/strings/atom/results/updated" /></span>
+              </div>
+              <div class="column-content">
+                <span><xsl:value-of select="atom:updated" /></span>
+              </div>
+            </div>
+          </div>
+        </xsl:for-each>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Fixes for INSPIRE ATOM remote feeds, related to validation issues (http://inspire-sandbox.jrc.ec.europa.eu/etf-webapp).

- Update OpenSearchDescription to add Query element for each dataset and remove default ports from urls.

- Add searchhtml endpoint to return feeds as html as required by the validator.

```
<Url type="text/html" rel="results" 
template="http://localhost:8080/geonetwork/opensearch/eng/
5cfe8a91-3dc9-4cf6-a40a-6a6d6f3124ab/searchhtml?any={filter}"/>
```

![searchhtml](https://user-images.githubusercontent.com/1695003/42563628-004e4b7a-84ff-11e8-9897-d4f94196e308.png)

- Use `application/atom+xml` content type for ATOM Describe service as required by the validator.

- Add support for `redirect` option in Jeeves, used in ATOM Download service.
