### PR TITLE
Load static pages into GeoNetwork

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/page/Page.java
+++ b/domain/src/main/java/org/fao/geonet/domain/page/Page.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.List;
 
 import javax.annotation.Nullable;
+import javax.persistence.Basic;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -33,6 +34,7 @@ import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.Lob;
 import javax.persistence.Table;
 
@@ -48,7 +50,7 @@ public class Page extends GeonetEntity implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private PageIdentity pageIdentity;
-    private String data;
+    private byte[] data;
     private PageFormat format;
     private List<PageSection> sections;
     private PageStatus status;
@@ -57,7 +59,7 @@ public class Page extends GeonetEntity implements Serializable {
 
     }
 
-    public Page(PageIdentity pageIdentity, String data, PageFormat format, List<PageSection> sections, PageStatus status) {
+    public Page(PageIdentity pageIdentity, byte[] data, PageFormat format, List<PageSection> sections, PageStatus status) {
         super();
         this.pageIdentity = pageIdentity;
         this.data = data;
@@ -65,7 +67,6 @@ public class Page extends GeonetEntity implements Serializable {
         this.sections = sections;
         this.status = status;
     }
-
 
     public enum PageStatus {
         PUBLIC,
@@ -101,7 +102,8 @@ public class Page extends GeonetEntity implements Serializable {
     @Column
     @Nullable
     @Lob
-    public String getData() {
+    @Basic(fetch = FetchType.LAZY)
+    public byte[] getData() {
         return data;
     }
 
@@ -129,7 +131,7 @@ public class Page extends GeonetEntity implements Serializable {
         this.pageIdentity = pageIdentity;
     }
 
-    public void setData(String data) {
+    public void setData(byte[] data) {
         this.data = data;
     }
 

--- a/domain/src/main/java/org/fao/geonet/domain/page/Page.java
+++ b/domain/src/main/java/org/fao/geonet/domain/page/Page.java
@@ -51,6 +51,7 @@ public class Page extends GeonetEntity implements Serializable {
 
     private PageIdentity pageIdentity;
     private byte[] data;
+    private String link;
     private PageFormat format;
     private List<PageSection> sections;
     private PageStatus status;
@@ -59,39 +60,27 @@ public class Page extends GeonetEntity implements Serializable {
 
     }
 
-    public Page(PageIdentity pageIdentity, byte[] data, PageFormat format, List<PageSection> sections, PageStatus status) {
+    public Page(PageIdentity pageIdentity, byte[] data, String link, PageFormat format, List<PageSection> sections, PageStatus status) {
         super();
         this.pageIdentity = pageIdentity;
         this.data = data;
+        this.link = link;
         this.format = format;
         this.sections = sections;
         this.status = status;
     }
 
     public enum PageStatus {
-        PUBLIC,
-        PRIVATE,
-        HIDDEN;
+        PUBLIC, PUBLIC_ONLY, PRIVATE, HIDDEN;
     }
 
     public enum PageFormat {
-        HTML,
-        TEXT,
-        MARKDOWN,
-        WIKI;
+        LINK, HTML, TEXT, MARKDOWN, WIKI;
     }
 
     // These are the sections where is shown the link to the Page object
     public enum PageSection {
-        ALL,
-        TOP,
-        FOOTER,
-        MENU,
-        SUBMENU,
-        CUSTOM_MENU1,
-        CUSTOM_MENU2,
-        CUSTOM_MENU3,
-        DRAFT;
+        ALL, TOP, FOOTER, MENU, SUBMENU, CUSTOM_MENU1, CUSTOM_MENU2, CUSTOM_MENU3, DRAFT;
     }
 
     @EmbeddedId
@@ -107,16 +96,23 @@ public class Page extends GeonetEntity implements Serializable {
         return data;
     }
 
+    @Column
+    @Nullable
+    @Basic(fetch = FetchType.LAZY)
+    public String getLink() {
+        return link;
+    }
+
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     public PageFormat getFormat() {
         return format;
     }
 
-    @ElementCollection(targetClass=PageSection.class)
+    @ElementCollection(targetClass = PageSection.class)
     @Enumerated(EnumType.STRING)
-    @CollectionTable(name="SPG_Sections")
-    @Column(name="section")
+    @CollectionTable(name = "SPG_Sections")
+    @Column(name = "section")
     public List<PageSection> getSections() {
         return sections;
     }
@@ -135,20 +131,21 @@ public class Page extends GeonetEntity implements Serializable {
         this.data = data;
     }
 
+    public void setLink(String link) {
+        this.link = link;
+    }
+
     public void setFormat(PageFormat format) {
         this.format = format;
     }
-
 
     public void setSections(List<PageSection> sections) {
         this.sections = sections;
     }
 
-
     public void setStatus(PageStatus status) {
         this.status = status;
     }
-
 
     @Override
     public String toString() {
@@ -156,5 +153,3 @@ public class Page extends GeonetEntity implements Serializable {
     }
 
 }
-
-

--- a/domain/src/main/java/org/fao/geonet/domain/page/Page.java
+++ b/domain/src/main/java/org/fao/geonet/domain/page/Page.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.domain.page;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.annotation.Nullable;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+
+import org.fao.geonet.domain.GeonetEntity;
+
+/**
+ * A page with content and properties
+ */
+@Entity(name = "SPG_Page")
+@Table(name = "SPG_Page")
+public class Page extends GeonetEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private PageIdentity pageIdentity;
+    private String data;
+    private PageFormat format;
+    private List<PageSection> sections;
+    private PageStatus status;
+
+    public Page() {
+
+    }
+
+    public Page(PageIdentity pageIdentity, String data, PageFormat format, List<PageSection> sections, PageStatus status) {
+        super();
+        this.pageIdentity = pageIdentity;
+        this.data = data;
+        this.format = format;
+        this.sections = sections;
+        this.status = status;
+    }
+
+
+    public enum PageStatus {
+        PUBLIC,
+        PRIVATE,
+        HIDDEN;
+    }
+
+    public enum PageFormat {
+        HTML,
+        TEXT,
+        MARKDOWN,
+        WIKI;
+    }
+
+    // These are the sections where is shown the link to the Page object
+    public enum PageSection {
+        ALL,
+        TOP,
+        FOOTER,
+        MENU,
+        SUBMENU,
+        CUSTOM_MENU1,
+        CUSTOM_MENU2,
+        CUSTOM_MENU3,
+        DRAFT;
+    }
+
+    @EmbeddedId
+    public PageIdentity getPageIdentity() {
+        return pageIdentity;
+    }
+
+    @Column
+    @Nullable
+    @Lob
+    public String getData() {
+        return data;
+    }
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    public PageFormat getFormat() {
+        return format;
+    }
+
+    @ElementCollection(targetClass=PageSection.class)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name="SPG_Sections")
+    @Column(name="section")
+    public List<PageSection> getSections() {
+        return sections;
+    }
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    public PageStatus getStatus() {
+        return status;
+    }
+
+    public void setPageIdentity(PageIdentity pageIdentity) {
+        this.pageIdentity = pageIdentity;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public void setFormat(PageFormat format) {
+        this.format = format;
+    }
+
+
+    public void setSections(List<PageSection> sections) {
+        this.sections = sections;
+    }
+
+
+    public void setStatus(PageStatus status) {
+        this.status = status;
+    }
+
+
+    @Override
+    public String toString() {
+        return String.format("Entity of type %s with id: %s", this.getClass().getName(), getPageIdentity().getLinkText());
+    }
+
+}
+
+

--- a/domain/src/main/java/org/fao/geonet/domain/page/PageIdentity.java
+++ b/domain/src/main/java/org/fao/geonet/domain/page/PageIdentity.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.domain.page;
+
+import java.io.Serializable;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class PageIdentity implements Serializable {
+
+    private String language;
+    private String linkText; 
+    
+    public PageIdentity() {
+    
+    }
+    
+    public PageIdentity(String language, String linkText) {
+        super();
+        this.language = language;
+        this.linkText = linkText;
+    }
+
+
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getLinkText() {
+        return linkText;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public void setLinkText(String linkText) {
+        this.linkText = linkText;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PageIdentity that = (PageIdentity) o;
+
+        if (!language.equals(that.language)) return false;
+        return linkText.equals(that.linkText);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = language.hashCode();
+        result = 31 * result + linkText.hashCode();
+        return result;
+    }
+
+}  
+

--- a/domain/src/main/java/org/fao/geonet/domain/page/PageIdentity.java
+++ b/domain/src/main/java/org/fao/geonet/domain/page/PageIdentity.java
@@ -29,20 +29,23 @@ import javax.persistence.Embeddable;
 @Embeddable
 public class PageIdentity implements Serializable {
 
+    /**
+        *
+        */
+
+    private static final long serialVersionUID = 1L;
     private String language;
-    private String linkText; 
-    
+    private String linkText;
+
     public PageIdentity() {
-    
+
     }
-    
+
     public PageIdentity(String language, String linkText) {
         super();
         this.language = language;
         this.linkText = linkText;
     }
-
-
 
     public String getLanguage() {
         return language;
@@ -59,15 +62,21 @@ public class PageIdentity implements Serializable {
     public void setLinkText(String linkText) {
         this.linkText = linkText;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         PageIdentity that = (PageIdentity) o;
 
-        if (!language.equals(that.language)) return false;
+        if (!language.equals(that.language)) {
+            return false;
+        }
         return linkText.equals(that.linkText);
     }
 
@@ -78,5 +87,4 @@ public class PageIdentity implements Serializable {
         return result;
     }
 
-}  
-
+}

--- a/domain/src/main/java/org/fao/geonet/repository/page/PageRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/page/PageRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.repository.page;
+
+import org.fao.geonet.domain.page.Page;
+import org.fao.geonet.domain.page.PageIdentity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PageRepository extends JpaRepository<Page, PageIdentity> {
+    
+}

--- a/services/src/main/java/org/fao/geonet/api/pages/PageJSONWrapper.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PageJSONWrapper.java
@@ -1,0 +1,51 @@
+package org.fao.geonet.api.pages;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.fao.geonet.domain.page.Page;
+import org.fao.geonet.domain.page.Page.PageFormat;
+import org.fao.geonet.domain.page.Page.PageSection;
+import org.fao.geonet.domain.page.Page.PageStatus;
+
+// Wrapper to filter the fields shown on JSON
+public class PageJSONWrapper implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Page page;
+
+    public PageJSONWrapper(Page p) {
+        page = p;
+    }
+
+    public String getLinkText() {
+        return page.getPageIdentity().getLinkText();
+    }
+
+    public String getLanguage() {
+        return page.getPageIdentity().getLanguage();
+    }
+
+    public PageFormat getFormat() {
+        return page.getFormat();
+    }
+
+    public String getLink() {
+        return page.getLink();
+    }
+
+    public List<PageSection> getSections() {
+        return page.getSections();
+    }
+
+    public PageStatus getStatus() {
+        return page.getStatus();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Entity of type %s with id: %s", this.getClass().getName(), getLinkText());
+    }
+
+}

--- a/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
@@ -93,6 +93,8 @@ public class PagesAPI {
 
         final ApplicationContext appContext = ApplicationContextHolder.get();
         final PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        
+        checkMandatoryContent(data, link);
 
         checkUniqueContent(data, link);
 
@@ -163,7 +165,7 @@ public class PagesAPI {
         final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
         if (page == null) {
-            throw new ResourceNotFoundException("Page " + pageId + " not found");
+            throw new ResourceNotFoundException("Page " + pageId + " not found.");
         }
 
         if (!language.equals(newLanguage) || !pageId.equals(newPageId)) {
@@ -297,7 +299,7 @@ public class PagesAPI {
         final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
         if (page == null) {
-            throw new ResourceNotFoundException("Page " + pageId + " not found");
+            throw new ResourceNotFoundException("Page " + pageId + " not found.");
         }
 
         final Page.PageSection sectionToAdd = section;
@@ -332,7 +334,7 @@ public class PagesAPI {
         final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
         if (page == null) {
-            throw new ResourceNotFoundException("Page " + pageId + " not found");
+            throw new ResourceNotFoundException("Page " + pageId + " not found.");
         }
 
         if (section.equals(Page.PageSection.ALL)) {
@@ -367,7 +369,7 @@ public class PagesAPI {
         final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
         if (page == null) {
-            throw new ResourceNotFoundException("Page " + pageId + " not found");
+            throw new ResourceNotFoundException("Page " + pageId + " not found.");
         }
 
         page.setStatus(status);
@@ -436,12 +438,25 @@ public class PagesAPI {
     private void checkCorrectFormat(final MultipartFile data, final String link, final Page.PageFormat format) {
         // Cannot set format to LINK and upload a file
         if (Page.PageFormat.LINK.equals(format) && data != null && !data.isEmpty()) {
-            throw new IllegalArgumentException("Wrong format");
+            throw new IllegalArgumentException("Wrong format.");
         }
 
         // Cannot set a link without setting format to LINK
         if (!Page.PageFormat.LINK.equals(format) && !StringUtils.isBlank(link)) {
-            throw new IllegalArgumentException("Wrong format");
+            throw new IllegalArgumentException("Wrong format.");
+        }
+    }
+    
+    /**
+     * Check that link or a file is defined.
+     *
+     * @param data the data
+     * @param link the link
+     */
+    private void checkMandatoryContent(final MultipartFile data, final String link) {
+        // Cannot set both: link and file
+        if (StringUtils.isBlank(link) && (data == null || data.isEmpty())) {
+            throw new IllegalArgumentException("A content associated to the page, a link or a file, is mandatory.");
         }
     }
 
@@ -454,7 +469,7 @@ public class PagesAPI {
     private void checkUniqueContent(final MultipartFile data, final String link) {
         // Cannot set both: link and file
         if (!StringUtils.isBlank(link) && data != null && !data.isEmpty()) {
-            throw new IllegalArgumentException("Cannot define link and file in the same page");
+            throw new IllegalArgumentException("A content associated to the page, a link or a file, is mandatory. But is not possible to associate both to the same page.");
         }
     }
 
@@ -469,7 +484,7 @@ public class PagesAPI {
             final String[] supportedExtensions = { "html", "HTML", "txt", "TXT", "md", "MD" };
 
             if (!ArrayUtils.contains(supportedExtensions, extension)) {
-                throw new MultipartException("Unsuppoted file type (only html, txt and md are allowed)");
+                throw new MultipartException("Unsuppoted file type (only html, txt and md are allowed).");
             }
         }
     }

--- a/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
@@ -29,10 +29,16 @@ import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.exception.ResourceAlreadyExistException;
+import org.fao.geonet.api.exception.ResourceNotFoundException;
+import org.fao.geonet.api.exception.WebApplicationException;
 import org.fao.geonet.domain.Profile;
 import org.fao.geonet.domain.page.Page;
 import org.fao.geonet.domain.page.PageIdentity;
@@ -42,372 +48,326 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.web.util.UrlUtils;
 import org.springframework.stereotype.Controller;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import jeeves.server.UserSession;
 import springfox.documentation.annotations.ApiIgnore;
 
 @RequestMapping(value = { "/api/pages", "/api/" + API.VERSION_0_1 + "/pages" })
-@Api(value = "pages", tags = "pages",
-description = "Static pages inside GeoNetwork")
+@Api(value = "pages", tags = "pages", description = "Static pages inside GeoNetwork")
 @Controller("pages")
 public class PagesAPI {
 
-    // HTTP status messages not from ApiParams
-    private static final String PAGE_OK="Page found";
-    private static final String PAGE_NOT_FOUND="Page not found";
-    private static final String PAGE_DUPLICATE="Page already in the system: use PUT";
-    private static final String PAGE_SAVED="Page saved";
-    private static final String PAGE_UPDATED="Page changes saved";
-    private static final String PAGE_DELETED="Page removed";
-    private static final String ERROR_FILE="File not valid";
 
-    // WRITE, EDIT, DELETE, READ Page methods
 
-    @ApiOperation(
-            value = "Add a new Page object in DRAFT section in status HIDDEN",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "addPage")
-    @RequestMapping(
-            value = "/",
-            method = RequestMethod.POST)
-    @ResponseStatus(value = HttpStatus.OK)
+    @ApiOperation(value = "Add a new Page object in DRAFT section in status HIDDEN", notes = "<p>Is not possible to load a link and a file at the same time.</p> <a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "addPage")
+    @RequestMapping(value = "/", method = RequestMethod.POST)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = PAGE_SAVED),
             @ApiResponse(code = 404, message = PAGE_NOT_FOUND),
+            @ApiResponse(code = 400, message = ERROR_CREATE),
             @ApiResponse(code = 409, message = PAGE_DUPLICATE),
             @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT),
-            @ApiResponse(code = 500, message = ERROR_FILE)
-    })
+            @ApiResponse(code = 500, message = ERROR_FILE) })
     @PreAuthorize("hasRole('Administrator')")
     public void addPage(
-            @RequestParam(value = "language", required=true) final String language,
-            @RequestParam(value = "pageId", required=true) final String pageId,
-            @RequestParam(value = "data", required=false) MultipartFile data,
-            @RequestParam(value = "format", required=true) final Page.PageFormat format,
-            @ApiIgnore final HttpServletResponse response
-            ) {
+            @RequestParam(value = "language", required = true) final String language,
+            @RequestParam(value = "pageId", required = true) final String pageId,
+            @RequestParam(value = "data", required = false) final MultipartFile data,
+            @RequestParam(value = "link", required = false) final String link,
+            @RequestParam(value = "format", required = true) final Page.PageFormat format,
+            @ApiIgnore final HttpServletResponse response) throws ResourceAlreadyExistException {
+
 
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
 
-        if(pageRepository.findOne(new PageIdentity(language, pageId)) == null) {
+        checkUniqueContent(data, link);
 
-            List<Page.PageSection> sections = new ArrayList<Page.PageSection>();
-            sections.add(Page.PageSection.DRAFT);
-            byte[] bytesData;
-            try {
-                bytesData = data.getBytes();
-            } catch (Exception e) {
-                response.setStatus(HttpStatus.CONFLICT.value());
-                return;
-            }
+        checkCorrectFormat(data, link, format);
 
-            Page page = new Page(new PageIdentity(language, pageId), bytesData, format, sections, Page.PageStatus.HIDDEN);
+        if (pageRepository.findOne(new PageIdentity(language, pageId)) == null) {
+
+            Page page = getEmptyHiddenDraftPage(language, pageId, format);
+
+            fillContent(data, link, page);
 
             pageRepository.save(page);
+
         } else {
-            response.setStatus(HttpStatus.CONFLICT.value());
+            throw new ResourceAlreadyExistException();
         }
     }
 
+
     // Isn't done with PUT because the multipart support as used by Spring
     // doesn't support other request method then POST
-    @ApiOperation(
-            value = "Edit a Page object",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "editPage")
-    @RequestMapping(
-            value = "/{language}/{pageId}",
-            method = RequestMethod.POST)
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = PAGE_UPDATED),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
-    })
+    @ApiOperation(value = "Edit a Page content and format", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "editPage")
+    @RequestMapping(value = "/{language}/{pageId}", method = RequestMethod.POST)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = PAGE_UPDATED),
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT) })
     @PreAuthorize("hasRole('Administrator')")
     public void editPage(
             @PathVariable(value = "language") final String language,
             @PathVariable(value = "pageId") final String pageId,
-            @RequestParam(value = "data", required=false) MultipartFile data,
-            @RequestParam(value = "format", required=true) final Page.PageFormat format,
-            @ApiIgnore final HttpServletResponse response
-            ) {
+            @RequestParam(value = "data", required = false) final MultipartFile data,
+            @RequestParam(value = "link", required = false) final String link,
+            @RequestParam(value = "format", required = true) final Page.PageFormat format,
+            @ApiIgnore final HttpServletResponse response) throws ResourceNotFoundException {
+
+
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
 
-        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+        checkUniqueContent(data, link);
 
-        if(page == null) {
-            response.setStatus(HttpStatus.NOT_FOUND.value());
-            return;
-        }
+        checkCorrectFormat(data, link, format);
 
-        byte[] bytesData;
-        try {
-            bytesData = data.getBytes();
-        } catch (Exception e) {
-            response.setStatus(HttpStatus.CONFLICT.value());
-            return;
-        }
+        final Page page = searchPage(language, pageId, pageRepository);
 
-        page.setData(bytesData);
+        fillContent(data, link, page);
+
         page.setFormat(format);
-
         pageRepository.save(page);
     }
 
-    @ApiOperation(
-            value = "Delete a Page object",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "deletePage")
-    @RequestMapping(
-            value = "/{language}/{pageId}",
-            method = RequestMethod.DELETE)
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = PAGE_DELETED),
+
+    @ApiOperation(value = "Edit a Page name and language", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "editPage")
+    @RequestMapping(value = "/{language}/{pageId}", method = RequestMethod.PUT)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = PAGE_UPDATED),
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT) })
+    @PreAuthorize("hasRole('Administrator')")
+    public void editPageName(
+            @PathVariable(value = "language") final String language,
+            @PathVariable(value = "pageId") final String pageId,
+            @RequestParam(value = "newLanguage", required = false) final String newLanguage,
+            @RequestParam(value = "newPageId", required = false) final String newPageId,
+            @ApiIgnore final HttpServletResponse response) throws ResourceNotFoundException, ResourceAlreadyExistException {
+
+
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if (page == null) {
+            throw new ResourceNotFoundException("Page " + pageId + " not found");
+        }
+
+        if (!language.equals(newLanguage) || !pageId.equals(newPageId)) {
+            String updatedLanguage = StringUtils.isBlank(newLanguage) ? language : newLanguage;
+            String updatedPageId = StringUtils.isBlank(newPageId) ? pageId : newPageId;
+
+            Page newPage = pageRepository.findOne(new PageIdentity(updatedLanguage, updatedPageId));
+            if (newPage != null) {
+                throw new ResourceAlreadyExistException();
+            }
+
+            PageIdentity newId = new PageIdentity(updatedLanguage, updatedPageId);
+            newPage = new Page(newId, page.getData(), page.getLink(), page.getFormat(), page.getSections(), page.getStatus());
+
+            newPage.setSections(new ArrayList<Page.PageSection>());
+
+            for (Page.PageSection p : page.getSections()) {
+                newPage.getSections().add(p);
+            }
+
+            pageRepository.save(newPage);
+            pageRepository.delete(page);
+        }
+    }
+
+
+    @ApiOperation(value = "Delete a Page object", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "deletePage")
+    @RequestMapping(value = "/{language}/{pageId}", method = RequestMethod.DELETE)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = PAGE_DELETED),
             @ApiResponse(code = 404, message = PAGE_NOT_FOUND),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
