### PR TITLE
New map tool: Projection switcher

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
@@ -1,0 +1,110 @@
+<table class="table table-striped">
+	<tr data-ng-repeat="opt in mCfg[key] track by $index"
+		ng-init="parentIndex=$index">
+		<td>
+			<div class="input-group">
+				<span class="input-group-addon" data-translate="">ui-label</span> <input
+					type="text" class="form-control" id="ui-projectionLabel-{{$index}}"
+					data-ng-model="opt.label" />
+			</div>
+			<div class="input-group">
+				<p class="help-block" data-translate="">ui-label-help</p>
+			</div>
+			<div class="input-group">
+				<span class="input-group-addon" data-translate="">ui-code</span> <input
+					type="text" class="form-control" id="ui-projectionCode-{{$index}}"
+					data-ng-model="opt.code" />
+			</div>
+			<div class="input-group">
+				<p class="help-block" data-translate="">ui-code-help</p>
+			</div>
+      <div class="input-group">
+        <span class="input-group-addon" data-translate="">ui-definition</span>
+        <input type="text" class="form-control"
+          id="ui-projectionCode-{{$index}}" data-ng-model="opt.def" />
+      </div>
+      <div class="input-group">
+        <p class="help-block" data-translate="">ui-definition-help</p>
+      </div>
+			<div class="input-group">
+				<span class="input-group-addon" data-translate="">ui-extent</span> <input
+					type="text" class="form-control" gn-json-edit="opt.extent" />
+			</div>
+			<div class="input-group">
+				<span class="input-group-addon" data-translate="">ui-minx</span> <input
+					type="number" class="form-control"
+					id="ui-projectionCode-{{$index}}" data-ng-model="opt.extent[0]" />
+				<span class="input-group-addon" data-translate="">ui-miny</span> <input
+					type="number" class="form-control"
+					id="ui-projectionCode-{{$index}}" data-ng-model="opt.extent[1]" />
+				<span class="input-group-addon" data-translate="">ui-maxx</span> <input
+					type="number" class="form-control"
+					id="ui-projectionCode-{{$index}}" data-ng-model="opt.extent[2]" />
+				<span class="input-group-addon" data-translate="">ui-maxy</span> <input
+					type="number" class="form-control"
+					id="ui-projectionCode-{{$index}}" data-ng-model="opt.extent[3]" />
+			</div>
+			<div class="input-group">
+				<p class="help-block" data-translate="">ui-extent-help</p>
+			</div>
+			<div class="input-group">
+				<span class="input-group-addon" data-translate="">ui-worldExtent</span>
+				<input type="text" class="form-control"
+					gn-json-edit="opt.worldExtent" />
+			</div>
+			<div class="input-group">
+				<span class="input-group-addon" data-translate="">ui-minx</span> <input
+					type="number" class="form-control"
+					data-ng-model="opt.worldExtent[0]" /> <span
+					class="input-group-addon" data-translate="">ui-miny</span> <input
+					type="number" class="form-control"
+					data-ng-model="opt.worldExtent[1]" /> <span
+					class="input-group-addon" data-translate="">ui-maxx</span> <input
+					type="number" class="form-control"
+					data-ng-model="opt.worldExtent[2]" /> <span
+					class="input-group-addon" data-translate="">ui-maxy</span> <input
+					type="number" class="form-control"
+					data-ng-model="opt.worldExtent[3]" />
+			</div>
+			<div class="input-group">
+				<p class="help-block" data-translate="">ui-worldExtent-help</p>
+			</div>
+			<div class="input-group">
+				<span class="input-group-addon" data-translate="">ui-resolutions</span>
+
+				<table class="table table-striped">
+					<tr data-ng-repeat="resolution in opt.resolutions track by $index">
+						<td><input type="number" class="form-control"
+							data-ng-model="opt.resolutions[$index]" /></td>
+						<td><a class="btn btn-link text-danger"
+							title="{{'remove' | translate}}"
+							data-ng-click="removeItem(mCfg[key][parentIndex].resolutions, $index)">
+								<i class="fa fa-times text-danger" />
+						</a></td>
+					</tr>
+					<tr>
+						<td><a class="btn btn-link" title="{{'add' | translate}}"
+							data-ng-click="addItem(mCfg[key][$index].resolutions, '')"> <i
+								class="fa fa-plus" />
+						</a></td>
+					</tr>
+				</table>
+			</div>
+			<div class="input-group">
+				<p class="help-block" data-translate="">ui-resolutions-help</p>
+			</div>
+		</td>
+		<td><a class="btn btn-link text-danger"
+			title="{{'remove' | translate}}"
+			data-ng-click="removeItem(mCfg[key], $index)"> <i
+				class="fa fa-times text-danger" />
+		</a></td>
+	</tr>
+	<tr>
+		<td><a class="btn btn-link" title="{{'add' | translate}}"
+			data-ng-click="addItem(mCfg[key], {'label': '', 'code': 
+			'EPSG:', 'extent': [], worldExtent: [], resolutions: []})">
+				<i class="fa fa-plus" />
+		</a></td>
+	</tr>
+</table>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
@@ -4,45 +4,38 @@
 		<td>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-label</span> <input
-					type="text" class="form-control" id="ui-projectionLabel-{{$index}}"
-					data-ng-model="opt.label" />
+					type="text" class="form-control" data-ng-model="opt.label" />
 			</div>
 			<div class="input-group">
 				<p class="help-block" data-translate="">ui-label-help</p>
 			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-code</span> <input
-					type="text" class="form-control" id="ui-projectionCode-{{$index}}"
-					data-ng-model="opt.code" />
+					type="text" class="form-control" data-ng-model="opt.code" />
 			</div>
 			<div class="input-group">
 				<p class="help-block" data-translate="">ui-code-help</p>
 			</div>
-      <div class="input-group">
-        <span class="input-group-addon" data-translate="">ui-definition</span>
-        <input type="text" class="form-control"
-          id="ui-projectionCode-{{$index}}" data-ng-model="opt.def" />
-      </div>
-      <div class="input-group">
-        <p class="help-block" data-translate="">ui-definition-help</p>
-      </div>
+			<div class="input-group">
+				<span class="input-group-addon" data-translate="">ui-definition</span>
+				<input type="text" class="form-control" data-ng-model="opt.def" />
+			</div>
+			<div class="input-group">
+				<p class="help-block" data-translate="">ui-definition-help</p>
+			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-extent</span> <input
 					type="text" class="form-control" gn-json-edit="opt.extent" />
 			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-minx</span> <input
