### PR TITLE
Fix for the width of a datepicker in the editor

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -200,6 +200,14 @@
     .gn-date-picker > input[type=date], .gn-date-picker > input[type=time] {
       width: 50%;
     }
+    .gn-date-picker.gn-time-with-ind-position {
+      input[type=month], input[type=number] {
+        width: 80%;
+      }
+      &> input[type=date], &> input[type=time] {
+        width: 40%;
+      }
+    }
     // default switch
     [data-ng-switch-default] {
       .col-xs-8, .col-xs-4 {
@@ -294,6 +302,9 @@
     }
     // field in field
     .gn-field {
+      label {
+        font-size: 12px;
+      }
       .gn-field {
         padding-top: 0;
         padding-bottom: 0;


### PR DESCRIPTION
In the editor there are cases (INSPIRE view) where the date picker is displayed on 2 lines. This PR fixes this and display the date picker on 1 line.

**Screenshot of the old situation**
![gn-datepicker-old](https://user-images.githubusercontent.com/19608667/51241748-c26ce180-197e-11e9-84f7-753d465d0038.png)

**Screenshot after the fix**
![gn-datepicker-new](https://user-images.githubusercontent.com/19608667/51241798-dca6bf80-197e-11e9-8646-41a1b63b8df2.png)
