### PR TITLE
ISO19139 / Multilingual record / Preserve order of languages

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/templates/vector-multilingual.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/templates/vector-multilingual.xml
@@ -100,7 +100,7 @@
     <gco:CharacterString>1.0</gco:CharacterString>
   </gmd:metadataStandardVersion>
   <gmd:locale>
-    <gmd:PT_Locale id="FRE">
+    <gmd:PT_Locale id="FR">
       <gmd:languageCode>
         <gmd:LanguageCode codeList="" codeListValue="fre"/>
       </gmd:languageCode>
@@ -108,7 +108,7 @@
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale>
-    <gmd:PT_Locale id="GER">
+    <gmd:PT_Locale id="GE">
       <gmd:languageCode>
         <gmd:LanguageCode codeList="" codeListValue="ger"/>
       </gmd:languageCode>
@@ -116,7 +116,7 @@
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale>
-    <gmd:PT_Locale id="CHI">
+    <gmd:PT_Locale id="CH">
       <gmd:languageCode>
         <gmd:LanguageCode codeList="" codeListValue="chi"/>
       </gmd:languageCode>
@@ -126,7 +126,7 @@
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale>
-    <gmd:PT_Locale id="ARA">
+    <gmd:PT_Locale id="AR">
       <gmd:languageCode>
         <gmd:LanguageCode codeList="" codeListValue="ara"/>
       </gmd:languageCode>
@@ -136,7 +136,7 @@
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale>
-    <gmd:PT_Locale id="SPA">
+    <gmd:PT_Locale id="SP">
       <gmd:languageCode>
         <gmd:LanguageCode codeList="" codeListValue="spa"/>
       </gmd:languageCode>
@@ -146,7 +146,7 @@
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale>
-    <gmd:PT_Locale id="RUS">
+    <gmd:PT_Locale id="RU">
       <gmd:languageCode>
         <gmd:LanguageCode codeList="" codeListValue="rus"/>
       </gmd:languageCode>
@@ -175,32 +175,32 @@
             </gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#FRE">Modèle de données vectorielles en
+                <gmd:LocalisedCharacterString locale="#FR">Modèle de données vectorielles en
                   ISO19139 (multilingue)
                 </gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#GER">Vorlage für die Vektor-Daten in ISO19139
+                <gmd:LocalisedCharacterString locale="#GE">Vorlage für die Vektor-Daten in ISO19139
                   (mehrsprachig)
                 </gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#SPA">De plantilla para el vector de datos en
+                <gmd:LocalisedCharacterString locale="#SP">De plantilla para el vector de datos en
                   ISO19139 (multilingüe)
                 </gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RUS">Шаблон для векторных данных в ISO19139
+                <gmd:LocalisedCharacterString locale="#RU">Шаблон для векторных данных в ISO19139
                   (многоязычное)
                 </gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#ARA">نموذج البيانات الموجهة في ISO19139
+                <gmd:LocalisedCharacterString locale="#AR">نموذج البيانات الموجهة في ISO19139
                   (متعددة اللغات)
                 </gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#CHI">模板矢量数据ISO19139（多种语言）
+                <gmd:LocalisedCharacterString locale="#CH">模板矢量数据ISO19139（多种语言）
                 </gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
@@ -233,19 +233,19 @@
         </gco:CharacterString>
         <gmd:PT_FreeText>
           <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#CHI">
+            <gmd:LocalisedCharacterString locale="#CH">
               元数据标准的ISO19115是首选元数据标准使用。这个模板是多语种的默认语言设置为英语。其他语言可以用来翻译部分的元数据记录。主要语言是界定元一节。其他语言可以增加元数据节/地区因素。
             </gmd:LocalisedCharacterString>
           </gmd:textGroup>
           <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#ARA">فإن معيار ISO19115 الفوقية هو المفضل
+            <gmd:LocalisedCharacterString locale="#AR">فإن معيار ISO19115 الفوقية هو المفضل
               لاستخدام البيانات الوصفية القياسية. هذا القالب هو متعدد اللغات مع اللغة الافتراضية
               لمجموعة الانجليزية. لغة أخرى يمكن استخدامها لتحويل جزء من الفوقية. اللغة الرئيسية هي
               تحديد الفوقية في هذا الباب. لغات أخرى يمكن أن تضاف إلى الباب الفوقية / عنصر المكان.
             </gmd:LocalisedCharacterString>
           </gmd:textGroup>
           <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#RUS">В метаданных стандарта ISO19115
