### PR TITLE
Align facet toggle buttons to the left

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-list.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-list.html
@@ -1,7 +1,7 @@
 <div class="gn-facet-list">
 
   <!--Collapse all button for first panel-->
-  <div class="btn-group width-100 flex-row flex-center" ng-hide="isTabMode">
+  <div class="btn-group width-100 flex-row flex-left" ng-hide="isTabMode">
     <button type="button" class="btn btn-default btn-sm gn-facet-toggle-btn"
       ng-click="expandAll()" title="{{'expandAllFacet' | translate}}">
       <i class="fa fa-plus-circle"/>


### PR DESCRIPTION
The facet toggle buttons are now aligned in the center. This looks good on wider screens where the facets and search results are beside each other. On smaller screens the search result are display below the facets, and then the toggle buttons are somewhere floating in the middle of the screen.

**Screenshot of centered buttons**
![gn-facet-center](https://user-images.githubusercontent.com/19608667/51250038-898c3700-1995-11e9-9d4a-656503e8131f.png)


This PR aligns the toggle buttons to the left, so on smaller screens the toggle buttons are displayed right above the facets and now also have a visual connection

**Screenshot of buttons aligned to the left**
![gn-facet-left](https://user-images.githubusercontent.com/19608667/51250055-90b34500-1995-11e9-8231-c852a502d405.png)
