### PR TITLE
Open cron help in a new window

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/schedule.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/schedule.html
@@ -32,6 +32,7 @@
           <li>
             <a class="btn btn-link"
                href="http://quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger"
+               target="_blank"
                data-translate="">moreExamples</a>
           </li>
         </ul>


### PR DESCRIPTION
In the harvesters admin page, in the dropdown shown next to the cron expression for executing the harvester there is a link for more cron syntax examples. This PR opens this link in a new window instead of the current one.