### PR TITLE
Restyle and reorganise the elements on the admin dashboard

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/admin.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/admin.html
@@ -50,44 +50,46 @@
     </div>
     <!-- /.sidebar -->
     <div class="main"">
-      <div class="row">
-        <div class="col-lg-8" data-ng-controller="GnAdminController">
-          <div class="clearfix">
-            <a data-ng-repeat="m in getMenu()" href="{{getMenuUrl(m)}}"
-              class="btn btn-lg btn-block {{m.classes}} gn-btn-admin">
-              <i class="fa {{m.icon}} fa-4x"/>
-              <p data-translate="">{{m.name}}</p>
+
+      <div class="row gn-row-admin-buttons">
+        <div class="col-md-12" data-ng-controller="GnAdminController">
+          <div class="btn-group btn-group-justified">
+            <a data-ng-repeat="m in getMenu()"
+                href="{{getMenuUrl(m)}}"
+                title="{{m.name}}"
+                class="btn btn-default">
+              <i class="fa fa-fw {{m.icon}} fa-2x"/>
+              <p class="hidden-sm hidden-xs" data-translate="">{{m.name}}</p>
             </a>
           </div>
         </div>
-        <div class="col-lg-4">
-          <div class="panel panel-default" data-ng-hide="true">
-            <div class="panel-heading" data-translate="">latestNews</div>
-          </div>
-          <div class="panel panel-default" data-ng-hide="true">
-            <div class="panel-heading" data-translate="">quicklinks</div>
-          </div>
-          <div class="panel panel-default text-center" data-ng-hide="searchInfo.facet.types.length === 0">
+      </div>
+      <!-- /.gn-row-admin-buttons -->
+      <div class="row gn-row-admin-stats">
+        <div class="col-lg-2 col-md-4 col-sm-4" data-ng-repeat="type in searchInfo.facet.types" data-ng-hide="searchInfo.facet.types.length === 0">
+          <div class="panel panel-default panel-primary1">
+            <div class="panel-heading">
+              <h5>{{(type['@label'] || type['@name']) | translate}}</h5>
+            </div>
             <div class="panel-body">
-              <div data-ng-repeat="type in searchInfo.facet.types">
-                <h2>{{type['@count']}}</h2>
-                <h5>{{(type['@label'] || type['@name']) | translate}}</h5>
-              </div>
+              <h2>{{type['@count']}}</h2>
             </div>
           </div>
-          <div class="panel panel-default text-center">
+        </div>
+        <div class="col-md-4 col-sm-8" data-ng-hide="searchInfo.count == 0">
+          <div class="panel panel-default panel-success">
+            <div class="panel-heading">
+              <h5 data-translate="" title="{{'totalNumberOfRecordsHelp' | translate}}">totalNumberOfRecords</h5>
+            </div>
             <div class="panel-body">
-              <div data-ng-hide="searchInfo.count == 0">
-                <h2>{{searchInfo.count}}</h2>
-                <h5 data-translate="" title="{{'totalNumberOfRecordsHelp' | translate}}"
-                >totalNumberOfRecords</h5>
-              </div>
-              <div data-ng-show="searchInfo.count == 0" data-translate=""> emptyCatalogShouldBeFilled
-              </div>
+              <h2>{{searchInfo.count}}</h2>
+            </div>
+            <div data-ng-show="searchInfo.count == 0" data-translate=""> emptyCatalogShouldBeFilled
             </div>
           </div>
         </div>
       </div>
+      <!-- /.gn-row-admin-stats -->
     </div>
     <!-- /.main -->
   </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -1,6 +1,21 @@
 @import "gn_search_default.less";
 @import "../../../style/gn_admin";
 
+@gn-sidebar-width: 270px;
+@gn-col-main-width: 45px;
+
+@keyframes fadein{
+  0% { opacity:0; }
+  66% { opacity:0; }
+  100% { opacity:1; }
+}
+
+@-webkit-keyframes fadein{
+  0% { opacity:0; }
+  66% { opacity:0; }
+  100% { opacity:1; }
+}
+
 ul.gn-resultview li.list-group-item {
   margin-bottom: 0;
 }
