### PR TITLE
Fix thumbnail remove button

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -483,21 +483,15 @@
         removeThumbnail: function(thumb) {
           var scope = this;
 
-          // It is a url thumbnail
-          if (thumb.id.indexOf('resources.get') < 0) {
+          if(thumb && gnCurrentEdit.id) {
             runProcess(this,
-                setParams('thumbnail-remove', {
-                  id: gnCurrentEdit.id,
-                  thumbnail_url: thumb.id
-                }));
-          }
-          // It is an uploaded tumbnail
-          else {
-            runService('removeThumbnail', {
-              type: (thumb.title === 'thumbnail' ? 'small' : 'large'),
-              id: gnCurrentEdit.id,
-              version: gnCurrentEdit.version
-            }, this);
+              setParams('thumbnail-remove', {
+                id: gnCurrentEdit.id,
+                thumbnail_url: thumb.id
+            }));
+          } else {
+            console.error('Error in removeThumbnail');
+            console.error(thumb);
           }
         },
 


### PR DESCRIPTION
The bug is described here https://github.com/geonetwork/core-geonetwork/issues/3437

It's already fixed on master and 3.6.x here https://github.com/geonetwork/core-geonetwork/pull/3440 this PR is the porting to 3.4.x 