### PR TITLE
Harvester / OGC WxS / More valid records and better multilingual support

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCCSWGetCapabilities-to-19119.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCCSWGetCapabilities-to-19119.xsl
@@ -57,9 +57,8 @@ Mapping between :
         </gco:CharacterString>
       </fileIdentifier>
       <language>
-        <gco:CharacterString>
-          <xsl:value-of select="$lang"/>
-        </gco:CharacterString>
+        <LanguageCode codeList="http://www.loc.gov/standards/iso639-2/"
+                      codeListValue="{$lang}"/>
         <!-- English is default. Not available in GetCapabilities.
                 Selected by user from GUI -->
       </language>

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCSOSGetCapabilities-to-19119.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCSOSGetCapabilities-to-19119.xsl
@@ -74,9 +74,8 @@
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
       <language>
-        <gco:CharacterString>
-          <xsl:value-of select="$lang"/>
-        </gco:CharacterString>
+        <LanguageCode codeList="http://www.loc.gov/standards/iso639-2/"
+                      codeListValue="{$lang}"/>
         <!-- English is default. Not available in GetCapabilities.
                 Selected by user from GUI -->
       </language>

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCSOSGetCapabilitiesLayer-to-19139.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCSOSGetCapabilitiesLayer-to-19139.xsl
@@ -78,9 +78,8 @@
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
       <language>
-        <gco:CharacterString>
-          <xsl:value-of select="$lang"/>
-        </gco:CharacterString>
+        <LanguageCode codeList="http://www.loc.gov/standards/iso639-2/"
+                      codeListValue="{$lang}"/>
       </language>
 
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -394,7 +393,8 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
     <language gco:nilReason="missing">
-      <gco:CharacterString/>
+      <LanguageCode codeList="http://www.loc.gov/standards/iso639-2/"
+                    codeListValue=""/>
     </language>
 
     <characterSet>

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCWxSGetCapabilitiesLayer-to-19139.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/OGCWxSGetCapabilitiesLayer-to-19139.xsl
@@ -106,9 +106,8 @@
             -->
 
       <language>
-        <gco:CharacterString>
-          <xsl:value-of select="$lang"/>
-        </gco:CharacterString>
+        <LanguageCode codeList="http://www.loc.gov/standards/iso639-2/"
+                      codeListValue="{$lang}"/>
       </language>
 
       <!--

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/identification.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/identification.xsl
@@ -931,7 +931,8 @@
     </xsl:if>
 
     <language gco:nilReason="missing">
-      <gco:CharacterString/>
+      <LanguageCode codeList="http://www.loc.gov/standards/iso639-2/"
+                    codeListValue=""/>
     </language>
 
     <characterSet>

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/resp-party.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/OGCWxSGetCapabilitiesto19119/resp-party.xsl
@@ -142,7 +142,8 @@
     </xsl:if>
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <xsl:for-each select="ContactAddress|../wms:ContactInformation|wms:ContactAddress|
+    <xsl:for-each select="ContactAddress|
+              ../wms:ContactInformation/wms:ContactAddress|
               wcs:contactInfo|
               ows:ServiceContact/ows:ContactInfo/ows:Address|
               ows11:ServiceContact/ows11:ContactInfo/ows11:Address|
@@ -229,10 +230,10 @@
       </gmd:country>
     </xsl:for-each>
 
-    <!-- TODO - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
     <xsl:for-each
-      select="(ContactElectronicMailAddress|wms:ContactElectronicMailAddress|wcs:address/wcs:electronicMailAddress|ows:ElectronicMailAddress|ows11:ElectronicMailAddress|ows2:ElectronicMailAddress)[. != '']">
+      select="(../ContactElectronicMailAddress|../wms:ContactElectronicMailAddress|wcs:address/wcs:electronicMailAddress|ows:ElectronicMailAddress|ows11:ElectronicMailAddress|ows2:ElectronicMailAddress)[. != '']" >
       <gmd:electronicMailAddress>
         <gco:CharacterString>
           <xsl:value-of select="."/>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/ogcwxs.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/ogcwxs.html
@@ -85,17 +85,20 @@
           <span data-translate="">ogcwxs-datasetTemplateUuid</span>
         </label>
         <select id="gn-harvest-settings-ogc-advanced-records-template-list" 
-                ata-ng-show="harvesterSelected.site.ogctype.match('^(WMS|WFS|WCS|SOS)') != null"
+                data-ng-show="harvesterSelected.site.ogctype.match('^(WMS|WFS|WCS|SOS|WPS)') != null"
                 class="form-control"
                 data-ng-model="harvesterSelected.options.datasetTemplateUuid"
                 data-ng-options="t['geonet:info'].uuid as t.getTitle() for t in ogcwxsDatasetTemplates">
         </select>
+        <!--
+        TODO: This need more work as it requires changes in the XSL transformation
+        to inject process info in a serviceIdentification and not a dataIdentification.
         <select id="gn-harvest-settings-ogc-advanced-records-template-list-wps2"
                 data-ng-show="harvesterSelected.site.ogctype.match('^(WPS2)') != null"
                 class="form-control"
-                data-ng-model="harvesterSelected.options.serviceTemplateUuid"
+                data-ng-model="harvesterSelected.options.datasetTemplateUuid"
                 data-ng-options="t['geonet:info'].uuid as t.getTitle() for t in ogcwxsTemplates">
-        </select>
+        </select>-->
         <p class="help-block" data-translate="">ogcwxs-datasetTemplateUuidHelp</p>
       </div>
 


### PR DESCRIPTION
* Language encoding now use LanguageCode instead of CharacterString
* Language can now be defined in the record and preserved (priority is now: INSPIRE GetCapabilities language, record language, harvester config language and 'eng')
* Multilingual / Preserve translation in title and abstract fields in case a record is first harvested and then editor add translations. On next harvest preserve them.
* Validation / Avoid creation of 2 address blocs (one for address, one for the email)
* Validation / Abstract avoid nested CharacterString
* Validation / Online / Name was place before protocol


Those fix mainly applies when using the template mode of the OGC WxS harvester and when editor makes changes to the harvested records:

![image](https://user-images.githubusercontent.com/1701393/53151997-bc3cd700-35b4-11e9-935d-02c308705d26.png)

Work made in collaboration with Cantone di Ticino after advanced testing of this harvester.