@@ -19,7 +34,7 @@ ul.gn-resultview li.list-group-item {
 [ng-app="gn_admin"] {
   body {
     padding-top: calc(~"@{gn-menubar-height} + 1px");
-    background-color: #f9f9f9;
+    background-color: #f7f7f7;
   }
   .gn-top-bar {
     position: fixed;
@@ -33,158 +48,235 @@ ul.gn-resultview li.list-group-item {
       background: #fff;
     }
   }
-}
-
-@gn-sidebar-width: 270px;
-@gn-col-main-width: 45px;
-
-@keyframes fadein{
-  0% { opacity:0; }
-  66% { opacity:0; }
-  100% { opacity:1; }
-}
-
-@-webkit-keyframes fadein{
-  0% { opacity:0; }
-  66% { opacity:0; }
-  100% { opacity:1; }
-}
-
-.sidebar {
-	position: fixed;
-  padding: 0;
-  width: @gn-sidebar-width;
-  border-right: 1px solid @navbar-default-border;
-  background-color: #fff;
-  height: 100%;
-  @media (max-width: @screen-xs-max) {
-    display: none;
-  }
-  .sidebar-col-main {
-    position: fixed;
-    width: @gn-col-main-width;
-    float: left;
-    border-right: 1px solid @navbar-default-border;
-    height: 100%;
-    background-color: #fff;
-    white-space: nowrap;
-    z-index: 10;
-    transition: width 0.5s;
-    .nav-sidebar {
-      span {
+  [data-ng-controller="GnAdminController"] {
+    .sidebar {
+      position: fixed;
+      padding: 0;
+      width: @gn-sidebar-width;
+      border-right: 1px solid @navbar-default-border;
+      background-color: #fff;
+      height: 100%;
+      @media (max-width: @screen-xs-max) {
         display: none;
       }
-    }
-    &:hover {
-      width: calc(~"@{gn-sidebar-width} - @{gn-col-main-width}");
-      .nav-sidebar {
-        span {
-          display: inline-block;
-          -webkit-animation: 0.5s ease 0s normal forwards 1 fadein;
-          animation: 0.5s ease 0s normal forwards 1 fadein;
+      .sidebar-col-main {
+        position: fixed;
+        width: @gn-col-main-width;
+        float: left;
+        border-right: 1px solid @navbar-default-border;
+        height: 100%;
+        background-color: #fff;
+        white-space: nowrap;
+        z-index: 10;
+        transition: width 0.5s;
+        .nav-sidebar {
+          span {
+            display: none;
+          }
         }
-      }
-    }
-  }
-  .sidebar-col-sub {
-    width: calc(~"100% - @{gn-col-main-width}");
-    margin-left: @gn-col-main-width;
-    float: left;
-  }
-  .sidebar-col-full {
-    width: @gn-sidebar-width;
-    transition: none;
-    .nav-sidebar {
-      span {
-        display: inline-block;
-      }
-    }
-    &:hover {
-      width: @gn-sidebar-width;
-      .nav-sidebar {
-        span {
-          animation: none;
-        }
-      }
-    }
-  }
-  .nav-sidebar {
-    span {
-      padding-left: 10px;
-    }
-  }
-	h2 {
-		font-size: 12px;
-		text-transform: uppercase;
-		padding-left: 15px;
-	}
-	ul {
-		li {
-			a {
-        padding-left: 15px;
-        border-left: 3px solid #fff;
-				color: @gray;
-				padding: 10px;
-				&:hover {
-					color: @gray-dark;
-				}
-      }
-      &.active, &:hover {
-        a {
-          color: @gray-darker;
-          background-color: lighten(@brand-primary, 46.7%);
-          border-left-color: @brand-primary;
-        }
-      }
-
-		}
-	}
-}
-.main {
-  margin-left: @gn-sidebar-width;
-  padding: 25px 10px 10px 10px;
-  @media (max-width: @screen-xs-max) {
-    margin-left: 0;
-  }
-  .btn-toolbar {
-    margin-left: 0;
-    .input-group {
-      float: none;
-    }
-    .navbar-right {
-      margin-right: 0;
-      @media (max-width: @screen-xs-max) {
-        .form-control, .btn {
-          margin: 10px 0;
-          width: 100%;
-        }
-      }
-    }
-  }
-  .panel {
-    .panel-heading {
-      .clearfix();
-      .btn-toolbar {
-        float: right;
-      }
-    }
-
-  }
-  .thumbnail {
-    padding: 0;
-    .caption {
-      padding: 5px;
-      margin-bottom: 10px;
-      background-color: @panel-default-heading-bg;
-      border-bottom: 1px solid @panel-default-border;
-      p {
-        margin: 0;
-      }
-      a {
         &:hover {
-          text-decoration: none;
+          width: calc(~"@{gn-sidebar-width} - @{gn-col-main-width}");
+          .nav-sidebar {
+            span {
+              display: inline-block;
+              -webkit-animation: 0.5s ease 0s normal forwards 1 fadein;
+              animation: 0.5s ease 0s normal forwards 1 fadein;
+            }
+          }
+        }
+      }
+      .sidebar-col-sub {
+        width: calc(~"100% - @{gn-col-main-width}");
+        margin-left: @gn-col-main-width;
+        float: left;
+      }
+      .sidebar-col-full {
+        width: @gn-sidebar-width;
+        transition: none;
+        .nav-sidebar {
+          span {
+            display: inline-block;
+          }
+        }
+        &:hover {
+          width: @gn-sidebar-width;
+          .nav-sidebar {
+            span {
+              animation: none;
+            }
+          }
+        }
+      }
+      .nav-sidebar {
+        span {
+          padding-left: 10px;
+        }
+      }
+      h2 {
+        font-size: 12px;
+        text-transform: uppercase;
+        padding-left: 15px;
+      }
+      ul {
+        li {
+          a {
+            padding-left: 15px;
+            border-left: 3px solid #fff;
+            color: @gray;
+            padding: 10px;
+            &:hover {
+              color: @gray-dark;
+            }
+          }
+          &.active, &:hover {
+            a {
+              color: @gray-darker;
+              background-color: lighten(@brand-primary, 46.7%);
+              border-left-color: @brand-primary;
+            }
+          }
+    
         }
       }
     }
+    .main {
+      margin-left: @gn-sidebar-width;
+      padding: 25px 10px 10px 10px;
+      @media (max-width: @screen-xs-max) {
+        margin-left: 0;
+      }
+      // dashboard
+      .gn-row-admin-buttons {
+        margin-bottom: 20px;
+        .btn-group {
+          box-shadow: 0 0.5px 0.5px rgba(0,0,0,.03);
+          .btn {
+            border-color: darken(@gray-lighter, 6.5%);
+            padding: 15px;
+            border-right: 0;
+            p {
+              white-space: initial;
+              height: 2em;
+              margin-top: 5px;
+              @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+                height: 3em;
+                font-size: 90%;
+              }
+            }
+            &:hover {
+              background: @gray-lighter;
+              i {
+                color: @brand-primary;
+              }
+            }
+            &:last-child {
+              border-right: 1px solid darken(@gray-lighter, 6.5%);
+            }
+          }
+          @media (max-width: @screen-xs-max) {
+            margin-left: -5px;
+            margin-right: -5px;
+            width: calc(~"100% + 10px");
+            box-shadow: none;
+            .btn {
+              padding: 15px 10px;
+              width: calc(~"50% - 10px");
+              display: block;
+              float: left;
+              border: 1px solid darken(@gray-lighter, 6.5%) !important;
+              margin: 5px;
+              border-radius: 4px;
+            }
+          }
+        }
+  
+      }
+      .gn-row-admin-stats {
+        .panel {
+          border-color: darken(@gray-lighter, 6.5%);
+          box-shadow: 0 0.5px 0.5px rgba(0,0,0,.03);
+          .panel-heading {
+            padding: 5px 15px;
+            background: @gray-lighter;
+            border-color: darken(@gray-lighter, 6.5%);
+            h5 {
+              font-weight: 200;
+            }
+          }
+          .panel-body {
+            padding: 5px 15px;
+            background: @gray-lighter;
+  
+            h2 {
+              margin: 0;
+              padding: 10px 0;
+            }
+          }
+        }
+        .panel-primary {
+          border-color: darken(@brand-primary, 6.5%);
+          .panel-heading, .panel-body {
+            color: #fff;
+            background: @brand-primary;
+            border-color: darken(@brand-primary, 6.5%);
+          }
+        }
+        .panel-success {
+          border-color: darken(@brand-success, 6.5%);
+          .panel-heading, .panel-body {
+            color: #fff;
+            background: @brand-success;
+            border-color: darken(@brand-success, 6.5%);
+          }
+        }
+      }
+      // admin pages
+      .btn-toolbar {
+        margin-left: 0;
+        .input-group {
+          float: none;
+        }
+        .navbar-right {
+          margin-right: 0;
+          @media (max-width: @screen-xs-max) {
+            .form-control, .btn {
+              margin: 10px 0;
+              width: 100%;
+            }
+          }
+        }
+      }
+      .panel {
+        .panel-heading {
+          .clearfix();
+          .btn-toolbar {
+            float: right;
+          }
+        }
+    
+      }
+      .thumbnail {
+        padding: 0;
+        .caption {
+          padding: 5px;
+          margin-bottom: 10px;
+          background-color: @panel-default-heading-bg;
+          border-bottom: 1px solid @panel-default-border;
+          p {
+            margin: 0;
+          }
+          a {
+            &:hover {
+              text-decoration: none;
+            }
+          }
+        }
+      }
+    }
+
   }
+
 }
+
+
+


### PR DESCRIPTION
This PR replaces https://github.com/geonetwork/core-geonetwork/pull/3384

Extra changes have been made to match and combine the new admin sidebar styles and colours better.

This PR restyles and reorganises the elements (a little) on the dashboard. The colours of the buttons are removed and the list with numbers is divided into single blocks.

A little background colour has been added to let the elements stand out more.

**Screenshot after the restyling:**

![gn-restyle-dashboard](https://user-images.githubusercontent.com/19608667/50894089-a4453580-1402-11e9-9597-f0be674a4d24.png)



