### PR TITLE
Fix for the logo in the header: default is false (#3306)

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -78,7 +78,7 @@
             'chi': 'zh',
             'slo': 'sk'
           },
-          'isLogoInHeader': true,
+          'isLogoInHeader': false,
           'logoInHeaderPosition': 'left'
         },
         'home': {

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v350/LogoPositionInHeaderMigration.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v350/LogoPositionInHeaderMigration.java
@@ -39,7 +39,7 @@ public class LogoPositionInHeaderMigration extends JsonDatabaseMigration {
     protected Map<String, String> setUpNewSettingValues() {
         Map<String, String> fieldsToUpdate = new HashMap<>(1);
         fieldsToUpdate.put("/mods/header/isLogoInHeader",
-            "true");
+            "false");
         fieldsToUpdate.put("/mods/header/logoInHeaderPosition",
             "\"left\"");
 


### PR DESCRIPTION
Fix for the logo in the header: the default option is now set to `false` (do not show the logo in the header).

Related to: https://github.com/geonetwork/core-geonetwork/pull/3306#discussion_r247828108