### PR TITLE
Editor / Bbox / Do not show projection selector if there is only one.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
@@ -59,7 +59,7 @@
   </div>
 
   <!--Projection selector-->
-  <div class="row">
+  <div class="row" data-ng-show="projs.list.length > 1">
     <div class="btn-group">
       <button type="button" class="btn btn-link dropdown-toggle"
               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"


### PR DESCRIPTION
If only one projection is configured to be used in the editor form, a list with one item mis proposed. To keep things simple, do not show the switcher in such case. Most of the time only the local projection is used to input coordinates.

![image](https://user-images.githubusercontent.com/1701393/51104700-1b097680-17e7-11e9-8790-ff0c28b8232a.png)

After the change
![image](https://user-images.githubusercontent.com/1701393/51104754-49875180-17e7-11e9-8d7c-bf3c1a56af94.png)