+            <gmd:LocalisedCharacterString locale="#RU">В метаданных стандарта ISO19115
               предпочтительным является стандарт метаданных для использования. Этот шаблон
               многоязычный с языком по умолчанию установлен на английском языке. Другие языки могут
               использоваться для перевода части метаданных записи. Основным языком является
@@ -254,7 +254,7 @@
             </gmd:LocalisedCharacterString>
           </gmd:textGroup>
           <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#SPA">El estándar de metadatos ISO19115 es el
+            <gmd:LocalisedCharacterString locale="#SP">El estándar de metadatos ISO19115 es el
               estándar de metadatos a utilizar. Esta plantilla es multilingüe, con un idioma por
               defecto configurado en Inglés. En otros idiomas puede ser usado para traducir parte
               del registro de metadatos. Idioma principal es definir los metadatos en la sección.
@@ -262,7 +262,7 @@
             </gmd:LocalisedCharacterString>
           </gmd:textGroup>
           <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#GER">Die ISO19115 Metadaten-Standard ist der
+            <gmd:LocalisedCharacterString locale="#GE">Die ISO19115 Metadaten-Standard ist der
               bevorzugte Metadaten-Standard zu verwenden. Diese Vorlage ist mehrsprachig mit einer
               Standard-Sprache auf Englisch. Andere Sprache verwendet werden könnten, um Teil der
               Metadaten werden. Sprache definieren, ist in Abschnitt Metadaten. Weitere Sprachen
@@ -270,7 +270,7 @@
             </gmd:LocalisedCharacterString>
           </gmd:textGroup>
           <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#FRE">La norme de métadonnées ISO19115 est la
+            <gmd:LocalisedCharacterString locale="#FR">La norme de métadonnées ISO19115 est la
               norme de métadonnées à utiliser. Ce modèle est multilingue avec une langue par défaut
               en anglais. D'autres langues pourraient être utilisées pour traduire une partie de la
               de métadonnées. La langue principale est de définir dans la section des métadonnées.

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -385,7 +385,7 @@
     <xsl:for-each select="$locales[@id != $mainLanguageId]">
       <xsl:variable name="localId"
                     select="@id"/>
-<xsl:message><xsl:value-of select="$localId"/>aa </xsl:message>
+
       <xsl:variable name="element"
                     select="$freeText[*/@locale = concat('#', $localId)]"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -340,30 +340,7 @@
 
               <xsl:if test="gmd:PT_FreeText[normalize-space(.) != '']">
                 <gmd:PT_FreeText>
-                  <xsl:variable name="freeText"
-                                select="gmd:PT_FreeText/gmd:textGroup"/>
-  
-                  <!-- Loop on locales in order to preserve order.
-                      Keep main language on top.
-                      Translations having no locale are ignored. eg. when removing a lang. -->
-                  <xsl:for-each select="$locales[@id = $mainLanguageId]">
-                    <xsl:variable name="localId"
-                                  select="@id"/>
-
-                    <xsl:variable name="element"
-                                  select="$freeText[*/@locale = concat('#', $localId)]"/>
-
-                    <xsl:apply-templates select="$element"/>
-                  </xsl:for-each>
-                  <xsl:for-each select="$locales[@id != $mainLanguageId]">
-                    <xsl:variable name="localId"
-                                  select="@id"/>
-
-                    <xsl:variable name="element"
-                                  select="$freeText[*/@locale = concat('#', $localId)]"/>
-
-                    <xsl:apply-templates select="$element"/>
-                  </xsl:for-each>
+                  <xsl:call-template name="populate-free-text"/>
                 </gmd:PT_FreeText>
               </xsl:if>
 
@@ -378,38 +355,42 @@
                     <xsl:value-of select="gco:CharacterString"/>
                   </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
-
-                <!-- Process all translations ... -->
-                <xsl:variable name="freeText"
-                              select="gmd:PT_FreeText/gmd:textGroup"/>
-
-                <!-- Loop on locales in order to preserve order.
-                    Keep main language on top.
-                    Translations having no locale are ignored. eg. when removing a lang. -->
-                <xsl:for-each select="$locales[@id = $mainLanguageId]">
-                  <xsl:variable name="localId"
-                                select="@id"/>
-
-                  <xsl:variable name="element"
-                                select="$freeText[*/@locale = concat('#', $localId)]"/>
-
-                  <xsl:apply-templates select="$element"/>
-                </xsl:for-each>
-                <xsl:for-each select="$locales[@id != $mainLanguageId]">
-                  <xsl:variable name="localId"
-                                select="@id"/>
-
-                  <xsl:variable name="element"
-                                select="$freeText[*/@locale = concat('#', $localId)]"/>
-
-                  <xsl:apply-templates select="$element"/>
-                </xsl:for-each>
+                <xsl:call-template name="populate-free-text"/>
               </gmd:PT_FreeText>
             </xsl:otherwise>
           </xsl:choose>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:copy>
