### PR TITLE
Uniform look for Login, Register and Password pages

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -49,6 +49,7 @@
     "viewSelectionOnly": "Selection only",
     "add": "Add",
     "address": "Address",
+    "personal": "Personal",
     "gnToggle": "Show/hide sections",
     "cookieWarning": "This webpage uses cookies. If you continue navigating this page, we will assume you accept this.",
     "moreOnCookie": "Want to know more about this message ?",

--- a/web-ui/src/main/resources/catalog/templates/new-account.html
+++ b/web-ui/src/main/resources/catalog/templates/new-account.html
@@ -1,104 +1,46 @@
 <div class="container" data-ng-controller="GnLoginController" role="main">
-  <div class="col-lg-6">
+  <div class="col-lg-6 col-md-6 col-md-offset-3 col-lg-offset-3">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h1 data-translate="">needAnAccount</h1>
+        <h1 data-translate="">createAnAccount</h1>
       </div>
       <div class="panel-body">
-        <form class="form-horizontal" id="userinfo">
-         <input type="hidden" name="_csrf" value="{{csrf}}"/>
-          <div class="form-group">
-            <label class="control-label col-lg-4" data-translate="">email</label>
-            <div class="col-lg-8">
+        <p data-translate="">newAccountInfo</p>
+        <form class="form-horizontal clearfix" id="userinfo">
+          <input type="hidden" name="_csrf" value="{{csrf}}"/>
+
+          <fieldset class="pull-left">
+            <legend data-translate="">personal</legend>
+            <div class="form-group">
+              <label for="inputName" translate="">name</label>
+              <input type="text" class="form-control"
+                      aria-label="{{'name' | translate}}"
+                      data-ng-model="userInfo.name"
+                      id="inputName" name="name"/>
+            </div>
+            <div class="form-group">
+              <label for="inputUsername" translate="">surname</label>
+              <input type="text" class="form-control"
+                      aria-label="{{'surname' | translate}}"
+                      data-ng-model="userInfo.surname"
+                      id="inputUsername" name="surname"/>
+            </div>
+            <div class="form-group">
+              <label data-translate="">email</label>
               <input type="email" name="email"
-                     aria-label="{{'email' | translate}}"
-                     data-ng-model="userInfo.username"
-                     autofocus="" class="form-control"/>
+                      aria-label="{{'email' | translate}}"
+                      data-ng-model="userInfo.username"
+                      autofocus="" class="form-control"/>
             </div>
-          </div>
-
-          <div class="form-group">
-            <label class="control-label col-lg-4" for="inputName" translate="">name</label>
-            <div class="col-lg-8">
-              <input type="text" class="form-control"
-                     aria-label="{{'name' | translate}}"
-                     data-ng-model="userInfo.name"
-                     id="inputName" name="name"/>
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label class="control-label col-lg-4" for="inputUsername" translate="">surname</label>
-            <div class="col-lg-8">
-              <input type="text" class="form-control"
-                     aria-label="{{'surname' | translate}}"
-                     data-ng-model="userInfo.surname"
-                     id="inputUsername" name="surname"/>
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label class="control-label col-lg-4" data-translate="">organisation</label>
-            <div class="col-lg-8">
+            <div class="form-group">
+              <label data-translate="">organisation</label>
               <input type="text" name="org"
-                     aria-label="{{'organisation' | translate}}"
-                     data-ng-model="userInfo.organisation"
-                     class="form-control"/>
-            </div>
-          </div>
-
-
-          <fieldset>
-            <legend data-translate="">address</legend>
-
-
-            <div class="form-group">
-              <label class="control-label col-lg-4" data-translate="">address</label>
-              <div class="col-lg-8">
-                <input type="text" name="address"
-                       aria-label="{{'address' | translate}}"
-                       data-ng-model="userInfo.address.address"
-                       class="form-control"/>
-              </div>
+                      aria-label="{{'organisation' | translate}}"
+                      data-ng-model="userInfo.organisation"
+                      class="form-control"/>
             </div>
             <div class="form-group">
