### PR TITLE
Editor / Add configuration for field to use a thesaurus.

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -91,7 +91,8 @@ The list of possible values are:
 
 - all HTML5 input type or
 
-- an AngularJS directive name.
+- an AngularJS directive name. MUST starts with 'data-' and
+  could end with '-textarea' to create a textarea element
 
 
 An element can only have one type defined.

--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -92,7 +92,9 @@ The list of possible values are:
 - all HTML5 input type or
 
 - an AngularJS directive name. MUST starts with 'data-' and
-  could end with '-textarea' to create a textarea element
+  could end with '-textarea' to create a textarea element.
+  It could end with '-div' if the directive does not apply
+  to the input or textarea but to the div containing it.
 
 
 An element can only have one type defined.

--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1043,7 +1043,8 @@ Activate the "flat" mode at the tab level to make the form display only existing
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="1" ref="template"/>
+        <xs:element ref="template" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="directiveAttributes" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute name="if">
         <xs:annotation>
@@ -1157,6 +1158,7 @@ displayed based on the XML template snippet field configuration. Default is fals
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute ref="use"/>
     </xs:complexType>
   </xs:element>
 
@@ -1598,7 +1600,7 @@ instead of the text input.
           <xs:restriction base="xs:string">
             <xs:enumeration value="textarea"/>
             <xs:enumeration value="number"/>
-            <xs:enumeration value="gn-date-picker">
+            <xs:enumeration value="data-gn-date-picker">
               <xs:annotation>
                 <xs:documentation>
                   Custom date picker directive which rely on
@@ -1631,9 +1633,42 @@ instead of the text input.
                 </xs:documentation>
               </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="data-gn-topiccategory-selector-div">
+              <xs:annotation>
+                <xs:documentation>A directive to render topic category like keywords widget.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="data-gn-field-duration-div">
+              <xs:annotation>
+                <xs:documentation>A directive to set a complete duration type informations.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="data-gn-logo-selector">
+              <xs:annotation>
+                <xs:documentation>A directive to select a logo URL.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="data-gn-language-picker">
               <xs:annotation>
                 <xs:documentation>An autocompletion list for languages.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="data-gn-keyword-picker">
+              <xs:annotation>
+                <xs:documentation><![CDATA[
+An autocompletion list based on a thesaurus.
+
+.. code-block:: xml
+
+                  <for name="gmd:otherConstraints"
+                       use="data-gn-keyword-picker">
+                    <directiveAttributes
+                      data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistOnLineDescriptionCode-OnLineDescriptionCode"
+                      data-display-definition="true"/>
+                  </for>
+
+
+                ]]></xs:documentation>
               </xs:annotation>
             </xs:enumeration>
           </xs:restriction>

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139Namespaces.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139Namespaces.java
@@ -47,4 +47,7 @@ public class ISO19139Namespaces {
         Namespace.getNamespace("gmx", "http://www.isotc211.org/2005/gmx");
     public static final Namespace XLINK =
         Namespace.getNamespace("xlink", "http://www.w3.org/1999/xlink");
+    public static final Namespace GEONET =
+        Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork");
+
 }

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139Namespaces.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139Namespaces.java
@@ -47,7 +47,4 @@ public class ISO19139Namespaces {
         Namespace.getNamespace("gmx", "http://www.isotc211.org/2005/gmx");
     public static final Namespace XLINK =
         Namespace.getNamespace("xlink", "http://www.w3.org/1999/xlink");
-    public static final Namespace GEONET =
-        Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork");
-
 }

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -458,6 +458,11 @@ public class ISO19139SchemaPlugin
                 el.setAttribute("href", "", XLINK);
                 return el;
             }
+        } else if (StringUtils.isNotEmpty(parsedAttributeName) &&
+            parsedAttributeName.startsWith(":")) {
+            // eg. :codeSpace
+            el.setAttribute(parsedAttributeName.substring(1), attributeValue);
+            return el;
         } else {
             return super.processElement(el, attributeRef, parsedAttributeName, attributeValue);
         }

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -25,13 +25,16 @@ package org.fao.geonet.schema.iso19139;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.kernel.schema.*;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
+import org.jdom.Content;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
+import org.jdom.Text;
 import org.jdom.filter.ElementFilter;
 import org.jdom.xpath.XPath;
 
@@ -405,5 +408,31 @@ public class ISO19139SchemaPlugin
     @Override
     public Map<String, String> getExportFormats() {
         return allExportFormats;
+    }
+
+    @Override
+    public Element processElement(Element el, String attributeRef, String parsedAttributeName, String attributeValue) {
+        if (Log.isDebugEnabled(LOGGER_NAME)) {
+            Log.debug(LOGGER_NAME, "Processing element " + el + ", attribute " + attributeRef
+                + " with attributeValue " + attributeValue);
+        }
+
+        if (parsedAttributeName.equals("xlink:href")) {
+            Element originalGeonetInfo = (Element) el.getChild("element", GEONET).clone();
+            String originalValue = el.getText();
+
+            Element anchor = new Element("Anchor", GMX)
+                .setAttribute("href", "", XLINK);
+
+            Element geonetAttribute = new Element("attribute", GEONET)
+                .setAttribute("name", parsedAttributeName)
+                .setAttribute("ref", attributeRef);
+
+            anchor.setContent(Lists.newArrayList(new Text(originalValue), geonetAttribute, originalGeonetInfo));
+            return anchor;
+        } else {
+            return super.processElement(el, attributeRef, parsedAttributeName, attributeValue);
+        }
+
     }
 }

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -438,27 +438,25 @@ public class ISO19139SchemaPlugin
 
         if (parsedAttributeName.equals("xlink:href")) {
             boolean isEmptyLink = StringUtils.isEmpty(attributeValue);
-            Element originalGeonetInfo = (Element) el.getChild("element", GEONET).clone();
-            String originalValue = el.getText();
+            boolean isMultilingualElement = el.getName().equals("LocalisedCharacterString");
+
+            if (isMultilingualElement) {
+                // The attribute provided relates to the CharacterString and not to the LocalisedCharacterString
+                Element targetElement = el.getParentElement().getParentElement().getParentElement()
+                                            .getChild("CharacterString", GCO);
+                if (targetElement != null) {
+                    el = targetElement;
+                }
+            }
 
             if (isEmptyLink) {
-                Element characterString =
-                    new Element("CharacterString", GCO);
-                characterString.setContent(Lists.newArrayList(new Text(originalValue),
-                    originalGeonetInfo));
-                return characterString;
+                el.setNamespace(GCO).setName("CharacterString");
+                el.removeAttribute("href", XLINK);
+                return el;
             } else {
-                Element anchor =
-                    new Element("Anchor", GMX).setAttribute("href", "", XLINK);
-
-                Element geonetAttribute = new Element("attribute", GEONET)
-                    .setAttribute("name", parsedAttributeName)
-                    .setAttribute("ref", attributeRef);
-
-                anchor.setContent(Lists.newArrayList(new Text(originalValue),
-                                        geonetAttribute,
-                                        originalGeonetInfo));
-                return anchor;
+                el.setNamespace(GMX).setName("Anchor");
+                el.setAttribute("href", "", XLINK);
+                return el;
             }
         } else {
             return super.processElement(el, attributeRef, parsedAttributeName, attributeValue);

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -45,18 +45,32 @@
     <for name="gmd:measureDescription" use="textarea"/>
     <for name="gmd:purpose" use="textarea"/>
     <for name="gmd:orderingInstructions" use="textarea"/>
-    <for name="gmd:otherConstraints" use="textarea"/>
+
+
+    <!--<for name="gmd:otherConstraints" use="textarea"/>-->
+    <for name="gmd:otherConstraints"
+         use="data-gn-keyword-picker">
+      <directiveAttributes
+        data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistOnLineDescriptionCode-OnLineDescriptionCode"
+        data-display-definition="true"
+        data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
+    </for>
+
+
+
+
     <for name="gmd:statement" use="textarea"/>
     <for name="gmd:supplementalInformation" use="textarea"/>
     <for name="gmd:specificUsage" use="textarea"/>
     <for name="gmd:userNote" use="textarea"/>
 
-    <for name="gmd:useLimitation" use="textarea"/>
-    <!--<for name="gmd:useLimitation"
+    <!--<for name="gmd:useLimitation" use="textarea"/>-->
+    <for name="gmd:useLimitation"
          use="data-gn-keyword-picker">
-      <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"/>
-    </for>-->
-    
+      <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"
+                           data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
+    </for>
+
     <for name="gts:TM_PeriodDuration" use="data-gn-field-duration-div"/>
     <for name="gml:duration" use="data-gn-field-duration-div"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -86,7 +86,7 @@
 
 
     <!-- gmx:FileName/@src attribute -->
-    <for name="src" use="data-gn-logo-selector"/>
+    <for name="gmx:FileName/@src" use="data-gn-logo-selector"/>
 
     <for name="gmd:electronicMailAddress" use="email"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -45,18 +45,36 @@
     <for name="gmd:measureDescription" use="textarea"/>
     <for name="gmd:purpose" use="textarea"/>
     <for name="gmd:orderingInstructions" use="textarea"/>
-<for name="gmd:otherConstraints" use="textarea"/>
+    <for name="gmd:otherConstraints" use="textarea"/>
     <for name="gmd:statement" use="textarea"/>
     <for name="gmd:supplementalInformation" use="textarea"/>
     <for name="gmd:specificUsage" use="textarea"/>
     <for name="gmd:userNote" use="textarea"/>
     <for name="gmd:useLimitation" use="textarea"/>
-    <!-- Example configuration to use INSPIRE codelist to set use limitation.
-    This will apply to all views in the editor
+    <!-- Example configuration to use thesaurus to populate a CharacterString field
+    (including multilingual fields).
+
+    eg. INSPIRE codelist to set use limitation. This will apply to all views in the editor
+    1) Set the CharacterString value with the concept value
+    <for name="gmd:useLimitation"
+         use="data-gn-keyword-picker">
+      <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"/>
+    </for>
+
+    2) Use the concept Identifier in the xlink:href attribute.
+    This will automatically use the appropriate substitute depending on the presence
+    or not of the xlink:href. Either a CharacterString or an Anchor is used.
     <for name="gmd:useLimitation"
          use="data-gn-keyword-picker">
       <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"
                            data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
