### PR TITLE
fix a bug in csw replace handling (do not want last text to override content)

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataType.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataType.java
@@ -145,6 +145,10 @@ public class MetadataType {
         return name;
     }
 
+    public List<String> getAlElements() {return alElements; }
+
+    public List<MetadataAttribute> getAlAttribs() {return alAttribs; }
+
     //---------------------------------------------------------------------------
     //---
     //--- Package protected API methods

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -703,7 +703,6 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
      * adding an attribute to the existing element does not work.
      */
     @Test
-    @Ignore
     public void testAddAttributeExistingElement() throws JDOMException, IOException {
         SchemaManager manager = _schemaManager;
         MetadataSchema schema = manager.getSchema("iso19139");
@@ -720,7 +719,7 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
         boolean a1 = el.addElementOrFragmentFromXpath(metadataElement, schema, charStringXpath, new AddElemValue(text), true);
         boolean a2 = el.addElementOrFragmentFromXpath(metadataElement, schema, attXPath, new AddElemValue(att), true);
 
-        assertEquals(2, a1 && a2);
+        assertEquals(true, a1 && a2);
 
         assertEqualsText(text, metadataElement, charStringXpath, GMD, GCO);
         assertEquals(att, Xml.selectString(metadataElement, attXPath, Arrays.asList(GMD, GCO)));

--- a/services/src/main/java/org/fao/geonet/api/records/editing/EditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/EditUtils.java
@@ -270,7 +270,7 @@ class EditUtils {
                 if (Log.isDebugEnabled(Geonet.EDITOR))
                     Log.debug(Geonet.EDITOR, "replacing XML content");
                 el.removeContent();
-                val = EditLib.addNamespaceToFragment(val);
+                val = EditLib.addGmlNamespaceToFragment(val);
                 el.addContent(Xml.loadString(val, false));
             } else {
                 @SuppressWarnings("unchecked")


### PR DESCRIPTION
come with a lot of refactoring.

for csw, trouble was that

```xml
<gn_replace>
<gco:Date>ValueTimestamp</gco:Date>
</gn_replace>
```

fails whereas 

```xml
<gn_replace><gco:Date>ValueTimestamp</gco:Date></gn_replace>
```

works.
so "do not want last text to override content".

relates to 

https://github.com/geonetwork/core-geonetwork/commit/d134d5a0d8dcbd0fa48584700c9772a084f649b2#diff-38f2b06a4b51beceb472a010acd91187

Files with more than 800 lines are in my opinion very hard to maintain, because hard to understand and hence forbidding evolution as we shouldn't modify something we don't understand.