### PR TITLE
Fix `gn.project.version` property in schemas module

### DIFF
--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -54,7 +54,7 @@
   </modules>
   <properties>
     <rootProjectDir>../..</rootProjectDir>
-    <gn.project.version>3.4.4-SNAPSHOT</gn.project.version>
+    <gn.project.version>3.4.5-SNAPSHOT</gn.project.version>
   </properties>
 
 </project>


### PR DESCRIPTION
It should be `3.4.5-SNAPSHOT` since the release of v3.4.4.