### PR TITLE
Map is blank in non debug mode when opening the map tab

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -43,10 +43,10 @@
     'gnAlertService',
     'gnMeasure',
     'gnViewerService',
-    '$location', '$q', '$translate',
+    '$location', '$q', '$translate', '$timeout',
     function(gnMap, gnConfig, gnSearchLocation, gnMetadataManager,
              gnSearchSettings, gnViewerSettings, gnAlertService, gnMeasure,
-             gnViewerService, $location, $q, $translate) {
+             gnViewerService, $location, $q, $translate, $timeout) {
       return {
         restrict: 'A',
         replace: true,
@@ -211,6 +211,12 @@
 
               // Define UI status based on the location parameters
               function initFromLocation() {
+                if (!angular.isArray(scope.map.getSize()) ||
+                  scope.map.getSize().indexOf(0) >= 0) {
+                  $timeout(function() {
+                    scope.map.updateSize();
+                  }, 300);
+                }
 
                 // Add command allows to add element to the map
                 // based on an array of objects.
@@ -381,7 +387,7 @@
               //TODO: find another solution to render the map
               setTimeout(function() {
                 scope.map.updateSize();
-              }, 100);
+              }, 300);
             }
           };
         }


### PR DESCRIPTION
Not sure since when this happens (3.4.x is fine. Maybe related to the projection switcher change or other changes made on the map in the last month?) but when opening the map, in non debug mode (why this does not happen in debug mode?) the map is blank. Resizing the window or refreshing the tab make the map to be rendered properly.

![image](https://user-images.githubusercontent.com/1701393/49869717-82f82600-fe11-11e8-844a-7b6e0c5ca448.png)


Force OL to render the map if not yet initialized on location change.