### PR TITLE
Fix update from empty groups

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -535,7 +535,10 @@ public class MetadataSharingApi {
         IMetadataManager metadataManager = appContext.getBean(IMetadataManager.class);
 
         Integer previousGroup = metadata.getSourceInfo().getGroupOwner();
-        Group oldGroup = appContext.getBean(GroupRepository.class).findOne(previousGroup);
+        Group oldGroup = null;
+        if(previousGroup!=null) {
+            oldGroup = appContext.getBean(GroupRepository.class).findOne(previousGroup);
+        }
 
         metadata.getSourceInfo().setGroupOwner(groupIdentifier);
         metadataManager.save(metadata);


### PR DESCRIPTION
The error reported here https://github.com/geonetwork/core-geonetwork/issues/3596 happens only when you try to update from a record that is not registered in any group (could happen during import, where the destination group is not mandatory). This is a fix.