### PR TITLE
hide datepicker artifact

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -295,6 +295,14 @@ span.gn-facet-label:first-letter {
   padding-right: 15px;
 }
 
+//removes some artifacts that prevent clicks on the datepicker
+.datepicker-dropdown.datepicker-orient-bottom,
+.datepicker-dropdown.datepicker-orient-top {
+  &:before, &:after {
+    display:none;
+  }
+}
+
 [gn-collapsible], [data-gn-collapsible] {
   cursor: pointer;
 }


### PR DESCRIPTION
hides some artifacts that prevent clicking on last month on the datepicker in advanced search

![image](https://user-images.githubusercontent.com/299829/49304990-338b2f00-f4ce-11e8-998f-056502afb8ad.png)
