### PR TITLE
Cookies / add possibility to enable Secure flag on all cookies

### DIFF
--- a/core/src/main/java/org/geonetwork/http/SessionTimeoutCookieFilter.java
+++ b/core/src/main/java/org/geonetwork/http/SessionTimeoutCookieFilter.java
@@ -66,6 +66,7 @@ public class SessionTimeoutCookieFilter implements javax.servlet.Filter {
 
             Cookie cookie = new Cookie("serverTime", "" + currTime);
             cookie.setPath("/");
+            cookie.setSecure(req.isSecure());
             httpResp.addCookie(cookie);
 
             UserSession userSession = null;
@@ -83,6 +84,7 @@ public class SessionTimeoutCookieFilter implements javax.servlet.Filter {
                 cookie = new Cookie("sessionExpiry", "" + currTime);
             }
             cookie.setPath("/");
+            cookie.setSecure(req.isSecure());
             httpResp.addCookie(cookie);
         }
 

--- a/web/src/main/filters/dev.properties
+++ b/web/src/main/filters/dev.properties
@@ -41,3 +41,5 @@ xsl_TransformerFactoryImpl=net.sf.saxon.TransformerFactoryImpl
 
 # goes in web.xml session-timeout tag.  It is in minutes
 sessionTimeout=180
+
+cookieSecureFlag=false

--- a/web/src/main/filters/inspire.properties
+++ b/web/src/main/filters/inspire.properties
@@ -40,3 +40,5 @@ xsl_TransformerFactoryImpl=de.fzi.dbs.xml.transform.CachingTransformerFactory
 
 # goes in web.xml session-timeout tag.  It is in minutes
 sessionTimeout=15
+
+cookieSecureFlag=false

--- a/web/src/main/filters/prod.properties
+++ b/web/src/main/filters/prod.properties
@@ -40,3 +40,6 @@ xsl_TransformerFactoryImpl=de.fzi.dbs.xml.transform.CachingTransformerFactory
 
 # goes in web.xml session-timeout tag.  It is in minutes
 sessionTimeout=35
+
+# set to true to have cookies flagged as Secure in production (requires HTTPS)
+cookieSecureFlag=false

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -472,8 +472,7 @@
     <session-timeout>${sessionTimeout}</session-timeout>
     <cookie-config>
       <http-only>true</http-only>
-      <!-- Uncomment if using https -->
-      <!--<secure>true</secure>-->
+      <secure>${cookieSecureFlag}</secure>
     </cookie-config>
  </session-config>
 


### PR DESCRIPTION
When setting the property `cookieSecureFlag` to true, the JSESSIONID cookie will be set as Secure (which requires HTTPS transport).

This allows to have secure cookies only on production environment, but not in development ones.

Also the `sessionExpiry` and `sessionTime` cookies will be set as secure too in HTTPS.