### PR TITLE
Small accessibility and UI changes to the list view of the search results

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -1,5 +1,5 @@
 <ul class="list-group gn-resultview">
-  <li class="list-group-item"
+  <li class="list-group-item gn-list"
       data-ng-repeat="md in searchResults.records"
       gn-displayextent-onhover=""
       gn-zoomto-onclick=""
@@ -7,16 +7,18 @@
     <div class="row">
       <div class="col-md-1">
         <!--Catalog or group Logo-->
-        <a class="pull-left" ng-if="md.groupWebsite" href="{{md.groupWebsite}}" target="_blank">
-          <img ng-src="../..{{md.logo}}"
-               alt="{{'siteLogo' | translate}}"
-               class="media-object"/>
-        </a>
-        <a class="pull-left" ng-if="!md.groupWebsite">
-          <img ng-src="../..{{md.logo}}"
-               alt="{{'siteLogo' | translate}}"
-               class="media-object"/>
-        </a>
+        <div class="gn-md-logo">
+          <a class="pull-left" ng-if="md.groupWebsite" href="{{md.groupWebsite}}" target="_blank">
+            <img ng-src="../..{{md.logo}}"
+                alt="{{'siteLogo' | translate}}"
+                class="media-object"/>
+          </a>
+          <a class="pull-left" ng-if="!md.groupWebsite">
+            <img ng-src="../..{{md.logo}}"
+                alt="{{'siteLogo' | translate}}"
+                class="media-object"/>
+          </a>
+        </div>
       </div>
       <div class="col-md-9">
         <div class="gn-md-title">
@@ -49,24 +51,27 @@
             </a>
           </div>
 
-          <h3 data-ng-click="openRecord($index, md, searchResults.records)">
+          <h1 data-ng-click="openRecord($index, md, searchResults.records)"
+          >
             <!-- Icon for types -->
             <a data-ng-href="#/metadata/{{md.getUuid()}}"
                title="{{md.title || md.defaultTitle}}">
               <i class="fa gn-icon-{{md.type[0]}}" title="{{md.type[0] | translate}}"/>
               {{md.title || md.defaultTitle}}</a>
-          </h3>
+          </h1>
         </div>
 
-        <p class="text-justify"
-           data-ng-click="openRecord($index, md, searchResults.records)"
-           dd-text-collapse dd-text-collapse-max-length="350"
-           dd-text-collapse-text="{{md.abstract || md.defaultAbstract}}"></p>
-        <blockquote ng-if="md.getContacts().resource">{{::md.getContacts().resource}}</blockquote>
+        <div class="gn-md-abstract">
+          <p class="text-justify"
+            data-ng-click="openRecord($index, md, searchResults.records)"
+            dd-text-collapse dd-text-collapse-max-length="350"
+            dd-text-collapse-text="{{md.abstract || md.defaultAbstract}}"></p>
+          <address ng-if="md.getContacts().resource">{{::md.getContacts().resource}}</address>
+        </div>
 
         <div class="row gn-md-links">
           <div class="btn-group" ng-if="::links.length > 0">
-            <button type="button" class="btn btn-success dropdown-toggle btn-xs" data-toggle="dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
               <span class="fa fa-link"></span>
               {{::links.length}}
               <ng-pluralize count="::links.length"
@@ -74,13 +79,13 @@
               <span class="caret"></span>
             </button>
             <ul class="dropdown-menu" role="menu">
-              <li ng-repeat="link in ::links">
+              <li ng-repeat="link in ::links" role="menuitem">
                 <a href="{{::link.url}}" target="_blank">{{::link.desc}}</a></li>
             </ul>
           </div>
 
           <div class="btn-group" ng-if="::downloads.length > 0">
-            <button type="button" class="btn btn-success dropdown-toggle btn-xs" data-toggle="dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
               <span class="fa fa-download"></span>
               {{::downloads.length}}
               <ng-pluralize count="::downloads.length"
@@ -88,7 +93,7 @@
               <span class="caret"></span>
             </button>
             <ul class="dropdown-menu" role="menu">
-              <li ng-repeat="link in ::downloads">
+              <li ng-repeat="link in ::downloads" role="menuitem">
                 <a href="{{::link.url}}" download="{{::link.desc}}">
                   <span class="fa fa-file-zip-o" ng-if="link.contentType=='application/zip'"></span>
                   {{link.desc || (link.name + ' - ' + link.contentType) }} </a></li>
@@ -96,7 +101,7 @@
           </div>
 
           <div class="btn-group" ng-if="layers.length > 0">
-            <button type="button" class="btn btn-success dropdown-toggle btn-xs" data-toggle="dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
               <span class="fa fa-globe"></span>
               {{::layers.length}}
               <ng-pluralize count="::layers.length"
@@ -104,38 +109,44 @@
               <span class="caret"></span>
             </button>
             <ul class="dropdown-menu" role="menu">
