### PR TITLE
Small improvements to the scrollspy

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/scrollspy/partials/scrollspy.html
+++ b/web-ui/src/main/resources/catalog/components/common/scrollspy/partials/scrollspy.html
@@ -11,6 +11,11 @@
   <ul class="nav nav-pills nav-stacked"
       data-ng-class="isEnabled ? '' : 'hidden'"
       role="menu">
+    <button class="close"
+      data-ng-click="toggle()"
+      title="{{'toggleScrollSpy' | translate}}">
+      <span aria-hidden="true">&times;</span>
+    </button>
     <li data-ng-repeat="s in spyElems"
         data-ng-class="s.active ? 'active' : ''"
         role="menuitem">

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -233,10 +233,17 @@ div.gn-scroll-spy {
   overflow: auto;
   background-color: @panel-bg;
   border-left: 1px solid @panel-default-border;
+  .close {
+    position: absolute;
+    z-index: 100;
+    right: 15px;
+    font-size: 24px;
+  }
   .btn-toolbar {
     position: fixed;
     bottom: 10px;
     right: 10px;
+    z-index: 100;
     button {
       .pull-right();
       &:hover {


### PR DESCRIPTION
Small improvements:
- increased the `z-index` for the `toggle` and `go to top` buttons
- added a `close` button in the upper right corner

![gn-scrollspy-close-button](https://user-images.githubusercontent.com/19608667/48414485-24288980-e74b-11e8-8f55-6e7ab23a6658.png)

