### PR TITLE
Improvements in projectionSwitcher configuration

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
@@ -117,7 +117,7 @@
         }, true);
 
         element.on('change', function(eventObject) {
-          scope.$apply(function () {
+          scope.$apply(function() {
             var newValue = element.val();
             try {
               angular.merge(scope.value, JSON.parse(newValue));

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
@@ -110,10 +110,8 @@
       link: function(scope, element, attrs) {
         element.val(JSON.stringify(scope.value));
 
-        scope.$watch('value', function(newValue, oldValue, s) {
-          if (newValue !== oldValue) {
-            element.val(JSON.stringify(newValue));
-          }
+        scope.$watch('value', function(newValue, oldValue) {
+          element.val(JSON.stringify(newValue));
         }, true);
 
         element.on('change', function(eventObject) {

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
@@ -109,9 +109,16 @@
       },
       link: function(scope, element, attrs) {
         element.val(JSON.stringify(scope.value));
-        element.on('change', function() {
+
+        scope.$watch('value', function(newValue, oldValue, s) {
+          if (newValue !== oldValue) {
+            element.val(JSON.stringify(newValue));
+          }
+        }, true);
+
+        element.on('change', function(eventObject) {
           scope.$apply(function () {
-            var newValue = $(this).val();
+            var newValue = element.val();
             try {
               angular.merge(scope.value, JSON.parse(newValue));
             } catch (e) {

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
@@ -110,12 +110,14 @@
       link: function(scope, element, attrs) {
         element.val(JSON.stringify(scope.value));
         element.on('change', function() {
-          var newValue = $(this).val();
-          try {
-            angular.merge(scope.value, JSON.parse(newValue));
-          } catch (e) {
-            console.warn('Error parsing JSON: ', newValue);
-          }
+          scope.$apply(function () {
+            var newValue = $(this).val();
+            try {
+              angular.merge(scope.value, JSON.parse(newValue));
+            } catch (e) {
+              console.warn('Error parsing JSON: ', newValue);
+            }
+          });
         });
       }
     };

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
@@ -24,8 +24,11 @@
 				<p class="help-block" data-translate="">ui-definition-help</p>
 			</div>
 			<div class="input-group">
-				<span class="input-group-addon" data-translate="">ui-extent</span> <input
-					type="text" class="form-control" gn-json-edit="opt.extent" />
+				<span class="input-group-addon" data-translate="">ui-extent</span>
+        <input
+					type="text" class="form-control"
+          gn-json-edit="opt.extent"
+          readonly="readonly"/>
 			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-minx</span> <input
@@ -43,7 +46,8 @@
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-worldExtent</span>
 				<input type="text" class="form-control"
-					gn-json-edit="opt.worldExtent" />
+               gn-json-edit="opt.worldExtent"
+               readonly="readonly"/>
 			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-minx</span> <input

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
@@ -32,13 +32,13 @@
 			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-minx</span> <input
-					type="number" class="form-control" data-ng-model="opt.extent[0]" />
+					type="number" step="any" class="form-control" data-ng-model="opt.extent[0]" />
 				<span class="input-group-addon" data-translate="">ui-miny</span> <input
-					type="number" class="form-control" data-ng-model="opt.extent[1]" />
+					type="number" step="any" class="form-control" data-ng-model="opt.extent[1]" />
 				<span class="input-group-addon" data-translate="">ui-maxx</span> <input
-					type="number" class="form-control" data-ng-model="opt.extent[2]" />
+					type="number" step="any" class="form-control" data-ng-model="opt.extent[2]" />
 				<span class="input-group-addon" data-translate="">ui-maxy</span> <input
-					type="number" class="form-control" data-ng-model="opt.extent[3]" />
+					type="number" step="any" class="form-control" data-ng-model="opt.extent[3]" />
 			</div>
 			<div class="input-group">
 				<p class="help-block" data-translate="">ui-extent-help</p>
@@ -51,16 +51,16 @@
 			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-minx</span> <input
-					type="number" class="form-control"
+					type="number" step="any" class="form-control"
 					data-ng-model="opt.worldExtent[0]" /> <span
 					class="input-group-addon" data-translate="">ui-miny</span> <input
-					type="number" class="form-control"
+					type="number" step="any" class="form-control"
 					data-ng-model="opt.worldExtent[1]" /> <span
 					class="input-group-addon" data-translate="">ui-maxx</span> <input
-					type="number" class="form-control"
+					type="number" step="any" class="form-control"
 					data-ng-model="opt.worldExtent[2]" /> <span
 					class="input-group-addon" data-translate="">ui-maxy</span> <input
-					type="number" class="form-control"
+					type="number" step="any" class="form-control"
 					data-ng-model="opt.worldExtent[3]" />
 			</div>
 			<div class="input-group">

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
@@ -24,13 +24,6 @@
 				<p class="help-block" data-translate="">ui-definition-help</p>
 			</div>
 			<div class="input-group">
-				<span class="input-group-addon" data-translate="">ui-extent</span>
-        <input
-					type="text" class="form-control"
-          gn-json-edit="opt.extent"
-          readonly="readonly"/>
-			</div>
-			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-minx</span> <input
 					type="number" step="any" class="form-control" data-ng-model="opt.extent[0]" />
 				<span class="input-group-addon" data-translate="">ui-miny</span> <input
@@ -42,12 +35,6 @@
 			</div>
 			<div class="input-group">
 				<p class="help-block" data-translate="">ui-extent-help</p>
-			</div>
-			<div class="input-group">
-				<span class="input-group-addon" data-translate="">ui-worldExtent</span>
-				<input type="text" class="form-control"
-               gn-json-edit="opt.worldExtent"
-               readonly="readonly"/>
 			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-minx</span> <input


### PR DESCRIPTION
* Sync angular model with input values. When changing values in individual coordinates the general field is updated. Also update the model on general field change using `$scope.$apply` to integrate it in angular `$digest` cycle and make changes more immediate.
* Make the `extent` and `worldExtent` fields readonly to avoid the user to enter wrong values, like objects instead of arrays.
* Allow floating point numbers in coordinate fields.

![image](https://user-images.githubusercontent.com/826920/49530205-0e286780-f8b8-11e8-926f-abbfd3b47237.png)
