### PR TITLE
ID's added Import, Harvester and Online Resource pages

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/account.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/account.html
@@ -1,20 +1,28 @@
 <div>
   <label class="control-label">
-    <input type="checkbox"
-           data-ng-model="harvester.site.account.use"/>&nbsp;<span
-    data-translate="">useAccount</span></label>
+    <input id="gn-harvest-settings-gn-advanced-remote-checkbox"
+           type="checkbox"
+           data-ng-model="harvester.site.account.use"/>
+    <span id="gn-harvest-settings-gn-advanced-remote-label" data-translate="">useAccount</span>
+  </label>
 
   <fieldset data-ng-show="harvester.site.account.use">
-    <div>
-      <label class="control-label" data-translate="">username</label>
-      <input type="text" class="form-control"
-             data-ng-model="harvester.site.account.username"/>
-    </div>
-    <div>
-      <label class="control-label" data-translate="">password</label>
-      <input type="password" class="form-control"
-             autocomplete="off"
-             data-ng-model="harvester.site.account.password"/>
+    <div class="well">
+      <div id="gn-harvest-settings-gn-advanced-remote-username-row">
+        <label id="gn-harvest-settings-gn-advanced-remote-username-label" class="control-label" data-translate="">username</label>
+        <input id="gn-harvest-settings-gn-advanced-remote-username-input"
+              type="text"
+              class="form-control"
+              data-ng-model="harvester.site.account.username"/>
+      </div>
+      <div id="gn-harvest-settings-gn-advanced-remote-password-row">
+        <label id="gn-harvest-settings-gn-advanced-remote-password-label" class="control-label" data-translate="">password</label>
+        <input id="gn-harvest-settings-gn-advanced-remote-password-input"
+              type="password"
+              class="form-control"
+              autocomplete="off"
+              data-ng-model="harvester.site.account.password"/>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/identification.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/identification.html
@@ -1,7 +1,8 @@
 <fieldset>
   <legend data-translate="">harvesterIdentification</legend>
-  <div data-ng-class="harvester.site.name == '' ? 'has-error' : ''">
-    <label class="control-label"> <span data-translate="">harvesterName</span>
+  <div id="gn-harvest-settings-selected-name-row"
+       data-ng-class="harvester.site.name == '' ? 'has-error' : ''">
+    <label id="gn-harvest-settings-selected-name-label" class="control-label"> <span data-translate="">harvesterName</span>
       <span data-ng-hide="harvester['@type'] == 'geonetwork'"
       data-translate="">andNodeLogo</span>
     </label> <input type="hidden" class="form-control"
@@ -9,32 +10,34 @@
 
     <div class="input-group">
       <div class="input-group margin-bottom-sm">
-        <a class="input-group-addon highlight" target="_blank"
-          href="#/settings/sources"
-          title="{{'sourceTranslations' | translate}}"> <i
+        <a id="gn-harvest-settings-selected-name-button"
+           class="input-group-addon highlight"
+           target="_blank"
+           href="#/settings/sources"
+           title="{{'sourceTranslations' | translate}}"> <i
           class="fa fa-database fa-fw"></i>
-        </a> <input type="text" class="form-control"
+        </a> <input id="gn-harvest-settings-selected-name-input" type="text" class="form-control"
           data-ng-model="harvester.site.name" />
       </div>
-      <div class="input-group-btn" gn-logo-picker="harvester.site.icon"
+      <div id="gn-harvest-settings-selected-name-list" class="input-group-btn" gn-logo-picker="harvester.site.icon"
         data-ng-hide="harvester['@type'] == 'geonetwork' || harvester['@type'] == 'geonetwork20'">
       </div>
     </div>
     <p class="help-block" data-translate="">harvesterNameHelp</p>
   </div>
-  <div data-ng-show="groups.length"
+  <div id="gn-harvest-settings-selected-group-row" data-ng-show="groups.length"
     data-ng-class="harvester.site.ownerGroup == '' ? 'has-error' : ''">
-    <label class="control-label" data-translate="">harvesterGroup</label>
-    <div data-groups-combo="" data-owner-group="harvester.ownerGroup[0]"
+    <label id="gn-harvest-settings-selected-group-label" class="control-label" data-translate="">harvesterGroup</label>
+    <div id="gn-harvest-settings-selected-group-list" data-groups-combo="" data-owner-group="harvester.ownerGroup[0]"
       lang="lang" groups="groups" data-optional
       data-exclude-special-groups="true" />
 
     <p class="help-block" data-translate="">harvesterGroupHelp</p>
   </div>
-  <div data-ng-show="users.length"
+  <div id="gn-harvest-settings-selected-user-row" data-ng-show="users.length"
     data-ng-class="harvester.site.ownerUser == '' ? 'has-error' : ''">
-    <label class="control-label" data-translate="">harvesterUser</label>
-    <div data-users-combo="" data-owner-user="harvester.ownerUser[0]"
+    <label id="gn-harvest-settings-selected-user-label" class="control-label" data-translate="">harvesterUser</label>
+    <div id="gn-harvest-settings-selected-user-list" data-users-combo="" data-owner-user="harvester.ownerUser[0]"
       data-users="users"></div>
 
     <p class="help-block" data-translate="">harvesterUserHelp</p>

--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/privileges.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/privileges.html
@@ -1,16 +1,17 @@
 <fieldset>
-  <legend data-translate="">harvestedRecordPrivileges</legend>
-  <ul class="list-group">
+  <legend id="gn-harvest-settings-gn-priviliges-title" data-translate="">harvestedRecordPrivileges</legend>
+  <ul id="gn-harvest-settings-gn-priviliges-list" class="list-group">
     <li class="list-group-item">
       <div>
-        <input class="form-control" data-ng-model="groupSearch.$"
+        <input id="gn-harvest-settings-gn-priviliges-input"
+               class="form-control" data-ng-model="groupSearch.$"
                placeholder="{{'filter' | translate}}"/>
       </div>
       </tr>
     </li>
-    <li class="list-group-item">
-      <a href='' class="privilege-check-order" ng-click="sorter='checked'">{{'selected' | translate}} &#x2193;</a>
-      <a href='' ng-click="sorter='name'">{{'groups' | translate}} &#x2193;</a>
+    <li id="gn-harvest-settings-gn-priviliges-buttons" class="list-group-item">
+      <a id="gn-harvest-settings-gn-priviliges-buttons-asc" href='' class="privilege-check-order" ng-click="sorter='checked'">{{'selected' | translate}} &#x2193;</a>
+      <a id="gn-harvest-settings-gn-priviliges-buttons-desc" href='' ng-click="sorter='name'">{{'groups' | translate}} &#x2193;</a>
     </li>
     <li data-ng-repeat="g in groups" ng-if="keepInternalGroups(g)" class="list-group-item list-group-interne">
       <input type="checkbox" id="int-group-{{g['@id']}}" data-ng-model="selectedPrivileges[g['@id']]"/>

--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/schedule.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/schedule.html
@@ -1,13 +1,17 @@
 <fieldset>
-  <legend>
+  <legend id="gn-harvest-settings-selected-schedule-title">
     <span data-translate="">harvesterSchedule</span>
-    <div class="btn-group pull-right" data-toggle="buttons">
-      <label class="btn btn-primary" data-ng-click="harvester.options.status = 'active'"
+
+    <div id="gn-harvest-settings-selected-schedule-buttons" class="btn-group pull-right" data-toggle="buttons">
+      <label id="gn-harvest-settings-selected-schedule-buttons-enable"
+             class="btn btn-primary"
+             data-ng-click="harvester.options.status = 'active'"
              data-ng-class="harvester.options.status === 'active' ? 'active' : ''">
         <input type="radio" name="harvesterStatus"/>
         <strong data-translate="" class="">enable</strong>
       </label>
-      <label class="btn btn-primary"
+      <label id="gn-harvest-settings-selected-schedule-buttons-disable"
+             class="btn btn-primary"
              data-ng-class="harvester.options.status === 'active' ? '' : 'active'"
              data-ng-click="harvester.options.status = 'inactive'">
         <input type="radio" name="harvesterStatus"/>
@@ -15,12 +19,12 @@
       </label>
     </div>
   </legend>
-  <div data-ng-show="harvester.options.status === 'active'">
-    <label class="control-label" data-translate="">frequency</label>
+  <div id="gn-harvest-settings-selected-schedule-freq-row" data-ng-show="harvester.options.status === 'active'">
+    <label id="gn-harvest-settings-selected-schedule-freq-label" class="control-label" data-translate="">frequency</label>
     <div class="input-group">
-      <input type="text" class="form-control" data-ng-model="harvester.options.every"/>
+      <input id="gn-harvest-settings-selected-schedule-freq-input" type="text" class="form-control" data-ng-model="harvester.options.every"/>
       <div class="input-group-btn">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+        <button id="gn-harvest-settings-selected-schedule-freq-list" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
           <i class="fa fa-clock-o"></i>&nbsp;<span class="caret"/>
         </button>
         <ul class="dropdown-menu pull-right">
@@ -40,10 +44,10 @@
     </div>
   </div>
 
-  <div data-ng-show="harvester.options.status === 'active'">
+  <div id="gn-harvest-settings-selected-schedule-run-row" data-ng-show="harvester.options.status === 'active'">
     <label class="control-label">
-      <input type="checkbox" data-ng-model="harvester.options.oneRunOnly"/>&nbsp;
-      <span data-translate="">oneRunOnly</span>
+      <input id="gn-harvest-settings-selected-schedule-run-checkbox" type="checkbox" data-ng-model="harvester.options.oneRunOnly"/>&nbsp;
+      <span id="gn-harvest-settings-selected-schedule-run-label" data-translate="">oneRunOnly</span>
     </label>
     <p class="help-block" data-translate="">oneRunOnlyHelp</p>
   </div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -1,4 +1,4 @@
-<div>
+<div id="gn-addonlinesrc-container">
   <div class="row gn-modal-content">
     <div class="col-md-6">
       <form id="gn-upload-onlinesrc"
@@ -6,10 +6,11 @@
             class="form-horizontal"
             role="form"
             method="POST">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+        <input type="hidden" name="_csrf" value="{{csrf}}"/>
         <div class="onlinesrc-container">
 
-          <div data-ng-show="config.types.length > 1 && config.display == 'radio'">
+          <div id="gn-addonlinesrc-radio-row"
+               data-ng-show="config.types.length > 1 && config.display == 'radio'">
             <label class="radio-inline"
                    data-ng-repeat="c in config.types">
               <input type="radio"
@@ -22,7 +23,8 @@
             </label>
           </div>
 
-          <div class="form-group"
+          <div id="gn-addonlinesrc-select-row"
+               class="form-group"
                data-ng-show="config.types.length > 1 && config.display == 'select'">
             <label class="col-sm-2 control-label">
               <span data-translate="">onlineChooseDocType</span>
@@ -36,20 +38,24 @@
           </div>
 
           <br/>
-          <div class="alert alert-info"
+          <div id="gn-addonlinesrc-alert-row"
+               class="alert alert-info"
                data-ng-show="(params.linkType.label + '-help') != ((params.linkType.label + '-help') | translate)">
             {{(params.linkType.label + '-help') | translate}}
           </div>
           <br/>
           <!-- Function Combo -->
-          <div class="form-group"
+          <div id="gn-addonlinesrc-function-row"
+               class="form-group"
                data-ng-show="params.linkType.fields.function &&
                              !params.linkType.fields.function.hidden">
-            <label class="col-sm-2 control-label">
+            <label id="gn-addonlinesrc-function-label"
+                   class="col-sm-2 control-label">
               <span data-translate="">onlineFunction</span>
             </label>
             <div class="col-sm-10">
-              <div data-schema-info-combo="codelist"
+              <div id="gn-addonlinesrc-function-list"
+                   data-schema-info-combo="codelist"
                    data-init-on-load="true"
                    data-selected-info="params.function"
                    data-gn-schema-info="function" lang="lang"></div>
@@ -57,14 +63,17 @@
           </div>
 
           <!-- Protocol Combo -->
-          <div class="form-group"
+          <div id="gn-addonlinesrc-protocol-row"
+               class="form-group"
                data-ng-show="params.linkType.fields.protocol &&
                              !params.linkType.fields.protocol.hidden">
-            <label class="col-sm-2 control-label">
+            <label id="gn-addonlinesrc-protocol-label"
+                   class="col-sm-2 control-label">
               <span data-translate="">protocol</span>
             </label>
             <div class="col-sm-10">
-              <div data-schema-info-combo="element"
+              <div id="gn-addonlinesrc-protocol-list"
+                   data-schema-info-combo="element"
                    data-init-on-load="true"
                    data-selected-info="params.protocol"
                    data-gn-schema-info="protocol" lang="lang"></div>
@@ -72,26 +81,31 @@
           </div>
 
           <!-- URL text field -->
-          <div class="form-group gn-required"
+          <div id="gn-addonlinesrc-url-row"
+               class="form-group gn-required"
                data-ng-class="{'has-error' : !isFieldMultilingual('url') ? !gnAddLink.url.$valid : false}">
-            <label for="onlinesrcUrl"
+            <label id="gn-addonlinesrc-url-label"
+                   for="gn-addonlinesrc-url-list-single-input"
                    class="col-sm-2 control-label"
                    data-translate="">url</label>
 
-            <div class="col-sm-10"
+            <div id="gn-addonlinesrc-url-list-multilingual-row"
+                 class="col-sm-10"
                  data-ng-if="isFieldMultilingual('url')"
                  gn-multilingual-field="{{mdOtherLanguages}}"
                  current-language="ctrl.urlCurLang"
                  data-main-language="{{mdLang}}"
                  expanded="false">
               <input data-ng-repeat="(key, val) in mdLangs"
+                     id="gn-addonlinesrc-url-{{val}}"
                      class="form-control input-sm"
                      lang="{{val}}"
                      ng-model-options="{debounce: 500}"
                      data-ng-model="params.url[val]">
             </div>
 
-            <div class="col-sm-10" data-ng-if="!isFieldMultilingual('url')">
+            <div id="gn-addonlinesrc-url-list-single-row"
+                 class="col-sm-10" data-ng-if="!isFieldMultilingual('url')">
               <div data-ng-class="{'input-group': OGCProtocol != null}">
                 <input data-ng-model="params.url"
                        data-ng-model-options="{debounce: 500}"
@@ -100,11 +114,12 @@
                        class="form-control"
                        type="text"
                        data-ng-blur="loadCurrentLink()"
-                       id="onlinesrcUrl"
+                       id="gn-addonlinesrc-url-list-single-input"
                        placeholder="http://">
                 <span class="input-group-btn" data-ng-show="OGCProtocol != null">
                   <!-- Refresh Grid Button -->
-                  <button type="button"
+                  <button id="gn-addonlinesrc-url-list-single-button"
+                          type="button"
                           class="btn btn-warning"
                           title="{{'loadCapabilitiesLayers' | translate}}"
                           data-gn-click-and-spin="loadCurrentLink(true)">
@@ -112,25 +127,25 @@
                   </button>
                 </span>
               </div>
-
-
             </div>
           </div>
 
-
-          <div class="form-group"
+          <div id="gn-addonlinesrc-overview-row"
+               class="form-group"
                data-ng-if="isImage">
-            <label class="col-sm-2 control-label"
+            <label id="gn-addonlinesrc-overview-label"
+                   class="col-sm-2 control-label"
                    data-translate="">overview</label>
             <div class="col-sm-10">
-              <img ng-src="{{isFieldMultilingual('url') ? params.url[ctrl.urlCurLang] : params.url}}"
+              <img id="gn-addonlinesrc-overview-image"
+                   ng-src="{{isFieldMultilingual('url') ? params.url[ctrl.urlCurLang] : params.url}}"
                    class="img-thumbnail">
             </div>
           </div>
 
