### PR TITLE
Proxy / do not forwards STS header

### DIFF
--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -21,7 +21,12 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
      * parent
      */
     static {
-        String[] headers = new String[]{"X-XSRF-TOKEN", "Access-Control-Allow-Origin", "Vary", "Access-Control-Allow-Credentials"};
+        String[] headers = new String[]{
+                "X-XSRF-TOKEN",
+                "Access-Control-Allow-Origin",
+                "Vary",
+                "Access-Control-Allow-Credentials",
+                "Strict-Transport-Security"};
         for (String header : headers) {
             hopByHopHeaders.addHeader(new BasicHeader(header, null));
         }


### PR DESCRIPTION
Some sites use the [Strict-Transport-Security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) to add another layer of safety by preventing access to their data in unsecured HTTP altogether.
When transmitted by the proxy, this policy may wrongly apply to a Geonetwork catalog, which may in turn cause some general trouble (inaccessible resources, errors...).

This PR prevents the proxy from forwarding the STS header.