### PR TITLE
API / Formatter / Add JSON and text responses support.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatType.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatType.java
@@ -32,7 +32,13 @@ import java.util.List;
  * @author Jesse on 10/26/2014.
  */
 public enum FormatType {
-    xml("application/xml"), html("text/html"), pdf("application/pdf"), txt("text/plain"), testpdf("application/test-pdf");
+    txt("text/plain"),
+    html("text/html"),
+    xml("application/xml"),
+    json("application/json"),
+    jsonld("application/vnd.schemaorg.ld+json"),
+    pdf("application/pdf"),
+    testpdf("application/test-pdf");
     public final String contentType;
 
     private FormatType(String contentType) {

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -299,7 +299,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         if (formatType == null) {
             formatType = FormatType.xml;
         }
-        
+
         final String language = LanguageUtils.locale2gnCode(locale.getISO3Language());
         final ServiceContext context = createServiceContext(
             language,
@@ -523,14 +523,14 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
 
     private void writeOutResponse(ServiceContext context, String metadataUuid, String lang, HttpServletResponse response, FormatType formatType, byte[] formattedMetadata) throws Exception {
         response.setContentType(formatType.contentType);
-        String filename = "metadata." + metadataUuid + formatType;
+        String filename = "metadata-" + metadataUuid + "." + formatType;
         response.addHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
         response.setStatus(HttpServletResponse.SC_OK);
         if (formatType == FormatType.pdf) {
             writerAsPDF(context, response, formattedMetadata, lang);
         } else {
             response.setCharacterEncoding(Constants.ENCODING);
-            response.setContentType("text/html");
+            response.setContentType(formatType.contentType);
             response.setContentLength(formattedMetadata.length);
             response.setHeader("Cache-Control", "no-cache");
             response.getOutputStream().write(formattedMetadata);

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
@@ -134,7 +134,9 @@ public class XsltFormatter implements FormatterImpl {
             requestParameters.put(key, fparams.webRequest.getParameterMap().get(key));
         }
         Element transformed = Xml.transform(root, fparams.viewFile, requestParameters);
-        return Xml.getString(transformed);
+        return "textResponse".equals(transformed.getName()) ?
+            transformed.getTextNormalize() :
+            Xml.getString(transformed);
     }
 
     /**


### PR DESCRIPTION
Some formatter may provide text response and not only XML or PDF as
currently supported. Rename file with a proper extension based on file
type. Add support to formatter providing a text response. In such case
the XSLT formatter has to return one element like the following with the
text to be returned:

```
  <xsl:template match="/">
    <textResponse>
    {
    "@context": "http://schema.org",
    "@type": "Dataset",
    "@id": "https://doi.org/10.5438/4K3M-NYVG"
    ...
    }
    </textResponse>
```

The text response can be CSV or JSON, ...

The content type can still be controlled using accept header or the
output URL parameter.

eg.
http://localhost:8080/geonetwork/srv/api/records/ff8d8cd6-c753-4581-99a3-af23fe4c996b/formatters/jsonld?output=json