### PR TITLE
Restyle and reorganise the elements on the admin dashboard

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/admin.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/admin.html
@@ -1,37 +1,51 @@
 <span>
-  <div class="col-lg-8" data-ng-controller="GnAdminController">
-    <div class="clearfix">
-      <a data-ng-repeat="m in getMenu()" href="{{getMenuUrl(m)}}"
-         class="btn btn-lg btn-block {{m.classes}} gn-btn-admin">
-        <i class="fa {{m.icon}} fa-4x"/>
-        <p data-translate="">{{m.name}}</p>
-      </a>
+  <div class="row gn-row-admin-buttons">
+    <div class="col-md-12" data-ng-controller="GnAdminController">
+      <div class="btn-group btn-group-justified">
+        <a data-ng-repeat="m in getMenu()"
+           href="{{getMenuUrl(m)}}"
+           title="{{m.name}}"
+           class="btn btn-default">
+          <i class="fa fa-fw {{m.icon}} fa-2x"/>
+          <p class="hidden-sm" data-translate="">{{m.name}}</p>
+        </a>
+      </div>
     </div>
   </div>
-  <div class="col-lg-4">
-    <div class="panel panel-default" data-ng-hide="true">
-      <div class="panel-heading" data-translate="">latestNews</div>
-    </div>
-    <div class="panel panel-default" data-ng-hide="true">
-      <div class="panel-heading" data-translate="">quicklinks</div>
-    </div>
-    <div class="panel panel-default text-center" data-ng-hide="searchInfo.facet.types.length === 0">
-      <div class="panel-body">
-        <div data-ng-repeat="type in searchInfo.facet.types">
-          <h2>{{type['@count']}}</h2>
+
+  <div class="row gn-row-admin-stats">
+    <div class="col-lg-2 col-md-4 col-sm-4" data-ng-repeat="type in searchInfo.facet.types" data-ng-hide="searchInfo.facet.types.length === 0">
+      <div class="panel panel-default panel-primary1">
+        <div class="panel-heading">
           <h5>{{(type['@label'] || type['@name']) | translate}}</h5>
+        </div>
+        <div class="panel-body">
+          <h2>{{type['@count']}}</h2>
         </div>
       </div>
     </div>
-    <div class="panel panel-default text-center">
-      <div class="panel-body">
-        <div data-ng-hide="searchInfo.count == 0">
+
+    <div class="col-md-4 col-sm-8" data-ng-hide="searchInfo.count == 0">
+      <div class="panel panel-default panel-success">
+        <div class="panel-heading">
+          <h5 data-translate="" title="{{'totalNumberOfRecordsHelp' | translate}}">totalNumberOfRecords</h5>
+        </div>
+        <div class="panel-body">
           <h2>{{searchInfo.count}}</h2>
-          <h5 data-translate="" title="{{'totalNumberOfRecordsHelp' | translate}}"
-          >totalNumberOfRecords</h5>
         </div>
         <div data-ng-show="searchInfo.count == 0" data-translate=""> emptyCatalogShouldBeFilled
         </div>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-lg-4">
+      <div class="panel panel-default" data-ng-hide="true">
+        <div class="panel-heading" data-translate="">latestNews</div>
+      </div> 
+      <div class="panel panel-default" data-ng-hide="true">
+        <div class="panel-heading" data-translate="">quicklinks</div>
       </div>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -15,3 +15,85 @@ ul.gn-resultview li.list-group-item {
     margin-bottom: 0;
   }
 }
+
+
+[ng-app="gn_admin"] {
+  body {
+    background-color: #f7f7f7;
+  }
+  .navbar-default {
+    background-color: @body-bg;
+  }
+  [data-ng-controller="GnAdminController"] {
+    padding-top: 15px;
+    .gn-row-admin-buttons {
+      margin-bottom: 20px;
+      .btn-group {
+        box-shadow: 0 0.5px 0.5px rgba(0,0,0,.03);
+        .btn {
+          border-color: darken(@gray-lighter, 6.5%);
+          padding: 15px;
+          border-right: 0;
+          p {
+            white-space: initial;
+            height: 2em;
+            margin-top: 5px;
+            @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+              height: 3em;
+              font-size: 90%;
+            }
+          }
+          &:hover {
+            background: @gray-lighter;
+            i {
+              color: @brand-warning;
+            }
+          }
+          &:last-child {
+            border-right: 1px solid darken(@gray-lighter, 6.5%);
+          }
+        }
+      }
+
+    }
+    .gn-row-admin-stats {
+      .panel {
+        border-color: darken(@gray-lighter, 6.5%);
+        box-shadow: 0 0.5px 0.5px rgba(0,0,0,.03);
+        .panel-heading {
+          padding: 5px 15px;
+          background: @gray-lighter;
+          border-color: darken(@gray-lighter, 6.5%);
+          h5 {
+            font-weight: 200;
+          }
+        }
+        .panel-body {
+          padding: 5px 15px;
+          background: @gray-lighter;
+          
+          h2 {
+            margin: 0;
+            padding: 10px 0;
+          }
+        }
+      }
+      .panel-primary {
+        border-color: darken(@brand-primary, 6.5%);
+        .panel-heading, .panel-body {
+          color: #fff;
+          background: @brand-primary;
+          border-color: darken(@brand-primary, 6.5%);
+        }
+      }
+      .panel-success {
+        border-color: darken(@brand-success, 6.5%);
+        .panel-heading, .panel-body {
+          color: #fff;
+          background: @brand-success;
+          border-color: darken(@brand-success, 6.5%);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR restyles and reorganises the elements (a little) on the dashboard. The colours of the buttons are removed and the list with numbers is divided into single blocks.

A little background colour has been added to let the elements stand out more.

**Screenshot after the restyling:**

![gn-restyle-dashboard](https://user-images.githubusercontent.com/19608667/50290009-b28adc00-046a-11e9-9fd4-df51c7ce0f68.png)