+    </for>
+
+    3) Use the concept identifier to populate another attribute (not having namespace)
+    <for name="gmd:featureTypes"
+         use="data-gn-keyword-picker">
+      <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"
+                           data-thesaurus-concept-id-attribute="codeSpace"/>
     </for>
     -->
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -50,8 +50,15 @@
     <for name="gmd:supplementalInformation" use="textarea"/>
     <for name="gmd:specificUsage" use="textarea"/>
     <for name="gmd:userNote" use="textarea"/>
-    <for name="gmd:useLimitation" use="textarea"/>
 
+    <for name="gmd:useLimitation" use="textarea"/>
+    <!--<for name="gmd:useLimitation"
+         use="data-gn-keyword-picker">
+      <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"/>
+    </for>-->
+    
+    <for name="gts:TM_PeriodDuration" use="data-gn-field-duration-div"/>
+    <for name="gml:duration" use="data-gn-field-duration-div"/>
 
     <for name="gco:Distance" use="number"/>
     <for name="gco:Decimal" use="number"/>
@@ -164,6 +171,8 @@
         data-insert-modes=""
         data-template-type="report"/>
     </for>
+
+
 
 
     <!-- Example configuration: Add onLine source from subtemplate

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -45,31 +45,20 @@
     <for name="gmd:measureDescription" use="textarea"/>
     <for name="gmd:purpose" use="textarea"/>
     <for name="gmd:orderingInstructions" use="textarea"/>
-
-
-    <!--<for name="gmd:otherConstraints" use="textarea"/>-->
-    <for name="gmd:otherConstraints"
-         use="data-gn-keyword-picker">
-      <directiveAttributes
-        data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistOnLineDescriptionCode-OnLineDescriptionCode"
-        data-display-definition="true"
-        data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
-    </for>
-
-
-
-
+<for name="gmd:otherConstraints" use="textarea"/>
     <for name="gmd:statement" use="textarea"/>
     <for name="gmd:supplementalInformation" use="textarea"/>
     <for name="gmd:specificUsage" use="textarea"/>
     <for name="gmd:userNote" use="textarea"/>
-
-    <!--<for name="gmd:useLimitation" use="textarea"/>-->
+    <for name="gmd:useLimitation" use="textarea"/>
+    <!-- Example configuration to use INSPIRE codelist to set use limitation.
+    This will apply to all views in the editor
     <for name="gmd:useLimitation"
          use="data-gn-keyword-picker">
       <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"
                            data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
     </for>
+    -->
 
     <for name="gts:TM_PeriodDuration" use="data-gn-field-duration-div"/>
     <for name="gml:duration" use="data-gn-field-duration-div"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/dispatcher.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/dispatcher.xsl
@@ -50,9 +50,11 @@
     <xsl:param name="base" as="node()"/>
     <xsl:param name="overrideLabel" as="xs:string" required="no" select="''"/>
     <xsl:param name="refToDelete" as="node()?" required="no"/>
+    <xsl:param name="config" as="node()?" required="no"/>
     <xsl:apply-templates mode="mode-iso19139" select="$base">
       <xsl:with-param name="overrideLabel" select="$overrideLabel"/>
       <xsl:with-param name="refToDelete" select="$refToDelete"/>
+      <xsl:with-param name="config" select="$config"/>
     </xsl:apply-templates>
   </xsl:template>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -128,41 +128,7 @@
   </xsl:template>
 
 
-  <!-- Duration
 
-       xsd:duration elements use the following format:
-
-       Format: PnYnMnDTnHnMnS
-
-       *  P indicates the period (required)
-       * nY indicates the number of years
-       * nM indicates the number of months
-       * nD indicates the number of days
-       * T indicates the start of a time section (required if you are going to specify hours, minutes, or seconds)
-       * nH indicates the number of hours
-       * nM indicates the number of minutes
-       * nS indicates the number of seconds
-
-       A custom directive is created.
-  -->
-  <xsl:template mode="mode-iso19139" match="gts:TM_PeriodDuration|gml:duration" priority="200">
-
-    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
-    <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
-
-    <xsl:call-template name="render-element">
-      <xsl:with-param name="label"
-                      select="$labelConfig"/>
-      <xsl:with-param name="value" select="."/>
-      <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="$xpath"/>
-      <xsl:with-param name="directive" select="'gn-field-duration'"/>
-      <xsl:with-param name="editInfo" select="gn:element"/>
-      <xsl:with-param name="parentEditInfo" select="../gn:element"/>
-    </xsl:call-template>
-
-  </xsl:template>
 
   <!-- ===================================================================== -->
   <!-- gml:TimePeriod (format = %Y-%m-%dThh:mm:ss) -->

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -185,6 +185,7 @@
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="overrideLabel" select="''" required="no"/>
     <xsl:param name="refToDelete" required="no"/>
+    <xsl:param name="config" required="no"/>
 
     <xsl:variable name="elementName" select="name()"/>
     <xsl:variable name="excluded"
@@ -331,10 +332,23 @@
       <xsl:with-param name="xpath" select="$xpath"/>
       <xsl:with-param name="attributesSnippet" select="$attributes"/>
       <xsl:with-param name="type"
-                      select="gn-fn-metadata:getFieldType($editorConfig, name(),
+                      select="if ($config and $config/@use != '')
+                              then $config/@use
+                              else gn-fn-metadata:getFieldType($editorConfig, name(),
         name($theElement))"/>
-      <xsl:with-param name="directiveAttributes"
-                      select="gn-fn-metadata:getFieldDirective($editorConfig, name())"/>
+      <xsl:with-param name="directiveAttributes">
+        <xsl:choose>
+          <xsl:when test="$config and $config/@use != ''">
+            <xsl:element name="directive">
+              <xsl:attribute name="data-directive-name" select="$config/@use"/>
+              <xsl:copy-of select="$config/directiveAttributes/@*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="gn-fn-metadata:getFieldDirective($editorConfig, name())"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:with-param>
       <xsl:with-param name="name" select="$theElement/gn:element/@ref"/>
       <xsl:with-param name="editInfo" select="$theElement/gn:element"/>
       <xsl:with-param name="parentEditInfo"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -252,7 +252,8 @@
   <xsl:template mode="mode-iso19139" priority="200"
                 match="*[gco:CharacterString|gco:Integer|gco:Decimal|
        gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
-       gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|gco:LocalName|gmd:PT_FreeText]">
+       gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|gco:LocalName|gmd:PT_FreeText|
+       gts:TM_PeriodDuration|gml:duration]">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="overrideLabel" select="''" required="no"/>
@@ -278,7 +279,8 @@
     <!-- TODO: Support gmd:LocalisedCharacterString -->
     <xsl:variable name="monoLingualValue" select="gco:CharacterString|gco:Integer|gco:Decimal|
       gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
-      gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|gco:LocalName"/>
+      gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|gco:LocalName|
+       gts:TM_PeriodDuration|gml:duration"/>
     <xsl:variable name="theElement"
                   select="if ($isMultilingualElement and $hasOnlyPTFreeText or not($monoLingualValue))
                           then gmd:PT_FreeText
