### PR TITLE
Fix for too small maps in the editor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
@@ -78,7 +78,7 @@
 
   <!--Map and coordinates inputs-->
   <div class="text-center">
-    <div class="thumbnail extent">
+    <div class="gn-editor-map">
       <span>
         <div class="input-group coord coord-north">
           <input data-ng-model="extent.form[3]"
@@ -117,7 +117,14 @@
           <span class="input-group-addon hidden-xs">W</span>
         </div>
       </span>
-      <div ng-if="map" ngeo-map="map"></div>
+      <table>
+        <tr>
+          <td>
+            <div ng-if="map" ngeo-map="map"></div>
+          </td>
+        </tr>
+      </table>
     </div>
+    
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -306,10 +306,14 @@
       margin: 0;
       text-align: left;
     }
-    .extent {
-      display: inline-block;
+    .gn-editor-map {
+      padding: 15px;
       position: relative;
       margin-top: 30px;
+      [ngeo-map] {
+        border: 1px solid @input-border;
+        border-radius: @border-radius-base;
+      }
     }
     .coord {
       position: absolute;
@@ -317,22 +321,22 @@
       z-index: 100;
     }
     .coord-north {
-      top: -1.25em;
+      top: -0.25em;
       left: 50%;
       margin-left: -75px;
     }
     .coord-south {
-      bottom: -1.25em;
+      bottom: -0.25em;
       left: 50%;
       margin-left: -75px;
     }
     .coord-east {
-      right: -75px;
+      right: -15px;
       top: 50%;
       margin-top: -1.25em;
     }
     .coord-west {
-      left: -75px;
+      left: -15px;
       top: 50%;
       margin-top: -1.25em;
     }


### PR DESCRIPTION
This PR fixes too small maps in the editor. After resizing or displaying the map on a small screen the map could have a width of almost 0.

Related to https://github.com/geonetwork/core-geonetwork/pull/3390#issuecomment-452674591