### PR TITLE
Small improvements to the mini map on the search results page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -64,6 +64,16 @@
 }
 
 // minimap on search results
+.gn-search-map {
+  [ngeo-map] {
+    background: @body-bg;
+    .ol-attribution {
+      li, a {
+        font-size: 10px;
+      }
+    }
+  }
+}
 .gn-toggle {
   background-color: @brand-primary;
   color: white !important;
@@ -79,6 +89,9 @@
   bottom: 10px;
   right: 10px;
   z-index: 999;
+  &:focus {
+    background-color: @brand-primary;
+  }
 }
 .gn-minimap-button {
   padding: 7px;

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -107,12 +107,12 @@
   <div data-gn-map-field="searchObj.searchMap"
        data-gn-map-field-geom="searchObj.params.geometry"
        data-gn-map-field-opt="searchObj.mapfieldOption"
-       class="gn-search-map">
+       class="gn-search-map hidden-xs">
   </div>
 
   <button data-ng-click="toggleMap()"
           title="{{'toggleMiniMap' | translate}}"
-          class="gn-toggle gn-minimap-toggle btn btn-link gn-minimap-button">
+          class="gn-toggle gn-minimap-toggle btn btn-link gn-minimap-button hidden-xs">
     <i class="fa fa-angle-double-right" ></i>
     <b class="gn-minimap-toggle gn-minimap-text" data-translate="">map</b>
   </button>


### PR DESCRIPTION
Small improvements to the mini map:
- background-color added (looks better when refreshing the page and there are no maptiles yet)
- toggle button has an `:focus` background
- mini map is hidden on small screens
- larger font for attribution text