### PR TITLE
Translate true/false values on xslt formatter. Fixes #3045

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -257,6 +257,24 @@
     </xsl:if>
   </xsl:template>
 
+  <!-- Template for boolean fields that can be empty: no gco:Boolean subelement and @gco:nilReason attribute -->
+  <!-- Uncomment and add required fields to be handled in the match clause -->
+  <!--<xsl:template mode="render-field" match="gmd:pass[@gco:nilReason and not(gco:Boolean)]"
+                priority="100">
+    <xsl:param name="fieldName" select="''" as="xs:string"/>
+
+    <dl>
+      <dt>
+        <xsl:value-of select="if ($fieldName)
+                                  then $fieldName
+                                  else tr:node-label(tr:create($schema), name(), null)"/>
+      </dt>
+      <dd>
+        <xsl:value-of select="$schemaStrings/nilValue"/>
+      </dd>
+    </dl>
+  </xsl:template>-->
+
   <xsl:template mode="render-field"
                 match="*[gco:CharacterString]|gml:beginPosition[. != '']|gml:endPosition[. != '']"
                 priority="50">
@@ -795,7 +813,7 @@
 
   <xsl:template mode="render-value"
                 match="gco:Integer|gco:Decimal|
-       gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
+       gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
        gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|
        gco:LocalName|gml:beginPosition|gml:endPosition">
 
@@ -821,6 +839,21 @@
     <xsl:if test="@uom">
       &#160;<xsl:value-of select="@uom"/>
     </xsl:if>
+  </xsl:template>
+
+  <!-- Translate boolean values -->
+  <xsl:template mode="render-value"
+                match="gco:Boolean">
+
+    <xsl:choose>
+      <xsl:when test=". = 'true'">
+        <xsl:value-of select="$schemaStrings/trueValue"/>
+      </xsl:when>
+      <xsl:when test=". = 'false'">
+        <xsl:value-of select="$schemaStrings/falseValue"/>
+      </xsl:when>
+
+    </xsl:choose>
   </xsl:template>
 
   <!-- filename -->

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/strings.xml
@@ -36,4 +36,8 @@
   <providedBy>Provided by</providedBy>
   <shareOnSocialSite>Share on social sites</shareOnSocialSite>
   <viewMode>Views</viewMode>
+
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/strings.xml
@@ -220,4 +220,7 @@
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
 
+  <trueValue>Si</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Sense definir</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/strings.xml
@@ -84,4 +84,7 @@
   <enum2>is not valid for the field</enum2>
   <enum3>List of values is :</enum3>
 
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/strings.xml
@@ -204,4 +204,8 @@
 
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
+
+  <trueValue>Ja</trueValue>
+  <falseValue>Nee</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
@@ -228,4 +228,8 @@
 
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
+
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/strings.xml
@@ -212,4 +212,7 @@
   <sds-section-custodian>Vastuutaho</sds-section-custodian>
   <sds-addOperation>Lisää toiminto</sds-addOperation>
 
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
@@ -225,4 +225,8 @@
 
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
+
+  <trueValue>Oui</trueValue>
+  <falseValue>Non</falseValue>
+  <nilValue>Non défini</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/strings.xml
@@ -221,4 +221,7 @@
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
 
+  <trueValue>Ja</trueValue>
+  <falseValue>Nein</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/strings.xml
@@ -221,4 +221,8 @@
 
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
+
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/strings.xml
@@ -179,4 +179,8 @@
 
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
+
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/strings.xml
@@ -180,4 +180,8 @@
 
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
+
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/strings.xml
@@ -179,4 +179,8 @@
 
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
+
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/strings.xml
@@ -221,4 +221,7 @@
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
 
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/slo/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/slo/strings.xml
@@ -203,4 +203,8 @@ Zložte identifikátor zdroja pomocou adresy URL katalógu a identifikátora
   <sds-limitation>Obmedzenie</sds-limitation>
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addoperation>Add Operation</sds-addoperation>
+
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Nil</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/strings.xml
@@ -220,4 +220,7 @@
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
 
+  <trueValue>Sí</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>No definido</nilValue>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/strings.xml
@@ -184,4 +184,7 @@
   <sds-section-custodian>Responsible custodian</sds-section-custodian>
   <sds-addOperation>Add Operation</sds-addOperation>
 
+  <trueValue>Yes</trueValue>
+  <falseValue>No</falseValue>
+  <nilValue>Undefined</nilValue>
 </strings>


### PR DESCRIPTION
Translates the true/false values in the detail page full view:

![boolean-values-xslt-formatter](https://user-images.githubusercontent.com/1695003/53864545-07aba800-3fed-11e9-89dc-653261e02a43.png)

Also adds in `view.xsl` a commented template to handle boolean elements that should handle undefined values, that can be uncommented for the required elements.