### PR TITLE
Removing "Refresh validation" button from side panel

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -15,15 +15,6 @@
   <!-- /.panel-heading -->
   <div class="panel-body">
     <div class="btn-toolbar" role="toolbar">
-      <button type="button" class="btn btn-default btn-xs"
-              data-ng-click="load();$event.stopPropagation();"
-              data-toggle="tooltip"
-              data-placement="top"
-              title="{{'runValidation' | translate}}">
-        <i data-ng-hide="loading" class="fa fa-fw fa-refresh"></i>
-        <i data-ng-show="loading" class="fa fa-fw fa-spinner fa-spin"></i>
-        <span data-translate="">runValidation</span>
-      </button>
 
       <div class="pull-right">
         <div class="btn-group ">


### PR DESCRIPTION
Following the discussion here https://github.com/geonetwork/core-geonetwork/issues/3056

This removes the refresh validation button from the right column panel in the metadata editor.