-    })
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT) })
     @PreAuthorize("hasRole('Administrator')")
     public void deletePage(
             @PathVariable(value = "language") final String language,
             @PathVariable(value = "pageId") final String pageId,
-            @RequestParam(value = "format", required=true) final Page.PageFormat format,
-            @ApiIgnore final HttpServletResponse response
-            ) {
+            @RequestParam(value = "format", required = true) final Page.PageFormat format,
+            @ApiIgnore final HttpServletResponse response) throws ResourceNotFoundException {
+
+
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
 
-        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+        searchPage(language, pageId, pageRepository);
 
-        if(page == null) {
-            response.setStatus(HttpStatus.NOT_FOUND.value());
-            return;
-        }
-
-        pageRepository.delete(new PageIdentity(language, pageId));        
+        pageRepository.delete(new PageIdentity(language, pageId));
     }
 
-    @ApiOperation(
-            value = "Return the page object",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "getPage")
-    @RequestMapping(
-            value = "/{language}/{pageId}",
-            method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = PAGE_OK),
+
+    @ApiOperation(value = "Return the page object details except the content", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "getPage")
+    @RequestMapping(value = "/{language}/{pageId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = PAGE_OK),
             @ApiResponse(code = 404, message = PAGE_NOT_FOUND),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
-    })
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW) })
     @ResponseBody
