### PR TITLE
Editor / Associated resource / Display name and description for OGC resources

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/partials/layersGrid.html
+++ b/web-ui/src/main/resources/catalog/components/common/ows/partials/layersGrid.html
@@ -3,7 +3,6 @@
     class="table-content table table-striped table-hover table-condensed">
     <tbody>
     <tr data-ng-repeat="layer in layers | orderBy:'title':reverse"
-        data-ng-show="layer.Name !== undefined"
         data-ng-click="select(layer)"
         title="{{layer.abstract}}"
         class="

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -725,7 +725,8 @@
                       process: 'fcats-file-add',
                       fields: {
                         'url': {isMultilingual: false},
-                        'name': {}
+                        'name': {},
+                        'desc': {}
                       }
                     }, {
                       group: 'onlineUse',
@@ -787,7 +788,8 @@
                       process: 'legend-add',
                       fields: {
                         'url': {isMultilingual: false},
-                        'name': {}
+                        'name': {},
+                        'desc': {}
                       }
                     }, {
                       group: 'onlineUse',
@@ -801,7 +803,8 @@
                       process: 'legend-add',
                       fields: {
                         'url': {isMultilingual: false},
-                        'name': {}
+                        'name': {},
+                        'desc': {}
                       }
                     }, {
                       group: 'onlineUse',
@@ -815,7 +818,8 @@
                       process: 'legend-add',
                       fields: {
                         'url': {isMultilingual: false},
-                        'name': {}
+                        'name': {},
+                        'desc': {}
                       }
                       //},{
                       //  group: 'onlineUse',
@@ -1297,6 +1301,7 @@
                  * passed to the layers grid directive.
                  */
                 scope.loadCurrentLink = function(reportError) {
+                  var withGroupLayers = true;
 
                   // If multilingual or not
                   var url = scope.params.url;
@@ -1315,7 +1320,7 @@
                             scope.layers = [];
                             scope.isUrlOk = true;
                             angular.forEach(capabilities.layers, function(l) {
-                              if (angular.isDefined(l.Name)) {
+                              if (withGroupLayers || (!withGroupLayers && angular.isDefined(l.Name))) {
                                 scope.layers.push(l);
                               }
                             });

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -156,7 +156,7 @@
           <div id="gn-addonlinesrc-name-row"
                class="form-group"
                data-ng-show="params.linkType.fields.name &&
-                             !params.linkType.fields.name.hidden && !(OGCProtocol && !isEditing)">
+                             !params.linkType.fields.name.hidden">
             <label id="gn-addonlinesrc-name-label"
                    for="gn-addonlinesrc-name-single-input"
                    class="col-sm-2 control-label"
@@ -188,7 +188,7 @@
           <div id="gn-addonlinesrc-description-row"
                class="form-group"
                data-ng-show="params.linkType.fields.desc &&
-                             !params.linkType.fields.desc.hidden && !(OGCProtocol && !isEditing)">
+                             !params.linkType.fields.desc.hidden">
             <label id="gn-addonlinesrc-description-label"
                    for="gn-addonlinesrc-description-single-input"
                    class="col-sm-2 control-label"


### PR DESCRIPTION

* This is useful when service is in error, requires auth, .... 
* Also add the possibility to choose a group of layers. 

![image](https://user-images.githubusercontent.com/1701393/52557712-7fbcee80-2df0-11e9-841b-c51ad24cde79.png)



Add description in some ISO19115-3 resource types.


