### PR TITLE
Support custom titles for metadata editor tables

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -322,6 +322,11 @@ Element to match for creating the table.
                 </xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="label" type="xs:string" use="optional">
+              <xs:annotation>
+                <xs:documentation>Table header label (from strings.xml), if not defined is used the value of attribute 'for' use the related element label from labels.xml</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:sequence>
               <xs:element maxOccurs="1" ref="header"/>
               <xs:element maxOccurs="1" ref="row"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
@@ -138,9 +138,14 @@
         </xsl:call-template>
       </xsl:when>
       <xsl:otherwise>
+
+        <xsl:variable name="tableTitle" select="if (($tableConfig/@label) and (string($strings/*[name() = $tableConfig/@label])))
+              then $strings/*[name() = $tableConfig/@label]
+              else gn-fn-metadata:getLabel($schema, $name, $labels, name(..), $isoType, $xpath)/label" />
+
         <xsl:call-template name="render-boxed-element">
           <xsl:with-param name="label"
-                          select="gn-fn-metadata:getLabel($schema, $name, $labels, name(..), $isoType, $xpath)/label"/>
+                          select="$tableTitle"/>
           <xsl:with-param name="cls" select="local-name()"/>
           <xsl:with-param name="subTreeSnippet">
 


### PR DESCRIPTION
The `table` configuration in `config-editor.xml` use the `for` attribute to match the element to process and also the table title to display (matching the value in `labels.xml` file).

This pull request adds a new optional attribute `label` to the `table`:

- If defined, searches the value in `strings.xml` file. 
- If not defined or the value doesn't exist in `strings.xml` file, uses `for` to match the value in `labels.xml` file as the current behaviour.

**Example:**

_config-editor.xml_

```
<table for="gmd:DQ_ConceptualConsistency" title="qos">
...
```

_strings.xml_

```
<qos>Quality of service reports</qos>
```