### PR TITLE
Small bug in harvester creation

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -184,7 +184,7 @@
       $scope.getTplForHarvester = function() {
         // TODO : return view by calling harvester ?
         if ($scope.harvesterSelected) {
-          if ($scope.harvesterSelected.site.ogctype.match('^(WPS2)') != null){
+          if ($scope.harvesterSelected.site.ogctype && $scope.harvesterSelected.site.ogctype.match('^(WPS2)') != null){
             $scope.metadataTemplateType =$translate.instant('process');
           } else {
             $scope.metadataTemplateType =$translate.instant('layer');


### PR DESCRIPTION
On master, I'm getting this error when I try to define a new Harvester:

```
TypeError: Cannot read property 'match' of undefined
    at m.a.getTplForHarvester (gn_admin.js?v=29577de66801486a7ffd26921633d82764a02b08&:1350)
    at fn (eval at compile (lib.js?v=29577de66801486a7ffd26921633d82764a02b08:740), <anonymous>:4:245)
    at m.$digest (lib.js?v=29577de66801486a7ffd26921633d82764a02b08:653)
    at m.$apply (lib.js?v=29577de66801486a7ffd26921633d82764a02b08:657)
    at HTMLAnchorElement.<anonymous> (lib.js?v=29577de66801486a7ffd26921633d82764a02b08:781)
    at HTMLAnchorElement.dispatch (lib.js?v=29577de66801486a7ffd26921633d82764a02b08:7)
    at HTMLAnchorElement.r.handle (lib.js?v=29577de66801486a7ffd26921633d82764a02b08:7)
```

The fix is to avoid this, but to check if it would be better another kind of error message when ogctype is undefined.
