### PR TITLE
Update versions release script

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -116,8 +116,8 @@ sed $sedopt "s/'system\/platform\/subVersion', '.*', 0/'system\/platform\/subVer
 find . -wholename *v${version//[.]/}/migrate-default.sql -exec sed $sedopt "s/value='${version}' WHERE name='system\/platform\/version'/value='${new_version_main}' WHERE name='system\/platform\/version'/g" {} \;
 find . -wholename *v${version//[.]/}/migrate-default.sql -exec sed $sedopt "s/value='.*' WHERE name='system\/platform\/subVersion'/value='${sub_version}' WHERE name='system\/platform\/subVersion'/g" {} \;
 
-
 # Update version pom files
+mvn versions:set-property -Dproperty=gn.project.version -DnewVersion=${new_version}
 echo 'Module'
 mvn versions:set -DnewVersion=${new_version} -DgenerateBackupPoms=false -Pwith-doc
 echo


### PR DESCRIPTION
* Fixes update of maven `gn.project.version` property. It will avoid to forget updating the property manually when doing a release like in #3268 