### PR TITLE
Small styling and usability changes for the maptools

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
@@ -8,23 +8,23 @@
        title="{{'loadMap' | translate}}">
       <div title="{{(md.abstract || md.defaultAbstract) | striptags}}"
            data-ng-click="loadMap(maps[0], md)">
+
+        <span class="gn-img-thumbnail-caption">
+          {{(md.title || md.defaultTitle) | characters:80}}
+        </span>
+        <a class=""
+           data-ng-href="#/metadata/{{md.getUuid()}}"
+           title="{{'openRecord' | translate}}">
+          <i class="fa fa-fw fa-info-circle"/>
+        </a>
+
         <div class="gn-md-thumbnail">
           <img class="gn-img-thumbnail"
                alt="{{md.title || md.defaultTitle}}"
                data-ng-src="{{md.getThumbnails().list[0].url}}"
                data-ng-if="md.getThumbnails().list[0].url"/>
         </div>
-        <div style="clear: both;"></div>
 
-        <span class="gn-img-thumbnail-caption">
-        {{(md.title || md.defaultTitle) | characters:80}}
-        </span>
-
-        <a class=""
-           data-ng-href="#/metadata/{{md.getUuid()}}"
-           title="{{'openRecord' | translate}}">
-          <i class="fa fa-fw fa-info-circle"/>
-        </a>
       </div>
     </a>
     <div style="clear: both;"></div>

--- a/web-ui/src/main/resources/catalog/components/viewer/legendpanel/partials/legendpanel.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/legendpanel/partials/legendpanel.html
@@ -12,4 +12,9 @@
       <em>{{layer.get('attribution')}}</em>
     </h6>
   </li>
+  <li data-ng-if="(layers | gnReverse | filter:layerFilterFn).length == 0"
+      class="list-group-item">
+    <span data-translate="">noLayersFound</span>
+  </li>
 </ul>
+

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
@@ -1,115 +1,95 @@
 <div class="context">
-  <fieldset>
-    <form class="form-horizontal"
-          role="grid"
-          data-ng-controller="gnsMapSearchController"
-          data-ng-search-form=""
-          data-runSearch="true">
-      <legend data-gn-slide-toggle="">
-        <span data-translate="">loadAMap</span>&nbsp;
-        <div class="btn btn-link"
-             data-ng-click="triggerSearch(); $event.stopPropagation();">
-          <i class="fa fa-refresh"/>
-        </div>
-      </legend>
-      <div>
+  <form class="form-horizontal clearfix"
+        role="grid"
+        data-ng-controller="gnsMapSearchController"
+        data-ng-search-form=""
+        data-runSearch="true">
 
-          <input type="hidden" name="_csrf" value="{{csrf}}"/>
+    <h4>
+      <span data-translate="">loadAMap</span>
+      <a class="btn btn-default btn-xs pull-right"
+         data-ng-click="triggerSearch(); $event.stopPropagation();">
+        <i class="fa fa-refresh"/>
+    </a>
+    </h4>
 
-          <ul class="list-group gn-resultview gn-resultview-sumup">
-            <li class="list-group-item gn-grid">
-              <div data-ng-click="reset()">
-                <div class="gn-md-thumbnail">
-                  <br/>
-                  <i class="fa fa-map fa-5x"></i>
-                  <br/>
-                  <span class="gn-img-thumbnail-caption"
-                        data-translate="">resetContext</span>
-                </div>
-              </div>
-            </li>
-            <li class="list-group-item gn-grid import">
-              <div>
-                <div class="gn-md-thumbnail">
-                  <br/>
-                  <i class="fa fa-upload fa-5x"></i>
-                  <br/>
-                  <span class="gn-img-thumbnail-caption"
-                        data-translate="">uploadContext</span>
-                </div>
-              </div>
-            </li>
-          </ul>
+    <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
+    <div class="btn-group" role="group">
+      <a class="btn btn-default"
+          data-ng-click="reset()">
+        <i class="fa fa-map-o"></i>&nbsp;
+        <span data-translate="">resetContext</span>
+      </a>
+      <a class="btn btn-default import">
+        <i class="fa fa-upload"></i>&nbsp;
+        <span data-translate="">uploadContext</span>
+      </a>
+    </div>
 
-          <div data-ng-show="searchResults.records.length > 0"
-               data-gn-results-container=""
-               data-search-results="searchResults"
-               data-template-url="resultTemplate"></div>
+    <div data-ng-show="searchResults.records.length > 0"
+         data-gn-results-container=""
+         data-search-results="searchResults"
+         data-template-url="resultTemplate"></div>
 
