### PR TITLE
Search not trigged if geom is empty or undefined

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
@@ -79,7 +79,9 @@
                    */
                   scope.setRelation = function(rel) {
                     scope.searchObj.params.relation = rel;
-                    scope.triggerSearch();
+                    if (!!scope.searchObj.params.geometry) {
+                      scope.triggerSearch();
+                    }
                   };
                 }
               };
@@ -172,7 +174,9 @@
               scope.$watch('interaction.active', function(v, o) {
                 if (!v && o) {
                   resetSpatialFilter();
-                  scope.triggerSearch();
+                  if (!!scope.searchObj.params.geometry) {
+                    scope.triggerSearch();
+                  }
                 }
               });
 


### PR DESCRIPTION
The pr will check if there is an actual valid geometry before triggering the search, 
when the user clicks on either the draw or the type of intersection buttons