+  </xsl:template>
+
+
+  <xsl:template name="populate-free-text">
+    <xsl:variable name="freeText"
+                  select="gmd:PT_FreeText/gmd:textGroup"/>
+
+    <!-- Loop on locales in order to preserve order.
+        Keep main language on top.
+        Translations having no locale are ignored. eg. when removing a lang. -->
+    <xsl:for-each select="$locales[@id = $mainLanguageId]">
+      <xsl:variable name="localId"
+                    select="@id"/>
+
+      <xsl:variable name="element"
+                    select="$freeText[*/@locale = concat('#', $localId)]"/>
+
+      <xsl:apply-templates select="$element"/>
+    </xsl:for-each>
+
+    <xsl:for-each select="$locales[@id != $mainLanguageId]">
+      <xsl:variable name="localId"
+                    select="@id"/>
+<xsl:message><xsl:value-of select="$localId"/>aa </xsl:message>
+      <xsl:variable name="element"
+                    select="$freeText[*/@locale = concat('#', $localId)]"/>
+
+      <xsl:apply-templates select="$element"/>
+    </xsl:for-each>
   </xsl:template>
 
   <!-- For multilingual elements. Check that the local

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -337,9 +337,39 @@
                 <xsl:value-of select="gmd:PT_FreeText/*/gmd:LocalisedCharacterString[
                                             @locale = concat('#', $mainLanguageId)]/text()"/>
               </xsl:element>
-              <xsl:apply-templates select="gmd:PT_FreeText[normalize-space(.) != '']"/>
+
+              <xsl:if test="gmd:PT_FreeText[normalize-space(.) != '']">
+                <gmd:PT_FreeText>
+                  <xsl:variable name="freeText"
+                                select="gmd:PT_FreeText/gmd:textGroup"/>
+  
+                  <!-- Loop on locales in order to preserve order.
+                      Keep main language on top.
+                      Translations having no locale are ignored. eg. when removing a lang. -->
+                  <xsl:for-each select="$locales[@id = $mainLanguageId]">
+                    <xsl:variable name="localId"
+                                  select="@id"/>
+
+                    <xsl:variable name="element"
+                                  select="$freeText[*/@locale = concat('#', $localId)]"/>
+
+                    <xsl:apply-templates select="$element"/>
+                  </xsl:for-each>
+                  <xsl:for-each select="$locales[@id != $mainLanguageId]">
+                    <xsl:variable name="localId"
+                                  select="@id"/>
+
+                    <xsl:variable name="element"
+                                  select="$freeText[*/@locale = concat('#', $localId)]"/>
+
+                    <xsl:apply-templates select="$element"/>
+                  </xsl:for-each>
+                </gmd:PT_FreeText>
+              </xsl:if>
+
             </xsl:when>
             <xsl:otherwise>
+
               <!-- Populate PT_FreeText for default language if not existing. -->
               <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
               <gmd:PT_FreeText>
@@ -349,7 +379,31 @@
                   </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
 
-                <xsl:apply-templates select="gmd:PT_FreeText/gmd:textGroup"/>
+                <!-- Process all translations ... -->
+                <xsl:variable name="freeText"
+                              select="gmd:PT_FreeText/gmd:textGroup"/>
+
+                <!-- Loop on locales in order to preserve order.
+                    Keep main language on top.
+                    Translations having no locale are ignored. eg. when removing a lang. -->
+                <xsl:for-each select="$locales[@id = $mainLanguageId]">
+                  <xsl:variable name="localId"
+                                select="@id"/>
+
+                  <xsl:variable name="element"
+                                select="$freeText[*/@locale = concat('#', $localId)]"/>
+
+                  <xsl:apply-templates select="$element"/>
+                </xsl:for-each>
+                <xsl:for-each select="$locales[@id != $mainLanguageId]">
+                  <xsl:variable name="localId"
+                                select="@id"/>
+
+                  <xsl:variable name="element"
+                                select="$freeText[*/@locale = concat('#', $localId)]"/>
+
+                  <xsl:apply-templates select="$element"/>
+                </xsl:for-each>
               </gmd:PT_FreeText>
             </xsl:otherwise>
           </xsl:choose>