-              <label class="control-label col-lg-4" data-translate="">zip</label>
-              <div class="col-lg-8">
-                <input type="text" name="zip" class="form-control"
-                       aria-label="{{'zip' | translate}}"
-                       data-ng-model="userInfo.address.zip"/>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-lg-4" data-translate="">state</label>
-              <div class="col-lg-8">
-                <input type="text" name="state" class="form-control"
-                       aria-label="{{'state' | translate}}"
-                       data-ng-model="userInfo.address.state"/>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-lg-4" data-translate="">city</label>
-              <div class="col-lg-8">
-                <input type="text" name="city" class="form-control"
-                       aria-label="{{'city' | translate}}"
-                       data-ng-model="userInfo.address.city"/>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-lg-4" data-translate=""
-                     data-ng-model="userInfo.address.country">country</label>
-              <div class="col-lg-8">
-                <!-- TODO : Add country list -->
-                <input type="text" name="country" class="form-control"
-                       aria-label="{{'country' | translate}}"/>
-              </div>
-            </div>
-          </fieldset>
-
-          <div class="form-group">
-            <label class="control-label col-lg-4" data-translate="">requestedProfile</label>
-            <div class="col-lg-8">
+              <label data-translate="">requestedProfile</label>
               <select name="profile"
                       data-ng-model="userInfo.profile"
                       aria-label="{{'requestedProfile' | translate}}"
@@ -106,7 +48,45 @@
                 <option data-ng-repeat="p in profiles" value="{{p}}">{{p | translate}}</option>
               </select>
             </div>
-          </div>
+          </fieldset>
+
+          <fieldset class="pull-right">
+            <legend data-translate="">address</legend>
+
+            <div class="form-group">
+              <label data-translate="">address</label>
+              <input type="text" name="address"
+                      aria-label="{{'address' | translate}}"
+                      data-ng-model="userInfo.address.address"
+                      class="form-control"/>
+            </div>
+            <div class="form-group">
+              <label data-translate="">zip</label>
+                <input type="text" name="zip" class="form-control"
+                       aria-label="{{'zip' | translate}}"
+                       data-ng-model="userInfo.address.zip"/>
+            </div>
+            <div class="form-group">
+              <label data-translate="">state</label>
+              <input type="text" name="state" class="form-control"
+                      aria-label="{{'state' | translate}}"
+                      data-ng-model="userInfo.address.state"/>
+            </div>
+            <div class="form-group">
+              <label data-translate="">city</label>
+              <input type="text" name="city" class="form-control"
+                      aria-label="{{'city' | translate}}"
+                      data-ng-model="userInfo.address.city"/>
+            </div>
+            <div class="form-group">
+              <label data-translate=""
+                     data-ng-model="userInfo.address.country">country</label>
+              <!-- TODO : Add country list -->
+              <input type="text" name="country" class="form-control"
+                      aria-label="{{'country' | translate}}"/>
+            </div>
+          </fieldset>
+
 
           <div class="form-group" data-ng-if="recaptchaEnabled">
             <div vc-recaptcha class="col-lg-8"
@@ -123,8 +103,5 @@
         </button>
       </div>
     </div>
-  </div>
-  <div class="col-lg-6">
-    <p data-translate="">newAccountInfo</p>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/new-password.html
+++ b/web-ui/src/main/resources/catalog/templates/new-password.html
@@ -1,5 +1,5 @@
 <div class="container" data-ng-controller="GnLoginController" role="main">
-  <div class="col-lg-6">
+    <div class="col-lg-4 col-md-4 col-md-offset-4 col-lg-offset-4">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h1 data-translate="">updatePassword</h1>
@@ -12,33 +12,29 @@
                  name="changeKey" value="{{changeKey}}"/>
 
           <div class="form-group">
