### PR TITLE
The doc in the website looks to have moved to some new folder.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/needhelp/NeedHelpDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/needhelp/NeedHelpDirective.js
@@ -55,16 +55,11 @@
         link: function(scope, element, attrs) {
           scope.iconOnly = attrs.iconOnly === 'true';
           var helpBaseUrl = gnGlobalSettings.docUrl ||
-              'http://geonetwork-opensource.org/manuals/3.4.x/';
+              'https://geonetwork-opensource.org/manuals/3.4.x/';
 
           scope.showHelp = function() {
             var page = attrs.gnNeedHelp;
             var helpPageUrl = helpBaseUrl + gnGlobalSettings.lang + '/' + page;
-            // GeoNetwork website language folder are different
-            if (helpBaseUrl.indexOf('http://geonet') === 0) {
-              lang = gnGlobalSettings.lang == 'fr' ? 'fr' : 'en';
-              helpPageUrl = helpBaseUrl + lang + '/html/' + page;
-            }
             window.open(helpPageUrl, 'gn-documentation');
             return true;
           };


### PR DESCRIPTION
This fix the links to the doc available with the need help directive which currently return 404
