### PR TITLE
Indexing / improve fallback logic with online resources in multilingual records

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -565,10 +565,8 @@
 
       <xsl:for-each select="gmd:transferOptions/gmd:MD_DigitalTransferOptions">
         <xsl:variable name="tPosition" select="position()"></xsl:variable>
-        <xsl:for-each select="gmd:onLine/gmd:CI_OnlineResource[
-        gmd:name/*/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId] or
-        gmd:description/*/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId]
-        ]">
+
+        <xsl:for-each select="gmd:onLine/gmd:CI_OnlineResource">
           <xsl:variable name="download_check"><xsl:text>&amp;fname=&amp;access</xsl:text></xsl:variable>
           <xsl:variable name="linkage" select="gmd:linkage/gmd:URL" />
           <xsl:variable name="title"


### PR DESCRIPTION
Currently, an online resource (aka *link*) will not be indexed if the name and desc are not translated in the current lang, although fallback values might be available in the default language.

I could not find any reason for this, and it caused some links to appear in certain languages but not others depending on which fields are translated or not.