### PR TITLE
Editor / Associated resource / Protocol might be null and trigger JS error

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -146,7 +146,7 @@
                 <!-- For OGC resources, the description contains the label
                 and the title the layer name which in some cases eg. ESRI
                 is a number only. -->
-                {{(resource[resource.protocol.indexOf('OGC') !== -1 ? 'description' : 'title'] | gnLocalized: lang) || resource.lUrl}}
+                {{(resource[resource.protocol && resource.protocol.indexOf('OGC') !== -1 ? 'description' : 'title'] | gnLocalized: lang) || resource.lUrl}}
               </a>
               <span data-ng-if="resource.lUrl.match('^http|ftp') === null">
                 {{(resource.title | gnLocalized: lang) || resource.lUrl}}


### PR DESCRIPTION
As a result the url is displayed instead of title.

## Before change

![image](https://user-images.githubusercontent.com/1701393/52331571-d2656780-29f8-11e9-9745-04b7d27055ff.png)


## After change

![image](https://user-images.githubusercontent.com/1701393/52331544-c24d8800-29f8-11e9-9369-010a30e1c284.png)
