### PR TITLE
Force use of v1.1.0 in wfs capabilities

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -248,7 +248,7 @@
             var defer = $q.defer();
             if (url) {
               url = mergeDefaultParams(url, {
-                REQUEST: 'GetCapabilities',
+                request: 'GetCapabilities',
                 service: 'WMTS'
               });
 
@@ -277,9 +277,9 @@
             var defer = $q.defer();
             if (url) {
               defaultVersion = '1.1.0';
-              version = version || defaultVersion;
-              url = mergeDefaultParams(url, {
-                REQUEST: 'GetCapabilities',
+              version = defaultVersion; //gn supports no other versions
+              url = mergeParams(url, {
+                request: 'GetCapabilities',
                 service: 'WFS',
                 version: version
               });

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -68,6 +68,7 @@
   "wfsCapabilitiesNotAvailable": "Couldn't check the GetCapabilities response",
   "wfsLayerNotAvailable": "The featuretype {{layerName}} is not available in the WFS service. However, you can view one of the available ones",
   "wfsChooseLayerToAdd": "Choose a featuretype to add to the map",
+  "Unable_to_connect_to_service": "Unable to connect to service",
   "wcsCapabilitiesNotAvailable": "Couldn't check the GetCapabilities response",
   "wcsLayerNotAvailable": "The coverage {{layerName}} is not available in the WCS service. However, you can view one of the available ones",
   "wcsChooseLayerToAdd": "Choose a coverage to add to the map",


### PR DESCRIPTION
force use of v1.1.0, because gn currently doesn't have v2 available

fixes scenario 1 and 3 in #3016