@@ -391,7 +393,6 @@
       </xsl:choose>
     </xsl:variable>
 
-
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
                       select="$labelConfig/*"/>
@@ -405,6 +406,8 @@
       <xsl:with-param name="type"
                       select="gn-fn-metadata:getFieldType($editorConfig, name(),
         name($theElement))"/>
+      <xsl:with-param name="directive"
+                      select="gn-fn-metadata:getFieldDirective($editorConfig, name())"/>
       <xsl:with-param name="name" select="$theElement/gn:element/@ref"/>
       <xsl:with-param name="editInfo" select="$theElement/gn:element"/>
       <xsl:with-param name="parentEditInfo"
@@ -619,7 +622,7 @@
       <xsl:with-param name="value" select="$topicCategories"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
-      <xsl:with-param name="directive" select="'gn-topiccategory-selector'"/>
+      <xsl:with-param name="type" select="'data-gn-topiccategory-selector-div'"/>
       <xsl:with-param name="editInfo" select="gn:element"/>
       <xsl:with-param name="parentEditInfo" select="../gn:element"/>
     </xsl:call-template>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -174,93 +174,10 @@
 
   </xsl:template>
 
-  <!-- Render simple element with gmx:Anchor -->
-  <xsl:template mode="mode-iso19139" priority="200"
-                match="*[gmx:Anchor]">
-    <xsl:param name="schema" select="$schema" required="no"/>
-    <xsl:param name="labels" select="$labels" required="no"/>
-    <xsl:param name="overrideLabel" select="''" required="no"/>
-    <xsl:param name="refToDelete" required="no"/>
-
-    <xsl:variable name="elementName" select="name()"/>
-    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
-    <xsl:variable name="labelConfig"
-                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
-    <xsl:variable name="helper" select="gn-fn-metadata:getHelper($labelConfig/helper, .)"/>
-    <xsl:variable name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(),
-            name(gmx:Anchor))"/>
-    <xsl:variable name="isTypeADirective" select="starts-with($type, 'data-')" />
-
-    <xsl:variable name="attributes">
-      <xsl:choose>
-        <xsl:when test="$isEditing">
-          <!-- Create form for all existing attribute (not in gn namespace)
-              and all non existing attributes not already present for the
-              current element and its children (eg. @uom in gco:Distance).
-              A list of exception is defined in form-builder.xsl#render-for-field-for-attribute. -->
-          <xsl:apply-templates mode="render-for-field-for-attribute"
-                               select="
-              @*|
-              gn:attribute[not(@name = parent::node()/@*/name())]">
-            <xsl:with-param name="ref" select="gn:element/@ref"/>
-            <xsl:with-param name="insertRef" select="*/gn:element/@ref"/>
-          </xsl:apply-templates>
-          <xsl:apply-templates mode="render-for-field-for-attribute"
-                               select="
-                                   */@*|
-                                   */gn:attribute[not(@name = parent::node()/@*/name())]">
-            <xsl:with-param name="ref" select="*/gn:element/@ref"/>
-            <xsl:with-param name="insertRef" select="*/gn:element/@ref"/>
-          </xsl:apply-templates>
-        </xsl:when>
-        <xsl:otherwise></xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-
-    <xsl:variable name="directiveAttributes" select="if ($isTypeADirective) then gn-fn-metadata:getFieldDirective($editorConfig, name()) else ''"/>
-
-    <xsl:variable name="labelConfig">
-      <xsl:choose>
-        <xsl:when test="$overrideLabel != ''">
-          <element>
-            <label><xsl:value-of select="$overrideLabel"/></label>
-          </element>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:copy-of select="$labelConfig"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-
-    <xsl:call-template name="render-element">
-      <xsl:with-param name="label" select="$labelConfig/*[1]"/>
-      <xsl:with-param name="value" select="*"/>
-      <xsl:with-param name="cls" select="local-name()"/>
-      <!--<xsl:with-param name="widget"/>
-      <xsl:with-param name="widgetParams"/>-->
-      <xsl:with-param name="xpath" select="$xpath"/>
-      <xsl:with-param name="attributesSnippet" select="if (count($attributes/*) = 0)
-        then normalize-space($attributes)
-        else $attributes"/>
-      <xsl:with-param name="forceDisplayAttributes" select="true()" />
-      <xsl:with-param name="type"
-                      select="$type"/>
-      <xsl:with-param name="directiveAttributes" select="$directiveAttributes" />
-      <xsl:with-param name="name" select="if ($isEditing) then */gn:element/@ref else ''"/>
-      <xsl:with-param name="editInfo" select="*/gn:element"/>
-      <xsl:with-param name="parentEditInfo"
-                      select="if ($refToDelete) then $refToDelete else gn:element"/>
-      <!-- TODO: Handle conditional helper -->
-      <xsl:with-param name="listOfValues" select="$helper"/>
-      <xsl:with-param name="isFirst"
-                      select="count(preceding-sibling::*[name() = $elementName]) = 0"/>
-    </xsl:call-template>
-  </xsl:template>
 
   <!-- Render simple element which usually match a form field -->
   <xsl:template mode="mode-iso19139" priority="200"
-                match="*[gco:CharacterString|gco:Integer|gco:Decimal|
+                match="*[gco:CharacterString|gmx:Anchor|gco:Integer|gco:Decimal|
        gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
        gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|gco:LocalName|gmd:PT_FreeText|
        gts:TM_PeriodDuration|gml:duration]">
@@ -276,7 +193,7 @@
     <xsl:variable name="hasPTFreeText"
                   select="count(gmd:PT_FreeText) > 0"/>
     <xsl:variable name="hasOnlyPTFreeText"
-                  select="count(gmd:PT_FreeText) > 0 and count(gco:CharacterString) = 0"/>
+                  select="count(gmd:PT_FreeText) > 0 and count(gco:CharacterString|gmx:Anchor) = 0"/>
     <xsl:variable name="isMultilingualElement"
                   select="$metadataIsMultilingual and $excluded = false()"/>
     <xsl:variable name="isMultilingualElementExpanded"
@@ -287,7 +204,7 @@
     <xsl:variable name="forceDisplayAttributes" select="count(gmx:FileName) > 0"/>
 
     <!-- TODO: Support gmd:LocalisedCharacterString -->
-    <xsl:variable name="monoLingualValue" select="gco:CharacterString|gco:Integer|gco:Decimal|
+    <xsl:variable name="monoLingualValue" select="gco:CharacterString|gmx:Anchor|gco:Integer|gco:Decimal|
       gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
       gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|gco:LocalName|
        gts:TM_PeriodDuration|gml:duration"/>
@@ -323,7 +240,7 @@
                            select="
         */@*|
         */gn:attribute[not(@name = parent::node()/@*/name())]">
-        <xsl:with-param name="ref" select="*/gn:element/@ref"/>
+        <xsl:with-param name="ref" select="$theElement/gn:element/@ref"/>
         <xsl:with-param name="insertRef" select="$theElement/gn:element/@ref"/>
       </xsl:apply-templates>
     </xsl:variable>
@@ -340,7 +257,7 @@
     <xsl:variable name="values">
       <xsl:if test="$isMultilingualElement">
         <xsl:variable name="text"
-                      select="normalize-space(gco:CharacterString)"/>
+                      select="normalize-space(gco:CharacterString|gmx:Anchor)"/>
 
         <values>
           <!--

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -202,7 +202,7 @@
 
     <!-- For some fields, always display attributes.
     TODO: move to editor config ? -->
-    <xsl:variable name="forceDisplayAttributes" select="count(gmx:FileName) > 0"/>
+    <xsl:variable name="forceDisplayAttributes" select="count(gmx:FileName|gmx:Anchor) > 0"/>
 
     <!-- TODO: Support gmd:LocalisedCharacterString -->
     <xsl:variable name="monoLingualValue" select="gco:CharacterString|gmx:Anchor|gco:Integer|gco:Decimal|

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -28,6 +28,7 @@
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:gml="http://www.opengis.net/gml"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:gn="http://www.fao.org/geonetwork"
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
                 xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
@@ -193,7 +194,7 @@
 
     <xsl:variable name="attributes">
       <xsl:choose>
-        <xsl:when test="not($isTypeADirective) and $isEditing">
+        <xsl:when test="$isEditing">
           <!-- Create form for all existing attribute (not in gn namespace)
               and all non existing attributes not already present for the
               current element and its children (eg. @uom in gco:Distance).

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -406,7 +406,7 @@
       <xsl:with-param name="type"
                       select="gn-fn-metadata:getFieldType($editorConfig, name(),
         name($theElement))"/>
