### PR TITLE
Access rights overview panel.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -678,6 +678,17 @@
       $scope.session = gnSessionService.getSession();
 
       $scope.loadCatalogInfo();
+
+
+      $scope.healthCheck = {};
+      function healthCheckStatus(data) {
+        angular.forEach(data, function(o) {
+          $scope.healthCheck[o.name] = (o.status === 'OK');
+        });
+      };
+      $http.get('../../warninghealthcheck')
+        .success(healthCheckStatus)
+        .error(healthCheckStatus);
     }]);
 
 })();

--- a/web-ui/src/main/resources/catalog/js/GnEditorModule.js
+++ b/web-ui/src/main/resources/catalog/js/GnEditorModule.js
@@ -26,6 +26,7 @@
 
   goog.require('gn_app_templates');
   goog.require('gn_batch_service');
+  goog.require('gn_access_manager');
   goog.require('gn_draggable_directive');
   goog.require('gn_editor_controller');
   goog.require('gn_geopublisher');
@@ -49,6 +50,7 @@
     'gn_ows',
     'gn_geopublisher',
     'gn_batch_service',
+    'gn_access_manager_controller',
     'gn_mdactions_directive',
     'ui.ace'
   ]);

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardController.js
@@ -92,23 +92,14 @@
             '5b407790-4fa1-11e7-a577-3197d1592a1d?embed=true&_g=()')
       }];
 
