### PR TITLE
Don't concat port number if it's null or 80 in settings

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -511,9 +511,15 @@
          */
         getServiceURL: function() {
           var port = '';
-          if(gnConfig['system.server.port'] &&
+          if(gnConfig['system.server.protocol']==='http' &&
+             gnConfig['system.server.port'] &&
              gnConfig['system.server.port']!=null &&
              gnConfig['system.server.port']!=80) {
+            port = ':'+gnConfig['system.server.port'];
+          } else if(gnConfig['system.server.protocol']==='https' &&
+             gnConfig['system.server.port'] &&
+             gnConfig['system.server.port']!=null &&
+             gnConfig['system.server.port']!=443) {
             port = ':'+gnConfig['system.server.port'];
           }
 

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -510,9 +510,15 @@
          * @return {String} service url.
          */
         getServiceURL: function() {
+          var port = '';
+          if(gnConfig['system.server.port'] &&
+             gnConfig['system.server.port']!=null &&
+             gnConfig['system.server.port']!=80) {
+            port = ':'+gnConfig['system.server.port'];
+          }
+
           var url = gnConfig['system.server.protocol'] + '://' +
-              gnConfig['system.server.host'] + ':' +
-              gnConfig['system.server.port'] +
+              gnConfig['system.server.host'] + port +
               gnConfig.env.baseURL + '/' +
               gnConfig.env.node + '/';
           return url;


### PR DESCRIPTION
The behaviour is not consistent with other parts of the code, where the port is not added to the URL when equals to 80 or null.


