### PR TITLE
WFS Indexing / Admin panel does not display correct information

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
@@ -35,7 +35,7 @@
       $scope.url = decodeURIComponent($location.search()['wfs-indexing']);
 
       // URL of the index service endpoint
-      $scope.indexUrl = gnHttp.getService('indexproxy') + '/_search';
+      $scope.indexUrl = gnHttp.getService('featureindexproxy') + '?_=_search';
 
       // list of wfs indexing jobs received from the index
       // null means loading
@@ -62,7 +62,7 @@
           try {
             $scope.jobs = result.data.hits.hits.map(function (hit) {
               var source = hit._source;
-              var infos = source.id.split('#');
+              var infos = decodeURIComponent(source.id).split('#');
               return {
                 url: infos[0],
                 featureType: infos[1],


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/3205 which now encode URL and feature type name to support ES 6.4+ and to point to the correct index containing features (and not to the ES cluster root only).