-    public ResponseEntity<Page> getPage(
+    public ResponseEntity<PageJSONWrapper> getPage(
             @PathVariable(value = "language") final String language,
             @PathVariable(value = "pageId") final String pageId,
             @ApiIgnore final HttpServletResponse response,
-            @ApiIgnore final HttpSession session
-            ) {
+            @ApiIgnore final HttpSession session) {
+
+
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
 
-        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+        final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
-        if(page == null) {
-            return new ResponseEntity<Page>(HttpStatus.NOT_FOUND);
-        } else {
-            UserSession us = ApiUtils.getUserSession(session);
-            if(page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile()!= Profile.Administrator) {
-                return new ResponseEntity<Page>(HttpStatus.FORBIDDEN);
-            } else if(page.getStatus().equals(Page.PageStatus.PRIVATE) && (us.getProfile()== null || us.getProfile()== Profile.Guest)) {
-                return new ResponseEntity<Page>(HttpStatus.FORBIDDEN);
-            } else {
-                return new ResponseEntity<Page>(page, HttpStatus.OK);
-            }
-        }
+        return checkPermissionsOnSinglePageAndReturn(session, page);
     }
 
-    @ApiOperation(
-            value = "Return the static html content identified by pageId",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "getPage")
-    @RequestMapping(
-            value = "/{language}/{pageId}/data",
-            method = RequestMethod.GET,
-            produces = MediaType.TEXT_HTML_VALUE)
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = PAGE_OK),
+
+    @ApiOperation(value = "Return the static html content identified by pageId", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "getPage")
+    @RequestMapping(value = "/{language}/{pageId}/content", method = RequestMethod.GET, produces = "text/plain;charset=UTF-8")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = PAGE_OK),
             @ApiResponse(code = 404, message = PAGE_NOT_FOUND),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
