### PR TITLE
Directory Editor / prevent locale from breaking bouding box generation in shared extents

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Locale;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -655,7 +656,7 @@ public final class XslUtil {
 
             final Envelope envelope = jts.getEnvelopeInternal();
             return
-                String.format("%f|%f|%f|%f",
+                String.format(Locale.US, "%f|%f|%f|%f",
                     envelope.getMinX(), envelope.getMinY(),
                     envelope.getMaxX(), envelope.getMaxY());
         } catch (Throwable e) {


### PR DESCRIPTION
Fixes a bug where shared extents (directory objects) were having an invalid bounding box generated from a bounding polygon depending on the current locale:

![image](https://user-images.githubusercontent.com/10629150/43194204-239074e2-9002-11e8-878d-1f1f1c43ad98.png)
