### PR TITLE
New design for the info list (Recent/Popular) on the homepage (replaces #3134)

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -404,5 +404,8 @@
     "group": "Group",
     "showOptions": "Show options",
     "projectionSwitcher": "Projection Switcher",
-    "projection": "Projection"
+    "projection": "Projection",
+    "listTypeBlocks": "Switch to Blocked list",
+    "listTypeLarge": "Switch to Large list",
+    "listTypeSmall": "Switch to Small list"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_infolist.less
+++ b/web-ui/src/main/resources/catalog/style/gn_infolist.less
@@ -1,195 +1,247 @@
 // Color variables
 @import "../lib/style/bootstrap/less/variables.less";
-@cardtext: @gray-dark;
-@cardbackground: @gray-light;
 
-// Width variables 
-@width3: 100%; 
-
-// Height variables 
-@height4: 100%; 
-
-.quickresultcard {
-
-  border-radius: 4px;
-  border: 1px solid #dddddd;
-  cursor: pointer;
-  height: 150px;
-  .flip {
-    -moz-transition: all 0.5s ease;
-    -o-transition: all 0.5s ease;
-    -webkit-transition: all 0.5s ease;
-    transition: all 0.5s ease;
-  }
-  .front {
-    -moz-transform: scale(1, 1);
-    -moz-transition: all 0.6s ease;
-    -ms-transform: scale(1, 1);
-    -o-transition: all 0.6s ease;
-    -webkit-transform: scale(1, 1);
-    -webkit-transition: all 0.6s ease;
-    border-radius: 4px;
-    height: 149px;
-    position: absolute;
-    transform: scale(1, 1);
-    transition: all 0.6s ease;
-    width: 32%;
-    z-index: 11;
-    .top {
-      background: @cardbackground;
-      float:left;
-      height: @height4;
-      width: 30%;
-      &:after {
-        -moz-transform: translateX(-50%) rotate(45deg);
-        -ms-transform: translateX(-50%) rotate(45deg);
-        -webkit-transform: translateX(-50%) rotate(45deg);
-        background: inherit;
-        bottom: 40%;
-        content: '';
-        height: 2.5em;
-        left: 30%;
-        pointer-events: none;
-        position: absolute;
-        transform: translateX(-50%) rotate(45deg);
-        width: 2.5em;
-        z-index: 10;
-      }
-    }
-    .rigth {
-      -moz-transform: translateY(0);
-      -ms-transform: translateY(0);
-      -webkit-transform: translateY(0);
-      height: @height4;
-      transform: translateY(0);
-      width: auto;
-      z-index: 8;
-    }
-    .header-card {
-      -moz-transform: translateY(0);
-      -ms-transform: translateY(0);
-      -webkit-transform: translateY(0);
-      margin-left: 2%;
-      margin-right: 4%;
-      margin-top: 10%;
-      transform: translateY(0);
-    }
-    .title {
-      color: @cardtext;
-      font-size: 120%;
-      text-align: center;
-      &:after {
-        background: @cardtext;
-        content: '';
-        display: block;
-        height: 1px;
-        left: 40%;
-        position: absolute;
-        right: 40%;
-        width: 20%;
-      }
-    }
-    .introduction {
-      color: @cardtext;
-      font-family: 'Old Standard TT', serif;
-      font-style: italic;
-      text-align: center;
-    }
-    .content-card {
-
-      font-weight: 300;
-      height:10%;
-      margin-left: 5%;
-      visibility: hidden;
-      span {
-        color: #2D3244;
-        display: inline-block;
-        font-size: 1.7em;
-        width: 1.3em;
-      }
-      a {
-        bottom: .24em;
-        position: relative;
-      }
-    }
-    .footer-card {
-      margin-left: 5%;
-      margin-right: 2%;
-      text-align: right;
-    }
-  }
-  .back {
-    backface-visibility: hidden;
-    position: absolute;
-    width: @width3;
-  }
-}
-.front .top, .front .top:after, .front .header-card, .front .content-card, .gn-md-thumbnail img  {
-  -moz-transition: all 0.7s ease-in-out;
-  -o-transition: all 0.7s ease-in-out;
-  -webkit-transition: all 0.7s ease-in-out;
-  transition: all 0.7s ease-in-out;
-}
-.flip {
+// tabs above the info list
+.nav-tabs > li > a {
   &:hover {
-    .front {
-      .top {
-        width: 8%;
-        &:after {
-          bottom: 40%;
-          height: 1.5em;
-          left:8%;
-          width: 1.5em;
+    cursor: pointer;
+  }
+}
+
+// toggle buttons
+#info-toggle-buttons {
+  // do not display on smartphones
+  @media (max-width: @screen-xs) {
+    display: none;
+  }
+}
+
+// list of records
+.gn-info-list {
+  padding: 5px 0px;
+  margin: auto -10px;
+  li {
+    width: 100%;
+    zoom: 1;
+    list-style: none;
+    float: left;
+    padding: 10px;
+    cursor: pointer;
+    // info lists
+    // 
+    // ----- general
+    .resultcard {
+      padding: 0 0 10px 0;
+      .title {
+        min-height: 40%;
+        padding: 10px;
+        h4 {
+          font-size: 18px;
+          font-weight: 300;
+          margin: 0;
         }
       }
-      .header-card {
-        -moz-transform: translateY(0%);
-        -ms-transform: translateY(0%);
-        -webkit-transform: translateY(0%);
-        margin: 1%;
-        transform: translateY(0%);
-      }
-      .content-card {
-        color: @cardtext;
-        height:auto;
-        margin-bottom: 1%;
-        margin-top: 0%;
-        margin-top: 1%;
-        padding-right: 3%;
-        padding-top: 0%;
-        visibility:visible;
-      }
-      .footer-card {
-        visibility: hidden;
+      .abstract {
+        overflow: auto;
+        padding: 0 10px 0 10px;
+        height: 60%;
       }
       .gn-md-thumbnail {
-        height: 0%;
-        left: 0%;
-        margin: 0;
+        display: none;
+        float: left;
+        width: 150px;
+        height: 150px;
+        border: 1px solid @input-border;
+        background-color: #fff;
+        .gn-img-thumbnail {
+          width: 100%;
+          height: 100%;
+          background-repeat: no-repeat;
+          background-position: center center;
+          background-size: cover;
+          filter: grayscale(100%);
+        }
+      }
+    }
+    .noThumbnail {
+      // display icon when there is no thumbnail
+      .gn-img-thumbnail:after {
+        content: "\f03e"; 
+        font-family: FontAwesome;
+        font-style: normal;
+        font-weight: normal;
+        text-decoration: inherit;
         position: absolute;
-        top: 0%;
-        width: 5%;
-        z-index: 100;
-        img {
-          max-height: 0%;
-          max-width: 0%;
+        font-size: 46px;
+        color: @gray-lighter;
+        top: 50%;
+        left: 50%;
+        margin: -32px 0 0 -23px;
+        z-index: 1;
+      }
+    }
+    &:hover {
+      .title {
+        color: @gray-base;
+      }
+    }
+  }
+}
+
+// 3 types of info lists
+// 
+// ----- small
+.gn-info-list-small {
+  .gn-info-list {
+    li {
+      width: 100%;
+      padding: 5px 10px;
+      margin-bottom: 10px;
+      .resultcard {
+        border-left: 3px solid @list-group-border;
+        padding-left: 10px;
+        .title {
+          padding-left: 0;
+          padding-bottom: 5px;
+        }
+        .abstract {
+          max-height: 1.5em;
+          overflow: hidden;
+          padding-left: 0;
+        }
+        .introduction {
+          display: none;
+        }
+        &:hover {
+          background-color: @list-group-hover-bg;
         }
       }
     }
   }
 }
-.front {
-  .gn-md-thumbnail {
-    height: 70%;
-    left: 4%;
-    margin: 0;
-    position: absolute;
-    top: 10%;
-    width: 22%;
-    z-index: 100;
-    img {
-      max-height: @height4;
-      max-width: @width3;
+// ----- large
+.gn-info-list-large {
+  .gn-info-list {
+    li {
+      width: 100%;
+      .resultcard {
+        .title {
+          padding-left: 0;
+        }
+        .content {
+          float: left;
+          max-width: 70%
+        }
+        .abstract {
+          max-height: auto;
+          max-height: 250px;
+          padding-left: 0;
+        }
+        .introduction {
+          margin-top: 10px;
+          .badge {
+            font-weight: normal;
+            background-color: @gray-dark;
+          }
+        }
+        .gn-md-thumbnail {
+          float: left;
+          display: block;
+          margin-top: 4px;
+          margin-right: 10px;
+        }
+      }
+      &:hover {
+        .resultcard {
+          background-color: @list-group-hover-bg;
+        }
+        .resultcard.hasThumbnail {
+          .gn-img-thumbnail {
+            filter: none;
+          }
+        }
+      }
+    }
+  }
+}
+// ----- blocks
+.gn-info-list-blocks {
+  .gn-info-list {
+    li {
+      width: 33%;
+      height: 250px;
+      transition: all 200ms ease-in;
+      transform: scale(1);
+      .resultcard {
+        .title {
+          background: @gray-dark;
+          border: @gray-dark;
+          h4 {
+            color: #fff;
+            font-size: 15px;
+            font-weight: 300;
+            margin: 0;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            line-height: 22px;
+          }
+        }
+        .abstract {
+          border: 1px solid #ccc;
+          height: 150px;
+          padding-bottom: 5px;
+        }
+        .introduction {
+          display: none;
+        }
+        .gn-md-thumbnail {
+          display: block;
+          width: 100%;
+        }
+      }
+      .abstract {
+        display: none;
+      }
+      &:hover {
+        transition: all 200ms ease-in;
+        transform: scale(1.03);
+        .resultcard {
+          .title {
+            background: @gray-darker;
+          }
+        }
+        .resultcard.hasThumbnail {
+          .gn-img-thumbnail {
+            filter: none;
+          }
+        }
+        &:before {
+          content: "";
+        }
+      }
+    }
+  }
+}
+// more blocks on 1 row when the screen is wider
+.gn-info-list-blocks {
+  .gn-info-list {
+    @media (min-width: @screen-lg-min) {
+      li {
+        width: 25%;
+      }
+    }
+    @media (max-width: @screen-sm-min) {
+      li {
+        width: 50%;
+      }
+    }
+    // smartphones in landscape
+    @media (max-width: @screen-xs) {
+      li {
+        width: 100%;
+      }
     }
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -2,40 +2,31 @@
   <li
     data-ng-repeat="md in searchResults.records"
     data-ng-click="openRecord($index, md, searchResults.records)"
-    data-ng-mouseenter="showMore(true)"
-    data-ng-mouseleave="showMore(false)"
     id="gn-info-list-mw-{{md.getUuid()}}">
-    <section class="quickresultcard">
-      <div class="flip">
-        <div class="front">
-          <div class="top">
-            <div class="gn-md-thumbnail">
-              <img class="gn-img-thumbnail"
-                   alt="{{md.title || md.defaultTitle}}"
-                   data-ng-src="{{md.getThumbnails().list[0].url}}"
-                   data-ng-if="md.getThumbnails().list[0].url"/>
-            </div>
-          </div>
-          <div class="rigth">
-            <div class="header-card">
-              <div class="title">{{md.title || md.defaultTitle}}</div>
-              <div class="introduction">
-                <span data-ng-repeat="t in md.type">{{t | translate}}
-                <span data-ng-if="!$last">, </span>
-                </span>
-              </div>
-            </div>
-            <div class="content-card">
-              <div class="abstract">
-                {{md.abstract}}
-              </div>
-            </div>
-            <div class="footer-card">
-            </div>
-          </div>
-        </div>
-        <div class="back"></div>
+    <section class="resultcard clearfix"
+             data-ng-class="md.getThumbnails().list[0].url ? 'hasThumbnail' : 'noThumbnail'">
+
+      <div class="title">
+        <h4>{{md.title || md.defaultTitle}}&nbsp;</h4>
       </div>
+
+      <div class="gn-md-thumbnail">
+        <div class="gn-img-thumbnail"
+             style="background-image: url({{md.getThumbnails().list[0].url}})">
+        </div>
+      </div>
+
+      <div class="content">
+        <div class="abstract">
+          {{md.abstract}}
+        </div>
+
+        <div class="introduction">
+          <span class="badge" data-ng-repeat="t in md.type">{{t | translate}}
+          </span>
+        </div>
+      </div>
+
     </section>
   </li>
 </ul>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_infolist_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_infolist_default.less
@@ -1,0 +1,37 @@
+@import "../../../style/gn_bootstrap.less";
+@import "gn_variables_default.less";
+
+// row for the info lists
+.gn-row-info {
+    padding: 30px 20px 40px 20px;
+    background-color: @gn-info-background-color;
+    .nav-pills {
+      text-align: left !important;
+      border-bottom: 1px solid #ddd;
+      padding-bottom: 10px;
+    }
+  }
+  
+  // custom colors for the blocks in the info list
+  .gn-info-list-blocks {
+    .gn-info-list {
+      li {
+        .resultcard {
+          .title {
+            background: @gn-resultcard-title-background-color;
+            border: @gn-resultcard-title-border;
+            h4 {
+              color: @gn-resultcard-title-color;
+            }
+          }
+        }
+        .resultcard.hasThumbnail {
+          &:hover {
+            .title {
+              background: @gn-resultcard-title-background-color-hover;
+            }
+          }
+        }
+      }
+    }
+  }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -17,6 +17,8 @@
 @import "gn_map_default.less";
 // footer and bottombar
 @import "gn_footer_default.less";
+// infolists on the homepage
+@import "gn_infolist_default.less";
 // variables for manipulating the theme
 @import "gn_variables_default.less"; // must be last
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -4,8 +4,6 @@
 
 // body background (image & color)
 //
-// picture from https://unsplash.com/
-//
 // when there is an empty string, no background image is used.
 @gn-background-image: '';
 @gn-background-color: @body-bg;
@@ -44,7 +42,10 @@
 @gn-info-background-color: @body-bg;
 // ----- resultcards
 @gn-resultcard-background-color: @body-bg;
-@gn-resultcard-title-background-color: @gray-light;
+@gn-resultcard-title-background-color: #505050;
+@gn-resultcard-title-background-color-hover: #333;
+@gn-resultcard-title-color: #fff; // @navbar-default-link-color;
+@gn-resultcard-title-border: 0px solid @navbar-default-border;
 
 // search results page
 @gn-results-background-color: @body-bg;

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -52,7 +52,7 @@
         params: {
           sortBy: 'popularity',
           from: 1,
-          to: 9
+          to: 12
         }
       };
     }]);
@@ -68,7 +68,7 @@
         params: {
           sortBy: 'changeDate',
           from: 1,
-          to: 9
+          to: 12
         }
       };
     }]);
@@ -226,6 +226,14 @@
         }
       };
 
+      /**
+       * Toggle the list types on the homepage
+       * @param  {String} type Type of list selected
+       */
+      $scope.toggleListType = function(type) {
+        $scope.type = type;
+      };
+      
       $scope.infoTabs = {
         lastRecords: {
           title: 'lastRecords',

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -146,13 +146,43 @@
       </div>
     </div>
   </div>
-  <div class="row gn-row-info" data-ng-show="searchInfo.count > 0">
+  
+  <div class="row gn-row-info"
+       data-ng-show="searchInfo.count > 0"
+       data-ng-class="{'gn-info-list-blocks': type === 'blocks' || type === undefined, 'gn-info-list-large': type === 'large', 'gn-info-list-small': type === 'small'}">
     <div class="col-sm-12">
-      <tabset class="info-tabset">
+
+      <!-- toggle buttons -->
+      <div id="info-toggle-buttons" class="btn-group pull-right" data-toggle="buttons">
+        <button id="btn-toggle-blocks" type="button" class="btn btn-default"
+                data-ng-click="toggleListType('blocks')"
+                data-ng-model="type"
+                data-ng-class="{'active': type === 'blocks' || type === undefined}"
+                aria-label="{{'listTypeBlocks' | translate}}">
+          <i class="fa fa-th-large" aria-hidden="true"></i>
+        </button>
+        <button id="btn-toggle-large" type="button" class="btn btn-default"
+                data-ng-click="toggleListType('large')"
+                data-ng-model="type"
+                data-ng-class="{'active': type === 'large'}"
+                aria-label="{{'listTypeLarge' | translate}}">
+          <i class="fa fa-bars" aria-hidden="true"></i>
+        </button>
+        <button id="btn-toggle-small" type="button" class="btn btn-default"
+                data-ng-click="toggleListType('small')"
+                data-ng-model="type"
+                data-ng-class="{'active': type === 'small'}"
+                aria-label="{{'listTypeSmall' | translate}}">
+          <i class="fa fa-align-justify" aria-hidden="true"></i>
+        </button>
+      </div>
+
+      <tabset id="info-tabset pull-left" type="pills" justified="false">
         <tab heading="{{'lastRecords' | translate}}"
-             active="infoTabs.lastRecords.active"
-             role="tab">
+             role="tab"
+             active="infoTabs.lastRecords.active">
           <form class="form-horizontal"
+                role="form"
                 data-ng-controller="gnsSearchLatestController"
                 data-ng-search-form=""
                 data-runSearch="true"
@@ -163,9 +193,10 @@
           </form>
         </tab>
         <tab heading="{{'preferredRecords' | translate}}"
-             active="infoTabs.preferredRecords.active"
-             role="tab">
+             role="tab"
+             active="infoTabs.preferredRecords.active">
           <form class="form-horizontal"
+                role="form"
                 data-ng-controller="gnsSearchPopularController"
                 data-ng-search-form=""
                 data-runSearch="true"
@@ -180,10 +211,12 @@
              role="tab">
           <form class="form-horizontal">
             <div class="data-gn-userfeedbacklasthome"
-                 data-nb-of-comments="10"></div>
+                  data-nb-of-comments="10"></div>
           </form>
         </tab>
       </tabset>
     </div>
   </div>
+  <!-- /.gn-row-info -->
+
 </div>


### PR DESCRIPTION
This replaces PR https://github.com/geonetwork/core-geonetwork/pull/3134

The homepage had an animated section for recent and popular datasets. This PR replaces this with blocks showing only the thumbnails in black/white (default). There is also the opportunity to change the list type with the 3 toggle buttons on the top right of the list.

**Screenshot of the new design:**
![gn-new-infolist](https://user-images.githubusercontent.com/19608667/43128417-41dc3646-8f32-11e8-94d0-0e538eed69a9.png)

Changes and improvements:
- accessibility color scheme
- no thumbnail then display text
- added aria roles
- color thumbnails on hover
- 12 cards instead of 9 (better for displaying a 4x3 of 3x4 grid)
- smooth zoom in/out effect on hover
- background color on hover over list items
- display an icon when there is no thumbnail
- responsive view for all the lists

Reordering and cleaning css and less:
- remove old and unused css
- added bootstrap variables for the default colors