### PR TITLE
Small UI improvements for the admin `Settings` and `User Interface`

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
@@ -67,7 +67,7 @@
 						</a></td>
 					</tr>
 					<tr>
-						<td><a class="btn btn-link" title="{{'add' | translate}}"
+						<td colspan="2"><a class="btn btn-link" title="{{'add' | translate}}"
 							data-ng-click="addItem(mCfg[key][$index].resolutions, '')"> <i
 								class="fa fa-plus" />
 						</a></td>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -47,7 +47,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], mCfg[key][mCfg[key].length - 1] * 10)">
@@ -80,7 +80,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {key: 'fieldName'})">
@@ -122,7 +122,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'iso3code': 'iso2code'})">
@@ -163,7 +163,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'sortBy': 'fieldName', 'sortOrder': ''})">
@@ -206,7 +206,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'field': 'value'})">
@@ -253,7 +253,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'icon': 'fa-fw', 'tplUrl': '', 'tooltip': ''})">
@@ -295,7 +295,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key].list, {'label': '', 'url': ''})">
@@ -311,9 +311,9 @@
 
 
       <div data-ng-switch-when="linkTypes">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
+        <h3>{{('ui-' + key) | translate}}</h3>
         <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
-          <h3>{{type}}</h3>
+          <label class="control-label">{{type}}</label>
           <table class="table table-striped">
             <tr data-ng-repeat="protocol in value track by $index">
               <td>
@@ -331,7 +331,7 @@
               </td>
             </tr>
             <tr>
-              <td>
+              <td colspan="2">
                 <a class="btn btn-link"
                    title="{{'add' | translate}}"
                    data-ng-click="addItem(mCfg[key][type], 'protocol')">
@@ -350,9 +350,9 @@
 
 
       <div data-ng-switch-when="listOfServices">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
+        <h3>{{('ui-' + key) | translate}}</h3>
         <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
-          <h3>{{type}}</h3>
+          <label class="control-label">{{type}}</label>
           <table class="table table-striped">
             <tr data-ng-repeat="s in value track by $index">
               <td>
@@ -378,7 +378,7 @@
               </td>
             </tr>
             <tr>
-              <td>
+              <td colspan="2">
                 <a class="btn btn-link"
                    title="{{'add' | translate}}"
                    data-ng-click="addItem(mCfg[key][type], {'name': 'Service label', 'url': 'http://'})">
@@ -422,7 +422,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'label': '', 'code': 'EPSG:'})">
@@ -593,8 +593,8 @@
       </div>
 
       <div data-ng-switch-when="grid">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <h3 translate>gridConfigRelatedTypes</h3>
+        <h3>{{('ui-' + key) | translate}}</h3>
+        <label class="control-label" translate>gridConfigRelatedTypes</label>
         <table class="table table-striped">
           <tr data-ng-repeat="relatedType in mCfg[key]['related'] track by $index">
             <td>
@@ -607,7 +607,7 @@
             </td>
           </tr>
           <tr>
-            <td>
+            <td colspan="2">
               <a class="btn btn-link" title="{{'add' | translate}}" data-ng-click="addItem(mCfg[key]['related'], '')">
                 <i class="fa fa-plus"/>
               </a>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
@@ -56,7 +56,7 @@
         </div>
         <div class="panel-body">
           <div class="row">
-            <div class="col-lg-6">
+            <div class="col-lg-6 gn-nopadding-left">
               <label for="filter-settings" data-translate="">filterSettings</label>
               <div class="input-group">
                 <span class="input-group-addon"">
@@ -77,7 +77,7 @@
               </span>
               </div>
             </div>
-            <div class="col-lg-6">
+            <div class="col-lg-6 gn-nopadding-right">
               <div class="btn-toolbar">
                 <button type="submit" class="btn btn-primary pull-right"
                         id="gn-btn-settings-save"

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -154,7 +154,7 @@ ul.gn-resultview li.list-group-item {
     }
     .main {
       margin-left: @gn-sidebar-width;
-      padding: 25px 10px 10px 10px;
+      padding: 25px 10px 50px 10px;
       @media (max-width: @screen-xs-max) {
         margin-left: 0;
       }
@@ -281,6 +281,47 @@ ul.gn-resultview li.list-group-item {
           a {
             &:hover {
               text-decoration: none;
+            }
+          }
+        }
+      }
+    }
+    // settings page
+    [data-ng-controller="GnSystemSettingsController"] {
+      #gn-settings {
+        margin-top: 15px;
+      }
+      fieldset, [data-ng-show="uiConfiguration"] {
+        h1 {
+          font-size: 24px;
+          margin-bottom: 15px;
+          margin-top: 0;
+        }
+        fieldset {
+          padding: 10px;
+          border: 1px solid @panel-default-border;
+          border-bottom-left-radius: @gn-border-radius;
+          border-bottom-right-radius: @gn-border-radius;
+          margin-bottom: 15px;
+          legend {
+            margin: -15px -11px 0 -11px;
+            background-color: @panel-default-heading-bg;
+            border: 1px solid @panel-default-border;
+            padding: 10px;
+            width: calc(~"100% + 22px");
+            font-size: 14px;
+            border-top-left-radius: @gn-border-radius;
+            border-top-right-radius: @gn-border-radius;
+            label {
+              padding-top: 0;
+              font-size: 14px;
+              font-weight: normal;
+            }
+          }
+          .form-group {
+            margin-bottom: 5px;
+            .control-label {
+              margin-bottom: 5px;
             }
           }
         }


### PR DESCRIPTION
Small UI improvements for the admin `Settings` and `User Interface` :
- better hierarchy of labels and headings
- added visual 'blocks' to distinguish between settings/inputs
- more padding at the bottom so the `scrollspy` buttons do not overlap

**Screenshot of the 'blocks'**
![gn-admin-blocks](https://user-images.githubusercontent.com/19608667/53959283-884cd000-40e3-11e9-92be-6f740796351d.png)
