### PR TITLE
Fix: Decrease the `z-index` of the draw map elements in the editor

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -110,7 +110,7 @@ div[gn-transfer-ownership] * .list-group {
     top: 0;
     left: 0;
     right: 0;
-    z-index: 10;
+    z-index: 30;
     height: 52px;
   }
   .gn-sub-bar {

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -66,7 +66,7 @@ input[type=text], input[type=number], select {
     .fa {
       position: absolute;
       top: 11px;
-      z-index: 100;
+      z-index: 20;
       right: 10px;
       &.fa-spinner {
         right: 25px;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -318,7 +318,7 @@
     .coord {
       position: absolute;
       width: 200px;
-      z-index: 100;
+      z-index: 20;
     }
     .coord-north {
       top: -0.25em;


### PR DESCRIPTION
Increase the `z-index` of the topbar and decrease the `z-index` of the draw map elements (autocomplete, coordinate inputs) in the editor.

Fix for: https://github.com/geonetwork/core-geonetwork/issues/3121