### PR TITLE
Fix for small display does not have menu labels #2934

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -850,6 +850,16 @@ input.ng-invalid {
   margin: 8px 0px;
 }
 
+// styles for the username dropdown in the navbar
+.username-dropdown {
+  .dropdown-menu {
+    & > .active > a {
+      color: #333;
+      background-color: transparent;
+      font-weight: 500;
+    }
+  }
+}
 // styles for login popup in the navbar
 .signin-dropdown {
   .dropdown-menu {

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -15,12 +15,14 @@
   </div>
   <div id="navbar" class="navbar-collapse collapse">
     <ul class="nav navbar-nav">
-      <li data-ng-if="gnCfg.mods.home.enabled">
-        <a data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
-          <img class="gn-logo"
-               alt="{{'siteLogo' | translate}}"
-               data-ng-src="{{gnUrl}}../images/logos/{{info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
-          <span class="hidden-sm hidden-md gn-name" 
+      <li class="clearfix" data-ng-if="gnCfg.mods.home.enabled">
+          <a class="pull-left" data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
+            <img class="gn-logo"
+                  alt="{{'siteLogo' | translate}}"
+                  data-ng-src="{{gnUrl}}../images/logos/{{info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
+          </a>
+        <a class="gn-nopadding-left hidden-sm hidden-md pull-left" data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
+          <span class="gn-name" 
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
                 title="{{info['system/site/name']}}">{{info['system/site/name']}}</span>
         </a>
@@ -28,15 +30,15 @@
       <li data-ng-if="gnCfg.mods.search.enabled">
         <a data-gn-active-tb-item="{{gnCfg.mods.search.appUrl}}"
            title="{{'search' | translate}}">
-          <i class="fa fa-search"></i>
-          <span class="hidden-sm" data-translate="">search</span>
+          <i class="fa fa-fw fa-search hidden-sm"></i>
+          <span data-translate="">search</span>
         </a>
       </li>
       <li data-ng-if="gnCfg.mods.map.enabled">
         <a data-gn-active-tb-item="{{gnCfg.mods.map.externalViewer.baseUrl || gnCfg.mods.map.appUrl}}"
            title="{{'map' | translate}}">
-          <i class="fa fa-globe"></i>
-          <span class="hidden-sm" data-translate="">makeYourMap</span>
+          <i class="fa fa-fw fa-globe hidden-sm"></i>
+          <span data-translate="">makeYourMap</span>
 
           <span data-gnv-layer-indicator=""/>
         </a>
@@ -48,8 +50,8 @@
            title="{{'editorBoard' | translate}}"
            class="dropdown-toggle"
            role="button" aria-expanded="false">
-          <i class="fa fa-pencil"></i>
-          <span class="hidden-sm" data-translate="">contribute</span>
+          <i class="fa fa-fw fa-pencil hidden-sm"></i>
+          <span data-translate="">contribute</span>
         </a>
         <ul class="dropdown-menu" role="menu">
           <li>
@@ -79,8 +81,8 @@
            title="{{'adminConsole' | translate}}"
            class="dropdown-toggle"
            role="button" aria-expanded="false">
-          <i class="fa fa-wrench"></i>
-          <span class="hidden-sm" data-translate="">adminConsole</span>
+          <i class="fa fa-fw fa-wrench hidden-sm"></i>
+          <span data-translate="">adminConsole</span>
         </a>
         <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu" role="menu">
           <li data-ng-repeat="t in userAdminMenu">
@@ -108,7 +110,7 @@
     </form>
 
     <ul data-ng-if="gnCfg.mods.signin.enabled"
-        class="nav navbar-nav navbar-right">
+        class="nav navbar-nav navbar-right username-dropdown">
       <li class="dropdown dropdown-hover open" data-ng-show="authenticated">
         <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}"
           title="{{'userDetails' | translate}}"
@@ -116,9 +118,9 @@
           role="button" aria-expanded="false">
           <img class="img-circle"
             alt="{{'avatar' | translate}}"
-            data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=18"/>&nbsp;
-          <div class="gn-user-info">
-            {{user.name}} {{user.surname}}<br>
+            data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=18"/>
+          <div class="gn-user-info hidden-sm">
+            &nbsp;{{user.name}} {{user.surname}}<br>
             <span class="gn-user-role">{{user.profile | lowercase | translate}}</span>
           </div>
           <span class="alert alert-danger ng-hide"
@@ -130,9 +132,24 @@
           </span>
         </a>
         <ul class="dropdown-menu" role="menu">
+          <li class="text-center hidden-xs">
+            <img class="img-circle"
+                 alt="{{'avatar' | translate}}"
+                 data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=56"/>
+          </li>
+          <li role="separator" class="divider hidden-xs"></li>
+          <li class="dropdown-header hidden-xs" data-translate="">username</li>
+          <li class="hidden-xs">
+            <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}">{{user.name}} {{user.surname}}</a>
+          </li>
+          <li class="dropdown-header hidden-xs" data-translate="">profile</li>
+          <li class="hidden-xs">
+            <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}">{{user.profile | lowercase | translate}}</a>
+          </li>
+          <li role="separator" class="divider hidden-xs"></li>
           <li role="menuitem">
             <a href="{{gnCfg.mods.signout.appUrl}}"
