### PR TITLE
Record view / Do not display twice feature catalogue links

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -142,7 +142,7 @@
           </div>
           <div data-gn-related="mdView.current.record"
               data-user="user"
-              data-types="siblings|associated|related"
+              data-types="siblings|associated"
               data-title="{{'siblings' | translate}}">
           </div>
         </div>


### PR DESCRIPTION
To avoid:
![image](https://user-images.githubusercontent.com/1701393/51524406-436c2300-1e2e-11e9-9b24-013a9accc866.png)


Line 140, `related` elements are already displayed.