### PR TITLE
More uniform styling for Detail Page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -26,7 +26,7 @@
         </strong>
       </strong>
       </div>
-      <div data-ng-class="mainType === 'MDFCATS' ? 'col-xs-11' : 'col-xs-7 col-sm-7'" >
+      <div data-ng-class="mainType === 'MDFCATS' ? 'col-xs-11' : 'col-xs-8 col-sm-8'" >
         <!-- WMS & WFS contains layer name in title -->
         <h3 data-ng-if="((mainType === 'WMS' || mainType === 'WMSSERVICE' ||
                           mainType === 'WMTS' || mainType === 'WMTSSERVICE' ||
@@ -93,7 +93,7 @@
                data-ng-if="!isLayerProtocol(r)">
             <span data-translate=""
                   data-translate-values="{url:'{{r.url | gnLocalized: lang}}'}">
-          wfsServiceLinkDetails</span>
+              wfsServiceLinkDetails</span>
             </p>
             <div data-ng-if="!isLayerProtocol(r)"
                  data-gn-no-map-wfs-download=""
@@ -165,14 +165,10 @@
           </div>
           
           <div data-ng-switch-when="MDFCATS">
-          <p class="text-muted">
-            <h2>{{(r.title | gnLocalized: lang) }}</h2>
-            
-           <h2 data-translate="">technicalInformation</h2>
-           
-           <div data-gn-attribute-table-renderer="r.featureType.attributeTable.element">
-	        </div>
-            </p>
+            <h3>{{(r.title | gnLocalized: lang) }}</h3>
+            <h4 data-translate="">technicalInformation</h4>
+            <div data-gn-attribute-table-renderer="r.featureType.attributeTable.element">
+            </div>
           </div>
 
           <div data-ng-switch-default>
@@ -193,7 +189,7 @@
         </div>
       </div>
 
-      <div class="col-xs-12 col-sm-4">
+      <div class="col-xs-12 col-sm-3">
         <button type="button"
                 class="btn btn-default btn-sm btn-block"
                 data-ng-show="hasAction(mainType)"

--- a/web-ui/src/main/resources/catalog/components/viewer/atom/partials/atomDownload.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/atom/partials/atomDownload.html
@@ -29,7 +29,7 @@
   <!-- show links from dataset atom -->
   <div class="btn-group" data-ng-if="isAtomAvailable && isLayerInAtom && atomLinks">
       <br/><b>{{'atomDatasetsInFeed' | translate}}</b><br/>
