### PR TITLE
Indexing / fix keyword grouping from same thesaurus

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -433,7 +433,7 @@
         <xsl:for-each-group select="//gmd:MD_Keywords[gmd:thesaurusName/*/gmd:title/*/text() != '']"
                             group-by="gmd:thesaurusName/*/gmd:title/*/text()">
           '<xsl:value-of select="replace(current-grouping-key(), '''', '\\''')"/>' :[
-          <xsl:for-each select="gmd:keyword/(gco:CharacterString|gmx:Anchor)">
+          <xsl:for-each select="current-group()/gmd:keyword/(gco:CharacterString|gmx:Anchor)">
             {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>,
             'link': '<xsl:value-of select="@xlink:href"/>'}
             <xsl:if test="position() != last()">,</xsl:if>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -368,7 +368,7 @@
                               group-by="gmd:thesaurusName/*/gmd:title/*/text()">
 
             '<xsl:value-of select="replace(current-grouping-key(), '''', '\\''')"/>' :[
-            <xsl:for-each select="gmd:keyword//gmd:LocalisedCharacterString[@locale = $langId and text() != '']">
+            <xsl:for-each select="current-group()/gmd:keyword//gmd:LocalisedCharacterString[@locale = $langId and text() != '']">
               {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>,
               'link': '<xsl:value-of select="@xlink:href"/>'}
               <xsl:if test="position() != last()">,</xsl:if>


### PR DESCRIPTION
This PR fixes the indexing behaviour when two keywords from the same thesaurus are described in two different `gmd:descriptiveKeywords` elements, ie:
```xml
<gmd:descriptiveKeywords>
  <gmd:MD_Keywords>
      <gmd:keyword>
        <gco:CharacterString>Keyword 1</gco:CharacterString>
      </gmd:keyword>
      <gmd:type>
        <gmd:MD_KeywordTypeCode codeListValue="theme"
                                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode"/>
      </gmd:type>
      <gmd:thesaurusName>
        <gmd:CI_Citation>
            <gmd:title>
              <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
            </gmd:title>
            <gmd:date>
              <gmd:CI_Date>
                  <gmd:date>
                    <gco:Date>2008-06-01</gco:Date>
                  </gmd:date>
                  <gmd:dateType>
                    <gmd:CI_DateTypeCode codeListValue="publication"
                                          codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"/>
                  </gmd:dateType>
              </gmd:CI_Date>
            </gmd:date>
        </gmd:CI_Citation>
      </gmd:thesaurusName>
  </gmd:MD_Keywords>
</gmd:descriptiveKeywords>
<gmd:descriptiveKeywords>
  <gmd:MD_Keywords>
      <gmd:keyword>
        <gco:CharacterString>Keyword 2</gco:CharacterString>
      </gmd:keyword>
      <gmd:type>
        <gmd:MD_KeywordTypeCode codeListValue="theme"
                                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode"/>
      </gmd:type>
      <gmd:thesaurusName>
        <gmd:CI_Citation>
            <gmd:title>
              <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
            </gmd:title>
            <gmd:date>
              <gmd:CI_Date>
                  <gmd:date>
                    <gco:Date>2008-06-01</gco:Date>
                  </gmd:date>
                  <gmd:dateType>
                    <gmd:CI_DateTypeCode codeListValue="publication"
                                          codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"/>
                  </gmd:dateType>
              </gmd:CI_Date>
            </gmd:date>
        </gmd:CI_Citation>
      </gmd:thesaurusName>
  </gmd:MD_Keywords>
</gmd:descriptiveKeywords>
```

Without this PR, only the first keyword would appear in the simple view (both would appear correctly in the complete view).