### PR TITLE
ISO19139 / Dimension size is not a multilingual field.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -337,6 +337,7 @@
       <name>gmd:domainValue</name>
       <name>gmd:minimumValue</name>
       <name>gmd:maximumValue</name>
+      <name>gmd:dimensionSize</name>
       <name>gmd:densityUnits</name>
       <name>gmd:descriptor</name>
       <name>gmd:denominator</name>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1701393/48716261-360c9f80-ec17-11e8-86a0-c2f330c2272c.png)
