### PR TITLE
Updated jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -982,7 +982,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate4</artifactId>
-        <version>2.7.4</version>
+        <version>2.9.7</version>
       </dependency>
 
       <dependency>
@@ -1016,17 +1016,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.5.5</version>
+        <version>2.9.7</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.5.5</version>
+        <version>2.9.7</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.5.5</version>
+        <version>2.9.7</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Updated jackson core dependencies from 2.5.5 to 2.9.7 version. Artifacts affected: jackson-core, jackson-databind and jackson-annotations.

Updated jackson datatype dependencies from 2.7.4 to 2.9.7 version. Artifacts affected: jackson-datatype-hibernate4.