### PR TITLE
User administrator can delete his own group 

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
@@ -34,6 +34,7 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.records.attachments.AttachmentsApi;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
@@ -457,7 +458,7 @@ public class GroupsApi {
         produces = MediaType.APPLICATION_JSON_VALUE,
         method = RequestMethod.DELETE)
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
-    @PreAuthorize("hasRole('UserAdmin')")
+    @PreAuthorize("hasRole('Administrator')")
     @ApiResponses(value = {
         @ApiResponse(code = 204, message = "Group removed."),
         @ApiResponse(code = 404, message = ApiParams.API_RESPONSE_RESOURCE_NOT_FOUND),
@@ -470,6 +471,11 @@ public class GroupsApi {
         )
         @PathVariable
             Integer groupIdentifier,
+        @ApiParam(
+            value = "Force removal even if records are assigned to that group."
+        )
+        @RequestParam(defaultValue = "false")
+            boolean force,
         @ApiIgnore
             ServletRequest request
     ) throws Exception {
@@ -484,13 +490,21 @@ public class GroupsApi {
             List<Integer> reindex = operationAllowedRepo.findAllIds(OperationAllowedSpecs.hasGroupId(groupIdentifier),
                 OperationAllowedId_.metadataId);
 
-            operationAllowedRepo.deleteAllByIdAttribute(OperationAllowedId_.groupId, groupIdentifier);
-            userGroupRepo.deleteAllByIdAttribute(UserGroupId_.groupId, Arrays.asList(groupIdentifier));
-            groupRepository.delete(groupIdentifier);
+            if (reindex.size() > 0 && force) {
+                operationAllowedRepo.deleteAllByIdAttribute(OperationAllowedId_.groupId, groupIdentifier);
+                userGroupRepo.deleteAllByIdAttribute(UserGroupId_.groupId, Arrays.asList(groupIdentifier));
 
-            //--- reindex affected metadata
-            DataManager dm = ApplicationContextHolder.get().getBean(DataManager.class);
-            dm.indexMetadata(Lists.transform(reindex, Functions.toStringFunction()));
+                //--- reindex affected metadata
+                DataManager dm = ApplicationContextHolder.get().getBean(DataManager.class);
+                dm.indexMetadata(Lists.transform(reindex, Functions.toStringFunction()));
+            } else if (reindex.size() > 0 && !force) {
+                throw new NotAllowedException(String.format(
+                    "Group %s has privileges associated with %d record(s). Add 'force' parameter to remove it or remove privileges associated with that group first.",
+                    group.getName(), reindex.size()
+                ));
+            }
+
+            groupRepository.delete(groupIdentifier);
 
         } else {
             throw new ResourceNotFoundException(String.format(

--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -654,7 +654,7 @@
 
       $scope.deleteGroup = function(formId) {
         $http.delete('../api/groups/' +
-                $scope.groupSelected.id)
+                $scope.groupSelected.id + '?force=true')
             .success(function(data) {
               $scope.unselectGroup();
               loadGroups();

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
@@ -45,7 +45,7 @@
         <span data-ng-hide="groupSelected.id != ''" data-translate="">newGroup</span>
         <span><strong>{{groupSelected.name}}</strong></span>
         <div class="btn-toolbar"
-             data-ng-show="user.isUserAdminOrMore()">
+             data-ng-show="user.isAdministratorOrMore()">
           <button type="button" class="btn btn-primary pull-right"
                   data-ng-disabled="!gnGroupEdit.$valid && !gnGroupEdit.dirty"
                   data-ng-click="saveGroup('#gn-group-edit', '#group-logo-upload')"


### PR DESCRIPTION
Fix for #2391

* User admin can't remove or update a group
* Group API / Add force parameter to remove a group associated with
records (as it is now, UI is using the force parameter)

![image](https://user-images.githubusercontent.com/1701393/51469259-3fc69680-1d71-11e9-93f4-fbeb5b522162.png)
