### PR TITLE
If a harvester type bean is not available don't fail on GN initialisation

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -26,6 +26,7 @@ package org.fao.geonet.kernel.harvest;
 import jeeves.server.context.ServiceContext;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
@@ -406,19 +407,26 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
             if (Log.isDebugEnabled(Geonet.HARVEST_MAN)) {
                 Log.debug(Geonet.HARVEST_MAN, "Removing harvesting with id : " + id);
             }
-            AbstractHarvester ah = hmHarvesters.get(id);
-
-            if (ah == null) {
+            if (!NumberUtils.isDigits(id)) {
                 return OperResult.NOT_FOUND;
             }
-            ah.destroy();
-            settingMan.remove("harvesting/id:" + id);
+            AbstractHarvester ah = hmHarvesters.get(id);
+            String harvesterSetting = settingMan.getValue("harvesting/id:" + id);
+            String uuid = settingMan.getValue("harvesting/id:" + id + "/site/uuid");
+            if (StringUtils.isNotBlank(harvesterSetting)) {
+                settingMan.remove("harvesting/id:" + id);
 
-            final HarvestHistoryRepository historyRepository = context.getBean(HarvestHistoryRepository.class);
-            // set deleted status in harvest history table to 'y'
-            historyRepository.markAllAsDeleted(ah.getParams().getUuid());
-            hmHarvesters.remove(id);
-            return OperResult.OK;
+                final HarvestHistoryRepository historyRepository = context.getBean(HarvestHistoryRepository.class);
+                // set deleted status in harvest history table to 'y'
+                historyRepository.markAllAsDeleted(uuid);
+                hmHarvesters.remove(id);
+                if (ah != null) {
+                    ah.destroy();
+                }
+                return OperResult.OK;
+            } else {
+                return OperResult.NOT_FOUND;
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -133,7 +133,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
                         hmHarvestLookup.put(ah.getParams().getUuid(), ah);
                     } catch (OperationAbortedEx oae) {
                         Log.error(Geonet.HARVEST_MAN, "Cannot create harvester " + id + " of type \""
-                            + type + "\"");
+                            + type + "\"", oae);
                     }
 
                 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -172,7 +172,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
             ah.setContext(context);
             return ah;
         } catch (Exception e) {
-            throw new OperationAbortedEx("Cannot instantiate harvester", e);
+            throw new OperationAbortedEx("Cannot instantiate harvester of type " + type, e);
         }
     }
 


### PR DESCRIPTION
If an existing harvester is of a type that there is not defined in `config-spring-geonetwork.xml` anymore don't make GN fail on startup, just write this fact in the log.
Also, allow removing a harvester that has not type bean anymore.
Fixes #2607.