-					type="number" class="form-control"
-					id="ui-projectionCode-{{$index}}" data-ng-model="opt.extent[0]" />
+					type="number" class="form-control" data-ng-model="opt.extent[0]" />
 				<span class="input-group-addon" data-translate="">ui-miny</span> <input
-					type="number" class="form-control"
-					id="ui-projectionCode-{{$index}}" data-ng-model="opt.extent[1]" />
+					type="number" class="form-control" data-ng-model="opt.extent[1]" />
 				<span class="input-group-addon" data-translate="">ui-maxx</span> <input
-					type="number" class="form-control"
-					id="ui-projectionCode-{{$index}}" data-ng-model="opt.extent[2]" />
+					type="number" class="form-control" data-ng-model="opt.extent[2]" />
 				<span class="input-group-addon" data-translate="">ui-maxy</span> <input
-					type="number" class="form-control"
-					id="ui-projectionCode-{{$index}}" data-ng-model="opt.extent[3]" />
+					type="number" class="form-control" data-ng-model="opt.extent[3]" />
 			</div>
 			<div class="input-group">
 				<p class="help-block" data-translate="">ui-extent-help</p>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -436,6 +436,78 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <div data-ng-switch-when="switcherProjectionList">
+        <label class="control-label">{{('ui-' + key) | translate}}</label>
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+        <table class="table table-striped">
+          <tr data-ng-repeat="opt in mCfg[key] track by $index">
+            <td>
+              <div class="input-group">
+                <span class="input-group-addon">Label </span>
+                <input type="text"
+                       class="form-control"
+                       id="ui-projectionLabel-{{$index}}"
+                       data-ng-model="opt.label"/>
+                <span class="input-group-addon">Code </span>
+                <input type="text"
+                       class="form-control"
+                       id="ui-projectionCode-{{$index}}"
+                       data-ng-model="opt.code"/>
+              </div>
+              <div class="input-group">
+                <span class="input-group-addon">Extent </span>
+                <input type="text"
+                       class="form-control"
+                       id="ui-projectionCode-{{$index}}"
+                       data-ng-model="opt.extent"/>
+                <span class="input-group-addon">WorldExtent </span>
+                <input type="text"
+                       class="form-control"
+                       id="ui-projectionCode-{{$index}}"
+                       data-ng-model="opt.worldExtent"/>
+              </div>
+              <div class="input-group">
+                <span class="input-group-addon">Resolutions </span>
+                <input type="text"
+                       class="form-control"
+                       id="ui-projectionCode-{{$index}}"
+                       data-ng-model="opt.resolutions"/>
+                <span class="input-group-addon">Center </span>
+                <input type="text"
+                       class="form-control"
+                       id="ui-projectionCode-{{$index}}"
+                       data-ng-model="opt.center"/>
+              </div>
+              <div class="input-group">
+                <span class="input-group-addon">Definition </span>
+                <input type="text"
+                       class="form-control"
+                       id="ui-projectionCode-{{$index}}"
+                       data-ng-model="opt.def"/>
+              </div>
+            </td>
+            <td>
+              <a class="btn btn-link text-danger"
+                 title="{{'remove' | translate}}"
+                 data-ng-click="removeItem(mCfg[key], $index)">
+                <i class="fa fa-times text-danger"/>
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a class="btn btn-link"
+                 title="{{'add' | translate}}"
+                 data-ng-click="addItem(mCfg[key], {'label': '', 'code': 'EPSG:', 'extent': ''})">
+                <i class="fa fa-plus"/>
+              </a>
+            </td>
+          </tr>
+        </table>
+      </div>
+
       <!-- numbers -->
       <div data-ng-switch-when="paginationInfo">
         <label class="control-label">{{('ui-' + key) | translate}}</label>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -436,78 +436,16 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <!-- Projection Switcher -->
       <div data-ng-switch-when="switcherProjectionList">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
         <p class="help-block"
            data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
           {{('ui-' + key + '-help') | translate}} </p>
-        <table class="table table-striped">
-          <tr data-ng-repeat="opt in mCfg[key] track by $index">
-            <td>
-              <div class="input-group">
-                <span class="input-group-addon">Label </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionLabel-{{$index}}"
-                       data-ng-model="opt.label"/>
-                <span class="input-group-addon">Code </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionCode-{{$index}}"
-                       data-ng-model="opt.code"/>
-              </div>
-              <div class="input-group">
-                <span class="input-group-addon">Extent </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionCode-{{$index}}"
-                       data-ng-model="opt.extent"/>
-                <span class="input-group-addon">WorldExtent </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionCode-{{$index}}"
-                       data-ng-model="opt.worldExtent"/>
-              </div>
-              <div class="input-group">
-                <span class="input-group-addon">Resolutions </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionCode-{{$index}}"
-                       data-ng-model="opt.resolutions"/>
-                <span class="input-group-addon">Center </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionCode-{{$index}}"
-                       data-ng-model="opt.center"/>
-              </div>
-              <div class="input-group">
-                <span class="input-group-addon">Definition </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionCode-{{$index}}"
-                       data-ng-model="opt.def"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a class="btn btn-link"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], {'label': '', 'code': 'EPSG:', 'extent': ''})">
-                <i class="fa fa-plus"/>
-              </a>
-            </td>
-          </tr>
-        </table>
+          <div ng-include="'../../catalog/components/admin/uiconfig/partials/projectionSwitcher.html'">
+        </div>
       </div>
-
+      
       <!-- numbers -->
       <div data-ng-switch-when="paginationInfo">
         <label class="control-label">{{('ui-' + key) | translate}}</label>

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -162,6 +162,24 @@
               defer.reject();
               return $q.defer().promise;
             }
+            
+            //Check if the layer has some projection restriction
+            //If no restriction, just (try to) add it
+            if(layerInfo.projectionList && layerInfo.projectionList.length 
+                && layerInfo.projectionList.length > 0) {
+              var addIt = false;
+              
+              $.each(layerInfo.projectionList, function(i, p){
+                if(map.getView().getProjection().getCode() == p) {
+                  addIt = true;
+                }
+              });
+              
+              if(!addIt) {
+                defer.reject();
+                return $q.defer().promise;
+              }
+            }
 
             switch (layerInfo.type) {
               case 'osm':

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -189,11 +189,18 @@
                 }));
                 break;
 
