### PR TITLE
Only index INSPIRE related fields if thesaurus is present

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -313,6 +313,8 @@
         <xsl:variable name="listOfKeywords"
                       select="gmd:keyword/gco:CharacterString|
                                         gmd:keyword/gmx:Anchor"/>
+        <xsl:variable name="thesaurusName" select="gmd:thesaurusName/gmd:CI_Citation/gmd:title/*[1]"/>
+
         <xsl:for-each select="$listOfKeywords">
           <xsl:variable name="keyword" select="string(.)"/>
 
@@ -320,7 +322,8 @@
 
           <!-- If INSPIRE is enabled, check if the keyword is one of the 34 themes
                and index annex, theme and theme in english. -->
-          <xsl:if test="$inspire='true'">
+          <xsl:if test="$inspire='true' and normalize-space(lower-case($thesaurusName)) = 'gemet - inspire themes, version 1.0'">
+
             <xsl:if test="string-length(.) &gt; 0">
 
               <xsl:variable name="inspireannex">


### PR DESCRIPTION
Fixes #2719. Only create fields `inspiretheme`, `inspirethemewithac`, `inspiretheme_en`, `inspireannex` and `inspirecat` if the element `gmd:MD_keywords` contains the `GEMET - Inspire themes, version 1.0` thesaurus.

(PR #2733 in 3.4.x branch)