### PR TITLE
Fix for gfi result to pop over panels (#2917)

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -550,11 +550,14 @@
 gn-features-tables, .gn-viewer-info-pane {
   display          : block;
   position         : absolute;
-  bottom           : 1em;
+  bottom           : 0;
   left             : 1em;
-  right            : 3.8em;
-  background-color : rgba(255,255,255, .6);
-  border-radius    : 3px;
+  right            : 3.5em;
+  background-color:#fff;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  box-shadow: 0px 0px 4px 2px rgba(0, 0, 0, 0.1);
+  z-index: 95;
   .nav li a {
     background  : rgba(255, 255, 255, .5);
     text-shadow : 0 0 1px white;

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -15,6 +15,7 @@
     position: absolute;
     clip: rect(1px, 1px, 1px, 1px);
     right: 0;
+    z-index: 60;
   }
 
   fieldset legend {
@@ -128,8 +129,8 @@
   }
   .control-tools {
     top: auto;
-    bottom: 50px;
-    position: fixed;
+    bottom: 5px;
+    position: absolute;
   }
   & > .panel {
     background: rgba(255,255,255,.8);
@@ -556,8 +557,7 @@ gn-features-tables, .gn-viewer-info-pane {
   background-color:#fff;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
-  box-shadow: 0px 0px 4px 2px rgba(0, 0, 0, 0.1);
-  z-index: 95;
+  z-index: 55;
   .nav li a {
     background  : rgba(255, 255, 255, .5);
     text-shadow : 0 0 1px white;
@@ -572,6 +572,7 @@ gn-features-tables, .gn-viewer-info-pane {
   }
   .gn-features-table {
     padding          : .25em;
+    box-shadow: 0px 0px 4px 2px rgba(0, 0, 0, 0.1);
   }
   .layername {
     display        : inline-block;


### PR DESCRIPTION
Fix for issue: https://github.com/geonetwork/core-geonetwork/issues/2917

Changes in this PR:
- small position changes for the feature info popup
- no more opacity (accessibility)
- added box-shadow
- control tools are positioned absolute for the tooltips to display over the featureinfo

**Screenshot after the fix:**
![gn-featureinfo-pop-over](https://user-images.githubusercontent.com/19608667/42572121-411cf326-8519-11e8-858c-ab5ebd50145b.png)