-
           <!-- Layers grid directive -->
           <div data-gn-layers-grid
+               id="gn-addonlinesrc-layers-row"
                data-ng-show="OGCProtocol != null"
                data-gn-selection-mode="isEditing ? 'single' : 'multiple'"
                data-layers="layers"
@@ -138,26 +153,31 @@
           </div>
 
           <!-- Name text Field -->
-          <div class="form-group"
+          <div id="gn-addonlinesrc-name-row"
+               class="form-group"
                data-ng-show="params.linkType.fields.name &&
                              !params.linkType.fields.name.hidden && !(OGCProtocol && !isEditing)">
-            <label for="onlinesrcName"
+            <label id="gn-addonlinesrc-name-label"
+                   for="gn-addonlinesrc-name-single-input"
                    class="col-sm-2 control-label"
                    data-translate="">onlineResourceName</label>
-            <div class="col-sm-10"
+            <div id="gn-addonlinesrc-name-single-row"
+                 class="col-sm-10"
                  data-ng-if="!isFieldMultilingual('name')">
-              <input ng-model="params.name"
+              <input id="gn-addonlinesrc-name-single-input"
+                     ng-model="params.name"
                      name="name"
                      type="text"
-                     id="onlinesrcName"
                      placeholder="Name">
             </div>
-            <div class="col-sm-10"
+            <div id="gn-addonlinesrc-name-multilingual-row"
+                 class="col-sm-10"
                  data-ng-if="isFieldMultilingual('name')"
                  data-gn-multilingual-field="{{mdOtherLanguages}}"
                  data-main-language="{{mdLang}}"
                  expanded="false">
               <input data-ng-repeat="(key, val) in mdLangs"
+                     id="gn-addonlinesrc-name-multilingual-{{val}}"
                      class="form-control input-sm"
                      lang="{{val}}"
                      data-ng-model="params.name[val]">
@@ -165,28 +185,33 @@
           </div>
 
           <!-- Description Text area -->
-          <div class="form-group"
+          <div id="gn-addonlinesrc-description-row"
+               class="form-group"
                data-ng-show="params.linkType.fields.desc &&
                              !params.linkType.fields.desc.hidden && !(OGCProtocol && !isEditing)">
-            <label for="onlinesrcDescr"
+            <label id="gn-addonlinesrc-description-label"
+                   for="gn-addonlinesrc-description-single-input"
                    class="col-sm-2 control-label"
                    data-translate="">description</label>
-            <div class="col-sm-10"
+            <div id="gn-addonlinesrc-description-single-row"
+                 class="col-sm-10"
                  data-ng-if="!isFieldMultilingual('desc')">
               <textarea rows="3"
+                        id="gn-addonlinesrc-description-single-textarea"
                         data-gn-autogrow=""
                         data-ng-model="params.desc"
                         class="form-control input-sm"
-                        id="onlinesrcDescr"
                         placeholder="description"
                         name="description"/>
             </div>
-            <div class="col-sm-10"
+            <div id="gn-addonlinesrc-description-multilingual-row"
+                 class="col-sm-10"
                  data-ng-if="isFieldMultilingual('desc')"
                  gn-multilingual-field="{{mdOtherLanguages}}"
                  data-main-language="{{mdLang}}"
                  expanded="false">
               <textarea data-ng-repeat="(key, val) in mdLangs"
+                        id="gn-addonlinesrc-description-multilingual-{{val}}"
                         rows="3"
                         lang="{{val}}"
                         data-ng-model="params.desc[val]"
@@ -196,39 +221,44 @@
             </div>
           </div>
 
-
           <!-- application profile text field -->
-          <div class="form-group"
+          <div id="gn-addonlinesrc-profile-row"
+               class="form-group"
                data-ng-show="params.linkType.fields.applicationProfile &&
                              !params.linkType.fields.applicationProfile.hidden">
-            <label for="applicationProfile"
+            <label id="gn-addonlinesrc-profile-label"
+                   for="gn-addonlinesrc-profile-input"
                    class="col-sm-2 control-label"
                    data-translate="">applicationProfile</label>
             <div class="col-sm-10">
               <input data-ng-model="params.applicationProfile"
+                     id="gn-addonlinesrc-profile-input"
                      name="applicationProfile"
                      class="form-control"
-                     type="text"
-                     id="applicationProfile">
+                     type="text">
             </div>
           </div>
         </div>
       </form>
     </div>
+
     <div class="col-md-6">
-      <div class="panel panel-default"
+      <div id="gn-addonlinesrc-file-panel"
+           class="panel panel-default"
            data-ng-show="params.linkType.sources.filestore">
         <div class="panel-heading"
              data-translate>fileStore
         </div>
         <div class="panel-body">
-          <div data-gn-file-store="gnCurrentEdit.uuid"
+          <div id="gn-addonlinesrc-file-input"
+               data-gn-file-store="gnCurrentEdit.uuid"
                data-select-callback="selectUploadedResource(selected)"
                data-filter="params.linkType.fileStoreFilter || ''"/>
         </div>
       </div>
 
-      <div class="panel panel-default"
+      <div id="gn-addonlinesrc-link-panel"
+           class="panel panel-default"
            data-ng-show="params.linkType.sources.metadataStore.label">
         <div class="panel-heading">
           {{params.linkType.sources.metadataStore.label | translate}}
@@ -276,38 +306,45 @@
         </div>
       </div>
 
-      <div class="panel panel-default"
+      <div id="gn-addonlinesrc-thumbnail-panel"
+           class="panel panel-default"
            data-ng-show="params.linkType.sources.thumbnailMaker">
         <div class="panel-heading"
              data-translate="">createAThumbnail
         </div>
         <div class="panel-body">
-          <div class="form-group gn-thumbnail-maker-panel">
-            <div class="alert alert-warning"
+          <div id="gn-addonlinesrc-thumbnail-map"
+               class="form-group gn-thumbnail-maker-panel">
+            <div id="gn-addonlinesrc-thumbnail-warning"
+                 class="alert alert-warning"
                  data-ng-show="layers == undefined"
                  data-translate="">noLayersForThumbnail
             </div>
             <div data-ng-hide="layers == undefined">
-            <textarea class="form-control hidden"
-                      name="config">{{jsonSpec}}</textarea>
+              <textarea id="gn-addonlinesrc-thumbnail-json"
+                        class="form-control hidden"
+                        name="config">{{jsonSpec}}</textarea>
               <input type="hidden" name="rotation" value="90"/>
               <div class="row">
                 <div class="col-xs-8">
                   <div id="{{mapId}}" class="map"></div>
                   <br/>
-                  <a class="btn btn-success btn-block"
+                  <a id="gn-addonlinesrc-thumbnail-button"
+                     class="btn btn-success btn-block"
                      data-gn-click-and-spin="generateThumbnail()"
                      title="{{'generateThumbnail-help' | translate}}">
                     <i class="fa fa-cog"></i>&nbsp;
                     <span data-translate="">generateThumbnail</a>
                 </div>
                 <div class="col-xs-4">
-                  <p class="help-block"
+                  <p id="gn-addonlinesrc-thumbnail-help"
+                     class="help-block"
                      data-translate="">thumbnailMaker-help</p>
-                  <div class="panel-body">
-                    <div data-ga-print=""
+                  <!-- <div class="panel-body"> -->
+                    <div id="gn-addonlinesrc-thumbnail-settings"
+                         data-ga-print=""
                          data-layout="Thumbnail"></div>
-                  </div>
+                  <!-- </div> -->
                 </div>
               </div>
             </div>
@@ -317,8 +354,9 @@
     </div>
   </div>
 
-  <div class="">
-    <button type="button"
+  <div id="gn-addonlinesrc-add-row">
+    <button id="gn-addonlinesrc-add-button"
+            type="button"
             class="btn navbar-btn"
             data-ng-class="gnAddLink.$valid && !isUrlOk ? 'btn-warning' : 'btn-success'"
             data-gn-click-and-spin="addOnlinesrc()">
@@ -331,10 +369,12 @@
         {{((isEditing ? 'update' : 'add') + 'LinkAnyway') | translate}}
       </span>
     </button>
-    <div data-gn-need-help="user-guide/associating-resources/linking-documents.html"
+    <div id="gn-addonlinesrc-add-help"
+         data-gn-need-help="user-guide/associating-resources/linking-documents.html"
          class="pull-right"></div>
     <br/>
-    <div class="alert alert-warning"
+    <div id="gn-addonlinesrc-add-alert"
+         class="alert alert-warning"
          data-ng-show="gnAddLink.$valid && !isUrlOk">
       <span data-translate="">areYouSureToAddALinkWithError</span>
       <a class="btn btn-link"

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -1,20 +1,21 @@
-<div class="row" data-ng-controller="GnHarvestSettingsController">
+<div id="gn-harvest-container" class="row" data-ng-controller="GnHarvestSettingsController">
   <div class="col-lg-4">
-    <div class="panel panel-default">
+    <div id="gn-harvest-select-panel" class="panel panel-default">
       <div class="panel-heading">
         <span data-translate="">harvester</span>
         <i data-ng-show="$parent.isLoadingHarvester" class="fa fa-spinner fa-spin"></i>
       </div>
 
       <div class="panel-body">
-        <input class="form-control"
+        <input id="gn-harvest-select-search"
+               class="form-control"
                data-ng-show="$parent.harvesters.length > 1"
                data-ng-model="harvesterSearch.$"
                data-ng-change="firstPage()"
                autofocus=""
                placeholder="{{'filter' | translate}}"/>
 
-        <div class="list-group" data-ng-hide="$parent.isLoadingHarvester">
+        <div id="gn-harvest-select-saved-row" class="list-group" data-ng-hide="$parent.isLoadingHarvester">
           <a href="" class="list-group-item"
              data-ng-repeat="h in pageItems()"
              data-ng-class="[h['@id'] === harvesterSelected['@id'] ? 'active' : '', h.error ? 'list-group-item-danger' : '']"
@@ -24,23 +25,26 @@
 
             <i data-ng-show="h.options.status === 'active'" class="fa fa-play"/>
             <i data-ng-show="h.options.status === 'inactive'" class="fa fa-pause"/> {{h.site.name}}
-            ({{('harvester-' + h['@type']) | translate}}) <span class="badge"
-          >{{h.info.result.total}}</span>
+            ({{('harvester-' + h['@type']) | translate}}) <span class="badge">{{h.info.result.total}}</span>
             <i data-ng-show="h.info.running" class="fa fa-spinner fa-spin"/>
           </a>
-        <span data-gn-pagination-list=""
-              data-items="$parent.harvesters | filter:harvesterSearch | orderBy:'name'"
-              data-cache="$parent.harvesters"/>
+          <span data-gn-pagination-list=""
+                data-items="$parent.harvesters | filter:harvesterSearch | orderBy:'name'"
+                data-cache="$parent.harvesters"/>
         </div>
 
-        <div class="btn-group">
-          <button type="button" class="btn btn-primary dropdown-toggle"
+        <div id="gn-harvest-select-available-row" class="btn-group">
+          <button id="gn-harvest-select-available-button"
+                  type="button"
+                  class="btn btn-primary dropdown-toggle"
                   data-toggle="dropdown">
             <i class="fa fa-plus"> </i>&nbsp;
             <span data-translate="">newHarvester</span>
             <span class="caret"/>
           </button>
-          <ul class="dropdown-menu" role="menu">
+          <ul id="gn-harvest-select-available-list"
+              class="dropdown-menu"
+              role="menu">
             <li data-ng-repeat="h in getHarvesterTypes() | orderBy:'text'"
                 data-ng-class="h.loaded ? '' : 'disabled'">
               <a href="" data-ng-click="addHarvester(h.label)"
@@ -51,13 +55,18 @@
           </ul>
         </div>
 
-        <div class="btn-group" data-ng-show="$parent.harvesters.length > 0">
-          <button type="button" class="btn dropdown-toggle" data-toggle="dropdown">
+        <div id="gn-harvest-select-clone-row" class="btn-group" data-ng-show="$parent.harvesters.length > 0">
+          <button id="gn-harvest-select-clone-button"
+                  type="button"
+                  class="btn dropdown-toggle"
+                  data-toggle="dropdown">
             <span class="fa fa-copy"></span>&nbsp;
             <span data-translate="">cloneHarvester</span>
             <span class="caret"/>
           </button>
-          <ul class="dropdown-menu" role="menu">
+          <ul id="gn-harvest-select-clone-list"
+              class="dropdown-menu"
+              role="menu">
             <li data-ng-repeat="h in $parent.harvesters | orderBy:'site.name'">
               <a href="" data-ng-click="cloneHarvester(h['@id'])"
                  title="{{'cloneHarvester' | translate}} {{h.site.name}}"> {{h.site.name}}
@@ -65,42 +74,51 @@
             </li>
           </ul>
         </div>
-        <button type="button" class="btn" data-ng-show="$parent.harvesters.length > 0"
+
+        <button id="gn-harvest-select-refresh-button"
+                type="button"
+                class="btn"
+                data-ng-show="$parent.harvesters.length > 0"
                 data-ng-click="$parent.refreshHarvester()"
                 title="{{'refreshHarvester' | translate}}">
           <span class="fa fa-refresh"></span>
         </button>
 
         <br/>
-        <div data-gn-need-help="user-guide/harvesting/index.html"></div>
+        <div id="gn-harvest-select-help-button" data-gn-need-help="user-guide/harvesting/index.html"></div>
       </div>
     </div>
   </div>
 
 
   <div class="col-lg-8" data-ng-hide="harvesterSelected['@id'] == null">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <span data-ng-hide="harvesterSelected['@id'] == ''" data-translate="">updateHarvester</span>
-        <strong
-          data-ng-hide="harvesterSelected['@id'] == ''">{{harvesterSelected.site.name}}</strong>
+    <div id="gn-harvest-settings-panel" class="panel panel-default">
+      <div class="panel-heading clearfix">
+        <span id="gn-harvest-settings-title">
+          <span data-ng-hide="harvesterSelected['@id'] == ''" data-translate="">updateHarvester</span>
+          <strong
+            data-ng-hide="harvesterSelected['@id'] == ''">{{harvesterSelected.site.name}}</strong>
 
-        <span data-ng-hide="harvesterSelected['@id'] != ''" data-translate="">newHarvester</span>
-        <strong data-ng-hide="harvesterSelected['@id'] != ''">{{'harvester-' +
-          harvesterSelected['@type'] | translate}}</strong>
-        <i data-ng-show="isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1"
-           class="fa fa-spinner fa-spin"></i>
+          <span data-ng-hide="harvesterSelected['@id'] != ''" data-translate="">newHarvester</span>
+          <strong data-ng-hide="harvesterSelected['@id'] != ''">{{'harvester-' +
+            harvesterSelected['@type'] | translate}}</strong>
+          <i data-ng-show="isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1"
+            class="fa fa-spinner fa-spin"></i>
+        </span>
 
-
-        <div class="btn-toolbar" data-ng-hide="isLoadingOneHarvester">
-          <button type="button" class="btn btn-primary pull-right"
+        <div id="gn-harvest-settings-buttons-row" class="btn-toolbar pull-right" data-ng-hide="isLoadingOneHarvester">
+          <button id="gn-harvest-settings-buttons-run"
+                  type="button"
+                  class="btn btn-primary pull-right"
                   data-ng-hide="harvesterSelected['@id'] == '' || harvesterSelected.info.running === true"
                   data-ng-disabled="deleting.indexOf(harvesterSelected['@id']) > -1"
                   data-gn-click-and-spin="runHarvester(harvesterSelected['@id'])">
             <span class="fa fa-play"></span>&nbsp;
             <span data-translate="">runHarvester</span>
           </button>
