### PR TITLE
Editor / fix bugs on bounding box & bounding polygon editor

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Locale;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -655,7 +656,7 @@ public final class XslUtil {
 
             final Envelope envelope = jts.getEnvelopeInternal();
             return
-                String.format("%f|%f|%f|%f",
+                String.format(Locale.US, "%f|%f|%f|%f",
                     envelope.getMinX(), envelope.getMinY(),
                     envelope.getMaxX(), envelope.getMaxY());
         } catch (Throwable e) {

--- a/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
@@ -226,19 +226,12 @@
              element.data('map', map);
 
              // initialize extent & bbox on map load
-             map.get('creationPromise').then(function() {
-               //map may not be displayed at this moment
-               //wait for it to be displayed
-               var unregister = scope.$watch('map.getSize()', function(){ 
-            	   if(map.getSize()) {
-            		   drawBbox();
-                       if (gnMap.isValidExtent(scope.extent.map)) {
-                         map.getView().fit(scope.extent.map, map.getSize());
-                         //stop watching this
-                         unregister();
-                       }
-            	   }
-            	});
+             map.get('sizePromise').then(function() {
+               drawBbox();
+
+               if (gnMap.isValidExtent(scope.extent.map)) {
+                 map.getView().fit(scope.extent.map, map.getSize());
+               }
              });
 
              var dragbox = new ol.interaction.DragBox({

--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -129,6 +129,7 @@
           }, function(size) {
             if (size > 0) {
               map.updateSize();
+              map.renderSync();
               defer.resolve();
               unWatchFn();
               unBindFn();

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -79,7 +79,7 @@
 
             // init map
             ctrl.map = gnMapsManager.createMap(gnMapsManager.EDITOR_MAP);
-            ctrl.map.get('creationPromise').then(function() {
+            ctrl.map.get('sizePromise').then(function() {
               ctrl.initValue();
             });
 


### PR DESCRIPTION
* Previously, automatic generation of bounding box from a bounding polygon might fail on certain system (depending on locale). This is now fixed. Typical error was coordinates with `,` instead of `.` as decimal separator, which resulted in this:

  ![image](https://user-images.githubusercontent.com/10629150/43198626-9ea77c54-900f-11e8-806c-b987ecce22cb.png)

* Bounding polygon map now initializes properly using the `sizePromise` available on maps created by the Maps Manager. I have taken the liberty to adapt the bounding box map too (though it had already been fixed in https://github.com/geonetwork/core-geonetwork/pull/2811/commits/459ea1aea0bdd0a6a0d7a41b171468df3f1de542 ). Should be cleaner & more consistent.

  This promise resolves when the map is created *and* is guaranteed to have a size.