### PR TITLE
Caches .m2 folder in Travis builds to speed up them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ before_install:
 cache:
   directories:
   - $HOME/.m2
+before_cache:
+  - rm -f $HOME/.m2/repository/org/geonetwork-opensource

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ jdk:
 before_install:
   - unset _JAVA_OPTIONS
   - export MAVEN_OPTS="-Xmx512M -XX:MaxPermSize=256M"
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ cache:
   directories:
   - $HOME/.m2
 before_cache:
-  - rm -f $HOME/.m2/repository/org/geonetwork-opensource
+  - rm -rf $HOME/.m2/repository/org/geonetwork-opensource


### PR DESCRIPTION
Usually building and testing GeoNetwork in Travis are taking more than the maximum time allowed to run the jobs (50 minutes). Most of the time is spent in downloading maven dependencies.
This commit caches the `$HOME/.m2` folder between builds to speed up the job avoiding to download dependencies.