### PR TITLE
Align schema version in pom.xml for 3.6.x

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>geonetwork-integration-test</groupId>
   <artifactId>geonetwork-integration-test</artifactId>
-  <version>3.5.0-SNAPSHOT</version>
+  <version>3.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>geonetwork-integration-test</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1368,6 +1368,6 @@
     <xbean.version>3.18</xbean.version>
     <jolokia.version>1.6.0</jolokia.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
-    <gn.schemas.version>3.5</gn.schemas.version>
+    <gn.schemas.version>3.6</gn.schemas.version>
   </properties>
 </project>

--- a/schemas/csw-record/pom.xml
+++ b/schemas/csw-record/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.5</version>
+    <version>3.6</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>schema-csw-record</artifactId>

--- a/schemas/dublin-core/pom.xml
+++ b/schemas/dublin-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.5</version>
+    <version>3.6</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/schemas/iso19110/pom.xml
+++ b/schemas/iso19110/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.5</version>
+    <version>3.6</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/schemas/iso19139/pom.xml
+++ b/schemas/iso19139/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.5</version>
+    <version>3.6</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -31,7 +31,7 @@
     <version>3.6.1-SNAPSHOT</version>
   </parent>
 
-  <version>3.5</version>
+  <version>3.6</version>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>schemas</artifactId>

--- a/schemas/schema-core/pom.xml
+++ b/schemas/schema-core/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.5</version>
+    <version>3.6</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Currently, the version in pom.xml for schemas is 3.5. This PR changes to 3.6.