### PR TITLE
Transfer Owner / make dropdown content clearer

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
@@ -39,6 +39,7 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.OperationAllowed;
 import org.fao.geonet.domain.OperationAllowedId;
@@ -145,7 +146,17 @@ public class TransferApi {
         final UserGroupRepository userGroupRepository = applicationContext.getBean(UserGroupRepository.class);
         List<UserGroupsResponse> list = new ArrayList<>();
         if (myProfile == Profile.Administrator || myProfile == Profile.UserAdmin) {
+            // add all admins first
             List<User> allAdmin = userRepository.findAllByProfile(Profile.Administrator);
+            Group adminGroup = new Group();
+            adminGroup.setName("allAdmins");
+            for (User u : allAdmin) {
+                list.add(
+                    new UserGroupsResponse(u, adminGroup, Profile.Administrator.name())
+                );
+            }
+
+            // add all users
             List<UserGroup> userGroups;
 
             if (myProfile == Profile.Administrator) {
@@ -158,11 +169,6 @@ public class TransferApi {
                 list.add(
                     new UserGroupsResponse(ug.getUser(), ug.getGroup(), ug.getProfile().name())
                 );
-                for (User u : allAdmin) {
-                    list.add(
-                        new UserGroupsResponse(u, ug.getGroup(), Profile.Administrator.name())
-                    );
-                }
             }
             return list;
         } else {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -419,6 +419,9 @@
                   var key = g.groupId + '-' + g.userId;
                   if (!uniqueUserGroups[key]) {
                     uniqueUserGroups[key] = g;
+                    uniqueUserGroups[key].groupNameTranslated = g.groupName === 'allAdmins' ?
+                        $translate.instant(g.groupName) :
+                        $translate.instant('group-' + g.groupId);
                   }
                 });
                 scope.userGroups = uniqueUserGroups;

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
@@ -2,7 +2,7 @@
   <div class="col-md-12" data-ng-show="userGroupDefined">
     <select class="form-control"
             data-ng-model="selectedUserGroup"
-            data-ng-options="g.userName group by g.groupName
+            data-ng-options="g.userName group by g.groupNameTranslated
                     for (key, g) in userGroups">
     </select>
     <br/>

--- a/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
@@ -196,6 +196,9 @@
                 var key = g.groupId + '-' + g.userId;
                 if (!uniqueUserGroups[key]) {
                   uniqueUserGroups[key] = g;
+                  uniqueUserGroups[key].groupNameTranslated = g.groupName === 'allAdmins' ?
+                    $translate.instant(g.groupName) :
+                    $translate.instant('group-' + g.groupId);
                 }
               });
               $scope.userGroups = uniqueUserGroups;

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -399,5 +399,6 @@
     "avatar": "Avatar",
     "first": "First",
     "editorHome": "Editor board",
-    "adminHome": "Summary"
+    "adminHome": "Summary",
+    "allAdmins": "Administrators"
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/transferownership.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/transferownership.html
@@ -19,7 +19,7 @@
         <!--TODO: Only list group with records. -->
         <td><select class="form-control"
                     data-ng-model="transfertList[g.id].targetGroup"
-                    data-ng-options="g.userName group by g.groupName
+                    data-ng-options="g.userName group by g.groupNameTranslated
                     for (key, g) in userGroups">
         </select></td>
         <td>


### PR DESCRIPTION
When using the Transfer Owner tool, groups are now rendered a bit better:
* Admins are put in a separate group at the beginning of the list
* Group names are translated

![image](https://user-images.githubusercontent.com/10629150/45627251-d583a980-ba91-11e8-9304-d927187cf01f.png)

Note that being able to transfer records to admins appears to be misleading to some users. Maybe this could be allowed or not in the settings?