### PR TITLE
Bug fix: Editing privileges acting as view privileges

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryBuilder.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryBuilder.java
@@ -960,26 +960,35 @@ public class LuceneQueryBuilder {
     private void addPrivilegeQuery(LuceneQueryInput luceneQueryInput, BooleanQuery query) {
         // Set user groups privileges
         Set<String> groups = luceneQueryInput.getGroups();
-        String editable$ = luceneQueryInput.getEditable();
-        boolean editable = BooleanUtils.toBoolean(editable$);
+        Set<String> editableGroups = luceneQueryInput.getEditableGroups();
         BooleanQuery groupsQuery = new BooleanQuery();
         boolean groupsQueryEmpty = true;
         BooleanClause.Occur groupOccur = LuceneUtils.convertRequiredAndProhibitedToOccur(false, false);
-        if (!CollectionUtils.isEmpty(groups)) {
-            for (String group : groups) {
+
+        if (!CollectionUtils.isEmpty(editableGroups)) {
+        	Log.trace(Geonet.SEARCH_ENGINE, "We have editable groups to add");
+            for (String group : editableGroups) {
                 if (StringUtils.isNotBlank(group)) {
-                    if (!editable) {
-                        // add to view
-                        TermQuery viewQuery = new TermQuery(new Term(LuceneIndexField._OP0, group.trim()));
-                        BooleanClause viewClause = new BooleanClause(viewQuery, groupOccur);
-                        groupsQueryEmpty = false;
-                        groupsQuery.add(viewClause);
-                    }
+                	Log.trace(Geonet.SEARCH_ENGINE, " > Group: " + group);
                     // add to edit
                     TermQuery editQuery = new TermQuery(new Term(LuceneIndexField._OP2, group.trim()));
                     BooleanClause editClause = new BooleanClause(editQuery, groupOccur);
                     groupsQueryEmpty = false;
                     groupsQuery.add(editClause);
+                }
+            }
+        }
+        
+        if (!CollectionUtils.isEmpty(groups)) {
+        	Log.trace(Geonet.SEARCH_ENGINE, "We have viewable groups to add");
+            for (String group : groups) {
+                if (StringUtils.isNotBlank(group)) {
+                	Log.trace(Geonet.SEARCH_ENGINE, " > Group: " + group);
+                    // add to view
+                    TermQuery viewQuery = new TermQuery(new Term(LuceneIndexField._OP0, group.trim()));
+                    BooleanClause viewClause = new BooleanClause(viewQuery, groupOccur);
+                    groupsQueryEmpty = false;
+                    groupsQuery.add(viewClause);
                 }
             }
         }

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryInput.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryInput.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel.search;
 
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,6 +42,7 @@ public class LuceneQueryInput extends UserQueryInput {
 
     private String owner;
     private Set<String> groups;
+    private Set<String> editableGroups;
     private Set<String> groupOwners;
     private boolean isReviewer;
     private boolean isUserAdmin;
@@ -67,7 +69,18 @@ public class LuceneQueryInput extends UserQueryInput {
                 groups.add(groupE.getText());
             }
             setGroups(groups);
+        }     
+        
+        @SuppressWarnings("unchecked")
+        List<Element> groupsEd = (List<Element>)jdom.getChildren(SearchParameter.GROUPEDIT);
+        Set<String> groups = new HashSet<String>();
+        if(groupsEd != null) {
+            for(Element groupEd : groupsEd) {
+                groups.add(((Element)groupEd).getText());
+            }
         }
+        setEditableGroups(groups);
+        
         @SuppressWarnings("unchecked")
         List<Element> groupOwnersE = (List<Element>) jdom.getChildren(SearchParameter.GROUPOWNER);
         Set<String> groupOwners = new LinkedHashSet<String>();
@@ -133,6 +146,18 @@ public class LuceneQueryInput extends UserQueryInput {
             this.groups = new LinkedHashSet<String>();
         }
         this.groups = groups;
+    }
+
+
+    public Set<String> getEditableGroups() {
+        if(this.editableGroups == null) {
+            this.editableGroups = new HashSet<String>();
+        }
+        return editableGroups;
+    }
+
+    public void setEditableGroups(Set<String> editableGroups) {
+        this.editableGroups = editableGroups;
     }
 
     public boolean getReviewer() {

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchParameter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchParameter.java
@@ -31,6 +31,7 @@ public class SearchParameter {
 
     public static final String OWNER = "owner";
     public static final String GROUP = "group";
+    public static final String GROUPEDIT = "groupEdit";
     public static final String GROUPOWNER = "groupOwner";
     public static final String ISREVIEWER = "isReviewer";
     public static final String ISUSERADMIN = "isUserAdmin";

--- a/core/src/main/java/org/fao/geonet/kernel/search/UserQueryInput.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/UserQueryInput.java
@@ -62,6 +62,7 @@ public class UserQueryInput {
      */
     public static final List<String> RESERVED_FIELDS = Arrays.asList(
         SearchParameter.GROUP,
+        SearchParameter.GROUPEDIT,
         Geonet.SearchResult.FAST,
         Geonet.SearchResult.SORT_BY,
         Geonet.SearchResult.SORT_ORDER,


### PR DESCRIPTION
Registered users were able to see metadata without viewing privileges but with editing privileges.

So a metadata with 
![imagen](https://user-images.githubusercontent.com/726590/48410585-474d3c00-e73f-11e8-8fde-c639fd056546.png)
previously was seen by registered users of Sample Group.

Now it is only seen by editors or more of Sample Group.