### PR TITLE
Re-arrange the elements in the advanced search form

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -65,8 +65,8 @@
 [data-ng-search-form] {
   .gn-top-search {
     position: relative;
-    padding-top: 15px;
-    padding-bottom: 15px;
+    padding-top: 2em;
+    padding-bottom: 2em;
     [typeahead] {
       vertical-align: middle;
       display: inline-block;
@@ -81,7 +81,6 @@
       margin-left: 64px;
     }
     .gn-form-any {
-      max-width: 45vw;
       input[type="text"], button {
         height: 36px;
       }
@@ -102,25 +101,36 @@
     padding: .2em;
   }
 }
-
+// advanced search
 .gn-search-filter {
   padding: 5px;
   .nav-pills li {
     display: block;
   }
-  div {
-    ul, div.tab-content {
-      float: left;
-    }
-    ul.nav {
-      width: 10vw;
-    }
-    div.tab-content {
-      width: 84vw;
-
-    }
+  .form-group {
+    margin-bottom: 0;
+  }
+  .btn-link {
+    padding-left: 0;
+    font-size: 14px;
+  }
+  .control-label {
+    padding: 3px 0 2px 0;
   }
   .bootstrap-tagsinput {
+    padding-top: 6px;
+    padding-bottom: 5px;
+    .tagsinput-trigger {
+      top: 34px;
+      right: 25px;
+      @media (max-width: @screen-sm-max) {
+        top: 38px;
+      }
+    }
+    .tagsinput-clear {
+      right: 20px;
+      top: 0px;
+    }
     .tag {
       white-space: normal;
       display: inline-flex;
@@ -129,36 +139,31 @@
       font-weight: normal;
       margin-bottom: 3px;
     }
-  }
-}
-
-.gn-row-filters {
-  padding-bottom: 5px;
-  margin-bottom: 5px;
-
-  .gn-flfilter {
-
-  }
-  .gn-flfilter-icon {
-    text-align: center;
-    li {
-      list-style: none;
-      float: left;
-      width: 100px;
-    }
-    i {
-      //    .@{fa-css-prefix}-4x;
-      font-size: 4em;
-      width: 70px;
-      img {
-        width: 70px;
+    .tt-menu {
+      .tt-dataset {
+        .tt-suggestion {
+          &:hover {
+            cursor: pointer;
+            background-color: @dropdown-link-hover-bg;
+          }
+        }
       }
     }
   }
-}
-
-.gn-results-switch {
-  float: left;
+  .gn-search-filter-datepicker {
+    margin-bottom: 10px;
+    .col-md-6 {
+      padding-left: 0;
+      @media (min-width: 400px) and (max-width: @screen-sm-max) {
+        width: 50%;
+        float: left;
+      }
+      @media (max-width: 400px) {
+        padding-right: 0;
+        margin-bottom: 10px;
+      }
+    }
+  }
 }
 
 /*

--- a/web-ui/src/main/resources/catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html
@@ -1,16 +1,12 @@
-<div
-     class="gn-search-filter col-lg-12 advancedSearchForm">
-
-
+<div class="gn-search-filter col-lg-12 advancedSearchForm">
   <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-5 col-md-offset-1">
       <h3 data-translate="">what</h3>
       <div class="form-group">
-        <label for="categoriesF"
-               class="col-md-4 col-sm-12 control-label"
-               data-translate="">categories</label>
-
-        <div class="col-sm-8">
+        <div class="col-sm-12">
+          <label for="categoriesF"
+                class="control-label"
+                data-translate="">categories</label>
           <input type="text" id="categoriesF" value=""
                  class="form-control"
                  gn-typeahead="categoriesOptions"
@@ -18,11 +14,10 @@
         </div>
       </div>
       <div class="form-group">
-        <label for="keywordsF"
-               class="col-md-4 col-sm-12 control-label"
-               data-translate="">keywords</label>
-
-        <div class="col-sm-8">
+        <div class="col-sm-12">
+          <label for="keywordsF"
+                class="control-label"
+                data-translate="">keywords</label>
           <input type="text" id="keywordsF" value=""
                  class="form-control"
                  gn-values="searchObj.params.keyword"
@@ -30,11 +25,10 @@
         </div>
       </div>
       <div class="form-group">
-        <label for="orgNameF"
-               class="col-md-4 col-sm-12 control-label"
-               data-translate="">orgName</label>
-
-        <div class="col-sm-8">
+        <div class="col-sm-12">
+          <label for="orgNameF"
+                class="control-label"
+                data-translate="">orgName</label>
           <input type="text" id="orgNameF" value=""
                  class="form-control"
                  gn-values="searchObj.params.orgName"
@@ -42,20 +36,19 @@
         </div>
       </div>
     </div>
-    <div class="col-md-5">
+    <div class="col-md-5 gn-search-filter-datepickers">
       <h3 data-translate="">when</h3>
       <div data-gn-period-chooser="resourcesCreatedTheLast"
            data-date-from="searchObj.params.creationDateFrom"
-           data-date-to="searchObj.params.creationDateTo">
+           data-date-to="searchObj.params.creationDateTo"
+           class="gn-search-filter-datepicker">
       </div>
 
       <div data-gn-period-chooser="recordsCreatedTheLast"
            data-date-from="searchObj.params.dateFrom"
-           data-date-to="searchObj.params.dateTo">
+           data-date-to="searchObj.params.dateTo"
+           class="gn-search-filter-datepicker">
       </div>
-    </div>
-    <div class="col-md-5">
-
     </div>
   </div>
 </div>


### PR DESCRIPTION
The elements in the advanced search form are not aligned with each other (different horizontal positions) and are not centered on the page (whereas the search box is).

This PR aligns and centers the elements which results in a cleaner view.

**Screenshot of the old situation:**
![gn-advanced-old](https://user-images.githubusercontent.com/19608667/51255702-07efd580-19a4-11e9-9dd0-6c0ef8c99c82.png)

**Screenshot of the aligned elements:**
![gn-advanced-new](https://user-images.githubusercontent.com/19608667/51255765-2c4bb200-19a4-11e9-9110-1003f60812d1.png)

Changes:
- added hover styles in the typeahead
- cleanup unused styles
- wider search on small screens
- elements aligned with each other
- centered on the page
- better positioning of `trigger` and `clear` buttons