### PR TITLE
Transfert ownership / group owner may be null

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -820,8 +820,11 @@ public class MetadataSharingApi {
             ApplicationContext context = ApplicationContextHolder.get();
             if(!Objects.equals(groupIdentifier, sourceGrp)) {
               Group newGroup = context.getBean(GroupRepository.class).findOne(groupIdentifier);
-              Group oldGroup = context.getBean(GroupRepository.class).findOne(sourceGrp);
-              new RecordGroupOwnerChangeEvent(metadataId, ApiUtils.getUserSession(session).getUserIdAsInt(), ObjectJSONUtils.convertObjectInJsonObject(oldGroup, RecordGroupOwnerChangeEvent.FIELD), ObjectJSONUtils.convertObjectInJsonObject(newGroup, RecordGroupOwnerChangeEvent.FIELD)).publish(context);
+              Group oldGroup = sourceGrp == null ? null : context.getBean(GroupRepository.class).findOne(sourceGrp);
+              new RecordGroupOwnerChangeEvent(metadataId,
+                  ApiUtils.getUserSession(session).getUserIdAsInt(),
+                  sourceGrp == null ? null : ObjectJSONUtils.convertObjectInJsonObject(oldGroup, RecordGroupOwnerChangeEvent.FIELD),
+                  ObjectJSONUtils.convertObjectInJsonObject(newGroup, RecordGroupOwnerChangeEvent.FIELD)).publish(context);
             }
             if(!Objects.equals(userIdentifier, sourceUsr)) {
               User newOwner = context.getBean(UserRepository.class).findOne(userIdentifier);


### PR DESCRIPTION


Error is related to the record history change. In the model, groupowner may be null. Error is:
```
date: "2019-03-06T10:39:31"
message: "The given id must not be null!; nested exception is java.lang.IllegalArgumentException: The given id must not be null!"
stack: "org.springframework.dao.Invali
```