### PR TITLE
Admin console / Restore message suggesting to load samples & template when empty the catalogue is.

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/admin.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/admin.html
@@ -84,9 +84,13 @@
             <div class="panel-body">
               <h2>{{searchInfo.count}}</h2>
             </div>
-            <div data-ng-show="searchInfo.count == 0" data-translate=""> emptyCatalogShouldBeFilled
-            </div>
           </div>
+        </div>
+
+
+        <div class="col-md-4 col-sm-8"
+             data-ng-show="searchInfo.count == 0"
+             data-translate=""> emptyCatalogShouldBeFilled
         </div>
       </div>
       <!-- /.gn-row-admin-stats -->


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1701393/51189265-f7762700-18df-11e9-8396-d1b2b4ab243b.png)


Related to https://github.com/geonetwork/core-geonetwork/commit/f4d8324966304d426e9a930bfcff980a7c07a881