### PR TITLE
Fix a bug handling initial value of `ui/config` setting

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
@@ -43,7 +43,7 @@
           // merge on top of default config
           scope.jsonConfig = angular.merge(
             // If the config is empty, use the default one set in CatController
-            (Object.keys(scope.config).length === 0 ?
+            (Object.keys(scope.config).length === 0 || scope.config === "null" || !scope.config ?
               gnGlobalSettings.getDefaultConfig() :
               gnGlobalSettings.getMergeableDefaultConfig()),
               angular.fromJson(scope.config));

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -149,7 +149,7 @@
 
               // Stringify JSON for editing in text area
               angular.forEach(data, function(s) {
-                if (s.id === 'ui/config') {
+                if (s.name === 'ui/config') {
                   uiConfigFound = true;
                 }
                 if (s.dataType === 'JSON') {


### PR DESCRIPTION
This fixes a bug that occurs when started with an empty database. Then UI settings page shows duplicated values for all the fields.

* Setting name is in `name` property, not `id`
* `Object.keys` returns 4 for `"null"` value. Add this check also to the condition for
using `gnGlobalSettings.getDefaultConfig`.

Related to #3378.