-          <button type="button" class="btn btn-primary pull-right"
+          <button id="gn-harvest-settings-buttons-stop"
+                  type="button"
+                  class="btn btn-primary pull-right"
                   data-ng-hide="harvesterSelected['@id'] == '' || harvesterSelected.info.running === false"
                   data-gn-click-and-spin="stopHarvester(harvesterSelected['@id'])"
                   data-ng-disabled="stopping || deleting.indexOf(harvesterSelected['@id']) > -1">
@@ -108,13 +126,17 @@
             <span data-translate="">stop</span>
             <i data-ng-show="stopping" class="fa fa-spinner fa-spin"></i>
           </button>
-          <button type="button" class="btn btn-primary pull-right"
+          <button id="gn-harvest-settings-buttons-save"
+                  type="button"
+                  class="btn btn-primary pull-right"
                   data-ng-disabled="harvesterSelected.info.running === true ||deleting.indexOf(harvesterSelected['@id']) > -1"
                   data-gn-click-and-spin="saveHarvester('#gn-harvester-edit')">
             <i class="fa fa-save"></i>&nbsp;
             <span data-translate="">saveHarvester</span>
           </button>
-          <button type="button" class="btn btn-danger pull-right"
+          <button id="gn-harvest-settings-buttons-delete"
+                  type="button"
+                  class="btn btn-danger pull-right"
                   data-ng-hide="harvesterSelected['@id'] == ''"
                   data-gn-click-and-spin="deleteHarvester(harvesterSelected['@id'])"
                   data-ng-disabled="harvesterSelected.info.running === true || deleting.indexOf(harvesterSelected['@id']) > -1"
@@ -126,10 +148,10 @@
       </div>
       <div class="panel-body"
            data-ng-hide="isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1">
-        <div class="alert alert-info" data-ng-show="harvesterSelected.info.running === true">
+        <div id="gn-harvest-settings-info" class="alert alert-info" data-ng-show="harvesterSelected.info.running === true">
           <strong data-translate="">harvesterIsRunning</strong>
         </div>
-        <div class="alert alert-danger" data-ng-show="harvesterSelected.error">
+        <div id="gn-harvest-settings-danger" class="alert alert-danger" data-ng-show="harvesterSelected.error">
           <strong data-translate="">harvesterError</strong>
           {{harvesterSelected.error['@id']}}
           <pre>
@@ -137,17 +159,22 @@
           </pre>
         </div>
 
-        <div data-ng-include="getTplForHarvester()"></div>
+        <div id="gn-harvest-settings-selected-row" data-ng-include="getTplForHarvester()"></div>
       </div>
     </div>
 
-    <div class="panel panel-default"
+    <div id="gn-harvest-history-panel"
+         class="panel panel-default"
          data-ng-hide="harvesterSelected['@id'] == '' || isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1">
       <div class="panel-heading">
-        <span data-translate="">harvesterHistory</span>
-        <i data-ng-show="isLoadingHarvesterHistory" class="fa fa-spinner fa-spin"></i>
-        <div class="btn-toolbar">
-          <button type="button" class="btn btn-primary pull-right btn-danger"
+        <span id="gn-harvest-history-title">
+          <span data-translate="">harvesterHistory</span>
+          <i data-ng-show="isLoadingHarvesterHistory" class="fa fa-spinner fa-spin"></i>
+        </span>
+        <div id="gn-harvest-history-buttons" class="btn-toolbar">
+          <button id="gn-harvest-history-buttons-delete"
+                  type="button"
+                  class="btn btn-primary pull-right btn-danger"
                   data-ng-hide="harvesterHistory.length === 0"
                   data-ng-click="deleteHarvesterHistory()">
             <span class="fa fa-times"></span>
@@ -156,10 +183,10 @@
         </div>
       </div>
       <div class="panel-body">
-        <div class="alert alert-info" data-ng-show="harvesterHistory.length === 0">
+        <div id="gn-harvest-history-alert" class="alert alert-info" data-ng-show="harvesterHistory.length === 0">
           <strong data-translate="">noHarvesterHistory</strong>
         </div>
-        <ul class="timeline timeline-1-col" data-ng-show="harvesterHistory.length !== 0">
+        <ul id="gn-harvest-history-timeline-row" class="timeline timeline-1-col" data-ng-show="harvesterHistory.length !== 0">
           <li class="timeline-inverted"
               data-ng-repeat="h in harvesterHistory">
             <div class="timeline-badge"
@@ -222,7 +249,7 @@
             </div>
           </li>
         </ul>
-        <ul class="pager" data-ng-show="harvesterHistory.length !== 0">
+        <ul id="gn-harvest-history-pager-row" class="pager" data-ng-show="harvesterHistory.length !== 0">
           <li data-ng-class="harvesterHistoryPaging.page == 1 ? 'disabled' : ''"
               data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
                                                                  data-ng-click="historyFirstPage()"
@@ -251,15 +278,17 @@
       </div>
     </div>
 
-
-    <div class="panel panel-default"
+    <div id="gn-harvest-records-panel"
+         class="panel panel-default"
          data-ng-hide="harvesterSelected['@id'] == '' || isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1"
          data-ng-search-form=""
          data-ng-show="searchResults.count != '0'">
       <div class="panel-heading">
-        <span data-translate="">harvesterRecords</span>
-        <div class="btn-toolbar pull-right">
-          <button type="button" class="btn btn-primary btn-warning"
+        <span id="gn-harvest-records-title" data-translate="">harvesterRecords</span>
+        <div id="gn-harvest-records-buttons" class="btn-toolbar pull-right">
+          <button id="gn-harvest-records-buttons-assign"
+                  type="button"
+                  class="btn btn-primary btn-warning"
                   data-ng-disabled="harvesterSelected.info.running === true || deleting.indexOf(harvesterSelected['@id']) > -1"
                   data-gn-click-and-spin="assignHarvestedRecordToLocalNode()">
             <span class="fa fa-database"></span>
@@ -267,7 +296,9 @@
                   data-translate-values="{records: '{{searchResults.count}}'}">assignHarvestedRecordToLocalNode</span>
           </button>
 
-          <button type="button" class="btn btn-warning"
+          <button id="gn-harvest-records-buttons-delete"
+                  type="button"
+                  class="btn btn-warning"
                   data-gn-click-and-spin="deleteHarvesterRecord(harvesterSelected['@id'])"
                   data-ng-disabled="harvesterSelected.info.running === true || deleting.indexOf(harvesterSelected['@id']) > -1"
                   title="{{'deleteHarvesterRecordsHelp' | translate}}">

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/arcsde.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/arcsde.html
@@ -1,35 +1,34 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-sde-basic-row">
+    <legend id="gn-harvest-settings-sde-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.server == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">arcsde-server</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.server"/>
+    <div id="gn-harvest-settings-sde-basic-server-row" data-ng-class="harvesterSelected.site.server == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-sde-basic-server-label" class="control-label" data-translate="">arcsde-server</label>
+      <input id="gn-harvest-settings-sde-basic-server-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.server"/>
       <p class="help-block" data-translate="">arcsde-serverHelp</p>
     </div>
-    <div data-ng-class="harvesterSelected.site.port == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">arcsde-port</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.port"/>
+    <div id="gn-harvest-settings-sde-basic-port-row" data-ng-class="harvesterSelected.site.port == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-sde-basic-port-label" class="control-label" data-translate="">arcsde-port</label>
+      <input id="gn-harvest-settings-sde-basic-port-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.port"/>
       <p class="help-block" data-translate="">arcsde-portHelp</p>
     </div>
-    <div data-ng-class="harvesterSelected.site.database == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">arcsde-database</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.database"/>
+    <div id="gn-harvest-settings-sde-basic-database-row" data-ng-class="harvesterSelected.site.database == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-sde-basic-database-label" class="control-label" data-translate="">arcsde-database</label>
+      <input id="gn-harvest-settings-sde-basic-database-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.database"/>
       <p class="help-block" data-translate="">arcsde-databaseHelp</p>
     </div>
 
-    <div>
-      <label class="control-label" data-translate="">arcsde-version</label>
-      <select class="form-control" data-ng-model="harvesterSelected.site.version">
+    <div id="gn-harvest-settings-sde-basic-version-row">
+      <label id="gn-harvest-settings-sde-basic-version-label" class="control-label" data-translate="">arcsde-version</label>
+      <select id="gn-harvest-settings-sde-basic-version-list" class="form-control" data-ng-model="harvesterSelected.site.version">
         <option value="8">{{'arcsde-version-8' | translate}}</option>
         <option value="9">{{'arcsde-version-9' | translate}}</option>
       </select>
@@ -37,21 +36,23 @@
       <p class="help-block" data-translate="">arcsde-versionHelp</p>
     </div>
 
-    <div>
-      <label class="control-label" data-translate="">arcsde-connection</label>
+    <div id="gn-harvest-settings-sde-basic-connection-row">
+      <label id="gn-harvest-settings-sde-basic-connection-label" class="control-label" data-translate="">arcsde-connection</label>
       <p class="help-block" data-translate="">arcsde-connectionHelp</p>
 
-      <label class="control-label">
-        <input type="radio" data-ng-model="harvesterSelected.site.connectionType" value="ARCSDE">
+      <label id="gn-harvest-settings-sde-basic-connection-service-row" class="control-label">
+        <input id="gn-harvest-settings-sde-basic-connection-service-radio" type="radio" data-ng-model="harvesterSelected.site.connectionType" value="ARCSDE">
         <span data-translate="">arcsde-connection-sde</span></label>
       </label><br/>
-      <label  class="control-label">
-        <input type="radio" data-ng-model="harvesterSelected.site.connectionType" value="JDBC">
+      <label id="gn-harvest-settings-sde-basic-connection-database-row" class="control-label">
+        <input id="gn-harvest-settings-sde-basic-connection-database-radio" type="radio" data-ng-model="harvesterSelected.site.connectionType" value="JDBC">
         <span data-translate="">arcsde-connection-database</span></label>
       </label><br/>
 
-      <label class="control-label" data-translate="">arcsde-connection-database-type</label>
-      <select class="form-control" data-ng-model="harvesterSelected.site.databaseType"
+      <label id="gn-harvest-settings-sde-basic-connection-database-label" class="control-label" data-translate="">arcsde-connection-database-type</label>
+      <select id="gn-harvest-settings-sde-basic-connection-database-list"
+              class="form-control"
+              data-ng-model="harvesterSelected.site.databaseType"
               data-ng-disabled="harvesterSelected.site.connectionType != 'JDBC'">
         <option value="oracle">{{'arcsde-oracle' | translate}}</option>
         <option value="postgresql">{{'arcsde-postgres' | translate}}</option>
@@ -64,22 +65,19 @@
 
   </fieldset>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-sde-advanced-row">
+    <legend id="gn-harvest-settings-sde-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-sde-advanced-validate-row">
+      <label id="gn-harvest-settings-sde-advanced-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-sde-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-sde-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
@@ -1,28 +1,27 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected" lang=""/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
 
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-csw-basic-row">
+    <legend id="gn-harvest-settings-csw-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">serviceUrl</label>
-      <input type="text" class="form-control"
+    <div id="gn-harvest-settings-csw-basic-service-row" data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-csw-basic-service-label" class="control-label" data-translate="">serviceUrl</label>
+      <input id="gn-harvest-settings-csw-basic-service-input"
+             type="text"
+             class="form-control"
              data-ng-model="harvesterSelected.site.capabilitiesUrl"/>
       <p class="help-block" data-translate="">csw-capabilitiesUrlHelp</p>
     </div>
 
-    <fieldset class="form-horizontal cswCriteriaInfo">
-      <legend data-translate="">harvesterFilter</legend>
-
+    <fieldset id="gn-harvest-settings-csw-basic-service-criteria-row" class="form-horizontal cswCriteriaInfo">
+      <legend id="gn-harvest-settings-csw-basic-service-criteria-title" data-translate="">harvesterFilter</legend>
 
       <div class="alert alert-warning"
            data-ng-show="errorRetrievingCswCapabilities === true"
@@ -60,51 +59,53 @@
   </fieldset>
 
 
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-csw-advanced-row">
+    <legend id="gn-harvest-settings-csw-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
+    <div id="gn-harvest-settings-csw-advanced-authentication-row" data-gn-harvester-account="harvesterSelected"/>
 
-    <div data-gn-harvester-account="harvesterSelected"/>
-
-    <div>
+    <div id="gn-harvest-settings-csw-advanced-duplicate-row">
       <label class="control-label">
-        <input type="checkbox"
+        <input id="gn-harvest-settings-csw-advanced-duplicate-checkbox"
+               type="checkbox"
                data-ng-model="harvesterSelected.site.rejectDuplicateResource"/>
-        <span data-translate="">csw-rejectDuplicateResource</span>
+        <span id="gn-harvest-settings-csw-advanced-duplicate-label" data-translate="">csw-rejectDuplicateResource</span>
       </label>
       <p class="help-block" data-translate="">csw-rejectDuplicateResourceHelp</p>
     </div>
 
-
-    <div data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
+    <div id="gn-harvest-settings-csw-advanced-category-row" data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
          data-label="csw-category"/>
 
 
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-csw-advanced-validate-row">
+      <label id="gn-harvest-settings-csw-advanced-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-csw-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
-    <div>
-      <label class="control-label" data-translate="">applyXSLToRecord</label>
-      <div data-gn-import-xsl="harvesterSelected.site.xslfilter"/>
+    <div id="gn-harvest-settings-csw-advanced-xsl-row">
+      <label id="gn-harvest-settings-csw-advanced-xsl-label" class="control-label" data-translate="">applyXSLToRecord</label>
+      <div id="gn-harvest-settings-csw-advanced-xsl-list" data-gn-import-xsl="harvesterSelected.site.xslfilter"/>
 
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
     </div>
-    <div>
+    <div id="gn-harvest-settings-csw-advanced-scheme-row">
       <div class="row">
-        <div class="col-lg-8 col-md-8 col-sm-8 gn-nopadding-left gn-nopadding-right">
-          <label class="control-label" data-translate="">csw-outputSchema</label>
-          <input type="text" class="form-control gn-csw-criteria" id="csw-outputSchemaInput"
+        <div id="gn-harvest-settings-csw-advanced-scheme-output-row"
+             class="col-lg-8 col-md-8 col-sm-8 gn-nopadding-left gn-nopadding-right">
+          <label id="gn-harvest-settings-csw-advanced-scheme-output-label" class="control-label" data-translate="">csw-outputSchema</label>
+          <input id="gn-harvest-settings-csw-advanced-scheme-output-input" type="text" class="form-control gn-csw-criteria" id="csw-outputSchemaInput"
                  data-ng-model="harvesterSelected.site.outputSchema"/>
         </div>
-        <div class="col-lg-4 col-md-4 col-sm-4 hidden-xs gn-nopadding-right">
-          <label class="control-label" data-translate="">csw-outputSchemaOptions</label>
-          <select data-ng-model="harvesterSelected.site.outputSchema"
+        <div id="gn-harvest-settings-csw-advanced-scheme-recommended-row"
+             class="col-lg-4 col-md-4 col-sm-4 hidden-xs gn-nopadding-right">
+          <label id="gn-harvest-settings-csw-advanced-scheme-recommended-label" class="control-label" data-translate="">csw-outputSchemaOptions</label>
+          <select id="gn-harvest-settings-csw-advanced-scheme-recommended-list"
+                  data-ng-model="harvesterSelected.site.outputSchema"
                   class="form-control gn-csw-criteria"
                   id="csw-outputSchemaOptionsSelect">
             <option value="" disabled="" data-translate="">csw-recommendedValues</option>
