### PR TITLE
 Avoid fails when in first run when no log files exist yet

### DIFF
--- a/release/bin/shutdown.sh
+++ b/release/bin/shutdown.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 cd ../jetty
 export JETTY_HOME=.
 java -DSTOP.PORT=8079 -DSTOP.KEY=geonetwork -jar start.jar --stop

--- a/release/bin/startup.sh
+++ b/release/bin/startup.sh
@@ -4,6 +4,8 @@ export JETTY_HOME=../jetty
 export JETTY_FOREGROUND=0
 export JETTY_BASE=$JETTY_HOME
 cd $JETTY_HOME
+CURRENT_DIR=`pwd`
+echo "Working dir is $CURRENT_DIR"
 
 for i in "$@"
 do
@@ -17,10 +19,14 @@ case $i in
 esac
 done
 
-rm logs/*request.log*
-rm logs/output.log
-mv logs/geonetwork.log.* logs/archive
-mv logs/geoserver.log.* logs/archive
+echo "Archiving old log files..."
+if [ ! -d "logs/archive" ]; then
+    mkdir logs/archive
+fi
+rm -f logs/*request.log*
+rm -f logs/output.log
+find logs -maxdepth 1 -name 'geonetwork.log.*' -type f -exec mv -t logs/archive/ '{}' +
+find logs -maxdepth 1 -name 'geoserver.log.*' -type f -exec mv -t logs/archive/ '{}' +
 
 # Set custom data directory location using system property
 #export geonetwork_dir=/app/geonetwork_data_dir
@@ -36,8 +42,9 @@ export JAVA_OPTS="$JAVA_MEM_OPTS -Xss2M -Djeeves.filecharsetdetectandconvert=ena
 # export JAVA_OPTS="$JAVA_OPTS -Dgeonetwork.dir=/app/geonetwork_data_dir -Dgeonetwork.lucene.dir=/ssd/geonetwork_lucene_dir"
 
 export JETTY_CMD="$JAVA_OPTS -jar $JETTY_HOME/start.jar"
-
-if [ $JETTY_FOREGROUND = 1 ];
-then java $JETTY_CMD
-else java $JETTY_CMD > logs/output.log 2>&1 &
+echo "Starting Jetty..."
+if [ $JETTY_FOREGROUND = 1 ]; then
+    java $JETTY_CMD
+else 
+    java $JETTY_CMD > logs/output.log 2>&1 &
 fi


### PR DESCRIPTION
In Mac OS X, after installing GN using the installer, and running `startup.sh` this failed because no log files were present yet in the `logs` folder. This fixes the errors using `rm -f` for removing and `find -exec mv` for moving old files if present.

This should be backported to v3.4.5.