### PR TITLE
Settings / Link in setting documentation not rendered

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -321,9 +321,13 @@
                     <input data-ng-switch-default="" type="text" class="form-control"
                           id="{{s['name']}}" name="{{s.name}}" value="{{s.value}}"/>
 
-                    <p class="help-block"
-                      data-ng-show="(s['name'] + '-help' | translate) != (s['name'] + '-help')">
-                      {{s['name'] + '-help' | translate}} </p>
+                    <p class="help-block">
+                      <span
+                        data-ng-show="(s['name'] + '-help' | translate) !== (s['name'] + '-help')"
+                        data-translate="">
+                          {{(s['name'] + '-help')}}
+                      </span>
+                    </p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Was working fine for boolean setting but not for others:
![image](https://user-images.githubusercontent.com/1701393/48257932-3f765a80-e414-11e8-9960-64cf2acc2765.png)


Once fix, looks like 
![image](https://user-images.githubusercontent.com/1701393/48257941-456c3b80-e414-11e8-9a31-ccfd77506574.png)