@@ -118,5 +119,5 @@
   </fieldset>
 
 
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-csw-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
@@ -1,88 +1,85 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected" lang=""/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-file-basic-row">
+    <legend id="gn-harvest-settings-file-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.directory == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">filesystem-directory</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.directory"/>
+    <div id="gn-harvest-settings-file-basic-directory-row" data-ng-class="harvesterSelected.site.directory == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-file-basic-directory-label" class="control-label" data-translate="">filesystem-directory</label>
+      <input id="gn-harvest-settings-file-basic-directory-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.directory"/>
       <p class="help-block" data-translate="">filesystem-directoryHelp</p>
     </div>
 
     <!--Type of record-->
-    <div>
-      <label class="control-label" data-translate="">typeOfRecord</label>
-      <div gn-recordtypes-combo="harvesterSelected.site.recordType"></div>
+    <div id="gn-harvest-settings-file-basic-type-row">
+      <label id="gn-harvest-settings-file-basic-type-label" class="control-label" data-translate="">typeOfRecord</label>
+      <div id="gn-harvest-settings-file-basic-type-list" gn-recordtypes-combo="harvesterSelected.site.recordType"></div>
     </div>
 
   </fieldset>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-file-advanved-row">
+    <legend id="gn-harvest-settings-file-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-    <div>
+    <div id="gn-harvest-settings-file-advanved-subfolders-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.site.recurse"/>
-        <span data-translate="">filesystem-recurse</span>
+        <input id="gn-harvest-settings-file-advanved-subfolders-checkbox" type="checkbox" data-ng-model="harvesterSelected.site.recurse"/>
+        <span id="gn-harvest-settings-file-advanved-subfolders-label" data-translate="">filesystem-recurse</span>
       </label>
       <p class="help-block" data-translate="">filesystem-recurseHelp</p>
     </div>
 
-    <div>
+    <div id="gn-harvest-settings-file-advanved-nodelete-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.site.nodelete"/>
-        <span data-translate="">filesystem-nodelete</span>
+        <input id="gn-harvest-settings-file-advanved-nodelete-checkbox" type="checkbox" data-ng-model="harvesterSelected.site.nodelete"/>
+        <span id="gn-harvest-settings-file-advanved-nodelete-label" data-translate="">filesystem-nodelete</span>
       </label>
       <p class="help-block" data-translate="">filesystem-nodeleteHelp</p>
     </div>
 
-    <div>
+    <div id="gn-harvest-settings-file-advanved-update-row">
       <label class="control-label">
-        <input type="checkbox"
+        <input id="gn-harvest-settings-file-advanved-update-checkbox"
+               type="checkbox"
                data-ng-model="harvesterSelected.site.checkFileLastModifiedForUpdate"/>
-        <span data-translate="">filesystem-checkFileLastModifiedForUpdate</span>
+        <span id="gn-harvest-settings-file-advanved-update-label" data-translate="">filesystem-checkFileLastModifiedForUpdate</span>
       </label>
-      <p class="help-block" data-translate=""
-      >filesystem-checkFileLastModifiedForUpdateHelp</p>
+      <p class="help-block" data-translate="">filesystem-checkFileLastModifiedForUpdateHelp</p>
     </div>
 
-    <div data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
+    <div id="gn-harvest-settings-file-advanved-categories-row"
+         data-gn-category="harvesterSelected.categories[0]['@id']"
+         data-lang="{{lang}}"
          data-label="category"/>
 
-
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-file-advanved-validate-row">
+      <label id="gn-harvest-settings-file-advanved-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-file-advanved-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
-    <div>
-      <label class="control-label" data-translate="">applyXSLToRecord</label>
-      <div data-gn-import-xsl="harvesterSelected.content.importxslt"/>
 
+    <div id="gn-harvest-settings-file-advanved-xsl-row">
+      <label id="gn-harvest-settings-file-advanved-xsl-label" class="control-label" data-translate="">applyXSLToRecord</label>
+      <div id="gn-harvest-settings-file-advanved-xsl-list" data-gn-import-xsl="harvesterSelected.content.importxslt"/>
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
     </div>
 
-    <div>
-      <label class="control-label" data-translate="">filesystem-beforeScript</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.beforeScript"/>
+    <div id="gn-harvest-settings-file-advanved-script-row">
+      <label id="gn-harvest-settings-file-advanved-script-label" class="control-label" data-translate="">filesystem-beforeScript</label>
+      <input id="gn-harvest-settings-file-advanved-script-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.beforeScript"/>
       <p class="help-block" data-translate="">filesystem-beforeScriptHelp</p>
     </div>
   </fieldset>
 
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-file-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geoPREST.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geoPREST.html
@@ -1,29 +1,31 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-rest-basic-row">
+    <legend id="gn-harvest-settings-rest-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.host == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">geoPREST-host</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.baseUrl"/>
+
+    <div id="gn-harvest-settings-rest-basic-host-row" data-ng-class="harvesterSelected.site.host == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-rest-basic-host-label" class="control-label" data-translate="">geoPREST-host</label>
+      <input id="gn-harvest-settings-rest-basic-host-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.baseUrl"/>
       <p class="help-block" data-translate="">geoPREST-hostHelp</p>
     </div>
 
-    <fieldset class="form-horizontal">
-      <legend data-translate="">harvesterFilter</legend>
+    <fieldset id="gn-harvest-settings-rest-basic-filter-row" class="form-horizontal">
+      <legend id="gn-harvest-settings-rest-basic-filter-title" data-translate="">harvesterFilter</legend>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">any</label>
+      <div id="gn-harvest-settings-rest-basic-filter-any-row">
+        <label id="gn-harvest-settings-rest-basic-filter-any-label" class="control-label col-lg-4" data-translate="">any</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-rest-basic-filter-any-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].freeText"/>
         </div>
         <p class="help-block" data-translate="">geoPREST-anyHelp</p>
@@ -33,29 +35,26 @@
 
   </fieldset>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-rest-advanced-row">
+    <legend id="gn-harvest-settings-rest-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-    <div data-gn-harvester-account="harvesterSelected"/>
+    <div id="gn-harvest-settings-rest-advanced-remote-row" data-gn-harvester-account="harvesterSelected"/>
 
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-rest-advanced-validate-row">
+      <label id="gn-harvest-settings-rest-advanced-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-rest-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
-    <div>
-      <label class="control-label" data-translate="">applyXSLToRecord</label>
-      <div data-gn-import-xsl="harvesterSelected.content.importxslt"/>
-
+    <div id="gn-harvest-settings-rest-advanced-xsl-row">
+      <label id="gn-harvest-settings-rest-advanced-xsl-label" class="control-label" data-translate="">applyXSLToRecord</label>
+      <div id="gn-harvest-settings-rest-advanced-xsl-list" data-gn-import-xsl="harvesterSelected.content.importxslt"/>
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
     </div>
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-rest-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.html
@@ -2,145 +2,156 @@
               <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-gn-basic-row">
+    <legend id="gn-harvest-settings-gn-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
     <div data-ng-class="harvesterSelected.site.host == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">geonetwork-host</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.host"/>
-      <p class="help-block" data-translate="">geonetwork-hostHelp</p>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.node"/>
-      <p class="help-block" data-translate="">geonetwork-nodeHelp</p>
+      <div id="gn-harvest-settings-gn-basic-host-row">
+        <label id="gn-harvest-settings-gn-basic-host-label" class="control-label" data-translate="">geonetwork-host</label>
+        <input id="gn-harvest-settings-gn-basic-host-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.host"/>
+        <p class="help-block" data-translate="">geonetwork-hostHelp</p>
+      </div>
+      <div id="gn-harvest-settings-gn-basic-srv-row">
+        <input id="gn-harvest-settings-gn-basic-srv-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.node"/>
+        <p class="help-block" data-translate="">geonetwork-nodeHelp</p>
+      </div>
     </div>
 
-    <fieldset class="form-horizontal">
-      <legend data-translate="">harvesterFilter</legend>
+    <fieldset id="gn-harvest-settings-gn-basic-filter-row" class="form-horizontal">
+      <legend id="gn-harvest-settings-gn-basic-filter-title" data-translate="">harvesterFilter</legend>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">any</label>
+      <div id="gn-harvest-settings-gn-basic-filter-any-row">
+        <label id="gn-harvest-settings-gn-basic-filter-any-label" class="control-label col-lg-4" data-translate="">any</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn-basic-filter-any-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].freeText"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">title</label>
+      <div id="gn-harvest-settings-gn-basic-filter-title-row">
+        <label id="gn-harvest-settings-gn-basic-filter-title-label" class="control-label col-lg-4" data-translate="">title</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn-basic-filter-title-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].title"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">abstract</label>
+      <div id="gn-harvest-settings-gn-basic-filter-abstract-row">
+        <label id="gn-harvest-settings-gn-basic-filter-abstract-label" class="control-label col-lg-4" data-translate="">abstract</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn-basic-filter-abstract-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].abstract"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">keyword</label>
+      <div id="gn-harvest-settings-gn-basic-filter-keyword-row">
+        <label id="gn-harvest-settings-gn-basic-filter-keyword-label"class="control-label col-lg-4" data-translate="">keyword</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn-basic-filter-keyword-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].keywords"/>
         </div>
       </div>
 
-
-      <h4 data-translate="">geonetwork-customCriteria</h4>
-      <div class="row">
-        <label class="control-label col-lg-4">
-          <input type="text" class="form-control" placeholder="criteria"
-                 data-ng-model="harvesterSelected.searches[0].anyField"/>
-        </label>
-        <div class="col-lg-8">
-          <input type="text" class="form-control" placeholder="value"
-                 data-ng-model="harvesterSelected.searches[0].anyValue"/>
+      <div id="gn-harvest-settings-gn-basic-criteria-row">
+        <h4 id="gn-harvest-settings-gn-basic-criteria-title" data-translate="">geonetwork-customCriteria</h4>
+        <div class="row">
+          <label class="col-lg-4 gn-nopadding-left gn-nopadding-right">
+            <input type="text" class="form-control" placeholder="criteria"
+                  data-ng-model="harvesterSelected.searches[0].anyField"/>
+          </label>
+          <div class="col-lg-8">
+            <input type="text" class="form-control" placeholder="value"
+                  data-ng-model="harvesterSelected.searches[0].anyValue"/>
+          </div>
         </div>
+        <p class="help-block" data-translate="">geonetwork-customCriteriaHelp</p>
       </div>
-      <p class="help-block" data-translate="">geonetwork-customCriteriaHelp</p>
 
-      <div>
-        <label class="control-label" data-translate="">source</label>
-
+      <div id="gn-harvest-settings-gn-basic-source-row">
+        <label id="gn-harvest-settings-gn-basic-source-label" class="control-label" data-translate="">source</label>
         <div class="input-group">
-                    <span class="input-group-btn">
-                        <button type="button" class="btn btn-default"
-                                data-ng-click="geonetworkGetSources(harvesterSelected.site.host)"
-                                title="{{'geonetwork-retrieveSources' | translate}}"><i
-                          class="fa fa-refresh"></i>&nbsp;</button>
-                    </span>
-          <select class="form-control"
+          <span class="input-group-btn">
+            <button id="gn-harvest-settings-gn-basic-source-button"
+                    type="button" class="btn btn-default"
+                    data-ng-click="geonetworkGetSources(harvesterSelected.site.host)"
+                    title="{{'geonetwork-retrieveSources' | translate}}">
+              <i class="fa fa-refresh"></i>&nbsp;</button>
+          </span>
+          <select id="gn-harvest-settings-gn-basic-source-list"
+                  class="form-control"
                   data-ng-options="s.uuid as s.name for s in geonetworkSources"
                   data-ng-model="harvesterSelected.searches[0].source.uuid">
             <option value=""/>
           </select>
         </div>
-
-
       </div>
     </fieldset>
 
   </fieldset>
 
 
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-gn-advanced-row">
+    <legend id="gn-harvest-settings-gn-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-    <div data-gn-harvester-account="harvesterSelected"/>
+    <div id="gn-harvest-settings-gn-advanced-remote-row" data-gn-harvester-account="harvesterSelected"/>
 
-    <div>
+    <div id="gn-harvest-settings-gn-advanced-mef-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.site.mefFormatFull"/>
-        <span data-translate="">geonetwork-mefFormatFull</span>
+        <input id="gn-harvest-settings-gn-advanced-mef-checkbox" type="checkbox" data-ng-model="harvesterSelected.site.mefFormatFull"/>
+        <span id="gn-harvest-settings-gn-advanced-mef-label" data-translate="">geonetwork-mefFormatFull</span>
       </label>
       <p class="help-block" data-translate="">geonetwork-mefFormatFullHelp</p>
     </div>
 
-    <div>
+    <div id="gn-harvest-settings-gn-advanced-date-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.site.useChangeDateForUpdate"/>
-        <span data-translate="">geonetwork-useChangeDateForUpdate</span>
+        <input id="gn-harvest-settings-gn-advanced-date-checkbox" type="checkbox" data-ng-model="harvesterSelected.site.useChangeDateForUpdate"/>
+        <span id="gn-harvest-settings-gn-advanced-date-label" data-translate="">geonetwork-useChangeDateForUpdate</span>
       </label>
       <p class="help-block" data-translate="">geonetwork-useChangeDateForUpdateHelp</p>
     </div>
 
-    <div>
+    <div id="gn-harvest-settings-gn-advanced-category-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.site.createRemoteCategory"/>
-        <span data-translate="">geonetwork-createRemoteCategory</span>
+        <input id="gn-harvest-settings-gn-advanced-category-checkbox" type="checkbox" data-ng-model="harvesterSelected.site.createRemoteCategory"/>
+        <span id="gn-harvest-settings-gn-advanced-category-label" data-translate="">geonetwork-createRemoteCategory</span>
       </label>
       <p class="help-block" data-translate="">geonetwork-createRemoteCategoryHelp</p>
     </div>
 
-    <div data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
+    <div id="gn-harvest-settings-gn-advanced-categories-row"
+         data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
          data-label="csw-category"/>
-    <div>
-      <label class="control-label" data-translate="">geonetwork-xslfilter</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.xslfilter"/>
+
+    <div id="gn-harvest-settings-gn-advanced-xsl-row">
+      <label id="gn-harvest-settings-gn-advanced-xsl-label" class="control-label" data-translate="">geonetwork-xslfilter</label>
+      <input id="gn-harvest-settings-gn-advanced-xsl-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.xslfilter"/>
       <p class="help-block" data-translate="">geonetwork-xslfilterHelp</p>
     </div>
 
-
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-gn-advanced-validate-row">
+      <label id="gn-harvest-settings-gn-advanced-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-gn-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-gn-priviliges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork20.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork20.html
@@ -1,86 +1,92 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-gn2-basic-row">
+    <legend id="gn-harvest-settings-gn2-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.host == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">geonetwork-host</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.host"/>
+
+    <div id="gn-harvest-settings-gn2-basic-host-row" data-ng-class="harvesterSelected.site.host == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-gn2-basic-host-label" class="control-label" data-translate="">geonetwork-host</label>
+      <input id="gn-harvest-settings-gn2-basic-host-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.host"/>
       <p class="help-block" data-translate="">geonetwork-hostHelp</p>
     </div>
 
