### PR TITLE
Add support for xpath in the metadata editor fields configuration

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -479,6 +479,7 @@ relevant to have parent defined to have more control over the list.
       </xs:attribute>
       <xs:attribute ref="use"/>
       <xs:attribute ref="addDirective"/>
+      <xs:attribute name="xpath" type="xs:string" use="optional"/>
     </xs:complexType>
   </xs:element>
 

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
@@ -137,6 +137,8 @@
     <xsl:variable name="added" select="parent::node()/parent::node()/@gn:addedObj"/>
     <xsl:variable name="container" select="parent::node()/parent::node()"/>
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <!-- Add view and edit template-->
     <xsl:call-template name="render-element">
       <xsl:with-param name="label" select="$labelConfig"/>
@@ -144,9 +146,9 @@
       <xsl:with-param name="cls" select="local-name()"/>
       <!--<xsl:with-param name="widget"/>
             <xsl:with-param name="widgetParams"/>-->
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
       <!--<xsl:with-param name="attributesSnippet" as="node()"/>-->
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo"
                       select="gn:element"/>
@@ -204,13 +206,15 @@
   <!-- Readonly elements -->
   <xsl:template mode="mode-dublin-core" priority="200" match="dc:identifier|dct:modified">
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
                       select="gn-fn-metadata:getLabel($schema, name(), $labels)"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout-custom-fields.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout-custom-fields.xsl
@@ -45,7 +45,7 @@
       <xsl:with-param name="value" select="*"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
-      <xsl:with-param name="type" select="gn-fn-iso19110:getFieldType(name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-iso19110:getFieldType(name(), '', $xpath)"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
@@ -176,7 +176,7 @@
       <xsl:with-param name="forceDisplayAttributes" select="true()" />
       <xsl:with-param name="type"
                       select="gn-fn-iso19110:getFieldType(name(),
-            name(gmx:Anchor))"/>
+            name(gmx:Anchor), $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then */gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>
@@ -245,7 +245,7 @@
                       select="gn-fn-iso19110:getFieldType(name(),
             name(gco:CharacterString|gco:Date|gco:DateTime|gco:Integer|gco:Decimal|
                 gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|
-                gco:Scale|gco:RecordType|gmx:MimeFileType|gmd:URL))"/>
+                gco:Scale|gco:RecordType|gmx:MimeFileType|gmd:URL), $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then */gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/utility-fn.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/utility-fn.xsl
@@ -41,14 +41,15 @@
     <xsl:param name="name" as="xs:string"/>
     <!-- The element containing the value eg. gco:Date -->
     <xsl:param name="childName" as="xs:string?"/>
+    <xsl:param name="xpath" as="xs:string?"/>
 
     <xsl:variable name="iso19110type"
-                  select="gn-fn-metadata:getFieldType($editorConfig, $name, $childName)"/>
+                  select="gn-fn-metadata:getFieldType($editorConfig, $name, $childName, $xpath)"/>
 
     <xsl:choose>
       <xsl:when test="$iso19110type = $defaultFieldType">
         <xsl:value-of
-          select="gn-fn-metadata:getFieldType($iso19139EditorConfig, $name, $childName)"/>
+          select="gn-fn-metadata:getFieldType($iso19139EditorConfig, $name, $childName, $xpath)"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$iso19110type"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -70,7 +70,7 @@
       <xsl:with-param name="value" select="*"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -335,7 +335,7 @@
                       select="if ($config and $config/@use != '')
                               then $config/@use
                               else gn-fn-metadata:getFieldType($editorConfig, name(),
-        name($theElement))"/>
+        name($theElement), $xpath)"/>
       <xsl:with-param name="directiveAttributes">
         <xsl:choose>
           <xsl:when test="$config and $config/@use != ''">
@@ -367,13 +367,15 @@
    as read only. The associated resource panel is used to edit
     those values. -->
   <xsl:template mode="mode-iso19139" match="@uuidref" priority="2000">
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
                       select="gn-fn-metadata:getLabel($schema, name(..), $labels)"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="../gn:element"/>
       <xsl:with-param name="parentEditInfo" select="../gn:element"/>
@@ -384,13 +386,16 @@
 
 
   <xsl:template mode="mode-iso19139" match="gco:ScopedName|gco:LocalName">
+
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
                       select="gn-fn-metadata:getLabel($schema, name(.), $labels)"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="gn:element/@ref"/>
       <xsl:with-param name="editInfo" select="gn:element"/>
       <xsl:with-param name="parentEditInfo" select="../gn:element"/>
@@ -525,12 +530,14 @@
 
     <xsl:variable name="added" select="parent::node()/parent::node()/@gn:addedObj"/>
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <xsl:call-template name="render-element">
       <xsl:with-param name="label" select="$labelConfig"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo"
                       select="gn:element"/>

--- a/web/src/main/webapp/xslt/common/functions-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/functions-metadata.xsl
@@ -351,19 +351,29 @@
     <xsl:param name="name" as="xs:string"/>
     <!-- The element containing the value eg. gco:Date -->
     <xsl:param name="childName" as="xs:string?"/>
+    <xsl:param name="xpath" as="xs:string?"/>
 
     <xsl:variable name="childType"
                   select="normalize-space($configuration/editor/fields/for[@name = $childName]/@use)"/>
+    <xsl:variable name="childTypeXpath"
+                  select="normalize-space($configuration/editor/fields/for[@name = $childName and @xpath = $xpath]/@use)"/>
     <xsl:variable name="type"
-                  select="normalize-space($configuration/editor/fields/for[@name = $name]/@use)"/>
+                  select="normalize-space($configuration/editor/fields/for[@name = $name and not(@xpath)]/@use)"/>
+    <xsl:variable name="typeXpath"
+                  select="normalize-space($configuration/editor/fields/for[@name = $name and @xpath = $xpath]/@use)"/>
 
     <xsl:value-of
-      select="if ($childType != '')
+      select="if ($childTypeXpath != '')
+      then $childTypeXpath
+      else if ($childType != '')
       then $childType
+      else if ($typeXpath != '')
+      then $typeXpath
       else if ($type != '')
       then $type
       else $defaultFieldType"
     />
+
   </xsl:function>
 
   <xsl:function name="gn-fn-metadata:getAttributeFieldType" as="xs:string">


### PR DESCRIPTION
Some xml elements are available in different sections with different usage, but the configuration to use a directive or html control applies to all (this can be redefined in the views in some cases, but doesn't work for table mode for example).

This change allows to configure a field using the xpath. For example, for `gmd:name` in distribution format to use `gn-keyword-picker`, while `gmd:name` in other elements, like `gmd:onLine` will use the default control (input text):

```
<for name="gmd:name" xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format/gmd:name"
         use="data-gn-keyword-picker">
      <directiveAttributes data-thesaurus-key="external.theme.httpinspireeceuropaeumediatypes-media-types"
                           data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
</for>
```
