### PR TITLE
Build / Fix maven warning

### DIFF
--- a/workers/wfsfeature-harvester/pom.xml
+++ b/workers/wfsfeature-harvester/pom.xml
@@ -75,6 +75,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.5</version>
         <configuration>
             <excludes>
                 <exclude>log4j.*</exclude>


### PR DESCRIPTION
To avoid 
```
[WARNING] Some problems were encountered while building the effective model for org.geonetwork-opensource:wfsfeature-harvester:jar:3.5.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing.
 @ org.geonetwork-opensource:wfsfeature-harvester:[unknown-version],/geonetwork/workers/wfsfeature-harvester/pom.xml, line 75, column 15
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```