### PR TITLE
Thesaurus tests fix

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/KeywordBean.java
+++ b/core/src/main/java/org/fao/geonet/kernel/KeywordBean.java
@@ -697,4 +697,30 @@ public class KeywordBean {
     public String toString() {
         return getUriCode() + " : " + getDefaultValue();
     }
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((code == null) ? 0 : code.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		KeywordBean other = (KeywordBean) obj;
+		if (code == null) {
+			if (other.code != null)
+				return false;
+		} else if (!code.equals(other.code))
+			return false;
+		return true;
+	}
+
 }

--- a/core/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSearchParams.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSearchParams.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -104,16 +103,16 @@ public class KeywordSearchParams {
     }
 
     private List<KeywordBean> executeOne(QueryBuilder<KeywordBean> queryBuilder, ThesaurusFinder finder) throws IOException, MalformedQueryException, QueryEvaluationException, AccessDeniedException {
-        HashSet<KeywordBean> results = new HashSet<>();
+    	LinkedHashSet<KeywordBean> results = new LinkedHashSet<>();
         AtomicInteger id = new AtomicInteger();
         String thesaurusName = thesauriNames.iterator().next();
         Thesaurus thesaurus = finder.getThesaurusByName(thesaurusName);
-        Query<KeywordBean> query = queryBuilder.limit(maxResults - results.size()).build();
+        Query<KeywordBean> query = queryBuilder.limit(maxResults).build();
         if (thesaurus == null) {
             throw new IllegalArgumentException("The thesaurus " + thesaurusName + " does not exist, there for the query cannot be executed: '" + query + "'");
         }
 
-        id = executeQuery(id, results, thesaurus, query);
+        id = executeQuery(id, results, thesaurus, query, maxResults);
         return setToList(results);
     }
 
@@ -127,7 +126,7 @@ public class KeywordSearchParams {
             throw new IllegalArgumentException("The thesaurus " + thesaurusName + " does not exist, there for the query cannot be executed: '" + query + "'");
         }
 
-        id = executeQuery(id, orderedResults, thesaurus, query);
+        id = executeQuery(id, orderedResults, thesaurus, query, -1);
         return setToList(orderedResults);
     }
 
