### PR TITLE
[BUG] - Hide remove button from mandatory fields in editor

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1311,7 +1311,7 @@
                 $editInfo/@del = 'true' or
                 $editInfo/@min != 1
               )
-            )) and not($isRequired)">
+            )) and not($isRequired and ($editInfo and $editInfo/@max and $editInfo/@max = 1) and ($parentEditInfo and $parentEditInfo/@max and $parentEditInfo/@max = 1))">
 
       <xsl:variable name="elementToRemove" select="if ($parentEditInfo) then
         $parentEditInfo else $editInfo"/>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -164,6 +164,7 @@
               <xsl:call-template name="render-form-field-control-remove">
                 <xsl:with-param name="editInfo" select="$editInfo"/>
                 <xsl:with-param name="parentEditInfo" select="$parentEditInfo"/>
+                <xsl:with-param name="isRequired" select="$isRequired"/>
               </xsl:call-template>
             </xsl:if>
           </div>
@@ -293,6 +294,7 @@
               <xsl:call-template name="render-form-field-control-remove">
                 <xsl:with-param name="editInfo" select="$editInfo"/>
                 <xsl:with-param name="parentEditInfo" select="$parentEditInfo"/>
+                <xsl:with-param name="isRequired" select="$isRequired"/>
               </xsl:call-template>
             </xsl:if>
           </div>
@@ -1299,15 +1301,17 @@
   <xsl:template name="render-form-field-control-remove">
     <xsl:param name="editInfo"/>
     <xsl:param name="parentEditInfo" required="no"/>
+    <xsl:param name="isRequired" required="no"/>
     <xsl:if
-      test="($parentEditInfo and
-                     ($parentEditInfo/@del = 'true' or
-                     $parentEditInfo/@min != 1)
-                   ) or
-                   (not($parentEditInfo) and ($editInfo and
-                   ($editInfo/@del = 'true' or
-                   $editInfo/@min != 1)
-                   ))">
+      test="(($parentEditInfo and (
+              $parentEditInfo/@del = 'true' or
+              $parentEditInfo/@min != 1)
+            ) or (
+              not($parentEditInfo) and $editInfo and (
+                $editInfo/@del = 'true' or
+                $editInfo/@min != 1
+              )
+            )) and not($isRequired)">
 
       <xsl:variable name="elementToRemove" select="if ($parentEditInfo) then
         $parentEditInfo else $editInfo"/>


### PR DESCRIPTION
In the metadata editor on some dutch schema, it happens that the remove button is shown even close to specific mandatory fields when the parent is not mandatory. For example, check https://github.com/metadata101/iso19139.nl.geografie.2.0.0

This is an extra check on the current field, to check explicitly if it's mandatory, before showing the remove button.