-              <li ng-repeat="layer in ::layers"><a href="" ng-click="addToMap(layer)">
-              <span class="fa fa-google"
-                    ng-if="layer.contentType=='application/vnd.google-earth.kml+xml'"></span>
+              <li ng-repeat="layer in ::layers" role="menuitem">
+                <a href="" ng-click="addToMap(layer)">
+                <span class="fa fa-google"
+                      ng-if="layer.contentType=='application/vnd.google-earth.kml+xml'"></span>
                 <span class="fa fa-globe"
                       ng-if="layer.contentType=='application/vnd.ogc.wms_xml'"></span>
-                {{::layer.desc}} </a></li>
-              <li class="divider"></li>
-              <li><a href="#">Add all layers</a></li>
+                {{::layer.desc}} </a>
+              </li>
+              <li class="divider" role="menuitem"></li>
+              <li role="menuitem">
+                <a href="#">Add all layers</a>
+              </li>
             </ul>
           </div>
 
           <!--Edit button-->
-          <a class="btn btn-xs btn-primary"
+          <a class="btn btn-xs btn-default"
              ng-href="catalog.edit#/metadata/{{md['geonet:info'].id}}">
             <i class="fa fa-pencil"></i>
+            <span data-translate="" class="sr-only">edit</span>
           </a>
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-md-2 clearfix">
         <!-- Thumbnail -->
         <div class="gn-md-thumbnail"
              data-ng-class="{'gn-md-no-thumbnail': !md.getThumbnails().list[0].url}">
           <img class="gn-img-thumbnail"
+               alt="{{md.title || md.defaultTitle}}"
                data-ng-src="{{md.getThumbnails().list[0].url}}"
                data-ng-if="md.getThumbnails().list[0].url"/>
 
-          <!-- Display the first metadata status (apply to ISO19139 record) -->
-          <div data-ng-if="md.status_text.length > 0"
-               title="{{md.status_text[0]}}"
-               class="gn-status gn-status-{{md.status[0]}}">{{md.status_text[0]}}
-          </div>
         </div>
+        <!-- Display the first metadata status (apply to ISO19139 record) -->
+        <div data-ng-if="md.status_text.length > 0"
+             title="{{md.status_text[0]}}"
+             class="gn-status gn-status-{{md.status[0]}}">{{md.status_text[0]}}
+       </div>
       </div>
     </div>
   </li>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -175,6 +175,96 @@ ul.gn-resultview {
       margin-left: 18px;
     }
   }
+  li.gn-list {
+    .gn-md-title {
+      h1 {
+        line-height: 1.3em;
+        font-size: 20px;
+        margin-top: 0;
+        padding-top: 5px;
+        a {
+          color: #333;
+          &:hover {
+            color: #000;
+          }
+          .fa {
+            display: inline;
+          }
+        }
+        .md-title {
+          display: block;
+          float: right;
+          width: calc(~"100% - 50px");
+        }
+      }
+    }
+    .gn-md-category {
+      a {
+        margin-left: 5px;
+      }
+    }
+    .gn-md-logo {
+      margin-top: 5px;
+    }
+    .gn-md-thumbnail {
+      border-radius: 0;
+      margin-top: 5px;
+    }
+    .gn-status {
+      position: relative;
+      border: 0;
+      padding: 0;
+      margin-top: 5px;
+      top: auto;
+      left: auto;
+      transform: none;
+      font-weight: 400;
+      font-size: 95%;
+      text-transform: uppercase;
+      float: left;
+      color: darken(@brand-info, 25%);
+    }
+    .gn-status-completed {
+      color: darken(@brand-success, 20%);
+    }
+    .gn-status-historicalArchive {
+      color: darken(@brand-warning, 20%);
+    }
+    .gn-status-obsolete {
+      color: darken(@brand-danger, 20%);
+    }
+    .gn-md-abstract {
+      p {
+        font-size: 1em;
+        color: @text-muted;
+        &:empty {
+          display: none;
+        }
+      }
+      address {
+        margin-bottom: 5px;
+      }
+      .collapse-text-toggle {
+        columns: @brand-primary;
+      }
+    }    
+    .gn-md-links {
+      background: 0;
+      margin-top: 10px;
+      border-bottom: 1px solid @list-group-border;
+      padding-bottom: 10px;
+      line-height: 1em;
+      .btn {
+        margin-right: 5px;
+        .caret {
+          margin-left: 3px;
+        }
+      }
+    }
+    &:hover {
+      background-color: rgba(240, 240, 240, 0.5)
+    }
+  }
 }
 
 /* Extra small devices (phones, less than 768px) */


### PR DESCRIPTION
Some (small) changes where made to the search result list view (not the default grid view). Color (contrast) changes for accessibility, and some whitespace is added to improve readability.

Screenshot of new list:
![gn-searchresults-list](https://user-images.githubusercontent.com/19608667/42941816-3b362630-8b5e-11e8-9161-6697e3c2bdb0.png)

Small changes to the list view of the search results:
- added whitespace between buttons and icons
- aligned elements to the top
- changed status style to meet accessibility standards
- uniform style for buttons