### PR TITLE
[BP] Patches typeahead.bundle.js to fix an error in results shown

### DIFF
--- a/web-ui/src/main/resources/catalog/lib/bootstrap.ext/typeahead.js/typeahead.bundle.js
+++ b/web-ui/src/main/resources/catalog/lib/bootstrap.ext/typeahead.js/typeahead.bundle.js
@@ -1718,11 +1718,15 @@
                 }
                 function async(suggestions) {
                     suggestions = suggestions || [];
+
+                    // if the update has been canceled or if the query has changed
+                    // do not render the suggestions as they've become outdated
                     if (!canceled && rendered < that.limit) {
                         that.cancel = $.noop;
-                        rendered += suggestions.length;
-                        that._append(query, suggestions.slice(0, that.limit - rendered));
-                        that.async && that.trigger("asyncReceived", query);
+                        var idx = Math.abs(rendered - that.limit);
+                        rendered += idx;
+                        that._append(query, suggestions.slice(0, idx));
+                        that.async && that.trigger('asyncReceived', query, that.name);
                     }
                 }
             },


### PR DESCRIPTION
Backport of #3332.

When the server returns less suggestions than what is configured as
limit for the autocompleter, it only shows the first one, not adding the
others to the suggestions list. This is a bug detected in Typeahead
library, see https://github.com/twitter/typeahead.js/issues/1232.

This library seems not to be actively maintained by Twitter anymore
(latest commits were in 2015). I've taken the patch from a fork, Corejs
Typeahead.js https://github.com/corejavascript/typeahead.js

https://github.com/corejavascript/typeahead.js/blob/107a9b0d002e549be746d93a1fbcde05853d745a/src/typeahead/dataset.js#L269-L281