### PR TITLE
LDAP / Preserve user privileges on sign in.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
@@ -70,8 +70,15 @@ public class LDAPUtils {
         }
         User toSave = getUser(user, importPrivilegesFromLdap, userName);
 
-        // Add user groups
-        if (user.getPrivileges().size() > 0) {
+        // Add user groups if the user has no group assigned.
+        // This means that if some privileges has been assigned
+        // to the user after the creation, those are preserved.
+        // The default one from the LDAP config are only set
+        // it user has no privileges.
+        UserGroupRepository userGroupRepository = ApplicationContextHolder.get().getBean(UserGroupRepository.class);
+        List<UserGroup> existingGroups = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getUser().getId()));
+
+        if (existingGroups.size() == 0 && user.getPrivileges().size() > 0) {
             entityManager.flush();
             entityManager.clear();
             List<UserGroup> ug = getPrivilegesAndCreateGroups(user,


### PR DESCRIPTION
When a LDAP configuration define a default privilege for a group
eg.
```
ldapUserContextMapper.mapping[privilege]=privileges,eea_users
```
then on sign in, the user lost any other privileges which might
have been assigned from the admin console and defaults are restored.

If an LDAP user has privileges defined, preserve them and do not
apply the default one. If none, add the default.