### PR TITLE
Add info about profiles and groups in api/me services

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/users/MeApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/MeApi.java
@@ -23,11 +23,23 @@
 
 package org.fao.geonet.api.users;
 
-import io.swagger.annotations.*;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
-import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.users.model.MeResponse;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.repository.UserGroupRepository;
+import org.fao.geonet.repository.specification.UserGroupSpecs;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -35,59 +47,82 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
-import javax.servlet.http.HttpSession;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
 import springfox.documentation.annotations.ApiIgnore;
 
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-
 @RequestMapping(value = {
-    "/api/me",
-    "/api/" + API.VERSION_0_1 +
-        "/me"
-})
-@Api(value = "me",
-    tags = "me",
-    description = "Me operations")
-@Controller("me")
-public class MeApi {
-
-    @ApiOperation(
-        value = "Get information about me",
-        notes = "If not authenticated, return status 204 (NO_CONTENT), " +
-            "else return basic user information. This operation is usually used to " +
-            "know if current user is authenticated or not.",
-        nickname = "getMe")
-    @RequestMapping(
-        produces = MediaType.APPLICATION_JSON_VALUE,
-        method = RequestMethod.GET)
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Authenticated. Return user details."),
-        @ApiResponse(code = 204, message = "Not authenticated.")
+        "/api/me",
+        "/api/" + API.VERSION_0_1 +
+            "/me"
     })
-    @ResponseBody
-    public ResponseEntity<MeResponse> getMe(
-        @ApiIgnore
-        @ApiParam(
-            hidden = true
-        )
-        HttpSession session
-    ) throws Exception {
-        UserSession userSession = ApiUtils.getUserSession(session);
-        return userSession.isAuthenticated() ?
-            new ResponseEntity<>(new MeResponse()
-                .setId(userSession.getUserId())
-                .setProfile(userSession.getProfile().name())
-                .setUsername(userSession.getUsername())
-                .setName(userSession.getName())
-                .setSurname(userSession.getSurname())
-                .setEmail(userSession.getEmailAddr())
-                .setOrganisation(userSession.getOrganisation()),
-                    HttpStatus.OK) :
-            new ResponseEntity<>(NO_CONTENT);
-    }
+    @Api(value = "me",
+        tags = "me",
+        description = "Me operations")
+    @Controller("me")
+    public class MeApi {
+
+        @ApiOperation(
+            value = "Get information about me",
+            notes = "If not authenticated, return status 204 (NO_CONTENT), " +
+                "else return basic user information. This operation is usually used to " +
+                "know if current user is authenticated or not." +
+                "It returns also info about groups and profiles.",
+            nickname = "getMe")
+        @RequestMapping(
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            method = RequestMethod.GET)
+        @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Authenticated. Return user details."),
+            @ApiResponse(code = 204, message = "Not authenticated.")
+        })
+        @ResponseBody
+        public ResponseEntity<MeResponse> getMe(
+                @ApiIgnore
+                @ApiParam(
+                        hidden = true
+                        )
+                HttpSession session
+                ) throws Exception {
+
+            UserSession userSession = ApiUtils.getUserSession(session);
+
+            if (userSession.isAuthenticated()) {
+
+                MeResponse myInfos = new MeResponse().setId(userSession.getUserId()).setProfile(userSession.getProfile().name())
+                        .setUsername(userSession.getUsername()).setName(userSession.getName()).setSurname(userSession.getSurname())
+                        .setEmail(userSession.getEmailAddr()).setOrganisation(userSession.getOrganisation())
+                        .setAdmin(userSession.getProfile().equals(Profile.Administrator))
+                        .setGroupsWithRegisteredUser(getGroups(userSession, Profile.RegisteredUser))
+                        .setGroupsWithEditor(getGroups(userSession, Profile.Editor))
+                        .setGroupsWithReviewer(getGroups(userSession, Profile.Reviewer))
+                        .setGroupsWithUserAdmin(getGroups(userSession, Profile.UserAdmin));
+
+                return new ResponseEntity<>(myInfos, HttpStatus.OK);
+            }
+
+            return new ResponseEntity<>(NO_CONTENT);
+        }
+
+        /**
+         *  Retrieves the user's groups ids
+         * @param session
+         * @param profile
+         * @return
+         * @throws SQLException
+         */
+        private List<Integer> getGroups(UserSession session, Profile profile) throws SQLException {
+            ApplicationContext applicationContext = ApplicationContextHolder.get();
+            final UserGroupRepository userGroupRepository = applicationContext.getBean(UserGroupRepository.class);
+
+            Specifications<UserGroup> spec = Specifications.where(UserGroupSpecs.hasUserId(session.getUserIdAsInt()));
+            spec = spec.and(UserGroupSpecs.hasProfile(profile));
+
+            return userGroupRepository.findGroupIds(spec);
+        }
 }

