### PR TITLE
[BP] Fixes a bug when checking the waitForUse attribute in SearchFormDiretive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -436,7 +436,7 @@
                   gnSearchLocation.getParams());
             }
 
-            if (attrs.waitForUser === true) {
+            if (attrs.waitForUser === "true") {
               var userUnwatch = scope.$watch('user.id', function(userNewVal) {
                 // Don't trigger the search until the user id has been loaded
                 // Unregister the watch once we have the user id.


### PR DESCRIPTION
Backport of  #3349.
When `data-wait-for-user` is set there was a bug that didn't register the watch that waits for the user info to be available before triggering the search.