### PR TITLE
Fix: Show name + surname in harvester users dropdown (#3083)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/partials/usersCombo.html
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/partials/usersCombo.html
@@ -2,7 +2,7 @@
   <select class="form-control " data-ng-model="ownerUser">
     <option data-ng-repeat="u in users | orderBy:'name'" value="{{u['@id'] || u.id}}"
             data-ng-selected="ownerUser == (u['@id'] ? u['@id'] : u.id)">
-              {{u.name}}
+              {{u.name}} {{u.surname}}
     </option>
   </select>
 </div>


### PR DESCRIPTION
Fix for issue https://github.com/geonetwork/core-geonetwork/issues/3083

Added the surname to the users combobox, so now the name and surname are shown
![gn-harvester-user](https://user-images.githubusercontent.com/19608667/46744448-7b9a8c00-ccab-11e8-90f7-458ddbcf0431.png)


