### PR TITLE
Accessibility and styling changes to the scroll spy

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/scrollspy/ScrollSpyDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/scrollspy/ScrollSpyDirective.js
@@ -70,7 +70,7 @@
           scope.scrollTo = gnUtilityService.scrollTo;
           // Ordered list in an array of elements to spy
           scope.spyElems = [];
-          scope.isEnabled = true;
+          scope.isEnabled = false;
 
           var previousLabel = '';
           var registerSpy = function() {

--- a/web-ui/src/main/resources/catalog/components/common/scrollspy/partials/scrollspy.html
+++ b/web-ui/src/main/resources/catalog/components/common/scrollspy/partials/scrollspy.html
@@ -1,20 +1,34 @@
 <div class="visible-lg">
   <div class="btn-toolbar" role="toolbar">
     <!-- TODO: toggle icon when collapsed to fa-caret-square-o-up -->
-    <button class="btn btn-link fa fa-caret-square-o-down"
+    <button class="btn btn-primary btn-round fa fa-bars"
             data-ng-click="toggle()"
             title="{{'toggleScrollSpy' | translate}}"/>
-    <button class="btn btn-link fa fa-arrow-circle-up"
+    <button class="btn btn-primary btn-round fa fa-chevron-up"
             data-ng-click="scrollTo()"
             title="{{'scrollTop' | translate}}"/>
   </div>
   <ul class="nav nav-pills nav-stacked"
-      data-ng-class="isEnabled ? '' : 'hidden'">
-    <li data-ng-repeat="s in spyElems" data-ng-class="s.active ? 'active' : ''">
-      <a href="" data-ng-click="scrollTo(s.id)"> {{s.label}} </a>
-      <ul class="nav">
-        <li data-ng-repeat="ss in s.children" data-ng-class="ss.active ? 'active' : ''">
-          <a href="" data-ng-click="scrollTo(ss.id)">{{ss.label}}</a>
+      data-ng-class="isEnabled ? '' : 'hidden'"
+      role="menu">
+    <li data-ng-repeat="s in spyElems"
+        data-ng-class="s.active ? 'active' : ''"
+        role="menuitem">
+      <a href=""
+         aria-label="{{s.label}}"
+         data-ng-click="scrollTo(s.id)">
+        {{s.label}}
+      </a>
+      <ul class="nav"
+          role="menu">
+        <li data-ng-repeat="ss in s.children"
+            data-ng-class="ss.active ? 'active' : ''"
+            role="menuitem">
+          <a href=""
+             aria-label="{{ss.label}}"
+             data-ng-click="scrollTo(ss.id)">
+            {{ss.label}}
+          </a>
         </li>
       </ul>
     </li>

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -253,7 +253,9 @@ div.gn-scroll-spy {
       margin-top: 0;
       a {
         padding: 5px 15px;
-        color: #555;
+        color: @gray-dark;
+        font-size: 16px;
+        font-weight: bold;
         border-radius: 0;
         border-left: 3px solid transparent;
       }
@@ -261,6 +263,8 @@ div.gn-scroll-spy {
         li {
           a {
             padding: 5px 25px;
+            font-size: 14px;
+            font-weight: normal;
           }
         }
         li.active > a {
@@ -270,8 +274,8 @@ div.gn-scroll-spy {
     }
     li.active > a {
       font-weight: bold;
-      color: #333; // @brand-primary;
-      border-left-color: #555;
+      color: @gray-darker;
+      border-left-color: @gray-dark;
       background-color: @navbar-default-brand-hover-bg;
     }
   }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -226,48 +226,52 @@ a {
 
 div.gn-scroll-spy {
   position: fixed;
-  bottom: 0%;
+  bottom: 0px;
   right: 0px;
-  opacity: 0.8;
-  font-size: 80%;
-  width: 150px;
+  width: 350px;
   z-index: 999;
-  max-height: 99vh;
   overflow: auto;
   background-color: @panel-bg;
-  border-top-left-radius: @panel-border-radius;
-  border-top: 1px solid @panel-default-border;
   border-left: 1px solid @panel-default-border;
-
-  button {
-    .pull-right();
+  .btn-toolbar {
+    position: fixed;
+    bottom: 10px;
+    right: 10px;
+    button {
+      .pull-right();
+      &:hover {
+        color: @btn-primary-color;
+      }
+    }
+  }
+  ul.nav-pills {
+    height: 100vh;
+    padding-top: 10px;
   }
   ul {
-    opacity: 1;
     li {
+      margin-top: 0;
       a {
-      padding-left: 5px;
-      padding-right: 5px;
-      padding-top: 1px;
-      padding-bottom: 1px;
+        padding: 5px 15px;
+        color: #555;
+        border-radius: 0;
+        border-left: 3px solid transparent;
       }
       ul {
         li {
           a {
-            padding-top: 1px;
-            padding-bottom: 1px;
-            padding-left: 15px;
-            font-size: 90%;
+            padding: 5px 25px;
           }
         }
         li.active > a {
-            font-weight: bold;
+          font-weight: bold;
         }
       }
     }
     li.active > a {
       font-weight: bold;
-      color: @brand-primary;
+      color: #333; // @brand-primary;
+      border-left-color: #555;
       background-color: @navbar-default-brand-hover-bg;
     }
   }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -16,6 +16,6 @@
 }
 .btn-round {
   border-radius: 50%;
-  padding: 11px 16px;
+  padding: 11px 15px;
 }
 


### PR DESCRIPTION
Several changes have been made to follow more closely the Web Accessibility standards and guidelines.

This PR focusses on the scroll spy for the editor and settings for logged in users.

Changes made:
- full height
- more color contrast
- added aria-labels
- larger font
- scrollspy is closed by default
- changed the icons in more commenly used icons
- open and scroll buttons are larger and rounded

**Screenshot of new scrollspy - larger buttons, larger headers and full height:**

![gn-scrollspy-better-headers](https://user-images.githubusercontent.com/19608667/46406626-6e5e2a00-c70c-11e8-8a55-e3e2ee407c82.png)

