### PR TITLE
Search / Better map thumbnails

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
@@ -1,32 +1,22 @@
 <ul class="list-group gn-resultview gn-resultview-sumup">
-  <li class="list-group-item gn-grid"
+  <li class="list-group-item gn-grid gn-map-item flex-col flex-align-stretch"
       data-ng-repeat="md in searchResults.records"
-      data-gn-fix-mdlinks="">
+      data-gn-fix-mdlinks=""
+      title="{{(md.abstract || md.defaultAbstract) | striptags}}"
+      ng-click="loadMap(maps[0], md)">
+
+    <div class="gn-md-thumbnail flex-grow"
+         ng-style="{ 'background-image': md.getThumbnails().list[0].url && 'url(' + md.getThumbnails().list[0].url + ')' }">
+    </div>
+
+    <div class="gn-img-thumbnail-caption">
+      {{md.title || md.defaultTitle}}
+    </div>
 
     <a class=""
-       data-ng-href="#map?map={{maps[0].url}}"
-       title="{{'loadMap' | translate}}">
-      <div title="{{(md.abstract || md.defaultAbstract) | striptags}}"
-           data-ng-click="loadMap(maps[0], md)">
-
-        <span class="gn-img-thumbnail-caption">
-          {{(md.title || md.defaultTitle) | characters:80}}
-        </span>
-        <a class=""
-           data-ng-href="#/metadata/{{md.getUuid()}}"
-           title="{{'openRecord' | translate}}">
-          <i class="fa fa-fw fa-info-circle"/>
-        </a>
-
-        <div class="gn-md-thumbnail">
-          <img class="gn-img-thumbnail"
-               alt="{{md.title || md.defaultTitle}}"
-               data-ng-src="{{md.getThumbnails().list[0].url}}"
-               data-ng-if="md.getThumbnails().list[0].url"/>
-        </div>
-
-      </div>
+        ng-href="#/metadata/{{md.getUuid()}}"
+        title="{{'openRecord' | translate}}" translate>
+      openRecord
     </a>
-    <div style="clear: both;"></div>
   </li>
 </ul>

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -472,9 +472,6 @@ span.gn-facet-label:first-letter {
         display: inline-block;
         float: none;
         margin-right: 0px;
-        .gn-img-thumbnail {
-
-        }
       }
     }
   }
@@ -482,7 +479,6 @@ span.gn-facet-label:first-letter {
 
 .gn-img-thumbnail-caption {
   text-align: center;
-  font-size: 90%;
   font-style: italic;
   color: @text-muted;
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -36,7 +36,7 @@
   clear: both;
   flex-grow: 1;
   position: relative;
-  padding-bottom: calc(~"@{gn-bottombar-height} + 10px");  
+  padding-bottom: calc(~"@{gn-bottombar-height} + 10px");
   .badge {
       margin-right: 5px;
     }
@@ -225,5 +225,82 @@
 gn-wps-process-form {
   .panel-body {
     padding: 0px;
+  }
+}
+
+li.list-group-item.gn-map-item {
+  text-align: center;
+  font-size: 12px;
+
+  .gn-md-thumbnail {
+    display: inline-block;
+    float: none;
+    margin: 0px;
+    background-image: url(../catalog/views/default/images/no-thumbnail.png);
+    background-size: cover;
+    background-position: center;
+    width: auto;
+    height: auto;
+  }
+
+  .gn-img-thumbnail-caption {
+    height: 40px;
+    line-height: 1.2em;
+    overflow: hidden;
+    position: relative;
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 12px;
+      background: linear-gradient(to bottom, fade(@gn-results-background-color, 0%) 0%, @gn-results-background-color 100%);
+    }
+  }
+
+  .gn-top-records [data-gn-results-container]  & {
+    padding: 14px;
+    height: 205px;
+
+    .gn-img-thumbnail-caption {
+      margin: 5px 0px;
+    }
+
+    &:hover {
+      cursor: pointer;
+
+      // note, this may not be correct if a theme is applied,
+      // as the actual result hover color is transparent black
+      @result-hover-color: rgb(234, 234, 234);
+      .gn-img-thumbnail-caption::after {
+        background: linear-gradient(to bottom, fade(@result-hover-color, 0%) 0%, @result-hover-color 100%);
+      }
+    }
+  }
+
+  [gn-ows-context] ul.gn-resultview & {
+    padding: 5px;
+    height: 205px;
+    text-align: center;
+
+    .gn-md-thumbnail {
+      width: 147px;
+    }
+    .gn-img-thumbnail-caption {
+      height: 30px;
+    }
+
+    &:hover {
+      cursor: pointer;
+
+      // note, this may not be correct if a theme is applied,
+      // as the actual result hover color is transparent black
+      @result-hover-color: #f3f3f3;
+      .gn-img-thumbnail-caption::after {
+        background: linear-gradient(to bottom, fade(@result-hover-color, 0%) 0%, @result-hover-color 100%);
+      }
+    }
   }
 }


### PR DESCRIPTION
Map thumbnails now render a bit more nicely, including a multiline overflow effect.

Home page:
![image](https://user-images.githubusercontent.com/10629150/45686130-e7c21e00-bb4b-11e8-8a86-38c102afc401.png)

Map tools:
![image](https://user-images.githubusercontent.com/10629150/45686147-f01a5900-bb4b-11e8-8439-f7af5f8d5252.png)

When hovering a map preview, the tooltip will show the full title.

@MichelGabriel I've noticed you had reversed map title and thumbnail in #2997, didn't know if it was intentional considering the layout was a bit broken in the map tool and the change was not mentioned in your PR. Please let me know if this should be kept this way.