### PR TITLE
XSL Formatter / handle logos in contact info

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -813,7 +813,7 @@
     <xsl:variable name="label" select="."/>
 
     <xsl:choose>
-      <xsl:when test="ends-with($href, '.jpg') or ends-with($href, '.png') or ends-with($href, '.gif')">
+      <xsl:when test="matches($href, $imageExtensionsRegex, 'i')">
         <img src="{$href}" title="{$label}" alt="{$label}"/>
       </xsl:when>
       <xsl:otherwise>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -806,6 +806,24 @@
     </xsl:if>
   </xsl:template>
 
+  <!-- filename -->
+  <xsl:template mode="render-value"
+                match="gmx:FileName[@src != '']">
+    <xsl:variable name="href" select="@src"/>
+    <xsl:variable name="label" select="."/>
+
+    <xsl:choose>
+      <xsl:when test="ends-with($href, '.jpg') or ends-with($href, '.png') or ends-with($href, '.gif')">
+        <img src="{$href}" title="{$label}" alt="{$label}"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <a href="{$href}">
+          <xsl:value-of select="$label"/>&#160;
+        </a>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <!-- ... URL -->
   <xsl:template mode="render-value"
                 match="gmd:URL">

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -388,6 +388,10 @@ ul.container-list {
       }
     }
   }
+  .gn-contact img {
+    max-width: 100%;
+    max-height: 150px;
+  }
 }
 
 [data-gn-metadata-contacts], [gn-metadata-contacts] {

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
@@ -69,4 +69,7 @@
   <!-- Flat mode is defined in the first tab of the view -->
   <xsl:variable name="isFlatMode"
                 select="$viewConfig/tab[1]/@mode = 'flat'"/>
+
+  <!-- Regex for matching image filenames -->
+  <xsl:variable name="imageExtensionsRegex" select="'\.(gif|png|jpg|jpeg|svg)$'"/>
 </xsl:stylesheet>


### PR DESCRIPTION
A `<gmx:FileName>` element can be present in a contact info (or elsewhere), but these elements currently are rendered as plain text without taking into account the `@src` attribute. This PR adds support in the XSL formatter to render such element properly.

Example xml:
```xml
...
    <gmd:contactInstructions>
      <gmx:FileName src="https://www.geograndest.fr/metadata/live/logo/logo_ZAEU.png">Logo</gmx:FileName>
    </gmd:contactInstructions>
  </gmd:CI_Contact>
...
```

Before:
![image](https://user-images.githubusercontent.com/10629150/46608880-70f2c200-cb06-11e8-940e-6995b555797c.png)

After:
![image](https://user-images.githubusercontent.com/10629150/46608896-794afd00-cb06-11e8-9394-8cfcd8a83f7f.png)

Please let me know if this is redundant with another xsl process and/or may break other things in the formatter, thanks.