### PR TITLE
[BUG] - Map background, use default parameter defined in settings

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
@@ -403,7 +403,7 @@ public class Handlers {
             def xpath = f.getXPathFrom(el);
 
             if (xpath != null) {
-                def image = "<img src=\"region.getmap.png?mapsrs=$mapproj&amp;width=$width&amp;background=$background&amp;id=metadata:@id$mdId:@xpath$xpath\"\n" +
+                def image = "<img src=\"region.getmap.png?mapsrs=$mapproj&amp;width=$width&amp;background=settings&amp;id=metadata:@id$mdId:@xpath$xpath\"\n" +
                         "         style=\"min-width:${width/4}px; min-height:${width/4}px;\" />"
 
                 def inclusion = el.'gmd:extentTypeCode'.text() == '0' ? 'exclusive' : 'inclusive';

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/html/bbox.html
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/html/bbox.html
@@ -19,7 +19,7 @@
       </div>
     </span>
     <img
-      src="region.getmap.png?mapsrs={{mapconfig.mapproj}}&amp;amp;width={{mapconfig.width}}&amp;amp;background={{mapconfig.background}}&amp;amp;geom=Polygon(({{w}}%20{{n}},{{e}}%20{{n}},{{e}}%20{{s}},{{w}}%20{{s}},{{w}}%20{{n}}))&amp;amp;geomsrs={{geomproj}}"
+      src="region.getmap.png?mapsrs={{mapconfig.mapproj}}&amp;amp;width={{mapconfig.width}}&amp;amp;background=settings&amp;amp;geom=Polygon(({{w}}%20{{n}},{{e}}%20{{n}},{{e}}%20{{s}},{{w}}%20{{s}},{{w}}%20{{n}}))&amp;amp;geomsrs={{geomproj}}"
       style="min-width:{{minwidth}}px; min-height:{{minheight}}px;"
       alt=""/>
     <div fmt-if="pdfOutput">

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -91,11 +91,7 @@
                                          if ($width != '')
                                          then $width
                                          else '600'
-                                         }&amp;background={
-                                         if ($background != '')
-                                         then $background
-                                         else 'osm'
-                                         }&amp;geomsrs=EPSG:4326&amp;geom={$geometry}"/>
+                                         }&amp;background=settings&amp;geomsrs=EPSG:4326&amp;geom={$geometry}"/>
     </xsl:if>
 
   </xsl:function>


### PR DESCRIPTION
This PR adds the "_settings_" parameter also to other parts of the code where the **getmap** method is invoked, to follow the new approach defined here https://github.com/geonetwork/core-geonetwork/pull/2938

@jahow what do you think?

Another parameter that could be good to take from settings is the SRS, should we add the keyword "_settings_" also for this?