### PR TITLE
Editor / Properly close editor tab when a new window is opened. 

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -349,7 +349,7 @@
         //        $($scope.formId + ' > fieldset').fadeOut(duration);
         $scope.save(true);
 
-        $location.search('tab', tabIdentifier);
+        $location.search('tab', tabIdentifier).replace();
       };
 
       /**


### PR DESCRIPTION
Do not alter history when switching tabs. This means to close tab if empty history or use the redirectUrl parameter in other cases.