### PR TITLE
UI Improvements to the admin interface

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -13,7 +13,7 @@
        data-ng-show="(('ui-mod-' + m + '-help') | translate) != ('ui-mod-' + m + '-help')">
       {{('ui-' + m + '-help') | translate}} </p>
 
-    <div class="col-sm-12"
+    <div class="col-sm-12 form-group"
          data-ng-repeat="(key, value) in mCfg"
          data-ng-switch="key">
 

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -269,6 +269,34 @@
               by: buildUrl($scope.settings)
             });
       };
+      $scope.filterForm = function(e,formId) {
+
+        var filterValue = e.target.value.toLowerCase();
+
+        $(formId + " .form-group").filter(function() {
+
+          var filterText = $(this).find('label').text().toLowerCase();
+          var matchStart = filterText.indexOf("" + filterValue.toLowerCase() + "");
+
+          if (matchStart > -1) {
+            $(this).show();
+          } else {
+            $(this).hide();
+          }
+        });
+      };
+      $scope.resetFilter = function(formId) {
+
+        $(formId + " .form-group").each(function() {
+          // clear filter
+          $('#filter-settings').val('');
+          // show the element
+          $(this).show();
+          // show the fieldsets
+          $(formId + ' fieldset').show();
+        });
+
+      };
 
       $scope.testMailConfiguration = function() {
         $http.get('../api/0.1/tools/mail/test')

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1337,5 +1337,8 @@
     "usersInGroup": "Users in group",
     "ui-editorIndentType": "Editor page indent type",
     "ui-editorIndentType-default": "Default, minimal indents",
-    "ui-editorIndentType-colored": "Colored indents"
+    "ui-editorIndentType-colored": "Colored indents",
+    "filterSettings": "Filter settings ",
+    "filterPlaceHolder": "e.g. INSPIRE",
+    "filterReset": "Reset the filter"
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/admin.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/admin.html
@@ -1,38 +1,94 @@
-<span>
-  <div class="col-lg-8" data-ng-controller="GnAdminController">
-    <div class="clearfix">
-      <a data-ng-repeat="m in getMenu()" href="{{getMenuUrl(m)}}"
-         class="btn btn-lg btn-block {{m.classes}} gn-btn-admin">
-        <i class="fa {{m.icon}} fa-4x"/>
-        <p data-translate="">{{m.name}}</p>
-      </a>
+<div class="row" data-ng-controller="GnAdminController">
+
+    <div class="sidebar">
+  
+      <div class="sidebar-col-main sidebar-col-full">
+        <ul data-ng-if="user.isUserAdmin()" class="nav nav-sidebar" role="menu">
+            <li>
+              <a data-gn-active-tb-item="admin.console#/home">
+                <i class="fa fa-fw fa-th"></i>
+                <span translate>adminHome</span>
+              </a>
+            </li>
+            <li role="separator" class="divider"></li>
+            <li data-ng-repeat="t in userAdminMenu">
+              <a data-gn-active-tb-item="admin.console{{t.route}}">
+                <i class="fa fa-fw {{t.icon}}"></i>
+                <span translate>{{t.name | translate}}</span>
+              </a>
+            </li>
+          </ul>
+          <ul data-ng-if="user.isAdministrator()" class="nav nav-sidebar" role="menu">
+            <li>
+              <a data-gn-active-tb-item="admin.console#/home">
+                <i class="fa fa-fw fa-th"></i>
+                <span translate>adminHome</span>
+              </a>
+            </li>
+            <li role="separator" class="divider"></li>
+            <li data-ng-repeat="t in adminMenu">
+              <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}{{t.route}}">
+                <i class="fa fa-fw {{t.icon}}"></i>
+                <span translate>{{t.name | translate}}</span>
+              </a>
+            </li>
+          </ul>
+      </div>
+      <!-- /.sidebar-col-main -->
+      <div class="sidebar-col-sub">
+         <ul class="nav nav-sidebar">
+          <li data-ng-repeat="t in pageMenu.tabs"
+              data-ng-class="href === t.href && 'active'">
+            <a href="{{t.href}}">
+              <i class="fa fa-fw {{t.icon || 'fa-fw'}}"/>
+              <span data-translate="">{{t.label}}</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+      <!-- /.sidebar-col-sub -->
     </div>
