### PR TITLE
[WIP] - Update UI to use metadata id instead of uuid in API services using the metadata uuid/id as part of the url path, to avoid issues with encoding uuids with slashes or other characters. Fixes #3249

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -28,7 +28,6 @@ package org.fao.geonet.api.records.attachments;
 import com.google.common.net.UrlEscapers;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.exception.ResourceAlreadyExistException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
@@ -80,15 +79,7 @@ public class FilesystemStore implements Store {
                                                String filter) throws Exception {
         List<MetadataResource> resourceList = new ArrayList<>();
         ApplicationContext _appContext = ApplicationContextHolder.get();
-        String metadataId;
-
-        if (StringUtils.isNumeric(metadataUuid)) {
-            metadataId = metadataUuid;
-            metadataUuid = getAndCheckMetadataUuid(metadataId);
-        } else {
-            metadataId = getAndCheckMetadataId(metadataUuid);
-        }
-
+        String metadataId = getAndCheckMetadataId(metadataUuid);
         AccessManager accessManager = _appContext.getBean(AccessManager.class);
         boolean canEdit = accessManager.canEdit(context, metadataId);
 
@@ -369,17 +360,6 @@ public class FilesystemStore implements Store {
             ));
         }
         return metadataId;
-    }
-
-    private String getAndCheckMetadataUuid(String metadataId) throws Exception {
-        ApplicationContext _appContext = ApplicationContextHolder.get();
-        String metadataUuid = _appContext.getBean(DataManager.class).getMetadataUuid(metadataId);
-        if (metadataUuid == null) {
-            throw new ResourceNotFoundException(String.format(
-                "Metadata with ID '%s' not found.", metadataId
-            ));
-        }
-        return metadataUuid;
     }
 
     private void canEdit(ServiceContext context, String metadataUuid) throws Exception {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -28,6 +28,7 @@ package org.fao.geonet.api.records.attachments;
 import com.google.common.net.UrlEscapers;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.exception.ResourceAlreadyExistException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
@@ -79,7 +80,15 @@ public class FilesystemStore implements Store {
                                                String filter) throws Exception {
         List<MetadataResource> resourceList = new ArrayList<>();
         ApplicationContext _appContext = ApplicationContextHolder.get();
-        String metadataId = getAndCheckMetadataId(metadataUuid);
+        String metadataId;
+
+        if (StringUtils.isNumeric(metadataUuid)) {
+            metadataId = metadataUuid;
+            metadataUuid = getAndCheckMetadataUuid(metadataId);
+        } else {
+            metadataId = getAndCheckMetadataId(metadataUuid);
+        }
+
         AccessManager accessManager = _appContext.getBean(AccessManager.class);
         boolean canEdit = accessManager.canEdit(context, metadataId);
 
@@ -360,6 +369,17 @@ public class FilesystemStore implements Store {
             ));
         }
         return metadataId;
