### PR TITLE
Improve memory handling on CSW harvesters

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/AbstractAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/AbstractAligner.java
@@ -25,7 +25,6 @@ package org.fao.geonet.kernel.harvest;
 
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.kernel.harvest.harvester.AbstractParams;
-import org.fao.geonet.kernel.harvest.harvester.geonet.GeonetParams;
 
 public abstract class AbstractAligner<P extends AbstractParams> {
 
@@ -34,5 +33,10 @@ public abstract class AbstractAligner<P extends AbstractParams> {
     protected int getOwner() {
         return Integer.parseInt(
                 (StringUtils.isNumeric(params.getOwnerIdUser()) && params.getOwnerIdUser().length() > 0) ? params.getOwnerIdUser() : params.getOwnerId());
+    }
+
+    protected int getGroupOwner() {
+        return Integer.parseInt(
+                (StringUtils.isNumeric(params.getOwnerIdGroup()) && params.getOwnerIdGroup().length() > 0) ? params.getOwnerIdGroup() : "-1");
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -177,8 +177,6 @@ public class Aligner extends BaseAligner<CswParams> {
         processParams = filter.two();
 
         insertOrUpdate(records, errors);
-        dataMan.forceIndexChanges();
-
         log.debug("End of alignment for : " + params.getName());
 
         return result;
@@ -225,6 +223,7 @@ public class Aligner extends BaseAligner<CswParams> {
 
                 }
 
+                dataMan.forceIndexChanges();
                 result.totalMetadata++;
             } catch (Throwable t) {
                 errors.add(new HarvestError(this.context, t));
@@ -258,6 +257,7 @@ public class Aligner extends BaseAligner<CswParams> {
                 result.locallyRemoved++;
             }
         }
+        dataMan.forceIndexChanges();
         
         return result;
 	}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -263,7 +263,7 @@ public class Aligner extends BaseAligner<CswParams> {
 	}
 
 
-    private void addMetadata(RecordInfo ri, Integer ownerId, Integer groupId, String uuid) throws Exception {
+    private void addMetadata(RecordInfo ri, String uuid) throws Exception {
         if (cancelMonitor.get()) {
             return;
         }
@@ -301,7 +301,7 @@ public class Aligner extends BaseAligner<CswParams> {
         //
         AbstractMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
-        ownerId = getOwner();
+        Integer ownerId = getOwner();
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(md.getQualifiedName()).

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -28,6 +28,7 @@ import static org.fao.geonet.utils.AbstractHttpRequest.Method.POST;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -36,8 +37,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
 import org.apache.commons.lang.StringUtils;
-import jeeves.server.context.ServiceContext;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
@@ -54,7 +57,9 @@ import org.fao.geonet.domain.Pair;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.harvest.BaseAligner;
 import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
@@ -82,6 +87,7 @@ public class Aligner extends BaseAligner<CswParams> {
 
     private IMetadataUtils metadataUtils;
     private IMetadataManager metadataManager;
+    private IMetadataIndexer metadataIndexer;
     //--------------------------------------------------------------------------
     //---
     //--- Variables
@@ -103,6 +109,7 @@ public class Aligner extends BaseAligner<CswParams> {
         dataMan = gc.getBean(DataManager.class);
         metadataUtils = gc.getBean(IMetadataUtils.class);
         metadataManager = gc.getBean(IMetadataManager.class);
+        metadataIndexer = gc.getBean(IMetadataIndexer.class);
         result = new HarvestResult();
         result.unretrievable = 0;
         result.uuidSkipped = 0;
@@ -150,12 +157,12 @@ public class Aligner extends BaseAligner<CswParams> {
 
     }
 
-    public HarvestResult align(Set<RecordInfo> records, List<HarvestError> errors) throws Exception {
+    public HarvestResult align(Collection<RecordInfo> records, Collection<HarvestError> errors) throws Exception {
         if (cancelMonitor.get()) {
             return result;
         }
 
-        log.info("Start of alignment for : " + params.getName());
+        log.debug("Start of alignment for : " + params.getName());
 
         //-----------------------------------------------------------------------
         //--- retrieve all local categories and groups
@@ -165,46 +172,32 @@ public class Aligner extends BaseAligner<CswParams> {
         localGroups = new GroupMapper(context);
         localUuids = new UUIDMapper(context.getBean(IMetadataUtils.class), params.getUuid());
 
-        dataMan.flush();
-
         Pair<String, Map<String, Object>> filter = HarvesterUtil.parseXSLFilter(params.xslfilter);
         processName = filter.one();
         processParams = filter.two();
 
-        //-----------------------------------------------------------------------
-        //--- remove old metadata
+        insertOrUpdate(records, errors);
+        dataMan.forceIndexChanges();
 
-        for (String uuid : localUuids.getUUIDs()) {
-            if (cancelMonitor.get()) {
-                return result;
-            }
+        log.debug("End of alignment for : " + params.getName());
 
-            if (!exists(records, uuid)) {
-                String id = localUuids.getID(uuid);
-                log.debug("  - Removing old metadata with local id:" + id);
-                dataMan.deleteMetadata(context, id);
+        return result;
+    }
 
-                dataMan.flush();
-
-                result.locallyRemoved++;
-            }
-        }
-
-        //-----------------------------------------------------------------------
-        //--- insert/update new metadata
-
+	private void insertOrUpdate(Collection<RecordInfo> records, Collection<HarvestError> errors) {
         for (RecordInfo ri : records) {
+            
             if (cancelMonitor.get()) {
-                return result;
+                return;
             }
-
+            
             try {
 
-                String id = dataMan.getMetadataId(ri.uuid);
+                String id = metadataUtils.getMetadataId(ri.uuid);
 
                 if (id == null) {
                     //record doesn't exist (so it doesn't belong to this harvester)
-                    log.info("Adding record with uuid " + ri.uuid);
+                    log.debug("Adding record with uuid " + ri.uuid);
                     addMetadata(ri, getOwnerId(params), getOwnerGroupId(params), ri.uuid);
                 } else if (localUuids.getID(ri.uuid) == null) {
                     //Record does not belong to this harvester
@@ -237,16 +230,37 @@ public class Aligner extends BaseAligner<CswParams> {
                 errors.add(new HarvestError(this.context, t));
                 log.error("Unable to process record from csw (" + this.params.getName() + ")");
                 log.error("   Record failed: " +  ri.uuid + ". Error is: " + t.getMessage());
+				log.error(t);
             } finally {
                 result.originalMetadata++;
             }
         }
-        dataMan.forceIndexChanges();
+	}
 
-        log.debug("End of alignment for : " + params.getName());
+    /**
+     * Remove records no longer on the remote CSW server
+     * 
+     * @param records
+     * @throws Exception
+     */
+	@Transactional(value=TxType.REQUIRES_NEW)
+	public HarvestResult cleanupRemovedRecords(Set<String> records) throws Exception {
+		
+        if (cancelMonitor.get()) {
+            return result;
+        }
 
+        for (String uuid : localUuids.getUUIDs()) {
+            if (!records.contains(uuid)) {
+                String id = localUuids.getID(uuid);
+                log.debug("  - Removing old metadata with local id:" + id);
+                metadataManager.deleteMetadata(context, id);
+                result.locallyRemoved++;
+            }
+        }
+        
         return result;
-    }
+	}
 
 
     private void addMetadata(RecordInfo ri, Integer ownerId, Integer groupId, String uuid) throws Exception {
@@ -270,13 +284,13 @@ public class Aligner extends BaseAligner<CswParams> {
             return;
         }
 
-        log.info("  - Adding metadata with remote uuid:" + ri.uuid + " schema:" + schema);
+        log.debug("  - Adding metadata with remote uuid:" + ri.uuid + " schema:" + schema);
 
         String mdUuid = ri.uuid;
         if (!params.xslfilter.equals("")) {
             md = processMetadata(context, md, processName, processParams);
             // Get new uuid if modified by XSLT process
-            mdUuid = dataMan.extractUUID(schema, md);
+            mdUuid = metadataUtils.extractUUID(schema, md);
             if(mdUuid == null) {
                 mdUuid = ri.uuid;
             }
@@ -285,9 +299,6 @@ public class Aligner extends BaseAligner<CswParams> {
         //
         // insert metadata
         //
-         ownerId = Integer.parseInt(StringUtils.isNumeric(params.getOwnerIdUser()) ? params.getOwnerIdUser() : params.getOwnerId());
-       
-
         AbstractMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
         ownerId = getOwner();
@@ -300,25 +311,21 @@ public class Aligner extends BaseAligner<CswParams> {
         metadata.getSourceInfo().
             setSourceId(params.getUuid()).
             setOwner(ownerId).
-            setGroupOwner(Integer.valueOf(params.getOwnerIdGroup()));
+            setGroupOwner(getGroupOwner());
         metadata.getHarvestInfo().
             setHarvested(true).
             setUuid(params.getUuid());
 
-        try {
-            metadata.getSourceInfo().setGroupOwner(Integer.valueOf(params.getOwnerIdGroup()));
-        } catch (NumberFormatException e) {
-        }
-
+        metadata.getSourceInfo().setGroupOwner(getGroupOwner());
         addCategories(metadata, params.getCategories(), localCateg, context, log, null, false);
 
-        metadata = dataMan.insertMetadata(context, metadata, md, true, false, false, UpdateDatestamp.NO, false, false);
+        metadata = metadataManager.insertMetadata(context, metadata, md, true, false, false, UpdateDatestamp.NO, false, false);
 
         String id = String.valueOf(metadata.getId());
 
         addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, log);
 
-        dataMan.indexMetadata(id, Math.random() < 0.01, null);
+        metadataIndexer.indexMetadata(id, true, null);
         result.addedMetadata++;
     }
 
@@ -338,62 +345,56 @@ public class Aligner extends BaseAligner<CswParams> {
                 result.unchangedMetadata++;
             } else {
                 log.debug("  - Updating local metadata for uuid:" + ri.uuid);
-                Element md = retrieveMetadata(ri.uuid);
-
-                if (md == null) {
-                    result.unchangedMetadata++;
-                    return;
+                if(updatingLocalMetadata(ri, id, force)) {
+                	metadataIndexer.indexMetadata(id, true, null);
+                    result.updatedMetadata++;
                 }
-                
-                if (!params.xslfilter.equals("")) {
-                    md = processMetadata(context, md, processName, processParams);
-                }
-
-                //
-                // update metadata
-                //
-                boolean validate = false;
-                boolean ufo = false;
-                boolean index = false;
-                String language = context.getLanguage();
-
-                final AbstractMetadata metadata = dataMan.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, true);
-                
-                if(force) {
-                    //change ownership of metadata to new harvester
-                    metadata.getHarvestInfo().setUuid(params.getUuid());
-                    metadata.getSourceInfo().setSourceId(params.getUuid());
-
-                    metadataManager.save((Metadata) metadata);
-                }
-
-                OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
-                repository.deleteAllByIdAttribute(OperationAllowedId_.metadataId, Integer.parseInt(id));
-
-                addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, log);
-
-                metadata.getMetadataCategories().clear();
-                addCategories(metadata, params.getCategories(), localCateg, context, log, null, true);
-
-                dataMan.flush();
-
-                dataMan.indexMetadata(id, true, null);
-                result.updatedMetadata++;
             }
         }
     }
 
-    /**
-     * Returns true if the uuid is present in the remote node.
-     */
-    private boolean exists(Set<RecordInfo> records, String uuid) {
-        for (RecordInfo ri : records)
-            if (uuid.equals(ri.uuid))
-                return true;
+    @Transactional(value=TxType.REQUIRES_NEW)
+	private boolean updatingLocalMetadata(RecordInfo ri, String id, Boolean force) throws Exception {
+		Element md = retrieveMetadata(ri.uuid);
 
-        return false;
-    }
+		if (md == null) {
+		    result.unchangedMetadata++;
+		    return false;
+		}
+		
+		if (!params.xslfilter.equals("")) {
+		    md = processMetadata(context, md, processName, processParams);
+		}
 
+		//
+		// update metadata
+		//
+		boolean validate = false;
+		boolean ufo = false;
+		boolean index = false;
+		String language = context.getLanguage();
+
+		final AbstractMetadata metadata = metadataManager.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, true);
+		
+		if(force) {
+		    //change ownership of metadata to new harvester
+		    metadata.getHarvestInfo().setUuid(params.getUuid());
+		    metadata.getSourceInfo().setSourceId(params.getUuid());
+
+		    metadataManager.save((Metadata) metadata);
+		}
+
+		OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
+		repository.deleteAllByIdAttribute(OperationAllowedId_.metadataId, Integer.parseInt(id));
+
+		addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, log);
+
+		metadata.getMetadataCategories().clear();
+		addCategories(metadata, params.getCategories(), localCateg, context, log, null, true);
+		
+		return true;
+	}
+    
     /**
      * Does CSW GetRecordById request. If validation is requested and the metadata does not
      * validate, null is returned.
@@ -427,9 +428,9 @@ public class Aligner extends BaseAligner<CswParams> {
 
 
             try {
-                params.getValidate().validate(dataMan, context, response);
+                params.getValidate().validate(context.getBean(DataManager.class), context, response);
             } catch (Exception e) {
-                log.info("Ignoring invalid metadata with uuid " + uuid);
+                log.debug("Ignoring invalid metadata with uuid " + uuid);
                 result.doesNotValidate++;
                 return null;
             }
@@ -443,8 +444,8 @@ public class Aligner extends BaseAligner<CswParams> {
 
             return response;
         } catch (Exception e) {
-            log.warning("Raised exception while getting record : " +  e);
-            e.printStackTrace();
+            log.error("Raised exception while getting record : " +  e);
+            log.error(e);
             result.unretrievable++;
 
             //--- we don't raise any exception here. Just try to go on
@@ -512,7 +513,6 @@ public class Aligner extends BaseAligner<CswParams> {
                 }
             } catch (Throwable e) {
                 log.warning("      - Error when searching for resource duplicate " + uuid + ". Error is: " + e.getMessage());
-                e.printStackTrace();
             }
         }
         return false;
@@ -535,7 +535,7 @@ public class Aligner extends BaseAligner<CswParams> {
                                     Map<String, Object> processParams) {
         Path filePath = context.getAppPath().resolve(Geonet.Path.STYLESHEETS).resolve("conversion/import").resolve(processName + ".xsl");
         if (!Files.exists(filePath)) {
-            log.info("     processing instruction  " + processName + ". Metadata not filtered.");
+            log.debug("     processing instruction  " + processName + ". Metadata not filtered.");
         } else {
             Element processedMetadata;
             try {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
-import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
@@ -59,7 +58,6 @@ import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
 import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
-import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.harvest.BaseAligner;
 import org.fao.geonet.kernel.harvest.harvester.CategoryMapper;
@@ -70,6 +68,7 @@ import org.fao.geonet.kernel.harvest.harvester.HarvesterUtil;
 import org.fao.geonet.kernel.harvest.harvester.RecordInfo;
 import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
 import org.fao.geonet.kernel.search.LuceneSearcher;
+import org.fao.geonet.kernel.search.index.LuceneIndexLanguageTracker;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
@@ -222,8 +221,9 @@ public class Aligner extends BaseAligner<CswParams> {
                     updateMetadata(ri, id, false);
 
                 }
-
-                dataMan.forceIndexChanges();
+                
+                context.getBean(LuceneIndexLanguageTracker.class).commit();
+                
                 result.totalMetadata++;
             } catch (Throwable t) {
                 errors.add(new HarvestError(this.context, t));

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -122,7 +122,7 @@ class Harvester implements IHarvester<HarvestResult> {
 
     public HarvestResult harvest(Logger log) throws Exception {
         this.log = log;
-        log.info("Retrieving capabilities file for : " + params.getName());
+        log.debug("Retrieving capabilities file for : " + params.getName());
 
         CswServer server = retrieveCapabilities(log);
         if (cancelMonitor.get()) {
@@ -130,8 +130,6 @@ class Harvester implements IHarvester<HarvestResult> {
         }
 
         //--- perform all searches
-
-        Set<RecordInfo> records = new HashSet<RecordInfo>();
 
         Search s = new Search();
 
@@ -149,14 +147,13 @@ class Harvester implements IHarvester<HarvestResult> {
             }
         }
 
-        HarvestResult result = new HarvestResult();
         boolean error = false;
+        HarvestResult result = null;
+    	Set<String> uuids = new HashSet<String>();
         try {
-            records.addAll(search(server, s));
-
-            //--- align local node
             Aligner aligner = new Aligner(cancelMonitor, context, server, params, log);
-            result = aligner.align(records, errors);
+            searchAndAlign(server, s, uuids, aligner, errors);
+            result = aligner.cleanupRemovedRecords(uuids);
         } catch (Exception t) {
             error = true;
             log.error("Unknown error trying to harvest");
@@ -170,7 +167,7 @@ class Harvester implements IHarvester<HarvestResult> {
             errors.add(new HarvestError(context, t));
         }
 
-        log.info("Total records processed in all searches :" + records.size());
+        log.info("Total records processed in all searches :" + uuids.size());
         if (error) {
             log.warning("Due to previous errors the align process has not been called");
         }
@@ -246,8 +243,11 @@ class Harvester implements IHarvester<HarvestResult> {
 
     /**
      * Does CSW GetRecordsRequest.
+     * @param aligner 
+     * @param errors2 
      */
-    private Set<RecordInfo> search(CswServer server, Search s) throws Exception {
+    private void searchAndAlign(CswServer server, Search s, Set<String> uuids, 
+    		Aligner aligner, List<HarvestError> harvesterErrors) throws Exception {
         int start = 1;
 
         GetRecordsRequest request = new GetRecordsRequest(context);
@@ -270,7 +270,7 @@ class Harvester implements IHarvester<HarvestResult> {
         }
         // Simple fallback mechanism. Try search with PREFERRED_HTTP_METHOD method, if fails change it
         try {
-            log.info(String.format("Trying the search with HTTP %s method.", PREFERRED_HTTP_METHOD));
+            log.debug(String.format("Trying the search with HTTP %s method.", PREFERRED_HTTP_METHOD));
             request.setStartPosition(start);
             doSearch(request, start, 1);
         } catch (Exception ex) {
@@ -283,13 +283,12 @@ class Harvester implements IHarvester<HarvestResult> {
             configRequest(request, oper, server, s, PREFERRED_HTTP_METHOD.equals("GET") ? "POST" : "GET");
         }
 
-        Set<RecordInfo> records = new HashSet<RecordInfo>();
 
         while (true) {
             if(this.cancelMonitor.get()) {
               log.error("Harvester stopped in the middle of running!");
               //Returning whatever, we have to move on and finish!
-              return records;
+              return;
             }
             request.setStartPosition(start);
             Element response = doSearch(request, start, GETRECORDS_REQUEST_MAXRECORDS);
@@ -312,20 +311,21 @@ class Harvester implements IHarvester<HarvestResult> {
             if(this.cancelMonitor.get()) {
               log.error("Harvester stopped in the middle of running!");
               //Returning whatever, we have to move on and finish!
-              return records;
+              return;
             }
             @SuppressWarnings("unchecked")
             List<Element> list = results.getChildren();
             int foundCnt = 0;
 
             log.debug("Extracting all elements in the csw harvesting response");
+            Set<RecordInfo> records = new HashSet<RecordInfo>();
             for (Element record : list) {
-                foundCnt++;
                 try {
                     RecordInfo recInfo = getRecordInfo((Element) record.clone());
 
                     if (recInfo != null) {
                         records.add(recInfo);
+                        uuids.add(recInfo.uuid);
                     }
 
                 } catch (Exception ex) {
@@ -336,6 +336,10 @@ class Harvester implements IHarvester<HarvestResult> {
                 }
 
             }
+
+            foundCnt += records.size();
+            //Align here to keep memory clean
+            aligner.align(records, harvesterErrors);
 
             //--- check to see if we have to perform other searches
             int matchedCount = getSearchResultAttribute(results, ATTRIB_SEARCHRESULT_MATCHED);
@@ -397,9 +401,9 @@ class Harvester implements IHarvester<HarvestResult> {
             start += returnedCount;
         }
 
-        log.info("Records added to result list : " + records.size());
+        log.debug("Records added to result list : " + uuids.size());
 
-        return records;
+        return;
     }
 
     //---------------------------------------------------------------------------
@@ -613,7 +617,7 @@ class Harvester implements IHarvester<HarvestResult> {
 
     private Element doSearch(CatalogRequest request, int start, int max) throws Exception {
         try {
-            log.info("Searching on : " + params.getName() + " (" + start + ".." + (start + max) + ")");
+            log.debug("Searching on : " + params.getName() + " (" + start + ".." + (start + max) + ")");
             Element response = request.execute();
             if (log.isDebugEnabled()) {
                 log.debug("Sent request " + request.getSentData());
@@ -687,7 +691,6 @@ class Harvester implements IHarvester<HarvestResult> {
             return new RecordInfo(identif, modified);
         } catch (Exception e) {
             log.warning("Skipped record not in supported format : " + name);
-            e.printStackTrace();
         }
 
         // we get here if we didn't recognize the schema and/or couldn't get the


### PR DESCRIPTION
Instead of having everything on memory until the alignment in the end, start alignment as soon as we have a set of records available.

Improved also the database transaction management: no more forced flushes, rely on normal transactions which is better for general GN behaviour.

Removal of records is done at the end. To do this, we only store a Set<String> with all UUID instead of the full record. Still memory heavy but better than before. Coincidentally, as we are using a HashSet, removal of records is faster (no need to loop over the whole set of records to look for coincidences).

Also, leverages the final load on the database and index writing as it has a request petition between each batch of records.
Also, move some log info messages to debug to improve cleanliness and speed.
Also, improve some error message information.