### PR TITLE
Add headers to `multiselect` select boxes (#3153)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/multiselect/partials/multiselect.html
+++ b/web-ui/src/main/resources/catalog/components/common/multiselect/partials/multiselect.html
@@ -1,5 +1,6 @@
 <div class="row">
   <div class="col-md-5">
+    <label data-translate="" class="text-capitalize">unselected</label>
     <input class="form-control"
            data-ng-model="optionsSearch.$"
            placeholder="{{'filter' | translate}}"/>
@@ -20,6 +21,7 @@
     </div>
   </div>
   <div class="col-md-5">
+    <label data-translate="" class="text-capitalize">selected</label>
     <input class="form-control"
            data-ng-model="selectedSearch.$"
            placeholder="{{'filter' | translate}}"/>

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -408,5 +408,6 @@
     "listTypeBlocks": "Switch to Blocked list",
     "listTypeLarge": "Switch to Large list",
     "listTypeSmall": "Switch to Small list",
-    "layersWithWhiteSpaces": "Some layers on this map contains white spaces on their name. Layers with white spaces may not be properly printed."
+    "layersWithWhiteSpaces": "Some layers on this map contains white spaces on their name. Layers with white spaces may not be properly printed.",
+    "unselected": "unselected"
 }

--- a/web-ui/src/main/resources/catalog/locales/nl-core.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-core.json
@@ -380,5 +380,6 @@
     "resolveCaptcha": "Captcha oplossen",
     "resolutions": "Resolutie",
     "loginTitle": "Inloggen",
-    "loginText": "Login met uw gebruikersnaam en wachtwoord om aan de catalogus bij te dragen."
+    "loginText": "Login met uw gebruikersnaam en wachtwoord om aan de catalogus bij te dragen.",
+    "unselected": "gedeselecteerd"
 }


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/3153

Header labels added to the `Multiselect` elements (see screenshot).

![gn-multiselect-headers](https://user-images.githubusercontent.com/19608667/48557898-3429a000-e8e8-11e8-8d66-52bc6641a00f.png)
