### PR TITLE
Fixes harvester type names not translated

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -160,9 +160,14 @@
             .success(function(data) {
               angular.forEach(data[0], function(value) {
                 $scope.harvesterTypes[value] = {
-                  label: value,
-                  text: $translate.instant('harvester-' + value)
+                  label: value
                 };
+                $translate('harvester-' + value).then(function(translated) {
+                  $scope.harvesterTypes[value] = {
+                    text: translated
+                  };
+                });
+
                 $.getScript('../../catalog/templates/admin/harvest/type/' +
                     value + '.js')
                 .done(function(script, textStatus) {


### PR DESCRIPTION
Due to timing issues while loading the Harvester admin page and the language files
sometimes the translation for the harvester type is not available yet when the page
is rendered. This is cause by the use of `$translate.instant` function. To fix this
and allow the translation to be set once the language is available we use now a promise
for setting the `text` translated value.
![image](https://user-images.githubusercontent.com/826920/49934374-7dace100-fece-11e8-9109-b5607dff7ab6.png)