-    })
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW) })
     @ResponseBody
     public ResponseEntity<String> getPageContent(
             @PathVariable(value = "language") final String language,
             @PathVariable(value = "pageId") final String pageId,
             @ApiIgnore final HttpServletResponse response,
-            @ApiIgnore final HttpSession session
-            ) {
+            @ApiIgnore final HttpSession session) {
+
+
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
 
-        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+        final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
-        if(page == null) {
-            return new ResponseEntity<String>(HttpStatus.NOT_FOUND);
+        if (page == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } else {
-            UserSession us = ApiUtils.getUserSession(session);
-            if(page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile()!= Profile.Administrator) {
-                return new ResponseEntity<String>(HttpStatus.FORBIDDEN);
-            } else if(page.getStatus().equals(Page.PageStatus.PRIVATE) && (us.getProfile()== null || us.getProfile()== Profile.Guest)) {
-                return new ResponseEntity<String>(HttpStatus.FORBIDDEN);
+            final UserSession us = ApiUtils.getUserSession(session);
+            if (page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() != Profile.Administrator) {
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+            } else if (page.getStatus().equals(Page.PageStatus.PRIVATE) && (us.getProfile() == null || us.getProfile() == Profile.Guest)) {
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
             } else {
                 String content = "";
-                try {
-                    content = new String(page.getData(), "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    content = new String(page.getData());
+                if (page.getData() != null && page.getData().length > 0) {
+                    try {
+                        content = new String(page.getData(), "UTF-8");
+                    } catch (final UnsupportedEncodingException e) {
+                        content = new String(page.getData());
+                    }
+                } else {
+                    content = page.getLink();
                 }
 
-                return new ResponseEntity<String>(content, HttpStatus.OK);
+                return new ResponseEntity<>(content, HttpStatus.OK);
             }
         }
     }
 
 
-    // SECTION OPERATIONS methods
-
-    @ApiOperation(
-            value = "Adds the page to a section. This means that the link to the page will be shown in the list associated to that section.",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "addPageToSection")
-    @RequestMapping(
-            value = "/{language}/{pageId}/{section}",
-            method = RequestMethod.POST)
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = PAGE_UPDATED),
+    @ApiOperation(value = "Adds the page to a section. This means that the link to the page will be shown in the list associated to that section.", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "addPageToSection")
+    @RequestMapping(value = "/{language}/{pageId}/{section}", method = RequestMethod.POST)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = PAGE_UPDATED),
             @ApiResponse(code = 404, message = PAGE_NOT_FOUND),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
-    })
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT) })
     @PreAuthorize("hasRole('Administrator')")
     public void addPageToSection(
             @PathVariable(value = "language") final String language,
             @PathVariable(value = "pageId") final String pageId,
             @PathVariable(value = "section") final Page.PageSection section,
-            @ApiIgnore final HttpServletResponse response
-            ) {
+            @ApiIgnore final HttpServletResponse response) throws ResourceNotFoundException {
+
+
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
 
-        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+        final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
-        if(page == null) {
-            response.setStatus(HttpStatus.NOT_FOUND.value());
-            return;
+        if (page == null) {
+            throw new ResourceNotFoundException("Page " + pageId + " not found");
         }
 
-        Page.PageSection sectionToAdd = section;
+        final Page.PageSection sectionToAdd = section;
 
-        if(sectionToAdd.equals(Page.PageSection.ALL)) {
+        if (sectionToAdd.equals(Page.PageSection.ALL)) {
             page.setSections(new ArrayList<Page.PageSection>());
             page.getSections().add(sectionToAdd);
-        } else if(!page.getSections().contains(sectionToAdd)) {
+        } else if (!page.getSections().contains(sectionToAdd)) {
             page.getSections().add(sectionToAdd);
         }
 
         pageRepository.save(page);
     }
 
-    @ApiOperation(
-            value = "Removes the page from a section. This means that the link to the page will not be shown in the list associated to that section.",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "removePageFromSection")
-    @RequestMapping(
-            value = "/{language}/{pageId}/{section}",
-            method = RequestMethod.DELETE)
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = PAGE_UPDATED),
+
+    @ApiOperation(value = "Removes the page from a section. This means that the link to the page will not be shown in the list associated to that section.", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "removePageFromSection")
+    @RequestMapping(value = "/{language}/{pageId}/{section}", method = RequestMethod.DELETE)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = PAGE_UPDATED),
             @ApiResponse(code = 404, message = PAGE_NOT_FOUND),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
