### PR TITLE
Workflow / Email not in correct language

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -116,8 +116,8 @@ public class MetadataWorkflowApi {
         throws Exception {
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
-        Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
-        ServiceContext context = ApiUtils.createServiceContext(request, locale.getISO3Language());
+        ServiceContext context = ApiUtils.createServiceContext(request, languageUtils.getIso3langCode(request.getLocales()));
+
 
 
         AccessManager am = appContext.getBean(AccessManager.class);


### PR DESCRIPTION
Use appropriate method to retrieve the correct language 3 letters code. Currently fra was returned for French for example.