### PR TITLE
Add WMS layer doesn't work fine when url ends with ? the proxy adds an extra ? character and the GetMap requests fail. Fixes #3088

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -882,9 +882,13 @@
                   }
                 }
               }
-    
+
               url = getCapLayer.url || url;
-              if(getCapLayer.useProxy 
+              if (url.slice(-1) === '?') {
+                url = url.substring(0, url.length-1);
+              }
+
+              if(getCapLayer.useProxy
                   && url.indexOf(gnGlobalSettings.proxyUrl) != 0) {
                 url = gnGlobalSettings.proxyUrl + encodeURIComponent(url);
               }


### PR DESCRIPTION
Fixes #3088.