### PR TITLE
Updated avalon-framework dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,7 +464,7 @@
       <dependency>
         <groupId>avalon-framework</groupId>
         <artifactId>avalon-framework-api</artifactId>
-        <version>4.2.0</version>
+        <version>4.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avalon.framework</groupId>


### PR DESCRIPTION
Updated avalon-framework dependencies from 4.2.0 to 4.3 version. Artifacts affected: avalon-framework-api.