### PR TITLE
Map / Restore layer style.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1306,7 +1306,7 @@
            * @param {boolean} createOnly or add it to the map
            * @param {!Object} md object
            */
-          addWmsFromScratch: function(map, url, name, createOnly, md, version) {
+          addWmsFromScratch: function(map, url, name, createOnly, md, version, style) {
             var defer = $q.defer();
             var $this = this;
 
@@ -1363,7 +1363,7 @@
               	       capL.useProxy = true;
   	              }
 
-                  olL = $this.createOlWMSFromCap(map, capL, url);
+                  olL = $this.createOlWMSFromCap(map, capL, url, style);
 
                   var finishCreation = function() {
 

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -270,10 +270,15 @@
               // WMS layer not in background
               else if (layer.server) {
                 var server = layer.server[0];
+                var currentStyle;
 
                 // load extension content (JSON)
                 if (layer.extension && layer.extension.any) {
                   var extension = JSON.parse(layer.extension.any);
+
+                  if (extension.style) {
+                    currentStyle = {Name: extension.style};
+                  }
 
                   // import saved filters if available
                   if (extension.filters && extension.wfsUrl) {
@@ -305,7 +310,7 @@
                   loadingLayer.displayInLayerManager = true;
 
                   var layerIndex = map.getLayers().push(loadingLayer);
-                  var p = self.createLayer(layer, map, undefined, i);
+                  var p = self.createLayer(layer, map, undefined, i, currentStyle);
                   loadingLayer.set('index', layerIndex);
 
                   (function(idx, loadingLayer) {
@@ -511,9 +516,15 @@
             layerParams.server[0].version = version;
           }
 
+
           // apply filters & processes inputs in extension if needed
-          if (filters || processInputs) {
+          if (layer.get('currentStyle') || filters || processInputs) {
             var extension = {};
+
+            if (layer.get('currentStyle')) {
+              extension.style = layer.get('currentStyle').Name;
+            }
+
             if (esObj) {
               var wfsUrl = esObj.config.params.wfsUrl;
               if (wfsUrl) {
@@ -594,7 +605,7 @@
        * dropdown
        * @param {numeric} index of the layer in the tree
        */
-      this.createLayer = function(layer, map, bgIdx, index) {
+      this.createLayer = function(layer, map, bgIdx, index, style) {
 
         var server = layer.server[0];
         var res = server.onlineResource[0];
@@ -640,7 +651,7 @@
           // even when loaded from a context.
           return gnMap.addWmsFromScratch(
               map, res.href, layer.name,
-              createOnly, null, server.version).
+              createOnly, null, server.version, style).
               then(function(olL) {
                 if (olL) {
                   try {


### PR DESCRIPTION
When user define a non default style for a layer. On page reload (or export/restore map from a context), the style is lost.

Can be tested with service http://www.aquacoope.org/geoserver/c_ge/ows and layer t_mostation

![image](https://user-images.githubusercontent.com/1701393/50785775-f591df80-12b1-11e9-84bd-939a9e5f4a49.png)

The style is now stored in the extension section (like filters and process info)
```xml
<ows-context:Layer name="t_mostation" hidden="false" opacity="1">
  <ows-context:Server service="urn:ogc:serviceType:WMS">
    <ows-context:OnlineResource xlink:href="http://www.aquacoope.org/geoserver/c_ge/ows?SERVICE=WMS&amp;"/>
  </ows-context:Server>
  <ows-context:Extension>{"style":"c_ge:t_mostation_ge_MON_GE002"}</ows-context:Extension>
</ows-context:Layer>
</ows-context:ResourceList>
</ows-context:OWSContext>
```
