### PR TITLE
Add rows and columns in a template

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -333,6 +333,24 @@
         padding-bottom: 0;
       }
     }
+    .gn-control {
+      padding-left: 0;
+      .field-tooltip, [data-gn-field-highlight-remove] {
+        padding: 6px;
+      }
+    }
+    .gn-multi-field {
+      label.gn-required:after, .gn-required > label:after, label.gn-mandatory:after, .gn-mandatory > label:after {
+        margin-top: -7px;
+      }
+      .col-sm-11 {
+        padding-left: 0;
+      }
+      .col-sm-1 {
+        padding-right: 0;
+      }
+    }
+      
   }
   // map
   .gn-drawmap-panel {

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -556,143 +556,147 @@
               </xsl:if>
               <!-- For each template field create an input.
               The directive takes care of setting values. -->
-              <xsl:for-each select="$template/values/key">
-                <xsl:variable name="valueLabelKey" select="@label"/>
-                <xsl:variable name="keyRequired" select="@required"/>
-                <xsl:variable name="helper"
-                              select="if ($keyValues) then $keyValues/field[@name = $valueLabelKey]/helper else ''"/>
-                <xsl:variable name="codelist"
-                              select="if ($keyValues) then $keyValues/field[@name = $valueLabelKey]/codelist else ''"/>
-                <xsl:variable name="readonly"
-                              select="if ($keyValues) then $keyValues/field[@name = $valueLabelKey]/readonly else ''"/>
-
-                <!-- Only display label if more than one key to match -->
-                <xsl:if test="count($template/values/key) > 1">
-                  <label for="{$id}_{@label}">
-                    <!-- if key has an attr required="true"-->
-                    <xsl:if test="$keyRequired">
-                      <xsl:attribute name="class" select="'gn-required'"/>
-                    </xsl:if>
-                    <xsl:value-of select="$strings/*[name() = $valueLabelKey]"/>
-                  </label>
-                </xsl:if>
-
-                <xsl:choose>
-                  <xsl:when test="@use = 'textarea'">
-                    <textarea class="form-control"
-                              data-gn-field-tooltip="{$schema}|{@tooltip}"
-                              id="{$id}_{@label}">
-                      <xsl:if test="$readonly = 'true'">
-                        <xsl:attribute name="disabled"/>
-                      </xsl:if>
-                    </textarea>
-                  </xsl:when>
-                  <xsl:when test="$codelist != ''">
-                    <select class="form-control input-sm"
-                            data-gn-field-tooltip="{$schema}|{@tooltip}"
-                            id="{$id}_{@label}">
-                      <xsl:if test="$readonly = 'true'">
-                        <xsl:attribute name="disabled"/>
-                      </xsl:if>
-                      <option></option>
-
-                      <xsl:for-each select="$codelist/entry">
-                        <xsl:sort select="if ($codelist/@sort = 'fixed') then position() else label"/>
-                        <option value="{code}" title="{normalize-space(description)}">
-                          <xsl:value-of select="label"/>
-                        </option>
-                      </xsl:for-each>
-                    </select>
-                  </xsl:when>
-                  <xsl:when test="@use = 'checkbox'">
-                    <span class="pull-left">
-                      <input type="checkbox"
-                             data-gn-field-tooltip="{$schema}|{@tooltip}"
-                             id="{$id}_{@label}">
-                        <xsl:if test="$readonly = 'true'">
-                          <xsl:attribute name="disabled"/>
+              <div class="gn-multi-field">
+                <xsl:for-each select="$template/values/key">
+                <div class="row">
+                  <xsl:variable name="valueLabelKey" select="@label"/>
+                  <xsl:variable name="keyRequired" select="@required"/>
+                  <xsl:variable name="helper"
+                                select="if ($keyValues) then $keyValues/field[@name = $valueLabelKey]/helper else ''"/>
+                  <xsl:variable name="codelist"
+                                select="if ($keyValues) then $keyValues/field[@name = $valueLabelKey]/codelist else ''"/>
+                  <xsl:variable name="readonly"
+                                select="if ($keyValues) then $keyValues/field[@name = $valueLabelKey]/readonly else ''"/>
+                  <div class="col-sm-11 gn-field">
+                    <!-- Only display label if more than one key to match -->
+                    <xsl:if test="count($template/values/key) > 1">
+                      <label for="{$id}_{@label}">
+                        <!-- if key has an attr required="true"-->
+                        <xsl:if test="$keyRequired">
+                          <xsl:attribute name="class" select="'gn-required'"/>
                         </xsl:if>
-                      </input>
-                      &#160;
-                    </span>
-                  </xsl:when>
-                  <!-- A directive -->
-                  <xsl:when test="@use = 'data-gn-language-picker'">
-                    <input class="form-control"
-                           value="{value}"
-                           data-gn-field-tooltip="{$schema}|{@tooltip}"
-                           data-gn-language-picker=""
-                           id="{$id}_{@label}"/>
-                  </xsl:when>
-                  <xsl:when test="starts-with(@use, 'gn-')">
-                    <input class="form-control"
-                           type="hidden"
-                           value="{value}"
-                           id="{$id}_{@label}"/>
+                        <xsl:value-of select="$strings/*[name() = $valueLabelKey]"/>
+                      </label>
+                    </xsl:if>
 
-                    <div data-gn-field-tooltip="{$schema}|{@tooltip}"
-                         data-id="#{$id}_{@label}">
-                      <xsl:attribute name="data-{@use}">
-                        <xsl:value-of
-                          select="if ($keyValues) then $keyValues/field[@name = $valueLabelKey]/value else ''"/>
-                      </xsl:attribute>
-                      <xsl:for-each select="directiveAttributes/attribute::*">
-                        <xsl:variable name="directiveAttributeName" select="name()"/>
+                    <xsl:choose>
+                      <xsl:when test="@use = 'textarea'">
+                        <textarea class="form-control"
+                                  data-gn-field-tooltip="{$schema}|{@tooltip}"
+                                  id="{$id}_{@label}">
+                          <xsl:if test="$readonly = 'true'">
+                            <xsl:attribute name="disabled"/>
+                          </xsl:if>
+                        </textarea>
+                      </xsl:when>
+                      <xsl:when test="$codelist != ''">
+                        <select class="form-control input-sm"
+                                data-gn-field-tooltip="{$schema}|{@tooltip}"
+                                id="{$id}_{@label}">
+                          <xsl:if test="$readonly = 'true'">
+                            <xsl:attribute name="disabled"/>
+                          </xsl:if>
+                          <option></option>
 
-                        <xsl:attribute name="{$directiveAttributeName}">
-                          <xsl:choose>
-                            <xsl:when test="$keyValues and
-                                            count($keyValues/field[@name = $valueLabelKey]/
-                              directiveAttributes[@name = $directiveAttributeName]) > 0">
-                              <xsl:value-of select="$keyValues/field[@name = $valueLabelKey]/
-                              directiveAttributes[@name = $directiveAttributeName]/text()"/>
-                            </xsl:when>
-                            <xsl:when test="starts-with(., 'eval#')">
-                              <!-- Empty value for XPath to evaluate. -->
-                            </xsl:when>
-                            <xsl:otherwise>
-                              <xsl:value-of select="."/>
-                            </xsl:otherwise>
-                          </xsl:choose>
-                        </xsl:attribute>
-                      </xsl:for-each>
-                    </div>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:variable name="keyIndex" select="position()"/>
-                    <input class="form-control"
-                           type="{if (@use) then @use else 'text'}"
-                           value="{if ($keyValues) then $keyValues/field[$keyIndex]/value/text() else ''}"
-                           id="{$id}_{@label}"
-                           data-gn-field-tooltip="{$schema}|{@tooltip}">
-                      <xsl:if test="$helper">
-                        <!-- hide the form field if helper is available, the
-                          value is set by the directive which provide customized
-                          forms -->
-                        <xsl:attribute name="class" select="'hidden'"/>
-                      </xsl:if>
-                      <xsl:if test="$readonly = 'true'">
-                        <xsl:attribute name="disabled"/>
-                      </xsl:if>
-                    </input>
-                  </xsl:otherwise>
-                </xsl:choose>
+                          <xsl:for-each select="$codelist/entry">
+                            <xsl:sort select="if ($codelist/@sort = 'fixed') then position() else label"/>
+                            <option value="{code}" title="{normalize-space(description)}">
+                              <xsl:value-of select="label"/>
+                            </option>
+                          </xsl:for-each>
+                        </select>
+                      </xsl:when>
+                      <xsl:when test="@use = 'checkbox'">
+                        <span class="pull-left">
+                          <input type="checkbox"
+                                data-gn-field-tooltip="{$schema}|{@tooltip}"
+                                id="{$id}_{@label}">
+                            <xsl:if test="$readonly = 'true'">
+                              <xsl:attribute name="disabled"/>
+                            </xsl:if>
+                          </input>
+                          &#160;
+                        </span>
+                      </xsl:when>
+                      <!-- A directive -->
+                      <xsl:when test="@use = 'data-gn-language-picker'">
+                        <input class="form-control"
+                              value="{value}"
+                              data-gn-field-tooltip="{$schema}|{@tooltip}"
+                              data-gn-language-picker=""
+                              id="{$id}_{@label}"/>
+                      </xsl:when>
+                      <xsl:when test="starts-with(@use, 'gn-')">
+                        <input class="form-control"
+                              type="hidden"
+                              value="{value}"
+                              id="{$id}_{@label}"/>
 
-                <xsl:if test="$helper">
-                  <xsl:variable name="elementName" select="concat($id, '_', @label)"/>
-                  <xsl:call-template name="render-form-field-helper">
-                    <xsl:with-param name="elementRef" select="$elementName"/>
-                    <xsl:with-param name="relatedElement" select="if ($helper/@rel)
-                      then concat($elementName, '_', substring-after($helper/@rel, ':'))
-                      else ''"/>
-                    <xsl:with-param name="dataType" select="'text'"/>
-                    <xsl:with-param name="listOfValues" select="$helper"/>
-                    <xsl:with-param name="tooltip" select="concat($schema, '|', @tooltip)"/>
-                  </xsl:call-template>
-                </xsl:if>
+                        <div data-gn-field-tooltip="{$schema}|{@tooltip}"
+                            data-id="#{$id}_{@label}">
+                          <xsl:attribute name="data-{@use}">
+                            <xsl:value-of
+                              select="if ($keyValues) then $keyValues/field[@name = $valueLabelKey]/value else ''"/>
+                          </xsl:attribute>
+                          <xsl:for-each select="directiveAttributes/attribute::*">
+                            <xsl:variable name="directiveAttributeName" select="name()"/>
 
-              </xsl:for-each>
+                            <xsl:attribute name="{$directiveAttributeName}">
+                              <xsl:choose>
+                                <xsl:when test="$keyValues and
+                                                count($keyValues/field[@name = $valueLabelKey]/
+                                  directiveAttributes[@name = $directiveAttributeName]) > 0">
+                                  <xsl:value-of select="$keyValues/field[@name = $valueLabelKey]/
+                                  directiveAttributes[@name = $directiveAttributeName]/text()"/>
+                                </xsl:when>
+                                <xsl:when test="starts-with(., 'eval#')">
+                                  <!-- Empty value for XPath to evaluate. -->
+                                </xsl:when>
+                                <xsl:otherwise>
+                                  <xsl:value-of select="."/>
+                                </xsl:otherwise>
+                              </xsl:choose>
+                            </xsl:attribute>
+                          </xsl:for-each>
+                        </div>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:variable name="keyIndex" select="position()"/>
+                        <input class="form-control"
+                              type="{if (@use) then @use else 'text'}"
+                              value="{if ($keyValues) then $keyValues/field[$keyIndex]/value/text() else ''}"
+                              id="{$id}_{@label}"
+                              data-gn-field-tooltip="{$schema}|{@tooltip}">
+                          <xsl:if test="$helper">
+                            <!-- hide the form field if helper is available, the
+                              value is set by the directive which provide customized
+                              forms -->
+                            <xsl:attribute name="class" select="'hidden'"/>
+                          </xsl:if>
+                          <xsl:if test="$readonly = 'true'">
+                            <xsl:attribute name="disabled"/>
+                          </xsl:if>
+                        </input>
+                      </xsl:otherwise>
+                    </xsl:choose>
 
+                    <xsl:if test="$helper">
+                      <xsl:variable name="elementName" select="concat($id, '_', @label)"/>
+                      <xsl:call-template name="render-form-field-helper">
+                        <xsl:with-param name="elementRef" select="$elementName"/>
+                        <xsl:with-param name="relatedElement" select="if ($helper/@rel)
+                          then concat($elementName, '_', substring-after($helper/@rel, ':'))
+                          else ''"/>
+                        <xsl:with-param name="dataType" select="'text'"/>
+                        <xsl:with-param name="listOfValues" select="$helper"/>
+                        <xsl:with-param name="tooltip" select="concat($schema, '|', @tooltip)"/>
+                      </xsl:call-template>
+                    </xsl:if>
+                  </div>
+                  <div class="col-sm-1 gn-control"></div>
+                </div>
+                </xsl:for-each>
+              </div>
               <xsl:if test="not($isExisting)">
                 <input class="gn-debug" type="text" name="{$xpathFieldId}" value="{@xpath}"/>
               </xsl:if>


### PR DESCRIPTION
Sometimes fields in the editor are put together in one, big column. Usually this is not a problem, but when you use tooltip icons in the editor (`displayTooltips="true" displayTooltipsMode="icon"`) the tooltips are displayed on a big pile:

![gn-tooltip-pile](https://user-images.githubusercontent.com/19608667/52715196-17127500-2f9c-11e9-8c75-749d77eadc62.png)

This PR adds rows and columns in this one, big column. This results in neatly ordered tooltip icons.

![gn-tooltips-ordered](https://user-images.githubusercontent.com/19608667/52715322-796b7580-2f9c-11e9-860d-fe1f7f4c0453.png)

_Note_: in this screenshot the labels are missing (but still the tooltips are nicely ordered)