### PR TITLE
Updated jetty dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1310,7 +1310,7 @@
     <cors.allowedHosts>*</cors.allowedHosts>
 
 
-    <jetty.version>9.3.9.v20160517</jetty.version>
+    <jetty.version>9.4.12.v20180830</jetty.version>
 
 
     <!-- NOTE: When updating GeoTools, check which version


### PR DESCRIPTION
Updated jetty dependencies from 9.3.9.v20160517 to 9.4.12.v20180830 version. Artifacts affected: jetty-server, jetty-servlet and jetty-webapp.