### PR TITLE
Map viewer not zooming to context extent

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -154,7 +154,9 @@
         var loadPromise = map.get('sizePromise');
         if (loadPromise) {
           loadPromise.then(function() {
-            map.getView().fit(extent, map.getSize(), { nearest: true });
+            $timeout(function () {
+              map.getView().fit(extent, map.getSize(), { nearest: true });
+            }, 300);
           })
         }
         else {


### PR DESCRIPTION
When a record describes a map and a context is associated to the record, when loading the map from the record view the map may not zoom to the map extent defined in the context. 


![image](https://user-images.githubusercontent.com/1701393/50984052-261b8880-1501-11e9-8f67-3b2a4e397221.png)

When loading from the map panel, it works. So it looks like it is related to the fact that the map may not be initialized early enough in this case. Adding a timeout (as done in other places) fix the issue.


This can be tested on http://www.aquacoope.org/cat_eecca/srv/eng/catalog.search#/metadata/75419ae3-bb54-4648-8330-20d15a82247c which is currently running master (but will soon have this fix in)