### PR TITLE
[WIP] Log a warning on duplicate UUID

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -125,7 +125,15 @@ public class ApiUtils {
         throws Exception {
         ApplicationContext appContext = ApplicationContextHolder.get();
         IMetadataUtils metadataRepository = appContext.getBean(IMetadataUtils.class);
-        AbstractMetadata metadata = metadataRepository.findOneByUuid(uuidOrInternalId);
+        AbstractMetadata metadata = null;
+        try {
+            metadata = metadataRepository.findOneByUuid(uuidOrInternalId);
+        } catch (IncorrectResultSizeDataAccessException e){
+            Log.warning(Geonet.GEONETWORK, String.format(
+                "More than one record found with UUID '%s'. Error is '%s'.",
+                uuidOrInternalId, e.getMessage()));
+        }
+
         if (metadata == null) {
             try {
                 metadata = metadataRepository.findOne(uuidOrInternalId);


### PR DESCRIPTION
Most of the API action can be done using an internal ID or a UUID. Usually both are unique BUT some schemas allow read/write UUIDs which may be based on some rules which sometimes lead to build duplicate UUID. In that case, add a warning in order to have the catalogue admin be able to track such case.

To handle also in:

- [ ] services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
- [ ] services/src/main/java/org/fao/geonet/api/registries/DirectoryEntriesApi.java
