### PR TITLE
Map / WFS download improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
@@ -75,7 +75,11 @@
               </li>
 
               <!--Download-->
-              <li class="" data-gn-wfs-download="layer" ng-show="hasDownload" has-download="hasDownload" data-map="map" role="menuitem">
+              <li class="" data-gn-wfs-download="layer"
+                           data-init-on-demand="true"
+                           data-mode="select"
+                           ng-show="hasDownload" 
+                           has-download="hasDownload" data-map="map" role="menuitem">
               </li>
 
               <!--Remove layer-->

--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
@@ -1,93 +1,122 @@
-<p data-ng-show="isWfsAvailable && featureType" data-translate=""
-   wfsDownloadDataInstruction
-</p>
-<p data-ng-show="!isWfsAvailable" class="text-warning clearfix">
-  <i class="fa fa-warning fa-2x fa-fw pull-left" />
-  {{'Unable_to_connect_to_service'|translate}}
-</p>
-
-<div class="btn-group"
-     data-ng-show="featureType && isWfsAvailable">
-
-  <button type="button"
-          class="btn btn-default btn-sm dropdown-toggle"
-          data-toggle="dropdown"
-          aria-haspopup="true"
-          aria-expanded="false">
-    <span data-translate="">downloadFeature</span>
-    <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu">
-    <li class="dropdown-header"
-        data-translate="">downloadAllIn
-    </li>
-    <li data-ng-repeat="f in formats | orderBy:f">
-      <a data-gn-click-and-spin="download(f)">
-        {{f | lowercase}}
-      </a>
-    </li>
-    <li data-ng-if="map"
-        role="separator" class="divider"></li>
-    <li class="dropdown-header"
-    data-ng-if="map"
-    data-translate="">downloadInCurrentMapExtent</li>
-    <li data-ng-if="map"
-        data-ng-repeat="f in formats | orderBy:f">
-      <a data-gn-click-and-spin="download(f, true)">
-        {{f | lowercase }}
-      </a>
-    </li>
-  </ul>
+<div data-ng-hide="isInitialized">
+   <button class="btn btn-default"
+      title="{{'checkIfDataIsDownloadableFromWfsHelp' | translate}}"
+      data-ng-click="init()">
+     <i class="fa fa-fw fa-download"/>
+     <span data-translate="">checkIfDataIsDownloadableFromWfs</span>
+   </button>
 </div>
-<p data-ng-if="formats.length == 0 && featureType" class="text-warning clearfix">
-  <div class="fa fa-warning fa-2x fa-fw pull-left"></div>
-  <div class="pull-left" data-translate="">wfsNoOutputFormats</div>
-</p>
-<div data-ng-if="formats.length > 0 && !featureType">
-  <p class="clearfix gn-margin-top gn-margin-bottom text-warning" data-ng-show="typename != ''">
-    <div class="fa fa-warning fa-2x fa-fw pull-left"></div>
-    <div data-translate=""
-          class="pull-left"
-          data-translate-values="{typename:'{{typename}}'}">wfsTypenameNotAvailable</div>
+<div data-ng-show="isInitialized">
+  <p data-ng-show="isWfsAvailable && featureType" data-translate=""
+     wfsDownloadDataInstruction
+  </div>
+  <p data-ng-show="!isWfsAvailable" class="text-warning clearfix">
+    <i class="fa fa-warning fa-2x fa-fw pull-left" />
+    {{'Unable_to_connect_to_service'|translate}}
   </p>
-  <div class="row">
-    <div class="col-md-8 gn-nopadding-left">
-      <select class="form-control"
-        data-ng-model="ftSelected"
-        aria-label="{{'wfsChooseFeatureTypeToDownload' | translate}}"
-        data-ng-options="featType as featType.name.localPart for featType in capabilities.featureTypeList.featureType | orderBy: 'name.localPart' track by featType.name.key">
-        <option value="">{{'wfsChooseFeatureTypeToDownload' | translate}}</option>
-      </select>
+
+  <div class="btn-group"
+       data-ng-show="featureType && isWfsAvailable">
+
+    <select class="form-control"
+            data-ng-if="mode == 'select'"
+            data-ng-model="downloadFormat">
+      <optgroup label="{{'downloadFeature'| translate}}">
+        <option data-ng-repeat="f in formats | orderBy:f"
+                value="{{f}}#false">
+          {{f | lowercase}}
+        </option>
+      </optgroup>
+      <optgroup label="{{'downloadInCurrentMapExtent'| translate}}">
+        <option data-ng-repeat="f in formats | orderBy:f"
+                value="{{f}}#true">
+          {{f | lowercase}}
+        </option>
+      </optgroup>
+
+    </select>
+    <div data-ng-if="mode == 'dropdown'">
+      <button type="button"
+              class="btn btn-default btn-sm dropdown-toggle"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false">
+        <span data-translate="">downloadFeature</span>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li class="dropdown-header"
+            data-translate="">downloadAllIn
+        </li>
+        <li data-ng-repeat="f in formats | orderBy:f">
+          <a data-gn-click-and-spin="download(f)">
+            {{f | lowercase}}
+          </a>
+        </li>
+        <li data-ng-if="map"
+            role="separator" class="divider"></li>
+        <li class="dropdown-header"
+        data-ng-if="map"
+        data-translate="">downloadInCurrentMapExtent</li>
+        <li data-ng-if="map"
+            data-ng-repeat="f in formats | orderBy:f">
+          <a data-gn-click-and-spin="download(f, true)">
+            {{f | lowercase }}
+          </a>
+        </li>
+      </ul>
     </div>
