### PR TITLE
API / Standard / Codelist not properly retrieved when multiple defined.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/standards/StandardsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/standards/StandardsApi.java
@@ -249,9 +249,21 @@ public class StandardsApi implements ApplicationContextAware {
             value = "Codelist element name or alias"
         )
         @PathVariable String codelist,
+        @ApiParam(
+            value = "Parent name with namespace which may indicate a more precise label as defined in context attribute."
+        )
         @RequestParam(required = false) String parent,
+        @ApiParam(
+            value = "Display if condition as defined in the codelist.xml file. Allows to select a more precise codelist when more than one is defined for same name."
+        )
         @RequestParam(required = false) String displayIf,
+        @ApiParam(
+            value = "XPath of the element to target which may indicate a more precise label as defined in context attribute."
+        )
         @RequestParam(required = false) String xpath,
+        @ApiParam(
+            value = "ISO type of the element to target which may indicate a more precise label as defined in context attribute. (Same as context. TODO: Deprecate ?)"
+        )
         @RequestParam(required = false) String isoType,
         HttpServletRequest request
     ) throws Exception {

--- a/services/src/main/java/org/fao/geonet/api/standards/StandardsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/standards/StandardsApi.java
@@ -27,7 +27,6 @@ import io.swagger.annotations.*;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
-import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.schema.MetadataSchema;
@@ -212,6 +211,7 @@ public class StandardsApi implements ApplicationContextAware {
         )
         @PathVariable String codelist,
         @RequestParam(required = false) String parent,
+        @RequestParam(required = false) String displayIf,
         @RequestParam(required = false) String xpath,
         @RequestParam(required = false) String isoType,
         HttpServletRequest request
@@ -222,7 +222,7 @@ public class StandardsApi implements ApplicationContextAware {
         context.setLanguage(language.getISO3Language());
 
         Element e = StandardsUtils.getCodelist(codelist, schemaManager,
-            schema, parent, xpath, isoType, context);
+            schema, parent, xpath, isoType, context, displayIf);
 
         List<Element> listOfEntry = e.getChildren("entry");
         for (Element entry : listOfEntry) {
@@ -250,6 +250,7 @@ public class StandardsApi implements ApplicationContextAware {
         )
         @PathVariable String codelist,
         @RequestParam(required = false) String parent,
+        @RequestParam(required = false) String displayIf,
         @RequestParam(required = false) String xpath,
         @RequestParam(required = false) String isoType,
         HttpServletRequest request
@@ -259,7 +260,7 @@ public class StandardsApi implements ApplicationContextAware {
         context.setLanguage(language.getISO3Language());
 
         Element e = StandardsUtils.getCodelist(codelist, schemaManager,
-            schema, parent, xpath, isoType, context);
+            schema, parent, xpath, isoType, context, displayIf);
 
         return (Codelists.Codelist) Xml.unmarshall(e, Codelists.Codelist.class);
     }
@@ -284,6 +285,7 @@ public class StandardsApi implements ApplicationContextAware {
         )
         @PathVariable String element,
         @RequestParam(required = false) String parent,
+        @RequestParam(required = false) String displayIf,
         @RequestParam(required = false) String xpath,
         @RequestParam(required = false) String isoType,
         HttpServletRequest request
@@ -293,7 +295,7 @@ public class StandardsApi implements ApplicationContextAware {
         context.setLanguage(language.getISO3Language());
 
         Element e = StandardsUtils.getLabel(element, schemaManager,
-            schema, parent, xpath, isoType, context);
+            schema, parent, xpath, isoType, displayIf, context);
 
         return (org.fao.geonet.kernel.schema.labels.Element) Xml.unmarshall(e, org.fao.geonet.kernel.schema.labels.Element.class);
     }