+    }
+
+    private String getAndCheckMetadataUuid(String metadataId) throws Exception {
+        ApplicationContext _appContext = ApplicationContextHolder.get();
+        String metadataUuid = _appContext.getBean(DataManager.class).getMetadataUuid(metadataId);
+        if (metadataUuid == null) {
+            throw new ResourceNotFoundException(String.format(
+                "Metadata with ID '%s' not found.", metadataId
+            ));
+        }
+        return metadataUuid;
     }
 
     private void canEdit(ServiceContext context, String metadataUuid) throws Exception {

--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
@@ -173,6 +173,9 @@ Insert is made in first transferOptions found.
       In that case on one online element is added per
       layer/featureType.
       -->
+
+      <xsl:variable name="localUrl" select="contains($url, '/api/records/')" />
+
       <xsl:choose>
         <xsl:when test="starts-with($protocol, 'OGC:') and $name != ''">
           <xsl:for-each select="tokenize($name, ',')">
@@ -184,7 +187,22 @@ Insert is made in first transferOptions found.
               <gmd:CI_OnlineResource>
                 <gmd:linkage>
                   <gmd:URL>
-                    <xsl:value-of select="$url"/>
+                    <xsl:choose>
+                      <xsl:when test="$localUrl = true()">
+                        <xsl:variable name="uuid" select="substring-before(substring-after($url, '/api/records/'), '/attachments')" />
+                        <xsl:variable name="encodedUuid" select="encode-for-uri($uuid)" />
+                        <xsl:variable name="updatedUrl" select="replace($url, $uuid, $encodedUuid)" />
+
+                        <gco:CharacterString>
+                          <xsl:value-of select="$updatedUrl"/>
+                        </gco:CharacterString>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <gco:CharacterString>
+                          <xsl:value-of select="$url"/>
+                        </gco:CharacterString>
+                      </xsl:otherwise>
+                    </xsl:choose>
                   </gmd:URL>
                 </gmd:linkage>
                 <gmd:protocol>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-add.xsl
@@ -101,6 +101,7 @@
   -->
 
   <xsl:template name="fill">
+
     <xsl:if test="$thumbnail_url != ''">
 
       <xsl:variable name="useOnlyPTFreeText"
@@ -149,9 +150,25 @@
                 </gmd:PT_FreeText>
               </xsl:when>
               <xsl:otherwise>
-                <gco:CharacterString>
-                  <xsl:value-of select="$thumbnail_url"/>
-                </gco:CharacterString>
+
+                <xsl:variable name="localUrl" select="contains($thumbnail_url, '/api/records/')" />
+
+                <xsl:choose>
+                  <xsl:when test="$localUrl = true()">
+                    <xsl:variable name="uuid" select="substring-before(substring-after($thumbnail_url, '/api/records/'), '/attachments')" />
+                    <xsl:variable name="encodedUuid" select="encode-for-uri($uuid)" />
+                    <xsl:variable name="updatedThumbnailUrl" select="replace($thumbnail_url, $uuid, $encodedUuid)" />
+
+                    <gco:CharacterString>
+                      <xsl:value-of select="$updatedThumbnailUrl"/>
+                    </gco:CharacterString>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <gco:CharacterString>
+                      <xsl:value-of select="$thumbnail_url"/>
+                    </gco:CharacterString>
+                  </xsl:otherwise>
+                </xsl:choose>
               </xsl:otherwise>
             </xsl:choose>
           </gmd:fileName>

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -28,8 +28,10 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,6 +44,7 @@ import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
@@ -272,5 +275,15 @@ public class ApiUtils {
         try (OutputStream out = Files.newOutputStream(outFile)) {
             ImageIO.write(bimg, type, out);
         }
+    }
+
+    public static String decodeValue(String value) throws UnsupportedEncodingException {
+
+        if (StringUtils.isNotEmpty(value)) {
+            return URLDecoder.decode(value, "UTF-8");
+        } else {
+            return value;
+        }
+
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -128,6 +128,8 @@ public class InspireValidationApi {
             HttpSession session
             ) throws Exception {
 
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         ApplicationContext appContext = ApplicationContextHolder.get();
         final SettingManager settingManager = appContext.getBean(SettingManager.class);
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -73,6 +73,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -158,6 +159,9 @@ public class MetadataApi implements ApplicationContextAware {
         HttpServletRequest request
     )
         throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         try {
             ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {
@@ -241,6 +245,9 @@ public class MetadataApi implements ApplicationContextAware {
         ApplicationContext appContext = ApplicationContextHolder.get();
         DataManager dataManager = appContext.getBean(DataManager.class);
         AbstractMetadata metadata;
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         try {
             metadata = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (ResourceNotFoundException e) {
@@ -376,6 +383,8 @@ public class MetadataApi implements ApplicationContextAware {
         ApplicationContext appContext = ApplicationContextHolder.get();
         GeonetworkDataDirectory dataDirectory = appContext.getBean(GeonetworkDataDirectory.class);
 
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata;
         try {
             metadata = ApiUtils.canViewRecord(metadataUuid, request);
@@ -483,6 +492,8 @@ public class MetadataApi implements ApplicationContextAware {
             int rows,
         HttpServletRequest request) throws Exception {
 
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata md;
         try{
             md = ApiUtils.canViewRecord(metadataUuid, request);
@@ -537,6 +548,7 @@ public class MetadataApi implements ApplicationContextAware {
             String metadataUuid,
         HttpServletRequest request) throws ResourceNotFoundException {
 
+
         RelatedItemType[] type = {RelatedItemType.fcats};
 
         FeatureResponse response = new FeatureResponse();
@@ -544,6 +556,8 @@ public class MetadataApi implements ApplicationContextAware {
         Map<String, String[]> decodeMap = new HashMap<>();
 
         try {
+            metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
             RelatedResponse related = getRelated(metadataUuid, type, 0, 100, request);
 
             if (isIncludedAttributeTable(related.getFcats())) {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -399,7 +399,7 @@ public class MetadataInsertDeleteApi {
 
         // User assigned uuid: check if already exists
         String metadataUuid = null;
-        if (generateUuid) {
+        if (!generateUuid) {
             if (StringUtils.isEmpty(targetUuid)) {
                 // Create a random UUID
                 metadataUuid = UUID.randomUUID().toString();
@@ -415,6 +415,8 @@ public class MetadataInsertDeleteApi {
                 } catch (ResourceNotFoundException e) {
                     // Ignore. Ok to create a new record with the requested UUID.
                 }
+
+                metadataUuid = targetUuid;
             }
         } else {
             metadataUuid = UUID.randomUUID().toString();

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
@@ -28,6 +28,7 @@ import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
 import static org.fao.geonet.api.ApiParams.API_OP_NOTE_PROCESS;
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 
+import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -100,6 +101,9 @@ public class MetadataProcessApi {
     public @ResponseBody List<SuggestionType> getSuggestions(
             @ApiParam(value = API_PARAM_RECORD_UUID, required = true) @PathVariable String metadataUuid,
             HttpServletRequest request) throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -172,6 +172,9 @@ public class MetadataSharingApi {
         HttpServletRequest request
     )
         throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -414,6 +417,8 @@ public class MetadataSharingApi {
         HttpServletRequest request
     )
         throws Exception {
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         // TODO: Restrict to user group only in response depending on settings?
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
@@ -520,6 +525,8 @@ public class MetadataSharingApi {
         HttpServletRequest request
     )
         throws Exception {
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -733,6 +740,8 @@ public class MetadataSharingApi {
         HttpServletRequest request
     )
         throws Exception {
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         MetadataProcessingReport report = new SimpleMetadataProcessingReport();
 
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
@@ -126,6 +126,9 @@ public class MetadataSocialApi {
         HttpServletRequest request
     )
         throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -154,6 +154,9 @@ public class MetadataTagApi {
             boolean clear,
         HttpServletRequest request
     ) throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         Set<MetadataCategory> before = metadata.getMetadataCategories();
@@ -215,6 +218,8 @@ public class MetadataTagApi {
             Integer[] id,
         HttpServletRequest request
     ) throws Exception {
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         Set<MetadataCategory> before = metadata.getMetadataCategories();

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
@@ -118,6 +118,9 @@ public class MetadataValidateApi {
             @ApiParam(value = API_PARAM_RECORD_UUID, required = true) @PathVariable String metadataUuid,
             @ApiParam(value = "Validation status. Should be provided only in case of SUBTEMPLATE validation. If provided for another type, throw a BadParameter Exception", required = false) @RequestParam(required = false) Boolean isvalid,
             HttpServletRequest request, @ApiParam(hidden = true) @ApiIgnore HttpSession session) throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataVersionningApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataVersionningApi.java
@@ -97,6 +97,8 @@ public class MetadataVersionningApi {
             String metadataUuid,
         HttpServletRequest request
     ) throws Exception {
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -139,6 +139,9 @@ public class MetadataWorkflowApi {
         )
             Sort.Direction sortOrder,
         HttpServletRequest request) throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         ServiceContext context = ApiUtils.createServiceContext(request);
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         MetadataStatusRepositoryCustom metadataStatusRepository =
@@ -186,6 +189,9 @@ public class MetadataWorkflowApi {
         )
             Sort.Direction sortOrder,
         HttpServletRequest request) throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         ServiceContext context = ApiUtils.createServiceContext(request);
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         MetadataStatusRepositoryCustom metadataStatusRepository =
@@ -232,6 +238,9 @@ public class MetadataWorkflowApi {
         HttpServletRequest request
     )
         throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
@@ -300,6 +309,9 @@ public class MetadataWorkflowApi {
         HttpServletRequest request
     )
         throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request, languageUtils.getIso3langCode(request.getLocales()));
@@ -378,6 +390,9 @@ public class MetadataWorkflowApi {
         HttpServletRequest request
     )
         throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         MetadataStatusRepository statusRepository = ApplicationContextHolder.get().getBean(MetadataStatusRepository.class);
@@ -434,6 +449,9 @@ public class MetadataWorkflowApi {
         HttpServletRequest request
     )
         throws Exception {
+
+        metadataUuid = ApiUtils.decodeValue(metadataUuid);
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         MetadataStatusRepository statusRepository = ApplicationContextHolder.get().getBean(MetadataStatusRepository.class);

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -62,6 +62,7 @@ import springfox.documentation.annotations.ApiIgnore;
 
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -159,6 +160,8 @@ public class AttachmentsApi {
             @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
 
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata md;
         try{
             md = ApiUtils.canViewRecord(metadataUuid, request);
@@ -181,6 +184,8 @@ public class AttachmentsApi {
             @ApiParam(value = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
             @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
+
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
 
         AbstractMetadata md;
         try{
@@ -210,6 +215,8 @@ public class AttachmentsApi {
             @ApiParam(value = "The file to upload") @RequestParam("file") MultipartFile file,
             @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
+
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
 
         AbstractMetadata md;
         try{
@@ -244,6 +251,8 @@ public class AttachmentsApi {
             @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
 
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata md;
         try{
             md = ApiUtils.canEditRecord(metadataUuid, request);
@@ -276,6 +285,8 @@ public class AttachmentsApi {
             @ApiParam(value = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
             @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
+
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
 
         AbstractMetadata md;
         try{
@@ -311,6 +322,8 @@ public class AttachmentsApi {
             @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
 
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata md;
         try{
             md = ApiUtils.canEditRecord(metadataUuid, request);
@@ -333,6 +346,8 @@ public class AttachmentsApi {
             @ApiParam(value = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
             @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
+
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
 
         AbstractMetadata md;
         try{

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -63,6 +63,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -144,6 +145,8 @@ public class MetadataEditingApi {
             Map<String,String> allRequestParams,
         HttpServletRequest request
         ) throws Exception {
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         boolean showValidationErrors = false;
@@ -241,6 +244,8 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
         ) throws Exception {
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
         AjaxEditUtils ajaxEditUtils = new AjaxEditUtils(context);
@@ -420,6 +425,8 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
@@ -487,6 +494,8 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
@@ -573,6 +582,8 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 
@@ -632,6 +643,8 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 
@@ -684,6 +697,8 @@ public class MetadataEditingApi {
         @ApiParam(hidden = true)
             HttpSession httpSession
     ) throws Exception {
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
+
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -29,8 +29,7 @@ import static org.fao.geonet.api.records.formatters.FormatterConstants.SCHEMA_PL
 import static org.springframework.data.jpa.domain.Specifications.where;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.*;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -279,6 +278,8 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             FormatType formatType,
         @ApiIgnore final NativeWebRequest request,
         final HttpServletRequest servletRequest) throws Exception {
+
+        metadataUuid = URLDecoder.decode(metadataUuid, "UTF-8");
 
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         Locale locale = languageUtils.parseAcceptLanguage(servletRequest.getLocales());

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -44,6 +44,7 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.api.userfeedback.UserFeedbackUtils.RatingAverage;
 import org.fao.geonet.api.userfeedback.service.IUserFeedbackService;
@@ -336,9 +337,18 @@ public class UserFeedbackAPI {
         )
         int size,
         @ApiIgnore final HttpServletResponse response,
+        @ApiIgnore final HttpServletRequest request,
         @ApiIgnore final HttpSession httpSession) throws Exception {
 
-        return getUserFeedback(metadataUuid, size, response, httpSession);
+        AbstractMetadata md;
+        try{
+            md = ApiUtils.canViewRecord(metadataUuid, request);
+        } catch (SecurityException e) {
+            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
+        }
+
+        return getUserFeedback(md.getUuid(), size, response, httpSession);
     }
 
     /**
@@ -379,9 +389,18 @@ public class UserFeedbackAPI {
         )
         int size,
         @ApiIgnore final HttpServletResponse response,
+        @ApiIgnore final HttpServletRequest request,
         @ApiIgnore final HttpSession httpSession) throws Exception {
 
-        return getUserFeedback(metadataUuid, size, response, httpSession);
+        AbstractMetadata md;
+        try{
+            md = ApiUtils.canViewRecord(metadataUuid, request);
+        } catch (SecurityException e) {
+            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
+        }
+
+        return getUserFeedback(md.getUuid(), size, response, httpSession);
     }
 
     private List<UserFeedbackDTO> getUserFeedback(
@@ -400,6 +419,7 @@ public class UserFeedbackAPI {
 
         try {
             Log.debug("org.fao.geonet.api.userfeedback.UserFeedback", "getUserComments");
+
 
             final IUserFeedbackService userFeedbackService = getUserFeedbackService();
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -69,7 +69,7 @@
           scope: {},
           link: function (scope, element, attrs) {
             scope.relations = {};
-            scope.uuid = undefined;
+            scope.mdId = undefined;
             scope.lang = scope.$parent.lang;
             scope.readonly = false;
             scope.numberOfOverviews = parseInt(attrs['numberOfOverviews']) || Infinity;
@@ -91,7 +91,7 @@
               scope.queue = [];
               scope.filestoreUploadOptions = {
                 autoUpload: true,
-                url: '../api/0.1/records/' + gnCurrentEdit.uuid +
+                url: '../api/0.1/records/' + gnCurrentEdit.id +
                 '/attachments?visibility=public',
                 dropZone: $('#gn-overview-dropzone'),
                 singleUpload: true,
@@ -143,6 +143,10 @@
                   loadRelations();
                 });
               } else {
+                // Encode the uuid in the path
+                var uuid = url.match(".*/api/records/(.*)/attachments/.*")[1];
+                url = url.replace(uuid, encodeURIComponent(uuid));
+
                 // A thumbnail from the filestore
                 gnFileStoreService.delete({url: url}).then(function () {
                   // then remove from record
@@ -155,10 +159,10 @@
 
             };
             http://localhost:8080/geonetwork/srv/api/records/01788925-ea24-4a7e-ac0d-aa10f8210b8c/attachments/oldmaps.jpeg
-            scope.$watch('gnCurrentEdit.uuid', function(n, o) {
-              if (angular.isUndefined(scope.uuid) ||
+            scope.$watch('gnCurrentEdit.id', function(n, o) {
+              if (angular.isUndefined(scope.mdId) ||
                 n != o) {
-                scope.uuid = n;
+                scope.mdId = n;
                 loadRelations();
                 uploadOverview();
               }
@@ -973,7 +977,7 @@
                 		  });
 
                   return $http.put('../api/0.1/records/' +
-                      scope.gnCurrentEdit.uuid +
+                      scope.gnCurrentEdit.id +
                       '/attachments/print-thumbnail', null, {
                         params: {
                           jsonConfig: angular.fromJson(jsonSpec),
@@ -1528,9 +1532,12 @@
                  */
                 scope.selectUploadedResource = function(res) {
                   if (res && res.url) {
+                    var uuid = res.url.match(".*/api/records/(.*)/attachments/.*")[1];
+                    var url = res.url.replace(uuid, encodeURIComponent(uuid));
+
                     var o = {
                       name: res.id.split('/').splice(2).join('/'),
-                      url: res.url
+                      url: url
                     };
                     ['url', 'name'].forEach(function(pName) {
                       setParameterValue(pName, o[pName]);

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -214,7 +214,7 @@
         getAllResources: function(types) {
 
           var defer = $q.defer();
-          var url = '../api/records/' + gnCurrentEdit.uuid + '/related' +
+          var url = '../api/records/' + gnCurrentEdit.id + '/related' +
                       (angular.isArray(types) ? '?' + types.join('&type=') : '');
           $http.get(url, {
             headers: {

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -251,7 +251,7 @@
         </div>
         <div class="panel-body">
           <div id="gn-addonlinesrc-file-input"
-               data-gn-file-store="gnCurrentEdit.id"
+               data-gn-file-store="gnCurrentEdit.uuid"
                data-select-callback="selectUploadedResource(selected)"
                data-filter="params.linkType.fileStoreFilter || ''"/>
         </div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -251,7 +251,7 @@
         </div>
         <div class="panel-body">
           <div id="gn-addonlinesrc-file-input"
-               data-gn-file-store="gnCurrentEdit.uuid"
+               data-gn-file-store="gnCurrentEdit.id"
                data-select-callback="selectUploadedResource(selected)"
                data-filter="params.linkType.fileStoreFilter || ''"/>
         </div>

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportService.js
@@ -35,7 +35,7 @@
       return {
         get: function() {
           return $http.put(
-              '../api/records/' + gnCurrentEdit.uuid + '/validate/internal');
+              '../api/records/' + gnCurrentEdit.id + '/validate/internal');
         },
         errorCheck: function() {
           return this.get()

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -41,7 +41,7 @@
             templateUrl: '../../catalog/components/filestore/' +
                 'partials/filestore.html',
             scope: {
-              uuid: '=gnFileStore',
+              mdId: '=gnFileStore',
               selectCallback: '&',
               filter: '='
             },
@@ -60,7 +60,7 @@
               scope.metadataResources = [];
 
               scope.loadMetadataResources = function() {
-                gnfilestoreService.get(scope.uuid, scope.filter).success(
+                gnfilestoreService.get(scope.mdId, scope.filter).success(
                     function(data) {
                       scope.metadataResources = data;
                     }
@@ -108,13 +108,13 @@
               };
 
               scope.$watch('filter', function(newValue, oldValue) {
-                if (angular.isDefined(scope.uuid) &&
+                if (angular.isDefined(scope.mdId) &&
                     newValue != oldValue) {
                   scope.loadMetadataResources();
                 }
               });
-              scope.$watch('uuid', function(newValue, oldValue) {
-                if (angular.isDefined(scope.uuid) &&
+              scope.$watch('mdId', function(newValue, oldValue) {
+                if (angular.isDefined(scope.mdId) &&
                     newValue != oldValue) {
 
                   scope.loadMetadataResources();
@@ -122,7 +122,7 @@
                   scope.queue = [];
                   scope.filestoreUploadOptions = {
                     autoUpload: scope.autoUpload,
-                    url: '../api/0.1/records/' + scope.uuid +
+                    url: '../api/0.1/records/' + scope.mdId +
                         '/attachments?visibility=' + defaultStatus,
                     dropZone: $('#' + scope.id),
                     singleUpload: false,

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -41,7 +41,7 @@
             templateUrl: '../../catalog/components/filestore/' +
                 'partials/filestore.html',
             scope: {
-              mdId: '=gnFileStore',
+              uuid: '=gnFileStore',
               selectCallback: '&',
               filter: '='
             },
@@ -60,7 +60,7 @@
               scope.metadataResources = [];
 
               scope.loadMetadataResources = function() {
-                gnfilestoreService.get(scope.mdId, scope.filter).success(
+                gnfilestoreService.get(scope.uuid, scope.filter).success(
                     function(data) {
                       scope.metadataResources = data;
                     }
@@ -108,13 +108,13 @@
               };
 
               scope.$watch('filter', function(newValue, oldValue) {
-                if (angular.isDefined(scope.mdId) &&
+                if (angular.isDefined(scope.uuid) &&
                     newValue != oldValue) {
                   scope.loadMetadataResources();
                 }
               });
-              scope.$watch('mdId', function(newValue, oldValue) {
-                if (angular.isDefined(scope.mdId) &&
+              scope.$watch('uuid', function(newValue, oldValue) {
+                if (angular.isDefined(scope.uuid) &&
                     newValue != oldValue) {
 
                   scope.loadMetadataResources();
@@ -122,7 +122,7 @@
                   scope.queue = [];
                   scope.filestoreUploadOptions = {
                     autoUpload: scope.autoUpload,
-                    url: '../api/0.1/records/' + scope.mdId +
+                    url: '../api/0.1/records/' + encodeURIComponent(scope.uuid) +
                         '/attachments?visibility=' + defaultStatus,
                     dropZone: $('#' + scope.id),
                     singleUpload: false,

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreService.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreService.js
@@ -32,7 +32,7 @@
          return {
            get: function(metadataUuid, filter) {
              return $http.get('../api/0.1/records/' +
-                                  metadataUuid + '/attachments', {
+               encodeURIComponent(metadataUuid) + '/attachments', {
                params: {
                  filter: filter,
                  _random: Math.floor(Math.random() * 10000)

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -270,12 +270,12 @@
       };
 
       this.openTransferOwnership = function(md, bucket, scope) {
-        var uuid = md ? md.getUuid() : '';
+        var mdId = md ? md.getId() : '';
         var ownerId = md ? md.getOwnerId() : '';
         var groupOwner = md ? md.getGroupOwner() : '';
         openModal({
           title: 'transferOwnership',
-          content: '<div gn-transfer-ownership="' + uuid +
+          content: '<div gn-transfer-ownership="' + mdId +
               '" gn-transfer-md-owner="' + ownerId + '" ' +
               '" gn-transfer-md-group-owner="' + groupOwner + '" ' +
               'selection-bucket="' + bucket + '"></div>'

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -155,7 +155,7 @@
             'metadatacategoryupdater.html',
         scope: {
           currentCategories: '=gnMetadataCategoryUpdater',
-          metadataUuid: '=',
+          metadataId: '=',
           groupOwner: '=gnGroupOwner'
         },
         link: function(scope, e, attrs) {
@@ -294,7 +294,7 @@
               method = 'delete';
             }
             $http[method]('../api/records/' +
-                          scope.metadataUuid + '/tags?id=' + c.id)
+                          scope.metadataId + '/tags?id=' + c.id)
                 .then(function() {
                   if (existIndex === -1) {
                     scope.ids.push(c.id);
@@ -429,7 +429,7 @@
           var ownerId = parseInt(attrs['gnTransferMdOwner']);
           var groupOwner = parseInt(attrs['gnTransferMdGroupOwner']);
           var bucket = attrs['selectionBucket'];
-          var mdUuid = attrs['gnTransferOwnership'];
+          var mdId = attrs['gnTransferOwnership'];
           scope.selectedUserGroup = null;
 
           scope.selectUser = function(user) {
@@ -475,7 +475,7 @@
             if (bucket != 'null') {
               url += 'ownership?bucket=' + bucket + '&';
             } else {
-              url += mdUuid + '/ownership?';
+              url += mdId + '/ownership?';
             }
             return $http.put(url +
                 'userIdentifier=' + scope.selectedUserGroup.userId +

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -138,13 +138,13 @@
 
               scope.updateRelations = function() {
                 scope.relations = null;
-                if (scope.uuid) {
+                if (scope.mdId) {
                   scope.relationFound = false;
                   if (controller) {
                     controller.startGnRelatedRequest(elem);
                   }
                   (promise = gnRelatedService.get(
-                     scope.uuid, scope.types)
+                     scope.mdId, scope.types)
                   ).then(function(data) {
                        angular.forEach(data, function(value, idx) {
                          if (!value) { return; }
@@ -200,12 +200,12 @@
               scope.config = gnRelatedResources;
 
               scope.$watchCollection('md', function(n, o) {
-                if (n && n !== o || angular.isUndefined(scope.uuid)) {
+                if (n && n !== o || angular.isUndefined(scope.mdId)) {
                   if (promise && angular.isFunction(promise.abort)) {
                     promise.abort();
                   }
                   if (scope.md != null) {
-                    scope.uuid = scope.md.getUuid();
+                    scope.mdId = scope.md.getId();
                   }
                   scope.updateRelations();
                 }

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -121,7 +121,7 @@
 
 
           scope.rateForRecord = function() {
-            return $http.put('../api/records/' + scope.md['geonet:info'].uuid +
+            return $http.put('../api/records/' + scope.md['geonet:info'].id +
                              '/rate', scope.rate).success(function(data) {
               scope.rate = data;
             });

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -238,7 +238,7 @@
 
         return promiseMd.then(function(md) {
           if (angular.isString(fUrl)) {
-            url = fUrl.replace('{{uuid}}', md.getUuid());
+            url = fUrl.replace('{{uuid}}', md.getId());
           }
           else if (angular.isFunction(fUrl)) {
             url = fUrl(md);

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/gridRelated.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/gridRelated.js
@@ -48,12 +48,12 @@
           gnGridRelatedList.types = types;
 
           scope.$watch('records', function(mds) {
-            var uuids = mds.map(function(md) {
-              return md.getUuid();
+            var mdIds = mds.map(function(md) {
+              return md.getId();
             });
-            if (uuids.length) {
+            if (mdIds.length) {
               gnGridRelatedList.promise =
-                  gnRelatedService.getMdsRelated(uuids, types).then(
+                  gnRelatedService.getMdsRelated(mdIds, types).then(
                   function(response) {
                     gnGridRelatedList.list = response.data;
                   });

--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
@@ -44,20 +44,20 @@
         }
       };
 
-      this.loadComments = function(metatdataUUID, size) {
+      this.loadComments = function(metatadataId, size) {
         var numberOfCommentsDisplayed = size || -1;
         return $http({
           method: 'GET',
-          url: '../api/records/' + metatdataUUID +
+          url: '../api/records/' + metatadataId +
           '/userfeedback?size=' + numberOfCommentsDisplayed,
           isArray: true
         });
       };
 
-      this.loadRating = function(metatdataUUID) {
+      this.loadRating = function(metatadataId) {
         return $http({
           method: 'GET',
-          url: '../api/records/' + metatdataUUID + '/userfeedbackrating',
+          url: '../api/records/' + metatadataId + '/userfeedbackrating',
           isArray: false
         });
       };
@@ -151,7 +151,7 @@
             function refreshList() {
               scope.loaded = false;
               scope.fewCommentsList = [];
-              gnUserfeedbackService.loadComments(scope.mdrecord.getUuid(),
+              gnUserfeedbackService.loadComments(scope.mdrecord.getId(),
                 scope.nbOfComments || defaultNbOfComments).then(
                 function(response) {
                   scope.fewCommentsList = [].concat(response.data);
@@ -160,7 +160,7 @@
                   console.log(response.statusText);
                 });
 
-              gnUserfeedbackService.loadRating(scope.mdrecord.getUuid()).then(
+              gnUserfeedbackService.loadRating(scope.mdrecord.getId()).then(
                 function mySuccess(response) {
                   scope.rating = null;
                   scope.rating = response.data;
@@ -193,7 +193,7 @@
             function initRecord(md) {
               if (scope.record != null) {
                 var m = new Metadata(md);
-                scope.metatdataUUID = m.getUuid();
+                scope.metatadataId = m.getId();
                 scope.metatdataTitle = m.getTitle();
               }
             }
@@ -226,11 +226,11 @@
               scope.fullCommentsList = [];
               scope.rating = null;
 
-              gnUserfeedbackService.loadComments(scope.metatdataUUID,
+              gnUserfeedbackService.loadComments(scope.metatadataId,
                 -1).then(function(response) {
                 scope.fullCommentsList = response.data;
               });
-              gnUserfeedbackService.loadRating(scope.metatdataUUID).then(
+              gnUserfeedbackService.loadRating(scope.metatadataId).then(
                 function(response) {
                   scope.rating = response.data;
                 }
@@ -285,7 +285,7 @@
             function initRecord(md) {
               if (scope.record != null) {
                 var m = new Metadata(md);
-                scope.metatdataUUID = m.getUuid();
+                scope.metadataUUID = m.getUuid();
                 scope.metatdataTitle = m.getTitle();
               }
             }
@@ -329,7 +329,7 @@
 
             scope.initPopup = function() {
 
-              if (gnUserfeedbackService.isBlank(scope.metatdataUUID)) {
+              if (gnUserfeedbackService.isBlank(scope.metadataUUID)) {
                 console.log('Metadata UUID is null');
                 return;
               }
@@ -402,9 +402,9 @@
                 }
               }
 
-              scope.uf.metadataUUID = scope.metatdataUUID;
+              scope.uf.metadataUUID = scope.metadataUUID;
 
-              if (angular.isUndefined(scope.metatdataUUID)) {
+              if (angular.isUndefined(scope.metadataUUID)) {
                 console.log('Metadata UUID is null!');
                 return;
               }

--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -16,7 +16,7 @@
     <!-- If using the category selector in the editor form directly, remove this directive. -->
     <div data-gn-metadata-category-updater="mdCategories"
          data-gn-group-owner="groupOwner"
-         data-metadata-uuid="gnCurrentEdit.uuid" title="{{'categories'|translate}}"/>
+         data-metadata-id="gnCurrentEdit.id" title="{{'categories'|translate}}"/>
 
     <div data-gn-metadata-group-updater="groupOwner"
          data-metadata-id="gnCurrentEdit.id" title="{{'group'|translate}}"/>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -135,14 +135,14 @@
         </a>
       </li>
       <li role="menuitem">
-        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xsl-view?root=div&output=pdf"
+        <a data-ng-href="../api/records/{{md.getId()}}/formatters/xsl-view?root=div&output=pdf"
            target="_blank">
           <i class="fa fa-fw fa-file-pdf-o"></i>&nbsp;
           <span data-translate="">exportPDF</span>
         </a>
       </li>
       <li role="menuitem">
-        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xml?attachment=true">
+        <a data-ng-href="../api/records/{{md.getId()}}/formatters/xml?attachment=true">
           <i class="fa fa-fw fa-file-code-o"></i>&nbsp;
           <span data-translate="">exportXML</span>
         </a>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -368,7 +368,7 @@
         <h2 data-translate="">metadataInformation</h2>
 
         <a class="btn btn-default gn-margin-bottom"
-          data-ng-href="../api/records/{{mdView.current.record.getUuid()}}/formatters/xml">
+          data-ng-href="../api/records/{{mdView.current.record.getId()}}/formatters/xml">
           <i class="fa fa-fw fa-file-code-o"/>
           <span data-translate="">metadataInXML</span>
         </a>

--- a/web/src/main/webResources/WEB-INF/spring-servlet.xml
+++ b/web/src/main/webResources/WEB-INF/spring-servlet.xml
@@ -28,11 +28,11 @@
        xmlns:sec="http://www.springframework.org/schema/security"
        xsi:schemaLocation="
 		http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+        http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.2.xsd
+        http://www.springframework.org/schema/context/spring-context-4.2.xsd
 	    http://www.springframework.org/schema/mvc
-	    http://www.springframework.org/schema/mvc/spring-mvc-3.2.xsd
+	    http://www.springframework.org/schema/mvc/spring-mvc-4.2.xsd
 	    http://www.springframework.org/schema/security
 	    http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
@@ -95,7 +95,9 @@
     </property>
   </bean>
 
+
   <mvc:annotation-driven content-negotiation-manager="cnManager">
+
     <mvc:message-converters>
       <bean class="org.fao.geonet.api.DOMElementMessageConverter"/>
       <bean class = "org.springframework.http.converter.StringHttpMessageConverter">
@@ -114,5 +116,15 @@
         </property>
       </bean>
     </mvc:message-converters>
+
+    <mvc:path-matching
+      path-helper="urlPathHelper" />
   </mvc:annotation-driven>
+
+  <!-- Don't decode url path items: used for metadata uuid values with slashes or other special chars.
+       If the catalog uses standard UUID values urlDecode can be set to true -->
+  <bean id="urlPathHelper" class="org.springframework.web.util.UrlPathHelper">
+    <property name="urlDecode" value="false" />
+  </bean>
+
 </beans>


### PR DESCRIPTION
Update service calls to Spring MVC API from UI to use metadata id instead of uuid, in the services that use metadata uuid as part of the url path typically: `/srv/api/service/{metadataUuid}/action`

Quite some services calls were using already the metadata id. But the ones using the metadata uuid as part of the url path, had issues with uuids having special characters like: `//data/metadata_files/pb_ilraid9abfe20151108.xml`

Trying to encode them in the url path, apart of looking a bit bizarre: 
http://localhost:8080/geonetwork/srv/api/records/%2F%2Fdata.daff.gov.au%2Fanrdl%2Fmetadata_files%2Fpb_ilraid9abfe20151108.xml/related?type=onlines, doesn't work as expected as Spring MVC is decoding the value and interpreting the slashes as part of the path to match, not working fine.

The Pull Request contains the changes in the UI to use metadata ids in Spring MVC services. Tested metadata detail page and metadata editor, looking fine. Also updated some backend services that were not friendly handling both uuid and id as parameter (most of there were handling this properly).