@@ -179,21 +178,21 @@ public class KeywordSearchParams {
     private List<KeywordBean> executeAllUnsorted(QueryBuilder<KeywordBean> queryBuilder, ThesaurusFinder finder) throws IOException,
         MalformedQueryException, QueryEvaluationException, AccessDeniedException {
     	AtomicInteger id = new AtomicInteger();
-        HashSet<KeywordBean> results = new HashSet<>();
+    	LinkedHashSet<KeywordBean> results = new LinkedHashSet<>();
         for (Thesaurus thesaurus : finder.getThesauriMap().values()) {
             if (thesaurus.getKey().equals(ALL_THESAURUS_KEY)) {
                 continue;
             }
             if (thesauriDomainName == null || thesauriDomainName.equals(thesaurus.getDname())) {
                 Query<KeywordBean> query = queryBuilder.limit(maxResults - results.size()).build();
-                id = executeQuery(id, results, thesaurus, query);
+                id = executeQuery(id, results, thesaurus, query, maxResults);
             }
         }
 
         return  setToList(results);
     }
 
-	private AtomicInteger executeQuery(AtomicInteger id, Collection<KeywordBean> results, Thesaurus thesaurus, Query<KeywordBean> query)
+	private AtomicInteger executeQuery(AtomicInteger id, Collection<KeywordBean> results, Thesaurus thesaurus, Query<KeywordBean> query, Integer maxResults)
 			throws IOException, MalformedQueryException, QueryEvaluationException, AccessDeniedException {
 		for (KeywordBean keywordBean : query.execute(thesaurus)) {
 		    if (maxResults > -1 && results.size() >= maxResults) {
@@ -216,7 +215,7 @@ public class KeywordSearchParams {
             }
             Query<KeywordBean> query = queryBuilder.build();
             if (thesauriDomainName == null || thesauriDomainName.equals(thesaurus.getDname())) {
-                id = executeQuery(id, results, thesaurus, query);
+                id = executeQuery(id, results, thesaurus, query, -1);
             }
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSearchParamsBuilder.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/keyword/KeywordSearchParamsBuilder.java
@@ -351,12 +351,14 @@ public class KeywordSearchParamsBuilder {
 
     }
 
-    public void requireBoundedBy(boolean require) {
+    public KeywordSearchParamsBuilder requireBoundedBy(boolean require) {
         this.requireBoundedBy = require;
+        return this;
 
     }
 
-    public void setComparator(Comparator<KeywordBean> comparator) {
+    public KeywordSearchParamsBuilder setComparator(Comparator<KeywordBean> comparator) {
         this.comparator = comparator;
+        return this;
     }
 }

--- a/core/src/test/java/org/fao/geonet/kernel/AbstractThesaurusBasedTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AbstractThesaurusBasedTest.java
@@ -37,6 +37,7 @@ import org.openrdf.sesame.config.SailConfig;
 import org.openrdf.sesame.constants.RDFFormat;
 import org.openrdf.sesame.repository.local.LocalRepository;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -67,11 +68,10 @@ public abstract class AbstractThesaurusBasedTest {
         createTestThesaurus();
 
         if (!readonly) {
-            final String className = getClass().getSimpleName() + ".class";
-            Path template = thesaurusFile;
+            Path template = this.thesaurusFile;
 
             // Now make copy for this test
-            this.thesaurusFile = this.folder.getRoot().toPath().resolve(getClass().getSimpleName() + "TestThesaurus.rdf");
+            this.thesaurusFile = locateThesaurus(getClass().getSimpleName() + "TestThesaurus.rdf");
 
             Files.copy(template, thesaurusFile);
             this.thesaurus = new Thesaurus(isoLangMapper, thesaurusFile.getFileName().toString(), "test", "test",
@@ -79,6 +79,10 @@ public abstract class AbstractThesaurusBasedTest {
         }
         this.thesaurus.initRepository();
     }
+
+	protected Path locateThesaurus(String name) {
+		return this.folder.getRoot().toPath().resolve(name);
+	}
 
     @After
     public void afterTest() throws Exception {
@@ -98,10 +102,6 @@ public abstract class AbstractThesaurusBasedTest {
         this.thesaurus.initRepository();
     }
 
-    private void populateThesaurus() throws Exception {
-        populateThesaurus(this.thesaurus, keywords, THESAURUS_KEYWORD_NS, "testValue", "testNote", languages);
-    }
-
     /**
      * Generate a thesaurus with the provided number of words etc...
      */
@@ -116,7 +116,7 @@ public abstract class AbstractThesaurusBasedTest {
         System.out.print(0);
         for (int i = 0; i < words; i++) {
             float percent = ((float) i) / words * 100;
-            if (System.currentTimeMillis() - lastUpdateTime > 5000) {
+            if (System.currentTimeMillis() - lastUpdateTime > 1000) {
                 System.out.print(Math.round(percent));
                 lastUpdateTime = System.currentTimeMillis();
             }

--- a/core/src/test/java/org/fao/geonet/kernel/AllThesaurusTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AllThesaurusTest.java
@@ -63,10 +63,7 @@ public class AllThesaurusTest extends AbstractThesaurusBasedTest {
 
     @Before
     public void setUp() throws Exception {
-        final String className = AbstractThesaurusBasedTest.class.getSimpleName() + ".class";
-        Path directory = IO.toPath(AbstractThesaurusBasedTest.class.getResource(className).toURI()).getParent();
-
-        Path gcThesaurusFile = directory.resolve("secondThesaurus.rdf");
+        Path gcThesaurusFile = this.folder.getRoot().toPath().resolve("secondThesaurus.rdf");
         this.secondThesaurus = new Thesaurus(isoLangMapper, gcThesaurusFile.getFileName().toString(), null, null, "external",
             "local", gcThesaurusFile, "http://org.fao.geonet", true);
         final boolean thesauriExist = Files.exists(gcThesaurusFile);

--- a/core/src/test/java/org/fao/geonet/kernel/ThesaurusTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/ThesaurusTest.java
@@ -60,8 +60,7 @@ public class ThesaurusTest extends AbstractThesaurusBasedTest {
 
     @Before
     public void prepareEmptyThesaurus() throws ConfigurationException, IOException {
-        Path file = this.thesaurusFile.getParent().resolve(ThesaurusTest.class.getSimpleName() + "_empyt.rdf");
-        Files.deleteIfExists(file);
+        Path file = locateThesaurus(ThesaurusTest.class.getSimpleName() + "_empyt.rdf");
 
         this.writableThesaurus = new Thesaurus(isoLangMapper, file.getFileName().toString(), null, null, Geonet.CodeList.LOCAL,
             file.getFileName().toString(), file, "http://test.com", true);
@@ -71,7 +70,6 @@ public class ThesaurusTest extends AbstractThesaurusBasedTest {
     @After
     public void deleteEmptyThesaurus() throws IOException {
         writableThesaurus.getRepository().shutDown();
-        Files.deleteIfExists(writableThesaurus.getFile());
     }
 
     @SuppressWarnings("deprecation")
@@ -350,6 +348,7 @@ public class ThesaurusTest extends AbstractThesaurusBasedTest {
     @Test
     public void testIsFreeCode() throws Exception {
         Query<KeywordBean> query = QueryBuilder.keywordQueryBuilder(isoLangMapper, "eng").limit(1).build();
+        assertFalse(query.execute(thesaurus).isEmpty());
         KeywordBean keyword = query.execute(thesaurus).get(0);
 
         assertFalse(thesaurus.isFreeCode(keyword.getNameSpaceCode(), keyword.getRelativeCode()));

--- a/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
@@ -34,13 +34,11 @@ import org.fao.geonet.kernel.search.keyword.KeywordSearchParamsBuilder;
 import org.fao.geonet.kernel.search.keyword.KeywordSearchType;
 import org.fao.geonet.kernel.search.keyword.KeywordSort;
 import org.fao.geonet.kernel.search.keyword.SortDirection;
-import org.fao.geonet.utils.IO;
 import org.jdom.Element;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -75,11 +73,8 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
 
     @Before
     public synchronized void createExtraThesauri() throws Exception {
-        final URL resource = KeywordsSearcherTest.class.getResource(KeywordsSearcherTest.class.getSimpleName() + ".class");
-        Path directory = IO.toPath(resource.toURI()).getParent();
-
-        thesaurusBlah = createThesaurus(directory, "blah");
-        thesaurusFoo = createThesaurus(directory, "foo");
+    	thesaurusBlah = createThesaurus("blah");
+        thesaurusFoo = createThesaurus("foo");
 
         this.thesaurusFinder = new ThesaurusFinder() {
             {
@@ -113,8 +108,8 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
         };
     }
 
-    private Thesaurus createThesaurus(Path directory, String string) throws Exception {
-        Path thesaurusBlahFile = directory.resolve(string + ".rdf");
+    private Thesaurus createThesaurus(String string) throws Exception {
+        Path thesaurusBlahFile = locateThesaurus(string + ".rdf");
         Thesaurus thes = new Thesaurus(isoLangMapper, string + ".rdf", Geonet.CodeList.EXTERNAL, string, thesaurusBlahFile, "http://" +
             string + ""
             + ".com");

--- a/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
@@ -400,6 +400,7 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
             .addLang("eng")
             .offset(5)
             .addThesaurus(thesaurus.getKey())
+            .setComparator(KeywordSort.defaultLabelSorter(SortDirection.DESC))
             .maxResults(5);
         searcher.search(params.build());
         assertEquals(5, searcher.getNbResults());


### PR DESCRIPTION
First: Remove duplicates on results from the thesauri search. This was making the tests fail on $random_unknown_environment_and_circunstamces.

Second: Use real temporary files for thesauri tests. This prevents errors due to unclean environments or, even, simultaneous tests running at the same time.

Third: Refactor a bit thesauri management, there was code rewritten over and over again.