-    <fieldset class="form-horizontal">
-      <legend data-translate="">harvesterFilter</legend>
+    <fieldset id="gn-harvest-settings-gn2-basic-filter-row" class="form-horizontal">
+      <legend id="gn-harvest-settings-gn2-basic-filter-title" data-translate="">harvesterFilter</legend>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">any</label>
+      <div id="gn-harvest-settings-gn2-basic-filter-any-row">
+        <label id="gn-harvest-settings-gn2-basic-filter-any-label" class="control-label col-lg-4" data-translate="">any</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn2-basic-filter-any-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].freeText"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">title</label>
+      <div id="gn-harvest-settings-gn2-basic-filter-title-row">
+        <label id="gn-harvest-settings-gn2-basic-filter-title-label" class="control-label col-lg-4" data-translate="">title</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn2-basic-filter-title-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].title"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">abstract</label>
+      <div id="gn-harvest-settings-gn2-basic-filter-abstract-row">
+        <label id="gn-harvest-settings-gn2-basic-filter-abstract-label" class="control-label col-lg-4" data-translate="">abstract</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn2-basic-filter-abstract-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].abstract"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">keyword</label>
+      <div id="gn-harvest-settings-gn2-basic-filter-keyword-row">
+        <label id="gn-harvest-settings-gn2-basic-filter-keyword-label" class="control-label col-lg-4" data-translate="">keyword</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn2-basic-filter-keyword-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].keywords"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">siteId</label>
+      <div id="gn-harvest-settings-gn2-basic-filter-site-row">
+        <label id="gn-harvest-settings-gn2-basic-filter-site-row"class="control-label col-lg-4" data-translate="">siteId</label>
         <div class="col-lg-8">
-          <input type="text" class="form-control"
+          <input id="gn-harvest-settings-gn2-basic-filter-site-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].siteId"/>
         </div>
       </div>
-
     </fieldset>
-
   </fieldset>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-gn2-advanced-row">
+    <legend id="gn-harvest-settings-gn2-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-    <div data-gn-harvester-account="harvesterSelected"/>
+    <div id="gn-harvest-settings-gn2-advanced-remote-row" data-gn-harvester-account="harvesterSelected"/>
 
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-gn2-advanced-validate-row">
+      <label id="gn-harvest-settings-gn2-advanced-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-gn2-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-gn2-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/oaipmh.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/oaipmh.html
@@ -1,49 +1,52 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected"/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-oai-basic-row">
+    <legend id="gn-harvest-settings-oai-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.host == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">oaipmh-url</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
+    <div id="gn-harvest-settings-oai-basic-url-row" data-ng-class="harvesterSelected.site.host == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-oai-basic-url-label" class="control-label" data-translate="">oaipmh-url</label>
+      <input id="gn-harvest-settings-oai-basic-url-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
       <p class="help-block" data-translate="">oaipmh-urlHelp</p>
 
       <div class="alert alert-danger" data-ng-show="oaipmhInfo !== null"> {{oaipmhInfo}}
       </div>
     </div>
 
-    <fieldset class="form-horizontal">
-      <legend data-translate="">harvesterFilter</legend>
-
-
-      <div>
-        <label class="control-label col-lg-4" data-translate="">from</label>
+    <fieldset id="gn-harvest-settings-oai-basic-filter-row" class="form-horizontal">
+      <legend id="gn-harvest-settings-oai-basic-filter-title" data-translate="">harvesterFilter</legend>
+      
+      <div id="gn-harvest-settings-oai-basic-filter-from-row">
+        <label id="gn-harvest-settings-oai-basic-filter-from-label" class="control-label col-lg-4" data-translate="">from</label>
         <div class="col-lg-8">
-          <input type="date" class="form-control"
+          <input id="gn-harvest-settings-oai-basic-filter-from-date"
+                 type="date"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].from"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">until</label>
+      <div id="gn-harvest-settings-oai-basic-filter-until-row">
+        <label id="gn-harvest-settings-oai-basic-filter-until-label" class="control-label col-lg-4" data-translate="">until</label>
         <div class="col-lg-8">
-          <input type="date" class="form-control"
+          <input id="gn-harvest-settings-oai-basic-filter-until-date"
+                 type="date"
+                 class="form-control"
                  data-ng-model="harvesterSelected.searches[0].until"/>
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">set</label>
+      <div id="gn-harvest-settings-oai-basic-filter-set-row">
+        <label id="gn-harvest-settings-oai-basic-filter-set-label" class="control-label col-lg-4" data-translate="">set</label>
         <div class="col-lg-8">
-          <select class="form-control"
+          <select id="gn-harvest-settings-oai-basic-filter-set-list"
+                  class="form-control"
                   data-ng-model="harvesterSelected.searches[0].set"
                   data-ng-options="s.name as (s.label + '(' + s.name + ')') for s in oaipmhSets">
             <option value=""></option>
@@ -51,10 +54,11 @@
         </div>
       </div>
 
-      <div>
-        <label class="control-label col-lg-4" data-translate="">prefix</label>
+      <div id="gn-harvest-settings-oai-basic-filter-prefix-row">
+        <label id="gn-harvest-settings-oai-basic-filter-prefix-label" class="control-label col-lg-4" data-translate="">prefix</label>
         <div class="col-lg-8">
-          <select class="form-control"
+          <select id="gn-harvest-settings-oai-basic-filter-prefix-list"
+                  class="form-control"
                   data-ng-model="harvesterSelected.searches[0].prefix"
                   data-ng-options="p for p in oaipmhPrefix"> </select>
         </div>
@@ -64,25 +68,24 @@
 
   </fieldset>
 
-
-  <fieldset>
+  <fieldset id="gn-harvest-settings-oai-advanced-row">
     <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-    <div data-gn-harvester-account="harvesterSelected"/>
+    <div id="gn-harvest-settings-oai-advanced-remote-row" data-gn-harvester-account="harvesterSelected"/>
 
-    <div data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
+    <div id="gn-harvest-settings-oai-advanced-categories-row"
+         data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
          data-label="category"/>
 
-    <div>
-      <label class="control-label" data-translate="">applyXSLToRecord</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.xslfilter"/>
+    <div id="gn-harvest-settings-oai-advanced-xsl-row">
+      <label id="gn-harvest-settings-oai-advanced-xsl-label" class="control-label" data-translate="">applyXSLToRecord</label>
+      <input id="gn-harvest-settings-oai-advanced-xsl-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.xslfilter"/>
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
     </div>
 
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-oai-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/ogcwxs.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/ogcwxs.html
@@ -1,27 +1,25 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected" lang=""/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-ogc-basic-row">
+    <legend id="gn-harvest-settings-ogc-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">serviceUrl</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
+
+    <div id="gn-harvest-settings-ogc-basic-service-row" data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-ogc-basic-service-label" class="control-label" data-translate="">serviceUrl</label>
+      <input id="gn-harvest-settings-ogc-basic-service-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
       <p class="help-block" data-translate="">serviceUrlHelp</p>
     </div>
-    <div data-ng-class="harvesterSelected.site.ogctype == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">serviceType</label>
 
-      <select class="form-control" data-ng-model="harvesterSelected.site.ogctype">
+    <div id="gn-harvest-settings-ogc-basic-type-row" data-ng-class="harvesterSelected.site.ogctype == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-ogc-basic-type-label" class="control-label" data-translate="">serviceType</label>
+      <select id="gn-harvest-settings-ogc-basic-type-list" class="form-control" data-ng-model="harvesterSelected.site.ogctype">
         <option
           data-ng-repeat="t in ['WMS1.0.0', 'WMS1.1.1', 'WMS1.3.0', '-', 'WFS1.0.0', 'WFS1.1.0', '-', 'WCS1.0.0', '-', 'CSW2.0.2', '-', 'WPS0.4.0', 'WPS1.0.0', 'WPS2.0.0','-', 'SOS1.0.0'] track by $index"
           value="{{t}}"
@@ -29,144 +27,135 @@
           {{t | translate}}
         </option>
       </select>
-
       <p class="help-block" data-translate="">serviceTypeHelp</p>
     </div>
   </fieldset>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-ogc-advanced-row">
+    <legend id="gn-harvest-settings-ogc-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-
-    <div data-gn-harvester-account="harvesterSelected"/>
-
+    <div id="gn-harvest-settings-ogc-advanced-remote-row" data-gn-harvester-account="harvesterSelected"/>
 
     <!-- Service metadata record -->
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-ogc-advanced-template-row">
+      <label id="gn-harvest-settings-ogc-advanced-template-label" class="control-label">
         <span data-translate="">ogcwxs-serviceTemplateUuid</span>
       </label>
-      <select class="form-control"
+      <select id="gn-harvest-settings-ogc-advanced-template-list"
+              class="form-control"
               data-ng-model="harvesterSelected.options.serviceTemplateUuid"
               data-ng-options="t['geonet:info'].uuid as t.getTitle() for t in ogcwxsTemplates">
       </select>
       <p class="help-block" data-translate="">ogcwxs-serviceTemplateUuidHelp</p>
     </div>
 
-    <div data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
+    <div id="gn-harvest-settings-ogc-advanced-category-row"
+         data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
          data-label="ogcwxs-serviceCategory"/>
 
-
     <!-- Dataset metadata records -->
-
-    <div>
+    <div id="gn-harvest-settings-ogc-advanced-record-row">
       <label class="control-label">
-        <input type="checkbox"
+        <input id="gn-harvest-settings-ogc-advanced-record-checkbox"
+               type="checkbox"
                data-ng-disabled="harvesterSelected.site.ogctype.match('^(WMS|WFS|WCS|SOS|WPS2)') == null"
                data-ng-model="harvesterSelected.options.useLayer"/>
-        <span data-translate="" translate-values="{metadataTemplateType: metadataTemplateType}">ogcwxs-createMetadataForEachLayer</span>
+        <span id="gn-harvest-settings-ogc-advanced-record-label" data-translate="" translate-values="{metadataTemplateType: metadataTemplateType}">ogcwxs-createMetadataForEachLayer</span>
       </label>
       <p class="help-block" data-translate="" translate-values="{metadataTemplateType: metadataTemplateType}">
         ogcwxs-createMetadataForEachLayerHelp</span>
     </div>
 
-    <div class="row"
+    <div id="gn-harvest-settings-ogc-advanced-records-row"
+         class="well"
          data-ng-show="harvesterSelected.options.useLayer">
-      <div class="col-md-offset-1">
-        <div>
-          <label class="control-label">
-            <input type="checkbox" data-ng-model="harvesterSelected.options.useLayerMd"/>
-            <span data-translate="" translate-values="{metadataTemplateType: metadataTemplateType}">ogcwxs-createMetadataForEachLayerUsingMetadataURL</span>
-          </label>
-          <p class="help-block" data-translate="" translate-values="{metadataTemplateType: metadataTemplateType}"
-          >ogcwxs-createMetadataForEachLayerUsingMetadataURLHelp</p>
-        </div>
-
-
-        <div>
-          <label class="control-label">
-            <span data-translate="">ogcwxs-datasetTemplateUuid</span>
-          </label>
-          <select data-ng-show="harvesterSelected.site.ogctype.match('^(WMS|WFS|WCS|SOS)') != null"
-                  class="form-control"
-                  data-ng-model="harvesterSelected.options.datasetTemplateUuid"
-                  data-ng-options="t['geonet:info'].uuid as t.getTitle() for t in ogcwxsDatasetTemplates">
-          </select>
-          <select data-ng-show="harvesterSelected.site.ogctype.match('^(WPS2)') != null"
-                  class="form-control"
-                  data-ng-model="harvesterSelected.options.serviceTemplateUuid"
-                  data-ng-options="t['geonet:info'].uuid as t.getTitle() for t in ogcwxsTemplates">
-          </select>
-          <p class="help-block" data-translate="">ogcwxs-datasetTemplateUuidHelp</p>
-        </div>
-
-
-        <div>
-          <label class="control-label">
-            <input type="checkbox"
-                   data-ng-disabled="harvesterSelected.site.ogctype.indexOf('WMS') !== 0"
-                   data-ng-model="harvesterSelected.options.createThumbnails"/>
-            <span data-translate="">ogcwxs-createThumbnails</span>
-          </label>
-          <p class="help-block" data-translate="">ogcwxs-createThumbnailsHelp</p>
-        </div>
-
-
-        <div data-gn-category="harvesterSelected.options.datasetCategory" data-lang="{{lang}}"
-             data-label="ogcwxs-datasetCategory"/>
+      <div id="gn-harvest-settings-ogc-advanced-records-imports-row">
+        <label class="control-label">
+          <input id="gn-harvest-settings-ogc-advanced-records-imports-checkbox" type="checkbox" data-ng-model="harvesterSelected.options.useLayerMd"/>
+          <span id="gn-harvest-settings-ogc-advanced-records-imports-label" data-translate="" translate-values="{metadataTemplateType: metadataTemplateType}">ogcwxs-createMetadataForEachLayerUsingMetadataURL</span>
+        </label>
+        <p class="help-block" data-translate="" translate-values="{metadataTemplateType: metadataTemplateType}"
+        >ogcwxs-createMetadataForEachLayerUsingMetadataURLHelp</p>
       </div>
+
+      <div id="gn-harvest-settings-ogc-advanced-records-template-row">
+        <label id="gn-harvest-settings-ogc-advanced-records-template-label" class="control-label">
+          <span data-translate="">ogcwxs-datasetTemplateUuid</span>
+        </label>
+        <select id="gn-harvest-settings-ogc-advanced-records-template-list" 
+                ata-ng-show="harvesterSelected.site.ogctype.match('^(WMS|WFS|WCS|SOS)') != null"
+                class="form-control"
+                data-ng-model="harvesterSelected.options.datasetTemplateUuid"
+                data-ng-options="t['geonet:info'].uuid as t.getTitle() for t in ogcwxsDatasetTemplates">
+        </select>
+        <select id="gn-harvest-settings-ogc-advanced-records-template-list-wps2"
+                data-ng-show="harvesterSelected.site.ogctype.match('^(WPS2)') != null"
+                class="form-control"
+                data-ng-model="harvesterSelected.options.serviceTemplateUuid"
+                data-ng-options="t['geonet:info'].uuid as t.getTitle() for t in ogcwxsTemplates">
+        </select>
+        <p class="help-block" data-translate="">ogcwxs-datasetTemplateUuidHelp</p>
+      </div>
+
+      <div id="gn-harvest-settings-ogc-advanced-records-thumbnail-row">
+        <label class="control-label">
+          <input id="gn-harvest-settings-ogc-advanced-records-thumbnail-checkbox"
+                 type="checkbox"
+                 data-ng-disabled="harvesterSelected.site.ogctype.indexOf('WMS') !== 0"
+                 data-ng-model="harvesterSelected.options.createThumbnails"/>
+          <span id="gn-harvest-settings-ogc-advanced-records-thumbnail-label" data-translate="">ogcwxs-createThumbnails</span>
+        </label>
+        <p class="help-block" data-translate="">ogcwxs-createThumbnailsHelp</p>
+      </div>
+
+      <div id="gn-harvest-settings-ogc-advanced-records-category-row"
+           data-gn-category="harvesterSelected.options.datasetCategory" 
+           data-lang="{{lang}}"
+           data-label="ogcwxs-datasetCategory"/>
     </div>
 
-
-
-
     <!-- Those properties are only required if a template is not used. -->
-    <div data-ng-show="harvesterSelected.options.serviceTemplateUuid == '' || harvesterSelected.options.datasetTemplateUuid == ''">
-      <label class="control-label" data-translate="">ogcwxs-topicCategory</label>
+    <div id="gn-harvest-settings-ogc-advanced-topic-row" data-ng-show="harvesterSelected.options.serviceTemplateUuid == '' || harvesterSelected.options.datasetTemplateUuid == ''">
+      <label id="gn-harvest-settings-ogc-advanced-topic-label" class="control-label" data-translate="">ogcwxs-topicCategory</label>
       <div
+        id="gn-harvest-settings-ogc-advanced-topic-list"
         data-schema-info-combo="codelist"
         data-selected-info="harvesterSelected.options.topic"
         data-gn-schema-info="gmd:MD_TopicCategoryCode"
         lang="lang"></div>
     </div>
 