-    })
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT) })
     @PreAuthorize("hasRole('Administrator')")
     public void removePageFromSection(
             @PathVariable(value = "language") final String language,
             @PathVariable(value = "pageId") final String pageId,
             @PathVariable(value = "section") final Page.PageSection section,
-            @ApiIgnore final HttpServletResponse response
-            ) {
+            @ApiIgnore final HttpServletResponse response) throws ResourceNotFoundException {
+
+
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
 
-        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+        final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
-        if(page == null) {
-            response.setStatus(HttpStatus.NOT_FOUND.value());
-            return;
+        if (page == null) {
+            throw new ResourceNotFoundException("Page " + pageId + " not found");
         }
 
-        if(section.equals(Page.PageSection.ALL)) {
+        if (section.equals(Page.PageSection.ALL)) {
             page.setSections(new ArrayList<Page.PageSection>());
             page.getSections().add(Page.PageSection.DRAFT);
-        } else if(section.equals(Page.PageSection.DRAFT)) {
+        } else if (section.equals(Page.PageSection.DRAFT)) {
             // Cannot remove a page from DRAFT section
-        } else if(page.getSections().contains(section)) {
+        } else if (page.getSections().contains(section)) {
             page.getSections().remove(section);
         }
 
         pageRepository.save(page);
     }
 
-    // STATUS OPERATION methods
 
-    @ApiOperation(
-            value = "Removes the page from a section. This means that the link to the page will not be shown in the list associated to that section.",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "removePageFromSection")
-    @RequestMapping(
-            value = "/{language}/{pageId}/{status}",
-            method = RequestMethod.PUT)
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = PAGE_UPDATED),
+    @ApiOperation(value = "Changes the status of a page.", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "removePageFromSection")
+    @RequestMapping(value = "/{language}/{pageId}/{status}", method = RequestMethod.PUT)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = PAGE_UPDATED),
             @ApiResponse(code = 404, message = PAGE_NOT_FOUND),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
