### PR TITLE
Match the dropdown menu colours in the admin with the sidebar colours

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -47,6 +47,19 @@ ul.gn-resultview li.list-group-item {
     .navbar-collapse {
       background: #fff;
     }
+    .dropdown-menu {
+      > li {
+        > a {
+          padding: 8px 20px;
+        }
+        &.active, &:hover {
+          > a {
+            color: @gn-menubar-color;
+            background-color: lighten(@brand-primary, 46.7%);
+          }
+        }
+      }
+    }
   }
   [data-ng-controller="GnAdminController"] {
     .sidebar {


### PR DESCRIPTION
The colours in the admin sidebar were different than the colours used in the dropdown menu of the menubar. This PR changes the colours of the dropdown to those used in the sidebar.

**Screenshot of the matching colours**
![gn-admin-match-colours](https://user-images.githubusercontent.com/19608667/51249414-78422b00-1993-11e9-93d5-d936acdf1143.png)