-          <div class="pull-right"
-               data-gn-pagination="paginationInfo"
-               data-hits-values="searchObj.hitsperpageValues"></div>
-      </div>
-    </fieldset>
+    <div data-ng-show="searchResults.records.length > 0"
+         class="text-center"
+         data-gn-pagination="paginationInfo"
+         data-hits-values="searchObj.hitsperpageValues"></div>
   </form>
 
-  <fieldset>
-    <legend data-gn-slide-toggle="" data-translate="">saveMap</legend>
-    <div>
-      <h4 data-translate="">downloadContext</h4>
-      <div class="btn-group" role="group">
-        <a class="btn btn-default"
-           data-ng-click="save($event)"
-           title="{{'downloadContext'|translate}}"
-           download="{{mapFileName}}.xml">
-          <i class="fa fa-file-code-o"></i>&nbsp;
-          <span data-translate="">saveMapAsContext</span>
-        </a>
-        <a class="btn btn-default"
-           data-ng-if="isExportMapAsImageEnabled"
-           data-ng-click="saveMapAsImage($event)"
-           download="{{mapFileName}}.png">
-          <i class="fa fa-file-image-o"></i>&nbsp;
-          <span data-translate="">saveMapAsImage</span>
-        </a>
-      </div>
+  <h4 data-translate="">downloadContext</h4>
+  <div class="btn-group" role="group">
+    <a class="btn btn-default"
+        data-ng-click="save($event)"
+        title="{{'downloadContext'|translate}}"
+        download="{{mapFileName}}.xml">
+      <i class="fa fa-file-code-o"></i>&nbsp;
+      <span data-translate="">saveMapAsContext</span>
+    </a>
+    <a class="btn btn-default"
+        data-ng-if="isExportMapAsImageEnabled"
+        data-ng-click="saveMapAsImage($event)"
+        download="{{mapFileName}}.png">
+      <i class="fa fa-file-image-o"></i>&nbsp;
+      <span data-translate="">saveMapAsImage</span>
+    </a>
+  </div>
 
-      <form data-ng-if="isSaveMapInCatalogAllowed && user.isEditorOrMore()">
-        <h4 data-translate="">saveMapInCatalog</h4>
+  <form data-ng-if="isSaveMapInCatalogAllowed && user.isEditorOrMore()">
+    <h4 data-translate="">saveMapInCatalog</h4>
 
-        <input type="hidden" name="_csrf" value="{{csrf}}"/>
-        <div class="form-group">
-          <label for="mapTitle"
-                 data-translate="">mapTitle</label>
-          <input type="text"
-                 class="form-control"
-                 name="mapTitle"
-                 data-ng-model="mapProps.title"
-                 data-ng-required=""
-                 id="mapTitle">
-        </div>
-        <div class="form-group">
-          <label for="mapAbstract"
-                 data-translate="">mapAbstract</label>
-          <textarea class="form-control"
-                    name="mapAbstract"
-                    data-ng-model="mapProps.recordAbstract"
-                    id="mapAbstract"></textarea>
-        </div>
-        <a class="btn btn-default btn-block"
-           data-gn-click-and-spin="saveInCatalog($event)"
-           title="{{'saveInCatalog'|translate}}">
-          <i class="fa fa-save"></i>&nbsp;
-          <span data-translate="">saveMapInCatalogAction</span>
-        </a>
-
-        <p data-ng-if="mapUuid != null"
-           data-translate=""
-           data-translate-values="{uuid: '{{mapUuid}}'}">mapSavedInCatalog</p>
-      </form>
+    <input type="hidden" name="_csrf" value="{{csrf}}"/>
+    <div class="form-group">
+      <label for="mapTitle"
+             data-translate="">mapTitle</label>
+      <input type="text"
+             class="form-control"
+             name="mapTitle"
+             data-ng-model="mapProps.title"
+             data-ng-required=""
+             id="mapTitle">
     </div>
-  </fieldset>
+    <div class="form-group">
+      <label for="mapAbstract"
+             data-translate="">mapAbstract</label>
+      <textarea class="form-control"
+                name="mapAbstract"
+                data-ng-model="mapProps.recordAbstract"
+                id="mapAbstract"></textarea>
+    </div>
+    <a class="btn btn-default btn-block"
+        data-gn-click-and-spin="saveInCatalog($event)"
+        title="{{'saveInCatalog'|translate}}">
+      <i class="fa fa-save"></i>&nbsp;
+      <span data-translate="">saveMapInCatalogAction</span>
+    </a>
+
+    <p data-ng-if="mapUuid != null"
+        data-translate=""
+        data-translate-values="{uuid: '{{mapUuid}}'}">mapSavedInCatalog</p>
+  </form>
+
 </div>
 
 <input class="hidden" type="file"

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -120,7 +120,7 @@
             graticule-ogc-service="graticuleOgcService"></button>
   </div>
 