-    })
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT) })
     @PreAuthorize("hasRole('Administrator')")
     public void changePageStatus(
             @PathVariable(value = "language") final String language,
             @PathVariable(value = "pageId") final String pageId,
             @PathVariable(value = "status") final Page.PageStatus status,
-            @ApiIgnore final HttpServletResponse response
-            ) {
+            @ApiIgnore final HttpServletResponse response) throws ResourceNotFoundException {
+
 
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
 
-        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+        final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
 
-        if(page == null) {
-            response.setStatus(HttpStatus.NOT_FOUND.value());
-            return;
+        if (page == null) {
+            throw new ResourceNotFoundException("Page " + pageId + " not found");
         }
 
         page.setStatus(status);
@@ -415,61 +375,205 @@ public class PagesAPI {
         pageRepository.save(page);
     }
 
-    // LIST PAGES methods
 
-    @ApiOperation(
-            value = "List all pages according to the filters",
-            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
-            nickname = "listPages")
-    @RequestMapping(
-            value = "/list",
-            method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
-    })
+    @ApiOperation(value = "List all pages according to the filters", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>", nickname = "listPages")
+    @RequestMapping(value = "/list", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = { @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW) })
     @ResponseBody
-    public ResponseEntity<List<Page>> listPages(
+    public ResponseEntity<List<PageJSONWrapper>> listPages(
             @RequestParam(value = "language", required = false) final String language,
             @RequestParam(value = "section", required = false) final Page.PageSection section,
             @RequestParam(value = "format", required = false) final Page.PageFormat format,
             @ApiIgnore final HttpServletResponse response,
-            @ApiIgnore final HttpSession session
-            ) {
-        final ApplicationContext appContext = ApplicationContextHolder.get();
-        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+            @ApiIgnore final HttpSession session) {
 
-        UserSession us = ApiUtils.getUserSession(session);
+
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        final PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        final UserSession us = ApiUtils.getUserSession(session);
         List<Page> unfilteredResult = null;
 
-        if(language == null) {
+        if (language == null) {
             unfilteredResult = pageRepository.findAll();
         } else {
             unfilteredResult = pageRepository.findByPageIdentityLanguage(language);
         }
 
-        List<Page> filteredResult = new ArrayList<Page>();
+        final List<PageJSONWrapper> filteredResult = new ArrayList<>();
 
-        for (Page page : unfilteredResult) {
-            if((page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile()== Profile.Administrator) ||
-                    (page.getStatus().equals(Page.PageStatus.PRIVATE) && us.getProfile()!= null && us.getProfile()!= Profile.Guest ) ||
-                    page.getStatus().equals(Page.PageStatus.PUBLIC)) {
-                if(section == null || Page.PageSection.ALL.equals(section)) {
-                    filteredResult.add(page);
+        for (final Page page : unfilteredResult) {
+            if (page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() == Profile.Administrator
+                    || page.getStatus().equals(Page.PageStatus.PRIVATE) && us.getProfile() != null && us.getProfile() != Profile.Guest
+                    || page.getStatus().equals(Page.PageStatus.PUBLIC)
+                    || page.getStatus().equals(Page.PageStatus.PUBLIC_ONLY) && !us.isAuthenticated()) {
+                if (section == null || Page.PageSection.ALL.equals(section)) {
+                    filteredResult.add(new PageJSONWrapper(page));
                 } else {
-                    List<Page.PageSection> sections = page.getSections();
-                    boolean containsALL = sections.contains(Page.PageSection.ALL);
-                    boolean containsRequestedSection = sections.contains(section);
-                    if(containsALL || containsRequestedSection) {
-                        filteredResult.add(page);
+                    final List<Page.PageSection> sections = page.getSections();
+                    final boolean containsALL = sections.contains(Page.PageSection.ALL);
+                    final boolean containsRequestedSection = sections.contains(section);
+                    if (containsALL || containsRequestedSection) {
+                        filteredResult.add(new PageJSONWrapper(page));
                     }
                 }
             }
         }
 
-        return new ResponseEntity<List<Page>>(filteredResult, HttpStatus.OK);
+        return new ResponseEntity<>(filteredResult, HttpStatus.OK);
     }
 
-}
 
+    /* Local Utility and constants */
+
+    /**
+     * Check correct format.
+     *
+     * @param data the data
+     * @param link the link
+     * @param format the format
+     */
+    private void checkCorrectFormat(final MultipartFile data, final String link, final Page.PageFormat format) {
+        // Cannot set format to LINK and upload a file
+        if (Page.PageFormat.LINK.equals(format) && data != null && !data.isEmpty()) {
+            throw new IllegalArgumentException("Wrong format");
+        }
+
+        // Cannot set a link without setting format to LINK
+        if (!Page.PageFormat.LINK.equals(format) && !StringUtils.isBlank(link)) {
+            throw new IllegalArgumentException("Wrong format");
+        }
+    }
+
+    /**
+     * Check unique content.
+     *
+     * @param data the data
+     * @param link the link
+     */
+    private void checkUniqueContent(final MultipartFile data, final String link) {
+        // Cannot set both: link and file
+        if (!StringUtils.isBlank(link) && data != null && !data.isEmpty()) {
+            throw new IllegalArgumentException("Cannot define link and file in the same page");
+        }
+    }
+
+    /**
+     * Check file type.
+     *
+     * @param data the data
+     */
+    private void checkFileType(final MultipartFile data) {
+        if (data != null) {
+            String extension = FilenameUtils.getExtension(data.getOriginalFilename());
+            final String[] supportedExtensions = { "html", "HTML", "txt", "TXT", "md", "MD" };
+
+            if (!ArrayUtils.contains(supportedExtensions, extension)) {
+                throw new MultipartException("Unsuppoted file type (only html, txt and md are allowed)");
+            }
+        }
+    }
+
+    /**
+     * Check permissions on single page and return.
+     *
+     * @param session the session
+     * @param page the page
+     * @return the response entity
+     */
+    private ResponseEntity<PageJSONWrapper> checkPermissionsOnSinglePageAndReturn(final HttpSession session, final Page page) {
+        if (page == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } else {
+            final UserSession us = ApiUtils.getUserSession(session);
+            if (page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() != Profile.Administrator) {
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+            } else if (page.getStatus().equals(Page.PageStatus.PRIVATE) && (us.getProfile() == null || us.getProfile() == Profile.Guest)) {
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+            } else {
+                return new ResponseEntity<>(new PageJSONWrapper(page), HttpStatus.OK);
+            }
+        }
+    }
+
+    /**
+     * Search page.
+     *
+     * @param language the language
+     * @param pageId the page id
+     * @param pageRepository the page repository
+     * @return the page
+     * @throws ResourceNotFoundException the resource not found exception
+     */
+    private Page searchPage(final String language, final String pageId, final PageRepository pageRepository)
+            throws ResourceNotFoundException {
+        final Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if (page == null) {
+            throw new ResourceNotFoundException("Page " + pageId + " not found");
+        }
+        return page;
+    }
+
+
+    /**
+     *
+     * @param language
+     * @param pageId
+     * @param format
+     * @return An empty hidden draft Page
+     */
+    private Page getEmptyHiddenDraftPage(final String language, final String pageId, final Page.PageFormat format) {
+        final List<Page.PageSection> sections = new ArrayList<>();
+        sections.add(Page.PageSection.DRAFT);
+        Page page = new Page(new PageIdentity(language, pageId), null, null, format, sections, Page.PageStatus.HIDDEN);
+        return page;
+    }
+
+
+    /**
+     * Set the content with file or with provided link
+     *
+     * @param data the file
+     * @param link the link
+     * @param page the page to set content
+     */
+    private void fillContent(final MultipartFile data, final String link, final Page page) {
+        byte[] bytesData = null;
+        if (data != null && !data.isEmpty()) {
+            checkFileType(data);
+            try {
+                bytesData = data.getBytes();
+            } catch (final Exception e) {
+                // Wrap into managed exception
+                throw new WebApplicationException(e);
+            }
+            page.setData(bytesData);
+        }
+
+        if (link != null && !UrlUtils.isValidRedirectUrl(link)) {
+            throw new IllegalArgumentException("The link provided is not valid");
+        } else {
+            page.setLink(link);
+        }
+    }
+
+    /* HTTP status messages not from ApiParams */
+
+    private static final String PAGE_OK = "Page found";
+
+    private static final String PAGE_NOT_FOUND = "Page not found";
+
+    private static final String PAGE_DUPLICATE = "Page already in the system: use PUT";
+
+    private static final String PAGE_SAVED = "Page saved";
+
+    private static final String PAGE_UPDATED = "Page changes saved";
+
+    private static final String PAGE_DELETED = "Page removed";
+
+    private static final String ERROR_FILE = "File not valid";
+
+    private static final String ERROR_CREATE = "Wrong parameters are provided";
+
+}

--- a/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.api.pages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.api.API;
+import org.fao.geonet.api.ApiParams;
+import org.fao.geonet.domain.page.Page;
+import org.fao.geonet.domain.page.PageIdentity;
+import org.fao.geonet.repository.page.PageRepository;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RequestMapping(value = { "/api", "/api/" + API.VERSION_0_1 })
+@Api(value = "pages", tags = "pages",
+description = "Static pages inside GeoNetwork")
+@Controller("pages")
+public class PagesAPI {
+
+    // HTTP status messages not from ApiParams
+    private static final String PAGE_NOT_FOUND="Page not found";
+    private static final String PAGE_DUPLICATE="Page already in the system: use PUT";
+    private static final String PAGE_SAVED="Page saved";
+    private static final String PAGE_UPDATED="Page changes saved";
+    private static final String PAGE_DELETED="Page removed";
+
+    // WRITE, EDIT, DELETE, READ Page methods
+
+    @ApiOperation(
+            value = "Add a new Page object in DRAFT section in status HIDDEN",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "addPage")
+    @RequestMapping(
+            value = "/",
+            method = RequestMethod.POST)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = PAGE_SAVED),
+            @ApiResponse(code = 404, message = PAGE_NOT_FOUND),
+            @ApiResponse(code = 409, message = PAGE_DUPLICATE),
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+    })
+    @ResponseBody
+    public void addPage(
+            @RequestParam(value = "language", required=true) final String language,
+            @RequestParam(value = "pageId", required=true) final String pageId,
+            @RequestParam(value = "data", required=false) final String data,
+            @RequestParam(value = "format", required=true) final Page.PageFormat format,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        if(pageRepository.findOne(new PageIdentity(language, pageId)) == null) {
+
+            List<Page.PageSection> sections = new ArrayList<Page.PageSection>();
+            sections.add(Page.PageSection.DRAFT);
+            Page page = new Page(new PageIdentity(language, pageId), data, format, sections, Page.PageStatus.HIDDEN);
+
+            pageRepository.save(page);
+        } else {
+            response.setStatus(HttpStatus.CONFLICT.value());
+        }
+    }
+
+    @ApiOperation(
+            value = "Edit a Page object",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "editPage")
+    @RequestMapping(
+            value = "/{language}/{pageId}",
+            method = RequestMethod.PUT)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = PAGE_UPDATED),
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+    })
+    @ResponseBody
+    public void editPage(
+            @PathVariable(value = "language") final String language,
+            @PathVariable(value = "pageId") final String pageId,
+            @RequestParam(value = "data", required=false) final String data,
+            @RequestParam(value = "format", required=true) final Page.PageFormat format,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if(page == null) {
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            return;
+        }
+
+        page.setData(data);
+        page.setFormat(format);
+
+        pageRepository.save(page);
+    }
+
+    @ApiOperation(
+            value = "Delete a Page object",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "deletePage")
+    @RequestMapping(
+            value = "/{language}/{pageId}",
+            method = RequestMethod.DELETE)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = PAGE_DELETED),
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+    })
+    @ResponseBody
+    public void deletePage(
+            @PathVariable(value = "language") final String language,
+            @PathVariable(value = "pageId") final String pageId,
+            @RequestParam(value = "data", required=false) final String data,
+            @RequestParam(value = "format", required=true) final Page.PageFormat format,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if(page == null) {
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            return;
+        }
+
+        pageRepository.delete(new PageIdentity(language, pageId));        
+    }
+
+    @ApiOperation(
+            value = "Return the page object",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "getPage")
+    @RequestMapping(
+            value = "/{language}/{pageId}",
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
+    })
+    @ResponseBody
+    public Page getPage(
+            @PathVariable(value = "language") final String language,
+            @PathVariable(value = "pageId") final String pageId,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if(page == null) {
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            return null;
+        }
+
+        return page;
+    }
+
+    @ApiOperation(
+            value = "Return the static html content identified by pageId",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "getPage")
+    @RequestMapping(
+            value = "/{language}/{pageId}/data",
+            method = RequestMethod.GET,
+            produces = MediaType.TEXT_HTML_VALUE)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
+    })
+    @ResponseBody
+    public String getPageContent(
+            @PathVariable(value = "language") final String language,
+            @PathVariable(value = "pageId") final String pageId,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if(page == null) {
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            return null;
+        }
+
+        return page.getData();
+    }
+
+
+    // SECTION OPERATIONS methods
+
+    @ApiOperation(
+            value = "Adds the page to a section. This means that the link to the page will be shown in the list associated to that section.",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "addPageToSection")
+    @RequestMapping(
+            value = "/{language}/{pageId}/{section}",
+            method = RequestMethod.POST)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = PAGE_UPDATED),
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+    })
+    @ResponseBody
+    public void addPageToSection(
+            @PathVariable(value = "language") final String language,
+            @PathVariable(value = "pageId") final String pageId,
+            @PathVariable(value = "section") final Page.PageSection section,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if(page == null) {
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            return;
+        }
+
+        Page.PageSection sectionToAdd = section;
+
+        if(sectionToAdd.equals(Page.PageSection.ALL)) {
+            page.setSections(new ArrayList<Page.PageSection>());
+            page.getSections().add(sectionToAdd);
+        } else if(!page.getSections().contains(sectionToAdd)) {
+            page.getSections().add(sectionToAdd);
+        }
+
+        pageRepository.save(page);
+    }
+
+    @ApiOperation(
+            value = "Removes the page from a section. This means that the link to the page will not be shown in the list associated to that section.",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "removePageFromSection")
+    @RequestMapping(
+            value = "/{language}/{pageId}/{section}",
+            method = RequestMethod.DELETE)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = PAGE_UPDATED),
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+    })
+    @ResponseBody
+    public void removePageFromSection(
+            @PathVariable(value = "language") final String language,
+            @PathVariable(value = "pageId") final String pageId,
+            @PathVariable(value = "section") final Page.PageSection section,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if(page == null) {
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            return;
+        }
+
+        if(section.equals(Page.PageSection.ALL)) {
+            page.setSections(new ArrayList<Page.PageSection>());
+            page.getSections().add(Page.PageSection.DRAFT);
+        } else if(section.equals(Page.PageSection.DRAFT)) {
+            // Cannot remove a page from DRAFT section
+        } else if(page.getSections().contains(section)) {
+            page.getSections().remove(section);
+        }
+
+        pageRepository.save(page);
+    }
+
+    // STATUS OPERATION methods
+
+    @ApiOperation(
+            value = "Removes the page from a section. This means that the link to the page will not be shown in the list associated to that section.",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "removePageFromSection")
+    @RequestMapping(
+            value = "/{language}/{pageId}/{status}",
+            method = RequestMethod.PUT)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = PAGE_UPDATED),
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+    })
+    @ResponseBody
+    public void changePageStatus(
+            @PathVariable(value = "language") final String language,
+            @PathVariable(value = "pageId") final String pageId,
+            @PathVariable(value = "status") final Page.PageStatus status,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        Page page = pageRepository.findOne(new PageIdentity(language, pageId));
+
+        if(page == null) {
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            return;
+        }
+
+        page.setStatus(status);
+
+        pageRepository.save(page);
+    }
+
+    // LIST PAGES methods
+
+    @ApiOperation(
+            value = "List all pages according to the filters",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/define-static-pages/define-pages.html'>More info</a>",
+            nickname = "listPages")
+    @RequestMapping(
+            value = "/list",
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
+    })
+    @ResponseBody
+    public List<Page> listPages(
+            @RequestParam(value = "language", required = false) final String language,
+            @RequestParam(value = "section", required = false) final Page.PageSection section,
+            @RequestParam(value = "format", required = false) final Page.PageFormat format,
+            @ApiIgnore final HttpServletResponse response
+            ) {
+        final ApplicationContext appContext = ApplicationContextHolder.get();
+        PageRepository pageRepository = appContext.getBean(PageRepository.class);
+
+        return pageRepository.findAll();
+
+    }
+
+}
+

