### PR TITLE
Display users of a group in the group maintenance #3341

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1011,6 +1011,9 @@
         replace: false,
         compile: function compile(tElement, tAttrs) {
           var cacheId = tAttrs.cache ? tAttrs.cache + '.paginator' : '';
+          var getItemsFunctionName = tAttrs.getItemsFunctionName ? tAttrs.getItemsFunctionName: 'pageItems';
+          var firstPageFunctionName = tAttrs.firstPageFunctionName ? tAttrs.firstPageFunctionName: 'firstPage';
+
           return {
             pre: function preLink(scope) {
               scope.pageSizeList = [10, 20, 50, 100];
@@ -1065,12 +1068,12 @@
 
               // ---- Functions available in parent scope -----
 
-              scope.$parent.firstPage = function() {
+              scope.$parent[firstPageFunctionName] = function() {
                 scope.firstPage();
               };
               // Function that returns the reduced items list,
               // to use in ng-repeat
-              scope.$parent.pageItems = function() {
+              scope.$parent[getItemsFunctionName] = function() {
                 if (angular.isArray(scope.items())) {
                   var start = scope.paginator.currentPage *
                       scope.paginator.pageSize;

--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -81,6 +81,7 @@
       // On going changes group ...
       $scope.groupUpdated = false;
       $scope.groupSearch = {};
+      $scope.groupusers = null;
 
       // Scope for user
       // List of catalog users
@@ -168,7 +169,19 @@
         });
       }
 
-
+      /**
+       * Loads the users for a group.
+       *
+       * @param groupId
+       */
+      function loadGroupUsers(groupId) {
+        $http.get('../api/groups/' + groupId + '/users').
+        success(function(data) {
+          $scope.groupusers = data;
+        }).error(function(data) {
+          $scope.groupusers = [];
+        });
+      }
 
       /**
        * Add an new user based on the default
@@ -676,6 +689,9 @@
           group: g.id,
           sortBy: 'title'
         });
+
+        loadGroupUsers($scope.groupSelected.id);
+
         $scope.groupUpdated = false;
 
         $timeout(function() {

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1312,5 +1312,6 @@
     "ui-definition-help": "Definition for Proj4 library. This is a mandatory field if the projection is not defined already on GeoNetwork. Without a definition, the map can't work.",
     "ui-mod-recordview": "Record View",
     "ui-isSocialbarEnabled": "Show Socialbar",
-    "ui-isSocialbarEnabled-help": "Show the button bar with all the social buttons (facebook, twitter, etc.)"
+    "ui-isSocialbarEnabled-help": "Show the button bar with all the social buttons (facebook, twitter, etc.)",
+    "usersInGroup": "Users in group"
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
@@ -201,6 +201,27 @@
                data-pagination-info="paginationInfo">
           </div>
         </div>
+
+        <!-- Display users of the group -->
+        <div data-ng-hide="!groupusers">
+          <h3><span data-translate="">usersInGroup</span> {{groupSelected.name}}</h3>
+        </div>
+
+        <div class="list-group">
+          <a href="#/organization/users/{{u.id}}" class="list-group-item"
+             data-ng-repeat="u in groupUsersPageItems()">
+            <img class="img-circle"
+                 ng-src="http://gravatar.com/avatar/{{u.emailAddresses[0] | md5}}?s=18"/>
+            <span class='badge' data-ng-show="u.enabled === false"
+                  data-translate="">disabled</span> {{u.name}} {{u.surname}}
+            ({{u.profile | translate}})
+          </a>
+          <span data-gn-pagination-list=""
+                data-get-items-function-name="groupUsersPageItems"
+                data-first-page-function-name="groupUsersFirstPage"
+                data-items="groupusers | orderBy:'name'"
+                data-cache="groupusers"/>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Displays at the end of the group form the users associated to the group:

![group-maintenance-users-in-group](https://user-images.githubusercontent.com/1695003/49736328-1acb0800-fc8a-11e8-9673-ef17d25bdf2c.png)

It's updated the `gnPaginationList` directive also, so can be added several times the directive in the same page to use different lists, previously that was not working.

Requires  https://github.com/geonetwork/core-geonetwork/pull/3343 to get working the links of the users page.

Thank @juanluisrp for the support in the AngularJs development.