-              case 'tms':
+              case 'tms':            
+                var prop = { 
+                  // Settings are usually encoded
+                    url: decodeURI(layerInfo.url)
+                };
+                
+                if(layerInfo.projection) {
+                  prop.projection = layerInfo.projection;
+                }
+                
                 defer.resolve(new ol.layer.Tile({
-                  source: new ol.source.XYZ({
-                        url: layerInfo.url
-                  }),
+                  source: new ol.source.XYZ(prop),
                   title: layerInfo.title || 'TMS Layer'
                 }));
                 break;

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1078,7 +1078,7 @@
               }
 
               if (!isLayerAvailableInMapProjection) {
-                errors.push($translate.instant('layerNotAvailableInMapProj'));
+              //  errors.push($translate.instant('layerNotAvailableInMapProj'));
                 console.warn($translate.instant('layerNotAvailableInMapProj'));
               }
 

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -199,6 +199,12 @@
                   prop.projection = layerInfo.projection;
                 }
                 
+                if(layerInfo.attribution) {
+                  prop.attributions = [
+                    new ol.Attribution({"html": layerInfo.attribution})
+                  ]
+                }
+                
                 defer.resolve(new ol.layer.Tile({
                   source: new ol.source.XYZ(prop),
                   title: layerInfo.title || 'TMS Layer'
@@ -244,6 +250,11 @@
                         layer.set('title', layerInfo.title);
                         layer.set('label', layerInfo.title);
                       }
+                      
+                      if(layerInfo.attribution) {
+                        layer.getSource().setAttributions(layerInfo.attribution);
+                      }
+                      
                       defer.resolve(layer);
                     });
                 break;
@@ -262,6 +273,11 @@
                         layer.set('title', layerInfo.title);
                         layer.set('label', layerInfo.title);
                       }
