### PR TITLE
Improved responsiveness for the editor board

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -118,6 +118,12 @@ div[gn-transfer-ownership] * .list-group {
     top: 52px;
     left: 20px;
     right: 20px;
+    @media (max-width: @screen-xs-max) {
+      left: 0;
+      right: 0;
+      border-left: 0;
+      border-right: 0;
+    }
   }
   .gn-editor-board {
     padding-top: 120px;

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -11,17 +11,16 @@
               role="form">
           <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <div class="row gn-top-search">
-            <div class="col-sm-6 col-md-6 col-lg-5">
+            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-5">
               <div class="input-group gn-form-any">
 
-              <span class="input-group-addon">
-                <label>
-                  <input type="checkbox" data-ng-model="onlyMyRecord.is"
-                         data-ng-change="toggleOnlyMyRecord(triggerSearch);">
-                  <span data-translate="">onlyMyRecord</span>
-                </label>
-              </span>
-
+                <span class="input-group-addon">
+                  <label>
+                    <input type="checkbox" data-ng-model="onlyMyRecord.is"
+                          data-ng-change="toggleOnlyMyRecord(triggerSearch);">
+                    <span data-translate="" class="hidden-xs">onlyMyRecord</span>
+                  </label>
+                </span>
                 <input type="text"
                        class="form-control"
                        id="gn-any-field"
@@ -32,7 +31,6 @@
                        data-typeahead="address for address in getAnySuggestions($viewValue)"
                        data-typeahead-loading="anyLoading" class="form-control"
                        data-typeahead-min-length="1">
-
                 <div class="input-group-btn">
                   <button type="button"
                           data-ng-click="triggerSearch()"
@@ -50,24 +48,24 @@
 
               </div>
             </div>
-            <div class="col-sm-6 col-md-6 col-lg-7 text-right">
+            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-7 text-right">
               <a href="#/create" class="btn btn-primary">
-                <i class="fa fa-plus"/>&nbsp;<span data-translate="">addRecord</span>
+                <i class="fa fa-fw fa-plus"/><span data-translate="">addRecord</span>
               </a>
               <a href="#/import" class="btn btn-default">
-                <i class="fa fa-upload"/>&nbsp;<span class="hidden-xs hidden-sm" data-translate="">ImportRecord</span>
+                <i class="fa fa-fw fa-upload"/><span class="hidden-xs hidden-sm" data-translate="">ImportRecord</span>
               </a>
               <a href="#/directory" class="btn btn-default"
                  ng-if="user.isEditorOrMore()">
-                <i class="fa fa-bookmark"/>&nbsp;<span class="hidden-xs hidden-sm hidden-md" data-translate="">directoryManager</span>
+                <i class="fa fa-fw fa-bookmark"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">directoryManager</span>
               </a>
               <a href="#/batchedit" class="btn btn-default"
                  ng-if="user.isEditorOrMore()">
-                <i class="fa fa-pencil"/>&nbsp;<span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
+                <i class="fa fa-fw fa-pencil"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
               </a>
               <a href="#/accessManager" class="btn btn-default"
                  ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
-                <i class="fa fa-lock"/>&nbsp;<span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
+                <i class="fa fa-fw fa-lock"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
               </a>
             </div>
           </div>
@@ -81,23 +79,7 @@
         </div>
       </div>
 
-      <div class="row"
-           data-ng-show="searchResults.records.length > 0">
-        <div class="col-sm-offset-3 col-md-offset-3 col-sm-4 col-md-4 relative">
-          <div data-gn-selection-widget=""
-               data-results="searchResults"></div>
-        </div>
-        <div class="col-sm-5 col-md-5">
-          <div class="pull-right"
-               data-gn-pagination="paginationInfo"
-               data-hits-values="searchObj.hitsperpageValues"></div>
 
-          <div class="pull-right"
-               data-sortby-combo=""
-               data-params="searchObj.params"
-               data-gn-sortby-values="searchObj.sortbyValues"></div>
-        </div>
-      </div>
 
       <div class="row">
         <div class="col-sm-3 col-md-3 gn-search-facet">
@@ -110,7 +92,8 @@
                data-current-facets="currentFacets">
           </div>
         </div>
-        <div class="col-md-9">
+        <div class="col-sm-9 col-md-9">
+
           <span class="loading fa fa-spinner fa-spin"
                 data-ng-show="searching"></span>
 
@@ -120,10 +103,30 @@
             <span data-translate="">zarooResult</span>
           </div>
 
-          <div data-ng-show="searchResults.records.length > 0"
-               data-gn-results-container=""
-               data-search-results="searchResults"
-               data-template-url="resultTemplate"></div>
+          <div class="row gn-margin-bottom"
+               data-ng-show="searchResults.records.length > 0">
+            <div class="col-xs-12 col-sm-5 col-md-3 relative gn-nopadding-left">
+              <div data-gn-selection-widget=""
+                   data-results="searchResults"></div>
+            </div>
+            <div class="col-xs-12 col-sm-7 col-md-5 gn-nopadding-left gn-nopadding-right pull-right">
+              <div class="pull-right"
+                   data-gn-pagination="paginationInfo"
+                   data-hits-values="searchObj.hitsperpageValues"></div>
+            </div>
+            <div class="col-xs-12 col-sm-12 col-md-3 gn-nopadding-right pull-right">
+              <div class="pull-right"
+                   data-sortby-combo=""
+                   data-params="searchObj.params"
+                   data-gn-sortby-values="searchObj.sortbyValues"></div>
+            </div>
+          </div>
+          <div class="row">
+            <div data-ng-show="searchResults.records.length > 0"
+                data-gn-results-container=""
+                data-search-results="searchResults"
+                data-template-url="resultTemplate"></div>
+            </div>
         </div>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -109,12 +109,12 @@
               <div data-gn-selection-widget=""
                    data-results="searchResults"></div>
             </div>
-            <div class="col-xs-12 col-sm-7 col-md-5 gn-nopadding-left gn-nopadding-right pull-right">
+            <div class="col-xs-12 col-sm-7 col-md-5 gn-nopadding-left gn-nopadding-right text-right">
               <div class="pull-right"
                    data-gn-pagination="paginationInfo"
                    data-hits-values="searchObj.hitsperpageValues"></div>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-3 gn-nopadding-right pull-right">
+            <div class="col-xs-12 col-sm-12 col-md-4 gn-nopadding-right text-right">
               <div class="pull-right"
                    data-sortby-combo=""
                    data-params="searchObj.params"

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -56,14 +56,23 @@
       }
     }
   }
-
+  .gn-sub-bar {
+    .gn-form-any {
+      @media (max-width: @screen-xs-max) {
+        margin-bottom: 10px;
+      }
+    }
+  }
   .gn-editor-board {
     .gn-top-search {
       padding-top: 0;
       padding-bottom: 0;
     }
   }
-
+  .gn-search-facet {
+    padding-top: 55px;
+    padding-bottom: 15px;
+  }
   form.gn-editor {
     // tabs above editor
     .nav {


### PR DESCRIPTION
The editorboard (contribute page) has some issues on smaller screens: buttons are covered by the button bar, facets not clickable because of layer on top of it, controls for the result list not directly above the list. This PR fixes these issues.

**Screenshot of an old situation:**

![gn-editorboard-old](https://user-images.githubusercontent.com/19608667/51598656-4a626680-1efe-11e9-9658-845389df4166.png)

**Screenshot after the changes:**

![gn-editorboard-new](https://user-images.githubusercontent.com/19608667/51598744-767de780-1efe-11e9-8487-f0f7729c8441.png)

Changes:
- hide labels on small screens
- selection, sort and pager above the search results on small screens
- added extra `col-*` classes (facets not covered with invisible layer anymore)
- added whitespace