### PR TITLE
Transfer Owner / fix available user lists when I am not an admin

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
@@ -72,6 +72,7 @@ import io.swagger.annotations.ApiOperation;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import springfox.documentation.annotations.ApiIgnore;
+import java.util.stream.Collectors;
 
 @RequestMapping(value = {
     "/api/users",
@@ -162,7 +163,9 @@ public class TransferApi {
             if (myProfile == Profile.Administrator) {
                 userGroups = userGroupRepository.findAll();
             } else {
-                userGroups  = userGroupRepository.findAll(UserGroupSpecs.hasUserId(session.getUserIdAsInt()));
+                List<Integer> myGroups = userGroupRepository.findAll(UserGroupSpecs.hasUserId(session.getUserIdAsInt()))
+                        .stream().map(ug -> ug.getGroup().getId()).collect(Collectors.toList());
+                userGroups = userGroupRepository.findAll(UserGroupSpecs.hasGroupIds(myGroups));
             }
 
             for (UserGroup ug : userGroups) {


### PR DESCRIPTION
Followup of #3102

Without this fix, a useradmin (or any role other than admin) would only see him/herself in the Transfer owner dropdown.