--- a/web-ui/src/main/resources/catalog/components/pages/GnStaticPagesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/pages/GnStaticPagesDirective.js
@@ -42,7 +42,7 @@
 
               $http({
                 method: 'GET',
-                url: '../api/pages/' + $scope.language + '/' + page + '/data'
+                url: '../api/pages/' + $scope.language + '/' + page + '/content'
               }).then(function mySuccess(response) {
                 $scope.content = response.data;
               }, function myError(response) {

--- a/web-ui/src/main/resources/catalog/components/pages/GnStaticPagesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/pages/GnStaticPagesDirective.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_static_pages_directive');
+
+  var module = angular.module('gn_static_pages_directive', []);
+
+  module.directive(
+      'gnStaticPagesViewer', ['$http', '$location',
+        function($http, $location) {
+        return {
+          restrict: 'AEC',
+          replace: true,
+          scope: {
+            language: '@language'
+          },
+          templateUrl: '../../catalog/components/pages/partials/content.html',
+          link: function($scope) {
+            $scope.loadPageContent = function() {
+              var page = $location.search().page;
+
+              $http({
+                method: 'GET',
+                url: '../api/pages/' + $scope.language + '/' + page + '/data'
+              }).then(function mySuccess(response) {
+                $scope.content = response.data;
+              }, function myError(response) {
+                $scope.content = 'Page not available';
+                console.log(response.statusText);
+              });
+
+            };
+
+            function reloadPageContent() {
+              $scope.loadPageContent();
+            }
+
+            $scope.$on('$locationChangeSuccess', reloadPageContent);
+
+            $scope.loadPageContent();
+          }
+        };
+      }]);
+
+  module.directive(
+      'gnStaticPagesListViewer', ['$http', '$location',
+        function($http, $location) {
+        return {
+          restrict: 'AEC',
+          replace: true,
+          scope: {
+            language: '@language',
+            section: '@section'
+          },
+          templateUrl: function(elem, attr) {
+            return '../../catalog/components/pages/partials/' + attr.section + '.html';
+          },
+          link: function($scope) {
+
+            $scope.loadPages = function() {
+              $http({
+                method: 'GET',
+                url: '../api/pages/list?language=' + $scope.language + '&section=' + $scope.section.toUpperCase()
+              }).then(function mySuccess(response) {
+                  $scope.pagesList = response.data;
+              }, function myError(response) {
+                $scope.pagesList = null;
+                console.log(response.statusText);
+              });
+            };
+
+            $scope.loadPages();
+
+          }
+        };
+      }]);
+})();

--- a/web-ui/src/main/resources/catalog/components/pages/GnStaticPagesModule.js
+++ b/web-ui/src/main/resources/catalog/components/pages/GnStaticPagesModule.js
@@ -20,16 +20,13 @@
  * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
  * Rome - Italy. email: geonetwork@osgeo.org
  */
-package org.fao.geonet.repository.page;
 
-import java.util.List;
+(function() {
+  goog.provide('gn_static_pages');
 
-import org.fao.geonet.domain.page.Page;
-import org.fao.geonet.domain.page.PageIdentity;
-import org.springframework.data.jpa.repository.JpaRepository;
+  goog.require('gn_static_pages_directive');
 
-public interface PageRepository extends JpaRepository<Page, PageIdentity> {
-    
-    List<Page> findByPageIdentityLanguage(String language);
+  var module = angular.module('gn_static_pages',
+      ['gn_static_pages_directive']);
 
-}
+})();

--- a/web-ui/src/main/resources/catalog/components/pages/partials/content.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/content.html
@@ -1,0 +1,1 @@
+<div data-ng-bind-html="content"></div>

--- a/web-ui/src/main/resources/catalog/components/pages/partials/footer.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/footer.html
@@ -1,5 +1,10 @@
 <li data-ng-repeat="page in pagesList">
-  <a data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.pageIdentity.linkText}}?page={{page.pageIdentity.linkText}}" title="{{page.pageIdentity.linkText}}" data-ng-click="changePage($event)">
-    <span>{{page.pageIdentity.linkText}}</span>
+  <a data-ng-show="{{page.format=='LINK'}}" title="{{page.linkText}}" href="{{page.link}}" target="_blank" >
+    <i class="fa fa-fw hidden-sm"></i>
+    <span>{{page.linkText}}</span>
+  </a>
+  <a data-ng-show="{{page.format!='LINK'}}" data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.linkText}}?page={{page.linkText}}" title="{{page.linkText}}" data-ng-click="changePage($event)">
+    <i class="fa fa-fw hidden-sm"></i>
+    <span>{{page.linkText}}</span>
   </a>
 </li>

--- a/web-ui/src/main/resources/catalog/components/pages/partials/footer.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/footer.html
@@ -1,0 +1,5 @@
+<li data-ng-repeat="page in pagesList">
+  <a data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.pageIdentity.linkText}}?page={{page.pageIdentity.linkText}}" title="{{page.pageIdentity.linkText}}" data-ng-click="changePage($event)">
+    <span>{{page.pageIdentity.linkText}}</span>
+  </a>
+</li>

