### PR TITLE
Improve display of `tables` and `listviews` of Detail page on small screens

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
@@ -1,10 +1,10 @@
 <p data-ng-show="isWfsAvailable && featureType" data-translate=""
    wfsDownloadDataInstruction
 </p>
-<div data-ng-show="!isWfsAvailable">
+<p data-ng-show="!isWfsAvailable" class="text-warning clearfix">
   <i class="fa fa-warning fa-2x fa-fw pull-left" />
   {{'Unable_to_connect_to_service'|translate}}
-</div>
+</p>
 
 <div class="btn-group"
      data-ng-show="featureType && isWfsAvailable">
@@ -39,17 +39,17 @@
     </li>
   </ul>
 </div>
-<div data-ng-if="formats.length == 0 && featureType" class="clearfix">
+<p data-ng-if="formats.length == 0 && featureType" class="text-warning clearfix">
   <div class="fa fa-warning fa-2x fa-fw pull-left"></div>
   <div class="pull-left" data-translate="">wfsNoOutputFormats</div>
-</div>
+</p>
 <div data-ng-if="formats.length > 0 && !featureType">
-  <div class="clearfix gn-margin-top gn-margin-bottom" data-ng-show="typename != ''">
+  <p class="clearfix gn-margin-top gn-margin-bottom text-warning" data-ng-show="typename != ''">
     <div class="fa fa-warning fa-2x fa-fw pull-left"></div>
     <div data-translate=""
           class="pull-left"
           data-translate-values="{typename:'{{typename}}'}">wfsTypenameNotAvailable</div>
-  </div>
+  </p>
   <div class="row">
     <div class="col-md-8 gn-nopadding-left">
       <select class="form-control"

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -6,10 +6,39 @@
 
 /* Angular view */
 .gn-md-view {
-  table tr th {
-    width: 35%;
+  table {
+    @media (max-width: @screen-xs-max) {
+      border-top: 1px solid @table-border-color;
+    }
+    tr {
+      @media (max-width: @screen-xs-max) {
+        border-bottom: 1px solid @table-border-color;
+      }
+      th {
+        width: 35%;
+      }
+      @media (max-width: @screen-xs-max) {
+        th, td {
+          width: 100%;
+          float: left;
+          border: 0;
+          padding: 8px;
+        }
+        td {
+          padding-left: 8px !important;
+          ul {
+            padding-left: 20px !important;
+          }
+          .gn-contact {
+            margin-left: 0;
+            ul {
+              padding-left: 0 !important;
+            }
+          }
+        }
+      }
+    }
   }
-
   .badge {
     word-break: break-all;
     white-space: normal;
@@ -261,6 +290,20 @@
   .gn-related-item {
     h4 {
       word-break: break-word;
+    }
+    .col-xs-12.col-sm-3 {
+      padding-right: 0;
+    }
+    @media (max-width: @screen-xs-max) {
+      border-left: 0;
+      border-right: 0;
+      padding: 10px 8px !important;
+      .col-xs-1.col-sm-1, .col-xs-12.col-sm-3 {
+        padding-left: 0;
+      }
+      .col-xs-8.col-sm-8 {
+        width: 90%;
+      }
     }
   }
   p {


### PR DESCRIPTION
Improve display of `tables` and `listviews` on small screens:
- display `<th>` and `<td>` beneath each other
- remove borders
- reduce padding left and right
- added `text-warning` to the warnings

**Detail view on wider screens:**

![gn-detailview-wide](https://user-images.githubusercontent.com/19608667/50225026-aab23580-039f-11e9-834f-97c98a71d7ab.png)

**Detail view on smaller screens:**

![gn-detailview-small](https://user-images.githubusercontent.com/19608667/50225032-b271da00-039f-11e9-95ab-269410eb0954.png)

