### PR TITLE
Highlight the active view in the dropdown menu of the editor

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -50,7 +50,6 @@
               margin-top: -1.5em;
               margin-right: 8px;
               content: "\f00c";
-              // display: inline-block;
               font: normal normal normal 14px/1 FontAwesome;
               font-size: inherit;
               text-rendering: auto;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -44,21 +44,11 @@
       .gn-view-menu-button {
         .dropdown-menu {
           li {
-            .gn-editor-view {
-              padding-left: 44px;
-            }
             &.disabled {
               background-color: @dropdown-link-hover-bg;
-              &:before {
-                position: absolute;
-                margin-top: 6px;
-                margin-left: 20px;
-                content: "\f1db";
-                font: normal normal normal 14px/1 FontAwesome;
-                font-size: inherit;
-                text-rendering: auto;
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
+              a {
+                color: @gray-base;
+                font-weight: bold;
               }
             }
           }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -40,6 +40,26 @@
           left: 0;
         }
       }
+      // highlight the active view
+      .gn-view-menu-button {
+        .dropdown-menu {
+          li.disabled {
+            background-color: @dropdown-link-hover-bg;
+            &:after {
+              float: right;
+              margin-top: -1.5em;
+              margin-right: 8px;
+              content: "\f00c";
+              // display: inline-block;
+              font: normal normal normal 14px/1 FontAwesome;
+              font-size: inherit;
+              text-rendering: auto;
+              -webkit-font-smoothing: antialiased;
+              -moz-osx-font-smoothing: grayscale;
+            }
+          }
+        } 
+      }
     }
   }
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -43,18 +43,23 @@
       // highlight the active view
       .gn-view-menu-button {
         .dropdown-menu {
-          li.disabled {
-            background-color: @dropdown-link-hover-bg;
-            &:after {
-              float: right;
-              margin-top: -1.5em;
-              margin-right: 8px;
-              content: "\f00c";
-              font: normal normal normal 14px/1 FontAwesome;
-              font-size: inherit;
-              text-rendering: auto;
-              -webkit-font-smoothing: antialiased;
-              -moz-osx-font-smoothing: grayscale;
+          li {
+            .gn-editor-view {
+              padding-left: 44px;
+            }
+            &.disabled {
+              background-color: @dropdown-link-hover-bg;
+              &:before {
+                position: absolute;
+                margin-top: 6px;
+                margin-left: 20px;
+                content: "\f1db";
+                font: normal normal normal 14px/1 FontAwesome;
+                font-size: inherit;
+                text-rendering: auto;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+              }
             }
           }
         } 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -18,6 +18,20 @@
 .gn-md-view {
   padding: 15px 20px;
   background-color: @gn-md-view-background-color;
+  // highlight the active view
+  .gn-view-menu-button {
+    .dropdown-menu {
+      li {
+        &.disabled {
+          background-color: @dropdown-link-hover-bg;
+          a {
+            color: @gray-base;
+            font-weight: bold;
+          }
+        }
+      }
+    } 
+  }
   .gn-related-item {
     margin-top: -1px;
     border-radius: 0;

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -44,7 +44,7 @@
         </button>
       </div>
 
-      <div class="btn-group pull-right">
+      <div class="btn-group pull-right gn-view-menu-button">
         <button type="button" class="btn btn-default dropdown-toggle"
                 data-toggle="dropdown"
                 aria-label="{{'chooseAView' | translate}}"
@@ -57,7 +57,6 @@
           <!-- <li class="dropdown-header" data-translate="">chooseAView</li> -->
           <li role="menuitem" data-ng-class="currentFormatter == undefined ? 'disabled' : ''">
             <a href="" data-ng-click="format()">
-              <i class="fa fa-fw"></i>
               <span data-translate="">defaultView</span>
             </a>
           </li>
@@ -65,7 +64,6 @@
               data-ng-repeat="f in formatter.list"
               data-ng-class="f === currentFormatter ? 'disabled' : ''">
             <a href="" data-ng-click="format(f)">
-              <i class="fa fa-fw"></i>
               {{f.label | translate}}
             </a>
           </li>

--- a/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
@@ -62,7 +62,7 @@
                 <xsl:if test="'simple' = $currentView/@name">
                   <xsl:attribute name="class">disabled</xsl:attribute>
                 </xsl:if>
-                <a data-ng-click="switchToTab('simple', '')" href="">
+                <a data-ng-click="switchToTab('simple', '')" href="" class="gn-editor-view">
                   <xsl:value-of select="$strings/*[name() = 'simple']"/>
                 </a>
               </li>
@@ -70,7 +70,7 @@
                 <xsl:if test="'xml' = $currentView/@name">
                   <xsl:attribute name="class">disabled</xsl:attribute>
                 </xsl:if>
-                <a data-ng-click="switchToTab('xml', '')" href="">
+                <a data-ng-click="switchToTab('xml', '')" href="" class="gn-editor-view">
                   <xsl:value-of select="$strings/*[name() = 'xml']"/>
                 </a>
               </li>
@@ -94,7 +94,7 @@
                     <!-- When a view contains multiple tab, the one with
                   the default attribute is the one to open -->
                     <a data-ng-click="switchToTab('{tab[@default]/@id}', '{tab[@default]/@mode}')"
-                       href="">
+                       href="" class="gn-editor-view">
                       <xsl:variable name="viewName" select="@name"/>
                       <xsl:value-of select="$strings/*[name() = $viewName]"/>
                     </a>
@@ -145,7 +145,7 @@
                   <xsl:if test="$tab = @id">
                     <xsl:attribute name="class">disabled</xsl:attribute>
                   </xsl:if>
-                  <a href="">
+                  <a href="" class="gn-editor-view">
                     <xsl:if test="$tab != @id">
                       <xsl:attribute name="data-ng-click"
                                      select="concat('switchToTab(''', @id, ''', ''', @mode, ''')')"/>
@@ -179,7 +179,7 @@
     -->
     <li role="menuitem"
       class="{if ($tab = @id) then 'active' else ''} {if ($isTabDisplayed) then '' else 'disabled'}">
-      <a href="">
+      <a href="" class="gn-editor-view">
         <xsl:if test="$tab != @id and $isTabDisplayed">
           <xsl:attribute name="data-ng-click"
                          select="concat('switchToTab(''', @id, ''', ''', @mode, ''')')"/>

--- a/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
@@ -62,7 +62,7 @@
                 <xsl:if test="'simple' = $currentView/@name">
                   <xsl:attribute name="class">disabled</xsl:attribute>
                 </xsl:if>
-                <a data-ng-click="switchToTab('simple', '')" href="" class="gn-editor-view">
+                <a data-ng-click="switchToTab('simple', '')" href="">
                   <xsl:value-of select="$strings/*[name() = 'simple']"/>
                 </a>
               </li>
@@ -70,7 +70,7 @@
                 <xsl:if test="'xml' = $currentView/@name">
                   <xsl:attribute name="class">disabled</xsl:attribute>
                 </xsl:if>
-                <a data-ng-click="switchToTab('xml', '')" href="" class="gn-editor-view">
+                <a data-ng-click="switchToTab('xml', '')" href="">
                   <xsl:value-of select="$strings/*[name() = 'xml']"/>
                 </a>
               </li>
@@ -94,7 +94,7 @@
                     <!-- When a view contains multiple tab, the one with
                   the default attribute is the one to open -->
                     <a data-ng-click="switchToTab('{tab[@default]/@id}', '{tab[@default]/@mode}')"
-                       href="" class="gn-editor-view">
+                       href="">
                       <xsl:variable name="viewName" select="@name"/>
                       <xsl:value-of select="$strings/*[name() = $viewName]"/>
                     </a>
@@ -145,7 +145,7 @@
                   <xsl:if test="$tab = @id">
                     <xsl:attribute name="class">disabled</xsl:attribute>
                   </xsl:if>
-                  <a href="" class="gn-editor-view">
+                  <a href="">
                     <xsl:if test="$tab != @id">
                       <xsl:attribute name="data-ng-click"
                                      select="concat('switchToTab(''', @id, ''', ''', @mode, ''')')"/>
@@ -179,7 +179,7 @@
     -->
     <li role="menuitem"
       class="{if ($tab = @id) then 'active' else ''} {if ($isTabDisplayed) then '' else 'disabled'}">
-      <a href="" class="gn-editor-view">
+      <a href="">
         <xsl:if test="$tab != @id and $isTabDisplayed">
           <xsl:attribute name="data-ng-click"
                          select="concat('switchToTab(''', @id, ''', ''', @mode, ''')')"/>


### PR DESCRIPTION
This PR adds a little bit of styling to the dropdown menu in the editor, highlighting the current view a bit more clear.

**Screenshot of the active view**
![gn-editor-highlight-view](https://user-images.githubusercontent.com/19608667/51246152-f7326600-1989-11e9-9bc7-2e10d260131c.png)
 