### PR TITLE
Updated json-path dependencies

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -122,13 +122,13 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.2.0</version>
+      <version>2.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path-assert</artifactId>
-      <version>2.2.0</version>
+      <version>2.4.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Updated json-path dependencies from 2.2.0 to 2.4.0 version. Artifacts affected: json-path and json-path-assert.