--- a/services/src/main/java/org/fao/geonet/api/users/model/MeResponse.java
+++ b/services/src/main/java/org/fao/geonet/api/users/model/MeResponse.java
@@ -23,82 +23,13 @@
 
 package org.fao.geonet.api.users.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Current user info
  */
 public class MeResponse {
-    public String getId() {
-        return id;
-    }
-
-    public MeResponse setId(String id) {
-        this.id = id;
-        return this;
-    }
-
-    public String getProfile() {
-        return profile;
-    }
-
-    public MeResponse setProfile(String profile) {
-        this.profile = profile;
-        return this;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public MeResponse setUsername(String username) {
-        this.username = username;
-        return this;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public MeResponse setName(String name) {
-        this.name = name;
-        return this;
-    }
-
-    public String getSurname() {
-        return surname;
-    }
-
-    public MeResponse setSurname(String surname) {
-        this.surname = surname;
-        return this;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public MeResponse setEmail(String email) {
-        this.email = email;
-        this.hash = email != null ? org.apache.commons.codec.digest.DigestUtils.md5Hex(email) : "";
-        return this;
-    }
-
-    public String getHash() {
-        return hash;
-    }
-
-    public MeResponse setHash(String hash) {
-        this.hash = hash;
-        return this;
-    }
-
-    public String getOrganisation() {
-        return organisation;
-    }
-
-    public MeResponse setOrganisation(String organisation) {
-        this.organisation = organisation;
-        return this;
-    }
 
     private String id;
     private String profile;
@@ -108,7 +39,133 @@ public class MeResponse {
     private String email;
     private String hash;
     private String organisation;
+    private boolean admin;
+
+    // Each list is associated with a profile and contains the groups for which the user is enabled with that profile
+    private List<Integer> groupsWithRegisteredUser = new ArrayList<>();
+    private List<Integer> groupsWithEditor = new ArrayList<>();
+    private List<Integer> groupsWithReviewer = new ArrayList<>();
+    private List<Integer> groupsWithUserAdmin = new ArrayList<>();
 
     public MeResponse() {
     }
+
+    public String getId() {
+        return id;
+    }
+
+    public MeResponse setId(final String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getProfile() {
+        return profile;
+    }
+
+    public MeResponse setProfile(final String profile) {
+        this.profile = profile;
+        return this;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public MeResponse setUsername(final String username) {
+        this.username = username;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public MeResponse setName(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public MeResponse setSurname(final String surname) {
+        this.surname = surname;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public MeResponse setEmail(final String email) {
+        this.email = email;
+        this.hash = email != null ? org.apache.commons.codec.digest.DigestUtils.md5Hex(email) : "";
+        return this;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public MeResponse setHash(final String hash) {
+        this.hash = hash;
+        return this;
+    }
+
+    public String getOrganisation() {
+        return organisation;
+    }
+
+    public MeResponse setOrganisation(final String organisation) {
+        this.organisation = organisation;
+        return this;
+    }
+
+    public boolean isAdmin() {
+        return admin;
+    }
+
+    public MeResponse setAdmin(final boolean admin) {
+        this.admin = admin;
+        return this;
+    }
+
+    public List<Integer> getGroupsWithRegisteredUser() {
+        return groupsWithRegisteredUser;
+    }
+
+    public MeResponse setGroupsWithRegisteredUser(List<Integer> groupsWithRegisteredUser) {
+        this.groupsWithRegisteredUser = groupsWithRegisteredUser;
+        return this;
+    }
+
+    public List<Integer> getGroupsWithEditor() {
+        return groupsWithEditor;
+    }
+
+    public MeResponse setGroupsWithEditor(List<Integer> groupsWithEditor) {
+        this.groupsWithEditor = groupsWithEditor;
+        return this;
+    }
+
+    public List<Integer> getGroupsWithReviewer() {
+        return groupsWithReviewer;
+    }
+
+    public MeResponse setGroupsWithReviewer(List<Integer> groupsWithReviewer) {
+        this.groupsWithReviewer = groupsWithReviewer;
+        return this;
+    }
+
+    public List<Integer> getGroupsWithUserAdmin() {
+        return groupsWithUserAdmin;
+    }
+
+    public MeResponse setGroupsWithUserAdmin(List<Integer> groupsWithUserAdmin) {
+        this.groupsWithUserAdmin = groupsWithUserAdmin;
+        return this;
+    }
+
 }


### PR DESCRIPTION
This PR introduces improvements that are required here https://github.com/geonetwork/core-geonetwork/pull/3600

The angular methods to check profile scope.user.isEditor() or user.isEditorOrMore() or user.isReviewerOrMore() etc... don't take into account the group, so they are not useful in contexts where to determine the profile is necessary to know the relative group (for example for an operation related to metadata).

This PR adds new methods like scope.user.isEditorInGroup(groupId), scope.user.isReviewerInGroup(groupId) etc...

To do so, it was necessary to improve the api/me message to return also information about the user profile and groups. So now it returns 4 lists, each one associated with a specific profile, that includes the groups where the user is allowed that profile.