-      <xsl:with-param name="directive"
+      <xsl:with-param name="directiveAttributes"
                       select="gn-fn-metadata:getFieldDirective($editorConfig, name())"/>
       <xsl:with-param name="name" select="$theElement/gn:element/@ref"/>
       <xsl:with-param name="editInfo" select="$theElement/gn:element"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
@@ -3133,7 +3133,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
@@ -3123,7 +3123,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
@@ -3365,7 +3365,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/labels.xml
@@ -3253,7 +3253,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
@@ -6402,7 +6402,7 @@ http://www.sandre.eaufrance.fr/?urn=urn:sandre:ensembledonnees:BDCarthage:FXX:::
     <description></description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -3718,7 +3718,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/labels.xml
@@ -3114,7 +3114,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
@@ -3053,7 +3053,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
@@ -3120,7 +3120,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
@@ -3204,7 +3204,7 @@
     </description>
   </element>
   <element name="xlink:href">
-    <label>Link href</label>
+    <label>URL</label>
     <description>Supplies the data that allows an XLink application to find a remote resource (or
       resource fragment) [W3C XLINK]
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -354,6 +354,34 @@
   </xsl:template>
 
   <!-- ================================================================= -->
+
+  <!-- Removes @nilReason from parents of gmd:Anchor if anchor has @xlink:href attribute filled. -->
+  <xsl:template match="*[gmx:Anchor]">
+    <xsl:copy>
+      <xsl:variable name="isEmptyAnchor" select="normalize-space(gmx:Anchor/@xlink:href) = ''" />
+      <xsl:apply-templates select="@*[not(name() = 'gco:nilReason')]"/>
+
+      <xsl:choose>
+        <xsl:when test="$isEmptyAnchor">
+          <xsl:attribute name="gco:nilReason">
+            <xsl:choose>
+              <xsl:when test="@gco:nilReason">
+                <xsl:value-of select="@gco:nilReason"/>
+              </xsl:when>
+              <xsl:otherwise>missing</xsl:otherwise>
+            </xsl:choose>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="@gco:nilReason != 'missing' and not($isEmptyAnchor)">
+          <xsl:copy-of select="@gco:nilReason"/>
+        </xsl:when>
+      </xsl:choose>
+      <xsl:apply-templates select="gmx:Anchor"/>
+    </xsl:copy>
+
+  </xsl:template>
+
+  <!-- ================================================================= -->
   <!-- codelists: set @codeList path -->
   <!-- ================================================================= -->
   <xsl:template match="gmd:LanguageCode[@codeListValue]" priority="10">

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -267,9 +267,9 @@
                             then $valueInPtFreeTextForMainLanguage = ''
                             else if ($valueInPtFreeTextForMainLanguage != '')
                             then $valueInPtFreeTextForMainLanguage = ''
-                            else normalize-space(gco:CharacterString) = ''"/>
+                            else normalize-space(gco:CharacterString|gmx:Anchor) = ''"/>
 
-      <!-- Removes @nilReason from parents of gmx:Anchor if anchor has @xlink:href attribute filled. -->
+      <!-- TODO ? Removes @nilReason from parents of gmx:Anchor if anchor has @xlink:href attribute filled. -->
       <xsl:variable name="isEmptyAnchor"
                     select="normalize-space(gmx:Anchor/@xlink:href) = ''" />
 
@@ -306,7 +306,7 @@
           import may use this encoding. -->
         <xsl:when test="not($isMultilingual) and
                         $valueInPtFreeTextForMainLanguage != '' and
-                        normalize-space(gco:CharacterString) = ''">
+                        normalize-space(gco:CharacterString|gmx:Anchor) = ''">
           <xsl:element name="{if (gmx:Anchor) then 'gmx:Anchor' else 'gco:CharacterString'}">
             <xsl:copy-of select="gmx:Anchor/@*"/>
             <xsl:value-of select="$valueInPtFreeTextForMainLanguage"/>
@@ -315,7 +315,7 @@
         <xsl:when test="not($isMultilingual) or
                         $excluded">
           <!-- Copy gco:CharacterString only. PT_FreeText are removed if not multilingual. -->
-          <xsl:apply-templates select="gco:CharacterString"/>
+          <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
         </xsl:when>
         <xsl:otherwise>
           <!-- Add xsi:type for multilingual element. -->

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -248,7 +248,7 @@
 
   <!-- ================================================================= -->
 
-  <xsl:template match="*[gco:CharacterString|gmd:PT_FreeText]">
+  <xsl:template match="*[gco:CharacterString|gmx:Anchor|gmd:PT_FreeText]">
     <xsl:copy>
       <xsl:apply-templates select="@*[not(name() = 'gco:nilReason') and not(name() = 'xsi:type')]"/>
 
@@ -269,6 +269,10 @@
                             then $valueInPtFreeTextForMainLanguage = ''
                             else normalize-space(gco:CharacterString) = ''"/>
 
+      <!-- Removes @nilReason from parents of gmx:Anchor if anchor has @xlink:href attribute filled. -->
+      <xsl:variable name="isEmptyAnchor"
+                    select="normalize-space(gmx:Anchor/@xlink:href) = ''" />
+
 
       <xsl:choose>
         <xsl:when test="$isEmpty">
@@ -288,7 +292,7 @@
 
 
       <!-- For multilingual records, for multilingual fields,
-       create a gco:CharacterString containing
+       create a gco:CharacterString or gmx:Anchor containing
        the same value as the default language PT_FreeText.
       -->
       <xsl:variable name="element" select="name()"/>
@@ -303,10 +307,10 @@
         <xsl:when test="not($isMultilingual) and
                         $valueInPtFreeTextForMainLanguage != '' and
                         normalize-space(gco:CharacterString) = ''">
-
-          <gco:CharacterString>
+          <xsl:element name="{if (gmx:Anchor) then 'gmx:Anchor' else 'gco:CharacterString'}">
+            <xsl:copy-of select="gmx:Anchor/@*"/>
             <xsl:value-of select="$valueInPtFreeTextForMainLanguage"/>
-          </gco:CharacterString>
+          </xsl:element>
         </xsl:when>
         <xsl:when test="not($isMultilingual) or
                         $excluded">
@@ -328,15 +332,16 @@
               <!-- Update gco:CharacterString to contains
                    the default language value from the PT_FreeText.
                    PT_FreeText takes priority. -->
-              <gco:CharacterString>
+              <xsl:element name="{if (gmx:Anchor) then 'gmx:Anchor' else 'gco:CharacterString'}">
+                <xsl:copy-of select="gmx:Anchor/@*"/>
                 <xsl:value-of select="gmd:PT_FreeText/*/gmd:LocalisedCharacterString[
                                             @locale = concat('#', $mainLanguageId)]/text()"/>
-              </gco:CharacterString>
+              </xsl:element>
               <xsl:apply-templates select="gmd:PT_FreeText[normalize-space(.) != '']"/>
             </xsl:when>
             <xsl:otherwise>
               <!-- Populate PT_FreeText for default language if not existing. -->
-              <xsl:apply-templates select="gco:CharacterString"/>
+              <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
               <gmd:PT_FreeText>
                 <gmd:textGroup>
                   <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">
@@ -353,33 +358,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- ================================================================= -->
-
-  <!-- Removes @nilReason from parents of gmd:Anchor if anchor has @xlink:href attribute filled. -->
-  <xsl:template match="*[gmx:Anchor]">
-    <xsl:copy>
-      <xsl:variable name="isEmptyAnchor" select="normalize-space(gmx:Anchor/@xlink:href) = ''" />
-      <xsl:apply-templates select="@*[not(name() = 'gco:nilReason')]"/>
-
-      <xsl:choose>
-        <xsl:when test="$isEmptyAnchor">
-          <xsl:attribute name="gco:nilReason">
-            <xsl:choose>
-              <xsl:when test="@gco:nilReason">
-                <xsl:value-of select="@gco:nilReason"/>
-              </xsl:when>
-              <xsl:otherwise>missing</xsl:otherwise>
-            </xsl:choose>
-          </xsl:attribute>
-        </xsl:when>
-        <xsl:when test="@gco:nilReason != 'missing' and not($isEmptyAnchor)">
-          <xsl:copy-of select="@gco:nilReason"/>
-        </xsl:when>
-      </xsl:choose>
-      <xsl:apply-templates select="gmx:Anchor"/>
-    </xsl:copy>
-
-  </xsl:template>
 
   <!-- ================================================================= -->
   <!-- codelists: set @codeList path -->

