### PR TITLE
ISO19139 / Parent identifier is not multilingual

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -268,6 +268,7 @@
       <name>gmd:metadataStandardName</name>
       <name>gmd:metadataStandardVersion</name>
       <name>gmd:hierarchyLevelName</name>
+      <name>gmd:parentIdentifier</name>
       <name>gmd:dataSetURI</name>
       <name>gmd:postalCode</name>
       <name>gmd:city</name>


### PR DESCRIPTION
Having a record with a parent identifier is encoded as multilingual string

```
   <gmd:fileIdentifier>
      <gco:CharacterString>290bb420-7ded-4195-9a54-8a9fc6e64670</gco:CharacterString>
   </gmd:fileIdentifier>
                               codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"/>
  </gmd:characterSet>
   <gmd:parentIdentifier xsi:type="gmd:PT_FreeText_PropertyType">
      <gco:CharacterString>04f28da2-ea7d-4ffc-b74a-ebb550748bf7</gco:CharacterString>
      <gmd:PT_FreeText>
         <gmd:textGroup>
            <gmd:LocalisedCharacterString locale="#FR">04f28da2-ea7d-4ffc-b74a-ebb550748bf7</gmd:LocalisedCharacterString>
         </gmd:textGroup>
      </gmd:PT_FreeText>
   </gmd:parentIdentifier>
```

Configure parent identifier to be excluded from multilingual fields.