### PR TITLE
Let layers with errors be shown on LayerManager.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1939,8 +1939,7 @@
          * appear in the layer manager
          */
         selected: function(layer) {
-          return layer.displayInLayerManager && !layer.get('fromWps') &&
-              (!layer.get('errors') || !layer.get('errors').length);
+          return layer.displayInLayerManager && !layer.get('fromWps');
         },
         visible: function(layer) {
           return layer.displayInLayerManager && layer.visible;


### PR DESCRIPTION
Layers with errors are shown on the map anyway, but as they don't appear on Layer Manager there is no way to handle them (or remove them). Better to show them with errors, so the user can:
1.- Check the list of errors associated to that layer. Not only as an alert that disappears.
2.- If there is something added to the map and shown, even if it is ugly and weird, have a button to remove it.
3.- If the layer was properly shown (as with OL reprojecting the layer), then why not show it, even if the projection missing error is there?

Not sure why the "layers from WPS" aren't shown either.