### PR TITLE
Larger map for editor on small screens

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
@@ -17,37 +17,38 @@
     </div>
   </div>
 
-  <div class="form-group gn-field" data-ng-show="identifierRef !== undefined">
-    <label class="col-sm-3 control-label"
-           data-translate="">bboxIdentifier</label>
-    <div class="col-sm-8 gn-value">
-      <input class="form-control"
-             data-ng-model="identifier"
-             name="{{identifierRef}}"
-             ng-disabled="readOnly"/>
+  <div class="row">
+    <div class="form-group gn-field" data-ng-show="identifierRef !== undefined">
+      <label class="col-sm-3 control-label"
+            data-translate="">bboxIdentifier</label>
+      <div class="col-sm-8 gn-value">
+        <input class="form-control"
+              data-ng-model="identifier"
+              name="{{identifierRef}}"
+              ng-disabled="readOnly"/>
+      </div>
+      <div class="col-sm-1 gn-control">
+        <a class="btn pull-right" data-ng-click="identifier = ''">
+          <i class="fa fa-times text-danger"></i>
+        </a>
+      </div>
     </div>
-    <div class="col-sm-1 gn-control">
-      <a class="btn pull-right" data-ng-click="identifier = ''">
-        <i class="fa fa-times text-danger"></i>
-      </a>
+    <div class="form-group gn-field" data-ng-show="descriptionRef !== undefined">
+      <label class="col-sm-3 control-label"
+            data-translate="">bboxDescription</label>
+      <div class="col-sm-8 gn-value">
+        <input class="form-control"
+              data-ng-model="description"
+              name="{{descriptionRef}}"
+              ng-disabled="readOnly"/>
+      </div>
+      <div class="col-sm-1 gn-control">
+        <a class="btn pull-right" data-ng-click="description = ''">
+          <i class="fa fa-times text-danger"></i>
+        </a>
+      </div>
     </div>
   </div>
-  <div class="form-group gn-field" data-ng-show="descriptionRef !== undefined">
-    <label class="col-sm-3 control-label"
-           data-translate="">bboxDescription</label>
-    <div class="col-sm-8 gn-value">
-      <input class="form-control"
-             data-ng-model="description"
-             name="{{descriptionRef}}"
-             ng-disabled="readOnly"/>
-    </div>
-    <div class="col-sm-1 gn-control">
-      <a class="btn pull-right" data-ng-click="description = ''">
-        <i class="fa fa-times text-danger"></i>
-      </a>
-    </div>
-  </div>
-
   <!-- Hidden field that match xml metadata schema -->
   <div class="hidden">
     <input data-ng-model="extent.md[0]" name="{{hleftRef}}"/>
@@ -58,70 +59,65 @@
   </div>
 
   <!--Projection selector-->
-  <div class="btn-group">
-    <button type="button" class="btn btn-link dropdown-toggle"
-            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-            title="{{'chooseAProj' | translate}}">
-      {{projs.formLabel}} <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu">
-      <li data-ng-repeat="proj in projs.list">
-        <a href="" data-ng-click="projs.form = proj.code; projs.formLabel = proj.label">
-          {{proj.label}}
-        </a>
-      </li>
-    </ul>
+  <div class="row">
+    <div class="btn-group">
+      <button type="button" class="btn btn-link dropdown-toggle"
+              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+              title="{{'chooseAProj' | translate}}">
+        {{projs.formLabel}} <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li data-ng-repeat="proj in projs.list">
+          <a href="" data-ng-click="projs.form = proj.code; projs.formLabel = proj.label">
+            {{proj.label}}
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 
   <!--Map and coordinates inputs-->
-  <table class="text-center">
-    <tr align="center" valign="middle">
-      <td align="left">
-      </td>
-      <td>
-        <div class="form-group">
-          <input
-            data-ng-model="extent.form[3]" type="number"
-            id="drawbbox-top" placeholder="{{'north' | translate}}"
-            data-ng-change="updateBbox(true)"
-            ng-disabled="readOnly"/>
-        </div>
-      </td>
-      <td>
-      </td>
-    </tr>
-    <tr valign="middle" align="center">
-      <td class="col-left">
-        <div class="form-group">
-          <input data-ng-model="extent.form[0]" type="number"
-                 id="drawbbox-left" placeholder="{{'west' | translate}}"
+  <div class="text-center">
+    <div class="thumbnail extent">
+      <span>
+        <div class="input-group coord coord-north">
+          <input data-ng-model="extent.form[3]"
+                 type="number"
+                 id="drawbbox-top"
+                 placeholder="{{'north' | translate}}"
                  data-ng-change="updateBbox(true)"
                  ng-disabled="readOnly"/>