+                      
+                      if(layerInfo.attribution) {
+                        layer.getSource().setAttributions(layerInfo.attribution);
+                      }
+                      
                       defer.resolve(layer);
                     });
                 break;

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -244,7 +244,8 @@
               //send request and decode result
               if (true) {
                 $http.get(url, {
-                  cache: true
+                  cache: true,
+                  timeout: 5000
                 })
                     .success(function(data) {
                       try {
@@ -278,7 +279,8 @@
               if (gnUrlUtils.isValid(url)) {
 
                 $http.get(url, {
-                  cache: true
+                  cache: true,
+                  timeout: 5000
                 })
                     .success(function(data, status, headers, config) {
                       if (data) {
@@ -309,7 +311,8 @@
 
               if (gnUrlUtils.isValid(url)) {
                 $http.get(url, {
-                  cache: true
+                  cache: true,
+                  timeout: 5000
                 })
                     .success(function(data, status, headers, config) {
                       var xfsCap = parseWFSCapabilities(data);

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -318,7 +318,7 @@
                       var xfsCap = parseWFSCapabilities(data);
 
                       if (!xfsCap || xfsCap.exception != undefined) {
-                        defer.reject({msg: 'wfsGetCapabilitiesFailed',
+                        defer.reject({msg: $translate.instant('wfsGetCapabilitiesFailed'),
                           owsExceptionReport: xfsCap});
                       } else {
                         defer.resolve(xfsCap);

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -326,7 +326,7 @@
 
                     })
                     .error(function(data, status, headers, config) {
-                      defer.reject(status);
+                      defer.reject($translate.instant('wfsGetCapabilitiesFailed'));
                     });
               }
             }

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -83,6 +83,7 @@
               /** active tool selector */
               scope.activeTools = {
                 addLayers: false,
+                projectionSwitcher: false,
                 contexts: false,
                 filter: false,
                 layers: false,
@@ -324,8 +325,10 @@
               }, function(openedTool) {
                 // open the correct tool using gi-btn magic
                 switch (openedTool.name.toLowerCase()) {
-                  case 'addlayers':
-                    scope.activeTools.addLayers = true; break;
+                case 'addlayers':
+                  scope.activeTools.addLayers = true; break;
+                case 'projectionSwitcher':
+                  scope.activeTools.projectionSwitcher = true; break;
                   case 'contexts':
                     scope.activeTools.contexts = true; break;
                   case 'filter':

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -95,6 +95,11 @@
               /** optional tabs **/
               scope.disabledTools = gnViewerSettings.mapConfig.disabledTools;
 
+              /** If only one projection on the list, hide **/
+              if(gnViewerSettings.mapConfig.switcherProjectionList.length < 2) {
+                scope.disabledTools.projectionSwitcher = true;
+              }
+              
               /** wps process tabs */
               scope.wpsTabs = {
                 byUrl: true,

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerModule.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerModule.js
@@ -33,6 +33,7 @@
   goog.require('gn_heatmap');
   goog.require('gn_index');
   goog.require('gn_layermanager');
+  goog.require('gn_projectionswitcher');
   goog.require('gn_localisation');
   goog.require('gn_measure');
   goog.require('gn_module');
@@ -68,6 +69,7 @@
     'gn_wfs_directive',
     'gn_owscontext',
     'gn_layermanager',
+    'gn_projectionswitcher',
     'gn_baselayerswitcher',
     'gn_measure',
     'gn_draw',

--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
@@ -57,9 +57,11 @@
             layer.setVisible(true);
             var layers = scope.map.getLayers();
             if(layers.getLength() > 0) {
+              layers.item(0).set("currentBackground", false)
               layers.removeAt(0);
             }
             layers.insertAt(0, layer);
+            layer.set("currentBackground", true);
             return false;
           };
 
@@ -68,11 +70,23 @@
             scope.setBgLayer(layer);
           };
           
-          scope.$watch(function() { return gnViewerSettings.bgLayers}, function(bgLayers) {
-            if(bgLayers && bgLayers.length && bgLayers.length > 0 ) {
-              scope.layers = bgLayers;
-              scope.setBgLayer(scope.layers[0]);
-            }
+          scope.$watch(function() { return gnViewerSettings.bgLayers}, 
+              function(bgLayers) {
+                if(bgLayers && bgLayers.length && bgLayers.length > 0 ) {
+                  scope.layers = bgLayers;
+                  
+                  //Do we remember the previous background layer?
+                  var i = 0;
+                  var j = 0;
+                  bgLayers.forEach(function(layer) {
+                    if(layer.get("currentBackground")) {
+                      i = j;
+                    }
+                    j++;
+                  });
+                  
+                  scope.setBgLayer(scope.layers[i]);
+                }
           });
 
           scope.reset = function() {

--- a/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/baselayerswitcher/BaseLayerSwitcherDirective.js
@@ -56,7 +56,9 @@
           scope.setBgLayer = function(layer) {
             layer.setVisible(true);
             var layers = scope.map.getLayers();
-            layers.removeAt(0);
+            if(layers.getLength() > 0) {
+              layers.removeAt(0);
+            }
             layers.insertAt(0, layer);
             return false;
           };
@@ -65,6 +67,13 @@
           scope.changeBackground = function (layer) {
             scope.setBgLayer(layer);
           };
+          
+          scope.$watch(function() { return gnViewerSettings.bgLayers}, function(bgLayers) {
+            if(bgLayers && bgLayers.length && bgLayers.length > 0 ) {
+              scope.layers = bgLayers;
+              scope.setBgLayer(scope.layers[0]);
+            }
+          });
 
           scope.reset = function() {
             $rootScope.$broadcast('owsContextReseted');

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -33,8 +33,8 @@
     <button class="btn btn-default" ng-model="activeTools.projectionSwitcher"
             type="submit" gi-btn="active" ng-hide="disabledTools.projectionSwitcher">
       <span class="fa fa-map-signs"></span>
-      <span class="label" ng-show="showToolLabels" translate="">ProjectionSwitcher</span>
-      <span role="tooltip" translate="">ProjectionSwitcher</span>
+      <span class="label" ng-show="showToolLabels" translate="">projectionSwitcher</span>
+      <span role="tooltip" translate="">projectionSwitcher</span>
     </button>
     <button class="btn btn-default" ng-model="activeTools.legend"
             type="submit" gi-btn="active" ng-hide="disabledTools.legend"
@@ -209,11 +209,17 @@
   <div class="panel panel-default panel-tools"
        ng-show="activeTools.projectionSwitcher">
     <div class="panel-heading">
-      <h3>{{'ProjectionSwitcher' | translate}}
+      <h3>{{'projectionSwitcher' | translate}}
         <button type="button" class="btn btn-default close"
-                ng-model="activeTools.projectionSwitcher" gi-btn>
+                ng-model="activeTools.projectionSwitcher" gi-btn >
+        </button>
+       </h3>
+      </div>
     <div class="panel-body">
       <div gn-projection-switcher="map"></div>
+     </div>
+   </div>
+
 
   <!-- Legend -->
   <div class="panel panel-default panel-tools"

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -32,7 +32,7 @@
     </button>
     <button class="btn btn-default" ng-model="activeTools.projectionSwitcher"
             type="submit" gi-btn="active" ng-hide="disabledTools.projectionSwitcher">
-      <span class="fa fa-map-signs"></span>
+      <span class="fa fa-th-large "></span>
       <span class="label" ng-show="showToolLabels" translate="">projectionSwitcher</span>
       <span role="tooltip" translate="">projectionSwitcher</span>
     </button>
@@ -206,18 +206,9 @@
   </div>
 
   <!-- Projection Switcher -->
-  <div class="panel panel-default panel-tools"
+  <div class="panel-default panel-tools"
        ng-show="activeTools.projectionSwitcher">
-    <div class="panel-heading">
-      <h3>{{'projectionSwitcher' | translate}}
-        <button type="button" class="btn btn-default close"
-                ng-model="activeTools.projectionSwitcher" gi-btn >
-        </button>
-       </h3>
-      </div>
-    <div class="panel-body">
       <div gn-projection-switcher="map"></div>
-     </div>
    </div>
 
 

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -30,6 +30,12 @@
       <span class="label" ng-show="showToolLabels" translate="">Layers</span>
       <span role="tooltip" translate="">Layers</span>
     </button>
+    <button class="btn btn-default" ng-model="activeTools.projectionSwitcher"
+            type="submit" gi-btn="active" ng-hide="disabledTools.projectionSwitcher">
+      <span class="fa fa-map-signs"></span>
+      <span class="label" ng-show="showToolLabels" translate="">ProjectionSwitcher</span>
+      <span role="tooltip" translate="">ProjectionSwitcher</span>
+    </button>
     <button class="btn btn-default" ng-model="activeTools.legend"
             type="submit" gi-btn="active" ng-hide="disabledTools.legend"
             aria-label="{{'mapLegend' | translate}}">
@@ -198,6 +204,16 @@
           data-ng-show="is3dEnabled"></div>
     </div>
   </div>
+
+  <!-- Projection Switcher -->
+  <div class="panel panel-default panel-tools"
+       ng-show="activeTools.projectionSwitcher">
+    <div class="panel-heading">
+      <h3>{{'ProjectionSwitcher' | translate}}
+        <button type="button" class="btn btn-default close"
+                ng-model="activeTools.projectionSwitcher" gi-btn>
+    <div class="panel-body">
+      <div gn-projection-switcher="map"></div>
 
   <!-- Legend -->
   <div class="panel panel-default panel-tools"

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
@@ -21,12 +21,10 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-(function() {
+(function () {
   goog.provide('gn_projectionswitcher');
 
-  var module = angular.module('gn_projectionswitcher', [
-  ]);
-
+  var module = angular.module('gn_projectionswitcher', []);
 
   /**
    * @ngdoc directive
@@ -35,172 +33,185 @@
    * @description The `gnProjectionSwitcher` directive adds a button to the map
    *              that allows you to change the projection.
    */
-  module.directive('gnProjectionSwitcher', [
-    'gnViewerSettings',
-    function(gnViewerSettings) {
-      return {
-        restrict: 'A',
-        templateUrl: '../../catalog/components/viewer/projectionSwitcher/' +
-            'partials/projectionSwitcher.html',
-        scope: {
-          map: '=gnProjectionSwitcher'
-        },
-        controllerAs: 'gnProjectionSwitcherCtrl',
-        controller: ['$scope', 'gnViewerSettings', 'gnMap', '$rootScope', 
-          function(scope, gnViewerSettings, gnMap, $rootScope) {
+  module
+      .directive(
+          'gnProjectionSwitcher',
+          [
+              'gnViewerSettings',
+              function (gnViewerSettings) {
+                return {
+                  restrict : 'A',
+                  templateUrl : '../../catalog/components/viewer/projectionSwitcher/'
+                      + 'partials/projectionSwitcher.html',
+                  scope : {
+                    map : '=gnProjectionSwitcher'
+                  },
+                  controllerAs : 'gnProjectionSwitcherCtrl',
+                  controller : [
+                      '$scope',
+                      'gnViewerSettings',
+                      'gnMap',
+                      '$rootScope',
+                      function (scope, gnViewerSettings, gnMap, $rootScope) {
 
-          //Change the projection of an existing layer
-          scope.changeLayerProjection = function(
-            layer, oldProj, newProj) {
-            if (layer instanceof ol.layer.Group) {
-              layer.getLayers().forEach(
-                  function(subLayer) {
-                    this.changeLayerProjection(
-                      subLayer, oldProj,
-                      newProj);
-                  });
-            } else if (layer instanceof ol.layer.Tile) {
-              var tileLoadFunc = layer.getSource()
-                .getTileLoadFunction();
-              layer.getSource().setTileLoadFunction(
-                tileLoadFunc);
-            } else if (layer instanceof ol.layer.Vector) {
-              var features = layer.getSource().getFeatures();
-              for (var i = 0; i < features.length; i += 1) {
-                features[i].getGeometry().transform(
-                  oldProj, newProj);
-              }
-            }
-          };
-          
-          //Main function to switch the projection
-          scope.switchProjection = function(projection) {
-              var view = scope.map.getView();
-              var oldProj = view.getProjection();
-              var newProj = ol.proj.get(projection);
-              
-              if(oldProj == newProj) {
-                //There is no real change, don't do anything
-                return;
-              }
-              
-              //First, get all the info to populate the map
-              
-              var projectionConfig = {};
-              
-              gnViewerSettings.mapConfig.switcherProjectionList.forEach(function(config) {
-                if(config['code'] == projection) {
-                  projectionConfig = config;
-                }
-              });
-              
-              var newExtent = ol.proj.transformExtent(
-                  view.calculateExtent(scope.map.getSize()), oldProj, newProj);
-              
-              if(newProj.getExtent()) {
-                newExtent = newProj.getExtent();
-              }
-              
-              var newCenter = ol.proj.transform(scope.map.getView().getCenter(), oldProj, newProj);
-              
-              if(projectionConfig.center) {
-                newCenter = JSON.parse(projectionConfig.center);
-              }
+                        // Change the projection of an existing layer
+                        scope.changeLayerProjection = function (layer, oldProj,
+                            newProj) {
+                          if (layer instanceof ol.layer.Group) {
+                            layer.getLayers().forEach(
+                                function (subLayer) {
+                                  this.changeLayerProjection(subLayer, oldProj,
+                                      newProj);
+                                });
+                          } else if (layer instanceof ol.layer.Tile) {
+                            var tileLoadFunc = layer.getSource()
+                                .getTileLoadFunction();
+                            layer.getSource().setTileLoadFunction(tileLoadFunc);
+                          } else if (layer instanceof ol.layer.Vector) {
+                            var features = layer.getSource().getFeatures();
+                            for (var i = 0; i < features.length; i += 1) {
+                              features[i].getGeometry().transform(oldProj,
+                                  newProj);
+                            }
+                          }
+                        };
 
-              var mapsConfig = {
-                projection: newProj,
-                extent: newExtent,
-                center: newCenter
-              };
-              
-              if (projectionConfig.resolutions) {
-                angular.extend(mapsConfig, {resolutions: JSON.parse(projectionConfig.resolutions)})
-              }
+                        // Main function to switch the projection
+                        scope.switchProjection = function (projection) {
+                          var view = scope.map.getView();
+                          var oldProj = view.getProjection();
+                          var newProj = ol.proj.get(projection);
 
-              var newView = new ol.View(mapsConfig);
-              
-              // Rearrange base layers to adapt (if possible) to new projection
-              var layersToRemove = [];
-              var bgLayers = [];
+                          if (oldProj == newProj) {
+                            // There is no real change, don't do anything
+                            return;
+                          }
 
-              gnViewerSettings.bgLayers.forEach(function(layer) {
-                //is this layer coming from original context?
-                //layers from original context should be kept
-                if(!layer.get("fromGNSettings")){
-                  bgLayers.push(layer);
-                  //Remember current background, if possible
-                  layer.set("currentBackground", layer.getVisible());
-                }
-              });
-              
-              // Loop over all background layers currently on the map
-              // to start from scratch
-              scope.map.getLayers().forEach(function(layer) {
-                if (layer.get("group") == 'Background layers' 
-                  || !layer.displayInLayerManager) {
-                  
-                  //is this layer coming from original context?
-                  //layers from original context should be kept
-                  if(layer.get("fromGNSettings")){
-                    layersToRemove.push(layer);                    
-                  } 
-                }
-              });
-              
-              // Remove from map all base layers that don't belong to this projection
-              // different loop from previous one as it may break forEach
-             layersToRemove.forEach(function(layer){
-               scope.map.removeLayer(layer);
-             }); 
+                          // First, get all the info to populate the map
 
-              // Renew base layers from settings
-              var layers = gnViewerSettings.mapConfig['map-viewer'].layers;
-              if (layers && layers.length) {
-                layers.forEach(function(layerInfo) {
-                  gnMap.createLayerFromProperties(layerInfo, scope.map)
-                    .then(function(layer) {
-                      if (layer) {
-                        layer.displayInLayerManager = false;
-                        layer.set("group", "Background layers");
-                        layer.set("fromGNSettings", true);
-                        layer.set("currentBackground", false);
-                        bgLayers.push(layer);
-                      }
-                    });
-                });
-              }
-              
-              //We have all the info, change the map
+                          var projectionConfig = {};
 
-              // Set the view
-              scope.map.setView(newView);
-              
-              //Update Background Layers to trigger tool changes
-              gnViewerSettings.bgLayers = bgLayers;
+                          gnViewerSettings.mapConfig.switcherProjectionList
+                              .forEach(function (config) {
+                                if (config['code'] == projection) {
+                                  projectionConfig = config;
+                                }
+                              });
 
-              // Reproject all layers in the map
-              scope.map.getLayers().forEach(function(layer) {
-                scope.changeLayerProjection(layer, oldProj, newProj);
-              });
+                          var newExtent = ol.proj.transformExtent(view
+                              .calculateExtent(scope.map.getSize()), oldProj,
+                              newProj);
 
-              // Reproject all controls in the map
-              scope.map.getControls().forEach(function(control) {
-                if (typeof control.setProjection === "function") {
-                  control.setProjection(newProj);
-                }
-              });
-              
-              //Relocate map to extent
-              scope.map.getView().fit(newExtent, scope.map.getSize());
+                          if (newProj.getExtent()) {
+                            newExtent = newProj.getExtent();
+                          }
 
-          };
-        
-          
-        }],
-        link: function(scope, element, attrs) {
-          scope.projections = gnViewerSettings.mapConfig.switcherProjectionList;
-        }
-      };
-    }]);
+                          var mapsConfig = {
+                            projection : newProj,
+                            extent : newExtent
+                          };
+
+                          if (projectionConfig.resolutions
+                              && projectionConfig.resolutions.length
+                              && projectionConfig.resolutions.length > 0) {
+                            angular.extend(mapsConfig, {
+                              resolutions : projectionConfig.resolutions
+                            })
+                          }
+
+                          var newView = new ol.View(mapsConfig);
+
+                          // Rearrange base layers to adapt (if possible) to new
+                          // projection
+                          var layersToRemove = [];
+                          var bgLayers = [];
+
+                          gnViewerSettings.bgLayers
+                              .forEach(function (layer) {
+                                // is this layer coming from original context?
+                                // layers from original context should be kept
+                                if (!layer.get("fromGNSettings")) {
+                                  bgLayers.push(layer);
+                                  // Remember current background, if possible
+                                  layer.set("currentBackground", layer
+                                      .getVisible());
+                                }
+                              });
+
+                          // Loop over all background layers currently on the
+                          // map
+                          // to start from scratch
+                          scope.map.getLayers().forEach(
+                              function (layer) {
+                                if (layer.get("group") == 'Background layers'
+                                    || !layer.displayInLayerManager) {
+
+                                  // is this layer coming from original context?
+                                  // layers from original context should be kept
+                                  if (layer.get("fromGNSettings")) {
+                                    layersToRemove.push(layer);
+                                  }
+                                }
+                              });
+
+                          // Remove from map all base layers that don't belong
+                          // to this projection
+                          // different loop from previous one as it may break
+                          // forEach
+                          layersToRemove.forEach(function (layer) {
+                            scope.map.removeLayer(layer);
+                          });
+
+                          // Renew base layers from settings
+                          var layers = gnViewerSettings.mapConfig['map-viewer'].layers;
+                          if (layers && layers.length) {
+                            layers.forEach(function (layerInfo) {
+                              gnMap.createLayerFromProperties(layerInfo,
+                                  scope.map).then(function (layer) {
+                                if (layer) {
+                                  layer.displayInLayerManager = false;
+                                  layer.set("group", "Background layers");
+                                  layer.set("fromGNSettings", true);
+                                  layer.set("currentBackground", false);
+                                  bgLayers.push(layer);
+                                }
+                              });
+                            });
+                          }
+
+                          // We have all the info, change the map
+
+                          // Set the view
+                          scope.map.setView(newView);
+
+                          // Update Background Layers to trigger tool changes
+                          gnViewerSettings.bgLayers = bgLayers;
+
+                          // Reproject all layers in the map
+                          scope.map.getLayers().forEach(
+                              function (layer) {
+                                scope.changeLayerProjection(layer, oldProj,
+                                    newProj);
+                              });
+
+                          // Reproject all controls in the map
+                          scope.map.getControls().forEach(function (control) {
+                            if (typeof control.setProjection === "function") {
+                              control.setProjection(newProj);
+                            }
+                          });
+
+                          // Relocate map to extent
+                          scope.map.getView().fit(newExtent,
+                              scope.map.getSize());
+
+                        };
+
+                      } ],
+                  link : function (scope, element, attrs) {
+                    scope.projections = gnViewerSettings.mapConfig.switcherProjectionList;
+                  }
+                };
+              } ]);
 
 })();

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
@@ -82,7 +82,7 @@
                           var oldProj = view.getProjection();
                           var newProj = ol.proj.get(projection);
 
-                          if (oldProj == newProj) {
+                          if (oldProj.getCode() == newProj.getCode()) {
                             // There is no real change, don't do anything
                             return;
                           }

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
@@ -53,6 +53,12 @@
                       'gnMap',
                       '$rootScope',
                       function (scope, gnViewerSettings, gnMap, $rootScope) {
+                        
+                        scope.listOpen = false;
+                        
+                        scope.toggleList = function() {
+                          scope.listOpen = !scope.listOpen;
+                        }
 
                         // Change the projection of an existing layer
                         scope.changeLayerProjection = function (layer, oldProj,
@@ -119,7 +125,9 @@
                             })
                           }
 
+                          // Set the view
                           var newView = new ol.View(mapsConfig);
+                          scope.map.setView(newView);
 
                           // Rearrange base layers to adapt (if possible) to new
                           // projection
@@ -181,9 +189,6 @@
 
                           // We have all the info, change the map
 
-                          // Set the view
-                          scope.map.setView(newView);
-
                           // Update Background Layers to trigger tool changes
                           gnViewerSettings.bgLayers = bgLayers;
 
@@ -204,6 +209,8 @@
                           // Relocate map to extent
                           scope.map.getView().fit(newExtent,
                               scope.map.getSize());
+                          
+                          scope.listOpen = false;
 
                         };
 

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_projectionswitcher');
+
+  var module = angular.module('gn_projectionswitcher', [
+  ]);
+
+
+  /**
+   * @ngdoc directive
+   * @name gn_projectionswitcher.directive:gnProjectionSwitcher
+   * 
+   * @description The `gnProjectionSwitcher` directive adds a button to the map
+   *              that allows you to change the projection.
+   */
+  module.directive('gnProjectionSwitcher', [
+    'gnViewerSettings',
+    function(gnViewerSettings) {
+      return {
+        restrict: 'A',
+        templateUrl: '../../catalog/components/viewer/projectionSwitcher/' +
+            'partials/projectionSwitcher.html',
+        scope: {
+          map: '=gnProjectionSwitcher'
+        },
+        controllerAs: 'gnProjectionSwitcherCtrl',
+        controller: ['$scope', 'gnViewerSettings', 'gnMap', '$rootScope', 
+          function(scope, gnViewerSettings, gnMap, $rootScope) {
+
+          scope.changeLayerProjection = function(
+            layer, oldProj, newProj) {
+            if (layer instanceof ol.layer.Group) {
+              layer.getLayers().forEach(
+                  function(subLayer) {
+                    this.changeLayerProjection(
+                      subLayer, oldProj,
+                      newProj);
+                  });
+            } else if (layer instanceof ol.layer.Tile) {
+              var tileLoadFunc = layer.getSource()
+                .getTileLoadFunction();
+              layer.getSource().setTileLoadFunction(
+                tileLoadFunc);
+            } else if (layer instanceof ol.layer.Vector) {
+              var features = layer.getSource().getFeatures();
+              for (var i = 0; i < features.length; i += 1) {
+                features[i].getGeometry().transform(
+                  oldProj, newProj);
+              }
+            }
+          };
+          
+          scope.switchProjection = function(projection) {
+              var view = scope.map.getView();
+              var oldProj = view.getProjection();
+              var newProj = ol.proj.get(projection);
+              
+              if(oldProj == newProj) {
+                return;
+              }
+              
+              var projectionConfig = {};
+              
+              $.each(gnViewerSettings.mapConfig.switcherProjectionList, function(i, config) {
+                if(config['code'] == projection) {
+                  projectionConfig = config;
+                }
+              });
+              
+              var newExtent = ol.proj.transformExtent(
+                  view.calculateExtent(scope.map.getSize()), oldProj, newProj);
+              
+              if(newProj.getExtent()) {
+                newExtent = newProj.getExtent();
+              }
+              
+              var newCenter = ol.proj.transform(scope.map.getView().getCenter(), oldProj, newProj);
+              
+              if(projectionConfig.center) {
+                newCenter = JSON.parse(projectionConfig.center);
+              }
+
+              var mapsConfig = {
+                projection: newProj,
+                extent: newExtent,
+                center: newCenter
+              };
+              
+              if (projectionConfig.resolutions) {
+                angular.extend(mapsConfig, {resolutions: JSON.parse(projectionConfig.resolutions)})
+              }
+
+              var newView = new ol.View(mapsConfig);
+
+              // Set the view
+              scope.map.setView(newView);
+
+              // Rearrange base layers to adapt (if possible) to new projection
+              var layersToRemove = [];
+
+              scope.map.getLayers().forEach(function(layer) {
+                if (layer.get("group") == 'Background layers' 
+                  || !layer.displayInLayerManager) {
+                  layersToRemove.push(layer);
+                }
+              });
+              
+              for (var i = 0; i < layersToRemove.length; i++) {
+                scope.map.removeLayer(layersToRemove[i]);
+              }
+
+
+              // Renew base layers
+              gnViewerSettings.bgLayers = [];
+              var layers = gnViewerSettings.mapConfig['map-viewer'].layers;
+              if (layers && layers.length) {
+                layers.forEach(function(layerInfo) {
+                  gnMap.createLayerFromProperties(layerInfo, scope.map)
+                    .then(function(layer) {
+                      if (layer) {
+                        layer.displayInLayerManager = false;
+                        layer.set("group", "Background layers");
+                        gnViewerSettings.bgLayers.push(layer);
+                      }
+                    });
+                });
+              }
+
+              // Reproject layers
+              scope.map.getLayers().forEach(function(layer) {
+                scope.changeLayerProjection(layer, oldProj, newProj);
+              });
+
+              // Reproject controls
+              scope.map.getControls().forEach(function(control) {
+                if (typeof control.setProjection === "function") {
+                  control.setProjection(newProj);
+                }
+              });
+              
+              scope.map.getView().fit(newExtent, scope.map.getSize());
+
+          };
+        
+          
+        }],
+        link: function(scope, element, attrs) {
+          scope.projections = gnViewerSettings.mapConfig.switcherProjectionList;
+        }
+      };
+    }]);
+
+})();

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/partials/projectionSwitcher.html
@@ -1,6 +1,11 @@
 <ul class="list-group">
-	<li ng-repeat="p in (projections)" class="list-group-item"
+	<li ng-repeat="p in (projections)" class="input-group"
 		data-ng-click="switchProjection(p.code)"
-		data-ng-class="map.getView().getProjection().getCode() == p.code ? 'active' : ''">
-		{{p.label}}</li>
+		data-ng-class="map.getView().getProjection().getCode() == p.code ? 'active' : ''"
+		data-ng-if="map.getView().getProjection().getCode() == p.code || listOpen"><span
+		class="input-group-addon" data-ng-translate="">projection</span> <span
+		class="form-control clickable">{{p.label}} <span style="float: right"
+			class="fa clickable" data-ng-click="toggleList()"
+			data-ng-if="map.getView().getProjection().getCode() == p.code"
+			data-ng-class="listOpen? 'fa-caret-left' : 'fa-caret-down'"></span></span></li>
 </ul>

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/partials/projectionSwitcher.html
@@ -1,0 +1,6 @@
+<ul class="list-group">
+	<li ng-repeat="p in (projections)" class="list-group-item"
+		data-ng-click="switchProjection(p.code)"
+		data-ng-class="map.getView().getProjection().getCode() == p.code ? 'active' : ''">
+		{{p.label}}</li>
+</ul>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -175,9 +175,14 @@
             'code': 'EPSG:3857',
             'label': 'Google mercator (EPSG:3857)'
           }],
+          'switcherProjectionList': [{
+            'code': 'EPSG:3857',
+            'label': 'Google mercator (EPSG:3857)'
+          }],
           'disabledTools': {
             'processes': false,
             'addLayers': false,
+            'projectionSwitcher': false,
             'layers': false,
             'legend': false,
             'filter': false,

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1153,6 +1153,8 @@
     "ui-listOfServices-help": "If none defined, service metadata records are proposed to the users",
     "ui-storage": "User preference persistence",
     "ui-storage-help": "'' or 'sessionStorage' or 'localStorage'. An empty value means that the viewer map will not be saved when leaving the application and restored when coming back.",
+    "ui-switcherProjectionList": "Projections to display maps into",
+    "ui-switcherProjectionList-help": "These are the projections to show on the projections switcher of the main map. Remember to fill the definition if it is not already available.",
     "ui-isExportMapAsImageEnabled": "Export map as image",
     "ui-isExportMapAsImageEnabled-help": "This requires CORS to be enabled on the WMS services used in the map application. If not sure, you should disable that option that may cause trouble displaying WMS layers.",
     "ui-is3DModeAllowed": "Allow 3D mode",
@@ -1270,5 +1272,6 @@
     "ui-externalViewer-openNewWindow": "Open new window",
     "ui-externalViewer-openNewWindow-help": "If checked, the external viewer will be opened in a new tab/window.",
     "indexInEsDoneError": "There is an error with the ElasticSearch index. See the logs for details",
-    "indexInEsDone": "The ElasticSearch index completed successfully"
+    "indexInEsDone": "The ElasticSearch index completed successfully",
+    "projectionSwitcherTool": "Projection Switcher Tool"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1273,5 +1273,21 @@
     "ui-externalViewer-openNewWindow-help": "If checked, the external viewer will be opened in a new tab/window.",
     "indexInEsDoneError": "There is an error with the ElasticSearch index. See the logs for details",
     "indexInEsDone": "The ElasticSearch index completed successfully",
-    "projectionSwitcherTool": "Projection Switcher Tool"
+    "projectionSwitcherTool": "Projection Switcher Tool",
+    "ui-minx": "Min X",
+    "ui-maxx": "Max X",
+    "ui-miny": "Min Y",
+    "ui-maxy": "Max Y",
+    "ui-worldExtent": "World Extent",
+    "ui-extent": "Extent",
+    "ui-resolutions": "Resolutions",
+    "ui-definition": "Definition",
+    "ui-label": "Label",
+    "ui-code": "Code",
+    "ui-extent-help": "This is the default extension of the map on this projection. You can define it as an array of four components or by each coordinate. This is an optional field.",
+    "ui-worldExtent-help": "This is the maximum extension of the map on this projection.You can define it as an array of four components or by each coordinate. This is an optional field.",
+    "ui-label-help": "Label to show on the user interface to identify this projection. This is a mandatory field.",
+    "ui-code-help": "EPSG unique identifier for this projection eg. 'EPSG:4326'. This is a mandatory field.",
+    "ui-resolutions-help": "Allowed resolutions (zooms) for this projection. This is an optional field.",
+    "ui-definition-help": "Definition for Proj4 library. This is a mandatory field if the projection is not defined already on GeoNetwork. Without a definition, the map can't work."
 }

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -403,5 +403,5 @@
     "allAdmins": "Administrators",
     "group": "Group",
     "showOptions": "Show options",
-    "ProjectionSwitcher": "Projection Switcher"
+    "projectionSwitcher": "Projection Switcher"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -403,5 +403,6 @@
     "allAdmins": "Administrators",
     "group": "Group",
     "showOptions": "Show options",
-    "projectionSwitcher": "Projection Switcher"
+    "projectionSwitcher": "Projection Switcher",
+    "projection": "Projection"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -215,7 +215,6 @@
     "sendPasswordLinkToMyEmail": "Send password link to my email",
     "service": "Service",
     "serviceType": "Service type",
-    "serviceType": "Service type",
     "serviceTypes": "Service types",
     "signIn": "Sign in",
     "signedInAs": "Signed in as",
@@ -403,5 +402,6 @@
     "adminHome": "Summary",
     "allAdmins": "Administrators",
     "group": "Group",
-    "showOptions": "Show options"
+    "showOptions": "Show options",
+    "ProjectionSwitcher": "Projection Switcher"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -382,7 +382,6 @@
   "fbPhone": "Phone",
   "fbEmail": "Email",
   "fbFeedback": "Feedback",
-  "fbFunction": "Function",
   "fbCategory": "Category",
   "fbComments": "Comments",
   "fbQuestion": "Question",

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -918,3 +918,9 @@ html {
   // TODO Remove this if Bootstrap version is >= 4.0.0
   -ms-overflow-style: scrollbar;
 }
+
+
+// Clickable elements
+.clickable {
+  cursor: pointer;
+}

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -139,12 +139,20 @@
               }
             }
 
-            var bng = ol.proj.get(p.code);
-            if(p.extent) {
-              bng.setExtent(JSON.parse(p.extent));
+            var projection = ol.proj.get(p.code);
+            if(p.extent && p.extent.length && p.extent.length == 4
+                && !isNaN(p.extent[0]) && p.extent[0] != null
+                && !isNaN(p.extent[1]) && p.extent[1] != null
+                && !isNaN(p.extent[2]) && p.extent[2] != null
+                && !isNaN(p.extent[3]) && p.extent[3] != null) {
+              projection.setExtent(p.extent);
             }
-            if(p.worldExtent) {
-              bng.setWorldExtent(JSON.parse(p.worldExtent));
+            if(p.worldExtent && p.worldExtent.length && p.worldExtent.length == 4
+                && !isNaN(p.worldExtent[0]) && p.worldExtent[0] != null
+                && !isNaN(p.worldExtent[1]) && p.worldExtent[1] != null
+                && !isNaN(p.worldExtent[2]) && p.worldExtent[2] != null
+                && !isNaN(p.worldExtent[3]) && p.worldExtent[3] != null) {
+              projection.setWorldExtent(p.worldExtent);
             }
           });
 

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -95,7 +95,7 @@
             })
 
           };
-
+          
           var searchMap = gnMapsManager.createMap(gnMapsManager.SEARCH_MAP);
           var viewerMap = gnMapsManager.createMap(gnMapsManager.VIEWER_MAP);
 
@@ -123,6 +123,29 @@
           angular.extend(searchSettings, {
             viewerMap: viewerMap,
             searchMap: searchMap
+          });
+          
+          
+          //Add projections from UI settings:
+          $.each(viewerSettings.mapConfig.switcherProjectionList, function(i, p) {
+            if(!ol.proj.get(p.code)) {
+              if(p.def) {
+                // Define an OL3 projection based on the included Proj4js projection
+                // definition and set it's extent.
+                proj4.defs(p.code,p.def);
+              } else {
+                console.error("Trying to use unknown projection '" + p.code 
+                      + "'. Please add definition on settings.");
+              }
+            }
+
+            var bng = ol.proj.get(p.code);
+            if(p.extent) {
+              bng.setExtent(JSON.parse(p.extent));
+            }
+            if(p.worldExtent) {
+              bng.setWorldExtent(JSON.parse(p.worldExtent));
+            }
           });
 
         }]);

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -95,7 +95,7 @@
             })
 
           };
-          
+
           var searchMap = gnMapsManager.createMap(gnMapsManager.SEARCH_MAP);
           var viewerMap = gnMapsManager.createMap(gnMapsManager.VIEWER_MAP);
 


### PR DESCRIPTION
Projection Switcher: change the projection of the map on the fly with just a button.

Comes with:
* New configuration on the UI Settings to add a list of projections to populate the projection switcher.
* Fixed bug on loading TMS layer from settings: encoding.
* Enhancement: Now layers from settings can have attribution.

This also adds a couple of indirect features:
 * Now you can define projections on the settings to be used on the map.
 * Now you can change the default projection on the map on the settings.

If you want, we can even deprecate the initial context file from the map and use this. 

Documentation ready here to be merged once this gets into master: https://github.com/Delawen/doc/commit/36a26ce9f5c380300b8ebe5e804d1c009b91894d