### PR TITLE
API / Delete metadata record API endpoint doesn't work when a UUID is provided

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -193,7 +193,7 @@ public class MetadataInsertDeleteApi {
             Lib.resource.getMetadataDir(context.getBean(GeonetworkDataDirectory.class),
                 String.valueOf(metadata.getId())));
 
-        dataManager.deleteMetadata(context, metadataUuid);
+        dataManager.deleteMetadata(context, metadata.getId() + "");
 
         searchManager.forceIndexChanges();
     }


### PR DESCRIPTION
Fix for #3255