### PR TITLE
Editor / Simple overview manager

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -695,6 +695,23 @@ To include text block use the following:
         <text ref="defaultviewdesc"></text>
         ....
 
+For overview, a simple manager can be used or the general one:
+
+.. code-block:: xml
+
+        <!-- Simple overview manager + online source manger for other types
+        Limit the max number of overviews with data-number-of-overviews="3" attribute.
+        In the full view, editor can access and manage the file store and
+        thumbnail name and description not supported by the overview manager.
+        -->
+        <directive data-gn-overview-manager=""/>
+        <directive data-gn-onlinesrc-list=""
+                   data-types="onlinesrc|parent|dataset|service|source|sibling|associated|fcats"/>
+
+
+        <!-- General online source manager
+        <directive data-gn-onlinesrc-list=""/>
+        -->
 
 
 ]]>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -3111,7 +3111,19 @@
     <view name="default" class="gn-indent-bluescale gn-label-above-input">-->
     <view name="default">
       <sidePanel>
+        <!-- General online source manager
         <directive data-gn-onlinesrc-list=""/>
+        -->
+
+        <!-- Simple overview manager + online source manger for other types
+        Limit the max number of overviews with data-number-of-overviews="3" attribute.
+        In the full view, editor can access and manage the file store and
+        thumbnail name and description not supported by the overview manager.
+        -->
+        <directive data-gn-overview-manager=""/>
+        <directive data-gn-onlinesrc-list=""
+                   data-types="onlinesrc|parent|dataset|service|source|sibling|associated|fcats"/>
+
         <directive gn-geo-publisher=""
                    data-ng-if="gnCurrentEdit.geoPublisherConfig"
                    data-config="{{gnCurrentEdit.geoPublisherConfig}}"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -258,7 +258,7 @@
             for (var i = 0; i < data.siblings.length; i++) {
               var type = data.siblings[i].associationType;
               if ($.inArray(type, scope.siblingTypes) == -1) {
-                scope.siblingTypes.push(type);
+                siblingTypes.push(type);
               }
             }
           }

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -211,11 +211,12 @@
          *
          * @return {HttpPromise} Future object
          */
