### PR TITLE
NullPointerException in metadata notifications management

### DIFF
--- a/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierManager.java
+++ b/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierManager.java
@@ -22,14 +22,7 @@
 //==============================================================================
 package org.fao.geonet.notifier;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nonnull;
-
+import jeeves.server.context.ServiceContext;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
@@ -38,16 +31,21 @@ import org.fao.geonet.domain.MetadataNotification;
 import org.fao.geonet.domain.MetadataNotificationAction;
 import org.fao.geonet.domain.MetadataNotificationId;
 import org.fao.geonet.domain.MetadataNotifier;
-import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataNotificationRepository;
 import org.fao.geonet.repository.MetadataNotifierRepository;
+import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.Updater;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.springframework.context.ConfigurableApplicationContext;
 
-import jeeves.server.context.ServiceContext;
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -79,10 +77,11 @@ public class MetadataNotifierManager {
                     client.webUpdate(notifier, metadata.getData(), metadata.getUuid());
 
                     // mark metadata as notified for current notifier service
-                    setMetadataNotified(metadata.getId(), notifier, false);
+                    setMetadataNotified(metadata.getId(), metadata.getUuid(), notifier, false);
                 }
 
-                Map<AbstractMetadata, MetadataNotification> unregisteredMetadataToDelete = getUnnotifiedMetadata(notifier.getId(), MetadataNotificationAction.DELETE);
+                Map<AbstractMetadata, MetadataNotification> unregisteredMetadataToDelete =
+                    getUnnotifiedMetadata(notifier.getId(), MetadataNotificationAction.DELETE);
 
                 // process metadata
                 for (Map.Entry<AbstractMetadata, MetadataNotification> entry : unregisteredMetadataToDelete.entrySet()) {
@@ -94,7 +93,7 @@ public class MetadataNotifierManager {
                     client.webDelete(notifier, uuid);
 
                     // mark metadata as notified for current notifier service
-                    setMetadataNotified(metadata.getId(), notifier, true);
+                    setMetadataNotified(metadata.getId(), metadata.getUuid(), notifier, true);
                 }
 
             } catch (Exception ex) {
@@ -107,23 +106,26 @@ public class MetadataNotifierManager {
     /**
      * Updates/inserts a metadata record.
      *
-     * @param ISO19139 Metadata content
-     * @param uuid     Metadata uuid identifier
-     * @param context  GeoNetwork context
+     * @param metadataElement Metadata content
+     * @param uuid            Metadata uuid identifier
+     * @param context         GeoNetwork context
+     * @throws MetadataNotifierException
      */
-    public void updateMetadata(Element ISO19139, String id, String uuid, ServiceContext context) throws MetadataNotifierException {
+    public void updateMetadata(Element metadataElement, String id, String uuid, ServiceContext context) {
         final ConfigurableApplicationContext applicationContext = context.getApplicationContext();
         ScheduledThreadPoolExecutor timer = applicationContext.getBean("timerThreadPool", ScheduledThreadPoolExecutor.class);
 
-        timer.schedule(new UpdateTask(ISO19139, id, uuid), 10, TimeUnit.MILLISECONDS);
+        timer.schedule(new UpdateTask(metadataElement, id, uuid), 10, TimeUnit.MILLISECONDS);
     }
 
     /**
      * Deletes a metadata record.
      *
+     * @param uuid
      * @param context GeoNetwork context
+     * @throws MetadataNotifierException
      */
-    public void deleteMetadata(String id, String uuid, ServiceContext context) throws MetadataNotifierException {
+    public void deleteMetadata(String id, String uuid, ServiceContext context) {
         final ConfigurableApplicationContext applicationContext = context.getApplicationContext();
         ScheduledThreadPoolExecutor timer = applicationContext.getBean("timerThreadPool", ScheduledThreadPoolExecutor.class);
         timer.schedule(new DeleteTask(id, uuid), 10, TimeUnit.MILLISECONDS);
@@ -144,28 +146,32 @@ public class MetadataNotifierManager {
 
     /**
      * Retrieves the unnotified metadata to update/insert for a notifier service
+     *
+     * @param notifierId
+     * @return
+     * @throws Exception
      */
     private Map<AbstractMetadata, MetadataNotification> getUnnotifiedMetadata(int notifierId,
-                                                                      MetadataNotificationAction... actions) throws Exception {
+                                                                              MetadataNotificationAction... actions) {
         if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
             Log.debug(Geonet.DATA_MANAGER, "getUnnotifiedMetadata start");
         }
         final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         MetadataNotificationRepository metadataNotificationRepository = applicationContext.getBean(MetadataNotificationRepository.class);
-        IMetadataUtils metadataRepository = applicationContext.getBean(IMetadataUtils.class);
+        MetadataRepository metadataRepository = applicationContext.getBean(MetadataRepository.class);
 
         List<MetadataNotification> unNotified = metadataNotificationRepository.findAllNotNotifiedForNotifier(notifierId, actions);
 
-        Map<Integer, MetadataNotification> idToNotification = new HashMap<Integer, MetadataNotification>();
+        Map<Integer, MetadataNotification> idToNotification = new HashMap<>();
         for (MetadataNotification metadataNotification : unNotified) {
             idToNotification.put(metadataNotification.getId().getMetadataId(), metadataNotification);
 
         }
 
-        final Iterable<? extends AbstractMetadata> allMetadata = metadataRepository.findAll(idToNotification.keySet());
-        Map<AbstractMetadata, MetadataNotification> notificationMap = new HashMap<AbstractMetadata, MetadataNotification>();
+        final Iterable<Metadata> allMetadata = metadataRepository.findAll(idToNotification.keySet());
+        Map<AbstractMetadata, MetadataNotification> notificationMap = new HashMap<>();
 
-        for (AbstractMetadata metadata : allMetadata) {
+        for (Metadata metadata : allMetadata) {
             notificationMap.put(metadata, idToNotification.get(metadata.getId()));
         }
 
@@ -179,9 +185,10 @@ public class MetadataNotifierManager {
      * Marks a metadata record as notified for a notifier service.
      *
      * @param deleteNotification Indicates if the notification was a delete action
+     * @throws Exception
      */
-    private void setMetadataNotified(int metadataId, MetadataNotifier notifier,
-                                     boolean deleteNotification) throws Exception {
+    private void setMetadataNotified(final int metadataId, final String uuid, final MetadataNotifier notifier,
+                                     final boolean deleteNotification) {
 
         final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         MetadataNotificationRepository metadataNotificationRepository = applicationContext.getBean(MetadataNotificationRepository.class);
@@ -193,6 +200,11 @@ public class MetadataNotifierManager {
             metadataNotificationRepository.delete(notificationId);
         } else {
             MetadataNotification notification = metadataNotificationRepository.findOne(notificationId);
+            if (notification == null) {
+                notification = new MetadataNotification();
+                notification.setId(notificationId);
+            }
+            notification.setMetadataUuid(uuid);
             notification.setNotified(true);
             notification.setAction(MetadataNotificationAction.UPDATE);
             metadataNotificationRepository.save(notification);
@@ -208,9 +220,10 @@ public class MetadataNotifierManager {
      * Marks a metadata record as notified for a notifier service.
      *
      * @param metadataId Metadata identifier
+     * @throws Exception
      */
-    private void setMetadataNotifiedError(final int metadataId, final MetadataNotifier notifier,
-                                          final boolean deleteNotification, final String error) throws Exception {
+    private void setMetadataNotifiedError(final int metadataId, final String uuid, final MetadataNotifier notifier,
+                                          final boolean deleteNotification, final String error) {
         if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
             Log.debug(Geonet.DATA_MANAGER, "setMetadataNotifiedError");
         }
@@ -220,18 +233,34 @@ public class MetadataNotifierManager {
                 .class);
 
             MetadataNotificationId id = new MetadataNotificationId().setMetadataId(metadataId).setNotifierId(notifier.getId());
-            metadataNotificationRepository.update(id, new Updater<MetadataNotification>() {
-                @Override
-                public void apply(@Nonnull MetadataNotification entity) {
-                    entity.setErrorMessage(error);
-                    if (deleteNotification == true) {
-                        entity.setAction(MetadataNotificationAction.DELETE);
-                    } else {
-                        entity.setAction(MetadataNotificationAction.UPDATE);
-
-                    }
+            MetadataNotification errorNotification = metadataNotificationRepository.findOne(id);
+            if (errorNotification == null) {
+                // Not existing notification
+                errorNotification = new MetadataNotification();
+                errorNotification.setId(id);
+                errorNotification.setNotified(true);
+                errorNotification.setMetadataUuid(uuid);
+                if (deleteNotification) {
+                    errorNotification.setAction(MetadataNotificationAction.DELETE);
+                } else {
+                    errorNotification.setAction(MetadataNotificationAction.UPDATE);
                 }
-            });
+                metadataNotificationRepository.save(errorNotification);
+            } else {
+                // notification already exists. Update it.
+                metadataNotificationRepository.update(id, new Updater<MetadataNotification>() {
+                    @Override
+                    public void apply(@Nonnull MetadataNotification entity) {
+                        entity.setErrorMessage(error);
+                        if (deleteNotification) {
+                            entity.setAction(MetadataNotificationAction.DELETE);
+                        } else {
+                            entity.setAction(MetadataNotificationAction.UPDATE);
+
+                        }
+                    }
+                });
+            }
 
             if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
                 Log.debug(Geonet.DATA_MANAGER, "setMetadataNotifiedError finished for metadata with id " + metadataId + "and notitifer " +
@@ -254,19 +283,19 @@ public class MetadataNotifierManager {
     }
 
     class UpdateTask implements Runnable {
-        private int metadataId;
-        private Element ISO19139;
-        private String uuid;
+        private final int metadataId;
+        private final Element metadataElement;
+        private final String uuid;
 
-        UpdateTask(Element ISO19139, String metadataId, String uuid) {
-            this.metadataId = Integer.valueOf(metadataId);
+        UpdateTask(Element metadataElement, String metadataId, String uuid) {
+            this.metadataId = Integer.parseInt(metadataId);
             this.uuid = uuid;
-            this.ISO19139 = ISO19139;
+            this.metadataElement = metadataElement;
         }
 
         public void run() {
             try {
-                String metadataString = Xml.getString(ISO19139);
+                String metadataString = Xml.getString(metadataElement);
                 if (Log.isDebugEnabled("MetadataNotifierManager")) {
                     Log.debug("MetadataNotifierManager", "updateMetadata before (uuid): " + uuid);
                 }
@@ -285,7 +314,7 @@ public class MetadataNotifierManager {
                         }
 
                         // mark metadata as notified for current notifier service
-                        setMetadataNotified(metadataId, service, false);
+                        setMetadataNotified(metadataId, uuid, service, false);
 
                     } catch (Exception ex) {
                         Log.error("MetadataNotifierManager", "updateMetadata ERROR (uuid): " + uuid + "notifier url "
@@ -294,7 +323,7 @@ public class MetadataNotifierManager {
 
                         // mark metadata as not notified for current notifier service
                         try {
-                            setMetadataNotifiedError(metadataId, service, false, ex.getMessage());
+                            setMetadataNotifiedError(metadataId, uuid, service, false, ex.getMessage());
                         } catch (Exception ex2) {
                             Log.error("MetadataNotifierManager", "updateMetadata ERROR (uuid): " + uuid + "notifier url " +
                                 service.getUrl() + " " + ex2.getMessage());
@@ -303,17 +332,19 @@ public class MetadataNotifierManager {
 
                 }
             } catch (Exception e) {
+                Log.error("MetadataNotifierManager", "updateTask ERROR (uuid): " + uuid + ", (id): " + metadataId
+                    + " " + e.getMessage());
                 e.printStackTrace();
             }
         }
     }
 
     class DeleteTask implements Runnable {
-        private int metadataId;
-        private String uuid;
+        private final int metadataId;
+        private final String uuid;
 
         DeleteTask(String metadataId, String uuid) {
-            this.metadataId = Integer.valueOf(metadataId);
+            this.metadataId = Integer.parseInt(metadataId);
             this.uuid = uuid;
         }
 
@@ -325,8 +356,6 @@ public class MetadataNotifierManager {
                 for (MetadataNotifier service : loadNotifiers()) {
                     int notifierId = service.getId();
                     String notifierUrl = service.getUrl();
-                    String username = service.getUsername();
-                    String password = String.valueOf(service.getPassword());
 
                     try {
                         if (Log.isDebugEnabled("MetadataNotifierManager")) {
@@ -340,7 +369,7 @@ public class MetadataNotifierManager {
                         System.out.println("deleteMetadata (id): " + metadataId + " notifier id: " + notifierId);
 
                         // mark metadata as notified for current notifier service
-                        setMetadataNotified(metadataId, service, true);
+                        setMetadataNotified(metadataId, uuid, service, true);
                     } catch (Exception ex) {
                         System.out.println("deleteMetadata ERROR:" + ex.getMessage());
 
@@ -350,7 +379,7 @@ public class MetadataNotifierManager {
 
                         // mark metadata as not notified for current notifier service
                         try {
-                            setMetadataNotifiedError(metadataId, service, true, ex.getMessage());
+                            setMetadataNotifiedError(metadataId, uuid, service, true, ex.getMessage());
                         } catch (Exception ex2) {
                             Log.error("MetadataNotifierManager", "updateMetadata ERROR (uuid): " + uuid + "notifier url " +
                                 notifierUrl + " " + ex2.getMessage());
@@ -360,6 +389,8 @@ public class MetadataNotifierManager {
                 }
 
             } catch (Exception e) {
+                Log.error("MetadataNotifierManager", "deleteTask ERROR (uuid): " + uuid + ", (id): " + metadataId
+                    + " " + e.getMessage());
                 e.printStackTrace();
             }
         }

--- a/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierManager.java
+++ b/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierManager.java
@@ -1,24 +1,24 @@
 //=============================================================================
-//===	Copyright (C) 2001-2010 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
+//===   Copyright (C) 2001-2010 Food and Agriculture Organization of the
+//===   United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===   and United Nations Environment Programme (UNEP)
 //===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
+//===   This program is free software; you can redistribute it and/or modify
+//===   it under the terms of the GNU General Public License as published by
+//===   the Free Software Foundation; either version 2 of the License, or (at
+//===   your option) any later version.
 //===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
+//===   This program is distributed in the hope that it will be useful, but
+//===   WITHOUT ANY WARRANTY; without even the implied warranty of
+//===   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===   General Public License for more details.
 //===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===   You should have received a copy of the GNU General Public License
+//===   along with this program; if not, write to the Free Software
+//===   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 //===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
+//===   Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===   Rome - Italy. email: geonetwork@osgeo.org
 //==============================================================================
 package org.fao.geonet.notifier;
 
@@ -196,22 +196,23 @@ public class MetadataNotifierManager {
         final MetadataNotificationId notificationId = new MetadataNotificationId().
             setMetadataId(metadataId).
             setNotifierId(notifier.getId());
-        if (deleteNotification) {
-            metadataNotificationRepository.delete(notificationId);
-        } else {
-            MetadataNotification notification = metadataNotificationRepository.findOne(notificationId);
-            if (notification == null) {
-                notification = new MetadataNotification();
-                notification.setId(notificationId);
-            }
-            notification.setMetadataUuid(uuid);
-            notification.setNotified(true);
-            notification.setAction(MetadataNotificationAction.UPDATE);
-            metadataNotificationRepository.save(notification);
+        MetadataNotification notification = metadataNotificationRepository.findOne(notificationId);
+        if (notification == null) {
+            notification = new MetadataNotification();
+            notification.setId(notificationId);
         }
+        notification.setMetadataUuid(uuid);
+        notification.setNotified(true);
+        if (deleteNotification) {
+            notification.setAction(MetadataNotificationAction.DELETE);
+        } else {
+            notification.setAction(MetadataNotificationAction.UPDATE);
+        }
+        metadataNotificationRepository.save(notification);
+
 
         if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-            Log.debug(Geonet.DATA_MANAGER, "setMetadataNotified finished for metadata with id " + metadataId + "and notifier with id "
+            Log.debug(Geonet.DATA_MANAGER, "setMetadataNotified finished for metadata with id " + metadataId + " and notifier with id "
                 + notifier.getId());
         }
     }


### PR DESCRIPTION
Metadata notifiers system doesn't work well since it can't store the result of the notifications in the table `MetadataNotifications`. This PR  fixes #1184. Create a new `MetadataNotification` if it doesn't exist in the database. Also don't delete the notification when deleteNotification is true. 
