### PR TITLE
Patches typeahead.bundle.js to fix an error in results shown

### DIFF
--- a/web-ui/src/main/resources/catalog/lib/bootstrap.ext/typeahead.js/typeahead.bundle.js
+++ b/web-ui/src/main/resources/catalog/lib/bootstrap.ext/typeahead.js/typeahead.bundle.js
@@ -1718,11 +1718,15 @@
                 }
                 function async(suggestions) {
                     suggestions = suggestions || [];
+
+                    // if the update has been canceled or if the query has changed
+                    // do not render the suggestions as they've become outdated
                     if (!canceled && rendered < that.limit) {
                         that.cancel = $.noop;
-                        rendered += suggestions.length;
-                        that._append(query, suggestions.slice(0, that.limit - rendered));
-                        that.async && that.trigger("asyncReceived", query);
+                        var idx = Math.abs(rendered - that.limit);
+                        rendered += idx;
+                        that._append(query, suggestions.slice(0, idx));
+                        that.async && that.trigger('asyncReceived', query, that.name);
                     }
                 }
             },


### PR DESCRIPTION
When the server returns less suggestions than what is configured as limit for the autocompleter, it only shows the first one, not adding the others to the suggestions list. 

![before](https://user-images.githubusercontent.com/826920/49580760-07e5ca00-f950-11e8-997b-f9c398cd5d10.png)

This is a bug detected in Typeahead library, see https://github.com/twitter/typeahead.js/issues/1232.

This library seems not to be actively maintained by Twitter anymore (latest commits were in 2015). I've taken the patch from a fork https://github.com/corejavascript/typeahead.js

Patch: https://github.com/corejavascript/typeahead.js/blob/107a9b0d002e549be746d93a1fbcde05853d745a/src/typeahead/dataset.js#L269-L281

After applying the patch this is the result:
![image pasted at 2018-12-6 11-49](https://user-images.githubusercontent.com/826920/49580855-43809400-f950-11e8-9889-2480c36a47f3.png)