-      $scope.isDashboardAvailable = false;
-      function buildMenuBasedOnStatus(data) {
-        angular.forEach(data, function(o) {
-          if (o.name === 'DashboardAppHealthCheck' &&
-              o.status === 'OK') {
-            tabs = tabs.concat(dashboards);
-          }
-          $scope.pageMenu = {
-            folder: 'dashboard/',
-            defaultTab: 'status',
-            tabs: tabs
-          };
-        });
+      if ($scope.healthCheck.DashboardAppHealthCheck === true) {
+        tabs = tabs.concat(dashboards);
+      }
+      $scope.pageMenu = {
+        folder: 'dashboard/',
+        defaultTab: 'status',
+        tabs: tabs
       };
-      $http.get('../../warninghealthcheck')
-          .success(buildMenuBasedOnStatus)
-          .error(buildMenuBasedOnStatus);
 
       $http.get('../api/site/info').
           success(function(data) {

--- a/web-ui/src/main/resources/catalog/js/edit/AccessManagerController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/AccessManagerController.js
@@ -122,21 +122,21 @@
 
 
         var query = '{' +
-          '  "sort" : [{"resourceTitle.keyword": "asc"}],' +
-          '  "query": {' +
-          '    "bool": {' +
-          '      "must": [' +
-          (filter.length > 0 ? filter.join(',') : '{"match_all": {}}') +
-          '      ]' +
-          '    }' +
-          '  },' +
-          '  "from": 0,' +
-          '  "size": ' + $scope.size + ',' +
-          '  "_source": "resourceTitle", ' +
-          '  "script_fields": {' +
-          scriptFields.join(',') +
-          '  }' +
-          '}';
+            '  "sort" : [{"resourceTitle.keyword": "asc"}],' +
+            '  "query": {' +
+            '    "bool": {' +
+            '      "must": [' +
+            (filter.length > 0 ? filter.join(',') : '{"match_all": {}}') +
+            '      ]' +
+            '    }' +
+            '  },' +
+            '  "from": 0,' +
+            '  "size": ' + $scope.size + ',' +
+            '  "_source": ["resourceTitle", "uuid"], ' +
+            '  "script_fields": {' +
+            scriptFields.join(',') +
+            '  }' +
+            '}';
 
         $http.post('../../index/records/_search', query, {
           headers: {'Content-type': 'application/json'}

--- a/web-ui/src/main/resources/catalog/js/edit/AccessManagerController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/AccessManagerController.js
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 (function() {
   goog.provide('gn_access_manager');
 

--- a/web-ui/src/main/resources/catalog/js/edit/AccessManagerController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/AccessManagerController.js
@@ -70,6 +70,25 @@
         $scope.selectedGroups = [];
         $scope.columns = [];
 
+
+        var filter = [];
+        if ($scope.params.any != '') {
+          filter.push('{"match": {"resourceTitle": {' +
+            '"query": "' + $scope.params.any + '", ' +
+            '"zero_terms_query": "all", "fuzziness": "auto"}}}');
+        }
+        if ($scope.params.group != '') {
+          filter.push('{"term": {"groupPublished": "' + $scope.params.group + '"}}');
+          // Add the group filtered to the table column
+          for (var i = 0; i < $scope.groups.length; i++) {
+            if ($scope.groups[i].name === $scope.params.group) {
+              $scope.groups[i].selected = true;
+              break;
+            }
+          }
+        }
+
+
         for (var i = 0; i < $scope.operations.length; i++) {
           var o = $scope.operations[i];
           if (o.selected === true) {
@@ -102,31 +121,22 @@
         }
 
 
-        var filter = [];
-        if ($scope.params.any != '') {
-          filter.push('{"match": {"resourceTitle": {' +
-            '"query": "' + $scope.params.any + '", ' +
-            '"zero_terms_query": "all", "fuzziness": "auto"}}}');
-        }
-        if ($scope.params.group != '') {
-          filter.push('{"term": {"groupPublished": "' + $scope.params.group + '"}}');
-        }
         var query = '{' +
-            '  "sort" : [{"resourceTitle.keyword": "asc"}],' +
-            '  "query": {' +
-            '    "bool": {' +
-            '      "must": [' +
-            (filter.length > 0 ? filter.join(',') : '{"match_all": {}}') +
-            '      ]' +
-            '    }' +
-            '  },'
-            '  "from": 0,' +
-            '  "size": ' + $scope.size + ',' +
-            '  "_source": "resourceTitle", ' +
-            '  "script_fields": {' +
-            scriptFields.join(',') +
-            '  }' +
-            '}';
+          '  "sort" : [{"resourceTitle.keyword": "asc"}],' +
+          '  "query": {' +
+          '    "bool": {' +
+          '      "must": [' +
+          (filter.length > 0 ? filter.join(',') : '{"match_all": {}}') +
+          '      ]' +
+          '    }' +
+          '  },' +
+          '  "from": 0,' +
+          '  "size": ' + $scope.size + ',' +
+          '  "_source": "resourceTitle", ' +
+          '  "script_fields": {' +
+          scriptFields.join(',') +
+          '  }' +
+          '}';
 
         $http.post('../../index/records/_search', query, {
           headers: {'Content-type': 'application/json'}

--- a/web-ui/src/main/resources/catalog/js/edit/AccessManagerController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/AccessManagerController.js
@@ -67,6 +67,7 @@
       $scope.buildQuery = function() {
         var selectedOperations = [];
         var scriptFields = [];
+        $scope.results = undefined;
         $scope.selectedGroups = [];
         $scope.columns = [];
 
@@ -143,6 +144,9 @@
         }).
         then(function(r) {
           $scope.results = r.data;
+        }, function(r) {
+          // TODO report ES error message globally
+          $scope.hasSearchError = true;
         });
       };
 

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -183,6 +183,12 @@
             $location.path('/import');
           }
         }).add({
+          combo: 'r',
+          description: $translate.instant('hotkeyAccessManager'),
+          callback: function(event) {
+            $location.path('/accessManager');
+          }
+        }).add({
           combo: 'h',
           description: $translate.instant('hotkeyEditorBoard'),
           callback: function(event) {

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -95,6 +95,9 @@
           when('/batchedit', {
             templateUrl: tplFolder + 'batchedit.html',
             controller: 'GnBatchEditController'}).
+          when('/accessManager', {
+            templateUrl: tplFolder + 'accessManager.html',
+            controller: 'GnAccessManagerController'}).
           when('/board', {
             templateUrl: tplFolder + 'editorboard.html',
             controller: 'GnEditorBoardController'}).

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -374,5 +374,11 @@
     "hotkeyBatchEdit": "Batch editing",
     "hotkeyEditorBoard": "Editor board",
     "cancelMetadataError": "Error, please reload the page",
-    "showMessages": "Show messages:"
+    "showMessages": "Show messages:",
+    "hotkeyAccessManager": "Access rights manager",
+    "searchByTitle": "Filter by title",
+    "accessManager": "Access rights",
+    "accessManagerTitle": "Access rights by records",
+    "accessManagerChooseGroups": "Choose one or more groups",
+    "accessManagerChooseOperations": "Choose one or more operation types"
 }

--- a/web-ui/src/main/resources/catalog/templates/editor/accessManager.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/accessManager.html
@@ -60,8 +60,7 @@
             </div>
           </div>
 
-
-          <table class="table table-striped">
+          <table class="table table-striped" data-ng-if="results">
             <tr>
               <th></th>
               <th data-ng-repeat="g in selectedGroups"

--- a/web-ui/src/main/resources/catalog/templates/editor/accessManager.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/accessManager.html
@@ -1,0 +1,99 @@
+<div class="container" id="gn-access-manager-container">
+  <br/>
+  <br/>
+  <br/>
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <span data-translate="">accessManagerTitle</span>
+        </div>
+
+        <div class="panel-body" data-ng-controller="GnAccessManagerController">
+
+          <div class="row">
+            <div class="col-md-6">
+              <label class="control-label"
+                     data-translate>searchByTitle</label>
+              <input type="text"
+                     class="form-control"
+                     data-ng-model="params.any"
+                     placeholder="{{'anyPlaceHolder' | translate}}"
+                     aria-label="{{'anyPlaceHolder' | translate}}">
+
+              <br/>
+              <label class="control-label"
+                     data-translate>_groupPublished</label>
+              <select class="form-control" data-ng-model="params.group">
+                <option value=""></option>
+                <option data-ng-repeat="g in groups | orderBy:'name'"
+                        value="{{g.name}}">
+                  {{g.label[lang]|empty:g.name}}
+                </option>
+              </select>
+            </div>
+            <div class="col-md-6">
+              <h4 data-translate>accessManagerChooseGroups</h4>
+              <ul>
+                <li data-ng-repeat="g in groups">
+                  <label>
+                    <input type="checkbox"
+                           data-ng-model="g.selected"
+                           data-ng-change="buildQuery()"/>
+                    <span>{{g.label[lang]|empty:g.name}}</span>
+                  </label>
+                </li>
+              </ul>
+
+              <h4 data-translate>accessManagerChooseOperations</h4>
+              <ul>
+                <li data-ng-repeat="o in operations">
+                  <label>
+                    <input type="checkbox"
+                           data-ng-model="o.selected"
+                           data-ng-change="buildQuery()"/>
+                    <span>{{o.label[lang]|empty:o.name}}</span>
+                  </label>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+
+          <table class="table table-striped">
+            <tr>
+              <th></th>
+              <th data-ng-repeat="g in selectedGroups"
+                  colspan="{{nbOperations}}">
+                {{g.label[lang]|empty:g.name}}
+              </th>
+            </tr>
+            <tr>
+              <th>{{size > results.hits.total ? results.hits.total : size}}/{{results.hits.total}}&nbsp;<span data-translate>records</span></th>
+              <th data-ng-repeat="c in columns">
+                {{c.operation.label[lang]|empty:c.operation.name}}
+              </th>
+            </tr>
+            <tr data-ng-repeat="r in results.hits.hits">
+              <td>{{r._source.resourceTitle}}</td>
+              <td data-ng-repeat="c in columns"
+                  class="{{r.fields[c.fieldName][0] == false ? 'danger' : 'success'}}">
+                &nbsp;
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <button class="btn btn-link"
+                        data-ng-click="more()"
+                        data-ng-if="results.hits.total > size"
+                        data-translate>
+                  more
+                </button>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/templates/editor/accessManager.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/accessManager.html
@@ -18,6 +18,7 @@
               <input type="text"
                      class="form-control"
                      data-ng-model="params.any"
+                     data-ng-model-options="{debounce: 300}"
                      placeholder="{{'anyPlaceHolder' | translate}}"
                      aria-label="{{'anyPlaceHolder' | translate}}">
 
@@ -75,7 +76,7 @@
               </th>
             </tr>
             <tr data-ng-repeat="r in results.hits.hits">
-              <td>{{r._source.resourceTitle}}</td>
+              <td><a data-ng-href="catalog.search#/metadata/{{r._source.uuid}}">{{r._source.resourceTitle}}</a></td>
               <td data-ng-repeat="c in columns"
                   class="{{r.fields[c.fieldName][0] == false ? 'danger' : 'success'}}">
                 &nbsp;

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -65,6 +65,10 @@
                  ng-if="user.isEditorOrMore()">
                 <i class="fa fa-pencil"/>&nbsp;<span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
               </a>
+              <a href="#/accessManager" class="btn btn-default"
+                 ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
+                <i class="fa fa-lock"/>&nbsp;<span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
+              </a>
             </div>
           </div>
         </form>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -79,6 +79,11 @@
               <i class="fa fa-fw fa-pencil"></i>&nbsp;<span translate>batchEditing</span>
             </a>
           </li>
+          <li ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/accessManager">
+              <i class="fa fa-fw fa-lock"/>&nbsp;<span data-translate="">accessManager</span>
+            </a>
+          </li>
         </ul>
       </li>
       <li class="dropdown dropdown-hover open" data-ng-show="user.isUserAdminOrMore()">


### PR DESCRIPTION
This new panel only accessible by administrator user when ElasticSearch index is populated
provides an overview of privileges for a set of records.

This panel can be accessed from the editor board.
![image](https://user-images.githubusercontent.com/1701393/44567694-ecc1c680-a773-11e8-90f2-e698a3d0292d.png)


Records can be filtered by title and publication group.
User can choose which types of operation and groups to preview.


![image](https://user-images.githubusercontent.com/1701393/44567695-ef242080-a773-11e8-8d6c-497bfb413ee7.png)

This is using scripted fields in ES to create a field easily from a
simple expression; here, Is operation view available for group A?

This work is supported by Ifremer