### PR TITLE
Change the metadata action popup to modal (#3063)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -24,24 +24,28 @@
     <table class="table table-striped" data-ng-show="privileges.length > 0">
       <thead>
       <tr>
-        <th><a href="" ng-click="setSorter('g')">
-          <span translate>groupOwners</span>&nbsp;
-          <i data-ng-if="sorter.predicate == 'g'" class="fa"
+        <th>
+          <a href="" ng-click="setSorter('g')">
+            <span translate>groupOwners</span>&nbsp;
+            <i data-ng-if="sorter.predicate == 'g'" class="fa"
              ng-class="sorter.reverse ? 'fa-long-arrow-up' : 'fa-long-arrow-down'"></i>
-        </a>
+          </a>
         </th>
         <th data-ng-repeat="key in operations">
           <a href="" ng-click="setSorter(key)">
-            <i class="fa {{icons[key] || fa-fw}}"/>&nbsp;
-            <span>{{('op-' + key) | translate}}</span>&nbsp;
+            <i class="fa {{icons[key] || fa-fw}}"/>
+            <span class="hidden-xs">&nbsp;{{('op-' + key) | translate}}&nbsp;</span>
             <i data-ng-if="sorter.predicate == key" class="fa"
                data-ng-class="sorter.reverse ? 'fa-long-arrow-down' : 'fa-long-arrow-up'"></i>
           </a>
         </th>
         <th data-ng-if="!disableAllCol">
-          <span translate>setall</span>
+          <span class="visible-xs">
+            <i class="fa fa-fw fa-lock"></i>
+          </span>
+          <span class="hidden-xs" translate>setall</span>
         </th>
-        <th><a href="" ng-click="setSorter('p')" data-ng-if="displayProfile">
+        <th data-ng-if="displayProfile"><a href="" ng-click="setSorter('p')">
           <span translate>profile</span>&nbsp;
           <i data-ng-if="sorter.predicate == 'p'" class="fa"
              ng-class="sorter.reverse ? 'fa-long-arrow-up' : 'fa-long-arrow-down'"></i>
@@ -67,7 +71,7 @@
                  data-ng-click="checkAll(g)"
                  data-ng-model="g.isCheckedAll"/>
         </td>
-        <td class="text-center">
+        <td class="text-center" data-ng-if="displayProfile">
 
         </td>
       </tr>
@@ -87,9 +91,8 @@
                  data-ng-click="checkAll(g)"
                  data-ng-model="g.isCheckedAll"/>
         </td>
-        <td class="text-center">
-          <span data-ng-if="displayProfile"
-                data-ng-repeat="p in g.userProfiles">
+        <td class="text-center" data-ng-if="displayProfile">
+          <span data-ng-repeat="p in g.userProfiles">
             {{user.isAdministrator() ? ('Administrator' | translate) : (p | translate)}}&nbsp;
           </span>
         </td>
@@ -100,25 +103,24 @@
   </form>
 </div>
 
-<div class="btn-toolbar">
-  <button type="button" class="btn pull-right"
-          data-ng-click="reset()"
-          data-ng-show="batch"
-          title="{{'resetOps' | translate}}">
-    <i class="fa fa-undo"></i>&nbsp;
+<div class="btn-toolbar pull-right">
+  <div data-gn-need-help="user-guide/publishing/index.html"
+       data-icon-only="true"></div> 
+  <button type="button" class="btn btn-primary"
+          data-gn-click-and-spin="save(true)">
+    <i class="fa fa-eraser"></i>&nbsp;
+    <span data-translate="">replaceByThoseOperations</span>
   </button>
-  <button type="button" class="btn btn-primary pull-right"
+  <button type="button" class="btn btn-primary"
           data-gn-click-and-spin="save(false)"
           data-ng-show="batch">
     <i class="fa fa-plus"></i>&nbsp;
     <span data-translate="">addThoseOperations</span>
   </button>
-  <button type="button" class="btn btn-primary pull-right"
-          data-gn-click-and-spin="save(true)">
-    <i class="fa fa-eraser"></i>&nbsp;
-    <span data-translate="">replaceByThoseOperations</span>
+  <button type="button" class="btn btn-default"
+          data-ng-click="reset()"
+          data-ng-show="batch"
+          title="{{'resetOps' | translate}}">
+    <i class="fa fa-undo"></i>&nbsp;
   </button>
-  <div data-gn-need-help="user-guide/publishing/index.html"
-       data-icon-only="true"
-       class="pull-right"></div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -78,7 +78,7 @@
        * @param {string} eventName
        */
       var openModal = function(o, scope, eventName) {
-        var popup = gnPopup.create(o, scope);
+        var popup = gnPopup.createModal(o, scope);
         var myListener = $rootScope.$on(eventName,
             function(e, o) {
               $timeout(function() {

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -295,26 +295,6 @@ div.gn-scroll-spy {
   min-height: 100px;
   max-height: ~"calc(100% - 89px)";
   z-index: 2000;
-
-  // .gn-share-grid {
-  //   width: 100%;
-  //   height: 75%;
-  //   overflow-x: hidden;
-  //   overflow-y: auto;
-
-  //   table {
-  //     /* The col section define column width */
-  //     table-layout: fixed;
-
-  //     th, td {
-  //       font-size: 70%;
-  //     }
-  //     /* Group name often contains long upper case value */
-  //     td {
-  //       word-break: break-all;
-  //     }
-  //   }
-  // }
 }
 
 .onlinesrc-popup, .gn-modal-lg {

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -296,25 +296,25 @@ div.gn-scroll-spy {
   max-height: ~"calc(100% - 89px)";
   z-index: 2000;
 
-  .gn-share-grid {
-    width: 100%;
-    height: 75%;
-    overflow-x: hidden;
-    overflow-y: auto;
+  // .gn-share-grid {
+  //   width: 100%;
+  //   height: 75%;
+  //   overflow-x: hidden;
+  //   overflow-y: auto;
 
-    table {
-      /* The col section define column width */
-      table-layout: fixed;
+  //   table {
+  //     /* The col section define column width */
+  //     table-layout: fixed;
 
-      th, td {
-        font-size: 70%;
-      }
-      /* Group name often contains long upper case value */
-      td {
-        word-break: break-all;
-      }
-    }
-  }
+  //     th, td {
+  //       font-size: 70%;
+  //     }
+  //     /* Group name often contains long upper case value */
+  //     td {
+  //       word-break: break-all;
+  //     }
+  //   }
+  // }
 }
 
 .onlinesrc-popup, .gn-modal-lg {

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -633,7 +633,7 @@ button.active [role=tooltip] {
 }
 
 [gn-share] {
-
+  .clearfix();
   @media (min-width: @screen-md) {
     min-width: 600px;
   }
@@ -642,12 +642,6 @@ button.active [role=tooltip] {
     max-width: 400px;
   }
   .gn-share-grid {
-    table {
-      width: auto;
-    }
-    thead, tbody {
-      display: block;
-    }
     tbody {
       max-height: 400px;
       overflow-y: auto;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -14,6 +14,8 @@
 @navbar-default-link-color: @gray;
 @navbar-default-link-hover-color: @gray-dark;
 @text-muted: #707070;
+// width of modal dialog
+@modal-md: 700px;
 // slightly darker primary color, now color contrast on light gray backgrounds is high enough
 @brand-primary: #3277B3;
 @dropdown-border: @navbar-default-border;


### PR DESCRIPTION
Change the opening of metadata action from popup to modal

Fix for https://github.com/geonetwork/core-geonetwork/issues/3063

**Screenshot of the modal dialog:**
![gn-privileges](https://user-images.githubusercontent.com/19608667/45097172-7d0fec00-b122-11e8-82cf-6b975877439f.png)

The privileges table is made more responsive, columns are now the same width, labels are hidden on small screens.

**Screenshot of a small table on a small screen:**
![gn-privileges-small](https://user-images.githubusercontent.com/19608667/45097300-c4967800-b122-11e8-9a16-9f7aba5b2be7.png)
