### PR TITLE
fix map loading in non-google projection

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1590,7 +1590,8 @@
 
               var options = ol.source.WMTS.optionsFromCapabilities(cap, {
                 layer: getCapLayer.Identifier,
-                matrixSet: map.getView().getProjection().getCode()
+                matrixSet: map.getView().getProjection().getCode(),
+                projection: map.getView().getProjection().getCode()
               });
 
               //Configuring url for service


### PR DESCRIPTION
cherry-pick from 3.4.x

wmts loading in ngeo expects tilematrixset SupportedCRS in capabilities to have urn format, ngeo-debug.js line 91346

```
projection = ol.proj.get(matrixSetObj['SupportedCRS'].replace(
        /urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3'));
```

however many services use a plain epsg:xxx format

https://geodata.nationaalgeoregister.nl/tiles/service/wmts

by explicitly providing the projection in the config object, an error is prevented
