### PR TITLE
Remove trigger for closing tooltip on mouseout in the editor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -352,7 +352,6 @@
                        '</div><div class="popover-inner">' + closeBtn +
                        '<h3 class="popover-title"></h3>' +
                        '<div class="popover-content"><p></p></div></div></div>',
-                       //                       trigger: 'click',
                        trigger: isField ? 'focus' : 'click'
                      });
 
@@ -365,7 +364,6 @@
 
                      if (iconMode) {
                        tooltipTarget.mouseleave(function() {
-                         tooltipTarget.popover('hide');
                          isInitialized = false;
                        });
                      }


### PR DESCRIPTION
In the old situation the tooltip (with help text) in the editor, when you use the icon with a question mark, is closed by hovering away from the icon.

However if you add a hyperlink in the tooltip for example, you can not click it because the tooltip closes before you reach it.

This PR removes the close trigger on the `mouseout` event.

**Screenshot of tooltip with link:**
![gn-tooltip](https://user-images.githubusercontent.com/19608667/51606737-fdd55600-1f12-11e9-9a1d-35a537d6e151.png)
