### PR TITLE
Harvester / Runtime exception on startup with non escaped character 

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswParams.java
@@ -23,15 +23,12 @@
 
 package org.fao.geonet.kernel.harvest.harvester.csw;
 
-import org.fao.geonet.Constants;
 import org.fao.geonet.Util;
 import org.fao.geonet.exceptions.BadInputEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.harvest.harvester.AbstractParams;
 import org.jdom.Element;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,14 +91,6 @@ public class CswParams extends AbstractParams {
         hopCount = Util.getParam(site, "hopCount", 2);
         xslfilter = Util.getParam(site, "xslfilter", "");
         outputSchema = Util.getParam(site, "outputSchema", outputSchema);
-
-        try {
-            capabUrl = URLDecoder.decode(capabUrl, Constants.ENCODING);
-        } catch (UnsupportedEncodingException x) {
-            System.out.println(x.getMessage());
-            x.printStackTrace();
-            // TODO should not swallow
-        }
         icon = Util.getParam(site, "icon", "default.gif");
 
         if (searches != null) {
@@ -128,14 +117,6 @@ public class CswParams extends AbstractParams {
 
         capabUrl = Util.getParam(site, "capabilitiesUrl", capabUrl);
         rejectDuplicateResource = Util.getParam(site, "rejectDuplicateResource", rejectDuplicateResource);
-
-        try {
-            capabUrl = URLDecoder.decode(capabUrl, Constants.ENCODING);
-        } catch (UnsupportedEncodingException x) {
-            System.out.println(x.getMessage());
-            x.printStackTrace();
-            // TODO should not swallow
-        }
         queryScope = Util.getParam(site, "queryScope", queryScope);
         hopCount = Util.getParam(site, "hopCount", hopCount);
         xslfilter = Util.getParam(site, "xslfilter", "");

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/GeoPRESTParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/GeoPRESTParams.java
@@ -23,15 +23,12 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geoPREST;
 
-import org.fao.geonet.Constants;
 import org.fao.geonet.Util;
 import org.fao.geonet.exceptions.BadInputEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.harvest.harvester.AbstractParams;
 import org.jdom.Element;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -91,14 +88,6 @@ public class GeoPRESTParams extends AbstractParams {
 
         baseUrl = Util.getParam(site, "baseUrl", "");
         maxResults = MAX_HARVEST_RESULTS;
-
-        try {
-            baseUrl = URLDecoder.decode(baseUrl, Constants.ENCODING);
-        } catch (UnsupportedEncodingException x) {
-            System.out.println(x.getMessage());
-            x.printStackTrace();
-            // TODO should not swallow
-        }
         icon = Util.getParam(site, "icon", "default.gif");
 
         addSearches(searches);
@@ -118,15 +107,6 @@ public class GeoPRESTParams extends AbstractParams {
 
         baseUrl = Util.getParam(site, "baseUrl", baseUrl);
         maxResults = MAX_HARVEST_RESULTS;
-
-        try {
-            baseUrl = URLDecoder.decode(baseUrl, Constants.ENCODING);
-        } catch (UnsupportedEncodingException x) {
-            System.out.println(x.getMessage());
-            x.printStackTrace();
-            // TODO should not swallow
-        }
-
         icon = Util.getParam(site, "icon", icon);
 
         //--- if some search queries are given, we drop the previous ones and


### PR DESCRIPTION
Fix for #3422 +  Harvester URL not properly saved when containing characters to be escaped.

eg. for testing use https://sextant.ifremer.fr/geonetwork/srv/eng/csw?any=%25Like%25 and set AnyText=dorade should harvest 9 records
* save harvester, the URL is properly restored
* if  https://sextant.ifremer.fr/geonetwork/srv/eng/csw?any=%Like% then URL is saved, app can restart properly and proxy does not reach the server as the URL is not correct (maybe something to address in another ticket)

This code was introduced by https://trac.osgeo.org/geonetwork/ticket/728 but I think it was only required for the XSLT based UI (@josegar74 maybe you could review this one in case you remind some historical reasons ?)