### PR TITLE
Small improvements to the validation panel

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -40,13 +40,14 @@
     </div>
     <!-- /.btn-toolbar -->
     <div class="gn-validation-report gn-margin-top" data-ng-show="ruleTypes.length !== 0">
-      <div data-ng-repeat="type in ruleTypes"
+      <div class="panel panel-default"
+           data-ng-repeat="type in ruleTypes"
            data-ng-class="'schematron-result-list-' + labelImportanceClass(type)">
-        <div class="row">
+        <div data-gn-slide-toggle="" class="panel-heading clearfix">
           <div class="col-md-9">
             <h2 class="gn-schematron-title">{{(type.label || type.id) | translate}}</h2>
           </div>
-          <div class="col-md-3">
+          <div class="col-md-3 gn-nopadding-right">
             <span class="label pull-right"
                   data-ng-class="labelImportanceClass(type)"
                   data-ng-if="type.total === '?'">
@@ -61,16 +62,19 @@
                   data-ng-if="type.total !== '?'">{{type.success}} / {{type.total}}</span>
           </div>
         </div>
-        <ul class="list-group" data-ng-repeat="pattern in type.patterns.pattern">
-          <li class="list-group-item" data-ng-repeat="rule in pattern.rules.rule"
-              title="{{rule.details}}"
-              data-ng-show="(showErrors && rule.type === 'error') || (showSuccess && rule.type === 'success')"
-              data-ng-class="rule.type !== 'error' ? '' : (type.requirement === 'REQUIRED' ? 'text-danger' : 'text-info')">
-            <strong>{{pattern.title}}</strong>
-            <p>{{rule.msg}}</p>
-          </li>
-        </ul>
+        <div class="panel-body">
+          <ul class="list-group" data-ng-repeat="pattern in type.patterns.pattern">
+            <li class="list-group-item" data-ng-repeat="rule in pattern.rules.rule"
+                title="{{rule.details}}"
+                data-ng-show="(showErrors && rule.type === 'error') || (showSuccess && rule.type === 'success')"
+                data-ng-class="rule.type !== 'error' ? '' : (type.requirement === 'REQUIRED' ? 'text-danger' : 'text-info')">
+              <p data-ng-class="rule.msg ? 'text-bold' : ''">{{pattern.title}}</p>
+              <p data-ng-show="rule.msg">{{rule.msg}}</p>
+            </li>
+          </ul>
+        </div>
       </div>
+
     </div>
   </div>
   <!-- /.panel-body -->

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -567,14 +567,43 @@ form.gn-tab-inspire {
     padding-left: 1px;
     padding-right: 1px;
   }
+  .panel {
+    border: 0;
+    margin-top: 15px;
+    margin-bottom: 15px;
+    box-shadow: none;
+    [data-gn-slide-toggle]:before {
+      margin-left: 0px;
+    }
+    .panel-heading {
+      background: none;
+      padding: 0;
+      border: 0;
+    }
+    .panel-body {
+      padding: 0;
+    }
+  }
   .list-group {
     margin-bottom: 10px;
     .list-group-item {
-      strong {
+      border-left: 4px solid @brand-success;
+      padding-bottom: 5px;
+      .text-bold {
         font-weight: 500;
       }
       p {
         margin-top: 10px;
+        overflow: auto;
+        padding-bottom: 2px;
+      }
+      &.text-danger {
+        border-left: 4px solid @brand-danger;
+        color: @gray-darker;
+      }
+      &.text-info {
+        border-left: 4px solid @brand-info;
+        color: @gray-darker;
       }
     }
   }


### PR DESCRIPTION
The text color in the validation panel used colours, that made the text sometimes hard to read.

This PR changes the text colour to the default colour and adds a coloured left border (the same colour as the text used to be).

An extra addition is the toggle option for the different (sub)panels, so you can collapse a list you're not interested in.

**Screenshot of the changes:**
![gn-validation-panel](https://user-images.githubusercontent.com/19608667/49574185-1c21cb00-f940-11e8-8866-18020455df57.png)

