### PR TITLE
WFS Indexing dashboard / do not depend on index name

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
@@ -35,7 +35,7 @@
       $scope.url = decodeURIComponent($location.search()['wfs-indexing']);
 
       // URL of the index service endpoint
-      $scope.indexUrl = gnHttp.getService('indexproxy') + '/features/_search';
+      $scope.indexUrl = gnHttp.getService('indexproxy') + '/_search';
 
       // list of wfs indexing jobs received from the index
       // null means loading


### PR DESCRIPTION
Minor fix to handle the case where the ES index holding WFS features is *not* named `features`.