-            <label class="control-label col-lg-4" data-translate="">username</label>
-            <div class="col-lg-8">
-              <input type="text"
-                     class="form-control"
-                     disabled=""
-                     aria-label="{{'username' | translate}}"
-                     data-ng-model="userToRemind"/>
-              <!-- Hidden field to be sent - the other one is disabled-->
-              <input type="hidden" name="username" value="{{userToRemind}}"/>
-            </div>
+            <label data-translate="">username</label>
+            <input type="text"
+                    class="form-control"
+                    disabled=""
+                    aria-label="{{'username' | translate}}"
+                    data-ng-model="userToRemind"/>
+            <!-- Hidden field to be sent - the other one is disabled-->
+            <input type="hidden" name="username" value="{{userToRemind}}"/>
           </div>
 
           <!-- Password are disabled when updating user -->
           <div class="form-group"
                data-ng-class="gnUserEdit.password.$valid != true ? 'has-error' : ''">
-            <label class="control-label col-lg-4" data-translate="">password</label>
-            <div class="col-lg-8">
-              <input type="password"
-                     id="gn-user-password"
-                     name="password"
-                     class="form-control"
-                     autocomplete="off"
-                     required="required"
-                     aria-label="{{'password' | translate}}"
-                     data-ng-minlength="6"
-                     data-ng-model="password"/>
-            </div>
+            <label data-translate="">password</label>
+            <input type="password"
+                    id="gn-user-password"
+                    name="password"
+                    class="form-control"
+                    autocomplete="off"
+                    required="required"
+                    aria-label="{{'password' | translate}}"
+                    data-ng-minlength="6"
+                    data-ng-model="password"/>
             <p class="help-block">
               <span class="error" ng-show="gnUserEdit.password.$error.minlength" data-translate=""
               >passwordMinlength</span>
@@ -47,16 +43,14 @@
           <div class="form-group"
                data-ng-class="gnUserEdit.password.$valid == false ||
                         (passwordCheck !== password) ? 'has-error' : ''">
-            <label class="control-label col-lg-4" data-translate="">passwordRepeat</label>
-            <div class="col-lg-8">
-              <input type="password"
-                     id="gn-user-password2"
-                     name="password2"
-                     class="form-control"
-                     autocomplete="off"
-                     aria-label="{{'passwordRepeat' | translate}}"
-                     data-ng-model="passwordCheck"/>
-            </div>
+            <label data-translate="">passwordRepeat</label>
+            <input type="password"
+                    id="gn-user-password2"
+                    name="password2"
+                    class="form-control"
+                    autocomplete="off"
+                    aria-label="{{'passwordRepeat' | translate}}"
+                    data-ng-model="passwordCheck"/>
             <p class="help-block">
               <span class="error"
                     ng-show="gnUserEdit.password.$valid
@@ -68,7 +62,7 @@
         <button data-ng-click="updatePassword('#userinfo')"
                 data-ng-disabled="!gnUserEdit.$valid"
                 class="btn btn-primary btn-block">
-          <i class="fa fa-save"/>
+          <i class="fa fa-fw fa-save"/>
           <span data-translate="">updatePassword</span>
         </button>
       </div>

--- a/web-ui/src/main/resources/catalog/templates/signin.html
+++ b/web-ui/src/main/resources/catalog/templates/signin.html
@@ -1,121 +1,139 @@
 <div class="container" data-ng-controller="GnLoginController" role="main">
   <div class="row">
-    <div class="col-lg-12 col-md-12">
-      <h1 data-translate="">loginTitle</h1>
-      <p data-translate="">loginText</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-lg-6 col-md-6">
-      <form class="form-horizontal" name="gnSigninForm" action="{{formAction}}"
-            method="post" role="form" data-ng-if="::user" data-ng-show="!shibbolethEnabled">
-        <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
-        <div class="form-group">
-          <label class="col-sm-3 control-label"
-                 for="inputUsername" data-translate="">username</label>
-          <div class="col-sm-9">
-            <div class="input-group">
-              <span class="input-group-addon">
-                <i class="fa fa-user"></i>
-              </span>
-              <input type="text" class="form-control" id="inputUsername" name="username" autofocus=""
-                     placeholder="{{'username' | translate}}" data-ng-model="signinUsername"
-                     required=""/>
-            </div>
-          </div>
+    <div class="col-lg-4 col-md-4 col-md-offset-4 col-lg-offset-4">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h1 data-translate="">loginTitle</h1>
         </div>
