### PR TITLE
ISO19139 / Editor / Add possibility to customize field label for fileIdentifier and date stamp

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -42,15 +42,31 @@
 
   <!-- Readonly elements -->
   <xsl:template mode="mode-iso19139" priority="2100" match="gmd:fileIdentifier|gmd:dateStamp">
+    <xsl:param name="schema" select="$schema" required="no"/>
+    <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="overrideLabel" select="''" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
-    <xsl:variable name="labelConfig"
+    <xsl:variable name="fieldLabelConfig"
                   select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
+
+    <xsl:variable name="labelConfig">
+      <xsl:choose>
+        <xsl:when test="$overrideLabel != ''">
+          <element>
+            <label><xsl:value-of select="$overrideLabel"/></label>
+          </element>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:copy-of select="$fieldLabelConfig"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
 
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
-                      select="$labelConfig"/>
+                      select="$labelConfig/*"/>
       <xsl:with-param name="value" select="*"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
@@ -62,7 +78,6 @@
     </xsl:call-template>
 
   </xsl:template>
-
 
   <!-- Measure elements, gco:Distance, gco:Angle, gco:Scale, gco:Length, ... -->
   <xsl:template mode="mode-iso19139" priority="2000" match="*[gco:*/@uom]">


### PR DESCRIPTION
eg. in config-editor.xml
```
<field xpath="/gmd:MD_Metadata/gmd:fileIdentifier"
                 name="copernicusmarine-fileIdentifier"/>
```
and in strings.xml
```
<copernicusmarine-fileIdentifier>Internal permanent shortname</copernicusmarine-fileIdentifier>
  
```