### PR TITLE
Fix for #3474: 'Manage record' button dropdown

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -98,13 +98,21 @@
           scope.md = scope.$eval(attrs.gnMdActionsMenu);
 
           scope.tasks = [];
+          scope.hasVisibletasks = false;
 
           function loadTasks() {
             return $http.get('../api/status/task', {cache: true}).
             success(function(data) {
               scope.tasks = data;
+              scope.getVisibleTasks();
             });
           };
+
+          scope.getVisibleTasks = function() {
+            $.each(scope.tasks, function(i,t) {
+              scope.hasVisibletasks = scope.taskConfiguration[t.name].isVisible();
+            });
+          }
 
           scope.taskConfiguration = {
             doiCreationTask: {

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -44,10 +44,10 @@
           <span data-ng-if="!md.isPublished()"
                 data-translate="">publish</span>&nbsp;
 
-          <i class="fa"
+          <i class="fa fa-fw"
              data-ng-if="!md.isPublished() && md.hasValidation()"
              data-ng-class="md.isValid() ? 'gn-recordtype-n text-success' : 'gn-recordtype-n text-danger'"></i>
-          <i class="fa gn-recordtype-n text-muted"
+          <i class="fa fa-fw gn-recordtype-n text-muted"
              data-ng-if="!md.isPublished() && !md.hasValidation()"></i>
         </a>
 
@@ -70,13 +70,13 @@
         <a role="menuitem"
            data-ng-href=""
            data-ng-click="mdService.startWorkflow(md, getCatScope())">
-          <i class="fa fa-code-fork"></i>&nbsp;
+          <i class="fa fa-fw fa-code-fork"></i>&nbsp;
           <span data-translate="">enableWorkflow</span>
         </a>
       </li>
 
       <li role="menuitem" class="divider"
-          data-ng-if="user.isConnected()"></li>
+          data-ng-if="user.isConnected() && user.canEditRecord(md)"></li>
 
 
       <li data-ng-repeat="t in tasks"
@@ -88,8 +88,7 @@
         </a>
       </li>
       <li role="menuitem" class="divider"
-          data-ng-if="user.isConnected() && tasks.length > 0">&nbsp;</li>
-
+          data-ng-if="user.isConnected() && tasks.length > 0 && hasVisibletasks">&nbsp;</li>
 
       <li role="menuitem">
         <a data-ng-href=""


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/3474

Fixed in this PR:
- do not show divider when no tasks are shown
- add `fa-fw` to icons to menu items to better align labels

**Screenshot of new dropdown:**
![gn-manager-record](https://user-images.githubusercontent.com/19608667/51476421-cc7b4f80-1d85-11e9-9d5b-ab5fa042bf37.png)