### PR TITLE
hide warning when no wms-url is provided

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1525,15 +1525,15 @@
                           gnCurrentEdit.metadata.getLinksByType('OGC:WMS'));
                       links = links.concat(
                           gnCurrentEdit.metadata.getLinksByType('wms'));
-                      if (angular.isArray(links) && links.length === 1) {
+                      //todo: also support wfs, wcs, wmts, atom
+                      if (angular.isArray(links) && links.length > 0) {
                         var serviceUrl = links[0].url;
                         scope.loadCurrentLink(serviceUrl);
                         scope.srcParams.url = serviceUrl;
                         scope.srcParams.protocol = links[0].protocol || '';
                         scope.srcParams.uuidSrv = gnCurrentEdit.uuid;
                       } else {
-                        scope.alertMsg =
-                            $translate.instant('linkToServiceWithoutURLError');
+                        console.log('No WMS url available');
                       }
                     }
                   });


### PR DESCRIPTION
There are too many cases that there is no wms url

![image](https://user-images.githubusercontent.com/299829/47016427-f520f700-d14f-11e8-8659-eda7adb38ebf.png)

fix bug if multiple wms-urls provided, then take first