-    <div class="col-md-4 gn-nopadding-left">
-      <div class="btn-group"
-           data-ng-show="ftSelected">
-        <button type="button"
-                class="btn btn-default btn-sm dropdown-toggle"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false">
-          <span data-translate="">downloadFeature</span>
-          <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <li data-ng-repeat="format in formats | orderBy:format">
-            <a data-gn-click-and-spin="downloadFeatureType(format, ftSelected, ftSelected.name.prefix+':'+ftSelected.name.localPart)">
-              {{format|lowercase}}
-            </a>
-          </li>
-          <li data-ng-if="map"
-              role="separator" class="divider"></li>
-          <li class="dropdown-header"
-              data-ng-if="map"
-              data-translate="">downloadInCurrentMapExtent</li>
-          <li data-ng-if="map"
-              data-ng-repeat="format in formats | orderBy:f">
-            <a data-gn-click-and-spin="downloadFeatureType(format, ftSelected, ftSelected.name.localPart, true)">
-              {{format|lowercase}}
-            </a>
-          </li>
-        </ul>
+  </div>
+  <div data-ng-if="formats.length == 0 && featureType" class="text-warning clearfix">
+    <div class="fa fa-warning fa-2x fa-fw pull-left"></div>
+    <div class="pull-left" data-translate="">wfsNoOutputFormats</div>
+  </div>
+  <div data-ng-if="formats.length > 0 && !featureType">
+    <div class="clearfix gn-margin-top gn-margin-bottom text-warning" data-ng-show="typename != ''">
+      <div class="fa fa-warning fa-2x fa-fw pull-left"></div>
+      <div data-translate=""
+            class="pull-left"
+            data-translate-values="{typename:'{{typename}}'}">wfsTypenameNotAvailable</div>
+    </div>
+    <div class="row">
+      <div class="col-md-8 gn-nopadding-left">
+        <select class="form-control"
+          data-ng-model="ftSelected"
+          aria-label="{{'wfsChooseFeatureTypeToDownload' | translate}}"
+          data-ng-options="featType as featType.name.localPart for featType in capabilities.featureTypeList.featureType | orderBy: 'name.localPart' track by featType.name.key">
+          <option value="">{{'wfsChooseFeatureTypeToDownload' | translate}}</option>
+        </select>
+      </div>
+      <div class="col-md-4 gn-nopadding-left">
+        <div class="btn-group"
+             data-ng-show="ftSelected">
+          <button type="button"
+                  class="btn btn-default btn-sm dropdown-toggle"
+                  data-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false">
+            <span data-translate="">downloadFeature</span>
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li data-ng-repeat="format in formats | orderBy:format">
+              <a data-gn-click-and-spin="downloadFeatureType(format, ftSelected, ftSelected.name.prefix+':'+ftSelected.name.localPart)">
+                {{format|lowercase}}
+              </a>
+            </li>
+            <li data-ng-if="map"
+                role="separator" class="divider"></li>
+            <li class="dropdown-header"
+                data-ng-if="map"
+                data-translate="">downloadInCurrentMapExtent</li>
+            <li data-ng-if="map"
+                data-ng-repeat="format in formats | orderBy:f">
+              <a data-gn-click-and-spin="downloadFeatureType(format, ftSelected, ftSelected.name.localPart, true)">
+                {{format|lowercase}}
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -30,6 +30,8 @@
   "switchFrom2DTo3D": "Switch from 2D to 3D",
   "bbox": "bbox",
   "backgroundMap": "Background map:",
+  "checkIfDataIsDownloadableFromWfs": "Download service available?",
+  "checkIfDataIsDownloadableFromWfsHelp": "Check if this layer is available using a WFS service. If yes, then list available download formats as defined in the service capabilities.",
   "saveMap": "Save map",
   "downloadContext": "Download current map as",
   "saveMapAsContext": "OGC context (XML)",


### PR DESCRIPTION
* Fix dropdown not display in layer popup options (replaced by a select to be consistent with styling)

![image](https://user-images.githubusercontent.com/1701393/53568975-81621280-3b63-11e9-978f-24fce1048dbd.png)


* Fix JS errors on layer download menu due to undefined capabilities
* Add a directive attribute to only init the widget on demand (when done on load, if the WMS is public and the WFS restricted, user is asked for credentials because of this directive even if the map layer loads fine. Add a step to init the directive so credentials are requested only when a user want to download the data)

  * In layer menu, check only on demand
![image](https://user-images.githubusercontent.com/1701393/53568986-86bf5d00-3b63-11e9-84b2-7a70eb7552d7.png)


  * In record view, check on load

![image](https://user-images.githubusercontent.com/1701393/53569036-9a6ac380-3b63-11e9-95a3-1949a70b5547.png)
 

* Cleaning some useless console.log