### PR TITLE
ISO19139 / Avoid XSL error in case of a language is declared more than once in other locale section.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -181,8 +181,8 @@
         <xsl:variable name="guiLangId"
                       select="
                       if (count($metadata/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $lang]) = 1)
-                        then $metadata/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $lang]/@id
-                        else $metadata/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $metadataLanguage]/@id"/>
+                        then ($metadata/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $lang]/@id)[1]
+                        else ($metadata/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $metadataLanguage]/@id)[1]"/>
 
         <!--
         get keyword in gui lang

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
@@ -66,8 +66,8 @@
           </xsl:variable>
           <xsl:if test="$mainLanguage">
             <xsl:variable name="mainLanguageId"
-                          select="$metadata/gmd:locale/gmd:PT_Locale[
-                                gmd:languageCode/gmd:LanguageCode/@codeListValue = $mainLanguage]/@id"/>
+                          select="($metadata/gmd:locale/gmd:PT_Locale[
+                                gmd:languageCode/gmd:LanguageCode/@codeListValue = $mainLanguage]/@id)[1]"/>
 
             <lang>
               <xsl:value-of


### PR DESCRIPTION

This allows to at least open the editor in XML mode to apply a fix.
