### PR TITLE
Toolbar / add explicit 'home' submenus

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/AdminController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminController.js
@@ -306,7 +306,17 @@
               }
             }
           }).
-          otherwise({templateUrl: tplFolder + 'admin.html'});
+          when('/home', {
+            templateUrl: tplFolder + 'admin.html',
+            resolve: {
+              permission: function() {
+                authorizationService.$get[0]().check('Administrator');
+              }
+            }
+          }).
+          otherwise({
+            redirectTo: '/home'
+          });
     }]);
 
   /**

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -397,5 +397,7 @@
     "siteLogo": "Logo",
     "languageSwitcher": "Language switcher",
     "avatar": "Avatar",
-    "first": "First"
+    "first": "First",
+    "editorHome": "Editor board",
+    "adminHome": "Summary"
 }

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -59,7 +59,7 @@
               </a>
               <a href="#/directory" class="btn btn-default"
                  ng-if="user.isEditorOrMore()">
-                <i class="fa fa-list-ul"/>&nbsp;<span class="hidden-xs hidden-sm hidden-md" data-translate="">directoryManager</span>
+                <i class="fa fa-bookmark"/>&nbsp;<span class="hidden-xs hidden-sm hidden-md" data-translate="">directoryManager</span>
               </a>
               <a href="#/batchedit" class="btn btn-default"
                  ng-if="user.isEditorOrMore()">

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -16,11 +16,11 @@
   <div id="navbar" class="navbar-collapse collapse">
     <ul class="nav navbar-nav">
       <li class="clearfix" data-ng-if="gnCfg.mods.home.enabled">
-          <a class="pull-left" data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
-            <img class="gn-logo"
-                  alt="{{'siteLogo' | translate}}"
-                  data-ng-src="{{gnUrl}}../images/logos/{{info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
-          </a>
+        <a class="pull-left" data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
+          <img class="gn-logo"
+                alt="{{'siteLogo' | translate}}"
+                data-ng-src="{{gnUrl}}../images/logos/{{info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
+        </a>
         <a class="gn-nopadding-left hidden-sm hidden-md pull-left" data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
           <span class="gn-name"
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
@@ -31,15 +31,14 @@
         <a data-gn-active-tb-item="{{gnCfg.mods.search.appUrl}}"
            title="{{'search' | translate}}">
           <i class="fa fa-fw fa-search hidden-sm"></i>
-          <span data-translate="">search</span>
+          <span translate>search</span>
         </a>
       </li>
       <li data-ng-if="gnCfg.mods.map.enabled">
         <a data-gn-active-tb-item="{{isExternalViewerEnabled ? externalViewerUrl : gnCfg.mods.map.appUrl}}"
            title="{{'map' | translate}}">
           <i class="fa fa-fw fa-globe hidden-sm"></i>
-          <span data-translate="">makeYourMap</span>
-
+          <span translate>makeYourMap</span>
           <span data-gnv-layer-indicator=""/>
         </a>
       </li>
@@ -51,33 +50,33 @@
            class="dropdown-toggle"
            role="button" aria-expanded="false">
           <i class="fa fa-fw fa-pencil hidden-sm"></i>
-          <span data-translate="">contribute</span>
+          <span translate>contribute</span>
         </a>
         <ul class="dropdown-menu" role="menu">
           <li>
             <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/board">
-              <i class="fa fa-fw fa-bars"/>&nbsp;<span data-translate="">editorHome</span>
+              <i class="fa fa-fw fa-bars"></i>&nbsp;<span translate>editorHome</span>
             </a>
           </li>
           <li role="separator" class="divider"></li>
           <li>
             <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/create">
-              <i class="fa fa-fw fa-plus"/>&nbsp;<span data-translate="">addRecord</span>
+              <i class="fa fa-fw fa-plus"></i>&nbsp;<span translate>addRecord</span>
             </a>
           </li>
           <li>
             <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/import">
-              <i class="fa fa-fw fa-upload"/>&nbsp;<span data-translate="">ImportRecord</span>
+              <i class="fa fa-fw fa-upload"></i>&nbsp;<span translate>ImportRecord</span>
             </a>
           </li>
           <li>
             <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/directory">
-              <i class="fa fa-fw fa-bookmark"/>&nbsp;<span data-translate="">directoryManager</span>
+              <i class="fa fa-fw fa-bookmark"></i>&nbsp;<span translate>directoryManager</span>
             </a>
           </li>
           <li>
             <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/batchedit">
-              <i class="fa fa-fw fa-pencil"/>&nbsp;<span data-translate="">batchEditing</span>
+              <i class="fa fa-fw fa-pencil"></i>&nbsp;<span translate>batchEditing</span>
             </a>
           </li>
         </ul>
@@ -88,31 +87,31 @@
            class="dropdown-toggle"
            role="button" aria-expanded="false">
           <i class="fa fa-fw fa-wrench hidden-sm"></i>
-          <span data-translate="">adminConsole</span>
+          <span translate>adminConsole</span>
         </a>
         <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu" role="menu">
           <li>
             <a data-gn-active-tb-item="admin.console#/home">
-              <i class="fa fa-fw fa-th"/>&nbsp;<span data-translate="">adminHome</span>
+              <i class="fa fa-fw fa-th"></i>&nbsp;<span translate>adminHome</span>
             </a>
           </li>
           <li role="separator" class="divider"></li>
           <li data-ng-repeat="t in userAdminMenu">
             <a data-gn-active-tb-item="admin.console{{t.route}}">
-              <i class="fa fa-fw {{t.icon}}"/>&nbsp;<span data-translate="">{{t.name | translate}}</span>
+              <i class="fa fa-fw {{t.icon}}"></i>&nbsp;<span translate>{{t.name | translate}}</span>
             </a>
           </li>
         </ul>
         <ul data-ng-if="user.isAdministrator()" class="dropdown-menu" role="menu">
           <li>
             <a data-gn-active-tb-item="admin.console#/home">
-              <i class="fa fa-fw fa-th"/>&nbsp;<span data-translate="">adminHome</span>
+              <i class="fa fa-fw fa-th"></i>&nbsp;<span translate>adminHome</span>
             </a>
           </li>
           <li role="separator" class="divider"></li>
           <li data-ng-repeat="t in adminMenu">
             <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}{{t.route}}">
-              <i class="fa fa-fw {{t.icon}}"/>&nbsp;<span data-translate="">{{t.name | translate}}</span>
+              <i class="fa fa-fw {{t.icon}}"></i>&nbsp;<span translate>{{t.name | translate}}</span>
             </a>
           </li>
         </ul>
@@ -124,7 +123,8 @@
       <div class="form-group"
            data-gn-language-switcher="lang"
            data-langs="langs"
-           data-lang-labels="langLabels"/>
+           data-lang-labels="langLabels">
+      </div>
     </form>
 
     <ul data-ng-if="gnCfg.mods.signin.enabled"
@@ -144,7 +144,7 @@
           <span class="alert alert-danger ng-hide"
                 data-ng-show="session.remainingTime > 0 &&
                     session.remainingTime < session.alertInTitleWhen"
-                data-translate=""
+                translate
                 data-translate-values="{remainingTime: '{{session.remainingTime}}'}">
             sessionWillExpireIn
           </span>
@@ -156,11 +156,11 @@
                  data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=56"/>
           </li>
           <li role="separator" class="divider hidden-xs"></li>
-          <li class="dropdown-header hidden-xs" data-translate="">username</li>
+          <li class="dropdown-header hidden-xs" translate>username</li>
           <li class="hidden-xs">
             <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}">{{user.name}} {{user.surname}}</a>
           </li>
-          <li class="dropdown-header hidden-xs" data-translate="">profile</li>
+          <li class="dropdown-header hidden-xs" translate>profile</li>
           <li class="hidden-xs">
             <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}">{{user.profile | lowercase | translate}}</a>
           </li>
@@ -181,7 +181,7 @@
            class="dropdown-toggle"
            data-ng-keypress="$event"
            data-ng-mouseover="focusLoginPopup()">
-          <i class="fa fa-sign-in hidden-sm"/>&nbsp;
+          <i class="fa fa-sign-in hidden-sm"></i>&nbsp;
           {{'signIn' | translate}}
         </a>
         <ul class="dropdown-menu" role="menu">
@@ -190,7 +190,7 @@
               action="{{signInFormAction}}" method="post" role="form">
               <input type="hidden" name="_csrf" value="{{csrf}}"/>
               <div class="form-group form-group-sm">
-                <label class="sr-only" for="inputUsername" data-translate="">username</label>
+                <label class="sr-only" for="inputUsername" translate>username</label>
                 <div class="input-group">
                   <span class="input-group-addon">
                     <i class="fa fa-user"></i>
@@ -202,7 +202,7 @@
               </div>
               <div class="flex-spacer"></div>
               <div class="form-group form-group-sm">
-                <label class="sr-only" for="inputPassword" data-translate="">password</label>
+                <label class="sr-only" for="inputPassword" translate>password</label>
                 <div class="input-group">
                   <span class="input-group-addon">
                     <i class="fa fa-lock"></i>
@@ -217,7 +217,7 @@
               <button type="submit" class="btn btn-primary btn-sm pull-right"
                       aria-label="{{'signIn' | translate}}"
                       data-ng-disabled="!gnSigninForm.$valid">
-                <i class="fa fa-sign-in"/>
+                <i class="fa fa-sign-in"></i>
               </button>
             </form>
           </li>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -55,6 +55,12 @@
         </a>
         <ul class="dropdown-menu" role="menu">
           <li>
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/board">
+              <i class="fa fa-fw fa-bars"/>&nbsp;<span data-translate="">editorHome</span>
+            </a>
+          </li>
+          <li role="separator" class="divider"></li>
+          <li>
             <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/create">
               <i class="fa fa-fw fa-plus"/>&nbsp;<span data-translate="">addRecord</span>
             </a>
@@ -66,7 +72,7 @@
           </li>
           <li>
             <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/directory">
-              <i class="fa fa-fw fa-list-ul"/>&nbsp;<span data-translate="">directoryManager</span>
+              <i class="fa fa-fw fa-bookmark"/>&nbsp;<span data-translate="">directoryManager</span>
             </a>
           </li>
           <li>
@@ -85,6 +91,12 @@
           <span data-translate="">adminConsole</span>
         </a>
         <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu" role="menu">
+          <li>
+            <a data-gn-active-tb-item="admin.console#/home">
+              <i class="fa fa-fw fa-th"/>&nbsp;<span data-translate="">adminHome</span>
+            </a>
+          </li>
+          <li role="separator" class="divider"></li>
           <li data-ng-repeat="t in userAdminMenu">
             <a data-gn-active-tb-item="admin.console{{t.route}}">
               <i class="fa fa-fw {{t.icon}}"/>&nbsp;<span data-translate="">{{t.name | translate}}</span>
@@ -92,6 +104,12 @@
           </li>
         </ul>
         <ul data-ng-if="user.isAdministrator()" class="dropdown-menu" role="menu">
+          <li>
+            <a data-gn-active-tb-item="admin.console#/home">
+              <i class="fa fa-fw fa-th"/>&nbsp;<span data-translate="">adminHome</span>
+            </a>
+          </li>
+          <li role="separator" class="divider"></li>
           <li data-ng-repeat="t in adminMenu">
             <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}{{t.route}}">
               <i class="fa fa-fw {{t.icon}}"/>&nbsp;<span data-translate="">{{t.name | translate}}</span>


### PR DESCRIPTION
The *Contribute* and *Admin console* dropdowns now have an explicit 'home' item:
![image](https://user-images.githubusercontent.com/10629150/44840358-234e8400-ac41-11e8-808e-7bd2a2f4259f.png) 
![image](https://user-images.githubusercontent.com/10629150/44840381-2f3a4600-ac41-11e8-91ad-6429e97df454.png)

Some users were having trouble finding the editor board UI for example, as they were expecting it to appear in the dropdown.

I've also changed the *Directory management* icon to make it more distinct.