### PR TITLE
Bug fix - Bulk update not propagated to editor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -153,6 +153,10 @@
             scope.updateCategoriesAllowed();
           });
 
+          scope.$watch('currentCategories', function(newvalue, oldvalue) {
+              init();
+          });
+
           var init = function() {
             return $http.get('../api/tags', {cache: true}).
                 success(function(data) {


### PR DESCRIPTION
This happens most of the time (it happens in master and 3.4x).

Bug description:

- Go to the metadata board (Contribute)
- Click on the edit button of one metadata record
- Check which categories are enabled then click Cancel and go back to metadata board
- Check that record and click "Update the categories" and do some change
- Click on the edit button of that metadata record again

The bug is that the changes done with the bulk update are not shown (but are correctly saved on the database)

The bug does not belong to the bulk update in the board, but the editor. There is some delay, that causes the editor to be loaded without latest change.