### PR TITLE
Show/Hide social bar in the footer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -620,7 +620,7 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
-      <div data-ng-switch-when="showSocialBar">
+      <div data-ng-switch-when="showSocialBarInFooter">
         <input type="checkbox"
                id="{{key}}-checkbox"
                data-ng-model="mCfg[key]"/>&nbsp;

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -620,6 +620,18 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <div data-ng-switch-when="showSocialBar">
+        <input type="checkbox"
+               id="{{key}}-checkbox"
+               data-ng-model="mCfg[key]"/>&nbsp;
+        <label class="control-label"
+               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
       <div data-ng-switch-when="isSocialbarEnabled">
         <input type="checkbox"
                id="{{key}}-checkbox"

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -81,13 +81,10 @@
           'isLogoInHeader': false,
           'logoInHeaderPosition': 'left'
         },
-        'footer': {
-          'enabled': true,
-          'showSocialBar': true
-        },
         'home': {
           'enabled': true,
-          'appUrl': '../../srv/{{lang}}/catalog.search#/home'
+          'appUrl': '../../srv/{{lang}}/catalog.search#/home',
+          'showSocialBarInFooter': true
         },
         'search': {
           'enabled': true,
@@ -424,20 +421,19 @@
       $scope.version = '0.0.1';
 
 
-      //Update Links for social media
-      $scope.showSocialBarInFooter = gnGlobalSettings.gnCfg.mods.footer.showSocialBar;
+      // Links for social media
       $scope.socialMediaLink = $location.absUrl();
-      $scope.$on('$locationChangeSuccess', function(event) {
-        $scope.socialMediaLink = $location.absUrl();
-        $scope.showSocialMediaLink =
-          (($scope.socialMediaLink.indexOf('/metadata/') == -1) && ($scope.showSocialBarInFooter));
-      });
       $scope.getPermalink = gnUtilityService.getPermalink;
 
       // If gnLangs current already set by config, do not use URL
       $scope.langs = gnGlobalSettings.gnCfg.mods.header.languages;
       $scope.lang = gnLangs.detectLang(null, gnGlobalSettings);
       $scope.iso2lang = gnLangs.getIso2Lang($scope.lang);
+
+      $scope.getSocialLinksVisible = function() {
+        var onMdView =  $location.absUrl().indexOf('/metadata/') > -1;
+        return !onMdView && gnGlobalSettings.gnCfg.mods.home.showSocialBarInFooter;
+      };
 
       function detectNode(detector) {
         if (detector.regexp) {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -81,6 +81,10 @@
           'isLogoInHeader': false,
           'logoInHeaderPosition': 'left'
         },
+        'footer': {
+          'enabled': true,
+          'showSocialBar': true
+        },
         'home': {
           'enabled': true,
           'appUrl': '../../srv/{{lang}}/catalog.search#/home'
@@ -421,11 +425,12 @@
 
 
       //Update Links for social media
+      $scope.showSocialBarInFooter = gnGlobalSettings.gnCfg.mods.footer.showSocialBar;
       $scope.socialMediaLink = $location.absUrl();
       $scope.$on('$locationChangeSuccess', function(event) {
         $scope.socialMediaLink = $location.absUrl();
         $scope.showSocialMediaLink =
-            ($scope.socialMediaLink.indexOf('/metadata/') != -1);
+          (($scope.socialMediaLink.indexOf('/metadata/') == -1) && ($scope.showSocialBarInFooter));
       });
       $scope.getPermalink = gnUtilityService.getPermalink;
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1348,5 +1348,8 @@
     "distributedSearch": "Distributed search",
     "distributedSearchHelp": "Enables the distributed search in remote server (if the remote server supports it). When this option is enabled, the remote catalog cascades the search to the Federated CSW servers that has configured.",
     "hopCount": "Hop count",
-    "hopCountHelp": "Control the maximum number of message hops (default to 2) before the search is terminated in a distributed search."
+    "hopCountHelp": "Control the maximum number of message hops (default to 2) before the search is terminated in a distributed search.",
+    "ui-mod-footer": "Footer",
+    "ui-showSocialBar": "Show Socialbar",
+    "ui-showSocialBar-help": "Show the button bar with all the social buttons (facebook, twitter, etc.) in the footer of GeoNetwork"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1349,7 +1349,6 @@
     "distributedSearchHelp": "Enables the distributed search in remote server (if the remote server supports it). When this option is enabled, the remote catalog cascades the search to the Federated CSW servers that has configured.",
     "hopCount": "Hop count",
     "hopCountHelp": "Control the maximum number of message hops (default to 2) before the search is terminated in a distributed search.",
-    "ui-mod-footer": "Footer",
-    "ui-showSocialBar": "Show Socialbar",
-    "ui-showSocialBar-help": "Show the button bar with all the social buttons (facebook, twitter, etc.) in the footer of GeoNetwork"
+    "ui-showSocialBarInFooter": "Show Socialbar",
+    "ui-showSocialBarInFooter-help": "Show the button bar with all the social buttons (facebook, twitter, etc.) in the footer of GeoNetwork"
 }

--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -15,10 +15,10 @@
     <a href="../../doc/api" title="{{'learnTheApi' | translate}}">API</a>
   </li>
   <li gn-static-pages-list-viewer data-section="footer" data-language="{{lang}}" />
-  <li class="gn-footer-text" ng-hide="showSocialMediaLink">
+  <li class="gn-footer-text" ng-show="showSocialMediaLink">
     <span data-translate="">shareOn</span>
   </li>
-  <li class="socialmedia" ng-hide="showSocialMediaLink">
+  <li class="socialmedia" ng-show="showSocialMediaLink">
     <a href="https://twitter.com/share?url={{socialMediaLink | encodeURIComponent}}"
        target="_blank" title="{{'shareOnTwitter' | translate}}"><i class="fa fa-twitter"></i>
     </a>
@@ -40,7 +40,7 @@
       data-ng-click="getPermalink('', socialMediaLink)"
       title="{{'permalink' | translate}}"><i class="fa fa-fw fa-link"></i></a>
   </li>
-  <li>
+  <li ng-show="showSocialMediaLink">
     <a href="rss.search?sortBy=changeDate&georss=simplepoint"
        title="{{'lastRecords' | translate}}">
       <i class="fa fa-rss"/>

--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -15,10 +15,10 @@
     <a href="../../doc/api" title="{{'learnTheApi' | translate}}">API</a>
   </li>
   <li gn-static-pages-list-viewer data-section="footer" data-language="{{lang}}" />
-  <li class="gn-footer-text" ng-show="showSocialMediaLink">
+  <li class="gn-footer-text" ng-show="getSocialLinksVisible()">
     <span data-translate="">shareOn</span>
   </li>
-  <li class="socialmedia" ng-show="showSocialMediaLink">
+  <li class="socialmedia" ng-show="getSocialLinksVisible()">
     <a href="https://twitter.com/share?url={{socialMediaLink | encodeURIComponent}}"
        target="_blank" title="{{'shareOnTwitter' | translate}}"><i class="fa fa-twitter"></i>
     </a>
@@ -40,7 +40,7 @@
       data-ng-click="getPermalink('', socialMediaLink)"
       title="{{'permalink' | translate}}"><i class="fa fa-fw fa-link"></i></a>
   </li>
-  <li ng-show="showSocialMediaLink">
+  <li>
     <a href="rss.search?sortBy=changeDate&georss=simplepoint"
        title="{{'lastRecords' | translate}}">
       <i class="fa fa-rss"/>


### PR DESCRIPTION
This PR adds a new setting for showing/hiding the social buttons in the footer.

There was already a check to not display the social buttons in the footer on the metadata page. This check has been extended with this new setting.

The default setting is to show the buttons like before.

**Screenshot of the new admin setting:**

![gn-admin-socialbar-in-footer](https://user-images.githubusercontent.com/19608667/52716761-c1d86280-2f9f-11e9-97be-a637a738ed8e.png)