-
+  <!-- Add layers -->
   <div class="panel panel-default panel-tools"
        ng-show="activeTools.addLayers">
     <div class="panel-heading">
@@ -175,6 +175,7 @@
     </div>
   </div>
 
+  <!-- Manage layers -->
   <div class="panel panel-default panel-tools"
        ng-show="activeTools.layers">
     <div class="panel-heading">
@@ -198,11 +199,21 @@
     </div>
   </div>
 
+  <!-- Legend -->
   <div class="panel panel-default panel-tools"
        ng-show="activeTools.legend">
+    <div class="panel-heading">
+      <h3>{{'mapLegend' | translate}}
+        <button type="button" class="btn btn-default close"
+                ng-model="activeTools.legend" gi-btn>
+          &times;
+        </button>
+      </h3>
+    </div>
     <div class="panel-carousel" gn-legend-panel="map"></div>
   </div>
 
+  <!-- Filter data -->
   <div class="panel panel-default panel-tools gn-data-filter-view"
        ng-show="activeTools.filter">
     <div class="panel-heading">
@@ -214,10 +225,12 @@
       </h3>
     </div>
     <div class="panel-body">
+      <p translate="" class="text-muted">filterDataDescription</p>
       <div data-gn-data-filter-view="map"/>
     </div>
   </div>
 
+  <!-- Maps -->
   <div class="panel panel-default panel-tools"
        ng-show="activeTools.contexts">
     <div class="panel-heading">
@@ -233,7 +246,6 @@
     </div>
   </div>
 
-
   <!--Measure Info Panel-->
   <div class="panel panel-default panel-tools"
        ng-show="mInteraction.active">
@@ -245,9 +257,9 @@
         </button>
       </h3>
     </div>
-    <div class="panel-body panel-sm">
+    <div class="panel-body">
       <div class="gn-measure-text">
-        <div class="alert alert-warning hidden-print" translate>measure_instruction</div>
+        <div class="text-muted hidden-print" translate>measure_instruction</div>
         <dl class="dl-horizontal">
           <dt>{{'Distance' | translate}}</dt>
           <dd>{{measureObj.distance | measure}}</dd>
@@ -257,7 +269,6 @@
       </div>
     </div>
   </div>
-
 
   <!--Draw Panel-->
   <div class="panel panel-default panel-tools"
@@ -276,7 +287,7 @@
     </div>
   </div>
 
-
+  <!-- Print -->
   <div class="panel panel-default panel-tools"
        ng-show="activeTools.print">
     <div class="panel-heading">
@@ -304,6 +315,7 @@
       </h3>
     </div>
     <div class="panel-body">
+      <p translate="" class="text-muted">WPSDescription</p>
       <tabset class="info-tabset">
         <tab heading="{{'wpsByUrl' | translate}}"
              active="wpsTabs.byUrl"

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -459,5 +459,7 @@
   "GUFrequired": "Required",
   "GUFtooLong": "Too long",
   "GUFnotValidFormat": "Not a valid format",
-  "clickToSelect": "Click to select or unselect"
+  "clickToSelect": "Click to select or unselect",
+  "filterDataDescription": "Select a layer on the map to begin filtering associated WFS features (if any). Features must first have been indexed by an administrator.",
+  "WPSDescription": "Enter a WPS endpoint URL to begin using the process through a dynamic form. Recently used WPS processes are shown in the second tab."
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -461,5 +461,6 @@
   "GUFnotValidFormat": "Not a valid format",
   "clickToSelect": "Click to select or unselect",
   "filterDataDescription": "Select a layer on the map to begin filtering associated WFS features (if any). Features must first have been indexed by an administrator.",
