### PR TITLE
typo and missing translation

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/logopicker.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/logopicker.html
@@ -2,15 +2,15 @@
         data-toggle="dropdown">
           <span data-ng-if="logo">
             <img class="gn-logo harvester-logo" data-ng-src="../../images/harvesting/{{logo}}"
-                 alt="{{'harvesterLogoHelo' | translate}}"/>
+                 alt="{{logo}}"/>
           </span>
   &nbsp;
   <span class="caret"/>
 </button>
 <ul class="dropdown-menu" role="menu">
-  <li data-ng-repeat="i in icons">
-    <a data-ng-click="setIcon(i)" title="">
-      <img class="gn-logo harvester-logo" data-ng-src="../../images/harvesting/{{i}}"/>
+  <li data-ng-repeat="i in icons" title="{{i}}">
+    <a data-ng-click="setIcon(i)">
+      <img class="gn-logo harvester-logo" data-ng-src="../../images/harvesting/{{i}}" />
     </a>
   </li>
 </ul>


### PR DESCRIPTION
In stead of fixing the typo (there were no translations) I suggest to just display the logo (file)name as label
Same in pulldown-list, add a hover-title with the logo name, may help to identify the relevant logo