-    <div data-ng-show="harvesterSelected.options.serviceTemplateUuid == '' || harvesterSelected.options.datasetTemplateUuid == ''">
-      <label class="control-label" data-translate="">ogcwxs-metadataLanguage</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.options.lang"
+    <div id="gn-harvest-settings-ogc-advanced-lang-row" data-ng-show="harvesterSelected.options.serviceTemplateUuid == '' || harvesterSelected.options.datasetTemplateUuid == ''">
+      <label id="gn-harvest-settings-ogc-advanced-lang-label"class="control-label" data-translate="">ogcwxs-metadataLanguage</label>
+      <input id="gn-harvest-settings-ogc-advanced-lang-input"
+             type="text"
+             class="form-control"
+             data-ng-model="harvesterSelected.options.lang"
              data-gn-language-picker=""/>
     </div>
 
-    <div data-ng-show="harvesterSelected.options.serviceTemplateUuid == '' || harvesterSelected.options.datasetTemplateUuid == ''">
-      <label class="control-label" data-translate="">ogcwxs-outputSchema</label>
-      <input type="text" class="form-control"
+    <div id="gn-harvest-settings-ogc-advanced-schema-row" data-ng-show="harvesterSelected.options.serviceTemplateUuid == '' || harvesterSelected.options.datasetTemplateUuid == ''">
+      <label id="gn-harvest-settings-ogc-advanced-schema-label" class="control-label" data-translate="">ogcwxs-outputSchema</label>
+      <input id="gn-harvest-settings-ogc-advanced-schema-input" type="text" class="form-control"
              data-ng-model="harvesterSelected.options.outputSchema"/>
     </div>
 
-
-
-
-
-
-
-
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-ogc-advanced-validate-row">
+      <label id="gn-harvest-settings-ogc-advanced-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-ogc-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
-    <div>
-      <label class="control-label" data-translate="">applyXSLToRecord</label>
-      <div data-gn-import-xsl="harvesterSelected.content.importxslt"/>
 
+    <div id="gn-harvest-settings-ogc-advanced-xsl-row">
+      <label id="gn-harvest-settings-ogc-advanced-xsl-label" class="control-label" data-translate="">applyXSLToRecord</label>
+      <div id="gn-harvest-settings-ogc-advanced-xsl-list" data-gn-import-xsl="harvesterSelected.content.importxslt"/>
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
     </div>
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-ogc-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/thredds.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/thredds.html
@@ -1,140 +1,144 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected" lang=""/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-thredds-basic-row">
+    <legend id="gn-harvest-settings-thredds-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">serviceUrl</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
+
+    <div id="gn-harvest-settings-thredds-basic-service-row" data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-thredds-basic-service-label" class="control-label" data-translate="">serviceUrl</label>
+      <input id="gn-harvest-settings-thredds-basic-service-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
       <p class="help-block" data-translate="">serviceUrlHelp</p>
     </div>
 
   </fieldset>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-thredds-advanced-row">
+    <legend id="gn-harvest-settings-thredds-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-
-    <div data-gn-harvester-account="harvesterSelected"/>
-
+    <div id="gn-harvest-settings-thredds-advanced-remote-row" data-gn-harvester-account="harvesterSelected"/>
 
     <!-- TODO: Could be nicer to have a list of languages -->
-    <div>
-      <label class="control-label" data-translate="">thredds-metadataLanguage</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.options.lang"/>
+    <div id="gn-harvest-settings-thredds-advanced-lang-row">
+      <label id="gn-harvest-settings-thredds-advanced-lang-label" class="control-label" data-translate="">thredds-metadataLanguage</label>
+      <input id="gn-harvest-settings-thredds-advanced-lang-input" type="text" class="form-control" data-ng-model="harvesterSelected.options.lang"/>
     </div>
 
     <!-- TODO: Should be ISO category -->
-    <div>
-      <label class="control-label" data-translate="">thredds-topic</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.options.topic"
+    <div id="gn-harvest-settings-thredds-advanced-topic-row">
+      <label id="gn-harvest-settings-thredds-advanced-topic-label" class="control-label" data-translate="">thredds-topic</label>
+      <input id="gn-harvest-settings-thredds-advanced-topic-input" type="text" class="form-control" data-ng-model="harvesterSelected.options.topic"
       />
     </div>
 
-    <div>
+    <div id="gn-harvest-settings-thredds-advanced-services-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.options.createServiceMd"/>
-        <span data-translate="">thredds-createServiceMd</span>
+        <input id="gn-harvest-settings-thredds-advanced-services-checkbox" type="checkbox" data-ng-model="harvesterSelected.options.createServiceMd"/>
+        <span id="gn-harvest-settings-thredds-advanced-services-label" data-translate="">thredds-createServiceMd</span>
       </label>
       <p class="help-block" data-translate="">thredds-createServiceMdHelp</p>
     </div>
 
-
     <!-- Collection dataset -->
-    <div class="panel panel-default">
+    <div id="gn-harvest-settings-thredds-advanced-collection-row" class="panel panel-default">
       <div class="panel-heading">
         <label class="control-label">
-          <input type="checkbox"
+          <input id="gn-harvest-settings-thredds-advanced-collection-checkbox"
+                 type="checkbox"
                  data-ng-model="harvesterSelected.options.createCollectionDatasetMd"/>
-          <span data-translate="">thredds-createCollectionDatasetMd</span>
+          <span id="gn-harvest-settings-thredds-advanced-collection-label" data-translate="">thredds-createCollectionDatasetMd</span>
         </label>
         <p class="help-block" data-translate="">thredds-createCollectionDatasetMdHelp</p>
       </div>
       <div class="panel-body"
            data-ng-show="harvesterSelected.options.createCollectionDatasetMd === true">
-        <div>
+        <div id="gn-harvest-settings-thredds-advanced-collection-ignore-row">
           <label class="control-label">
-            <input type="checkbox"
+            <input id="gn-harvest-settings-thredds-advanced-collection-ignore-checkbox"
+                   type="checkbox"
                    data-ng-model="harvesterSelected.options.ignoreHarvestOnCollections"/>
-            <span data-translate="">thredds-ignoreHarvestOnCollections</span>
+            <span id="gn-harvest-settings-thredds-advanced-collection-ignore-label" data-translate="">thredds-ignoreHarvestOnCollections</span>
           </label>
-          <p class="help-block" data-translate=""
-          >thredds-ignoreHarvestOnCollectionsHelp</p>
+          <p class="help-block" data-translate="">thredds-ignoreHarvestOnCollectionsHelp</p>
         </div>
 
-
-        <div class="radio">
+        <div id="gn-harvest-settings-thredds-advanced-collection-dif-row" class="radio">
           <label>
-            <input type="radio" name="optionsRadios"
-                   data-ng-model="threddsCollectionsMode" value="DIF" checked=""/>
+            <input id="gn-harvest-settings-thredds-advanced-collection-dif-radio"
+                   type="radio"
+                   name="optionsRadios"
+                   data-ng-model="threddsCollectionsMode"
+                   value="DIF"
+                   checked=""/>
             <span data-translate="">thredds-DIF</span>
           </label>
         </div>
         <div data-ng-show="threddsCollectionsMode === 'DIF'">
-          <label class="control-label" data-translate=""
-          >thredds-outputSchemaOnCollections</label>
-          <input type="text" class="form-control"
+          <label id="gn-harvest-settings-thredds-advanced-collection-dif-label" class="control-label" data-translate="">thredds-outputSchemaOnCollections</label>
+          <input id="gn-harvest-settings-thredds-advanced-collection-dif-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.options.outputSchemaOnCollectionsDIF"/>
         </div>
 
-        <div class="radio">
+        <div id="gn-harvest-settings-thredds-advanced-collection-uni-row" class="radio">
           <label>
-            <input type="radio" name="optionsRadios"
-                   data-ng-model="threddsCollectionsMode" value="UNIDATA" checked=""/>
+            <input id="gn-harvest-settings-thredds-advanced-collection-uni-radio"
+                   type="radio"
+                   name="optionsRadios"
+                   data-ng-model="threddsCollectionsMode"
+                   value="UNIDATA"
+                   checked=""/>
             <span data-translate="">thredds-UNIDATA</span>
           </label>
         </div>
         <div data-ng-show="threddsCollectionsMode === 'UNIDATA'">
-          <label class="control-label" data-translate=""
-          >thredds-outputSchemaOnCollections</label>
-          <input type="text" class="form-control"
-                 data-ng-model="harvesterSelected.options.outputSchemaOnCollectionsFragments"
-          />
+          <label id="gn-harvest-settings-thredds-advanced-collection-uni-label" class="control-label" data-translate="">thredds-outputSchemaOnCollections</label>
+          <input id="gn-harvest-settings-thredds-advanced-collection-uni-input"
+                 type="text"
+                 class="form-control"
+                 data-ng-model="harvesterSelected.options.outputSchemaOnCollectionsFragments"/>
         </div>
 
-        <fieldset
+        <fieldset id="gn-harvest-settings-thredds-advanced-collection-uni-options-row"
           data-ng-show="threddsCollectionsMode === 'UNIDATA' && harvesterSelected.options.outputSchemaOnCollectionsFragments">
-          <legend data-translate="">thredds-unidataCfg</legend>
+          <legend id="gn-harvest-settings-thredds-advanced-collection-uni-options-title" data-translate="">thredds-unidataCfg</legend>
 
-
-          <div>
-            <label class="control-label">
+          <div id="gn-harvest-settings-thredds-advanced-collection-uni-style-row">
+            <label id="gn-harvest-settings-thredds-advanced-collection-uni-style-label" class="control-label">
               <span data-translate="">thredds-stylesheet</span>
             </label>
-            <select class="form-control"
+            <select id="gn-harvest-settings-thredds-advanced-collection-uni-style-list"
+                    class="form-control"
                     data-ng-model="harvesterSelected.options.collectionFragmentStylesheet"
                     data-ng-options="s.id as (s.name + ' (' + s.schema + ')') for s in harvesterThreddsXSLT"> </select>
             <p class="help-block" data-translate="">thredds-stylesheetHelp</p>
           </div>
 
-          <div>
+          <div id="gn-harvest-settings-thredds-advanced-collection-uni-create-row">
             <label class="control-label">
-              <input type="checkbox"
+              <input id="gn-harvest-settings-thredds-advanced-collection-uni-create-checkbox"
+                     type="checkbox"
                      data-ng-model="harvesterSelected.options.createCollectionSubtemplates"/>
-              <span data-translate="">thredds-createCollectionSubtemplates</span>
+              <span id="gn-harvest-settings-thredds-advanced-collection-uni-create-label" data-translate="">thredds-createCollectionSubtemplates</span>
             </label>
-            <p class="help-block" data-translate=""
-            >thredds-createCollectionSubtemplatesHelp</p>
+            <p class="help-block" data-translate="">thredds-createCollectionSubtemplatesHelp</p>
           </div>
 
-          <div>
-            <label class="control-label">
+          <div id="gn-harvest-settings-thredds-advanced-collection-uni-template-row">
+            <label id="gn-harvest-settings-thredds-advanced-collection-uni-template-label" class="control-label">
               <span data-translate="">thredds-templateId</span>
             </label>
-            <select class="form-control"
+            <select id="gn-harvest-settings-thredds-advanced-collection-uni-template-list"
+                    class="form-control"
                     data-ng-model="harvesterSelected.options.collectionMetadataTemplate"
                     data-ng-options="t['@id'] as (t.schema + ' > ' + t.title) for t in harvesterTemplates"> </select>
             <p class="help-block" data-translate="">thredds-templateIdHelp</p>
@@ -144,113 +148,116 @@
 
     </div>
 
-
     <!-- Atomic dataset -->
-    <div class="panel panel-default">
+    <div id="gn-harvest-settings-thredds-advanced-atomic-row" class="panel panel-default">
       <div class="panel-heading">
         <label class="control-label">
-          <input type="checkbox"
+          <input id="gn-harvest-settings-thredds-advanced-atomic-checkbox"
+                 type="checkbox"
                  data-ng-model="harvesterSelected.options.createAtomicDatasetMd"/>
-          <span data-translate="">thredds-createAtomicDatasetMd</span>
+          <span id="gn-harvest-settings-thredds-advanced-atomic-label" data-translate="">thredds-createAtomicDatasetMd</span>
         </label>
-
         <p class="help-block" data-translate="">thredds-createAtomicDatasetMdHelp</p>
       </div>
       <div class="panel-body"
            data-ng-show="harvesterSelected.options.createAtomicDatasetMd === true">
-        <div>
+
+        <div id="gn-harvest-settings-thredds-advanced-atomic-ignore-row">
           <label class="control-label">
-            <input type="checkbox"
+            <input id="gn-harvest-settings-thredds-advanced-atomic-ignore-checkbox"
+                   type="checkbox"
                    data-ng-model="harvesterSelected.options.ignoreHarvestOnAtomics"/>
-            <span data-translate="">thredds-ignoreHarvestOnAtomics</span>
+            <span id="gn-harvest-settings-thredds-advanced-atomic-ignore-label" data-translate="">thredds-ignoreHarvestOnAtomics</span>
           </label>
           <p class="help-block" data-translate="">thredds-ignoreHarvestOnAtomicsHelp</p>
         </div>
 
-
-        <div class="radio">
+        <div id="gn-harvest-settings-thredds-advanced-atomic-dif-row" class="radio">
           <label>
-            <input type="radio" name="threddsAtomicsMode"
-                   data-ng-model="threddsAtomicsMode" value="DIF" checked=""/>
-            <span data-translate="">thredds-DIF</span>
+            <input id="gn-harvest-settings-thredds-advanced-atomic-dif-radio"
+                   type="radio"
+                   name="threddsAtomicsMode"
+                   data-ng-model="threddsAtomicsMode"
+                   value="DIF"
+                   checked=""/>
+            <span id="gn-harvest-settings-thredds-advanced-atomic-dif-label" data-translate="">thredds-DIF</span>
           </label>
         </div>
         <div data-ng-show="threddsAtomicsMode === 'DIF'">
-          <label class="control-label" data-translate=""
-          >thredds-outputSchemaOnAtomicsDIF</label>
-          <input type="text" class="form-control"
+          <label id="gn-harvest-settings-thredds-advanced-atomic-dif-label2 class="control-label" data-translate="">thredds-outputSchemaOnAtomicsDIF</label>
+          <input id="gn-harvest-settings-thredds-advanced-atomic-dif-input" type="text" class="form-control"
                  data-ng-model="harvesterSelected.options.outputSchemaOnAtomicsDIF"/>
         </div>
 
-        <div class="radio">
+        <div id="gn-harvest-settings-thredds-advanced-atomic-uni-row" class="radio">
           <label>
-            <input type="radio" name="threddsAtomicsMode"
+            <input id="gn-harvest-settings-thredds-advanced-atomic-uni-radio" type="radio" name="threddsAtomicsMode"
                    data-ng-model="threddsAtomicsMode" value="UNIDATA" checked=""/>
-            <span data-translate="">thredds-UNIDATA</span>
+            <span id="gn-harvest-settings-thredds-advanced-atomic-uni-label" data-translate="">thredds-UNIDATA</span>
           </label>
         </div>
         <div data-ng-show="threddsAtomicsMode === 'UNIDATA'">