--- a/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/SchemaPlugin.java
+++ b/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/SchemaPlugin.java
@@ -93,7 +93,10 @@ public abstract class SchemaPlugin implements CSWPlugin {
 
 
     /**
-     * Processes the passed element. This base class just return the same element without modifications.
+     * Processes the passed element. This base class just return the same element without modifications
+     * but can be overridden in a schema plugin in order to modify an element
+     * by one of its substitutes.
+     *
      * @param el element to process.
      * @param attributeName
      * @param parsedAttributeName the name of the attribute, for example <code>xlink:href</code>

--- a/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/SchemaPlugin.java
+++ b/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/SchemaPlugin.java
@@ -24,17 +24,15 @@
 package org.fao.geonet.kernel.schema;
 
 import com.google.common.collect.ImmutableSet;
-
+import org.jdom.Element;
 import org.jdom.Namespace;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by francois on 6/16/14.
@@ -92,4 +90,17 @@ public abstract class SchemaPlugin implements CSWPlugin {
     public List<String> getXpathTitle() {
         return xpathTitle;
     }
+
+
+    /**
+     * Processes the passed element. This base class just return the same element without modifications.
+     * @param el element to process.
+     * @param attributeName
+     * @param parsedAttributeName the name of the attribute, for example <code>xlink:href</code>
+     * @param attributeValue
+     * @return the same element passed without modifications.
+     */
+    public Element processElement(Element el, String attributeName, String parsedAttributeName, String attributeValue) {
+        return el;
+    };
 }

--- a/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/SchemaPlugin.java
+++ b/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/SchemaPlugin.java
@@ -101,7 +101,8 @@ public abstract class SchemaPlugin implements CSWPlugin {
      * @param attributeName
      * @param parsedAttributeName the name of the attribute, for example <code>xlink:href</code>
      * @param attributeValue
-     * @return the same element passed without modifications.
+     *
+     * @return the processed element.
      */
     public Element processElement(Element el, String attributeName, String parsedAttributeName, String attributeValue) {
         return el;

--- a/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
@@ -180,14 +180,12 @@ public class AjaxEditUtils extends EditUtils {
             }
             SchemaPlugin schemaPlugin = SchemaManager.getSchemaPlugin(schema);
             Element processedElement =  schemaPlugin.processElement(el, originalRef, parsedAttributeName, value);
-            Log.debug(Geonet.EDITOR, "processed element: " + processedElement);
             if (processedElement != el) {
+                Log.debug(Geonet.EDITOR, "Replacing processed element: " + processedElement);
                 Element parent = el.getParentElement();
                 int elIndex = parent.indexOf(el);
                 parent.setContent(elIndex, processedElement);
             }
-
-
         }
 
         // --- update elements

--- a/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
@@ -179,13 +179,7 @@ public class AjaxEditUtils extends EditUtils {
                 continue;
             }
             SchemaPlugin schemaPlugin = SchemaManager.getSchemaPlugin(schema);
-            Element processedElement =  schemaPlugin.processElement(el, originalRef, parsedAttributeName, value);
-            if (processedElement != el) {
-                Log.debug(Geonet.EDITOR, "Replacing processed element: " + processedElement);
-                Element parent = el.getParentElement();
-                int elIndex = parent.indexOf(el);
-                parent.setContent(elIndex, processedElement);
-            }
+            schemaPlugin.processElement(el, originalRef, parsedAttributeName, value);
         }
 
         // --- update elements