@@ -358,6 +412,38 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- For multilingual elements. Check that the local
+  is defined in record. If not, remove the element. -->
+  <xsl:template match="gmd:textGroup">
+    <xsl:variable name="elementLocalId"
+                  select="replace(gmd:LocalisedCharacterString/@locale, '^#', '')"/>
+    <xsl:choose>
+      <xsl:when test="count($locales[@id = $elementLocalId]) > 0">
+        <gmd:textGroup>
+          <gmd:LocalisedCharacterString>
+            <xsl:variable name="currentLocale"
+                          select="replace(gmd:LocalisedCharacterString/@locale, '^#', '')"/>
+            <xsl:variable name="ptLocale"
+                          select="$locales[@id = string($currentLocale)]"/>
+            <xsl:variable name="id"
+                          select="upper-case(java:twoCharLangCode($ptLocale/gmd:languageCode/gmd:LanguageCode/@codeListValue[. != '']))"/>
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="$id != ''">
+              <xsl:attribute name="locale">
+                <xsl:value-of select="concat('#',$id)"/>
+              </xsl:attribute>
+            </xsl:if>
+
+            <xsl:apply-templates select="gmd:LocalisedCharacterString/text()"/>
+          </gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+      </xsl:when>
+      <xsl:otherwise>
+        <!--<xsl:message>Removing <xsl:copy-of select="."/>.
+        This element was removed because not declared in record locales.</xsl:message>-->
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
   <!-- ================================================================= -->
   <!-- codelists: set @codeList path -->
@@ -505,39 +591,6 @@
     </xsl:element>
   </xsl:template>
 
-
-  <!-- For multilingual elements. Check that the local
-  is defined in record. If not, remove the element. -->
-  <xsl:template match="gmd:textGroup">
-    <xsl:variable name="elementLocalId"
-                  select="replace(gmd:LocalisedCharacterString/@locale, '^#', '')"/>
-    <xsl:choose>
-      <xsl:when test="count($locales[@id = $elementLocalId]) > 0">
-        <gmd:textGroup>
-          <gmd:LocalisedCharacterString>
-            <xsl:variable name="currentLocale"
-                          select="replace(gmd:LocalisedCharacterString/@locale, '^#', '')"/>
-            <xsl:variable name="ptLocale"
-                          select="$locales[@id = string($currentLocale)]"/>
-            <xsl:variable name="id"
-                          select="upper-case(java:twoCharLangCode($ptLocale/gmd:languageCode/gmd:LanguageCode/@codeListValue[. != '']))"/>
-            <xsl:apply-templates select="@*"/>
-            <xsl:if test="$id != ''">
-              <xsl:attribute name="locale">
-                <xsl:value-of select="concat('#',$id)"/>
-              </xsl:attribute>
-            </xsl:if>
-
-            <xsl:apply-templates select="gmd:LocalisedCharacterString/text()"/>
-          </gmd:LocalisedCharacterString>
-        </gmd:textGroup>
-      </xsl:when>
-      <xsl:otherwise>
-        <!--<xsl:message>Removing <xsl:copy-of select="."/>.
-          This element was removed because not declared in record locales.</xsl:message>-->
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
 
 
 

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -143,7 +143,6 @@
                 <xsl:attribute name="{$type}">
                 {
                 <xsl:for-each select="$value/values/value">
-                  <xsl:sort select="@lang"/>
                   "<xsl:value-of select="@lang" />":
                   {"ref" : "<xsl:value-of select="@ref" />", "value": "<xsl:value-of select="." />"}
                   <xsl:if test="position() != last()">,</xsl:if>
@@ -201,8 +200,8 @@
                 <xsl:variable name="tooltip"
                               select="concat($schema, '|', name(.), '|', name(..), '|', $xpath)"></xsl:variable>
 
+                <!-- Preserve order of the languages as defined in the record. -->
                 <xsl:for-each select="$value/values/value">
-                  <xsl:sort select="@lang"/>
                   <xsl:if test="@lang != ''">
                     <xsl:call-template name="render-form-field">
                       <xsl:with-param name="name" select="@ref"/>


### PR DESCRIPTION
Fields in the editor form should be displayed in the same order as
defined in the locales section of the record.

It applies to both input mode:

![image](https://user-images.githubusercontent.com/1701393/52199409-43c0e100-2866-11e9-992c-c7180f11584a.png)

![image](https://user-images.githubusercontent.com/1701393/52199425-51766680-2866-11e9-8816-6b5358e38849.png)