-  </div>
-  <div class="col-lg-4">
-    <div class="panel panel-default" data-ng-hide="true">
-      <div class="panel-heading" data-translate="">latestNews</div>
-    </div>
-    <div class="panel panel-default" data-ng-hide="true">
-      <div class="panel-heading" data-translate="">quicklinks</div>
-    </div>
-    <div class="panel panel-default text-center" data-ng-hide="searchInfo.facet.types.length === 0">
-      <div class="panel-body">
-        <div data-ng-repeat="type in searchInfo.facet.types">
-          <h2>{{type['@count']}}</h2>
-          <h5>{{(type['@label'] || type['@name']) | translate}}</h5>
+    <!-- /.sidebar -->
+    <div class="main"">
+      <div class="row">
+        <div class="col-lg-8" data-ng-controller="GnAdminController">
+          <div class="clearfix">
+            <a data-ng-repeat="m in getMenu()" href="{{getMenuUrl(m)}}"
+              class="btn btn-lg btn-block {{m.classes}} gn-btn-admin">
+              <i class="fa {{m.icon}} fa-4x"/>
+              <p data-translate="">{{m.name}}</p>
+            </a>
+          </div>
+        </div>
+        <div class="col-lg-4">
+          <div class="panel panel-default" data-ng-hide="true">
+            <div class="panel-heading" data-translate="">latestNews</div>
+          </div>
+          <div class="panel panel-default" data-ng-hide="true">
+            <div class="panel-heading" data-translate="">quicklinks</div>
+          </div>
+          <div class="panel panel-default text-center" data-ng-hide="searchInfo.facet.types.length === 0">
+            <div class="panel-body">
+              <div data-ng-repeat="type in searchInfo.facet.types">
+                <h2>{{type['@count']}}</h2>
+                <h5>{{(type['@label'] || type['@name']) | translate}}</h5>
+              </div>
+            </div>
+          </div>
+          <div class="panel panel-default text-center">
+            <div class="panel-body">
+              <div data-ng-hide="searchInfo.count == 0">
+                <h2>{{searchInfo.count}}</h2>
+                <h5 data-translate="" title="{{'totalNumberOfRecordsHelp' | translate}}"
+                >totalNumberOfRecords</h5>
+              </div>
+              <div data-ng-show="searchInfo.count == 0" data-translate=""> emptyCatalogShouldBeFilled
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div class="panel panel-default text-center">
-      <div class="panel-body">
-        <div data-ng-hide="searchInfo.count == 0">
-          <h2>{{searchInfo.count}}</h2>
-          <h5 data-translate="" title="{{'totalNumberOfRecordsHelp' | translate}}"
-          >totalNumberOfRecords</h5>
-        </div>
-        <div data-ng-show="searchInfo.count == 0" data-translate=""> emptyCatalogShouldBeFilled
-        </div>
-      </div>
-    </div>
+    <!-- /.main -->
   </div>
-</span>
+

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-report.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-report.html
@@ -9,10 +9,10 @@
       </div>
 
       <div class="panel-body">
-        <button type="button" class="btn btn-small"
-                data-ng-click="csvReport($event)" data-translate=""
-        >csvExport
-        </button>
+        <div class="navbar">
+        <button type="button" class="btn btn-default"
+                data-ng-click="csvReport($event)" data-translate="">csvExport
+        </button></div>
 
         <table id="harvestReport" class="table table-striped">
           <tr>
@@ -28,11 +28,11 @@
             <td class="gn-break">{{h.site.url || h.site.baseUrl || h.site.capabilitiesUrl ||
               h.site.host}}
             </td>
