### PR TITLE
Fixes for the editor fields (#3386)

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
@@ -196,7 +196,7 @@
           </xsl:otherwise>
         </xsl:choose>
       </label>
-      <div class="col-sm-9 gn-value nopadding-in-table">
+      <div class="col-sm-9 col-xs-11 gn-value nopadding-in-table">
         <div data-gn-date-picker="{gco:Date|gco:DateTime}"
              data-gn-field-tooltip="{$tooltip}"
              data-label=""
@@ -218,7 +218,7 @@
           </xsl:apply-templates>
         </div>
       </div>
-      <div class="col-sm-1 gn-control">
+      <div class="col-sm-1 col-xs-1 gn-control">
         <xsl:call-template name="render-form-field-control-remove">
           <xsl:with-param name="editInfo" select="gn:element"/>
         </xsl:call-template>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -118,7 +118,7 @@
           (<xsl:value-of select="$labelMeasureType/label"/>)
         </xsl:if>
       </label>
-      <div class="col-sm-9 gn-value nopadding-in-table">
+      <div class="col-sm-9 col-xs-11 gn-value nopadding-in-table">
         <xsl:variable name="elementRef"
                       select="gco:*/gn:element/@ref"/>
         <xsl:variable name="helper"
@@ -133,7 +133,7 @@
               saxon:serialize($helper, 'default-serialize-mode'))"/>
         </textarea>
       </div>
-      <div class="col-sm-1 gn-control">
+      <div class="col-sm-1 col-xs-1 gn-control">
         <xsl:call-template name="render-form-field-control-remove">
           <xsl:with-param name="editInfo" select="*/gn:element"/>
           <xsl:with-param name="parentEditInfo" select="$refToDelete"/>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -2,6 +2,8 @@
 @import "../../../style/gn_editor.less";
 @import "gn_view.less";
 
+
+
 [ng-app="gn_editor"] {
   .gn-top-bar {
     // status
@@ -72,7 +74,7 @@
       border-color: #ddd;
       box-shadow: none;
       outline: 0;
-      border-radius: 0;
+      border-radius: @gn-border-radius;
       &:focus {
         border-color: @brand-info;
         outline: 0;
@@ -80,10 +82,25 @@
       }
     }
     .btn {
-      border-radius: 0;
+      border-radius: @gn-border-radius;
     }
     .input-group-addon, .input-group-btn {
       width: 0.1%;
+    }
+    @media (max-width: @screen-xs-max) {
+      .col-xs-11.gn-value {
+        width: 90%;
+        padding-right: 0;
+      }
+      .col-xs-1.gn-control {
+        padding: 0;
+        [data-gn-field-highlight-remove] {
+          padding: 6px;
+        }
+      }
+      div.gn-extra-field > label {
+        display: none;
+      }
     }
     select:not([multiple]) {
       -webkit-appearance: none;
@@ -175,13 +192,13 @@
       .col-sm-9, .col-sm-12 {
         padding-left: 2px;
         padding-right: 0;
-      }
-      .input-group-btn {
-        float: left;
+        @media (max-width: @screen-xs-max) {
+          padding-left: 15px !important;
+        }
       }
     }
     .gn-date-picker > input[type=date], .gn-date-picker > input[type=time] {
-      width: 40%;
+      width: 50%;
     }
     // default switch
     [data-ng-switch-default] {
@@ -207,14 +224,20 @@
     }
     .gn-date {
       .col-sm-3 {
-        width: 21%;
-        padding-right: 0;
+        @media (min-width: @screen-sm-min) {
+          width: 25%;
+          padding-right: 0;
+        }
+        select {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
       }
       .col-sm-6 {
         padding-left: 0;
       }
     }
-    // special case
+    // special cases
     [data-gn-topiccategory-selector] {
       width: 90%;
       .col-sm-10 {
@@ -237,6 +260,35 @@
         }
       }
     }
+    [data-gn-directory-entry-selector] {
+      .input-group {
+        .input-group-btn {
+          a.btn-default {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+          }
+        }
+        .form-control {
+          border-top-right-radius: @gn-border-radius;
+          border-bottom-right-radius: @gn-border-radius;
+        }
+      }
+    }
+    [data-gn-editor-helper] {
+      .col-xs-8 {
+        .form-control {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+          // border-right: 0;
+        }
+      }
+      .col-xs-4 {
+        select {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+      }
+    }
     .col-lg-2.gn-control {
       width: 10%;
     }
@@ -251,7 +303,7 @@
   // sidebar in the editor
   .gn-editor-tools-container {
     .panel {
-      border-radius: 2px;
+      border-radius: @gn-border-radius;
       [data-gn-slide-toggle] {
         padding-left: 24px;
         &:before {
@@ -305,8 +357,8 @@ form.gn-editor.gn-indent-colored {
       font-size: 16px;
       padding: 3px 23px;
       line-height: 34px;
-      border-top-left-radius: 2px;
-      border-top-right-radius: 2px;
+      border-top-left-radius: @gn-border-radius;
+      border-top-right-radius: @gn-border-radius;
     }
     // No highlight on hover
     .field-bg {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -2,6 +2,9 @@
 //
 // this file must be first on the list of @import
 
+// general
+@gn-border-radius: 3px;
+
 // body background (image & color)
 //
 // when there is an empty string, no background image is used.

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -181,7 +181,7 @@
             <xsl:value-of select="$label/label"/>
           </label>
 
-          <div class="col-sm-9 gn-value nopadding-in-table">
+          <div class="col-sm-9 col-xs-11 gn-value nopadding-in-table">
             <xsl:if test="$isMultilingual">
               <xsl:attribute name="data-gn-multilingual-field"
                              select="$metadataOtherLanguagesAsJson"/>
@@ -288,7 +288,7 @@
               </xsl:for-each>
             </xsl:if>
           </div>
-          <div class="col-sm-1 gn-control">
+          <div class="col-sm-1 col-xs-1 gn-control">
             <xsl:if test="not($isDisabled)">
               <xsl:call-template name="render-form-field-control-remove">
                 <xsl:with-param name="editInfo" select="$editInfo"/>


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/3386

Changes:
- date picker stays on one line
- better responsiveness for delete buttons
- rounded corners are back (new variable added)

**Screenshot of the datepicker:**

![gn-editor-date](https://user-images.githubusercontent.com/19608667/50483356-c8a91700-09eb-11e9-8a3d-7533022b8aa1.png)

**Delete buttons on a small screen:**

![gn-editor-responsiveness](https://user-images.githubusercontent.com/19608667/50483377-de1e4100-09eb-11e9-84d8-9ee4cb920f4c.png)
