### PR TITLE
Editor / When label are placed above field, the offset of action button should be removed to keep all aligned left

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -378,16 +378,22 @@
 // Class to put label above fields
 form.gn-editor.gn-label-above-input {
   // override default bootstrap widths for the editor
+  // Increase label width to full width
   .col-sm-2 {
     width: 100%;
     text-align: left;
   }
+  // Form field on a second row
   .col-sm-9 {
     width: 90%;
     .col-sm-12 {
       padding-left: 0;
       padding-right: 0;
     }
+  }
+  // Cancel offset used in action
+  .col-xs-offset-2 {
+    margin-left: 0px;
   }
   div.gn-extra-field > label {
     display: none;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1701393/51104053-44c19e00-17e5-11e9-9523-9d3b40d106fe.png)

After the change:

![image](https://user-images.githubusercontent.com/1701393/51104055-4c814280-17e5-11e9-8bcf-a1ee5b0097bc.png)

Related to https://github.com/geonetwork/core-geonetwork/pull/3323/files

Example when adding an action like:
```
<action type="process"
                  btnClass="fa fa-square-o"
                  process="add-vector-info"
                  if="count(gmd:MD_Metadata/gmd:identificationInfo/*/gmd:spatialRepresentationType) = 0 and count(gmd:MD_Metadata/gmd:identificationInfo/*/gmd:spatialRepresentationType[*/@codeListValue = 'vector']) = 0"/>
```