-
-        <div class="form-group">
-          <label class="col-sm-3 control-label"
-                 for="inputPassword" data-translate="">password</label>
-          <div class="col-sm-9">
-            <div class="input-group">
-              <span class="input-group-addon">
-                <i class="fa fa-lock"></i>
-              </span>
-              <input type="password" class="form-control" id="inputPassword" name="password"
-                     autocomplete="off"
-                     data-ng-model="signinPassword" placeholder="{{'password' | translate}}"
-                     required=""/>
-            </div>
-          </div>
-        </div>
-
-        <input type="hidden" name="redirectUrl" data-ng-model="redirectUrl" value="{{redirectUrl}}"/>
-        <!--<div class="checkbox">
-                  <label class="checkbox">
-                      <input type="checkbox"/><span translate>rememberMe</span>
-                  </label>
-              </div>-->
-
-        <button type="submit" class="btn btn-primary pull-right"
-                data-ng-disabled="!gnSigninForm.$valid">
-          <i class="fa fa-sign-in"/>
-          <span data-translate="">signIn</span>
-        </button>
-        <div class="clearfix"></div>
-      </form>
-
-      <br/>
-      <p class="alert alert-danger"
-         data-ng-show="signinFailure">
-        <strong data-translate="">signinFailure</strong>
-        <span data-ng-show="gnConfig['system.feedback.mailServer.hostIsDefined']">
-          <a type="submit"
-             class="btn btn-link btn-danger"
-             data-ng-click="setSendPassword(true)">
-            <span
-              data-translate="">recoverPassword</span> ?</a>
-        </span>
-      </p>
-    </div>
-    <div class="col-lg-6 col-md-6">
-      <div class="panel panel-default" data-ng-show="gnConfig[gnConfig.key.isSelfRegisterEnabled]">
-        <div class="panel-heading" data-translate="">needAnAccount</div>
         <div class="panel-body">
-          <p data-translate="">needAnAccountInfo</p>
-          <p>
-            <a class="btn btn-default" href="new.account" data-translate="">createAnAccount</a>
+          <p data-translate="">loginText</p>
+          <form class="form-horizontal" name="gnSigninForm" action="{{formAction}}"
+                method="post" role="form" data-ng-if="::user" data-ng-show="!shibbolethEnabled">
+            <input type="hidden" name="_csrf" value="{{csrf}}"/>
+  
+            <!-- username -->
+            <div class="form-group">
+              <label for="inputUsername" data-translate="">username</label>
+              <div class="input-group">
+                <span class="input-group-addon">
+                  <i class="fa fa-user"></i>
+                </span>
+                <input type="text" 
+                       class="form-control"
+                       id="inputUsername"
+                       name="username"
+                       autofocus=""
+                       placeholder="{{'username' | translate}}"
+                       data-ng-model="signinUsername"
+                       required=""/>
+              </div>
+            </div>
+            <!-- password -->
+            <div class="form-group">
+              <label for="inputPassword" data-translate="">password</label>
+              <div class="input-group">
+                <span class="input-group-addon">
+                  <i class="fa fa-lock"></i>
+                </span>
+                <input type="password"
+                       class="form-control"
+                       id="inputPassword"
+                       name="password"
+                       autocomplete="off"
+                       data-ng-model="signinPassword"
+                       placeholder="{{'password' | translate}}"
+                       required=""/>
+              </div>
+            </div>
+  
+            <input type="hidden" name="redirectUrl" data-ng-model="redirectUrl" value="{{redirectUrl}}"/>
+            <!--<div class="checkbox">
+                      <label class="checkbox">
+                          <input type="checkbox"/><span translate>rememberMe</span>
+                      </label>
+                  </div>-->
+  
+            <button type="submit"
+                    class="btn btn-primary btn-block"
+                    data-ng-disabled="!gnSigninForm.$valid">
+              <i class="fa fa-fw fa-sign-in"/>
+              <span data-translate="">signIn</span>
+            </button>
+          </form>
+  
+          <p class="text-danger"
+            data-ng-show="signinFailure">
+            <strong data-translate="">signinFailure</strong>
+            <!-- <span data-ng-show="gnConfig['system.feedback.mailServer.hostIsDefined']">
+              <a type="submit"
+                class="btn-link"
+                data-ng-click="setSendPassword(true)">
+                <span
+                  data-translate="">recoverPassword</span>?</a>
+            </span> -->
           </p>
         </div>