-          <label class="control-label" data-translate=""
-          >thredds-outputSchemaOnAtomicsFragmentsUNIDATA</label>
-          <input type="text" class="form-control"
+          <label id="gn-harvest-settings-thredds-advanced-atomic-uni-label2"
+                 class="control-label" data-translate="">thredds-outputSchemaOnAtomicsFragmentsUNIDATA</label>
+          <input id="gn-harvest-settings-thredds-advanced-atomic-uni-input"
+                 type="text"
+                 class="form-control"
                  data-ng-model="harvesterSelected.options.outputSchemaOnAtomicsFragments"/>
         </div>
 
-        <fieldset
+        <fieldset id="gn-harvest-settings-thredds-advanced-atomic-uni-options-row"
           data-ng-show="threddsAtomicsMode === 'UNIDATA' && harvesterSelected.options.outputSchemaOnAtomicsFragments">
-          <legend data-translate="">thredds-unidataCfg</legend>
+          <legend id="gn-harvest-settings-thredds-advanced-atomic-uni-options-title" data-translate="">thredds-unidataCfg</legend>
 
-
-          <div>
-            <label class="control-label">
+          <div id="gn-harvest-settings-thredds-advanced-atomic-uni-style-row">
+            <label id="gn-harvest-settings-thredds-advanced-atomic-uni-style-label" class="control-label">
               <span data-translate="">thredds-stylesheet</span>
             </label>
-            <select class="form-control"
+            <select id="gn-harvest-settings-thredds-advanced-atomic-uni-style-list"
+                    class="form-control"
                     data-ng-model="harvesterSelected.options.atomicFragmentStylesheet"
                     data-ng-options="s.id as (s.name + ' (' + s.schema + ')') for s in harvesterThreddsXSLT"> </select>
             <p class="help-block" data-translate="">thredds-stylesheetHelp</p>
           </div>
 
-          <div>
+          <div id="gn-harvest-settings-thredds-advanced-atomic-uni-create-row">
             <label class="control-label">
-              <input type="checkbox"
+              <input id="gn-harvest-settings-thredds-advanced-atomic-uni-create-checkbox"
+                     type="checkbox"
                      data-ng-model="harvesterSelected.options.createAtomicSubtemplates"/>
-              <span data-translate="">thredds-createAtomicSubtemplates</span>
+              <span id="gn-harvest-settings-thredds-advanced-atomic-uni-create-label" data-translate="">thredds-createAtomicSubtemplates</span>
             </label>
-            <p class="help-block" data-translate=""
-            >thredds-createAtomicSubtemplatesHelp</p>
+            <p class="help-block" data-translate="">thredds-createAtomicSubtemplatesHelp</p>
           </div>
 
-          <div>
-            <label class="control-label">
+          <div id="gn-harvest-settings-thredds-advanced-atomic-uni-template-row">
+            <label id="gn-harvest-settings-thredds-advanced-atomic-uni-template-label" class="control-label">
               <span data-translate="">thredds-templateId</span>
             </label>
-            <select class="form-control"
+            <select id="gn-harvest-settings-thredds-advanced-atomic-uni-template-list"
+                    class="form-control"
                     data-ng-model="harvesterSelected.options.atomicMetadataTemplate"
                     data-ng-options="t['@id'] as (t.schema + ' > ' + t.title) for t in harvesterTemplates"> </select>
             <p class="help-block" data-translate="">thredds-templateIdHelp</p>
           </div>
 
-
         </fieldset>
       </div>
     </div>
 
-
-    <div>
+    <div id="gn-harvest-settings-thredds-advanced-thumbnail-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.options.createThumbnails"/>
-        <span data-translate="">thredds-createThumbnails</span>
+        <input id="gn-harvest-settings-thredds-advanced-thumbnail-checkbox" type="checkbox" data-ng-model="harvesterSelected.options.createThumbnails"/>
+        <span id="gn-harvest-settings-thredds-advanced-thumbnail-label" data-translate="">thredds-createThumbnails</span>
       </label>
       <p class="help-block" data-translate="">thredds-createThumbnailsHelp</p>
     </div>
 
-
-    <div data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
+    <div id="gn-harvest-settings-thredds-advanced-category-row"
+         data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
          data-label="thredds-datasetCategory"/>
 
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-thredds-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/webdav.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/webdav.html
@@ -1,68 +1,61 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected" lang=""/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-webdav-basic-row">
+    <legend id="gn-harvest-settings-webdav-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
 
-
-    <div data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">webdav-url</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
+    <div id="gn-harvest-settings-webdav-basic-url-row" data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-webdav-basic-url-label" class="control-label" data-translate="">webdav-url</label>
+      <input id="gn-harvest-settings-webdav-basic-url-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
       <p class="help-block" data-translate="">webdav-urlHelp</p>
     </div>
 
-    <div data-ng-class="harvesterSelected.options.subtype == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">webdav-subtype</label>
-
-      <select class="form-control" data-ng-model="harvesterSelected.options.subtype">
+    <div id="gn-harvest-settings-webdav-basic-type-row" data-ng-class="harvesterSelected.options.subtype == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-webdav-basic-type-label" class="control-label" data-translate="">webdav-subtype</label>
+      <select id="gn-harvest-settings-webdav-basic-type-list" class="form-control" data-ng-model="harvesterSelected.options.subtype">
         <option data-ng-repeat="t in ['waf', 'webdav']" value="{{t}}"
                 data-ng-selected="t == harvesterSelected.options.subtype">{{t |
           translate}}
         </option>
       </select>
-
       <p class="help-block" data-translate="">webdav-subtypeHelp</p>
     </div>
   </fieldset>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-webdav-advanced-row">
+    <legend id="gn-harvest-settings-webdav-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-    <div>
+    <div id="gn-harvest-settings-webdav-advanced-subfolder-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.options.recurse"/>
-        <span data-translate="">webdav-recurse</span>
+        <input id="gn-harvest-settings-webdav-advanced-subfolder-checkbox" type="checkbox" data-ng-model="harvesterSelected.options.recurse"/>
+        <span id="gn-harvest-settings-webdav-advanced-subfolder-label" data-translate="">webdav-recurse</span>
       </label>
       <p class="help-block" data-translate="">webdav-recurseHelp</p>
     </div>
 
-    <div data-gn-harvester-account="harvesterSelected"/>
+    <div id="gn-harvest-settings-webdav-advanced-remote-row" data-gn-harvester-account="harvesterSelected"/>
 
-    <div data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
+    <div id="gn-harvest-settings-webdav-advanced-category-row"
+         data-gn-category="harvesterSelected.categories[0]['@id']" data-lang="{{lang}}"
          data-label="category"/>
 
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-webdav-advanced-validate-row">
+      <label id="gn-harvest-settings-webdav-advanced-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-webdav-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-webdav-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/wfsfeatures.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/wfsfeatures.html
@@ -1,107 +1,97 @@
 <form data-ng-keypress="updatingHarvester()">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <div class="row">
-    <div class="col-lg-6" data-gn-harvester-identification="harvesterSelected" lang=""/>
-
-    <div class="col-lg-6" data-gn-harvester-schedule="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-id" class="col-lg-6 gn-nopadding-left" data-gn-harvester-identification="harvesterSelected"/>
+    <div id="gn-harvest-settings-selected-schedule" class="col-lg-6 gn-nopadding-right" data-gn-harvester-schedule="harvesterSelected"/>
   </div>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
+  <fieldset id="gn-harvest-settings-wfs-basic-row">
+    <legend id="gn-harvest-settings-wfs-basic-title"><span data-translate="">harvesterMainConfigurationFor</span> {{('harvester-' +
       harvesterSelected['@type']) | translate}}
     </legend>
-    <div data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
-      <label class="control-label" data-translate="">serviceUrl</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
+
+    <div id="gn-harvest-settings-wfs-basic-service-row" data-ng-class="harvesterSelected.site.url == '' ? 'has-error' : ''">
+      <label id="gn-harvest-settings-wfs-basic-service-label" class="control-label" data-translate="">serviceUrl</label>
+      <input id="gn-harvest-settings-wfs-basic-service-input" type="text" class="form-control" data-ng-model="harvesterSelected.site.url"/>
       <p class="help-block" data-translate="">serviceUrlHelp</p>
     </div>
 
-
-    <div>
-      <label class="control-label" data-translate="">wfsfeatures-query</label>
-      <textarea class="form-control" data-ng-model="harvesterSelected.options.query"/>
+    <div id="gn-harvest-settings-wfs-basic-query-row">
+      <label id="gn-harvest-settings-wfs-basic-query-label" class="control-label" data-translate="">wfsfeatures-query</label>
+      <textarea id="gn-harvest-settings-wfs-basic-query-textarea" class="form-control" data-ng-model="harvesterSelected.options.query"/>
     </div>
   </fieldset>
 
-
-  <fieldset>
-    <legend><span data-translate="">harvesterAdvancedConfigurationFor</span>
+  <fieldset id="gn-harvest-settings-wfs-advanced-row">
+    <legend id="gn-harvest-settings-wfs-advanced-title"><span data-translate="">harvesterAdvancedConfigurationFor</span>
       {{harvesterSelected['@type'] | translate}}
     </legend>
 
-
-    <div data-gn-harvester-account="harvesterSelected"/>
-
+    <div id="gn-harvest-settings-wfs-advanced-remote-row" data-gn-harvester-account="harvesterSelected"/>
 
     <!-- TODO: Could be nicer to have a list of languages -->
-    <div>
-      <label class="control-label" data-translate="">wfsfeatures-metadataLanguage</label>
-      <input type="text" class="form-control" data-ng-model="harvesterSelected.options.lang"/>
+    <div id="gn-harvest-settings-wfs-advanced-lang-row">
+      <label id="gn-harvest-settings-wfs-advanced-lang-label" class="control-label" data-translate="">wfsfeatures-metadataLanguage</label>
+      <input id="gn-harvest-settings-wfs-advanced-lang-input" type="text" class="form-control" data-ng-model="harvesterSelected.options.lang"/>
     </div>
 
-    <div>
-      <label class="control-label" data-translate="">wfsfeatures-outputSchema</label>
-      <input type="text" class="form-control"
+    <div id="gn-harvest-settings-wfs-advanced-schema-row">
+      <label id="gn-harvest-settings-wfs-advanced-schema-label" class="control-label" data-translate="">wfsfeatures-outputSchema</label>
+      <input id="gn-harvest-settings-wfs-advanced-schema-input" type="text" class="form-control"
              data-ng-model="harvesterSelected.options.outputSchema"/>
     </div>
 
-    <div>
+    <div id="gn-harvest-settings-wfs-advanced-stream-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.options.streamFeatures"/>
-        <span data-translate="">wfsfeatures-streamFeatures</span>
+        <input id="gn-harvest-settings-wfs-advanced-stream-checkbox" type="checkbox" data-ng-model="harvesterSelected.options.streamFeatures"/>
+        <span id="gn-harvest-settings-wfs-advanced-stream-label" data-translate="">wfsfeatures-streamFeatures</span>
       </label>
       <p class="help-block" data-translate="">wfsfeatures-streamFeaturesHelp</p>
     </div>
 
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-wfs-advanced-style-row">
+      <label id="gn-harvest-settings-wfs-advanced-style-label" class="control-label">
         <span data-translate="">wfsfeatures-stylesheet</span>
       </label>
-      <select class="form-control" data-ng-model="harvesterSelected.options.stylesheet"
+      <select id="gn-harvest-settings-wfs-advanced-style-list" class="form-control" data-ng-model="harvesterSelected.options.stylesheet"
               data-ng-options="s.id as (s.name + ' (' + s.schema + ')') for s in harvesterGetFeatureXSLT"> </select>
       <p class="help-block" data-translate="">wfsfeatures-stylesheetHelp</p>
     </div>
 
-
-    <div data-gn-category="harvesterSelected.options.recordsCategory" data-lang="{{lang}}"
+    <div id="gn-harvest-settings-wfs-advanced-category-row" data-gn-category="harvesterSelected.options.recordsCategory" data-lang="{{lang}}"
          data-label="wfsfeature-recordsCategory"/>
 
-
-    <div>
+    <div id="gn-harvest-settings-wfs-advanced-sub-row">
       <label class="control-label">
-        <input type="checkbox" data-ng-model="harvesterSelected.options.createSubtemplates"/>
-        <span data-translate="">wfsfeatures-createSubtemplates</span>
+        <input id="gn-harvest-settings-wfs-advanced-sub-checkbox" type="checkbox" data-ng-model="harvesterSelected.options.createSubtemplates"/>
+        <span id="gn-harvest-settings-wfs-advanced-sub-label" data-translate="">wfsfeatures-createSubtemplates</span>
       </label>
       <p class="help-block" data-translate="">wfsfeatures-createSubtemplatesHelp</p>
     </div>
 
-    <div>
-      <label class="control-label">
+    <div id="gn-harvest-settings-wfs-advanced-template-row">
+      <label id="gn-harvest-settings-wfs-advanced-template-label" class="control-label">
         <span data-translate="">wfsfeatures-templateId</span>
       </label>
-      <select class="form-control" data-ng-model="harvesterSelected.options.templateId"
+      <select id="gn-harvest-settings-wfs-advanced-template-list" class="form-control" data-ng-model="harvesterSelected.options.templateId"
               data-ng-options="t['@id'] as (t.schema + ' > ' + t.title) for t in harvesterTemplates"> </select>
       <p class="help-block" data-translate="">wfsfeatures-templateIdHelp</p>
     </div>
 
-
-    <div>
-      <label class="control-label" data-translate="">wfsfeature-subtemplateCategory</label>
-
-      <div data-gn-category="harvesterSelected.categories[0]['@id']" lang="{{lang}}"/>
+    <div id="gn-harvest-settings-wfs-advanced-subtemplate-row">
+      <label id="gn-harvest-settings-wfs-advanced-subtemplate-label" class="control-label" data-translate="">wfsfeature-subtemplateCategory</label>
+      <div id="gn-harvest-settings-wfs-advanced-subtemplate-list" data-gn-category="harvesterSelected.categories[0]['@id']" lang="{{lang}}"/>
     </div>
-    <div>
-      <label class="control-label">
+    
+    <div id="gn-harvest-settings-wfs-advanced-validate-row">
+      <label id="gn-harvest-settings-wfs-advanced-validate-label" class="control-label">
         <span data-translate="">harvesterValidate</span>
       </label>
-      <div data-gn-harvester-validation="harvesterSelected.content.validate"/>
+      <div id="gn-harvest-settings-wfs-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
   </fieldset>
 
-
-  <div data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
+  <div id="gn-harvest-settings-wfs-privileges-row" data-gn-harvester-privileges="harvesterSelected" data-lang="{{lang}}"/>
 </form>

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -10,32 +10,33 @@
         <div class="panel-body">
 
           <!--Radio button to chose mode of import-->
-          <div class="radio">
-            <label>
-              <input type="radio" data-ng-model="importMode" value="uploadFile"/>
-              <span data-translate="">uploadFile</span>
-            </label>
+          <div id="gn-import-mode-row">
+            <div id="gn-import-mode-uploadfile-row" class="radio">
+              <label>
+                <input id="gn-import-mode-uploadfile-radio" type="radio" data-ng-model="importMode" value="uploadFile"/>
+                <span id="gn-import-mode-uploadfile-label" data-translate="">uploadFile</span>
+              </label>
+            </div>
+            <div id="gn-import-mode-uploadurl-row" class="radio">
+              <label>
+                <input id="gn-import-mode-uploadurl-radio" type="radio" data-ng-model="importMode" value="uploadFileByUrl"/>
+                <span id="gn-import-mode-uploadurl-label" data-translate="">uploadFileByUrl</span>
+              </label>
+            </div>
+            <div id="gn-import-mode-copypaste-row" class="radio">
+              <label>
+                <input id="gn-import-mode-copypaste-radio" type="radio" data-ng-model="importMode" value="copyPaste"
+                      name="insert_mode" value="0"/>
+                <span id="gn-import-mode-copypaste-label" data-translate="">copyPaste</span>
+              </label>
+            </div>
+            <div id="gn-import-mode-folder-row" class="radio">
+              <label>
+                <input id="gn-import-mode-folder-radio" type="radio" data-ng-model="importMode" value="importFromDir"/>
+                <span id="gn-import-mode-folder-label" data-translate="">importFromDir</span>
+              </label>
+            </div>
           </div>
