### PR TITLE
DB / Missing indexes. Fixes #3358

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
+++ b/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
@@ -40,7 +40,8 @@ import java.util.List;
  */
 @Entity
 @Access(AccessType.PROPERTY)
-@Table(name = "InspireAtomFeed")
+@Table(name = "InspireAtomFeed",
+    indexes = { @Index(name = "idx_inspireatomfeed_metadataid", columnList = "metadataid") })
 @SequenceGenerator(name = InspireAtomFeed.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class InspireAtomFeed extends GeonetEntity implements Serializable {
     static final String ID_SEQ_NAME = "inspire_atom_feed_id_seq";

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataFileDownload.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataFileDownload.java
@@ -35,7 +35,8 @@ import javax.persistence.*;
  */
 @Entity
 @Access(AccessType.PROPERTY)
-@Table(name = "MetadataFileDownloads")
+@Table(name = "MetadataFileDownloads",
+    indexes = { @Index(name = "idx_metadatafiledownloads_metadataid", columnList = "metadataid") })
 @SequenceGenerator(name = MetadataFileDownload.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MetadataFileDownload {
     static final String ID_SEQ_NAME = "metadata_filedownload_id_seq";

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataFileUpload.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataFileUpload.java
@@ -35,7 +35,8 @@ import javax.persistence.*;
  */
 @Entity
 @Access(AccessType.PROPERTY)
-@Table(name = "MetadataFileUploads")
+@Table(name = "MetadataFileUploads",
+    indexes = { @Index(name = "idx_metadatafileuploads_metadataid", columnList = "metadataid") })
 @SequenceGenerator(name = MetadataFileUpload.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MetadataFileUpload extends GeonetEntity {
     static final String ID_SEQ_NAME = "metadata_fileupload_id_seq";

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataStatus.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataStatus.java
@@ -38,7 +38,8 @@ import javax.persistence.*;
  */
 @Entity
 @Access(AccessType.PROPERTY)
-@Table(name = "MetadataStatus")
+@Table(name = "MetadataStatus",
+    indexes = { @Index(name = "idx_metadatastatus_metadataid", columnList = "metadataid") })
 @EntityListeners(MetadataStatus.EntityListener.class)
 public class MetadataStatus extends GeonetEntity {
     /**

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataValidation.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataValidation.java
@@ -35,7 +35,8 @@ import javax.persistence.*;
  */
 @Entity
 @Access(AccessType.PROPERTY)
-@Table(name = "Validation")
+@Table(name = "Validation",
+    indexes = { @Index(name = "idx_validation_metadataid", columnList = "metadataid") })
 @EntityListeners(MetadataValidationEntityListenerManager.class)
 public class MetadataValidation extends GeonetEntity {
     private MetadataValidationId id;

--- a/domain/src/main/java/org/fao/geonet/domain/OperationAllowed.java
+++ b/domain/src/main/java/org/fao/geonet/domain/OperationAllowed.java
@@ -35,7 +35,8 @@ import javax.persistence.*;
  * @author Jesse
  */
 @Entity
-@Table(name = OperationAllowed.TABLE_NAME)
+@Table(name = OperationAllowed.TABLE_NAME,
+    indexes = { @Index(name = "idx_operationallowed_metadataid", columnList = "metadataid") })
 @Access(AccessType.PROPERTY)
 @EntityListeners(OperationAllowedEntityListenerManager.class)
 public class OperationAllowed extends GeonetEntity {


### PR DESCRIPTION
Added database index configuration at least for the fields used in queries to extract the data add to the Lucene indexing process. Probably more require to be reviewed. 

Also in most cases are required these explicit indexes as most tables are not using relations between entities (mostly to the `metadata` table), so no `FK` are defined. I guess this was done to maintain compatibility with the old database model and also to avoid issues with the loading of related entities in JPA, but we should review this, with a proper configuration of the data objects, this should not be a problem.