### PR TITLE
Accessibility changes for dropdowns on results page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/partials/sortByCombo.html
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/partials/sortByCombo.html
@@ -7,10 +7,11 @@
       <span data-translate=""
             data-translate-values="{field: '{{params.sortBy | translate}}'}"
             class="">sortedBy</span>
-      <i class="fa fa-sort"/>
+      <i class="fa fa-sort fa-fw"/>
     </button>
     <ul class="dropdown-menu" role="menu">
       <li data-ng-repeat="v in ::values"
+          role="menuitem"
           data-ng-class="v.sortBy === params.sortBy ? 'disabled' : ''">
         <a data-ng-click="sortBy(v)">{{v.sortBy | translate}}</a></li>
     </ul>

--- a/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
+++ b/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
@@ -35,6 +35,7 @@
             class="dropdown-header" data-translate="">hitsPerPage
         </li>
         <li data-ng-repeat="nb in values"
+            role="menuitem"
             data-ng-class="nb === config.hitsPerPage ? 'disabled' : ''">
           <a data-ng-click="updateSearch(nb)">{{nb}}</a>
         </li>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_pagination_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_pagination_default.less
@@ -35,3 +35,18 @@
     }
   }
 }
+
+.pagination > .disabled > span, .pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus, .pagination > .disabled > a,
+.pagination > .disabled > a:hover, .pagination > .disabled > a:focus {
+  border-color: @btn-default-border;
+}
+.pagination > li > a, .pagination > li > span {
+  border-color: @btn-default-border;
+  color: @btn-default-color;
+  &:hover {
+    background-color: #e6e6e6;
+    border-color: #adadad;
+    color: @btn-default-color;
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -32,11 +32,11 @@
   }
 }
 
-.gn-sort-by {
-  .btn-group > button {
-    .btn-link();
-  }
-}
+// .gn-sort-by {
+//   .btn-group > button {
+//     // .btn-link();
+//   }
+// }
 .gn-search-page {
   clear: both;
   flex-grow: 1;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -32,11 +32,6 @@
   }
 }
 
-// .gn-sort-by {
-//   .btn-group > button {
-//     // .btn-link();
-//   }
-// }
 .gn-search-page {
   clear: both;
   flex-grow: 1;


### PR DESCRIPTION
Several changes have been made to follow more closely the Web Accessibility standards and guidelines.

This PR focusses on accessibility changes for dropdowns for users that are not logged in. In addition to that some changes are made to get the same style and colors (also for accessibility) for the dropdowns on the results page.

**Screenshot of the same styles for the dropdowns:**
![gn-dropdowns](https://user-images.githubusercontent.com/19608667/42945551-f9d28ab6-8b68-11e8-9439-7aaeeb7dc71c.png)

**Screenshot of the old situation:**
![gn-dropdowns-old](https://user-images.githubusercontent.com/19608667/42945657-34653a3e-8b69-11e8-939d-270d048454a8.png)

Changes:
- added roles to dropdowns
- small color changes for pagination