### PR TITLE
ES / Configure ES only when the profil is set. 

### DIFF
--- a/es/es-core/src/main/java/org/fao/geonet/es/EsClient.java
+++ b/es/es-core/src/main/java/org/fao/geonet/es/EsClient.java
@@ -82,6 +82,17 @@ public class EsClient implements InitializingBean {
         return client;
     }
 
+    public String getDashboardAppUrl() {
+        return dashboardAppUrl;
+    }
+
+    public void setDashboardAppUrl(String dashboardAppUrl) {
+        this.dashboardAppUrl = dashboardAppUrl;
+    }
+
+    @Value("${kb.url}")
+    private String dashboardAppUrl;
+
 
     @Override
     public void afterPropertiesSet() throws Exception {

--- a/healthmonitor/src/main/java/org/fao/geonet/monitor/health/IndexHealthCheck.java
+++ b/healthmonitor/src/main/java/org/fao/geonet/monitor/health/IndexHealthCheck.java
@@ -49,6 +49,7 @@ public class IndexHealthCheck implements HealthCheckFactory {
                     try {
                         Search search = new Search.Builder("")
                             .addIndex(searchMan.getIndex())
+                            .addType(searchMan.getIndexType())
                             .build();
                         final SearchResult result = searchMan.getClient().getClient().execute(search);
 

--- a/pom.xml
+++ b/pom.xml
@@ -1298,15 +1298,15 @@
 
     <es.version>6.4.2</es.version>
     <es.version.sha512>23c610a8cd33d4229e8b79b0dc5e1f106e5f186d45c83e9994bb15708d2ce4e763fcb7c9be0f652ebdf12905be7f4ced14e1d8e18f6240dfe5ccb4a064239f86</es.version.sha512>
-    <es.port>9200</es.port>
-    <es.host>localhost</es.host>
-    <es.url>http://${es.host}:${es.port}</es.url>
-    <es.index.features>gn-features</es.index.features>
-    <es.index.features.type>features</es.index.features.type>
-    <es.index.records>gn-records</es.index.records>
-    <es.index.records.type>records</es.index.records.type>
-    <es.index.searchlogs>gn-searchlogs</es.index.searchlogs>
-    <es.index.searchlogs.type>searchlogs</es.index.searchlogs.type>
+    <es.port></es.port>
+    <es.host></es.host>
+    <es.url></es.url>
+    <es.index.features></es.index.features>
+    <es.index.features.type></es.index.features.type>
+    <es.index.records></es.index.records>
+    <es.index.records.type></es.index.records.type>
+    <es.index.searchlogs></es.index.searchlogs>
+    <es.index.searchlogs.type></es.index.searchlogs.type>
 
     <!-- to load spring configurations related to es and camel,
     you should use maven "es" profile (defined in web).
@@ -1318,8 +1318,8 @@
     <es.password></es.password>
 
     <kb.version.sha512>b3b422c3bd157e363f528a27f5243f2ee13eba3e3bb22e1a7a9f24ea33f75b864643e297047379dfbef040a0eaa05ed6d998dd2cfe798b9d058f5b3d346f4d1d</kb.version.sha512>
-    <kb.port>5601</kb.port>
-    <kb.url>http://localhost:${kb.port}</kb.url>
+    <kb.port></kb.port>
+    <kb.url></kb.url>
 
     <jms.url>tcp://localhost:61616</jms.url>
     <activemq.version>5.6.0</activemq.version>
@@ -1354,7 +1354,7 @@
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <rootProjectDir>..</rootProjectDir>
     <wro.version>1.7.9</wro.version>
-    <wro.debug>false</wro.debug>
+    <wro.debug>true</wro.debug>
 
     <node.version>v8.11.1</node.version>
     <npm.version>5.8.0</npm.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -933,6 +933,19 @@
       <id>es</id>
       <properties>
         <es.spring.profile>es</es.spring.profile>
+
+        <es.port>9200</es.port>
+        <es.host>localhost</es.host>
+        <es.url>http://${es.host}:${es.port}</es.url>
+        <es.index.features>gn-features</es.index.features>
+        <es.index.features.type>features</es.index.features.type>
+        <es.index.records>gn-records</es.index.records>
+        <es.index.records.type>records</es.index.records.type>
+        <es.index.searchlogs>gn-searchlogs</es.index.searchlogs>
+        <es.index.searchlogs.type>searchlogs</es.index.searchlogs.type>
+
+        <kb.port>5601</kb.port>
+        <kb.url>http://localhost:${kb.port}</kb.url>
       </properties>
     </profile>
 

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -29,4 +29,6 @@ es.index.records.type=${es.index.records.type}
 es.index.searchlogs=${es.index.searchlogs}
 es.index.searchlogs.type=${es.index.searchlogs.type}
 
+kb.url=${kb.url}
+
 jms.url=${jms.url}


### PR DESCRIPTION
* HealthCheck on Kibana only if URL is not empty to avoid exception in the log.
```
15-Nov-2018 17:49:22.364 SEVERE [ajp-nio-8112-exec-3] org.apache.catalina.core.StandardWrapperValve.invoke "Servlet.service()" pour la servlet HttpDashboardProxy a généré une exception
org.apache.http.conn.HttpHostConnectException: Connect to localhost:5601 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connexion refusée
```

* HealthCheck on index with the type to avoid forbidden when ES cluster is secured.