-        getAllResources: function() {
+        getAllResources: function(types) {
 
           var defer = $q.defer();
-
-          $http.get('../api/records/' + gnCurrentEdit.uuid + '/related', {
+          var url = '../api/records/' + gnCurrentEdit.uuid + '/related' +
+                      (angular.isArray(types) ? '?' + types.join('&type=') : '');
+          $http.get(url, {
             headers: {
               'Accept': 'application/json'
             }
@@ -226,6 +227,46 @@
           return defer.promise;
         },
 
+        /**
+         * @ngdoc method
+         * @methodOf gn_onlinesrc.service:gnOnlinesrc
+         * @name gnOnlinesrc#formatResources
+         *
+         * @description
+         * If multilingual, get current lang url to
+         * diplay the resource in the list (img, link)
+         * lUrl means localize Url
+         *
+         * @return {Object} Containing relations and siblingTypes properties
+         */
+        formatResources: function(data, lang, mdLanguage) {
+          var siblingTypes = [];
+          // If multilingual, get current lang url to
+          // diplay the resource in the list (img, link)
+          // lUrl means localize Url
+          angular.forEach(data.onlines, function(src) {
+            src.lUrl = src.url[lang] ||
+              src.url[mdLanguage] ||
+              src.url[Object.keys(src.url)[0]];
+          });
+          angular.forEach(data.thumbnails, function(img) {
+            img.lUrl = img.url[lang] ||
+              img.url[mdLanguage] ||
+              img.url[Object.keys(img.url)[0]];
+          });
+          if (data.siblings) {
+            for (var i = 0; i < data.siblings.length; i++) {
+              var type = data.siblings[i].associationType;
+              if ($.inArray(type, scope.siblingTypes) == -1) {
+                scope.siblingTypes.push(type);
+              }
+            }
+          }
+          return {
+            relations: data,
+            siblingTypes: siblingTypes
+          };
+        },
         /**
          * @ngdoc method
          * @methodOf gn_onlinesrc.service:gnOnlinesrc
@@ -485,7 +526,7 @@
 
           // It is a url thumbnail
           if (thumb.id.indexOf('resources.get') < 0) {
-            runProcess(this,
+            return runProcess(this,
                 setParams('thumbnail-remove', {
                   id: gnCurrentEdit.id,
                   thumbnail_url: thumb.id
@@ -493,7 +534,7 @@
           }
           // It is an uploaded tumbnail
           else {
-            runService('removeThumbnail', {
+            return runService('removeThumbnail', {
               type: (thumb.title === 'thumbnail' ? 'small' : 'large'),
               id: gnCurrentEdit.id,
               version: gnCurrentEdit.version

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/overview-manager.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/overview-manager.html
@@ -37,15 +37,16 @@
       </ul>
 
       <!-- The upload zone -->
-      <span class="btn btn-default btn-block fileinput-button"
+      <span class="btn btn-success btn-block fileinput-button"
             data-ng-class="{disabled: disabled}"
             data-ng-hide="relations.thumbnails.length >= numberOfOverviews">
-       <i class="fa fa-3x fa-plus-circle"
+       <i class="fa fa-fw fa-plus-circle"
           data-ng-class="{hidden: active()}"/>
-       <i class="fa fa-3x fa-spinner fa-spin"
+       <i class="fa fa-fw fa-spinner fa-spin"
           data-ng-class="{hidden: !active()}"
           data-file-upload-progress="progress()"
           data-file-upload-done="loadRelations()"/>
+        <span data-translate="">chooseImage</span>
         <input type="file"
                name="file"
                data-ng-disabled="disabled"/>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/overview-manager.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/overview-manager.html
@@ -1,0 +1,56 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <i class="fa gn-icon-thumbnail"></i><i class="icon-external-link"></i>&nbsp;
+    <span
+      data-translate="">overview</span>
+  </div>
+  <div class="panel-body">
+
+
+    <form class="form-horizontal"
+          role="form"
+          method="POST"
+          enctype="multipart/form-data"
+          data-file-upload="filestoreUploadOptions">
+
+      <ul class="list-inline">
+        <!-- Current thumbnails -->
+        <li class="gn-list-thumb thumbnail"
+            data-ng-repeat="thumb in relations.thumbnails">
+          <img class="thumb-small"
+               title="{{thumb.title | gnLocalized: lang}}"
+               data-ng-src="{{thumb.lUrl || thumb.id}}"/>
+
+          <a href="" class="onlinesrc-remove"
+             data-ng-if="readonly !== true"
+             data-ng-click="removeOverview(thumb)"
+             title="{{'removeThumbnail' | translate}}">
+            <i class="btn fa fa-times text-danger"></i>
+          </a>
+        </li>
+        <!-- The one currently uploaded -->
+        <li data-ng-repeat="file in queue"
+            class="gn-list-thumb thumbnail">
+          <i class="fa gn-icon-thumbnail fa-5x"></i>
+          {{file.name}}
+        </li>
+      </ul>
+
+      <!-- The upload zone -->
+      <span class="btn btn-default btn-block fileinput-button"
+            data-ng-class="{disabled: disabled}"
+            data-ng-hide="relations.thumbnails.length >= numberOfOverviews">
+       <i class="fa fa-3x fa-plus-circle"
+          data-ng-class="{hidden: active()}"/>
+       <i class="fa fa-3x fa-spinner fa-spin"
+          data-ng-class="{hidden: !active()}"
+          data-file-upload-progress="progress()"
+          data-file-upload-done="loadRelations()"/>
+        <input type="file"
+               name="file"
+               data-ng-disabled="disabled"/>
+      </span>
+
+    </form>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -52,7 +52,7 @@
 
     <span class="btn btn-success btn-block fileinput-button"
           data-ng-class="{disabled: disabled}">
-      <i class="fa fa-plus fa fa-white"></i>
+      <i class="fa fa-plus fa-white"></i>
       <span data-translate="">chooseOnlinesrc</span>
       <input type="file"
              multiple="multiple"

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -45,6 +45,7 @@
     "previousKeywords": "Previous",
     "previousPage": "Previous page",
     "nextPage": "Next page",
+    "chooseImage": "Choose or drop an image here",
     "topConcepts": "Top Concept(s)",
     "viewSelectionOnly": "Selection only",
     "add": "Add",


### PR DESCRIPTION
Simply drop a file here to set thumbnail.

![image](https://user-images.githubusercontent.com/1701393/46869952-a1e83500-ce2d-11e8-8d6b-fa96e4f1bf01.png)

Short video https://www.youtube.com/watch?v=5gHyE13gGws&feature=youtu.be

The panel allows:
* to add an overview
* to remove existing ones

It does not allow to set name and description.

The panel is enabled by default in simple view mode.


it is also an option to put the overview manager in the main form with:

```
      <tab id="default" default="true" mode="flat">
        <section xpath="/gmd:MD_Metadata/gmd:identificationInfo"/>

        <directive data-gn-overview-manager=""/>

        <section xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo"/>
```

which is rendered as:

![image](https://user-images.githubusercontent.com/1701393/46869914-7feeb280-ce2d-11e8-91ad-e12488020759.png)

