### PR TITLE
ISO19139 / Directory entry API xlink MUST contains languages in the order defined in the record.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/process/empty.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/empty.xsl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                  xmlns:gco="http://www.isotc211.org/2005/gco"
+                  xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                  xmlns:geonet="http://www.fao.org/geonetwork"
+                  exclude-result-prefixes="#all">
+  <!-- Empty process to pass through update fixed info. -->
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -485,6 +485,27 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- For XLinked subtemplates, the lang parameter MUST be in the same order as in the record.
+  Main language first, then other locales. If not, then the default CharacterString does not contain
+  the main language. It user change the language order in the record, the lang parameter needs to
+  be reordered too.
+
+  Example of URL:
+  <gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink"
+                             xlink:href="local://srv/api/registries/entries/af9e5d4e-2c1a-48c0-853f-3a771fcf9ee3?
+                               process=gmd:role/gmd:CI_RoleCode/@codeListValue~distributor&amp;
+                               lang=eng,ara,spa,rus,fre,ger,chi&amp;
+                               schema=iso19139"
+  Can also be using lang=eng&amp;lang=ara.
+  -->
+  <xsl:template match="@xlink:href[starts-with(., 'local://srv/api/registries/entries')]">
+    <xsl:attribute name="xlink:href"
+                   select="replace(.,
+                                  '(&amp;lang=.*)+&amp;',
+                                  concat('&amp;lang=', $mainLanguage, ',',
+                                    string-join($locales//gmd:LanguageCode/@codeListValue[. != $mainLanguage], ','),
+                                    '&amp;'))"/>
+  </xsl:template>
 
   <!-- ================================================================= -->
   <!-- Set local identifier to the first 2 letters of iso code. Locale ids

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -498,7 +498,7 @@
                                schema=iso19139"
   Can also be using lang=eng&amp;lang=ara.
   -->
-  <xsl:template match="@xlink:href[starts-with(., 'local://srv/api/registries/entries')]">
+  <xsl:template match="@xlink:href[starts-with(., 'local://srv/api/registries/entries') and contains(., '?')]">
     <xsl:variable name="urlBase"
                   select="substring-before(., '?')"/>
     <xsl:variable name="urlParameters"

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -499,13 +499,33 @@
   Can also be using lang=eng&amp;lang=ara.
   -->
   <xsl:template match="@xlink:href[starts-with(., 'local://srv/api/registries/entries')]">
+    <xsl:variable name="urlBase"
+                  select="substring-before(., '?')"/>
+    <xsl:variable name="urlParameters"
+                  select="substring-after(., '?')"/>
+
+    <!-- Collect all parameters excluding language -->
+    <xsl:variable name="listOfAllParameters">
+      <xsl:for-each select="tokenize($urlParameters, '&amp;')">
+        <xsl:variable name="parameterName"
+                      select="tokenize(., '=')[1]"/>
+
+        <xsl:if test="$parameterName != 'lang'">
+          <param name="{$parameterName}"
+                 value="{.}"/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
     <xsl:attribute name="xlink:href"
-                   select="replace(.,
-                                  '(&amp;lang=.*)+&amp;',
-                                  concat('&amp;lang=', $mainLanguage, ',',
-                                    string-join($locales//gmd:LanguageCode/@codeListValue[. != $mainLanguage], ','),
-                                    '&amp;'))"/>
+                   select="concat(
+                    $urlBase,
+                    '?lang=', $mainLanguage, ',',
+                    string-join($locales//gmd:LanguageCode/@codeListValue[. != $mainLanguage], ','),
+                    '&amp;',
+                    string-join($listOfAllParameters/param/@value, '&amp;'))"/>
   </xsl:template>
+
 
   <!-- ================================================================= -->
   <!-- Set local identifier to the first 2 letters of iso code. Locale ids


### PR DESCRIPTION
A directory entry does not have a main language. It can be multilingual but there is no main one. When retrieving a directory entry, the main language of the record embedding the entry must be the first one in order to set the CharacterString properly. Also, when changing the language of a record (switch main language, add/remove a language), xlink pointing to directory entries must be updated. Add in update-fixed-info a template to reorder the lang parameter according to the lang of the record.

Add an empty process in order to be able to apply update-fixed-info to a set of records using the process API.