### PR TITLE
[BP] Fixes link to XML in editor

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/ca-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "Conceptes més específics",
     "associatedConcept": "Conceptes associats",
     "xsd": "Validació de l'esquema",
-    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor</a>.",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/cs-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/cs-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "More specific concepts",
     "associatedConcept": "Associated concepts",
     "xsd": "Schema validation",
-    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor</a>.",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/de-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/de-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "More specific concepts",
     "associatedConcept": "Associated concepts",
     "xsd": "Schema validation",
-    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor</a>.",
     "directoryManagerSubtitle": "Hier können Sie folgende Verzeichnisse verwalten: Kontakte, Formate und Ausdehnungen.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -333,7 +333,7 @@
     "moreSpecificConcept":"More specific concepts",
     "associatedConcept":"Associated concepts",
     "xsd": "Schema validation",
-    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor</a>.",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/es-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/es-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "Conceptos más específicos",
     "associatedConcept": "Conceptos asociados",
     "xsd": "Validación del esquema",
-    "linkToXmlTab": "Algunos erroes se pueden solucionar usando el <a href=\"#/metadata/{{metadataId}}/tab/xml\">editor XML</a>.",
+    "linkToXmlTab": "Algunos erroes se pueden solucionar usando el <a href=\"#/metadata/{{metadataId}}?tab=xml\">editor XML</a>.",
     "directoryManagerSubtitle": "Esta pantalla te permite editar entradas del directorio como contactos, formatos, etc... incluyendo la administración de plantillas.",
     "directoryManagerSubtitleImport": "Introducir aquí el contenido XML completo de una entrada a importar a la base de datos.",
     "directoryEntryTypes": "Tipos de entradas",

--- a/web-ui/src/main/resources/catalog/locales/fi-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "Lisää alakäsitteitä",
     "associatedConcept": "Lähikäsitteet",
     "xsd": "Skeeman validointi",
-    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Jotkut virheistä voidaan korjata <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML-editointitilassa</a>.",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/fr-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "Concepts plus spécifiques",
     "associatedConcept": "Concepts associés",
     "xsd": "Validation du standard (XSD)",
-    "linkToXmlTab": "Certaines erreurs peuvent être corrigées <a href=\"#/metadata/{{metadataId}}/tab/xml\">dans la vue XML</a>.",
+    "linkToXmlTab": "Certaines erreurs peuvent être corrigées <a href=\"#/metadata/{{metadataId}}?tab=xml\">dans la vue XML</a>.",
     "directoryManagerSubtitle": "Ce menu vous permet de gérer des éléments réutilisables tel que des contacts, formats, etc. Ces éléments peuvent être construits à partir de gabarits.",
     "directoryManagerSubtitleImport": "Entrez ici le contenu complet en XML d'un élément réutilisable afin de l'importer dans la base de donnée.",
     "directoryEntryTypes": "Types d'éléments",

--- a/web-ui/src/main/resources/catalog/locales/is-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/is-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "Enn sérhæfðari hugtök",
     "associatedConcept": "Tengd hugtök",
     "xsd": "Skema fullgilding",
-    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Hægt er að laga sumar villur með því að nota <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor.</a>",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/it-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/it-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "More specific concepts",
     "associatedConcept": "Associated concepts",
     "xsd": "Schema validation",
-    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Alcuni tipi di errori possono essere corretti utilizzando l'<a href=\"#/metadata/{{metadataId}}?tab=xml\"> editor XML </a>.",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/ko-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "더 구체적인 개념",
     "associatedConcept": "연관 개념",
     "xsd": "스키마 유효성 검사",
-    "linkToXmlTab": "몇몇 오류는 <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML 편집기</a>를 사용하여 수정할 수 있습니다.",
+    "linkToXmlTab": "몇몇 오류는 <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML 편집기</a>를 사용하여 수정할 수 있습니다.",
     "directoryManagerSubtitle": "이 페이지는 템플릿 관리를 포함하여 연락처, 포맷 등 디렉토리 항목을 편집할 수 있습니다.",
     "directoryManagerSubtitleImport": "데이터베이스로 가져오려면 항목의 전체 XML 내용을 입력하십시오.",
     "directoryEntryTypes": "항목 유형",

--- a/web-ui/src/main/resources/catalog/locales/nl-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "Meer specifieke concepten",
     "associatedConcept": "Geassocieerde concepten",
     "xsd": "Schema validatie",
-    "linkToXmlTab": "XML structuur fouten kunnen opgelost worden in de <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "XML structuur fouten kunnen opgelost worden in de <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor</a>.",
     "directoryManagerSubtitle": "Dit scherm stelt u in staat om snippet entries zoals, contactgegevens, formaten, etc. te beheren, inclusief template beheer",
     "directoryManagerSubtitleImport": "Vul hier de XML inhoud van een snippet in om het te in de database te importeren",
     "directoryEntryTypes": "Snippet typen",

--- a/web-ui/src/main/resources/catalog/locales/ru-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "More specific concepts",
     "associatedConcept": "Associated concepts",
     "xsd": "Schema validation",
-    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor</a>.",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/sk-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-editor.json
@@ -330,7 +330,7 @@
     "moreSpecificConcept": "Viac špecifických konceptov",
     "associatedConcept": "Pridružené koncepty",
     "xsd": "Validačná schéma",
-    "linkToXmlTab": "Niektoré typy chýb môžu byť fixované použitím <a href=\"#/metadata/{{metadataId}}/tab/xml\">XML editor</a>.",
+    "linkToXmlTab": "Niektoré typy chýb môžu byť fixované použitím <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor</a>.",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
     "directoryEntryTypes": "Entry Types",

--- a/web-ui/src/main/resources/catalog/locales/zh-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-editor.json
@@ -329,7 +329,7 @@
     "moreSpecificConcept": "更具体的概念",
     "associatedConcept": "相关概念",
     "xsd": "模式验证",
-    "linkToXmlTab": "可以使用<a href=\"#/metadata/{{metadataId}}/tab/xml\"> XML编辑器</a>修复某些错误。",
+    "linkToXmlTab": "可以使用<a href=\"#/metadata/{{metadataId}}?tab=xml\"> XML编辑器</a>修复某些错误。",
     "directoryManagerSubtitle": "此屏幕允许您编辑目录条目，如联系人，格式等，包括模板管理。",
     "directoryManagerSubtitleImport": "在此处输入条目的完整的XML内容以将其导入数据库。",
     "directoryEntryTypes": "条目类型",


### PR DESCRIPTION
Since commit 2779b741d6 link to XML view shown in editor error messages doesn't
point to the right URL. This commit change it to the new format
`/metadata/:id?tab=xml`
Backport of #3575.