### PR TITLE
Batch editing / List of selected record is invalid 

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -66,6 +66,7 @@
     "availableSet": "Available set",
     "noChangesToApply": "Define changes first in order to update selected records.",
     "selectRecordsToEdit": "Select one or more records to edit.",
+    "tooManyRecordInSelForSearch": "There is too many (ie. {{count}}) records in current selection to be displayed here as a full list. But the process will run on the current selection (see first tab).",
     "advancedBatchEditMode": "Advanced mode (XPath)",
     "cancel": "Cancel",
     "cancelChangesFromNow": "Cancel all changes since the start of the editing session {{timeAgo}}.",

--- a/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
@@ -392,7 +392,12 @@
           <div class="col-sm-6"
                data-ng-hide="selectedRecords.metadata.length > 0">
             <p class="alert alert-warning"
+               data-ng-show="selectedRecordsCount == 0"
                data-translate="">selectRecordsToEdit</p>
+            <p class="alert alert-warning"
+               data-ng-show="tooManyRecordInSelForSearch"
+               data-translate=""
+               data-translate-values="{count: selectedRecordsCount}">tooManyRecordInSelForSearch</p>
           </div>
           <div class="col-sm-6"
                data-ng-show="selectedRecords.metadata.length > 0">


### PR DESCRIPTION
When too many records are selected due to HTTP 414 URI too long error. Search is made on all UUIDs selected.

![image](https://user-images.githubusercontent.com/1701393/51020614-5d307f00-157f-11e9-8716-d3dad4b23f22.png)

The displayed list is a search with no filter.


Display a message instead.

![image](https://user-images.githubusercontent.com/1701393/51020616-602b6f80-157f-11e9-9314-7d7f220d1ff3.png)

