### PR TITLE
Accessibility option and better responsiveness for the editor toolbar

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatacategoryupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatacategoryupdater.html
@@ -16,7 +16,8 @@
           data-translate="">setMetadataCategories
       </li>
       <li data-ng-repeat="c in categories | orderBy:sortByLabel"
-          data-ng-hide="enableallowedcategories && allowedcategories.indexOf(c.id) == -1">
+          data-ng-hide="enableallowedcategories && allowedcategories.indexOf(c.id) == -1"
+          role="menuitem">
         <a data-ng-click="assign(c, $event)" 
            href=""
            title="{{c.label[lang] | translate}}">

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatacategoryupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatacategoryupdater.html
@@ -2,20 +2,24 @@
   <div class="btn-group"
        data-ng-show="categories.length > 0 && mode === 'btn'">
     <button type="button"
-            class="btn btn-default dropdown-toggle"
+            class="btn btn-default navbar-btn dropdown-toggle"
+            aria-label="{{'listOfCategories' | translate}}"
             data-toggle="dropdown">
       <i class="fa fa-tags"></i>
       <span data-translate="" class="hidden-sm hidden-xs">listOfCategories</span>
       <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu pull-right"
-        role="menu">
-      <li role="presentation" class="dropdown-header"
+    <ul class="dropdown-menu" role="menu">
+      <li role="presentation"
+          class="dropdown-header"
+          title="{{'setMetadataCategories' | translate}}"
           data-translate="">setMetadataCategories
       </li>
       <li data-ng-repeat="c in categories | orderBy:sortByLabel"
           data-ng-hide="enableallowedcategories && allowedcategories.indexOf(c.id) == -1">
-        <a data-ng-click="assign(c, $event)" href="">
+        <a data-ng-click="assign(c, $event)" 
+           href=""
+           title="{{c.label[lang] | translate}}">
           <i class="fa" data-ng-class="ids.indexOf(c.id) !== -1 ? 'fa-check-square-o' : 'fa-square-o'"></i>
           &#160;
           <span class="fa gn-icon-{{c.name}}"></span>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatagroupupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatagroupupdater.html
@@ -3,14 +3,16 @@
           class="btn btn-default navbar-btn dropdown-toggle"
           data-ng-mouseover="init()"
           data-toggle="dropdown">
-    <i class="fa fa-group"></i>&nbsp;<span class="caret"></span>
+    <i class="fa fa-group"></i>
+    <span data-translate="" class="visible-lg">group</span>&nbsp;<span class="caret"></span>
   </button>
   <ul class="dropdown-menu"
       role="menu">
     <li role="presentation" class="dropdown-header"
         data-translate="">setMetadataGroup
     </li>
-    <li data-ng-repeat="g in groups | orderBy:sortByLabel">
+    <li data-ng-repeat="g in groups | orderBy:sortByLabel"
+        role="menuitem">
       <a data-ng-click="assignGroup(g, $event)" href="">
         <i class="fa" data-ng-class="g.id == groupOwner ? 'fa-check-square-o' : 'fa-square-o'"></i>
         &#160;

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatagroupupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadatagroupupdater.html
@@ -1,11 +1,11 @@
 <div class="btn-group">
   <button type="button"
-          class="btn btn-default dropdown-toggle"
+          class="btn btn-default navbar-btn dropdown-toggle"
           data-ng-mouseover="init()"
           data-toggle="dropdown">
     <i class="fa fa-group"></i>&nbsp;<span class="caret"></span>
   </button>
-  <ul class="dropdown-menu pull-right"
+  <ul class="dropdown-menu"
       role="menu">
     <li role="presentation" class="dropdown-header"
         data-translate="">setMetadataGroup

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -400,5 +400,7 @@
     "first": "First",
     "editorHome": "Editor board",
     "adminHome": "Summary",
-    "allAdmins": "Administrators"
+    "allAdmins": "Administrators",
+    "group": "Group",
+    "showOptions": "Show options"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -108,14 +108,14 @@ input[type=text], input[type=number], select {
   padding: 20px 5px;
 }
 