-  "WPSDescription": "Enter a WPS endpoint URL to begin using the process through a dynamic form. Recently used WPS processes are shown in the second tab."
+  "WPSDescription": "Enter a WPS endpoint URL to begin using the process through a dynamic form. Recently used WPS processes are shown in the second tab.",
+  "noLayersFound": "No layers found"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -632,11 +632,14 @@ gn-features-tables, .gn-viewer-info-pane {
   position         : absolute;
   bottom           : 0;
   left             : 1em;
-  right            : 3.5em;
+  right            : 4.5em;
   background-color:#fff;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
-  z-index: 55;
+  z-index: 85;
+  @media screen and (max-height: 768px) {
+    left: 4.5em;
+  }
   .nav li a {
     background  : rgba(255, 255, 255, .5);
     text-shadow : 0 0 1px white;

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -189,6 +189,7 @@
     overflow-y: auto;
     transition: opacity @transition-params;
     z-index: 80;
+    border-color: #ccc;
     .panel-heading {
       border-bottom: 0;
       h3 {
@@ -486,7 +487,7 @@
     }
     form {
       margin-top: 10px;
-      padding-bottom: 100px;
+      min-height: 17em;
       input[type='text'] {
         width: 146px;
       }

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -15,7 +15,6 @@
     position: absolute;
     clip: rect(1px, 1px, 1px, 1px);
     right: 0;
-    z-index: 60;
   }
 
   button:focus [role=tooltip],
@@ -38,6 +37,17 @@
       margin-left: 1.5em;
       margin-top: -7px;
       padding-top: 9px;
+    }
+  }
+  @media screen and (max-height: 768px) {
+    .control-tools {
+      button:focus [role=tooltip],
+      button:hover [role=tooltip] {
+        right: auto;
+        margin-left: 1.5em;
+        margin-top: -7px;
+        padding-top: 9px;
+      }
     }
   }
 
@@ -83,6 +93,7 @@
     top: @viewport-padding;
     left: @viewport-padding;
     width: 20em;
+    max-width: 75%;
     .dropdown-menu {
       width: 100%;
       top: ~"calc(100% - 3px)";
@@ -157,7 +168,11 @@
     top: auto;
     bottom: calc(~"50px + 1em");
     position: fixed;
+    @media screen and (max-height: 768px) {
+      left: @viewport-padding;
+    }
   }
+
   & > .panel {
     background: #fff;
   }
@@ -170,7 +185,7 @@
     border-radius: 0;
     min-height: 30em;
     max-height: ~"calc(100% - 2em)";
-    max-width: ~"calc(100% - 4em)";
+    max-width: ~"calc(100% - 4.5em)";
     overflow-y: auto;
     transition: opacity @transition-params;
     z-index: 80;
@@ -429,11 +444,15 @@
     .alert {
       margin-top: 1em;
     }
+    dl {
+      margin-top: 10px;
+    }
     dt {
-      width: 120px;
+      width: 100px;
+      text-align: left;
     }
     dd {
-      margin-left: 130px;
+      margin-left: 110px;
     }
   }
 

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -18,6 +18,29 @@
     z-index: 60;
   }
 
+  button:focus [role=tooltip],
+  button:hover [role=tooltip] {
+    clip: auto;
+    right: 3.5em;
+    background: @brand-success;
+    color: #fff;
+    padding: 8px 12px;
+    margin-top: -7px;
+    font-size: 12px;
+    border-radius: 0;
+    text-shadow: none;
+    z-index: 9000;
+  }
+  .search-container {
+    button:focus [role=tooltip],
+    button:hover [role=tooltip] {
+      right: auto;
+      margin-left: 1.5em;
+      margin-top: -7px;
+      padding-top: 9px;
+    }
+  }
+
   fieldset legend {
     margin-bottom: 2px;
   }
@@ -98,28 +121,31 @@
         color: #222;
       }
     }