--- a/web-ui/src/main/resources/catalog/components/pages/partials/menu.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/menu.html
@@ -1,0 +1,10 @@
+<li data-ng-repeat="page in pagesList">
+  <a data-ng-show="{{page.format=='LINK'}}" title="{{page.linkText}}" href="{{page.link}}" target="_blank" >
+    <i class="fa fa-fw hidden-sm"></i>
+    <span>{{page.linkText}}</span>
+  </a>
+  <a data-ng-show="{{page.format!='LINK'}}" data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.linkText}}?page={{page.linkText}}" title="{{page.linkText}}" data-ng-click="changePage($event)">
+    <i class="fa fa-fw hidden-sm"></i>
+    <span>{{page.linkText}}</span>
+  </a>
+</li>

--- a/web-ui/src/main/resources/catalog/components/pages/partials/top.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/top.html
@@ -1,6 +1,10 @@
 <li data-ng-repeat="page in pagesList">
-  <a data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.pageIdentity.linkText}}?page={{page.pageIdentity.linkText}}" title="{{page.pageIdentity.linkText}}" data-ng-click="changePage($event)">
+  <a data-ng-show="{{page.format=='LINK'}}" title="{{page.linkText}}" href="{{page.link}}" target="_blank" >
     <i class="fa fa-fw hidden-sm"></i>
-    <span>{{page.pageIdentity.linkText}}</span>
+    <span>{{page.linkText}}</span>
+  </a>
+  <a data-ng-show="{{page.format!='LINK'}}" data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.linkText}}?page={{page.linkText}}" title="{{page.linkText}}" data-ng-click="changePage($event)">
+    <i class="fa fa-fw hidden-sm"></i>
+    <span>{{page.linkText}}</span>
   </a>
 </li>

--- a/web-ui/src/main/resources/catalog/components/pages/partials/top.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/top.html
@@ -1,0 +1,6 @@
+<li data-ng-repeat="page in pagesList">
+  <a data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.pageIdentity.linkText}}?page={{page.pageIdentity.linkText}}" title="{{page.pageIdentity.linkText}}" data-ng-click="changePage($event)">
+    <i class="fa fa-fw hidden-sm"></i>
+    <span>{{page.pageIdentity.linkText}}</span>
+  </a>
+</li>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -233,6 +233,10 @@
         },
         'signout': {
           'appUrl': '../../signout'
+        },
+        'page': {
+          'enabled': true,
+          'appUrl': '../../srv/{{lang}}/catalog.search#/page'
         }
       }
     };

--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -29,11 +29,13 @@
 
   goog.require('gn_catalog_service');
   goog.require('gn_searchsuggestion_service');
+  goog.require('gn_static_pages');
 
   var module = angular.module('gn_search_controller', [
     'ui.bootstrap.typeahead',
     'gn_searchsuggestion_service',
-    'gn_catalog_service'
+    'gn_catalog_service',
+    'gn_static_pages'
   ]);
 
   /**

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -121,6 +121,7 @@
           </li>
         </ul>
       </li>
+      <li gn-static-pages-list-viewer data-section="top" data-language="{{lang}}" />
     </ul>
 
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -14,6 +14,7 @@
   <li>
     <a href="../../doc/api" title="{{'learnTheApi' | translate}}">API</a>
   </li>
+  <li gn-static-pages-list-viewer data-section="footer" data-language="{{lang}}" />
   <li class="gn-footer-text" ng-hide="showSocialMediaLink">
     <span data-translate="">shareOn</span>
   </li>

--- a/web-ui/src/main/resources/catalog/views/default/templates/index.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/index.html
@@ -23,6 +23,8 @@
            data-ng-show="activeTab == '/map'"/>
       <div data-ng-include="'../../catalog/views/default/templates/recordView.html'"
            data-ng-show="activeTab == '/metadata'"/>
+      <div data-ng-include="'../../catalog/views/default/templates/page.html'"
+           data-ng-show="activeTab == '/page'"/>
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/index.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/index.html
@@ -24,7 +24,7 @@
       <div data-ng-include="'../../catalog/views/default/templates/recordView.html'"
            data-ng-show="activeTab == '/metadata'"/>
       <div data-ng-include="'../../catalog/views/default/templates/page.html'"
-           data-ng-show="activeTab == '/page'"/>
+           data-ng-if="activeTab == '/page'"/>
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/page.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/page.html
@@ -1,0 +1,1 @@
+Landing page.

--- a/web-ui/src/main/resources/catalog/views/default/templates/page.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/page.html
@@ -1,1 +1,2 @@
-Landing page.
+<div gn-static-pages-viewer data-language="{{lang}}"/>
+

--- a/web/src/main/webResources/WEB-INF/urlrewrite.xml
+++ b/web/src/main/webResources/WEB-INF/urlrewrite.xml
@@ -291,6 +291,14 @@
   </rule>
   <rule>
     <note>
+      Redirects to hash with page name
+      Example URL: http://localhost:8080/geonetwork/page/about
+    </note>
+    <from>^/(.*)/page/(.*)</from>
+    <to type="permanent-redirect">%{context-path}/#/page/$2?page=$2</to>
+  </rule>
+  <rule>
+    <note>
       Redirects to hash with metadata (extjs-style permalinks)
       Example URL:
       http://localhost:8080/geonetwork/apps/search/?uuid=da165110-88fd-11da-a88f-000d939bc5d8


### PR DESCRIPTION
Following https://github.com/geonetwork/core-geonetwork/issues/3173

The idea is to support the creation of static pages of HTML inside GeoNetwork. This PR implements two aspects:

- Store the HTML content
- Show the links to these pages in specific points of the user interface

Enough for a low level (serviceable via API) working implementation.

In this solution:

- The HTML content is stored in a new table of the GN's database.
- The link to pages can be showed in different points of the GN's GUI according to a list of "sections" associated to each page. In this PR is introduced the support to show the links for the top toolbar and the footer.
- Each page can be in 3 states:
       _HIDDEN_: visible to administrator
       _PRIVATE_: visible to logged users
       _PUBLIC_: visible to everyone
- Only the administrator can edit the pages and see the pages in HIDDEN status.
- The creation and the managment of the content is done via a new API, no backoffice interface is done on top of it yet:

![api](https://user-images.githubusercontent.com/1323093/48893272-4784c000-ee40-11e8-8ecc-11d4c2872ea6.png)

- For the visualization of pages is supported the TEXT and HTML format for now
- Is not possible to apply custom CSS to the page
- Any external image must be loaded externally

![example](https://user-images.githubusercontent.com/1323093/48895835-553d4400-ee46-11e8-8ec5-e996e97c3278.png)

### HOW TO LOAD A PAGE IN THE TOP MENU

* Load the content by using the method **POST /api/0.1/pages/** the mandatory fields are:
**language** (3 letters like 'eng', 'ita', 'fra' ...)
**pageId** (the identifier/link description of the page)
**format** (must be LINK if a link is associated to the page)
**the content**: **data** (a file with the page content) or a **link** (URL to another page). Define both is not possible.

At this point the page is created but not visible because is in status HIDDEN and is not loaded explicitly in any section of the page, except DRAFT that is not visible (in the future could be added to a page with an editor interface).

* To associate a page to a section is necessary to use the method **POST /api/0.1/pages/{language}/{pageId}/{section}** and to remove a page from a section **DELETE /api/0.1/pages/{language}/{pageId}/{section}**

Currently the sections implemented are TOP (top menu of the main page) and FOOTER (footer of the main page).

* The status of the page can be changed with the method **PUT /api/0.1/pages/{language}/{pageId}/{status}** where status could assume these values:
**PUBLIC** - Visible to every user
**PUBLIC_ONLY** - Visible to **not** logged users
**PRIVATE** - Visible to logged users
**HIDDEN** - Hidden to anyone

_So, to view a page it's necessary to add it to a visible section (TOP or FOOTER) and put it in a visible state._

To optimize the size of the JSON objects, to load the content of a specific page is necessary to use the method page **GET /api/0.1/pages/{language}/{pageId}/content**

Other methods in the API are to change/delete a page and to GET the list of the pages or the info of a specific one.

