### PR TITLE
Editor / Suggestion list has transparent background

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -531,6 +531,8 @@ form.gn-editor {
   z-index: 999;
   max-height: 25em;
   overflow: auto;
+  background-color: #fff;
+  border: 1px solid lightgrey;
 
   .tt-suggestion {
     &:hover {


### PR DESCRIPTION
## Before 

![image](https://user-images.githubusercontent.com/1701393/52856330-6aafca80-3124-11e9-95ed-d29cfdfa09ab.png)

# After

![image](https://user-images.githubusercontent.com/1701393/52856338-6daabb00-3124-11e9-934f-36b162fb5920.png)



@MichelGabriel Could you have a look and see if there is no side effects ? Thanks a lot.