-@media only screen and (max-width: 815px) {
+@media only screen and (max-width: @screen-xs-max) {
   .gn-editor-container {
-    margin-top: 120px;
+    margin-top: 50px;
   }
 }
-@media only screen and (max-width: 425px) {
+@media only screen and (max-width: 490px) {
   .gn-editor-container {
-    margin-top: 160px;
+    margin-top: 100px;
   }
 }
 

--- a/web-ui/src/main/resources/catalog/templates/editor/editor.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editor.html
@@ -10,7 +10,8 @@
   <div
     data-ng-include="'../../catalog/templates/editor/top-toolbar.html'">
   </div>
-  <div class="row gn-editor-container">
+  <div class="row gn-editor-container"
+       role="main">
     <div class="modal-backdrop fade in" data-ng-show="gnCurrentEdit.working"></div>
 
     <div class="alert alert-danger" data-ng-if="unsupportedSchema"

--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -1,26 +1,18 @@
 <nav class="navbar navbar-default navbar-fixed-top gn-top-bar" role="navigation"
      data-ng-if="!unsupportedSchema">
 
-
   <p class="navbar-text gn-tooltip"
-     data-ng-mouseover="getSaveStatus()" title="{{savedStatus}}">
-    <span data-ng-class="saveError ? 'text-danger' : ''">{{savedStatus}}</span><br/>
+     data-ng-mouseover="getSaveStatus()"
+     title="{{savedStatus}}">
     <strong title="{{gnCurrentEdit.mdTitle}}">
       {{gnCurrentEdit.mdTitle | limitTo: 50 }}
       {{gnCurrentEdit.mdTitle.length > 50 ? '...' : ''}}
     </strong>
+    <span data-ng-class="saveError ? 'text-danger' : ''">{{savedStatus}}</span>
   </p>
 
-  <div class="pull-right">
-    <!--<button type="button" class="btn btn-primary navbar-btn gn-tooltip" data-ng-click="share()"
-      data-title="{{'share-help' | translate}}" data-placement="bottom">
-      <i class="fa fa-lock"/>
-      <span data-translate="">share</span>
-    </button>-->
-
-
-    <!-- If using the category selector in the editor
-    form directly, remove this directive. -->
+  <div class="gn-btn-toolbar navbar-right">
+    <!-- If using the category selector in the editor form directly, remove this directive. -->
     <div data-gn-metadata-category-updater="mdCategories"
          data-gn-group-owner="groupOwner"
          data-metadata-uuid="gnCurrentEdit.uuid" title="{{'categories'|translate}}"/>
@@ -29,54 +21,72 @@
          data-metadata-id="gnCurrentEdit.id" title="{{'group'|translate}}"/>
 
     <div class="btn-group">
-      <button class="btn btn-default dropdown-toggle"
+      <button class="btn btn-default navbar-btn dropdown-toggle"
               type="button"
-              data-toggle="dropdown" aria-expanded="true">
-        <i class="fa fa-cog"/>
+              data-toggle="dropdown"
+              aria-label="{{'tools' | translate}}"
+              aria-expanded="true">
+        <i class="fa fa-fw fa-cog"/>
+        <span class="visible-lg" data-translate="">tools</span>
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
         <li role="presentation">
-          <a role="menuitem" tabindex="-1"
+          <a role="menuitem"
+             tabindex="-1"
              data-gn-click-and-spin="startVersioning()"
              title="{{'startVersioning-help' | translate}}">
-            <i class="fa fa-history"/>&nbsp;
-            <span class="visible-lg" data-translate="">startVersioning</span>
+            <i class="fa fa-fw fa-history"/>
+            <span data-translate="">startVersioning</span>
           </a>
         </li>
       </ul>
     </div>
+    <!-- /.btn-group -->
 
     <data-gn-md-validation-tools></data-gn-md-validation-tools>
     <!-- TODO: automatic save status -->
-    <button type="button" class="btn btn-default navbar-btn gn-tooltip"
-            gn-click-and-spin="cancel()"
-            data-ng-mouseover="getCancelStatus()" title="{{cancelStatus}}">
-      <i class="fa fa-undo"/>&nbsp;
-      <span class="visible-lg" data-translate="">cancel</span>
-    </button>
-    <button type="button" class="btn btn-default navbar-btn gn-tooltip"
-            title="{{'closeEditor'|translate}}" gn-click-and-spin="close()">
-      <i class="fa fa-sign-out"/>&nbsp;
-      <span class="visible-lg" data-translate="">closeEditor</span>
-    </button>
+    <div class="btn-group">
+      <button type="button" class="btn btn-default navbar-btn gn-tooltip"
+              gn-click-and-spin="cancel()"
+              data-ng-mouseover="getCancelStatus()" title="{{cancelStatus}}">
+        <i class="fa fa-fw fa-undo"/>
+        <span class="visible-lg" data-translate="">cancel</span>
+      </button>
+    </div>
+    <div class="btn-group">
+      <button type="button"
+              class="btn btn-default navbar-btn gn-tooltip"
+              aria-label="{{'closeEditor' | translate}}"
+              title="{{'closeEditor'|translate}}"
+              gn-click-and-spin="close()">
+        <i class="fa fa-fw fa-sign-out"/>
+        <span class="visible-lg" data-translate="">closeEditor</span>
+      </button>
+    </div>
+    <!-- /.btn-group -->
     <div class="btn-group" title="{{(isTemplate() ? 'saveTemplate' : 'saveMetadata') | translate}}">
       <button type="button"
               data-gn-click-and-spin="save(true)"
-              class="btn btn-primary">
-        <i class="fa fa-save"/>&nbsp;
-        <span
-          class="visible-lg">{{(isTemplate() ? 'saveTemplate' : 'saveMetadata') | translate}}</span>
+              aria-label="{{(isTemplate() ? 'saveTemplate' : 'saveMetadata') | translate}}"
+              class="btn btn-success navbar-btn">
+        <i class="fa fa-fw fa-save"/>
+        <span class="visible-lg">{{(isTemplate() ? 'saveTemplate' : 'saveMetadata') | translate}}</span>
       </button>
-      <button type="button" class="btn btn-primary dropdown-toggle"
-              data-toggle="dropdown" aria-expanded="false">
+      <button type="button"
+              class="btn btn-success navbar-btn dropdown-toggle"
+              data-toggle="dropdown"
+              aria-expanded="false">
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
-        <li><a href="" title="{{(isTemplate() ? 'saveAsMetadata' : 'saveAsTemplate') | translate}}"
-               data-gn-click-and-spin="switchTypeAndSave(true)">
-          {{(isTemplate() ? 'saveAsMetadata' : 'saveAsTemplate') | translate}}
-        </a></li>
+        <li>
+          <a href=""
+             title="{{(isTemplate() ? 'saveAsMetadata' : 'saveAsTemplate') | translate}}"
+             data-gn-click-and-spin="switchTypeAndSave(true)">
+            {{(isTemplate() ? 'saveAsMetadata' : 'saveAsTemplate') | translate}}
+          </a>
+        </li>
         <li class="dropdown-header">
           <label title="{{'minorEditHelp' | translate}}">
             <input type="checkbox" data-ng-model="gnCurrentEdit.isMinor"/>
@@ -85,17 +95,20 @@
         </li>
       </ul>
     </div>
-
-    <div class="btn-group">
-      <ul class="gn-view-menu-button nav navbar-nav">
-        <!-- An empty drown down updated when form is loaded -->
-        <li class="dropdown">
-          <a class="dropdown-toggle" data-toggle="dropdown">
-            <i class="fa fa-eye"></i>&nbsp;
-            <b class="caret"/>
-          </a>
-        </li>
-      </ul>
+    <!-- /.btn-group -->
+    <div class="btn-group gn-view-menu-button">
+      <!-- An empty drown down updated when form is loaded -->
+      <button type="button"
+              class="btn btn-default navbar-btn dropdown-toggle"
+              data-toggle="dropdown"
+              aria-label="{$i18n/selectView}"
+              title="{$i18n/selectView}"
+              aria-expanded="false">
+        <i class="fa fa-eye"></i>
+        <span class="caret"></span>
+      </button>
     </div>
+    <!-- /.btn-group -->
   </div>
+  <!-- /.navbar-right -->
 </nav>

--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -1,15 +1,16 @@
 <nav class="navbar navbar-default navbar-fixed-top gn-top-bar" role="navigation"
      data-ng-if="!unsupportedSchema">
 
-  <p class="navbar-text gn-tooltip"
+  <div class="navbar-text gn-tooltip"
      data-ng-mouseover="getSaveStatus()"
      title="{{savedStatus}}">
-    <strong title="{{gnCurrentEdit.mdTitle}}">
+    <h1 title="{{gnCurrentEdit.mdTitle}}">
       {{gnCurrentEdit.mdTitle | limitTo: 50 }}
       {{gnCurrentEdit.mdTitle.length > 50 ? '...' : ''}}
-    </strong>
+    </h1>
+    <span data-ng-if="savedStatus">| </span>
     <span data-ng-class="saveError ? 'text-danger' : ''">{{savedStatus}}</span>
-  </p>
+  </div>
 
   <div class="gn-btn-toolbar navbar-right">
     <!-- If using the category selector in the editor form directly, remove this directive. -->
@@ -31,7 +32,7 @@
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
-        <li role="presentation">
+        <li role="menuitem">
           <a role="menuitem"
              tabindex="-1"
              data-gn-click-and-spin="startVersioning()"
@@ -75,19 +76,21 @@
       </button>
       <button type="button"
               class="btn btn-success navbar-btn dropdown-toggle"
+              aria-label="{{'showOptions' | translate}}"
               data-toggle="dropdown"
               aria-expanded="false">
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
-        <li>
+        <li role="menuitem">
           <a href=""
              title="{{(isTemplate() ? 'saveAsMetadata' : 'saveAsTemplate') | translate}}"
              data-gn-click-and-spin="switchTypeAndSave(true)">
             {{(isTemplate() ? 'saveAsMetadata' : 'saveAsTemplate') | translate}}
           </a>
         </li>
-        <li class="dropdown-header">
+        <li class="dropdown-header"
+            role="menuitem">
           <label title="{{'minorEditHelp' | translate}}">
             <input type="checkbox" data-ng-model="gnCurrentEdit.isMinor"/>
             {{'minorEdit' | translate}}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -4,6 +4,21 @@
 
 [ng-app="gn_editor"] {
   .gn-top-bar {
+    // status
+    div.gn-tooltip {
+      padding: 0;
+      margin: 15px 0;
+      h1 {
+        font-size: 14px;
+        font-weight: 700;
+        margin: 0;
+        padding: 0;
+        display: inline-block;
+      }
+      span {
+        font-weight: 200;
+      }
+    }
     .gn-btn-toolbar {
       margin-left: -20px;
       margin-right: -20px;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -3,6 +3,29 @@
 @import "gn_view.less";
 
 [ng-app="gn_editor"] {
+  .gn-top-bar {
+    .gn-btn-toolbar {
+      margin-left: -20px;
+      margin-right: -20px;
+      padding-left: 20px;
+      padding-right: 20px;
+      // smartphones
+      @media (max-width: @screen-xs-max) {
+        border-bottom: 1px solid @navbar-default-border;
+        background-color: #fff;
+        li > a {
+          color: #555 !important;
+        }
+      }
+      // on really small screen the submenu should open to the right
+      @media (max-width: 424px) {
+        .dropdown-menu-right {
+          left: 0;
+        }
+      }
+    }
+  }
+
   .gn-editor-board {
     .gn-top-search {
       padding-top: 0;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -16,6 +16,7 @@
 @text-muted: #707070;
 // width of modal dialog
 @modal-md: 700px;
+@navbar-default-color: #333;
 // slightly darker primary color, now color contrast on light gray backgrounds is high enough
 @brand-primary: #3277B3;
 @dropdown-border: @navbar-default-border;

--- a/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
@@ -42,19 +42,22 @@
          data-watch=""
          data-all-depth="{if ($isFlatMode) then 'true' else 'false'}"/>
 
-    <ul class="nav nav-tabs">
+    <div class="nav nav-tabs">
       <!-- Make a drop down choice to swith to one view to another -->
-      <li class="dropdown" id="gn-view-menu-{$metadataId}">
-        <a class="dropdown-toggle" data-toggle="dropdown" href=""
-           title="{$i18n/selectView}">
+      <span id="gn-view-menu-{$metadataId}">
+        <button type="button"
+                class="btn btn-default navbar-btn dropdown-toggle"
+                data-toggle="dropdown"
+                title="{$i18n/selectView}"
+                aria-expanded="false">
           <i class="fa fa-eye"></i>
-          <b class="caret"/>
-        </a>
-        <ul class="dropdown-menu dropdown-menu-right">
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
           <!-- links -->
           <xsl:choose>
             <xsl:when test="$isTemplate = 's'">
-              <li>
+              <li role="menuitem">
                 <xsl:if test="'simple' = $currentView/@name">
                   <xsl:attribute name="class">disabled</xsl:attribute>
                 </xsl:if>
@@ -62,7 +65,7 @@
                   <xsl:value-of select="$strings/*[name() = 'simple']"/>
                 </a>
               </li>
-              <li>
+              <li role="menuitem">
                 <xsl:if test="'xml' = $currentView/@name">
                   <xsl:attribute name="class">disabled</xsl:attribute>
                 </xsl:if>
@@ -83,7 +86,7 @@
 
 
                 <xsl:if test="$isViewDisplayed">
-                  <li>
+                  <li role="menuitem">
                     <xsl:if test="@name = $currentView/@name">
                       <xsl:attribute name="class">disabled</xsl:attribute>
                     </xsl:if>
@@ -98,8 +101,8 @@
                 </xsl:if>
               </xsl:for-each>
 
-              <li class="divider"/>
-              <li>
+              <li class="divider" role="menuitem"/>
+              <li role="menuitem">
                 <a data-ng-click="toggleAttributes(true)" href="">
                   <i class="fa"
                      data-ng-class="gnCurrentEdit.displayAttributes ? 'fa-check-square-o' : 'fa-square-o'"/>
@@ -107,7 +110,7 @@
                   <span data-translate="">toggleAttributes</span>
                 </a>
               </li>
-              <li>
+              <li role="menuitem">
                 <a data-ng-click="toggleTooltips(true)" href="">
                   <i class="fa"
                      data-ng-class="gnCurrentEdit.displayTooltips ? 'fa-check-square-o' : 'fa-square-o'"/>
@@ -118,7 +121,7 @@
             </xsl:otherwise>
           </xsl:choose>
         </ul>
-      </li>
+      </span>
 
       <!-- Make a tab switcher for all tabs of the current view -->
       <xsl:if test="count($currentView/tab) > 1">
@@ -128,16 +131,16 @@
 
         <!-- Some views may define tab to be grouped in an extra button -->
         <xsl:if test="count($config/editor/views/view[tab/@id = $tab]/tab[@toggle]) > 0">
-          <li class="dropdown">
+          <li class="dropdown" role="menuitem">
             <a class="dropdown-toggle" data-toggle="dropdown" href=""
                title="{$i18n/moreTabs}">
               <i class="fa fa-ellipsis-h"></i>
               <b class="caret"/>
             </a>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu" role="menu">
               <!-- links -->
               <xsl:for-each select="$config/editor/views/view[tab/@id = $tab]/tab[@toggle]">
-                <li>
+                <li role="menuitem">
                   <xsl:if test="$tab = @id">
                     <xsl:attribute name="class">disabled</xsl:attribute>
                   </xsl:if>
@@ -156,7 +159,7 @@
         </xsl:if>
       </xsl:if>
 
-    </ul>
+    </div>
   </xsl:template>
 
 
@@ -173,7 +176,7 @@
     <xsl:if test="$isTabDisplayed">
     </xsl:if>
     -->
-    <li
+    <li role="menuitem"
       class="{if ($tab = @id) then 'active' else ''} {if ($isTabDisplayed) then '' else 'disabled'}">
       <a href="">
         <xsl:if test="$tab != @id and $isTabDisplayed">

--- a/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
@@ -48,6 +48,7 @@
         <button type="button"
                 class="btn btn-default navbar-btn dropdown-toggle"
                 data-toggle="dropdown"
+                aria-label="{$i18n/selectView}"
                 title="{$i18n/selectView}"
                 aria-expanded="false">
           <i class="fa fa-eye"></i>


### PR DESCRIPTION
Replaces PR: https://github.com/geonetwork/core-geonetwork/pull/3048

Several changes have been made to follow more closely the Web Accessibility standards and guidelines.

This PR focusses on the editor toolbar for logged in users.

**Screenshot with the simplified display menu on the right:**
![gn-editor-toolbar](https://user-images.githubusercontent.com/19608667/44989538-794b6080-af8e-11e8-9dd7-7559a70efa9e.png)

Improved displaying of the editor toolbar:
- added `navbar-btn` to the buttons
- simplified the display menu (now with a `<button>` and not a `<a>`)
- changed the responsive breakpoint for the editor container

**Better displaying of the buttons on small screens:**
![gn-editor-toolbar-small](https://user-images.githubusercontent.com/19608667/44989575-92eca800-af8e-11e8-9a9e-a0b8dc6ae6b9.png)

Added a11y options:
- added titles and roles to the menu and menu items
- aria labels
- added `<h1>` to the page
- added main landmark
- added more color contrast to the toolbar