-                title="{{'signout' | translate}}">
+               title="{{'signout' | translate}}">
               <i class="fa fa-sign-out"></i>&nbsp;
               {{'signout' | translate}}
             </a>
@@ -146,7 +163,7 @@
            class="dropdown-toggle"
            data-ng-keypress="$event"
            data-ng-mouseover="focusLoginPopup()">
-          <i class="fa fa-sign-in"/>&nbsp;
+          <i class="fa fa-sign-in hidden-sm"/>&nbsp;
           {{'signIn' | translate}}
         </a>
         <ul class="dropdown-menu" role="menu">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -10,6 +10,7 @@
   background-color: @gn-menubar-background;
   border-color: @gn-menubar-border-color;
   .navbar-nav > li > a, .navbar-nav > .open > a, .navbar-nav > .active > a {
+    height: @gn-menubar-height;
     color: @gn-menubar-color;
     &:hover, &:focus {
       color: @gn-menubar-color-hover;
@@ -21,5 +22,16 @@
       display: inline-block;
       .text-overflow();
     }
+  }
+  // also add `display:none`, this doesn't take whitespace on the navbar
+  .badge.invisible {
+    display: none
+  }
+
+}
+
+@media (max-width: @grid-float-breakpoint) {
+  .navbar-nav {
+    margin: 0;
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -10,7 +10,10 @@
 @gn-background-image: '';
 @gn-background-color: @body-bg;
 
+@dropdown-border: @navbar-default-border;
+
 // menu bar
+@gn-menubar-height: 50px;
 @gn-menubar-background: @navbar-default-bg;
 @gn-menubar-background-active: @navbar-default-link-active-bg;
 @gn-menubar-color: @navbar-default-link-color;

--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -9,7 +9,7 @@
     <span data-translate="">about</span></a>
   </li>
   <li class="hidden-sm"><a href="https://github.com/geonetwork/core-geonetwork">
-    <i class="fa fa-github"></i>
+    <i class="fa fa-fw fa-github"></i>
     <span data-translate="">github</span></a></li>
   <li>
     <a href="../../doc/api" title="{{'learnTheApi' | translate}}">API</a>


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/2934

Display the menubar with labels on small screens.

**Screenshot with labels and user/profile menu:**
![gn-labels-on-small-screen](https://user-images.githubusercontent.com/19608667/43258013-a7798eb8-90d1-11e8-879c-8fe9b3040058.png)

Changes made:
- hide icons
- added a user/profile submenu
- fix for height when logged in (caused by truncating long GN title)
- layer indicator doesn't need whitespace anymore
- added margin in footer on small screens
- added class `fa-fw` to icon on the navbar