### PR TITLE
Fix for content that is overlapping the footer

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_footer_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_footer_default.less
@@ -36,6 +36,7 @@
   border-width: 1px 0 0 0;
   background: @gn-bottombar-background;
   border-color: @gn-bottombar-border-color;
+  z-index: 98;
   .gn-footer-text > span {
     color: @gn-bottombar-color !important;
   }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -41,6 +41,7 @@
   clear: both;
   flex-grow: 1;
   position: relative;
+  padding-bottom: calc(~"@{gn-bottombar-height} + 10px");  
   .badge {
       margin-right: 5px;
     }


### PR DESCRIPTION
Small fix for content that mixed/overlapped with the footer. The footer now has a z-index and the `.gn-search-page` now has a padding at the bottom so the content can be accessed and doesn't display behind the footer.

**Screenshot of the overlap:**
![gn-overlap-footer](https://user-images.githubusercontent.com/19608667/42565312-62c976cc-8503-11e8-8b02-f771ad7119fd.png)
