### PR TITLE
Added phone number to metadata contact in detail view

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -96,7 +96,7 @@
       <i class="fa fa-envelope"></i>
     </div>
     <div class="flex-spacer"></div>
-    <div>
+    <address>
       <div>
         <strong>{{org}}</strong>
       </div>
@@ -119,12 +119,17 @@
               <span data-ng-if="c.email === ''">{{c.name}}
                 <span data-ng-show="c.position">({{c.position}})</span>
               </span>
+              <br>
+              <a href="tel:{{c.phone}}"
+                data-ng-if="c.phone != ''">
+                {{c.phone}}
+              </a>
               <span data-ng-if="!$last">,</span>
             </span>
           </li>
         </ul>
       </div>
-    </div>
+    </address>
   </div>
 
 </div>


### PR DESCRIPTION
This PR adds a phone number to the contact details displayed in the detail view (record view). The phone number is only added when mode is `org-role`.

The `org-role` is now also using the `<address>` element in stead of a normal `<div>`.
