### PR TITLE
Fixes LoggingApi (#3549)

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/LoggingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/LoggingApi.java
@@ -140,7 +140,7 @@ public class LoggingApi {
             int lines) {
         String lastActivity = null;
 
-        if (isAppenderLogFileLoaded(fileAppender)) {
+        if (isAppenderLogFileLoaded()) {
             lastActivity = FileUtil.readLastLines(new File(fileAppender.getFile()),
                 Math.min(lines, maxLines));
         } else {
@@ -161,7 +161,7 @@ public class LoggingApi {
         })
     @ResponseBody
     public void getLastActivityInAZip(HttpServletResponse response) throws IOException {
-        if (isAppenderLogFileLoaded(fileAppender)) {
+        if (isAppenderLogFileLoaded()) {
             File file = new File(fileAppender.getFile());
 
             // create ZIP FILE
@@ -208,14 +208,15 @@ public class LoggingApi {
     private static final int maxLines = 20000;
     private FileAppender fileAppender = null;
 
-    private boolean isAppenderLogFileLoaded(FileAppender fileAppender) {
+    private boolean isAppenderLogFileLoaded() {
         if (fileAppender == null || fileAppender.getFile() == null) {
-            this.fileAppender = (FileAppender) Logger.getLogger(Geonet.GEONETWORK).getAppender(fileAppenderName);
-
+            // First, try the fileappender from the logger named "geonetwork"
+            fileAppender = (FileAppender) Logger.getLogger(Geonet.GEONETWORK).getAppender(fileAppenderName);
+            // If still not found, try the one from the logger named "jeeves"
             if (fileAppender == null) {
-                this.fileAppender = (FileAppender) Logger.getLogger(Log.JEEVES).getAppender(fileAppenderName);
+                fileAppender = (FileAppender) Logger.getLogger(Log.JEEVES).getAppender(fileAppenderName);
             }
-
+            // Still null ? Give up
             if (fileAppender == null) {
                 Log.error(Geonet.GEONETWORK,
                     "Error when getting appender named 'fileAppender'. " +
@@ -224,6 +225,7 @@ public class LoggingApi {
                 return false;
             } else {
                 String logFileName = fileAppender.getFile();
+                // fileAppender found, but no file available ?
                 if (logFileName == null) {
                     Log.error(Geonet.GEONETWORK,
                         "Error when getting logger file for the " +

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardStatusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardStatusController.js
@@ -168,11 +168,7 @@
       };
 
       $scope.downloadLog = function() {
-        $http.get('../api/site/logging/activity', null, {
-          headers: {
-            'Content-Type': 'application/zip'
-          }
-        });
+        window.location = '../api/site/logging/activity/zip';
       };
 
       $scope.indexRecordsWithErrors = function() {


### PR DESCRIPTION
LoggingApi  / admin UI (related to issue #3549):

* Removing the argument passed to the private method isAppenderLogFileLoaded, which results in calculating the fileAppender once (at first call)
* Replacing the XHR call in the admin UI by a window.location, forcing the browser to actually download the content returned by the webservice

Caveats:

If the logging configuration is reloaded, I am not sure the current code will update the fileAppender file location. this might require both beans to be aware of each other, then null'ing the fileAppender member variable each time the log4j config is changed.

Runtime tested
