### PR TITLE
Fix for Favicon doesn't work (#2992)

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -695,7 +695,7 @@ public class SiteApi {
                 if (asFavicon) {
                     ApiUtils.createFavicon(
                         source,
-                        dataDirectory.getResourcesDir().resolve("images").resolve("favicon.png"));
+                        dataDirectory.getResourcesDir().resolve("images").resolve("logos").resolve("favicon.png"));
                 } else {
                     Path logo = nodeLogoDirectory.resolve("logos").resolve(nodeUuid + ".png");
                     Path defaultLogo = nodeLogoDirectory.resolve("images").resolve("logo.png");


### PR DESCRIPTION
Fix for issue: https://github.com/geonetwork/core-geonetwork/issues/2992

Change the upload directory of the `favicon.png`. The favicon is now uploaded to the `images/logos` directory where the xslt expects it to be.
