### PR TITLE
Metadata editor - categories selection doesn't work for groups with allowed categories list

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -175,7 +175,7 @@
                     scope.enableallowedcategories =
                         data.enableAllowedCategories;
                     scope.allowedcategories = [];
-                    angular.forEach(data.allowedcategories, function(c) {
+                    angular.forEach(data.allowedCategories, function(c) {
                       scope.allowedcategories.push(c.id);
                     });
                   });


### PR DESCRIPTION
Fix for #3480