### PR TITLE
Improved messaging/user feedback in Import Page

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/ImportController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/ImportController.js
@@ -46,7 +46,8 @@
     '$scope',
     '$rootScope',
     'gnMetadataManager',
-    function($scope,  $rootScope, gnMetadataManager) {
+    '$window',
+    function($scope,  $rootScope, gnMetadataManager, $window) {
       $scope.importMode = 'uploadFile';
       $scope.file_type = 'single';
       $scope.queue = [];
@@ -152,6 +153,8 @@
               $(formId).serialize(), $scope.params.xml).then(
               onSuccessFn, onErrorFn);
         }
+        // scroll to top
+        $window.scrollTo(0, 0);
       };
     }
   ]);

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -889,6 +889,32 @@ gn-indexing-task-status {
   }
 }
 
+// fixed progress bar on top of the page
+.progress-bar-container {
+  height: 50px; // reserve height for the fixed bar
+  margin-top: -18px;
+  .progress-bar-container-fixed {
+    position: fixed;
+    z-index: 100;
+    padding-top: 15px;
+    background: #fff;
+    // width for different screensizes
+    width: calc(~"100% - " @grid-gutter-width);
+    @media (min-width: @screen-sm-min) {
+      width: (@container-sm - @grid-gutter-width);
+    }
+    @media (min-width: @screen-md-min) {
+      width: (@container-md - @grid-gutter-width);
+    }
+    @media (min-width: @screen-lg-min) {
+      width: (@container-lg - @grid-gutter-width);
+    }
+    .progress {
+      height: 15px;
+    }
+  }
+}
+
 // general purpose layout helpers
 .pos-relative { position: relative; }
 .pos-absolute { position: absolute; }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -895,7 +895,7 @@ gn-indexing-task-status {
   margin-top: -18px;
   .progress-bar-container-fixed {
     position: fixed;
-    z-index: 100;
+    z-index: 2;
     padding-top: 15px;
     background: #fff;
     // width for different screensizes

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -897,7 +897,7 @@ gn-indexing-task-status {
     position: fixed;
     z-index: 2;
     padding-top: 15px;
-    background: #fff;
+    background: @body-bg;
     // width for different screensizes
     width: calc(~"100% - " @grid-gutter-width);
     @media (min-width: @screen-sm-min) {

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -1,4 +1,14 @@
 <div class="container" id="gn-import-container">
+  <div class="row progress-bar-container">
+    <div class="col-sm-12 progress-bar-container-fixed gn-width-inherit1">
+      <div id="gn-import-progress-row"
+          class="progress progress-striped active"
+          data-ng-show="importing === true">
+        <div class="progress-bar" style="width: 100%"/>
+      </div>
+    </div>
+  </div>
+
   <!-- TODO : add form constraints -->
   <div class="row">
     <div class="col-sm-7">
@@ -305,11 +315,6 @@
       </div>
     </div>
     <div class="col-sm-5">
-      <div id="gn-import-progress-row"
-           class="progress progress-striped active"
-           data-ng-show="importing === true">
-        <div class="progress-bar" style="width: 100%"/>
-      </div>
 
       <div id="gn-import-reports-row">
         <div data-ng-repeat="report in reports track by $index">


### PR DESCRIPTION
When you import a lot of files at once you have to scroll down to click the import button. In the old situation the focus stays at the bottom but the progress and messages are displayed at the top of the page, outside the view port.

This PR adds some small changes. Fist of all the progress bar is replaced with a fixed progress bar on top of the page, this progress bar is always within the view port. And second a scroll to top action is added after the import button is clicked.

**Screenshot with the fixed progress bar**

![gn-fixed-progressbar](https://user-images.githubusercontent.com/19608667/49941625-5a406100-fee3-11e8-80b1-873473272735.png)

