### PR TITLE
Fix computations for WMTS layers in print map service

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
@@ -346,13 +346,13 @@
           var layerUrl = layer.get('url');
           for (var z = 0; z < tileGrid.getResolutions().length; ++z) {
             var mSize = (ol.extent.getWidth(proj.getExtent()) /
-                tileGrid.getTileSize()) /
+                tileGrid.getTileSize(z)) /
                 tileGrid.getResolutions()[z];
                 matrixIds[z] = {
                   identifier: tileGrid.getMatrixIds()[z],
                   resolution: tileGrid.getResolutions()[z],
-                  tileSize: [tileGrid.getTileSize(), tileGrid.getTileSize()],
-                  topLeftCorner: tileGrid.getOrigin(),
+                  tileSize: [tileGrid.getTileSize(z), tileGrid.getTileSize(z)],
+                  topLeftCorner: tileGrid.getOrigin(z),
                   matrixSize: [mSize, mSize]
                 };
           }


### PR DESCRIPTION
Without this fix, `tileGrid.getSize` and `tileGrid.getOrigin` would sometimes both return null, which caused the corresponding WMTS layer to not be rendered.

This does not happen for OSM though.

Example WMTS service: https://gis.ngdc.noaa.gov/arcgis/rest/services/web_mercator/etopo1_hillshade/MapServer/WMTS