### PR TITLE
Makes thesaurus of searchFilterTags configurable

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -14,6 +14,7 @@
        function($location, gnThesaurusService, $q, $cacheFactory, $browser, $timeout) {
          var cache = $cacheFactory('locationsSearchFilterTags');
          var useLocationParameters = true;
+         var thesaurusKey = 'external.place.regions';
 
 
          var searchInFilters = function(filters, filterKey, filterType) {
@@ -303,7 +304,7 @@
            var defer = $q.defer();
            if (!cache.get(uri)) {
              gnThesaurusService.lookupURI(
-              'external.place.administrativeAreas', uri).then(
+              thesaurusKey, uri).then(
              function(keyword) {
                if (keyword) {
                  var kw = {};
@@ -389,11 +390,16 @@
            'searchFilterTagsTemplate.html',
            scope: {
              privateVar: '@',
-             useLocationParameters: '@'
+             useLocationParameters: '@',
+             thesaurusKey: '@'
            },
            link: function(scope, element, attrs, ngSearchFormCtrl) {
              if (scope.useLocationParameters === 'false') {
                useLocationParameters = false;
+             }
+
+             if (scope.thesaurusKey && scope.thesaurusKey !== '') {
+               thesaurusKey = scope.thesaurusKey;
              }
 
              scope.currentFilters = [];


### PR DESCRIPTION
* Allows to configure the thesaurus used by searchFilterTags directive configurable.
* Sets `external.place.regions` as default value instead of `external.place.administrativeAreas` that doesn't exist in most GN instances.