### PR TITLE
Revert "Bug fix: Prefer to use capabilities url instead of hand-hard-coded URL."

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -883,7 +883,7 @@
                 }
               }
               
-              url = getCapLayer.url || url;
+              url = url || getCapLayer.url;
               if(getCapLayer.useProxy 
                   && url.indexOf(gnGlobalSettings.proxyUrl) != 0) {
                 url = gnGlobalSettings.proxyUrl + encodeURIComponent(url);


### PR DESCRIPTION
Reverts geonetwork/core-geonetwork#2846, this should be merged on develop first