### PR TITLE
Installer / Avoid error when parent dir does not exist.

### DIFF
--- a/release/bin/startup.sh
+++ b/release/bin/startup.sh
@@ -21,7 +21,7 @@ done
 
 echo "Archiving old log files..."
 if [ ! -d "logs/archive" ]; then
-    mkdir logs/archive
+    mkdir -p logs/archive
 fi
 rm -f logs/*request.log*
 rm -f logs/output.log


### PR DESCRIPTION
On first run, the logs dir does not exist. Create parent if needed.