### PR TITLE
improve scope to schema-org types

### DIFF
--- a/web/src/main/webapp/xslt/common/functions-core.xsl
+++ b/web/src/main/webapp/xslt/common/functions-core.xsl
@@ -36,16 +36,16 @@
     <xsl:variable name="map">
       <entry key="dataset" value="http://schema.org/Dataset"/>
       <entry key="series" value="http://schema.org/DataCatalog"/>
-      <entry key="service" value="http://schema.org/DataCatalog"/>
+      <entry key="service" value="http://schema.org/WebAPI"/>
       <entry key="application" value="http://schema.org/SoftwareApplication"/>
       <entry key="collectionHardware" value="http://schema.org/Thing"/>
       <entry key="nonGeographicDataset" value="http://schema.org/Dataset"/>
-      <entry key="dimensionGroup" value="http://schema.org/Dataset"/>
+      <entry key="dimensionGroup" value="http://schema.org/TechArticle"/>
       <entry key="featureType" value="http://schema.org/Dataset"/>
-      <entry key="model" value="http://schema.org/APIReference"/>
+      <entry key="model" value="http://schema.org/TechArticle"/>
       <entry key="tile" value="http://schema.org/Dataset"/>
-      <entry key="fieldSession" value="http://schema.org/Thing"/>
-      <entry key="collectionSession" value="http://schema.org/Thing"/>
+      <entry key="fieldSession" value="http://schema.org/Project"/>
+      <entry key="collectionSession" value="http://schema.org/Project"/>
     </xsl:variable>
 
     <xsl:variable name="match"


### PR DESCRIPTION
The meaning of iso19115 scope values are quite poorly documented, most relevant guess seems on comment at http://home.badc.rl.ac.uk/lawrence/blog/2008/03/19/the_scope_of_iso19115

I'm suggesting to use the type [WebAPI](http://schema.org/WebAPI) for "service", in stead of the dataCatalog type, this is the most relevant change, because service is used quite frequently in the scope of inspire. Following discussion schemaorg we may actually be able to at some point link WebAPI's to datasets. But we could also wait with merging this PR until schema-org has developed this as part of core