### PR TITLE
Editor / Link list / Remove duplicated protocol icon

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -149,8 +149,6 @@
                 {{(resource[resource.protocol.indexOf('OGC') !== -1 ? 'description' : 'title'] | gnLocalized: lang) || resource.lUrl}}
               </a>
               <span data-ng-if="resource.lUrl.match('^http|ftp') === null">
-                <i class="fa fa-fw"
-                   data-ng-class="onlinesrcService.getIconByProtocol(resource)"></i>
                 {{(resource.title | gnLocalized: lang) || resource.lUrl}}
               </span>
             </div>


### PR DESCRIPTION
This is to avoid 
![image](https://user-images.githubusercontent.com/1701393/50904046-93ef8380-141f-11e9-88bd-5bb30a1a6512.png)

for file not starting with http://

The icon is already added line 137.