### PR TITLE
Record history / Exception when owner is null.

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/MetadataStatus.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataStatus.java
@@ -155,7 +155,9 @@ public class MetadataStatus extends GeonetEntity {
      * @return this entity object
      */
     public MetadataStatus setOwner(Integer ownerId) {
-        this._owner = ownerId;
+        if (ownerId != null) {
+            this._owner = ownerId;
+        }
         return this;
     }
 


### PR DESCRIPTION
This may be possible depending on the type of events or on custom values
inserted in the db or old events.

Error is:
```
{"message":"JpaSystemException","code":"runtime_exception","description":"Exception occurred inside setter of org.fao.geonet.domain.MetadataStatus.owner; nested exception is org.hibernate.PropertyAccessException: Exception occurred inside setter of org.fao.geonet.domain.MetadataStatus.owner"}
```
when setting a null int.

For example, when calling http://localhost:8080/geonetwork/srv/api/records/status/search?type=workflow&type=task&type=event&from=0&size=20