-            <td class="text-center">{{('harvester-' + h['@type']) | translate}}</td>
-            <td class="text-center">{{h.info.lastRun.length === 0 ? '' : (h.info.lastRun |
+            <td >{{('harvester-' + h['@type']) | translate}}</td>
+            <td>{{h.info.lastRun.length === 0 ? '' : (h.info.lastRun |
               date:'medium')}}
             </td>
-            <td class="text-right">{{h.info.result.total}}</td>
+            <td>{{h.info.result.total}}</td>
           </tr>
         </table>
       </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/page-layout.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/page-layout.html
@@ -1,18 +1,54 @@
-<div data-ng-controller="GnAdminController">
-  <div class="row">
-    <div class="col-md-12">
-      <ul class="nav nav-pills">
+<div class="row" data-ng-controller="GnAdminController">
+
+  <div class="sidebar">
+
+    <div class="sidebar-col-main">
+      <ul data-ng-if="user.isUserAdmin()" class="nav nav-sidebar" role="menu">
+          <li>
+            <a data-gn-active-tb-item="admin.console#/home">
+              <i class="fa fa-fw fa-th"></i>
+              <span translate>adminHome</span>
+            </a>
+          </li>
+          <li role="separator" class="divider"></li>
+          <li data-ng-repeat="t in userAdminMenu">
+            <a data-gn-active-tb-item="admin.console{{t.route}}">
+              <i class="fa fa-fw {{t.icon}}"></i>
+              <span translate>{{t.name | translate}}</span>
+            </a>
+          </li>
+        </ul>
+        <ul data-ng-if="user.isAdministrator()" class="nav nav-sidebar" role="menu">
+          <li>
+            <a data-gn-active-tb-item="admin.console#/home">
+              <i class="fa fa-fw fa-th"></i>
+              <span translate>adminHome</span>
+            </a>
+          </li>
+          <li role="separator" class="divider"></li>
+          <li data-ng-repeat="t in adminMenu">
+            <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}{{t.route}}">
+              <i class="fa fa-fw {{t.icon}}"></i>
+              <span translate>{{t.name | translate}}</span>
+            </a>
+          </li>
+        </ul>
+    </div>
+    <!-- /.sidebar-col-main -->
+    <div class="sidebar-col-sub">
+       <ul class="nav nav-sidebar">
         <li data-ng-repeat="t in pageMenu.tabs"
-            data-ng-class="href === t.href && 'active'">
+            data-ng-class="(href === t.href && 'active') || (!href && t.href + '' === '#/' + pageMenu.folder + pageMenu.defaultTab && 'active')">
           <a href="{{t.href}}">
-            <i class="fa {{t.icon || 'fa-fw'}}"/>
+            <i class="fa fa-fw {{t.icon || 'fa-fw'}}"/>
             <span data-translate="">{{t.label}}</span>
           </a>
         </li>
       </ul>
     </div>
+    <!-- /.sidebar-col-sub -->
   </div>
-  <br/>
-
-  <div data-ng-include="getTpl(pageMenu)"></div>
+  <!-- /.sidebar -->
+  <div class="main" data-ng-include="getTpl(pageMenu)"></div>
+  <!-- /.main -->
 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
@@ -1,235 +1,216 @@
-<div class="row">&nbsp;</div>
-<div class="row">&nbsp;</div>
 <div class="row">
   <div class="col-md-12">
-    <div class="panel panel-default"
-      data-ng-controller="GnCssStyleSettingsController">
-      <div class="panel-heading">
-        <span data-translate="">cssstyle</span>
-      </div>
-      <div class="panel-body">
-        <form id="gn-settings" name="gnSettings" class="form-horizontal">
-          <div class="row">
-            <p data-translate="">gnCssStyleIntroMessage</p>
+    <div data-ng-controller="GnCssStyleSettingsController">
+      <form id="gn-settings" name="gnSettings" class="form-horizontal">
+      
+        <div class="navbar">
+          <div class="pull-right">
+            <button class="btn btn-primary"
+              data-ng-click="saveCssStyleSettings(gnCssStyle)">
+              <span class="fa fa-save"></span> {{"saveSettings"|translate}}
+            </button>
+            <a target="_blank" data-ng-href="../api/customstyle"
+              class="btn btn-default"> <span class="fa fa-clone"></span>
+              {{"exportSettings"|translate}}
+            </a>
+            <button class="btn btn-default"
+              data-gn-confirm-click="{{'restoreDefaultStyleConfirm' | translate}}"
+              data-ng-click="restoreDefaultCssStyleSettings(gnCssStyle)">
+              <span class="fa fa-history"></span>
+              {{"restoreDefaultSettings"|translate}}
+            </button>
           </div>
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnBackgroundCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnBackgroundImage" data-translate="">styleVariable-gnBackgroundImage</label>
-                <input class="form-control" type="text"
-                  data-ng-model="gnCssStyle.gnBackgroundImage" />
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnBackgroundColor" data-translate="">styleVariable-gnBackgroundColor</label>
-                <color-picker data-ng-model="gnCssStyle.gnBackgroundColor"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-            </div>
-          </div>
+        </div>
 
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnHeaderCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnHeaderBackground" data-translate="">styleVariable-gnHeaderBackground</label>
-                <color-picker data-ng-model="gnCssStyle.gnHeaderBackground"
-                  color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <span data-translate="">cssstyle</span>
+          </div>
+          <div class="panel-body">
+            
+            <div class="row">
+              <p data-translate="">gnCssStyleIntroMessage</p>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <legend >
+                  <span data-translate="">gnBackgroundCss</span>
+                </legend>
+              </div>
+              <div class="form-row">
+                <div class="col-md-9">
+                  <label for="gnCssStyle.gnBackgroundImage" data-translate="">styleVariable-gnBackgroundImage</label>
+                  <input class="form-control" type="text"
+                    data-ng-model="gnCssStyle.gnBackgroundImage" />
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnBackgroundColor" data-translate="">styleVariable-gnBackgroundColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnBackgroundColor"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <legend>
+                  <span data-translate="">gnHeaderCss</span>
+                </legend>
+              </div>
+              <div class="form-row">
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnHeaderBackground" data-translate="">styleVariable-gnHeaderBackground</label>
+                  <color-picker data-ng-model="gnCssStyle.gnHeaderBackground"
+                    color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <legend>
+                  <span data-translate="">gnMenubarCss</span>
+                </legend>
+              </div>
+              <div class="form-row">
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnMenubarBackground" data-translate="">styleVariable-gnMenubarBackground</label>
+                  <color-picker data-ng-model="gnCssStyle.gnMenubarBackground"
+                    color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gn-menubarBackgroundActive"
+                    data-translate="">styleVariable-gnMenubarBackgroundActive</label>
+                  <color-picker
+                    data-ng-model="gnCssStyle.gnMenubarBackgroundActive"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnMenubarColor" data-translate="">styleVariable-gnMenubarColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnMenubarColor"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gn-menubarColorHover" data-translate="">styleVariable-gnMenubarColorHover</label>
+                  <color-picker data-ng-model="gnCssStyle.gnMenubarColorHover"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnMenubarBorderColor" data-translate="">styleVariable-gnMenubarBorderColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnMenubarBorderColor"
+                    color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <legend>
+                  <span data-translate="">gnBottombarCss</span>
+                </legend>
+              </div>
+              <div class="form-row">
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnBottombarBackground" data-translate="">styleVariable-gnBottombarBackground</label>
+                  <color-picker data-ng-model="gnCssStyle.gnBottombarBackground"
+                    color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnBottombarColor" data-translate="">styleVariable-gnBottombarColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnBottombarColor"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnBottombarColorHover" data-translate="">styleVariable-gnBottombarColorHover</label>
+                  <color-picker data-ng-model="gnCssStyle.gnBottombarColorHover"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnBottombarBorderColor" data-translate="">styleVariable-gnBottombarBorderColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnBottombarBorderColor"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-6">
+                <legend>
+                  <span data-translate="">gnTopicsCss</span>
+                </legend>
+                <div class="form-row">
+                  <div class="col-md-6 gn-nopadding-left">
+                    <label for="gnCssStyle.gnTopicsBackgroundColor"
+                      data-translate="">styleVariable-gnTopicsBackgroundColor</label>
+                    <color-picker data-ng-model="gnCssStyle.gnTopicsBackgroundColor"
+                      color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                  </div>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <legend>
+                  <span data-translate="">gnInfoCss</span>
+                </legend>
+                <div class="form-row">
+                  <div class="col-md-6 gn-nopadding-left">
+                    <label for="gnCssStyle.gnInfoBackgroundColor" data-translate="">styleVariable-gnInfoBackgroundColor</label>
+                    <color-picker data-ng-model="gnCssStyle.gnInfoBackgroundColor"
+                      color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-6">
+                <legend>
+                  <span data-translate="">gnResultcardsCss</span>
+                </legend>
+                <div class="form-row">
+                  <div class="col-md-6 gn-nopadding-left">
+                    <label for="gnCssStyle.gnResultcardBackgroundColor"
+                      data-translate="">styleVariable-gnResultcardBackgroundColor</label>
+                    <color-picker
+                      data-ng-model="gnCssStyle.gnResultcardBackgroundColor"
+                      color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                  </div>
+                  <div class="col-md-6">
+                    <label for="gnCssStyle.gnResultcardTitleBackgroundColor"
+                      data-translate="">styleVariable-gnResultcardTitleBackgroundColor</label>
+                    <color-picker
+                      data-ng-model="gnCssStyle.gnResultcardTitleBackgroundColor"
+                      color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                  </div>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <legend>
+                  <span data-translate="">gnResultsCss</span>
+                </legend>
+                <div class="form-row">
+                  <div class="col-md-6 gn-nopadding-left">
+                    <label for="gnCssStyle.gnResultsBackgroundColor"
+                      data-translate="">styleVariable-gnResultsBackgroundColor</label>
+                    <color-picker
+                      data-ng-model="gnCssStyle.gnResultsBackgroundColor"
+                      color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <legend>
+                  <span data-translate="">gnMdViewCss</span>
+                </legend>
+              </div>
+              <div class="form-row">
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnMdViewBackgroundColor"
+                    data-translate="">styleVariable-gnMdViewBackgroundColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnMdViewBackgroundColor"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
               </div>
             </div>
           </div>
-
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnMenubarCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnMenubarBackground" data-translate="">styleVariable-gnMenubarBackground</label>
-                <color-picker data-ng-model="gnCssStyle.gnMenubarBackground"
-                  color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gn-menubarBackgroundActive"
-                  data-translate="">styleVariable-gnMenubarBackgroundActive</label>
-                <color-picker
-                  data-ng-model="gnCssStyle.gnMenubarBackgroundActive"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnMenubarColor" data-translate="">styleVariable-gnMenubarColor</label>
-                <color-picker data-ng-model="gnCssStyle.gnMenubarColor"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gn-menubarColorHover" data-translate="">styleVariable-gnMenubarColorHover</label>
-                <color-picker data-ng-model="gnCssStyle.gnMenubarColorHover"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnMenubarBorderColor" data-translate="">styleVariable-gnMenubarBorderColor</label>
-                <color-picker data-ng-model="gnCssStyle.gnMenubarBorderColor"
-                  color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnBottombarCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnBottombarBackground" data-translate="">styleVariable-gnBottombarBackground</label>
-                <color-picker data-ng-model="gnCssStyle.gnBottombarBackground"
-                  color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnBottombarColor" data-translate="">styleVariable-gnBottombarColor</label>
-                <color-picker data-ng-model="gnCssStyle.gnBottombarColor"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnBottombarColorHover" data-translate="">styleVariable-gnBottombarColorHover</label>
-                <color-picker data-ng-model="gnCssStyle.gnBottombarColorHover"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnBottombarBorderColor" data-translate="">styleVariable-gnBottombarBorderColor</label>
-                <color-picker data-ng-model="gnCssStyle.gnBottombarBorderColor"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnTopicsCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnTopicsBackgroundColor"
-                  data-translate="">styleVariable-gnTopicsBackgroundColor</label>
-                <color-picker data-ng-model="gnCssStyle.gnTopicsBackgroundColor"
-                  color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnInfoCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-
-                <label for="gnCssStyle.gnInfoBackgroundColor" data-translate="">styleVariable-gnInfoBackgroundColor</label>
-                <color-picker data-ng-model="gnCssStyle.gnInfoBackgroundColor"
-                  color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnResultcardsCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnResultcardBackgroundColor"
-                  data-translate="">styleVariable-gnResultcardBackgroundColor</label>
-                <color-picker
-                  data-ng-model="gnCssStyle.gnResultcardBackgroundColor"
-                  color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
-              </div>
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnResultcardTitleBackgroundColor"
-                  data-translate="">styleVariable-gnResultcardTitleBackgroundColor</label>
-                <color-picker
-                  data-ng-model="gnCssStyle.gnResultcardTitleBackgroundColor"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnResultsCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnResultsBackgroundColor"
-                  data-translate="">styleVariable-gnResultsBackgroundColor</label>
-                <color-picker
-                  data-ng-model="gnCssStyle.gnResultsBackgroundColor"
-                  color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <legend>
-              <span data-translate="">gnMdViewCss</span>
-            </legend>
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <label for="gnCssStyle.gnMdViewBackgroundColor"
-                  data-translate="">styleVariable-gnMdViewBackgroundColor</label>
-                <color-picker data-ng-model="gnCssStyle.gnMdViewBackgroundColor"
-                  color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
-              </div>
-            </div>
-          </div>
-          <div class="row">&nbsp;</div>
-          <div class="row">&nbsp;</div>
-          <div class="row">
-            <div class="form-row">
-              <div class="col-md-4 mb-6">
-                <button class="btn btn-primary"
-                  data-ng-click="saveCssStyleSettings(gnCssStyle)">
-                  <span class="fa fa-save"></span> {{"saveSettings"|translate}}
-                </button>
-              </div>
-              <div class="col-md-4 mb-6">
-                <a target="_blank" data-ng-href="../api/customstyle"
-                  class="btn btn-success"> <span class="fa fa-clone"></span>
-                  {{"exportSettings"|translate}}
-                </a>
-              </div>
-              <div class="col-md-4 mb-6">
-                <button class="btn btn-danger"
-                  data-gn-confirm-click="{{'restoreDefaultStyleConfirm' | translate}}"
-                  data-ng-click="restoreDefaultCssStyleSettings(gnCssStyle)">
-                  <span class="fa fa-history"></span>
-                  {{"restoreDefaultSettings"|translate}}
-                </button>
-              </div>
-            </div>
-          </div>
-        </form>
-      </div>
+        </div>
+      </form>
     </div>
     <div class="panel panel-default"
       data-ng-controller="GnCssStyleSettingsController">
@@ -239,20 +220,18 @@
       <div class="panel-body">
         <div class="row">
           <div class="form-row">
-            <div class="col-md-4 mb-6">
+            <div class="col-md-9">
               <textarea name="cssJsonContent" id="cssJsonContent"
                 data-ng-model="cssJsonContent" class="form-control ng-binding"></textarea>
             </div>
-            <div class="col-md-4 mb-6">
-              <button class="btn btn-primary"
+            <div class="col-md-3">
+              <button class="btn btn-default"
                 data-ng-click="uploadCssStyleSettings(cssJsonContent)">
                 <span class="fa fa-magic"></span> {{"uploadSettings"|translate}}
               </button>
             </div>
           </div>
         </div>
-
-        <div class="row">&nbsp;</div>
       </div>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/logo.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/logo.html
@@ -5,8 +5,10 @@
         <div class="panel-heading">
           <span data-translate="">currentCatalogLogo</span>
         </div>
-        <div class="panel-body thumbnail gn-thumbnail">
-          <img data-ng-src="../../images/logos/{{info['system/site/siteId']}}.png?{{info['system/site/lastUpdate']}}"/>
+        <div class="panel-body">
+          <div class="text-center">
+            <img data-ng-src="../../images/logos/{{info['system/site/siteId']}}.png?{{info['system/site/lastUpdate']}}"/>
+          </div>
         </div>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
@@ -124,16 +124,17 @@
             <div class="form-group">
               <label class="control-label col-sm-3" data-translate="">workspace</label>
 
-              <div class="col-sm-9 input-group">
-                <input type="text" name="namespaceprefix" class="form-control"
-                       required=""
-                       data-ng-model="mapserverSelected.namespacePrefix"
-                       placeholder=""/>
-                <span class="input-group-addon">:</span>
-                <input type="url" name="namespace" class="form-control"
-                       required=""
-                       data-ng-model="mapserverSelected.namespace" placeholder="http://"/>
-
+              <div class="col-sm-9">
+                <div class="input-group">
+                  <input type="text" name="namespaceprefix" class="form-control"
+                        required=""
+                        data-ng-model="mapserverSelected.namespacePrefix"
+                        placeholder=""/>
+                  <span class="input-group-addon">:</span>
+                  <input type="url" name="namespace" class="form-control"
+                        required=""
+                        data-ng-model="mapserverSelected.namespace" placeholder="http://"/>
+                </div>
               </div>
               <div class="col-sm-9 col-sm-offset-3">
                 <p class="help-block" data-translate="">workspace-help</p>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -1,29 +1,56 @@
-<div class="row">
+<div class="row" data-ng-controller="GnSystemSettingsController">
   <div class="col-md-12">
-    <div class="panel panel-default" data-ng-controller="GnSystemSettingsController">
+    <div class="navbar btn-toolbar">
+      <form class="form-inline">
+        <input type="hidden" name="_csrf" value="{{csrf}}"/>
+        <div class="pull-left">
+          <label for="filter-settings" data-translate="">filterSettings</label>
+          <div class="input-group">
+            <span class="input-group-addon"">
+              <i class="fa fa-filter" aria-hidden="true"></i>
+            </span>
+            <input class="form-control"
+                  type="text"
+                  id="filter-settings"
+                  placeholder="{{'filterPlaceHolder' | translate}}"
+                  data-ng-keyup="filterForm($event,'#gn-settings')" />
+            <span class="input-group-btn">
+              <button class="btn btn-default"
+                      type="button"
+                      title="{{'filterReset' | translate}}"
+                      data-ng-click="resetFilter('#gn-settings')">
+                <i class="fa fa-close" aria-hidden="true"></i>
+              </button>
+            </span>
+          </div>
+        </div>
+        <div class="navbar-right">
+          
+          <select ng-change="updateProfile()" class="form-control"
+                  data-ng-model="systemInfo.stagingProfile">
+            <option data-ng-repeat="p in stagingProfiles" value="{{p}}"
+                    ng-selected="p === systemInfo.stagingProfile">{{p | translate}}
+            </option>
+          </select>
+
+          <button type="submit" class="btn btn-primary"
+                  id="gn-btn-settings-save"
+                  data-ng-disabled="!gnSettings.$valid"
+                  data-ng-click="saveSettings('#gn-settings')">
+            <span class="fa fa-save"></span>
+            {{"saveSettings"|translate}}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="col-md-12">
+    <div class="panel panel-default">
       <div class="gn-scroll-spy" data-gn-scroll-spy="gn-settings-spy-target"
           data-watch="sectionsLevel1" data-depth="1"/>
       <div class="panel-heading">
         <span data-translate="">settings</span>
-        <div class="btn-toolbar">
-          <form class="form-inline pull-right">
-                  <input type="hidden" name="_csrf" value="{{csrf}}"/>
-            <select ng-change="updateProfile()" class="form-control"
-                    data-ng-model="systemInfo.stagingProfile">
-              <option data-ng-repeat="p in stagingProfiles" value="{{p}}"
-                      ng-selected="p === systemInfo.stagingProfile">{{p | translate}}
-              </option>
-            </select>
-            &nbsp;
-            <button type="submit" class="btn btn-primary"
-                    id="gn-btn-settings-save"
-                    data-ng-disabled="!gnSettings.$valid"
-                    data-ng-click="saveSettings('#gn-settings')">
-              <span class="fa fa-save"></span>
-              {{"saveSettings"|translate}}
-            </button>
-          </form>
-        </div>
+
       </div>
       <div class="panel-body">
         <form id="gn-settings" name="gnSettings" class="form-horizontal">
@@ -37,7 +64,7 @@
               <div data-ng-repeat="s in section2.children | hideLanguages | hideGeoNetworkInternalSettings | orderObjectBy:'position'"
                   data-ng-switch="s.dataType"
                   data-ng-if="s.name != ''">
-                <div data-ng-switch-when="BOOLEAN">
+                <div data-ng-switch-when="BOOLEAN" class="form-group">
                   <label class="col-sm-4 control-label" for="{{s['name']}}"> {{s['name'] |
                     translate}} </label>
                   <div class="col-sm-8">

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
@@ -1,11 +1,30 @@
 <div class="row">
-  <div class="col-md-12">
-    <div class="panel panel-default" data-ng-controller="GnSystemSettingsController">
-
-      <div class="panel-heading">
-        <span data-translate="">ui</span>
-        <div class="btn-toolbar">
-          <form class="form-inline pull-right">
+    <div class="col-md-12"  data-ng-controller="GnSystemSettingsController">
+      
+      <div class="navbar btn-toolbar">
+        <form class="form-inline">
+          <div class="pull-left">
+            <label for="filter-settings" data-translate="">filterSettings</label>
+            <div class="input-group">
+              <span class="input-group-addon"">
+                <i class="fa fa-filter" aria-hidden="true"></i>
+              </span>
+              <input class="form-control"
+                    type="text"
+                    id="filter-settings"
+                    placeholder="{{'filterPlaceHolder' | translate}}"
+                    data-ng-keyup="filterForm($event,'#gn-settings')" />
+              <span class="input-group-btn">
+                <button class="btn btn-default"
+                        type="button"
+                        title="{{'filterReset' | translate}}"
+                        data-ng-click="resetFilter('#gn-settings')">
+                  <i class="fa fa-close" aria-hidden="true"></i>
+                </button>
+              </span>
+            </div>
+          </div>
+          <div class="navbar-right">
             <button type="submit" class="btn btn-primary"
                     id="gn-btn-settings-save"
                     data-ng-disabled="!gnSettings.$valid"
@@ -13,31 +32,34 @@
               <span class="fa fa-save"></span>
               {{"saveSettings"|translate}}
             </button>
-          </form>
-        </div>
-      </div>
-      <div class="panel-body">
-        <form id="gn-settings" name="gnSettings" class="form-horizontal">
-          <fieldset data-ng-repeat="s in settings"
-                    data-ng-if="s.name === 'ui/config'">
-            <div
-              data-gn-ui-config="s.value"
-              data-id="s.name"
-            ></div>
-
-            <button type="submit"
-                    class="btn btn-primary pull-right"
-                    data-ng-disabled="!gnSettings.$valid"
-                    data-ng-click="saveSettings('#uiconfig')">
-              <span class="fa fa-save"></span>&nbsp;
-              {{"saveSettings"|translate}}
-            </button>
-          </fieldset>
+          </div>
         </form>
-
-        <div data-gn-need-help="administrator-guide/configuring-the-catalog/system-configuration.html"
-            class="pull-right"></div>
+      </div>
+      
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <span data-translate="">ui</span>
+        </div>
+        <div class="panel-body">
+          <form id="gn-settings" name="gnSettings" class="form-horizontal">
+            <fieldset data-ng-repeat="s in settings"
+                      data-ng-if="s.name === 'ui/config'">
+              <div data-gn-ui-config="s.value"
+                   data-id="s.name"></div>
+  
+              <button type="submit"
+                      class="btn btn-primary pull-right"
+                      data-ng-disabled="!gnSettings.$valid"
+                      data-ng-click="saveSettings('#uiconfig')">
+                <span class="fa fa-save"></span>&nbsp;
+                {{"saveSettings"|translate}}
+              </button>
+            </fieldset>
+          </form>
+  
+          <div data-gn-need-help="administrator-guide/configuring-the-catalog/system-configuration.html"
+              class="pull-right"></div>
+        </div>
       </div>
     </div>
   </div>
-</div>

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/transferownership.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/transferownership.html
@@ -1,35 +1,39 @@
-<div class="panel panel-default">
-  <div class="panel-heading" data-translate="">transfertPrivs</div>
-  <div class="panel-body">
-    <label data-translate="">chooseSourceEditor</label>
-    <select class="form-control" data-ng-model="editorsSelectedId"
-            autofocus="" data-ng-change="selectUser(editorsSelectedId)">
-      <option data-ng-repeat="e in editors | orderBy:'name'" value="{{e.id}}">{{e.name}}
-        ({{e.records}} {{'records' | translate}})
-      </option>
-    </select>
-    <table class="table" data-ng-hide="editorsSelectedId == null">
-      <tr>
-        <th data-translate="">sourceGroup</th>
-        <th data-translate="">targetGroup</th>
-      </tr>
-      <tr data-ng-repeat="(key, g) in editorGroups"
-          data-ng-init="transfertList[g.id] = {sourceGroup: g.id};">
-        <td>{{g.label[lang]|empty:g.name}}</td>
-        <!--TODO: Only list group with records. -->
-        <td><select class="form-control"
-                    data-ng-model="transfertList[g.id].targetGroup"
-                    data-ng-options="g.userName group by g.groupNameTranslated
-                    for (key, g) in userGroups">
-        </select></td>
-        <td>
-          <button type="button" class="btn btn-primary btn-block"
-                  data-gn-click-and-spin="tranferOwnership(g.id)"
-                  data-ng-disabled="!transfertList[g.id].targetGroup">
-            <span data-translate="">transfertPriv</span>
-          </button>
-        </td>
-      </tr>
-    </table>
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading" data-translate="">transfertPrivs</div>
+      <div class="panel-body">
+        <label data-translate="">chooseSourceEditor</label>
+        <select class="form-control" data-ng-model="editorsSelectedId"
+                autofocus="" data-ng-change="selectUser(editorsSelectedId)">
+          <option data-ng-repeat="e in editors | orderBy:'name'" value="{{e.id}}">{{e.name}}
+            ({{e.records}} {{'records' | translate}})
+          </option>
+        </select>
+        <table class="table" data-ng-hide="editorsSelectedId == null">
+          <tr>
+            <th data-translate="">sourceGroup</th>
+            <th data-translate="">targetGroup</th>
+          </tr>
+          <tr data-ng-repeat="(key, g) in editorGroups"
+              data-ng-init="transfertList[g.id] = {sourceGroup: g.id};">
+            <td>{{g.label[lang]|empty:g.name}}</td>
+            <!--TODO: Only list group with records. -->
+            <td><select class="form-control"
+                        data-ng-model="transfertList[g.id].targetGroup"
+                        data-ng-options="g.userName group by g.groupNameTranslated
+                        for (key, g) in userGroups">
+            </select></td>
+            <td>
+              <button type="button" class="btn btn-primary btn-block"
+                      data-gn-click-and-spin="tranferOwnership(g.id)"
+                      data-ng-disabled="!transfertList[g.id].targetGroup">
+                <span data-translate="">transfertPriv</span>
+              </button>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container-fluid">
   <div class="navbar-header">
     <button type="button"
             class="navbar-toggle collapsed"

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -15,3 +15,176 @@ ul.gn-resultview li.list-group-item {
     margin-bottom: 0;
   }
 }
+
+[ng-app="gn_admin"] {
+  body {
+    padding-top: calc(~"@{gn-menubar-height} + 1px");
+    background-color: #f9f9f9;
+  }
+  .gn-top-bar {
+    position: fixed;
+    width: 100%;
+    height: calc(~"@{gn-menubar-height} + 1px");
+    border-width: 0 0 1px 0;
+    background-color: #fff;
+    top: 0;
+    z-index: 100;
+    .navbar-collapse {
+      background: #fff;
+    }
+  }
+}
+
+@gn-sidebar-width: 270px;
+@gn-col-main-width: 45px;
+
+@keyframes fadein{
+  0% { opacity:0; }
+  66% { opacity:0; }
+  100% { opacity:1; }
+}
+
+@-webkit-keyframes fadein{
+  0% { opacity:0; }
+  66% { opacity:0; }
+  100% { opacity:1; }
+}
+
+.sidebar {
+	position: fixed;
+  padding: 0;
+  width: @gn-sidebar-width;
+  border-right: 1px solid @navbar-default-border;
+  background-color: #fff;
+  height: 100%;
+  @media (max-width: @screen-xs-max) {
+    display: none;
+  }
+  .sidebar-col-main {
+    position: fixed;
+    width: @gn-col-main-width;
+    float: left;
+    border-right: 1px solid @navbar-default-border;
+    height: 100%;
+    background-color: #fff;
+    white-space: nowrap;
+    z-index: 10;
+    transition: width 0.5s;
+    .nav-sidebar {
+      span {
+        display: none;
+      }
+    }
+    &:hover {
+      width: calc(~"@{gn-sidebar-width} - @{gn-col-main-width}");
+      .nav-sidebar {
+        span {
+          display: inline-block;
+          -webkit-animation: 0.5s ease 0s normal forwards 1 fadein;
+          animation: 0.5s ease 0s normal forwards 1 fadein;
+        }
+      }
+    }
+  }
+  .sidebar-col-sub {
+    width: calc(~"100% - @{gn-col-main-width}");
+    margin-left: @gn-col-main-width;
+    float: left;
+  }
+  .sidebar-col-full {
+    width: @gn-sidebar-width;
+    transition: none;
+    .nav-sidebar {
+      span {
+        display: inline-block;
+      }
+    }
+    &:hover {
+      width: @gn-sidebar-width;
+      .nav-sidebar {
+        span {
+          animation: none;
+        }
+      }
+    }
+  }
+  .nav-sidebar {
+    span {
+      padding-left: 10px;
+    }
+  }
+	h2 {
+		font-size: 12px;
+		text-transform: uppercase;
+		padding-left: 15px;
+	}
+	ul {
+		li {
+			a {
+        padding-left: 15px;
+        border-left: 3px solid #fff;
+				color: @gray;
+				padding: 10px;
+				&:hover {
+					color: @gray-dark;
+				}
+      }
+      &.active, &:hover {
+        a {
+          color: @gray-darker;
+          background-color: lighten(@brand-primary, 46.7%);
+          border-left-color: @brand-primary;
+        }
+      }
+
+		}
+	}
+}
+.main {
+  margin-left: @gn-sidebar-width;
+  padding: 25px 10px 10px 10px;
+  @media (max-width: @screen-xs-max) {
+    margin-left: 0;
+  }
+  .btn-toolbar {
+    margin-left: 0;
+    .input-group {
+      float: none;
+    }
+    .navbar-right {
+      margin-right: 0;
+      @media (max-width: @screen-xs-max) {
+        .form-control, .btn {
+          margin: 10px 0;
+          width: 100%;
+        }
+      }
+    }
+  }
+  .panel {
+    .panel-heading {
+      .clearfix();
+      .btn-toolbar {
+        float: right;
+      }
+    }
+
+  }
+  .thumbnail {
+    padding: 0;
+    .caption {
+      padding: 5px;
+      margin-bottom: 10px;
+      background-color: @panel-default-heading-bg;
+      border-bottom: 1px solid @panel-default-border;
+      p {
+        margin: 0;
+      }
+      a {
+        &:hover {
+          text-decoration: none;
+        }
+      }
+    }
+  }
+}

--- a/web/src/main/webapp/xslt/ui-admin/admin.xsl
+++ b/web/src/main/webapp/xslt/ui-admin/admin.xsl
@@ -27,7 +27,7 @@
   <xsl:include href="../base-layout.xsl"/>
 
   <xsl:template mode="content" match="/">
-    <div class="container" data-ng-controller="GnAdminController" data-ng-show="authenticated"
+    <div class="container-fluid" data-ng-controller="GnAdminController" data-ng-show="authenticated"
          data-ng-view="">
     </div>
 


### PR DESCRIPTION
This is a PR for small UI changes to the admin pages. A sidebar is added to the left, the tabs that used to be on top are added as a submenu to the left.

Two settings pages now have a filter option on top. This will filter on the labels used before each setting (_note_: sometimes labels are not properly used and therefore sometimes bigger blocks of settings are included in the filter results).

![gn-sidebar-filter](https://user-images.githubusercontent.com/19608667/50837388-c9329d80-135b-11e9-8b8d-244c8e6f75d2.png)

The `CSS & Style` is a bit reorganised, whitespace is removed, columns are added and a toolbar has been added at the top of the page. 

There is no toggle button yet, this could be in another PR. And more could have been added, but I wanted to keep this PR manageable and not too big.

Changes:
- menu in sidebar on the left
- uniform use of panels and rows
- filter option for `settings` and `user interface` settings
- reorganised `CSS & Style` page, added buttons to toolbar
- small changes to the logo page