### PR TITLE
Prevent un-escaped "%" in CSW Harvester URL from throwing IllegalArgumentException on startup - #3422

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswParams.java
@@ -96,6 +96,8 @@ public class CswParams extends AbstractParams {
         outputSchema = Util.getParam(site, "outputSchema", outputSchema);
 
         try {
+            capabUrl = capabUrl.replaceAll("%(?![0-9a-fA-F]{2})", "%25");
+            capabUrl = capabUrl.replaceAll("\\+", "%2B");
             capabUrl = URLDecoder.decode(capabUrl, Constants.ENCODING);
         } catch (UnsupportedEncodingException x) {
             System.out.println(x.getMessage());
@@ -130,6 +132,8 @@ public class CswParams extends AbstractParams {
         rejectDuplicateResource = Util.getParam(site, "rejectDuplicateResource", rejectDuplicateResource);
 
         try {
+            capabUrl = capabUrl.replaceAll("%(?![0-9a-fA-F]{2})", "%25");
+            capabUrl = capabUrl.replaceAll("\\+", "%2B");
             capabUrl = URLDecoder.decode(capabUrl, Constants.ENCODING);
         } catch (UnsupportedEncodingException x) {
             System.out.println(x.getMessage());


### PR DESCRIPTION
This pull request fix the issue #3422