### PR TITLE
Tooltip for datepicker in the editor

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
@@ -85,6 +85,7 @@
     <xsl:param name="overrideLabel" select="''" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="tooltip" select="concat($schema, '|', name(.), '|', name(..), '|', $xpath)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig"
                   select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
@@ -132,6 +133,7 @@
       </div>
       <div class="col-sm-6 gn-value">
         <div data-gn-date-picker="{gco:Date|gco:DateTime}"
+             data-gn-field-tooltip="{$tooltip}"
              data-label=""
              data-element-name="{name(gco:Date|gco:DateTime)}"
              data-element-ref="{concat('_X', gn:element/@ref)}"
@@ -172,6 +174,7 @@
     <xsl:param name="overrideLabel" select="''" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="tooltip" select="concat($schema, '|', name(.), '|', name(..), '|', $xpath)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig"
                   select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
@@ -195,6 +198,7 @@
       </label>
       <div class="col-sm-9 gn-value nopadding-in-table">
         <div data-gn-date-picker="{gco:Date|gco:DateTime}"
+             data-gn-field-tooltip="{$tooltip}"
              data-label=""
              data-element-name="{name(gco:Date|gco:DateTime)}"
              data-element-ref="{concat('_X', gn:element/@ref)}"

--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -189,15 +189,20 @@
              element.is('select');
              var tooltipTarget = element;
              var iconMode = gnCurrentEdit.displayTooltipsMode === 'icon';
+             var isDatePicker = 'gnDatePicker' in attrs;
 
-
+             var createTooltipForDatePicker = function (el, tooltip) {
+               var controlColumn = el.closest(".gn-field").find("div.gn-control");
+               if(controlColumn.length > 0) {
+                 controlColumn.append(tooltip);
+               }
+             };
 
              // use a icon to click on for a tooltip
              if (iconMode) {
                var tooltipAfterLabel = false;
                var tooltipIconCompiled = $compile(iconTemplate)(scope);
                var asideCol;
-
 
                if (isField && element.attr('type') !== 'hidden') {
 
@@ -249,6 +254,8 @@
                  }
                } else if (element.is('legend')) {
                  element.contents().first().after(tooltipIconCompiled);
+               } else if (isDatePicker) {
+                 element.closest(".gn-field").find("div.gn-control").append(tooltipIconCompiled);
                } else if (element.is('label')) {
                  if (tooltipAfterLabel) {
                    element.parent().children('div')
@@ -257,7 +264,6 @@
                    element.after(tooltipIconCompiled);
                  }
                }
-
 
                // close tooltips on click in editor container
                $('.gn-editor-container').on('mousedown', function(e) {
@@ -268,7 +274,6 @@
                  }
                });
 
-
                // replace element with tooltip
                tooltipTarget = tooltipIconCompiled;
              } else {
@@ -277,7 +282,6 @@
                });
              }
 
-
              var closeTooltips = function() {
                // Close all tooltips/popovers
                // (there still might be some open)
@@ -285,7 +289,6 @@
                // Less official way to hide
                $('.popover').hide();
              };
-
 
              var initTooltip = function(event) {
                if (!isInitialized && gnCurrentEdit.displayTooltips) {


### PR DESCRIPTION
Added tooltip support for the date picker in the editor.

![gn-datepicker-tooltip](https://user-images.githubusercontent.com/19608667/49736007-3255c100-fc89-11e8-9b55-e42604b552af.png)

Known issue: the tooltip doesn't close when another is opened, this is the same problem as for some other tooltips, e.g. contact