--- a/services/src/main/java/org/fao/geonet/api/standards/StandardsUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/standards/StandardsUtils.java
@@ -39,34 +39,34 @@ import java.util.Set;
  */
 public class StandardsUtils {
     public static Element getCodelist(String codelist, SchemaManager schemaManager,
-                                       String schema,
-                                       String parent, String xpath,
-                                       String isoType, ServiceContext context)
+                                      String schema,
+                                      String parent, String xpath,
+                                      String isoType, ServiceContext context, String displayIf)
         throws Exception {
         return getCodelistOrLabel(codelist, schemaManager, schema,
-                                    parent, xpath, isoType, context, "codelists.xml");
+                                    parent, xpath, isoType, context, displayIf, "codelists.xml");
     }
 
     public static Element getLabel(String element, SchemaManager schemaManager,
                                    String schema,
                                    String parent, String xpath,
-                                   String isoType, ServiceContext context)
+                                   String isoType, String displayIf, ServiceContext context)
         throws Exception {
         return getCodelistOrLabel(element, schemaManager, schema,
-                                    parent, xpath, isoType, context, "labels.xml");
+                                    parent, xpath, isoType, context, displayIf, "labels.xml");
     }
 
     private static Element getCodelistOrLabel(String element, SchemaManager schemaManager,
                                               String schema, String parent, String xpath,
                                               String isoType, ServiceContext context,
-                                              String fileName) throws Exception {
+                                              String displayIf, String fileName) throws Exception {
         String elementName = StandardsUtils.findNamespace(element, schemaManager, schema);
         Element e = StandardsUtils.getHelp(schemaManager, fileName,
-            schema, elementName, parent, xpath, isoType, context);
+            schema, elementName, parent, xpath, isoType, displayIf, context);
         if (e == null) {
             if (schema.startsWith("iso19139.")) {
                 e = StandardsUtils.getHelp(schemaManager, fileName,
-                    "iso19139", elementName, parent, xpath, isoType, context);
+                    "iso19139", elementName, parent, xpath, isoType, displayIf, context);
             }
             if (e == null) {
                 throw new ResourceNotFoundException(String.format(
@@ -79,7 +79,7 @@ public class StandardsUtils {
 
 
     public static Element getHelp(SchemaManager scm, String fileName, String schema,
-                                  String name, String parent, String xpath, String isoType, ServiceContext context)
+                                  String name, String parent, String xpath, String isoType, String displayIf, ServiceContext context)
         throws Exception {
 
         XmlFile xf = scm.getSchemaInfo(schema).get(fileName);
@@ -90,15 +90,15 @@ public class StandardsUtils {
 
         Element entries = xf.exec(new Element("junk"), context);
 
-        Element result = checkEntries(scm, schema, entries, xpath, name, isoType, true);
+        Element result = checkEntries(scm, schema, entries, xpath, name, isoType, displayIf, true);
         if (result == null) {
-            result = checkEntries(scm, schema, entries, parent, name, isoType, true);
+            result = checkEntries(scm, schema, entries, parent, name, isoType, displayIf, true);
         }
         if (result == null) {
-            result = checkEntries(scm, schema, entries, xpath, name, isoType, false);
+            result = checkEntries(scm, schema, entries, xpath, name, isoType, displayIf, false);
         }
         if (result == null) {
-            result = checkEntries(scm, schema, entries, parent, name, isoType, false);
+            result = checkEntries(scm, schema, entries, parent, name, isoType, displayIf, false);
         }
 
         if (result == null) {
@@ -106,7 +106,7 @@ public class StandardsUtils {
             // help/label exists in those - stop at the first one found
             Set<String> dependentSchemas = scm.getDependencies(schema);
             for (String baseSchema : dependentSchemas) {
-                result = getHelp(scm, fileName, baseSchema, name, parent, xpath, isoType, context);
+                result = getHelp(scm, fileName, baseSchema, name, parent, xpath, isoType, displayIf, context);
                 if (result != null) break;
             }
         }
@@ -115,13 +115,14 @@ public class StandardsUtils {
     }
 
     private static Element checkEntries(SchemaManager scm, String schema, Element entries, String context,
-                                        String name, String isoType, boolean requireContextMatch) throws OperationAbortedEx {
+                                        String name, String isoType, String displayIf, boolean requireContextMatch) throws OperationAbortedEx {
 
         for (Object o : entries.getChildren()) {
             Element currElem = (Element) o;
             String currName = currElem.getAttributeValue("name");
             String aliasName = currElem.getAttributeValue("alias");
             String currContext = currElem.getAttributeValue("context");
+            String displayIfAttribute = currElem.getAttributeValue("displayIf");
 
             currName = findNamespace(currName, scm, schema);
 
@@ -140,6 +141,8 @@ public class StandardsUtils {
                 }
             }
 
+            // If a context attribute is provided check if there is a match
+            // Context can be parent element name or an xpath
             if (currContext != null && (context != null || isoType != null)) {
                 // XPath context are supposed to use same namespace prefix
                 if (!currContext.contains("/")) {
@@ -151,10 +154,21 @@ public class StandardsUtils {
                     }
                 }
 
-                if ((context != null && context.equals(currContext)) || (isoType != null && isoType.equals(currContext))) {
+                if (
+                    (context != null && context.equals(currContext)) ||
+                    (isoType != null && isoType.equals(currContext))) {
                     return (Element) currElem.clone();
                 }
-            } else if (!requireContextMatch) {
+            } else if (displayIf != null && displayIf.equals(displayIfAttribute)) {
+                // A codelist may be uniquely defined with a displayIf attribute
+                // eg.
+                // <codelist name="gmd:CI_RoleCode" alias="roleCode"
+                //           displayIf="ancestor::node()[name()='gmd:MD_Metadata' and contains(gmd:metadataStandardName/gco:CharacterString, 'ISO 19139, MyOcean profile')]">
+
+                return (Element) currElem.clone();
+            } if (!requireContextMatch && displayIfAttribute == null) {
+                // Return an element not matching any context attribute
+                // or displayIf condition. Usually the default value of the standard.
                 return (Element) currElem.clone();
             }
         }

--- a/services/src/main/java/org/fao/geonet/services/schema/Info.java
+++ b/services/src/main/java/org/fao/geonet/services/schema/Info.java
@@ -170,7 +170,7 @@ public class Info implements Service {
             return StandardsUtils.buildError(elem, UNKNOWN_SCHEMA);
         }
 
-        Element result = StandardsUtils.getHelp(scm, fileName, schema, name, parent, xpath, isoType, servContext);
+        Element result = StandardsUtils.getHelp(scm, fileName, schema, name, parent, xpath, isoType, null, servContext);
         // if not found then return an error
         if (result == null) {
             return StandardsUtils.buildError(elem, NOT_FOUND);

--- a/services/src/main/java/org/fao/geonet/services/subtemplate/GetTypes.java
+++ b/services/src/main/java/org/fao/geonet/services/subtemplate/GetTypes.java
@@ -73,7 +73,7 @@ public class GetTypes implements Service {
                 try {
                     String schema = record.getChildText("schemaid");
                     String name = StandardsUtils.findNamespace(record.getChildText("type"), scm, (schema == null ? "iso19139" : schema));
-                    Element info = StandardsUtils.getHelp(scm, "labels.xml", schema, name, "", "", "", context);
+                    Element info = StandardsUtils.getHelp(scm, "labels.xml", schema, name, "", "", "", null, context);
                     if (info != null) {
                         for (String childName : elementNames) {
                             Element child = info.getChild(childName);

--- a/web-ui/src/main/resources/catalog/components/common/schemamanager/SchemaManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/common/schemamanager/SchemaManagerService.js
@@ -92,17 +92,19 @@
              return defer.promise;
            },
 
-           getCodelist: function(config) {
+           getCodelist: function(config, displayIf) {
              var defer = $q.defer();
-             var fromCache = infoCache.get(config);
+             var cacheKey = config + (displayIf || '');
+             var fromCache = infoCache.get(cacheKey);
              if (fromCache) {
                defer.resolve(fromCache);
              } else {
                var info = config.split('|');
-               $http.get('../api/standards/' + info[0] +
-               '/codelists/' + info[1] + '/details')
+               var url = '../api/standards/' + info[0] +
+                 '/codelists/' + info[1] + '/details';
+               $http.get(url + (displayIf ? '?displayIf=' + encodeURIComponent(displayIf) : ''))
                .success(function(data) {
-                 infoCache.put(config, data);
+                 infoCache.put(cacheKey, data);
                  defer.resolve(data);
                });
              }

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -77,6 +77,9 @@
               // If not using the directive in an editor context, set
               // the schema id to properly retrieve the codelists.
               schema: '@',
+              // An optional attribute matching a conditional codelist
+              // containing the same value for the displayIf attribute.
+              displayIf: '@',
               selectEntryCb: '=',
               // Can restrict how to insert the entry (xlink, text ..)
               // insertModes: '@'
@@ -296,7 +299,7 @@
 
                   var schemaId = gnCurrentEdit.schema || scope.schema;
                   gnSchemaManagerService
-                     .getCodelist(schemaId + '|' + 'roleCode')
+                     .getCodelist(schemaId + '|' + 'roleCode', scope.displayIf)
                       .then(function(data) {
                         scope.roles = data.entry;
                       });


### PR DESCRIPTION
Only happen when using advanced codelist configuration such as the following:

eg.
```
  <!-- A custom codelist to use under certain conditions ie. standard
name here -->
  <codelist name="gmd:CI_RoleCode" alias="roleCode"
            displayIf="ancestor::node()[name()='gmd:MD_Metadata' and contains(gmd:metadataStandardName/gco:CharacterString, 'ISO 19139, MyOcean profile')]">
    <entry>
      <code>custodian</code>
      <label>Production center</label>
      <description>Party that accepts accountability and responsability for the data and ensures
        appropriate care and maintenance of the resource</description>
    </entry>
    ...

  <!-- The default one -->
  <codelist name="gmd:CI_RoleCode" alias="roleCode">
    <entry>
      <code>resourceProvider</code>
      <label>Resource provider</label>
      <description>Party that supplies the resource</description>
    </entry>
```

In such case, the http://localhost:8080/geonetwork/srv/api/standards/iso19139/codelists/roleCode/details return the firs match on name. In such case the directory manager to choose contact is wrong.

Adding in a specific view an action with the displayIf attribute in
order to load the codelist which might the current view (also based on
standard name). eg.
```
<action name="cm-contact"
                    type="add"
                    addDirective="data-gn-directory-entry-selector"
                    or="pointOfContact"
                    in="/gmd:MD_Metadata/gmd:identificationInfo/*">
              <directiveAttributes
                data-template-add-action="false"
                data-search-action="true"
                data-popup-action="true"
                data-template-type="contact"
                data-display-if="ancestor::node()[name()='gmd:MD_Metadata' and contains(gmd:metadataStandardName/gco:CharacterString, 'ISO 19139, MyOcean profile')]"
                data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
            </action>
```

The API is called by http://localhost:8080/geonetwork/srv/api/standards/iso19139/codelists/roleCode/details?displayIf=ancestor%3A%3Anode()%5Bname()%3D%27gmd%3AMD_Metadata%27%20and%20contains(gmd%3AmetadataStandardName%2Fgco%3ACharacterString%2C%20%27ISO%2019139%2C%20MyOcean%20profile%27)%5D