### PR TITLE
Build installer is broken. Fixes #2743 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "geoserver"]
-	path = geoserver
-	url = https://github.com/geonetwork/core-geoserver.git
-	ignore = dirty
 [submodule "e2e-tests/chromedriver"]
 	path = e2e-tests/chromedriver
 	url = https://github.com/geonetwork/chromedriver.git

--- a/installer/installer-config.xml
+++ b/installer/installer-config.xml
@@ -123,18 +123,6 @@
     </pack>
 
 
-    <pack id="geoserver" name="GeoServer" required="no" preselected="yes">
-      <description/>
-
-      <fileset dir="../geoserver/target/geoserver" targetdir="$INSTALL_PATH/web/geoserver"/>
-
-      <!-- Unzipping when container start takes a long time on windows.
-        <singlefile target="$INSTALL_PATH/web/geoserver.war" src="../geoserver/target/geoserver.war"
-        override="true"/>
-      -->
-    </pack>
-
-
     <pack id="inspire" name="European Union INSPIRE Directive configuration pack" required="no"
           preselected="no">
       <description/>

--- a/installer/packsLang.xml
+++ b/installer/packsLang.xml
@@ -28,10 +28,6 @@
        txt="The GeoNetwork opensource application. This is the Spatial Data Catalog web application."/>
   <str id="idSampleM" txt="Sample metadata"/>
   <str id="idSampleM.description" txt="Import sample metadata for testing"/>
-  <str id="geoserver" txt="GeoServer web map server"/>
-  <str id="geoserver.description" txt="GeoServer is an Open Source server that connects your information to the Geospatial Web. This embedded version is setup to provide the base layers
-for the map viewers in GeoNetwork. You can safely install this on modern computers, but be careful on older computers with little memory (less then 256MB RAM). To have a full resolution background layer, check the GeoNetwork site for
-instructions and download."/>
   <str id="csw" txt="CSW test client"/>
   <str id="csw.description"
        txt="The GeoNetwork opensource provides Catalog Services for the Web 2.0.1 support. This is a separate test application that can be used to test the CSW 2.0.1 services."/>

--- a/installer/packsLang.xml_fra
+++ b/installer/packsLang.xml_fra
@@ -4,8 +4,6 @@
     <str id="core.description" txt="L'application GeoNetwork. Ce module correspond au catalogue de données géospatiales."/>
     <str id="idSampleM" txt="Métadonnées exemples"/>
     <str id="idSampleM.description" txt="Import de métadonnées pour les tests."/>
-    <str id="geoserver" txt="Serveur cartographique GeoServer"/>
-    <str id="geoserver.description" txt="GeoServer un serveur cartographique Open Source permettant la publication des données géographiques sur le web. Cette version permet d'avoir les couches de bases utilisées par l'application InterMap dans GeoNetwork. L'installation n'est pas recommandée pour les anciennes machines (moins de 256MB RAM)."/>
     <str id="csw" txt="Client CSW de test"/>
     <str id="csw.description" txt="GeoNetwork opensource fourni une application pour tester le support de la norme OGC Catalog Services for the Web 2.0."/>
     <str id="src" txt="Code source"/>
@@ -13,4 +11,3 @@
     <str id="ibt" txt="Outils de création de l'installer"/>
     <str id="ibt.description" txt="Les fichiers requis pour la création d'un nouvelle installeur."/>
 </langpack>
-        

--- a/installer/packsLang.xml_spa
+++ b/installer/packsLang.xml_spa
@@ -4,12 +4,10 @@
     <str id="core.description" txt="La aplicación GeoNetwork. Este módulo contiene el catálogo de datos geoespaciales."/>
     <str id="idSampleM" txt="Metadatos de ejemplo"/>
     <str id="idSampleM.description" txt="Importación de metadatos de ejemplo para testear."/>
-    <str id="geoserver" txt="GeoServer (servidor de mapas)"/>
-    <str id="geoserver.description" txt="GeoServer es un servidor de mapas Open Source que permite la publicación de datos geográficos en la web. Esta versión está configurada para proveer las capas base para la aplicación InterMap (visor de mapas) en Geonetwork. No se recomienda la instalación en ordenadores antiguos (menos de 256MB RAM)."/>
     <str id="csw" txt="Cliente CSW"/>
     <str id="csw.description" txt="Aplicación independiente para testear servicios OGC CSW (Catalog Services for the Web) 2.0."/>
     <str id="src" txt="Código fuente"/>
     <str id="src.description" txt="El código fuente de GeoNetwork y los scripts de compilación."/>
     <str id="ibt" txt="Herramientas para generar el instalador"/>
     <str id="ibt.description" txt="Ficheros necesarios para generar una instalación de Geonetwork opensource."/>
-</langpack>        
+</langpack>


### PR DESCRIPTION
Removes the  GeoServer module.

GeoServer is no longer used in GeoNetwork 3.x+ (In 2.10.x was used to provide the base map layers). Users that require GeoServer can download it from the official [GeoServer](http://geoserver.org/) repository and install it.