### PR TITLE
Small fix for outlining username/user role in the menu

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -845,6 +845,7 @@ input.ng-invalid {
   .gn-user-info {
     display: inline-block;
     vertical-align: middle;
+    padding-left: 3px;
     margin: -6px 0px;
     line-height: 1em;
     .gn-user-role {

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -146,7 +146,7 @@
             alt="{{'avatar' | translate}}"
             data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=18"/>
           <div class="gn-user-info hidden-sm">
-            &nbsp;{{user.name}} {{user.surname}}<br>
+            {{user.name}} {{user.surname}}<br>
             <span class="gn-user-role">{{user.profile | lowercase | translate}}</span>
           </div>
           <span class="alert alert-danger ng-hide"


### PR DESCRIPTION
Before the `Username` in the menubar a non-breaking space is added, but this means that `Username` and `Role` are not displayed right beneath each other. While this may look good for the admin, it doesn't for an editor:

![gn-userrole-old](https://user-images.githubusercontent.com/19608667/51470772-1f98d680-1d75-11e9-931f-1cdf6997ae59.png)

This PR removes the `nbsp;` so the items are aligned to the left, and adds some padding to increase whitespace:

![gn-userrole-new](https://user-images.githubusercontent.com/19608667/51470860-5cfd6400-1d75-11e9-98db-3bd38d7bad0f.png)