-          <div class="radio">
-            <label>
-              <input type="radio" data-ng-model="importMode" value="uploadFileByUrl"/>
-              <span data-translate="">uploadFileByUrl</span>
-            </label>
-          </div>
-          <div class="radio">
-            <label>
-              <input type="radio" data-ng-model="importMode" value="copyPaste"
-                     name="insert_mode" value="0"/>
-              <span data-translate="">copyPaste</span>
-            </label>
-          </div>
-          <div class="radio">
-            <label>
-              <input type="radio" data-ng-model="importMode" value="importFromDir"/>
-              <span data-translate="">importFromDir</span>
-            </label>
-          </div>
-
 
           <form id="gn-import" class="form-horizontal" role="form"
                 method="POST" enctype="{{enctype}}" action="{{action}}"
@@ -43,20 +44,22 @@
               <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
             <!-- Folder Path and subfolder options -->
-            <div class="form-group" data-ng-if="importMode === 'importFromDir'">
-              <label for="gn-io-directory"
+            <div id="gn-import-folder-row" class="form-group" data-ng-if="importMode === 'importFromDir'">
+              <label id="gn-import-folder-label"
+                     for="gn-import-folder-input"
                      class="col-sm-5 control-label"
                      data-translate="">directory</label>
               <div class="col-sm-7">
                 <input type="text"
                        class="form-control"
-                       id="gn-io-directory"
+                       id="gn-import-folder-input"
                        name="serverFolder"
                        data-ng-model="params.serverFolder"
                        placeholder="/tmp/metadata/to/import">
-                <div class="checkbox">
+                <div id="gn-import-subfolder-row" class="checkbox">
                   <label>
-                    <input type="checkbox"
+                    <input id="gn-import-subfolder-checkbox"
+                           type="checkbox"
                            name="recursiveSearch"
                            data-ng-model="params.recursiveSearch"/>
                     <span data-translate="">recursive</span>
@@ -66,24 +69,25 @@
             </div>
 
             <!-- Upload panel -->
-            <div class="form-group" data-ng-show="importMode === 'uploadFile'">
-              <label for="md-import-upload"
+            <div id="gn-import-uploadfile-row" class="form-group" data-ng-show="importMode === 'uploadFile'">
+              <label id="gn-import-uploadfile-label"
+                     for="md-import-upload"
                      class="col-sm-5 control-label"></label>
-              <div class="col-sm-7" id="md-import-upload">
+              <div id="gn-import-uploadfile-panel" class="col-sm-7">
 
                 <div class="panel panel-default">
                   <div class="panel-body">
 
-                <span class="btn btn-success btn-block fileinput-button">
-                  <i class="fa fa-plus fa-white"/>
-                  <span data-translate="">chooseOnlinesrc</span>
-                  <input type="file"
-                         multiple="true"
-                         id="md-import-file"
-                         name="file"/>
-                </span>
+                    <span class="btn btn-success btn-block fileinput-button">
+                      <i class="fa fa-plus fa-white"/>
+                      <span data-translate="">chooseOnlinesrc</span>
+                      <input type="file"
+                            multiple="true"
+                            id="md-import-file"
+                            name="file"/>
+                    </span>
 
-                    <ul>
+                    <ul id="gn-import-uploadfile-list">
                       <li data-ng-repeat="file in queue">
                         <div class="preview" data-file-upload-preview="file"></div>
                         {{file.name}} ({{file.type}} / {{file.size | formatFileSize}})
@@ -91,7 +95,8 @@
                       </li>
                     </ul>
 
-                    <div class="alert alert-warning"
+                    <div id="gn-import-uploadfile-alert"
+                         class="alert alert-warning"
                          data-ng-show="unsupportedFile"
                          data-translate="">unsupportedFileExtension
                     </div>
@@ -101,24 +106,30 @@
             </div>
 
             <!--copypaste metadata content-->
-            <div class="form-group" data-ng-if="importMode === 'copyPaste'">
-              <label for="gn-md-content"
+            <div id="gn-import-copypaste-row" class="form-group" data-ng-if="importMode === 'copyPaste'">
+              <label id="gn-import-copypaste-label"
+                     for="gn-import-copypaste-textarea"
                      class="col-sm-5 control-label"
                      data-translate="">metadataContent</label>
               <div class="col-sm-7">
-                <textarea class="form-control" rows="8" id="gn-md-content"
+                <textarea id="gn-import-copypaste-textarea"
+                          class="form-control"
+                          rows="8"
                           placeholder="<xml..."
                           data-ng-model="params.xml">
                 </textarea>
               </div>
             </div>
 
-            <div class="form-group" data-ng-if="importMode === 'uploadFileByUrl'">
-              <label for="gn-md-content"
+            <!-- upload by url -->
+            <div id="gn-import-uploadurl-row" class="form-group" data-ng-if="importMode === 'uploadFileByUrl'">
+              <label id="gn-import-uploadurl-label"
+                     for="gn-import-uploadurl-input"
                      class="col-sm-5 control-label"
                      data-translate="">metadataContent</label>
               <div class="col-sm-7">
-                <input class="form-control" type="text"
+                <input id="gn-import-uploadurl-input"
+                       class="form-control" type="text"
                        placeholder="http://"
                        name="url"
                        data-ng-model="params.url">
@@ -126,14 +137,14 @@
               </div>
             </div>
 
-
             <!--Type of record-->
-            <div class="form-group">
-              <label for="gn-typeOfRecord"
+            <div id="gn-import-type-row" class="form-group">
+              <label id="gn-import-type-label"
+                     for="gn-import-type-list"
                      class="col-sm-5 control-label"
                      data-translate="">typeOfRecord</label>
               <div class="col-sm-7">
-                <div id="gn-typeOfRecord"
+                <div id="gn-import-type-list"
                      gn-recordtypes-combo="params.metadataType"></div>
 
                 <input type="text" class="hidden"
@@ -142,30 +153,34 @@
               </div>
             </div>
 
-            <div class="form-group">
-              <label for="batchAction"
+            <div id="gn-import-action-row" class="form-group">
+              <label id="gn-import-action-label"
+                     for="gn-import-action-list"
                      class="col-sm-5 control-label"
                      data-translate="">uuidAction</label>
-              <div class="col-sm-7" id="batchAction">
-                <div class="radio">
+              <div id="gn-import-action-list" class="col-sm-7">
+                <div id="gn-import-action-list-none-row" class="radio">
                   <label>
-                    <input type="radio" name="uuidProcessing"
+                    <input id="gn-import-action-list-none-radio"
+                           type="radio" name="uuidProcessing"
                            data-ng-model="params.uuidProcessing"
                            value="NOTHING"/>
                     <span data-translate="">none</span>
                   </label>
                 </div>
-                <div class="radio">
+                <div id="gn-import-action-list-overwrite-row" class="radio">
                   <label>
-                    <input type="radio" name="uuidProcessing"
+                    <input id="gn-import-action-list-overwrite-radio"
+                           type="radio" name="uuidProcessing"
                            data-ng-model="params.uuidProcessing"
                            value="OVERWRITE"/>
                     <span data-translate="">overwrite</span>
                   </label>
                 </div>
-                <div class="radio">
+                <div id="gn-import-action-list-generate-row" class="radio">
                   <label>
-                    <input type="radio" name="uuidProcessing"
+                    <input id="gn-import-action-list-generate-radio"
+                           type="radio" name="uuidProcessing"
                            data-ng-model="params.uuidProcessing"
                            value="GENERATEUUID"/>
                     <span data-translate="">generateUUID</span>
@@ -174,95 +189,113 @@
               </div>
             </div>
 
-            <div class="form-group">
-              <label for="gn-io-directory"
+            <div id="gn-import-xslt-row" class="form-group">
+              <label id="gn-import-xslt-label"
+                     for="gn-import-xslt-input"
                      class="col-sm-5 control-label"
                      data-translate="">xsltToApply</label>
               <div class="col-sm-7">
                 <div data-gn-import-xsl="params.transformWith"/>
-                <input type="text"
+                <input id="gn-import-xslt-input"
+                       type="text"
                        data-ng-model="params.transformWith"
                        name="transformWith"
                        class="form-control hidden"/>
               </div>
             </div>
 
-            <div class="form-group">
+            <div id="gn-import-validate-row" class="form-group">
               <div class="col-sm-offset-5 col-sm-7">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox"
+                    <input id="gn-import-validate-checkbox"
+                           type="checkbox"
                            name="rejectIfInvalid"
                            data-ng-model="params.rejectIfInvalid"/>
-                    <span data-translate="">validate</span>
+                    <span id="gn-import-validate-label" data-translate="">validate</span>
                   </label>
                 </div>
               </div>
             </div>
 
-            <div class="form-group">
+            <div id="gn-import-publish-row" class="form-group">
               <div class="col-sm-offset-5 col-sm-7">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox"
+                    <input id="gn-import-publish-checkbox"
+                           type="checkbox"
                            name="publishToAll"
                            data-ng-disabled="!user.isReviewerOrMore() || file_type === 'mef'"
                            data-ng-model="params.publishToAll"/>
-                    <span data-translate="">publish</span>
+                    <span id="gn-import-publish-label" data-translate="">publish</span>
                   </label>
                 </div>
               </div>
             </div>
 
-            <div class="form-group">
+            <div id="gn-import-assigncatalog-row" class="form-group">
               <div class="col-sm-offset-5 col-sm-7">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox"
+                    <input id="gn-import-assigncatalog-checkbox"
+                           type="checkbox"
                            name="assignToCatalog"
                            data-ng-disabled="file_type !== 'mef'"
                            data-ng-model="params.assignToCatalog"/>
-                    <span data-translate="">assignToCatalog</span>
+                    <span id="gn-import-assigncatalog-label" data-translate="">assignToCatalog</span>
                   </label>
                 </div>
               </div>
             </div>
 
-            <div class="form-group">
-              <label class="col-sm-5 control-label" for="md-import-group"
+            <div id="gn-import-assigngroup-row" class="form-group">
+              <label id="gn-import-assigngroup-label"
+                     class="col-sm-5 control-label"
+                     for="gn-import-assigngroup-input"
                      data-translate="">assignToGroup</label>
               <div class="col-sm-7">
-                <div data-groups-combo=""
+                <div id="gn-import-assigngroup-list"
+                     data-groups-combo=""
                      data-owner-group="params.group"
                      lang="lang"
                      data-groups="groups" data-exclude-special-groups="true"/>
-                <input type="text"
+                <input id="gn-import-assigngroup-input"
+                       type="text"
                        data-ng-model="params.group"
-                       name="group" id="md-import-group"
+                       name="group"
                        class="form-control hidden"/>
               </div>
             </div>
 
-            <div class="form-group">
-              <label class="col-sm-5 control-label" for="md-import-cat"
+            <div id="gn-import-assigncategory-row" class="form-group">
+              <label id="gn-import-assigncategory-label"
+                     class="col-sm-5 control-label"
+                     for="gn-import-assigncategory-input"
                      data-translate="">assignToCategory</label>
               <div class="col-sm-7">
-                <div data-gn-category="params.category"
+                <div id="gn-import-assigncategory-list"
+                     data-gn-category="params.category"
                      data-lang="{{lang}}"/>
-                <input type="text"
-                       data-ng-model="params.category" id="md-import-cat"
+                <input id="gn-import-assigncategory-input"
+                       type="text"
+                       data-ng-model="params.category"
                        name="category"
                        class="form-control hidden"/>
               </div>
             </div>
 
-            <div class="pull-right">
-              <button type="button" class="btn btn-primary"
+            <div id="gn-import-buttons-row" class="pull-right">
+              <button id="gn-import-buttons-import"
+                      type="button"
+                      class="btn btn-primary"
                       data-ng-click="importRecords('#gn-import')"
                       title="{{'import' | translate}}">
-                <i class="fa fa-plus"/>&nbsp;<span data-translate="">importRecords</span>
+                <i class="fa fa-plus"/>&nbsp;
+                <span data-translate="">importRecords</span>
               </button>
-              <a href="#/board" class="btn btn-default">
+              <a id="gn-import-buttons-cancel"
+                 href="#/board"
+                 class="btn btn-default">
                 <i class="fa fa-close"/>&nbsp;
                 <span data-translate="">cancel</span>
               </a>
@@ -272,41 +305,43 @@
       </div>
     </div>
     <div class="col-sm-5">
-      <div class="progress progress-striped active"
+      <div id="gn-import-progress-row"
+           class="progress progress-striped active"
            data-ng-show="importing === true">
         <div class="progress-bar" style="width: 100%"/>
       </div>
 
+      <div id="gn-import-reports-row">
+        <div data-ng-repeat="report in reports track by $index">
+          <div class="panel panel-default"
+              data-ng-show="report.message || report.infos"
+              data-ng-class="report.code || (report.errors && report.errors.length > 0) ?
+                            'panel-danger' : 'panel-success'">
+            <div class="panel-heading" data-translate="">importReport</div>
+            <div class="panel-body">
 
-      <div data-ng-repeat="report in reports track by $index">
-        <div class="panel panel-default"
-             data-ng-show="report.message || report.infos"
-             data-ng-class="report.code || (report.errors && report.errors.length > 0) ?
-                          'panel-danger' : 'panel-success'">
-          <div class="panel-heading" data-translate="">importReport</div>
-          <div class="panel-body">
-
-            <p data-ng-show="report.message" translate="">
-              {{report.message}}
-            </p>
-            <p>
-              <div data-ng-repeat="(key, value) in report.infos">
-                <span>{{value.message}}</span>
-              </div>
-              <!--id and uuid from single import-->
-              <div data-ng-repeat="(key, value) in report.metadataInfos">
-                <span>{{value[0].message}}</span>
-                <a href='#/metadata/{{key}}?redirectUrl=catalog.edit'
-                   title="{{'edit' | translate}}">
-                  <i class='fa fa-pencil'></i>
-                </a>
-              </div>
-              <div data-ng-repeat="(key, value) in report.errors">
-                <span>{{value.message}}</span>
-              </div>
-              <!--Only one exception from single import-->
-              <span ng-show="report.code">{{report.description}}</span>
-            </p>
+              <p data-ng-show="report.message" translate="">
+                {{report.message}}
+              </p>
+              <p>
+                <div data-ng-repeat="(key, value) in report.infos">
+                  <span>{{value.message}}</span>
+                </div>
+                <!--id and uuid from single import-->
+                <div data-ng-repeat="(key, value) in report.metadataInfos">
+                  <span>{{value[0].message}}</span>
+                  <a href='#/metadata/{{key}}?redirectUrl=catalog.edit'
+                    title="{{'edit' | translate}}">
+                    <i class='fa fa-pencil'></i>
+                  </a>
+                </div>
+                <div data-ng-repeat="(key, value) in report.errors">
+                  <span>{{value.message}}</span>
+                </div>
+                <!--Only one exception from single import-->
+                <span ng-show="report.code">{{report.description}}</span>
+              </p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
ID's are added to be able to do automated testing and for hiding fields via `css`.

This is related to https://github.com/geonetwork/core-geonetwork/issues/3152, https://github.com/geonetwork/core-geonetwork/issues/3155 and https://github.com/geonetwork/core-geonetwork/issues/3168

The ID's are added to the following pages: 
- Import pages
- Harvester pages
- Online Resource pages