### PR TITLE
Updated mockito dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -819,7 +819,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
-        <version>1.9.5</version>
+        <version>2.0.2-beta</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Updated mockito dependencies from 1.9.5 to 2.0.2-beta version. Artifacts affected: mockito-all.