### PR TITLE
Avoid GN crashes when a projection is not correctly defined

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -37,8 +37,13 @@
       if (!ol.proj.get(p.code)) {
         if (p.def && p.code) {
           // Define an OL3 projection based on the included Proj4js projection
-          // definition and set it's extent.
-          proj4.defs(p.code, p.def);
+          try {
+            // definition and set it's extent.
+            proj4.defs(p.code, p.def);
+          } catch (e) {
+            console.error("Trying to use incorrectly defined projection '" + p.code +
+              "'. Please update definitions on Admin > Settings.");
+          }
         } else {
           console.error("Trying to use unknown projection '" + p.code +
               "'. Please update definitions on Admin > Settings.");
@@ -46,19 +51,21 @@
       }
 
       var projection = ol.proj.get(p.code);
-      if (p.extent && p.extent.length && p.extent.length === 4 &&
+      if (projection) {
+        if (p.extent && p.extent.length && p.extent.length === 4 &&
           !isNaN(p.extent[0]) && p.extent[0] != null &&
           !isNaN(p.extent[1]) && p.extent[1] != null &&
           !isNaN(p.extent[2]) && p.extent[2] != null &&
           !isNaN(p.extent[3]) && p.extent[3] != null) {
-        projection.setExtent(p.extent);
-      }
-      if (p.worldExtent && p.worldExtent.length && p.worldExtent.length === 4 &&
+          projection.setExtent(p.extent);
+        }
+        if (p.worldExtent && p.worldExtent.length && p.worldExtent.length === 4 &&
           !isNaN(p.worldExtent[0]) && p.worldExtent[0] != null &&
           !isNaN(p.worldExtent[1]) && p.worldExtent[1] != null &&
           !isNaN(p.worldExtent[2]) && p.worldExtent[2] != null &&
           !isNaN(p.worldExtent[3]) && p.worldExtent[3] != null) {
-        projection.setWorldExtent(p.worldExtent);
+          projection.setWorldExtent(p.worldExtent);
+        }
       }
     });
   };


### PR DESCRIPTION
When a projection defined in the projection list of Settings/Config UI is not defined correctly it causes GN not to load at all and makes also the Settings page not to load for fixing the error. 
This PR improves the error handling in the custom projections definition showing a console warning instead of crashing GN.