### PR TITLE
Add bootstrap classes to link button

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
@@ -1,6 +1,6 @@
 <div class="gn-md-links">
 
-  <a class="gn-md-edit-btn"
+  <a class="gn-md-edit-btn btn btn-default"
      data-ng-show="user.canEditRecord(md)"
      data-ng-href="catalog.edit#/metadata/{{md['geonet:info'].id}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{md['geonet:info'].uuid}}"
      title="{{'edit' | translate}}">


### PR DESCRIPTION
This PR makes the buttons look the same in the results view

Before:
![gn-linksbtn-before](https://user-images.githubusercontent.com/19608667/53168696-90811780-35db-11e9-8863-4483334c7eb9.png)

After:
![gn-linksbtn-after](https://user-images.githubusercontent.com/19608667/53168707-9840bc00-35db-11e9-9a90-7a90b39112bf.png)