+        <!-- /.panel-body -->
       </div>
-      <div class="panel panel-default"
-           data-ng-show="gnConfig['system.feedback.mailServer.hostIsDefined']">
-        <div class="panel-heading" data-translate="">forgetDetails</div>
-        <div class="panel-body">
-          <div data-ng-show="sendPassword === false">
-            <p data-translate="">forgetDetailsInfo</p>
-            <p>
-              <a type="submit" class="btn btn-default" data-ng-click="setSendPassword(true)"
-                 data-translate="">recoverPassword</a>
-            </p>
-          </div>
-          <div data-ng-show="sendPassword === true">
-            <div>
-              <form class="form-horizontal" id="userinfo" name="gnUserinfo">
-                <input type="hidden" name="_csrf" value="{{csrf}}"/>
-                <div class="form-group">
-                  <label class="control-label col-lg-3" data-translate="">username</label>
-                  <div class="col-lg-8">
-                    <input type="text" name="username" id="username"
-                           aria-label="{{'username' | translate}}"
-                           data-ng-model="usernameToRemind"
-                           data-ng-required="" class="form-control"/>
-                  </div>
-                </div>
-                <a type="submit" class="btn btn-default pull-right"
-                   data-ng-disabled="usernameToRemind == ''"
-                   data-ng-click="remindMyPassword('#userinfo')">
-                  <i class="fa fa-question-sign"/>
-                  <span data-translate="">sendPasswordLinkToMyEmail</span>
-                </a>
-                <div class="clearfix"></div>
-              </form>
-            </div>
-          </div>
-        </div>
-      </div>
+      <!-- /.panel -->
     </div>
   </div>
+  <!-- /.row -->
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-md-offset-4 col-lg-offset-4">
+      <div class="panel panel-default">
+        <div class="panel-body text-muted">
+
+          <!-- register -->
+          <div data-ng-show="gnConfig[gnConfig.key.isSelfRegisterEnabled]">
+            <b data-translate="">needAnAccount</b>
+            <p data-translate="">needAnAccountInfo</p>
+            <p>
+              <a class="btn btn-default" href="new.account" data-translate="">createAnAccount</a>
+            </p>
+          </div>
+
+          <!-- forgot passpword -->
+          <div data-ng-show="gnConfig['system.feedback.mailServer.hostIsDefined']">
+            <b data-translate="">forgetDetails</b>
+            <span data-ng-show="sendPassword === false">
+              <p data-translate="">forgetDetailsInfo</p>
+              <p>
+                <a type="submit" class="btn btn-default" data-ng-click="setSendPassword(true)"
+                  data-translate="">recoverPassword</a>
+              </p>
+            </span>
+
+            <div data-ng-show="sendPassword === true">
+              <div>
+                <form class="form-horizontal" id="userinfo" name="gnUserinfo">
+                  <input type="hidden" name="_csrf" value="{{csrf}}"/>
+                  <div class="form-group">
+                    <label data-translate="">username</label>
+                    <input type="text" name="username" id="username"
+                          aria-label="{{'username' | translate}}"
+                          data-ng-model="usernameToRemind"
+                          data-ng-required="" class="form-control"/>
+                  </div>
+                  <a type="submit" 
+                     class="btn btn-default btn-block"
+                     data-ng-disabled="usernameToRemind == ''"
+                     data-ng-click="remindMyPassword('#userinfo')">
+                    <i class="fa fa-question-sign"/>
+                    <span data-translate="">sendPasswordLinkToMyEmail</span>
+                  </a>
+                  <div class="clearfix"></div>
+                </form>
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <!-- /.panel-body -->
+      </div>
+      <!-- /.panel -->
+
+    </div>
+  </div>
+  <!-- /.row -->
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
@@ -37,8 +37,11 @@
       margin-top: 5px;
     }
   }