+    .input-group-addon:first-child, .input-group-btn:last-child > .btn {
+      border-radius: 0;
+    }
   }
   .tools {
     position: absolute;
     top: @viewport-padding;
-    right: 0;
+    right: 1em;
     width: 2.8em;
+    border-top: 1px solid @btn-default-border;
+    z-index: 85;
     button, [role="button"] {
-      margin-bottom: .2em;
-      border-right-width: none;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      background: rgba(255,255,255,.8);
+      border-top: 0;
+      height: 2.8em;
+      border-radius: 0;
+      background: #f5f5f5;
       width: 2.8em;
       transition: background @transition-params;
       &.active {
-        width: 3.0em;
-        border-left: medium none;
+        border-left-color: #fff;
         border-radius: 0;
-        margin-left: -0.2em;
-        background: none repeat scroll 0 0 rgba(0, 0, 0, 0.7);
-        border-color: transparent;
-        color: #FFF;
+        box-shadow: none;
+        border-color: @btn-default-border;
+        border-left-color: #fff;
+        background: #fff;
       }
     }
 
@@ -129,24 +155,31 @@
   }
   .control-tools {
     top: auto;
-    bottom: 5px;
-    position: absolute;
+    bottom: calc(~"50px + 1em");
+    position: fixed;
   }
   & > .panel {
-    background: rgba(255,255,255,.8);
+    background: #fff;
   }
   .panel-tools {
     position: absolute;
     top: @viewport-padding;
-    right: 3em;
+    right: 3.8em;
     width: 26em;
-    min-height: 12.8em;
+    margin-right: -1px;
+    border-radius: 0;
+    min-height: 30em;
     max-height: ~"calc(100% - 2em)";
     max-width: ~"calc(100% - 4em)";
     overflow-y: auto;
     transition: opacity @transition-params;
-    h3 {
-      margin-top: 15px;
+    z-index: 80;
+    .panel-heading {
+      border-bottom: 0;
+      h3 {
+        margin-top: 15px;
+        font-size: 22px;
+      }
     }
     li[gn-layermanager-item] {
       .fa-arrows-alt,.gn-layer-ordering {
@@ -157,7 +190,6 @@
         padding: 0px;
         display: block;
         margin-bottom: 0px;
-
       }
     }
     .gn-layer-outofrange > label {
@@ -216,8 +248,14 @@
     }
     .unfold,
     .close {
-      margin-top: -.1em;
+      margin-top: -.4em;
       margin-right: .2em;
+      opacity: 1;
+      &:hover, &:active {
+        background: 0;
+        box-shadow: none;
+        color: @brand-danger;
+      }
     }
     .details {
       font-size: 90%;
@@ -258,8 +296,23 @@
       font-size: 13px;
     }
     label {
-      padding: 10px 0;
+      font-size: 90%;
       font-weight: normal;
+    }
+    .checkbox {
+      label {
+        font-size: 100%;
+      }
+    }
+    .panel-carousel {
+      .list-group-item {
+        border: 0;
+        padding-bottom: 0;
+        h5 {
+          margin: 0.3em 0;
+          line-height: 1.4;
+        }
+      }
     }
   }
 
@@ -395,6 +448,12 @@
   [gn-localisation-input] {
     .dropdown-menu {
       padding-bottom: 0;
+      border-radius: 0;
+      .list-group-item {
+        border-radius: 0;
+        border-left: 0;
+        border-right: 0;
+      }
     }
   }
   .gn-draw-styleform {
@@ -675,19 +734,33 @@ gn-geometry-tool .btn-group {
 
 [gn-ows-context] {
   ul.gn-resultview li.gn-grid {
-    width: 150px;
-    min-width: 150px;
+    min-width: calc(~"50% - 10px");
     max-height: 170px;
-    padding: 2px;
-    margin: 2px;
-    font-size: 80%;
-    text-align: center;
+    height: auto;
+    padding: 0px;
+    margin: 0px 4px 4px 0;
+    border-radius: 2px;
+    text-align: left;
+    .gn-img-thumbnail-caption {
+      display: inline-block;
+      padding: 3px 3px 3px 6px;
+      font-style: normal;
+      font-size: 100%;
+    }
+    a:hover {
+      .gn-img-thumbnail-caption {
+        text-decoration: none;
+      }
+    }
   }
-  .gn-md-thumbnail {
-    float:left;
-    width: 110px;
-    height: 110px;
-    margin: 2px !important;
+  .gn-resultview .gn-md-thumbnail {
+    border-radius: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0px !important;
+    .gn-img-thumbnail {
+      max-width: 100%;
+    }
   }
 }
 [data-gn-search-layer-for-map] {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -100,3 +100,7 @@ gn-wps-process-form {
     padding: 0px;
   }
 }
+// drag/zoom box for on the map
+.ol-dragzoom {
+  border: 2px solid @brand-primary;
+}


### PR DESCRIPTION
In this PR the map tools and panels on the map did get some small style changes. The tools and the panel now look more like tabbed panels.

The content of the panels now has a more uniform look, all panels have a title and close button, have whitespace around titles and buttons. The tooltips of controls on the left side of the map are now opening to the right

Extra text and explanation has been added to several panels.

**Screenshot of the restyled buttons and panels**
![gn-maptools-new](https://user-images.githubusercontent.com/19608667/43198076-9a52bf58-900d-11e8-99c9-63c6855b2e1f.png)

Some changes have been made to the positioning of the tools on smaller screens, the control tools are displayed on the left side of the map on smaller screens and the searchbox is not overlapping other tools anymore.

**Screenshot of the map on smaller screens**
![gn-maptools-small-screen](https://user-images.githubusercontent.com/19608667/43198124-d379478e-900d-11e8-8aac-a77d3e13bc87.png)

