### PR TITLE
Extra padding in the menu items

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -17,6 +17,13 @@
       color: @gn-menubar-color-hover;
     }
   }
+  .dropdown-menu {
+    > li {
+      > a {
+        padding: 8px 20px;
+      }
+    }
+  }
   .gn-name.gn-truncate {
     @media (min-width: @screen-lg-min) {
       max-width: 230px;


### PR DESCRIPTION
This PR adds a little bit more padding/whitespace in the dropdown menus for better readability

**Screenshot of the new padding**
![gn-menu-extra-padding](https://user-images.githubusercontent.com/19608667/54130592-f27db180-4410-11e9-8ce0-0ebc29075cf0.png)