-  input.ng-invalid {
+  input.ng-invalid, .has-error .form-control {
     border-color: #f98258;
+    &:focus {
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 4px rgb(250, 140, 99);
+  }
   }
 }
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
@@ -3,11 +3,90 @@
 // variables for manipulating the theme
 @import "gn_variables_default.less"; // must be last
 
-.panel-default > .panel-heading {
-  h1 {
-    font-size: 14px;
-    padding: 0;
+[ng-app="gn_login"] {
+  .form-horizontal .form-group {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  label {
+    font-weight: 500;
+  }
+  fieldset.pull-left, fieldset.pull-right {
+    width: 48%;
+  }
+  legend {
+    font-size: 18px;
+  }
+  form {
+    margin-top: 10px;
+  }
+  .input-group-addon {
+    background-color: #fff;
+  }
+  p.text-danger {
+    margin-top: 10px;
+  }
+  .help-block {
+    margin-top: 0;
+    margin-bottom: 0;
+    .error {
+      display: block;
+      margin-top: 5px;
+    }
+  }
+  input.ng-invalid {
+    border-color: #f98258;
+  }
+}
+
+.navbar-default {
+  background-color: @gn-menubar-background;
+  border-color: @gn-menubar-border-color;
+  .navbar-nav > li > a, .navbar-nav > .open > a, .navbar-nav > .active > a {
+    height: @gn-menubar-height;
+    color: @gn-menubar-color;
+    &:hover, &:focus {
+      color: @gn-menubar-color-hover;
+    }
+  }
+  .gn-name.gn-truncate {
+    @media (min-width: @screen-lg-min) {
+      max-width: 230px;
+      display: inline-block;
+      .text-overflow();
+    }
+  }
+  // also add `display:none`, this doesn't take whitespace on the navbar
+  .badge.invisible {
+    display: none
+  }
+
+}
+
+@media (max-width: @grid-float-breakpoint) {
+  .navbar-nav {
     margin: 0;
-    font-weight: normal;
+  }
+}
+
+.panel-default {
+  border: 0;
+  box-shadow: none;
+  margin-bottom: 0;
+  .panel-heading {
+    background: 0;
+    border: 0;
+    padding-left: 0;
+    padding-right: 0;
+    h1 {
+      padding: 0;
+      margin: 0;
+      font-weight: 300;
+      font-size: 32px;
+    }
+  }
+  .panel-body {
+    padding-left: 0;
+    padding-right: 0;
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
@@ -13,6 +13,9 @@
   }
   fieldset.pull-left, fieldset.pull-right {
     width: 48%;
+    @media (max-width: @screen-xs-max) {
+      width: 100%;
+    }
   }
   legend {
     font-size: 18px;


### PR DESCRIPTION
The Login, Register and Password page now have more of the same styling and colours, elements and buttons are positioned the same. More color contrast is added for accessibility.

**The overall look has a more cleaner style:**
![gn-signin](https://user-images.githubusercontent.com/19608667/45090483-c440b180-b10f-11e8-874e-eafab3b0935b.png)

**New account:**
![gn-account](https://user-images.githubusercontent.com/19608667/45090486-c86ccf00-b10f-11e8-9c54-1719b52242f6.png)

**Reset pasword:**
![gn-password-update](https://user-images.githubusercontent.com/19608667/45090539-e63a3400-b10f-11e8-9c4e-dfe25962d6fa.png)
