### PR TITLE
Fix: Close a modal (#3310)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -82,7 +82,7 @@
         var myListener = $rootScope.$on(eventName,
             function(e, o) {
               $timeout(function() {
-                popup.close();
+                popup.modal('hide');
               }, 0);
               myListener();
             });


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/3310

Changed function to close a modal. The close function was trying to close a popup and not a modal. Now the bootstrap method to close a modal is used.