### PR TITLE
Editor / Add directive to hide a prefix or a suffix

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -57,6 +57,41 @@
 
   /**
    * @ngdoc directive
+   * @name gn_fields.directive:gnFieldWithPrefixOrSuffix
+   * @function
+   *
+   * @description
+   * A field which can hide a prefix or suffix
+   * added automatically to an existing value.
+   * The field type can also be constrained using fieldType attribute.
+   */
+  module.directive('gnFieldWithPrefixOrSuffix',
+    function() {
+      return {
+        restrict: 'A',
+        link: function(scope, element, attrs) {
+          // Using Jquery to parse attribute to preserve
+          // leading/trailing space which may have sense
+          scope.prefix = element.attr('data-prefix') || '';
+          scope.suffix = element.attr('data-suffix') || '';
+          var fieldType = attrs['fieldType'] || 'text';
+
+          // Create an input
+          var input = $('<input class="form-control" type="' + fieldType + '">');
+          // Copy the value without prefix/suffix
+          input.val(element.val()
+            .replace(scope.prefix, '')
+            .replace(scope.suffix, '')).change(function() {
+            element.val(scope.prefix + input.val() + scope.suffix);
+          });
+          element.after(input);
+          element.hide();
+        }
+      };
+    });
+
+  /**
+   * @ngdoc directive
    * @name gn_fields.directive:gnMeasure
    * @function
    *


### PR DESCRIPTION
Example of configuration:
```
          <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:supplementalInformation"
                 name="cm-display-priority"
                 use="data-gn-field-with-prefix-or-suffix">
            <directiveAttributes data-prefix="display priority: " 
                                            data-suffix=" meters" 
                                            data-field-type="number"/>
          </field>
```

Form field:

![image](https://user-images.githubusercontent.com/1701393/47104775-7ce72e00-d242-11e8-828a-407cb8730265.png)

XML encoding:

![image](https://user-images.githubusercontent.com/1701393/47104785-84a6d280-d242-11e8-96a0-4f111b61ff12.png)




