### PR TITLE
Updated slf4j dependencies

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.5</version>
+      <version>1.8.0-beta2</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -479,12 +479,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.5</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.5</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -1338,7 +1338,7 @@
     <camel.version>2.14.4</camel.version>
     <log4j.version>1.2.17</log4j.version>
     <log4j2.version>2.7</log4j2.version>
-    <slf4j.version>1.7.7</slf4j.version>
+    <slf4j.version>1.8.0-beta2</slf4j.version>
     <xbean.version>3.18</xbean.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
     <gn.schemas.version>3.5</gn.schemas.version>


### PR DESCRIPTION
Updated slf4j dependencies from 1.7.7 to 1.8.0-beta2 version. Artifacts affected: jcl-over-slf4j, jul-to-slf4j, slf4j-api and slf4j-log4j12.