-      <div style="max-height:250px;overflow:scroll;">
+      <div class="gn-atom">
           <div data-ng-repeat="link in atomLinks">
               <a href="{{link.url}}" target="_blank">{{link.title||link.url}}</a> ({{link.length}}mb, {{link.type}}, {{link.crs}})<br/>
           </div>

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -595,11 +595,16 @@ i.fa-times.delete:hover {
     background-color: rgba(255, 255, 255 , 0.7);
   }
   .gn-status-mdview {
-    font-size: 110%;
     position: relative;
-    float: right;
-    top: -52px;
-    margin-right: -20px;
+    top: 0;
+    left: 0;
+    display: inline-block;
+    font-size: 100%;
+    border-radius: 20px;
+    padding: 8px 12px;
+    font-weight: normal;
+    font-size: 80%;
+    transform: none;
   }
   /* Decide here which status should be displayed
   or not and with which colors */

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -7,7 +7,7 @@
 /* Angular view */
 .gn-md-view {
   table tr th {
-    width: 25%;
+    width: 35%;
   }
 
   .badge {

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -483,23 +483,6 @@ span.gn-facet-label:first-letter {
   color: @text-muted;
 }
 
-.gn-md-edit-btn {
-  .btn();
-  .btn-primary();
-}
-.gn-md-delete-btn {
-  .btn();
-  .btn-danger();
-}
-
-/* Add space between button when pulled right */
-.gn-md-edit-btn.pull-right,
-.gn-md-delete-btn.pull-right,
-.gn-md-actions-btn.pull-right.btn-group,
-.gn-md-actions-btn.pull-right {
-  margin-right: 5px;
-}
-
 [data-ng-search-form],
 [ng-search-form],
 .gn-search-page {

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/attributetable.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/attributetable.html
@@ -19,7 +19,7 @@
       <div data-ng-show="attribute.values.length > 0">
         <h5 data-translate="">attributeValues</h5>
 
-        <table class="table">
+        <table class="table table-bordered">
           <tr>
             <th data-translate="">valueName</th>
             <th data-translate="">valueCode</th>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -7,7 +7,7 @@
             data-toggle="dropdown"
             aria-label="{{'manageRecord' | translate}}"
             aria-expanded="false">
-      <i class="fa fa-cog"/>
+      <i class="fa fa-fw fa-cog"/>
       <span data-translate="" class="hidden-xs">manageRecord</span>
       <span class="caret"></span>
     </button>
@@ -101,7 +101,7 @@
             data-toggle="dropdown"
             aria-label="{{'download' | translate}}"
             aria-expanded="false">
-      <i class="fa fa-download"/>
+      <i class="fa fa-fw fa-download"/>
       <span data-translate="" class="hidden-xs">download</span>
       <span class="caret"></span>
     </button>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -4,9 +4,53 @@
 
 // styling for a single result: metadata view
 
+.btn-toolbar {
+  .btn-group {
+    margin-left: 0;
+    margin-right: 5px;
+  }
+  .btn-group.pull-right, .pull-right .btn-group {
+    margin-left: 5px;
+    margin-right: 0;
+  }
+}
+
 .gn-md-view {
   padding: 15px 20px;
   background-color: @gn-md-view-background-color;
+  .gn-related-item {
+    margin-top: -1px;
+    border-radius: 0;
+    padding: 10px 15px 10px 15px;
+    .col-xs-1 {
+      .fa {
+        font-size: 2em;
+      }
+      .fa-stack-1x {
+        font-size: 1em;
+      }
+      .fa-stack {
+        i {
+          opacity: 1 !important;
+        }
+        strong {
+          font-family: arial;
+          display: block;
+          margin-top: 2em;
+        }
+      }
+    }
+    h3 {
+      margin-top: 0;
+    }
+    .table-striped td {
+      padding-left: 8px;
+    }
+    .gn-atom {
+      max-height: 250px;
+      overflow: auto;
+    }
+  }
   .gn-md-side {
     .gn-img-thumbnail,
     .gn-img-extent {

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -12,84 +12,94 @@
 
   <div class="row gn-md-view"
        data-ng-show="mdView.current.record">
-    <button class="btn btn-primary"
-            data-ng-click="closeRecord(mdView.current.record)">
-      <i class="fa fa-search"></i> <span><span>
-      {{'backTo' + (fromView || 'search') | translate}}</span></span>
-    </button>
 
-    <button class="btn btn-link"
-            data-ng-class="searchObj.params.from == (mdView.current.index + 1) ? 'disabled' : ''"
-            data-ng-show="mdView.records.length > 1"
-            data-ng-click="previousRecord()">
-      <i class="fa fa-angle-left"></i>
-      <span data-ng-show="mdView.current.index === 0" data-translate="">previousPage</span>
-      <span data-ng-hide="mdView.current.index === 0" data-translate="">previous</span>
-    </button>
+    <div class="btn-toolbar" role="toolbar">
+      
+      <div class="btn-group" role="group">
+        <button class="btn btn-default"
+                data-ng-click="closeRecord(mdView.current.record)">
+          <i class="fa fa-fw fa-search"></i> <span><span>
+          {{'backTo' + (fromView || 'search') | translate}}</span></span>
+        </button>
+      </div>
 
-    <button class="btn btn-link"
-            data-ng-class="mdView.current.index === mdView.records.length - 1 &&
-                           searchObj.params.to > searchInfo.count &&
-                           searchInfo.count > searchObj.params.from ? 'disabled' : ''"
-            data-ng-show="mdView.records.length > 1"
-            data-ng-click="nextRecord()">
-      <span data-ng-show="mdView.current.index === mdView.records.length - 1" data-translate="">nextPage</span>
-      <span data-ng-hide="mdView.current.index === mdView.records.length - 1" data-translate="">next</span>
-      <i class="fa fa-angle-right"></i>
-    </button>
+      <div class="btn-group" role="group">
+        <button class="btn btn-default"
+                data-ng-class="searchObj.params.from == (mdView.current.index + 1) ? 'disabled' : ''"
+                data-ng-show="mdView.records.length > 1"
+                data-ng-click="previousRecord()">
+          <i class="fa fa-fw fa-angle-left"></i>
+          <span data-ng-show="mdView.current.index === 0" data-translate="">previousPage</span>
+          <span data-ng-hide="mdView.current.index === 0" data-translate="">previous</span>
+        </button>
+        <button class="btn btn-default"
+                data-ng-class="mdView.current.index === mdView.records.length - 1 &&
+                              searchObj.params.to > searchInfo.count &&
+                              searchInfo.count > searchObj.params.from ? 'disabled' : ''"
+                data-ng-show="mdView.records.length > 1"
+                data-ng-click="nextRecord()">
+          <span data-ng-show="mdView.current.index === mdView.records.length - 1" data-translate="">nextPage</span>
+          <span data-ng-hide="mdView.current.index === mdView.records.length - 1" data-translate="">next</span>
+          <i class="fa fa-fw fa-angle-right"></i>
+        </button>
+      </div>
 
+      <div class="btn-group pull-right">
+        <button type="button" class="btn btn-default dropdown-toggle"
+                data-toggle="dropdown"
+                aria-label="{{'chooseAView' | translate}}"
+                aria-expanded="false">
+          <i class="fa fa-fw fa-eye"></i>
+          <span data-translate="" class="hidden-sm hidden-xs">chooseAView</span>
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+          <!-- <li class="dropdown-header" data-translate="">chooseAView</li> -->
+          <li role="menuitem" data-ng-class="currentFormatter == undefined ? 'disabled' : ''">
+            <a href="" data-ng-click="format()">
+              <i class="fa fa-fw"></i>
+              <span data-translate="">defaultView</span>
+            </a>
+          </li>
+          <li role="menuitem"
+              data-ng-repeat="f in formatter.list"
+              data-ng-class="f === currentFormatter ? 'disabled' : ''">
+            <a href="" data-ng-click="format(f)">
+              <i class="fa fa-fw"></i>
+              {{f.label | translate}}
+            </a>
+          </li>
+        </ul>
+      </div>
 
-    <div class="btn-group pull-right">
-      <button type="button" class="btn btn-default dropdown-toggle"
-              data-toggle="dropdown"
-              aria-label="{{'chooseAView' | translate}}"
-              aria-expanded="false">
-        <i class="fa fa-eye"></i>
-        <span data-translate="" class="hidden-sm hidden-xs">chooseAView</span>
-        <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu" role="menu">
-        <!-- <li class="dropdown-header" data-translate="">chooseAView</li> -->
-        <li role="menuitem" data-ng-class="currentFormatter == undefined ? 'disabled' : ''">
-          <a href="" data-ng-click="format()">
-            <i class="fa fa-fw"></i>
-            <span data-translate="">defaultView</span>
-          </a>
-        </li>
-        <li role="menuitem"
-            data-ng-repeat="f in formatter.list"
-            data-ng-class="f === currentFormatter ? 'disabled' : ''">
-          <a href="" data-ng-click="format(f)">
-            <i class="fa fa-fw"></i>
-            {{f.label | translate}}
-          </a>
-        </li>
-      </ul>
+      <div class="gn-md-actions-btn pull-right"
+          data-gn-md-actions-menu="mdView.current.record"/>
+      
+      <div class="btn-group pull-right" role="group">
+        <a class="btn btn-default"
+          data-ng-show="user.canEditRecord(mdView.current.record)"
+          data-gn-click-and-spin="deleteRecord(mdView.current.record)"
+          data-gn-confirm-click="{{'deleteRecordConfirm' | translate:mdView.current.record}}"
+          title="{{'delete' | translate}}">
+          <i class="fa fa-fw fa-times"></i>
+          <span data-translate="" class="hidden-sm hidden-xs">delete</span>
+        </a>
+      </div>
+
+      <div class="btn-group pull-right" role="group">
+        <a class="btn btn-default"
+          data-ng-show="user.canEditRecord(mdView.current.record)"
+          data-ng-href="catalog.edit#/metadata/{{mdView.current.record.getId()}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.getUuid()}}"
+          title="{{'edit' | translate}}">
+          <i class="fa fa-fw fa-pencil"></i>
+          <span data-translate="" class="hidden-sm hidden-xs">edit</span>
+        </a>
+      </div>
     </div>
 
-    <div class="gn-md-actions-btn pull-right"
-         data-gn-md-actions-menu="mdView.current.record"/>
-
-    <a class="btn btn-danger gn-md-delete-btn pull-right"
-       data-ng-show="user.canEditRecord(mdView.current.record)"
-       data-gn-click-and-spin="deleteRecord(mdView.current.record)"
-       data-gn-confirm-click="{{'deleteRecordConfirm' | translate:mdView.current.record}}"
-       title="{{'delete' | translate}}">
-      <i class="fa fa-times"></i>
-      <span data-translate="" class="hidden-sm hidden-xs">delete</span>
-    </a>
-
-    <a class="btn btn-primary gn-md-edit-btn pull-right"
-       data-ng-show="user.canEditRecord(mdView.current.record)"
-       data-ng-href="catalog.edit#/metadata/{{mdView.current.record.getId()}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.getUuid()}}"
-       title="{{'edit' | translate}}">
-      <i class="fa fa-pencil"></i>
-      <span data-translate="" class="hidden-sm hidden-xs">edit</span>
-    </a>
-
     <div data-ng-show="usingFormatter"
-         id="gn-metadata-display"
-         class="gn-metadata-display">
+        id="gn-metadata-display"
+        class="gn-metadata-display">
     </div>
 
 
@@ -101,27 +111,41 @@
           {{mdView.current.record.title || mdView.current.record.defaultTitle}}
         </h1>
 
-        <div class="alert alert-info"
-             data-ng-bind-html="(mdView.current.record.abstract || mdView.current.record.defaultAbstract) | linky | newlines"/>
+        <div class="lead1 gn-margin-bottom"
+            data-ng-bind-html="(mdView.current.record.abstract || mdView.current.record.defaultAbstract) | linky | newlines"/>
 
         <!-- Display the first metadata status (apply to ISO19139 record) -->
         <div data-ng-if="mdView.current.record.status_text.length > 0"
-             title="{{mdView.current.record.status_text[0]}}"
-             class="gn-status gn-status-mdview gn-status-{{mdView.current.record.status[0]}}">
+            title="{{mdView.current.record.status_text[0]}}"
+            class="gn-status gn-status-mdview gn-status-{{mdView.current.record.status[0]}}">
           {{mdView.current.record.status_text[0]}}
         </div>
+        
         <div data-gn-related-observer>
           <div data-gn-related="mdView.current.record"
-               data-user="user"
-               data-types="onlines"
-               data-has-results="hasRelations.onlines"
-               data-title="{{'downloadsAndResources' | translate}}">
+              data-user="user"
+              data-types="onlines"
+              data-has-results="hasRelations.onlines"
+              data-title="{{'downloadsAndResources' | translate}}">
           </div>
 
           <div data-gn-related="mdView.current.record"
-               data-user="user"
-               data-types="parent|children|services|datasets"
-               data-title="{{'associatedResources' | translate}}">
+              data-user="user"
+              data-types="parent|children|services|datasets"
+              data-title="{{'associatedResources' | translate}}">
+          </div>
+        </div>
+
+        <div data-gn-related-observer>
+          <div data-gn-related="mdView.current.record"
+              data-user="user"
+              data-types="fcats|related"
+              data-title="{{'featureCatalog' | translate}}">
+          </div>
+          <div data-gn-related="mdView.current.record"
+              data-user="user"
+              data-types="siblings|associated|related"
+              data-title="{{'siblings' | translate}}">
           </div>
         </div>
 
@@ -147,17 +171,17 @@
             <th data-translate="">listOfCategories</th>
             <td>
               <button data-ng-repeat="cat in mdView.current.record.category"
-                   data-ng-click="search({'_cat': cat})"
-                   class="btn btn-sm btn-default"
-                   title="{{'clickToFilterOn' | translate}} {{('cat-' + cat) | translate}}">
+                  data-ng-click="search({'_cat': cat})"
+                  class="btn btn-sm btn-default"
+                  title="{{'clickToFilterOn' | translate}} {{('cat-' + cat) | translate}}">
                 <span class="fa gn-icon-{{cat}} resource-color"></span>&nbsp;
                 {{('cat-' + cat) | translate}}
               </button>
 
               <button data-ng-repeat="cat in mdView.current.record.topicCat track by $index"
-                   data-ng-click="search({'topicCat': cat})"
-                   class="btn btn-sm btn-default"
-                   title="{{'clickToFilterOn' | translate}} {{cat | translate}}">
+                  data-ng-click="search({'topicCat': cat})"
+                  class="btn btn-sm btn-default"
+                  title="{{'clickToFilterOn' | translate}} {{cat | translate}}">
                 <span class="fa gn-icon-{{cat}} topic-color"></span>&nbsp;
                 {{cat | translate}}
               </button>
@@ -172,12 +196,12 @@
                     class="tt-cursor">
                     <span data-ng-show="k.link == ''">{{k.value}}</span>
                     <a href=""
-                       data-ng-href="{{k.link}}"
-                       data-ng-hide="k.link == ''">
+                      data-ng-href="{{k.link}}"
+                      data-ng-hide="k.link == ''">
                       {{k.value}}</a>&nbsp;
                     <a href=""
-                       title="{{'clickToFilterOn' | translate}} {{k.value}}"
-                       data-ng-click="search({'keyword': k.value})">
+                      title="{{'clickToFilterOn' | translate}} {{k.value}}"
+                      data-ng-click="search({'keyword': k.value})">
                       <i class="fa fa-search"/>
                     </a>
                 </li>
@@ -264,7 +288,7 @@
 
 
         <div data-ng-if="mdView.current.record.attributeTable"
-             data-gn-attribute-table-renderer="mdView.current.record.attributeTable">
+            data-gn-attribute-table-renderer="mdView.current.record.attributeTable">
         </div>
 
 
@@ -324,18 +348,18 @@
             <td>
               <div data-gn-related-observer>
                 <div data-gn-related="mdView.current.record"
-                     data-user="user"
-                     data-types="sources"
-                     data-has-results="hasRelations.sources"
-                     data-title="{{'sourceDatasets' | translate}}">
+                    data-user="user"
+                    data-types="sources"
+                    data-has-results="hasRelations.sources"
+                    data-title="{{'sourceDatasets' | translate}}">
                 </div>
 
 
                 <div data-gn-related="mdView.current.record"
-                     data-user="user"
-                     data-types="hassources"
-                     data-has-results="hasRelations.hassources"
-                     data-title="{{'isSourceOfDatasets' | translate}}">
+                    data-user="user"
+                    data-types="hassources"
+                    data-has-results="hasRelations.hassources"
+                    data-title="{{'isSourceOfDatasets' | translate}}">
                 </div>
               </div>
             </td>
@@ -343,24 +367,11 @@
           </tbody>
         </table>
 
-        <div data-gn-related-observer>
-          <div data-gn-related="mdView.current.record"
-               data-user="user"
-               data-types="fcats|related"
-               data-title="{{'featureCatalog' | translate}}">
-          </div>
-          <div data-gn-related="mdView.current.record"
-               data-user="user"
-               data-types="siblings|associated|related"
-               data-title="{{'siblings' | translate}}">
-          </div>
-        </div>
-
         <h2 data-translate="">metadataInformation</h2>
 
-        <a class="btn btn-link"
-           data-ng-href="../api/records/{{mdView.current.record.getUuid()}}/formatters/xml">
-          <i class="fa fa-file-code-o"/>
+        <a class="btn btn-default gn-margin-bottom"
+          data-ng-href="../api/records/{{mdView.current.record.getUuid()}}/formatters/xml">
+          <i class="fa fa-fw fa-file-code-o"/>
           <span data-translate="">metadataInXML</span>
         </a>
 
@@ -399,20 +410,20 @@
 
           <div data-ng-repeat="img in mdView.current.record.overviews">
             <img data-gn-img-modal="img"
-                 class="gn-img-thumbnail img-thumbnail"
-                 alt="{{img.label}}"
-                 data-ng-src="{{img.url}}"/>
+                class="gn-img-thumbnail img-thumbnail"
+                alt="{{img.label}}"
+                data-ng-src="{{img.url}}"/>
 
             <div class="gn-img-thumbnail-caption"
-                 data-ng-show="img.label">{{img.label}}
+                data-ng-show="img.label">{{img.label}}
             </div>
           </div>
         </section>
         </br>
 
         <div data-gn-userfeedback='mdView.current.record'
-             data-gn-user={{user.username}}
-             data-ng-if="isUserFeedbackEnabled">
+            data-gn-user={{user.username}}
+            data-ng-if="isUserFeedbackEnabled">
         </div>
         <div class="gn-md-feedback-buttons clearfix">
           <div class="pull-left"
@@ -442,19 +453,19 @@
           <!-- TODO: use map config -->
           <p data-ng-repeat="bbox in mdView.current.record.geoBox">
             <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
-                 alt="{{'extent' | translate}}"
-                 aria-label="{{'extent' | translate}}"
-                 data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:3857&width=250&background=settings&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
+                alt="{{'extent' | translate}}"
+                aria-label="{{'extent' | translate}}"
+                data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:3857&width=250&background=settings&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
           </p>
 
         </section>
 
         <section class="gn-md-side-dates"
-                 data-ng-if="mdView.current.record.creationDate ||
-                             mdView.current.record.publicationDate ||
-                             mdView.current.record.revisionDate ||
-                             mdView.current.record.tempExtentBegin ||
-                             mdView.current.record.tempExtentEnd">
+                data-ng-if="mdView.current.record.creationDate ||
+                            mdView.current.record.publicationDate ||
+                            mdView.current.record.revisionDate ||
+                            mdView.current.record.tempExtentBegin ||
+                            mdView.current.record.tempExtentEnd">
           <h2>
             <i class="fa fa-fw fa-clock-o"></i>
             <span data-translate="">tempExtent</span>
@@ -515,7 +526,7 @@
                     <span data-ng-show="c.position">({{c.position}})</span>
                   </div>
                   <a href="tel:{{c.phone}}"
-                     data-ng-if="c.phone != ''">
+                    data-ng-if="c.phone != ''">
                     <span data-translate="">call</span> {{c.phone}}
                   </a>
                 </address>
@@ -530,8 +541,8 @@
             <span data-translate="">sourceCatalog</span>
           </h2>
           <img ng-src="{{gnUrl}}../images/logos/{{mdView.current.record.source}}.png"
-               aria-label="{{'sourceCatalog' | translate}}"
-               class="gn-source-logo"/>
+              aria-label="{{'sourceCatalog' | translate}}"
+              class="gn-source-logo"/>
         </section>
 
         <section class="gn-md-side-calendar">
@@ -551,9 +562,9 @@
             <span data-translate="">shareOn</span>
           </h2>
           <a data-ng-href="https://twitter.com/share?url={{socialMediaLink | encodeURIComponent}}"
-             title="{{'shareOnTwitter' | translate}}"
-             target="_blank"
-             class="btn btn-default"><i class="fa fa-fw fa-twitter"></i></a>
+            title="{{'shareOnTwitter' | translate}}"
+            target="_blank"
+            class="btn btn-default"><i class="fa fa-fw fa-twitter"></i></a>
           <a
             data-ng-href="https://plus.google.com/share?url={{socialMediaLink | encodeURIComponent}}"
             title="{{'shareOnGooglePlus' | translate}}"
@@ -590,5 +601,8 @@
       </div>
 
     </div>
+
+
+
   </div>
 </div>


### PR DESCRIPTION
Replaces PR: https://github.com/geonetwork/core-geonetwork/pull/3007

Some small changes for the detail page in order to get a more uniform look: same buttons, same tables, same size of icons.

**Screenshot of new page:**
![gn-new-detail-page](https://user-images.githubusercontent.com/19608667/44035719-68375f44-9f10-11e8-8470-8a5edc8a0c97.png)

Changes:
- same icons (colors, size, labels)
- smaller width for buttons
- uniform buttons in the button bar
- different style for the status
- other headings for feature catalog (`<h3>` and `<h4>` in stead of `<h2>`)

**Screenshot of new feature catalog block:**
![gn-new-detail-page-fcat](https://user-images.githubusercontent.com/19608667/44035873-c6baed56-9f10-11e8-8f53-45d74ff86f25.png)