+          <span class="input-group-addon hidden-xs">N</span>
         </div>
-      </td>
-      <td class="col-middle">
-        <div ng-if="map" ngeo-map="map"></div>
-      </td>
-      <td class="col-right">
-        <div class="form-group">
-          <input
-            data-ng-model="extent.form[2]"
-            type="number" id="drawbbox-right"
-            placeholder="{{'east' | translate}}" data-ng-change="updateBbox(true)"
-            ng-disabled="readOnly"/>
+        <div class="input-group coord coord-south">
+          <input data-ng-model="extent.form[1]"
+                 type="number"
+                 id="drawbbox-bottom"
+                 placeholder="{{'south' | translate}}"
+                 data-ng-change="updateBbox(true)"
+                 ng-disabled="readOnly"/>
+          <span class="input-group-addon hidden-xs">S</span>
         </div>
-      </td>
-    </tr>
-    <tr align="center">
-      <td colspan="3">
-        <div class="form-group">
-          <input
-            data-ng-model="extent.form[1]" type="number"
-            id="drawbbox-bottom" placeholder="{{'south' | translate}}"
-            data-ng-change="updateBbox(true)"
-            ng-disabled="readOnly"/>
+        <div class="input-group coord coord-east">
+          <input data-ng-model="extent.form[2]"
+                 type="number"
+                 id="drawbbox-right"
+                 placeholder="{{'east' | translate}}"
+                 data-ng-change="updateBbox(true)"
+                 ng-disabled="readOnly"/>
+          <span class="input-group-addon hidden-xs">E</span>
         </div>
-      </td>
-    </tr>
-  </table>
+        <div class="input-group coord coord-west">
+          <input data-ng-model="extent.form[0]"
+                 type="number"
+                 id="drawbbox-left"
+                 placeholder="{{'west' | translate}}"
+                 data-ng-change="updateBbox(true)"
+                 ng-disabled="readOnly"/>
+          <span class="input-group-addon hidden-xs">W</span>
+        </div>
+      </span>
+      <div ng-if="map" ngeo-map="map"></div>
+    </div>
+  </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -248,6 +248,54 @@
       }
     }
   }
+  // map
+  .gn-drawmap-panel {
+    input[type="number"] {
+      margin: 0;
+      text-align: left;
+    }
+    .extent {
+      display: inline-block;
+      position: relative;
+      margin-top: 30px;
+    }
+    .coord {
+      position: absolute;
+      width: 200px;
+      z-index: 100;
+    }
+    .coord-north {
+      top: -1.25em;
+      left: 50%;
+      margin-left: -75px;
+    }
+    .coord-south {
+      bottom: -1.25em;
+      left: 50%;
+      margin-left: -75px;
+    }
+    .coord-east {
+      right: -75px;
+      top: 50%;
+      margin-top: -1.25em;
+    }
+    .coord-west {
+      left: -75px;
+      top: 50%;
+      margin-top: -1.25em;
+    }
+    @media (max-width: @screen-xs-max) {
+      .coord {
+        width: 150px;
+      }
+      .coord-east {
+        right: -30px;
+      }
+      .coord-west {
+        left: -30px;
+      }
+    }
+  }
   // sidebar in the editor
   .gn-editor-tools-container {
     .panel {


### PR DESCRIPTION
The map in the editor is displayed in a table with the map in the center table cell. This means that when you use the editor on a small screen the map is usually only one third of the width of a screen.

This PR takes the styling from the detail view where the coordinate boxes are displayed over the map. This results in a better responsiveness and a larger map on small screens. 

The N, E, S and W labels are hidden on small screens.

**Old situation:**
![gn-editor-map-old](https://user-images.githubusercontent.com/19608667/50557857-6ac94780-0ce9-11e9-934a-3c1f4c1b7cb0.png)

**New situation:**
![gn-editor-map-new](https://user-images.githubusercontent.com/19608667/50557868-74eb4600-0ce9-11e9-81d0-e71cdd89af07.png)

**New situation on larger screens (with N, E, S and W labels):**
![gn-editor-map-new-large](https://user-images.githubusercontent.com/19608667/50557883-8df3f700-0ce9-11e9-829c-75db352dbd18.png)


