### PR TITLE
Formatter / fix edit link in formatter header

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/formatter-viewer.html
+++ b/web-ui/src/main/resources/catalog/templates/formatter-viewer.html
@@ -12,7 +12,7 @@
     </a>
     <a class="btn btn-primary gn-md-edit-btn pull-right"
        data-ng-show="user.canEditRecord(md)"
-       data-ng-href="catalog.edit#/metadata/{{mdId}}"
+       data-ng-href="catalog.edit#/metadata/{{md.getId()}}"
        title="{{'edit' | translate}}">
       <i class="fa fa-pencil"></i>
     </a>


### PR DESCRIPTION
Previously the edit button present at the top of a formatted record was sometimes not pointing to the right URL (ie when `mdId` was not defined in the scope).