--- a/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
@@ -31,7 +31,9 @@ import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.kernel.AddElemValue;
+import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.schema.iso19139.ISO19139Namespaces;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.constants.Edit;
@@ -82,18 +84,23 @@ public class AjaxEditUtils extends EditUtils {
      * <p> The changes are a list of KVP. A key contains at least the element identifier from the
      * meta-document. A key starting with an "X" should contain an XML fragment for the value. </p>
      *
-     * The following KVP combinations are allowed: <ul> <li>ElementId=ElementValue </li>
-     * <li>ElementId_AttributeName=AttributeValue</li> <li>ElementId_AttributeNamespacePrefixCOLONAttributeName=AttributeValue</li>
-     * <li>XElementId=ElementValue</li> <li>XElementId_replace=ElementValue</li>
-     * <li>XElementId_ElementName=ElementValue</li> <li>XElementId_ElementName_replace=ElementValue</li>
-     * <li>P{key}=xpath with P{key}_xml=XML snippet</li> </ul>
+     * The following KVP combinations are allowed:
+     *   <ul>
+     *     <li>ElementId=ElementValue </li>
+     *     <li>ElementId_AttributeName=AttributeValue</li>
+     *     <li>ElementId_AttributeNamespacePrefixCOLONAttributeName=AttributeValue</li>
+     *     <li>XElementId=ElementValue</li> <li>XElementId_replace=ElementValue</li>
+     *     <li>XElementId_ElementName=ElementValue</li>
+     *     <li>XElementId_ElementName_replace=ElementValue</li>
+     *     <li>P{key}=xpath with P{key}_xml=XML snippet</li>
+     *   </ul>
      *
-     * ElementName MUST contain "{@value #EditLib.COLON_SEPARATOR}" instead of ":" for prefixed
+     * ElementName MUST contain "{@value EditLib#COLON_SEPARATOR}" instead of ":" for prefixed
      * elements.
      *
      * <p> When using X key ElementValue could contains many XML fragments (eg. &lt;gmd:keywords
-     * .../&gt;{@value #XML_FRAGMENT_SEPARATOR}&lt;gmd:keywords .../&gt;) separated by {@link
-     * #XML_FRAGMENT_SEPARATOR}. All those fragments are inserted to the last element of this type
+     * .../&gt;{@value EditLib#XML_FRAGMENT_SEPARATOR}&lt;gmd:keywords .../&gt;) separated by {@link
+     * EditLib#XML_FRAGMENT_SEPARATOR}. All those fragments are inserted to the last element of this type
      * in its parent if ElementName is set. If not, the element with ElementId is replaced. If
      * _replace suffix is used, then all elements having the same type than elementId are removed
      * before insertion.
@@ -137,6 +144,51 @@ public class AjaxEditUtils extends EditUtils {
         // Store XML fragments to be handled after other elements update
         Map<String, String> xmlInputs = new HashMap<String, String>();
         LinkedHashMap<String, AddElemValue> xmlAndXpathInputs = new LinkedHashMap<String, AddElemValue>();
+
+        // Preprocess
+        for (Map.Entry<String, String> entry: changes.entrySet()) {
+            String originalRef = entry.getKey().trim();
+            String ref = null;
+            String value = entry.getValue().trim();
+            String originalAttributeName = null;
+            String parsedAttributeName = null;
+
+            // Avoid empty key
+            if (originalRef.equals("")) {
+                continue;
+            }
+
+            // Ignore element if ref starts with "P" or "X"
+            if (originalRef.startsWith("X") || originalRef.startsWith("P")) {
+                continue;
+            }
+
+            if (refIsAttribute(originalRef)) {
+                originalAttributeName = parseRefAndGetAttribute(originalRef);
+                ref = parseRefAndGetNewRef(originalRef);
+                Pair<Namespace, String> attributePair = parseAttributeName(originalAttributeName, EditLib.COLON_SEPARATOR, id, md, editLib);
+                parsedAttributeName = attributePair.one().getPrefix() + ":" + attributePair.two();
+            } else {
+                continue;
+            }
+
+            String actualRef = ref != null ? ref : originalRef;
+            Element el = editLib.findElement(md, actualRef);
+            if (el == null) {
+                Log.error(Geonet.EDITOR, EditLib.MSG_ELEMENT_NOT_FOUND_AT_REF + originalRef);
+                continue;
+            }
+            SchemaPlugin schemaPlugin = SchemaManager.getSchemaPlugin(schema);
+            Element processedElement =  schemaPlugin.processElement(el, originalRef, parsedAttributeName, value);
+            Log.debug(Geonet.EDITOR, "processed element: " + processedElement);
+            if (processedElement != el) {
+                Element parent = el.getParentElement();
+                int elIndex = parent.indexOf(el);
+                parent.setContent(elIndex, processedElement);
+            }
+
+
+        }
 
         // --- update elements
         for (Map.Entry<String, String> entry : changes.entrySet()) {
@@ -232,6 +284,43 @@ public class AjaxEditUtils extends EditUtils {
     }
 
     /**
+     * Reads a ref and extract the ID part from it.
+     * @param ref the ref to check.
+     * @return the ID part.
+     */
+    private String parseRefAndGetNewRef(String ref) {
+        String newRef = ref;
+        int underscorePosition = ref.indexOf('_');
+        if (underscorePosition != -1) {
+            newRef = ref.substring(0, underscorePosition);
+        }
+        return newRef;
+    }
+
+    /**
+     * Reads a ref and extract the attribute part from it.
+     * @param ref the ref to check.
+     * @return the attribute part or null if ref doesn't contain an attribute name.
+     */
+    private String parseRefAndGetAttribute(String ref) {
+        String attribute = null;
+        int underscorePosition = ref.indexOf('_');
+        if (underscorePosition != -1) {
+            attribute = ref.substring(underscorePosition + 1);
+        }
+        return attribute;
+    }
+
+    /**
+     * Checks if a ref name represents an attribute. This kind of ref is like <code>ID_ATTRIBUTENAME</code>.
+     * @param ref a ref element.
+     * @return true ref is an attribute, false in other case.
+     */
+    private boolean refIsAttribute(String ref) {
+        return ref.indexOf('_') != -1;
+    }
+
+    /**
      * TODO javadoc.
      */
     private void setMetadataIntoSession(UserSession session, Element md, String id) {
@@ -280,7 +369,7 @@ public class AjaxEditUtils extends EditUtils {
         //--- later re-use
         Element refEl = (Element) (el.getChild(Edit.RootChild.ELEMENT, Edit.NAMESPACE)).clone();
         Element info = null;
-        
+
         if(md.getChild(Edit.RootChild.INFO, Edit.NAMESPACE) != null) {
             info = (Element) (md.getChild(Edit.RootChild.INFO, Edit.NAMESPACE)).clone();
             md.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -174,6 +174,10 @@ public class KeywordsApi {
             required = false
         )
             String q,
+        @ApiParam(
+            value = "Query in that language",
+            required = false
+        )
         @RequestParam(
             value = "lang",
             defaultValue = "eng"
@@ -198,7 +202,7 @@ public class KeywordsApi {
         )
             int start,
         @ApiParam(
-                value = "Target langs",
+            value = "Return keyword information in one or more languages",
                 required = false
         )
         @RequestParam(

--- a/web-ui/src/main/resources/catalog/components/edit/fieldduration/FieldDurationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/fieldduration/FieldDurationDirective.js
@@ -41,7 +41,7 @@
      *  * nM indicates the number of minutes
      *  * nS indicates the number of seconds
      */
-  module.directive('gnFieldDuration', ['$http', '$rootScope',
+  module.directive('gnFieldDurationDiv', ['$http', '$rootScope',
     function($http, $rootScope) {
 
       return {
@@ -49,7 +49,7 @@
         replace: true,
         transclude: true,
         scope: {
-          value: '@gnFieldDuration',
+          value: '@gnFieldDurationDiv',
           label: '@label',
           ref: '@ref'
         },

--- a/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
@@ -55,7 +55,10 @@
           // Only inputs and textarea could be multilingual fields
           var formFieldsSelector =
               'div[data-ng-transclude] > input.form-control,' +
-              'div[data-ng-transclude] > textarea.form-control';
+              'div[data-ng-transclude] > textarea.form-control,' +
+              // + selector for field using directive eg. gn-keyword-picker
+              'div[data-ng-transclude] > span > input.form-control,' +
+              'div[data-ng-transclude] > span > textarea.form-control';
 
           // Some input should be displayed in Right-To-Left direction
           var rtlLanguages = ['AR'];

--- a/web-ui/src/main/resources/catalog/components/edit/topiccategory/TopicCategoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/topiccategory/TopicCategoryDirective.js
@@ -38,7 +38,7 @@
    * the input.
    *
    */
-  module.directive('gnTopiccategorySelector',
+  module.directive('gnTopiccategorySelectorDiv',
       ['$compile', '$timeout', '$translate',
        'gnTopicCategoryService', 'gnCurrentEdit',
        'TopicCategory', 'gnLangs',
@@ -50,7 +50,7 @@
            replace: true,
            transclude: true,
            scope: {
-             values: '@gnTopiccategorySelector',
+             values: '@gnTopiccategorySelectorDiv',
              label: '@label',
              ref: '@ref'
            },

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -368,6 +368,16 @@
                saving: false
              });
 
+             gnCurrentEdit.allLanguages = {code2iso: {}, iso2code: {}, iso: []};
+             if (gnCurrentEdit.mdOtherLanguages != '') {
+               angular.forEach(JSON.parse(gnCurrentEdit.mdOtherLanguages), function(code, iso) {
+                 gnCurrentEdit.allLanguages.code2iso[code] = iso;
+                 gnCurrentEdit.allLanguages.iso2code[iso] = code;
+                 gnCurrentEdit.allLanguages.iso.push(iso);
+                 ;
+               });
+             }
+
              if (angular.isFunction(gnCurrentEdit.formLoadExtraFn)) {
                gnCurrentEdit.formLoadExtraFn();
              }
@@ -394,7 +404,7 @@
 
              var defer = $q.defer();
              $http.put(this.buildEditUrlPrefix('editor/elements') +
-             '&displayAttributes=' + gnCurrentEdit.displayAttributes + 
+             '&displayAttributes=' + gnCurrentEdit.displayAttributes +
              '&ref=' + ref + '&name=' + name + attributeAction)
               .success(function(data) {
                // Append HTML snippet after current element - compile Angular
@@ -432,7 +442,7 @@
            insertRef, position) {
              var defer = $q.defer();
              $http.put(this.buildEditUrlPrefix('editor/elements') +
-             '&displayAttributes=' + gnCurrentEdit.displayAttributes + 
+             '&displayAttributes=' + gnCurrentEdit.displayAttributes +
              '&ref=' + ref +
              '&name=' + parent +
              '&child=' + name).success(function(data) {
@@ -462,8 +472,8 @@
              // Call service to remove element from metadata record in session
              var defer = $q.defer();
              $http.delete('../api/records/' + gnCurrentEdit.id +
-             '/editor/elements?ref=' + ref + 
-             '&displayAttributes=' + gnCurrentEdit.displayAttributes + 
+             '/editor/elements?ref=' + ref +
+             '&displayAttributes=' + gnCurrentEdit.displayAttributes +
              '&parent=' + parent)
               .success(function(data) {
                // For a fieldset, domref is equal to ref.

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -614,13 +614,32 @@
             );
 
 
-            // TODO: Anchor support
+            // When concept id attribute is set, then an extra input field is used.
+            // Eg. in ISO schema, an Anchor element is used.
+            // In such case, an xlink:href attribute store the concept id.
+            // By default, such an attribute is identified in the form by
+            // the parent element id + '_' + attribute name
             if (angular.isDefined(attrs.thesaurusConceptIdAttribute)) {
               var conceptIdElementName = attrs.name + '_' + attrs.thesaurusConceptIdAttribute;
 
-              var conceptIdElement =  angular.element('<input name="' + conceptIdElementName + '" class="hidden"></input>');
-              element.after(conceptIdElement);
-              scope.conceptIdElement = conceptIdElement;
+              // Check that the element does not exist already in the form
+              // Could be in the case it was already encoded.
+              var input = element.parent().parent().find('[name=' + conceptIdElementName + ']');
+
+              if (input.length === 0) {
+                // Add an extra form element to store the value
+                var conceptIdElement =  angular.element(
+                  '<div class="well well-sm">' +
+                  '<label class="col-sm-4" data-translate>Link</label>' +
+                  '<input name="' + conceptIdElementName + '" ' +
+                  '       class="gn-field-link form-control"/>' +
+                  '</div>');
+                element.after(conceptIdElement);
+
+                var input = element.parent().parent().find('[name=' + conceptIdElementName + ']');
+              }
+
+              scope.conceptIdElement =  $(input.get(0));
             }
 
 

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -566,6 +566,39 @@
             var isMultilingualMode =
               $(element).closest('div[data-gn-multilingual-field]').size() === 1;
 
+            // When concept id attribute is set, then an extra input field is used.
+            // Eg. in ISO schema, an Anchor element is used.
+            // In such case, an xlink:href attribute store the concept id.
+            // By default, such an attribute is identified in the form by
+            // the parent element id + '_' + attribute name
+            if (angular.isDefined(attrs.thesaurusConceptIdAttribute)) {
+              scope.conceptIdElementName =
+                // In multilingual mode, the ref to the CharacterString is known using the id
+                (isMultilingualMode ? '_' + attrs.id.replace('gn-field-', '') : attrs.name) +
+                '_' + attrs.thesaurusConceptIdAttribute;
+
+              // Check that the element does not exist already in the form
+              // Could be in the case it was already encoded.
+              var input = element.parent().parent().find('[name=' + scope.conceptIdElementName + ']');
+
+              var isFirstMultilingualElement = element.prev('div.gn-keyword-picker-concept-id').length === 0;
+
+              if ((!isMultilingualMode && input.length === 0) ||
+                // Add an extra form element to store the value
+                // If multilingual, only one field is added to the first input
+                // eg. in ISO19139, the xlink:href attribute is part of the
+                // CharacterString and not to the children
+                (isMultilingualMode && isFirstMultilingualElement && input.length === 0)) {
+
+                var conceptIdElement =  angular.element(
+                  '<div class="well well-sm gn-keyword-picker-concept-id">' +
+                  '<label class="col-sm-4" data-translate>Link</label>' +
+                  '<input name="' + scope.conceptIdElementName + '" ' +
+                  '       class="gn-field-link form-control"/>' +
+                  '</div>');
+                element.after(conceptIdElement);
+                }
+            }
 
             // Init typeahead
             element.typeahead({
@@ -606,41 +639,18 @@
                   $(obj.currentTarget).val(keyword.label);
                 }
 
-                if(scope.conceptIdElement) {
+                if(scope.conceptIdElementName) {
                   var keywordKey = keyword.props.uri;
-                  scope.conceptIdElement.val(keywordKey);
+                  // This directive may depend on others and populate
+                  // the same target input field for the attribute.
+                  // Use a search instead of a scope element to cope with init order.
+                  var input = element.parent().parent().find('[name=' + scope.conceptIdElementName + ']');
+                  input.val(keywordKey);
                 }
               }, $(element))
             );
 
 
-            // When concept id attribute is set, then an extra input field is used.
-            // Eg. in ISO schema, an Anchor element is used.
-            // In such case, an xlink:href attribute store the concept id.
-            // By default, such an attribute is identified in the form by
-            // the parent element id + '_' + attribute name
-            if (angular.isDefined(attrs.thesaurusConceptIdAttribute)) {
-              var conceptIdElementName = attrs.name + '_' + attrs.thesaurusConceptIdAttribute;
-
-              // Check that the element does not exist already in the form
-              // Could be in the case it was already encoded.
-              var input = element.parent().parent().find('[name=' + conceptIdElementName + ']');
-
-              if (input.length === 0) {
-                // Add an extra form element to store the value
-                var conceptIdElement =  angular.element(
-                  '<div class="well well-sm">' +
-                  '<label class="col-sm-4" data-translate>Link</label>' +
-                  '<input name="' + conceptIdElementName + '" ' +
-                  '       class="gn-field-link form-control"/>' +
-                  '</div>');
-                element.after(conceptIdElement);
-
-                var input = element.parent().parent().find('[name=' + conceptIdElementName + ']');
-              }
-
-              scope.conceptIdElement =  $(input.get(0));
-            }
 
 
             // When clicking the element trigger input

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -496,8 +496,8 @@
    * We can't transclude input (http://plnkr.co/edit/R2O2ixWA1QJUsVcUHl0N)
    */
   module.directive('gnKeywordPicker', [
-    'gnThesaurusService', '$compile', '$translate',
-    function(gnThesaurusService, $compile, $translate) {
+    'gnThesaurusService', '$compile', '$translate', 'gnCurrentEdit',
+    function(gnThesaurusService, $compile, $translate, gnCurrentEdit) {
       return {
         restrict: 'A',
         scope: {},
@@ -541,7 +541,9 @@
             var keywordsAutocompleter =
                 gnThesaurusService.getKeywordAutocompleter({
                   thesaurusKey: scope.thesaurusKey,
-                  lang: scope.lang,
+                  lang: gnCurrentEdit.allLanguages.code2iso['#' + attrs.lang] ||
+                        gnCurrentEdit.mdLanguage ||
+                        scope.lang,
                   orderById: scope.orderById
                 });
 
@@ -570,6 +572,8 @@
               element.trigger(ev);
               if (element.val() != initial) {
                 element.val('');
+                // TODO: Multilingual support
+                // TODO: Anchor support
               }
               return true;
             });

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -500,11 +500,14 @@
     function(gnThesaurusService, $compile, $translate, gnCurrentEdit) {
       return {
         restrict: 'A',
-        scope: {},
+        scope: {
+        },
         link: function(scope, element, attrs) {
           scope.thesaurusKey = attrs.thesaurusKey || '';
           scope.orderById = attrs.orderById || 'false';
           scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
+
+
 
           var displayDefinition = attrs.displayDefinition || '';
           var numberOfSuggestions = attrs.numberOfSuggestions || 20;
@@ -602,10 +605,23 @@
                 } else {
                   $(obj.currentTarget).val(keyword.label);
                 }
+
+                if(scope.conceptIdElement) {
+                  var keywordKey = keyword.props.uri;
+                  scope.conceptIdElement.val(keywordKey);
+                }
               }, $(element))
             );
 
+
             // TODO: Anchor support
+            if (angular.isDefined(attrs.thesaurusConceptIdAttribute)) {
+              var conceptIdElementName = attrs.name + '_' + attrs.thesaurusConceptIdAttribute;
+
+              var conceptIdElement =  angular.element('<input name="' + conceptIdElementName + '" class="hidden"></input>');
+              element.after(conceptIdElement);
+              scope.conceptIdElement = conceptIdElement;
+            }
 
 
             // When clicking the element trigger input
@@ -628,6 +644,12 @@
 
           scope.$watch('thesaurusKey', function(newValue) {
             init();
+          });
+
+          element.on('$destroy', function () {
+            if (scope.conceptIdElement) {
+              scope.conceptIdElement.remove();
+            }
           });
         }
       };

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -74,16 +74,20 @@
           'Thesaurus',
           function($q, $rootScope, $http, gnUrlUtils, Keyword, Thesaurus) {
             var getKeywordsSearchUrl = function(filter,
-                thesaurus, lang, max, typeSearch) {
+                thesaurus, lang, max, typeSearch, outputLang) {
+              var parameters = {
+                type: typeSearch || 'CONTAINS',
+                thesaurus: thesaurus,
+                rows: max,
+                q: filter || '',
+                uri: ('*' + filter + '*') || '',
+                lang: lang || 'eng'
+              };
+              if (outputLang) {
+                parameters['pLang'] = outputLang;
+              }
               return gnUrlUtils.append('../api/registries/vocabularies/search',
-                  gnUrlUtils.toKeyValue({
-                    type: typeSearch || 'CONTAINS',
-                    thesaurus: thesaurus,
-                    rows: max,
-                    q: filter || '',
-                    uri: ('*' + filter + '*') || '',
-                    lang: lang || 'eng'
-                  })
+                  gnUrlUtils.toKeyValue(parameters)
               );
             };
 
@@ -199,7 +203,9 @@
                     url: this.getKeywordsSearchUrl('QUERY',
                         config.thesaurusKey || '',
                         config.lang,
-                        config.max || this.DEFAULT_NUMBER_OF_RESULTS),
+                        config.max || this.DEFAULT_NUMBER_OF_RESULTS,
+                        undefined,
+                        config.outputLang),
                     filter: function(data) {
                       return parseKeywordsResponse(data, config.dataToExclude);
                     }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -501,6 +501,19 @@ form.gn-editor {
       margin-right: 0px;
   }
 
+  /* Multilingual badge positionning when
+  having suggestion or not */
+  [data-gn-multilingual-field] {
+    span.label {
+      position: absolute;
+      right: 15px;
+      line-height: 12px;
+    }
+    .twitter-typeahead span.label {
+      right: 2px;
+      top: 2px;
+    }
+  }
 }
 
 .gn-autocomplete-list {

--- a/web/src/main/webapp/xslt/common/functions-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/functions-metadata.xsl
@@ -367,6 +367,27 @@
   </xsl:function>
 
 
+  <!-- Return the directive to use for editing. -->
+  <xsl:function name="gn-fn-metadata:getFieldDirective" as="node()">
+    <xsl:param name="configuration" as="node()"/>
+    <xsl:param name="name" as="xs:string"/>
+
+    <xsl:variable name="type"
+                  select="$configuration/editor/fields/for[@name = $name and starts-with(@use, 'data-')]"/>
+    <xsl:choose>
+      <xsl:when test="$type">
+        <xsl:element name="directive">
+          <xsl:attribute name="data-directive-name" select="$type/@use"/>
+          <xsl:copy-of select="$type/directiveAttributes/@*"/>
+        </xsl:element>
+      </xsl:when>
+      <xsl:otherwise>
+        <null/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
+
   <!-- Return the directive to use for add control if a custom one
   is defined. Eg. Adding from a thesaurus propose a list of available
   thesaurus. -->

--- a/web/src/main/webapp/xslt/common/functions-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/functions-metadata.xsl
@@ -366,6 +366,21 @@
     />
   </xsl:function>
 
+  <xsl:function name="gn-fn-metadata:getAttributeFieldType" as="xs:string">
+    <xsl:param name="configuration" as="node()"/>
+    <!-- The container element gmx:fileName/@src-->
+    <xsl:param name="attributeNameWithParent" as="xs:string"/>
+
+    <xsl:variable name="type"
+                  select="normalize-space($configuration/editor/fields/for[@name = $attributeNameWithParent]/@use)"/>
+
+    <xsl:value-of
+      select="if ($type != '')
+      then $type
+      else $defaultFieldType"
+    />
+  </xsl:function>
+
 
   <!-- Return the directive to use for editing. -->
   <xsl:function name="gn-fn-metadata:getFieldDirective" as="node()">

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -221,7 +221,9 @@
                 </xsl:for-each>
 
                 <!-- Display the helper for a multilingual field below the field.
-                 The helper will be used only to populate the main language. -->
+                 The helper will be used only to populate the main language.
+                 It is recommended to use a thesaurus instead of an helper for
+                 multilingual records. -->
                 <xsl:if test="count($listOfValues/*) > 0">
                   <xsl:call-template name="render-form-field-helper">
                     <xsl:with-param name="elementRef" select="concat('_', $editInfo/@ref)"/>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -25,6 +25,7 @@
 <xsl:stylesheet xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:gn="http://www.fao.org/geonetwork" xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:java-xsl-util="java:org.fao.geonet.util.XslUtil"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:saxon="http://saxon.sf.net/" version="2.0"
@@ -1440,7 +1441,7 @@
   to a node (only for gn:attribute, see next template).
   -->
   <xsl:template mode="render-for-field-for-attribute"
-                match="@gn:xsderror|@gn:addedObj|
+                match="@gn:xsderror|@gn:addedObj|@xsi:type|
           @min|@max|@name|@del|@add|@id|@uuid|@ref|@parent|@up|@down" priority="2"/>
 
 

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1372,8 +1372,7 @@
     <xsl:variable name="attributeSpec" select="../gn:attribute[@name = $attributeName]"/>
 
     <xsl:variable name="directive"
-                  select="gn-fn-metadata:getFieldType($editorConfig, name(),
-      name(..))"/>
+                  select="gn-fn-metadata:getAttributeFieldType($editorConfig, concat(name(..), '/@', name()))"/>
 
     <!-- Form field name escaping ":" which will be invalid character for
     Jeeves request parameters. -->

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1139,8 +1139,9 @@
                            select="concat('_', $name)"/>
             <xsl:if test="$isDirective">
               <xsl:attribute name="{$type}"/>
+
               <xsl:if test="$directiveAttributes instance of node()+">
-                <xsl:copy-of select="$directiveAttributes/@*"/>
+                <xsl:copy-of select="$directiveAttributes//@*"/>
               </xsl:if>
             </xsl:if>
             <xsl:if test="$tooltip">

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -192,6 +192,8 @@
     <xsl:param name="base" as="node()"/>
 
     <xsl:if test="@xpath">
+      <xsl:variable name="config" select="."/>
+
       <!-- Seach any nodes in the metadata matching the XPath.
 
       We could have called saxon-evaluate from here like:
@@ -295,6 +297,7 @@
                                         then $overrideLabel
                                         else ''"/>
                   <xsl:with-param name="refToDelete" select="$refToDelete/gn:element"/>
+                  <xsl:with-param name="config" select="$config"/>
                 </saxon:call-template>
               </xsl:when>
               <xsl:otherwise>
@@ -318,6 +321,7 @@
                                         then $overrideLabel
                                         else ''"/>
                     <xsl:with-param name="refToDelete" select="$refToDelete/gn:element"/>
+                    <xsl:with-param name="config" select="$config"/>
                   </saxon:call-template>
                 </xsl:for-each>
               </xsl:otherwise>


### PR DESCRIPTION
Due to the increase of usage of registries (#2741) for managing list of values, catalogue administrators need to be able to configure which thesaurus to use to populate a field in the editor form.

When configured, then an autocomplete list is available in the editor:

![image](https://user-images.githubusercontent.com/1701393/45283003-f326a100-b4dc-11e8-9e31-0e3b8bea6edb.png)

Example of usage for use limitation which propose a list of values based on INSPIRE recommendation and Creative commons licenses https://www.youtube.com/watch?v=k5lONHoz-rU&feature=youtu.be 

Editor can still enter an alternative text and not pick a value from the list.

## Work description

- [x] Add editor configuration / Configuration for field in any views

Sample configurations:

Use LimitationsOnPublicAccess INSPIRE codelist to populate gmd:useLimitation. This is the easiest configuration where you use the ```data-gn-keyword-picker``` directive pointing to the thesaurus identified by the ```data-thesaurus-key```. The thesaurus key is available in the admin console > thesaurus panel.
```
<for name="gmd:useLimitation"
         use="data-gn-keyword-picker">
  <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"/>
</for>
```

Additional attributes are available to customize the suggestion:

* ```data-number-of-suggestions``` define the number of suggestions to list
* ```data-display-definition``` allows to display the definition

```
<for name="gmd:otherConstraints"
         use="data-gn-keyword-picker">
      <directiveAttributes 
              data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistOnLineDescriptionCode-OnLineDescriptionCode"
              data-display-definition="true"/>
</for>
```

![image](https://user-images.githubusercontent.com/1701393/45345036-79a6b580-b5a5-11e8-99fc-9bc73fd889a3.png)



- [x] Add editor configuration / Configuration for field in a specific view. Use and directive attributes can be used in a field defined in a view:

```
   <tab id="default" default="true" mode="flat">
        <section>
          <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:language"
                 use="data-gn-keyword-picker">
            <directiveAttributes
              data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistOnLineDescriptionCode-OnLineDescriptionCode"
              data-display-definition="true"
              data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
          </field>
        </section>
```


- [x] Add multilingual support. Populate all translations based on the record languages and the languages available in the thesaurus.

![image](https://user-images.githubusercontent.com/1701393/46611971-989a5800-cb0f-11e8-9114-40a31fb3d5c6.png)


- [x] Add Anchor encoding / Use keyword id when using autocomplete list (#3044)
- [x] Add Anchor encoding / Use URL (#2867)
- [x] Add Anchor with multilingual encoding / Keep Anchor instead of CharacterString (See https://github.com/geonetwork/core-geonetwork/blob/master/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl#L297-L309)
```
<gmx:Anchor xlink:href="http://example.com/fr">francais</gmx:Anchor>
<gmd:PT_FreeText>
   <gmd:textGroup>
      <gco:localisedCharacterString locale="#EN">english</gco:localisedCharacterString>
   </gmd:textGroup>
</gmd:PT_FreeText>
```
- [x] Add any attribute encoding based on concept id. Example for a LocalName element:
```
<gmd:featureTypes>
  <gco:LocalName codeSpace="http://purl.org/myocean/ontology/vocabulary/feature-type#Grid">Grid</gco:LocalName>
</gmd:featureTypes>
```
... the configuration would be:
```
          <field xpath="/gmd:MD_Metadata/gmd:contentInfo/*/gmd:featureTypes"
                   use="data-gn-keyword-picker">
              <directiveAttributes data-thesaurus-key="local.feature-type.myocean.feature-type"
                                              data-thesaurus-concept-id-attribute="codeSpace"/>
          </field>
```



This mode is recommended to be used instead of using helper which may trigger issues in multilingual context (#3076)

## Schema plugin changes for ISO19139 extension:

* add the following to config-editor.xml

```
    <for name="gts:TM_PeriodDuration" use="data-gn-field-duration-div"/>
    <for name="gml:duration" use="data-gn-field-duration-div"/>
```
* Update type mapping for attribute (to avoid to use a field directive on an attribute)
```
    <for name="src" use="data-gn-logo-selector"/>
```
by 
```
    <for name="gmx:FileName/@src" use="data-gn-logo-selector"/>
```

* replace for topic category (if using it)
```
      <xsl:with-param name="directive" select="'gn-topiccategory-selector'"/>
```
by
```
      <xsl:with-param name="type" select="'data-gn-topiccategory-selector-div'"/>
```

* Add field configuration per view in dispatcher template

```
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/dispatcher.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/dispatcher.xsl
@@ -50,9 +50,11 @@
     <xsl:param name="base" as="node()"/>
     <xsl:param name="overrideLabel" as="xs:string" required="no" select="''"/>
     <xsl:param name="refToDelete" as="node()?" required="no"/>
+    <xsl:param name="config" as="node()?" required="no"/>
     <xsl:apply-templates mode="mode-iso19139" select="$base">
       <xsl:with-param name="overrideLabel" select="$overrideLabel"/>
       <xsl:with-param name="refToDelete" select="$refToDelete"/>
+      <xsl:with-param name="config" select="$config"/>
     </xsl:apply-templates>
   </xsl:template>

```




## Future work to plan


- Indexing / Check indexing of Anchors and render them properly
- UI / Make link field layout more consistent (in attribute div or in the form or with "add/update link" button)
- UI / Display links when set (once indexed for the Angular view, add support for multilingual Anchor in XSL formatter)
- UI / Display images when link point to an image (related to https://github.com/geonetwork/core-geonetwork/pull/3149)


