### PR TITLE
Refresh board after bulk ownership change

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -443,6 +443,7 @@
                 'userIdentifier=' + scope.selectedUserGroup.userId +
                 '&groupIdentifier=' + scope.selectedUserGroup.groupId)
                 .then(function(r) {
+                  $rootScope.$broadcast('search');
                   $rootScope.$broadcast('StatusUpdated', {
                     msg: $translate.instant('transfertPrivilegesFinished', {
                       metadata: r.data.numberOfRecordsProcessed


### PR DESCRIPTION
Refresh board after bulk ownership change, so the new owner is shown on metadata records affected. Right now, after save, it shows the old values (you need to reload the page).

Contribute -> Editor Board
then select some records
selected -> Transfer Ownership

![update](https://user-images.githubusercontent.com/1323093/49746633-dfd4ce80-fca1-11e8-930d-de0e49d5abc9.png)
