### PR TITLE
Adds a parameter to resetSearch to preserve the geometry on facet filter changes

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/facets/FacetsConfigService.js
+++ b/web-ui/src/main/resources/catalog/components/search/facets/FacetsConfigService.js
@@ -122,8 +122,9 @@
         });
         scope.params['facet.q'] = facetQParam;
 
-        scope.$emit('resetSearch', scope.params);
-      };
+        var preserveGeometrySearch = true;
+        scope.$emit('resetSearch', scope.params, preserveGeometrySearch);
+      }
 
 
       buildPath = function(path, category) {

--- a/web-ui/src/main/resources/catalog/components/search/facets/FacetsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/facets/FacetsDirective.js
@@ -256,7 +256,8 @@
                     }
                   }
                 }
-                scope.$emit('resetSearch', scope.searchObj.params);
+                var preserveGeometrySearch = true;
+                scope.$emit('resetSearch', scope.searchObj.params, preserveGeometrySearch);
                 e.preventDefault();
               };
             }

--- a/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
@@ -181,9 +181,11 @@
               });
 
               // When search form is reset, remove the geom
-              scope.$on('beforeSearchReset', function() {
-                resetSpatialFilter();
-                scope.interaction.active = false;
+              scope.$on('beforeSearchReset', function(event, preserveGeometrySearch) {
+                if (!preserveGeometrySearch) {
+                  resetSpatialFilter();
+                  scope.interaction.active = false;
+                }
               });
             }
           };

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -337,9 +337,9 @@
       angular.extend($scope.searchObj.params, params);
     };
 
-    this.resetSearch = function(searchParams) {
+    this.resetSearch = function(searchParams, preserveGeometrySearch) {
 
-      $scope.$broadcast('beforeSearchReset');
+      $scope.$broadcast('beforeSearchReset', preserveGeometrySearch);
 
       if (searchParams) {
         $scope.searchObj.params = searchParams;
@@ -357,8 +357,8 @@
       $scope.triggerSearch();
       $scope.$broadcast('resetSelection');
     };
-    $scope.$on('resetSearch', function(evt, searchParams) {
-      $scope.controller.resetSearch(searchParams);
+    $scope.$on('resetSearch', function(evt, searchParams, preserveGeometrySearch) {
+      $scope.controller.resetSearch(searchParams, preserveGeometrySearch);
     });
 
     $scope.$on('search', function() {
@@ -401,9 +401,9 @@
         controllerAs: 'controller',
         link: function(scope, element, attrs) {
 
-          scope.resetSearch = function(htmlElementOrDefaultSearch) {
+          scope.resetSearch = function(htmlElementOrDefaultSearch, preserveGeometrySearch) {
             if (angular.isObject(htmlElementOrDefaultSearch)) {
-              scope.controller.resetSearch(htmlElementOrDefaultSearch);
+              scope.controller.resetSearch(htmlElementOrDefaultSearch, preserveGeometrySearch);
             } else {
               scope.controller.resetSearch();
               $(htmlElementOrDefaultSearch).focus();


### PR DESCRIPTION
Fixes #3566. Preserve the geometry parameter when the user updates the search facets.