### PR TITLE
Editor / Region selector / Add an optional attribute to set the default

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -116,6 +116,18 @@
 
           var addGeonames = !attrs['disableGeonames'];
           scope.regionTypes = [];
+         
+          function setDefault() {
+            var defaultThesaurus = attrs['default'];
+            for (t in scope.regionTypes) {
+              if (scope.regionTypes[t].name === defaultThesaurus) {
+                scope.regionType = scope.regionTypes[t];
+                return;
+              }
+            }
+            scope.regionType = scope.regionTypes[0];
+          }
+
           /**
            * Load list on init to fill the dropdown
            */
@@ -127,7 +139,7 @@
                 id: 'geonames'
               });
             }
-            scope.regionType = scope.regionTypes[0];
+            setDefault();
           });
 
           scope.setRegion = function(regionType) {


### PR DESCRIPTION
Currently the first one is selected and is GeoNames.
Some users have more important custom regions eg. Marine areas