### PR TITLE
Editor / State of collapsed fieldset

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -140,6 +140,8 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="refToDelete" required="no"/>
+    <xsl:variable name="name" select="name(.)"/>
+    <xsl:variable name="isSupportingSlideToggle" select="$editorConfig/editor/fieldsWithFieldset/name[.=$name]/@isSupportingSlideToggle='true'"/>
 
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
@@ -163,6 +165,7 @@
       <xsl:with-param name="editInfo" select="if ($refToDelete) then $refToDelete else gn:element"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="isSlideToggle" select="if ($isSupportingSlideToggle and $isDisplayingSections = false()) then 'true' else 'false'"/>
       <xsl:with-param name="attributesSnippet" select="$attributes"/>
       <xsl:with-param name="subTreeSnippet">
         <!-- Process child of those element. Propagate schema

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -363,6 +363,8 @@
                getInputValue('displayTooltips') == 'true',
                displayTooltipsMode:
                getInputValue('displayTooltipsMode') || '',
+               displaySections:
+               getInputValue('displaySections') == 'true',
                schema: getInputValue('schema'),
                version: getInputValue('version'),
                tab: getInputValue('currTab'),

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -540,20 +540,27 @@
    *
    * Add the event attribute to define a custom event.
    */
-  module.directive('gnToggle', [
-    function() {
+  module.directive('gnToggle', [ 'gnCurrentEdit',
+    function(gnCurrentEdit) {
       return {
         restrict: 'A',
         template: '<button title="{{\'gnToggle\' | translate}}">' +
-            '<i class="fa fa-fw fa-angle-double-up"/>&nbsp;' +
+            '<i class="fa fa-fw {{gnCurrentEdit.displaySections === true ? \'fa-angle-double-up\' : \'fa-angle-double-down\'}}"/>&nbsp;' +
             '</button>',
         link: function linkFn(scope, element, attr) {
           var selector = attr['gnSectionToggle'] ||
               'form > fieldset > legend[data-gn-slide-toggle]',
               event = attr['event'] || 'click';
           element.on('click', function() {
+            scope.gnCurrentEdit.displaySections = !(scope.gnCurrentEdit.displaySections === true);
+            $("#displaySections")[0].value = scope.gnCurrentEdit.displaySections;
             $(selector).each(function(idx, elem) {
-              $(elem).trigger(event);
+              if (scope.gnCurrentEdit.displaySections === true && elem.className.contains('collapsed')) {
+                $(elem).trigger(event);
+              }
+              if (scope.gnCurrentEdit.displaySections === false && !elem.className.contains('collapsed')) {
+                $(elem).trigger(event);
+              }
             });
             $(this).find('i').toggleClass(
                 'fa-angle-double-up fa-angle-double-down');

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -235,6 +235,7 @@
                   displayAttributes: $location.search()['displayAttributes'] === 'true',
                   displayTooltips: $location.search()['displayTooltips'] === 'true',
                   displayTooltipsMode: $location.search()['displayTooltipsMode'] || '',
+                  displaySections: ($location.search()['displaySections'] || 'true') === 'true',
                   compileScope: $scope,
                   formScope: $scope.$new(),
                   sessionStartTime: moment(),
@@ -266,6 +267,9 @@
                   editorFormUrl += '&displayTooltipsMode='
                     + gnCurrentEdit.displayTooltipsMode ;
                 }
+
+                editorFormUrl += '&displaySections='
+                	+ (gnCurrentEdit.displaySections === true ? 'true' : 'false');
 
                 gnEditor.load(editorFormUrl).then(function() {
                   // $scope.onFormLoad();

--- a/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
@@ -135,6 +135,12 @@
                         else if ($viewConfig/@displayTooltipsMode)
                         then $viewConfig/@displayTooltipsMode
                         else ''"/>
+  <xsl:variable name="isDisplayingSections"
+                select="if (/root/request/displaySections)
+                        then /root/request/displaySections = 'true'
+                        else if ($viewConfig/@displaySections)
+                        then $viewConfig/@displaySections = 'true'
+                        else true()"/>
 
 
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
@@ -100,6 +100,8 @@
                  value="{$isDisplayingTooltips = true()}"/>
           <input type="hidden" id="displayTooltipsMode" name="displayTooltipsMode"
                  value="{$displayTooltipsMode}"/>
+          <input type="hidden" id="displaySections" name="displaySections"
+                 value="{$isDisplayingSections = true()}"/>
           <input type="hidden" id="minor" name="minor" value="{$isMinorEdit}"/>
           <input type="hidden" id="flat" name="flat" value="{$isFlatMode}"/>
           <input type="hidden" id="showvalidationerrors" name="showvalidationerrors"

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -350,6 +350,9 @@
       <null/>
     </xsl:param>
     <xsl:param name="isDisabled" select="ancestor::node()[@xlink:href]"/>
+    <!-- Collapsed fieldsets reopens when saving, this param can be
+    used to collapse again the fieldset after loading -->
+    <xsl:param name="isSlideToggle" select="false()" required="no"/>
 
 
     <xsl:variable name="hasXlink" select="@xlink:href"/>
@@ -359,7 +362,7 @@
               class="{if ($hasXlink) then 'gn-has-xlink' else ''} gn-{substring-after(name(), ':')}">
 
       <legend class="{$cls}"
-              data-gn-slide-toggle=""
+              data-gn-slide-toggle="{$isSlideToggle}"
               data-gn-field-tooltip="{$schema}|{name()}|{name(..)}|">
         <!--
          The toggle title is in conflict with the element title

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -68,7 +68,7 @@
           <fieldset data-gn-field-highlight="" class="gn-{@name}">
             <!-- Get translation for labels.
             If labels contains ':', search into labels.xml. -->
-            <legend data-gn-slide-toggle="">
+            <legend data-gn-slide-toggle="{if ($isDisplayingSections = true()) then 'false' else 'true'}">
               <xsl:value-of
                 select="if (contains($sectionName, ':'))
                   then gn-fn-metadata:getLabel($schema, $sectionName, $labels)/label


### PR DESCRIPTION
**Describe the bug**
In the editor, the 'Show/hide sections'-button to show or hide all toplevel fieldsets has no state when saving the metadata or adding/deleting fields.  When you collapse some fieldsets to have a better overview and click on the save button, all the fieldsets are opened again.  This is not a good behavior.  Also the 'Show/hide sections'-button has a toggle function and doesn't close or open all the fieldsets.  When you have a mixture of closed and opened fieldsets and you click to close all fieldsets, the closed ones are opened.

**To Reproduce**
Steps to reproduce the behavior:
1. Log in and create a new dataset
2. Close some fieldsets
3. Click on the 'Show/hide sections'-button in top of the editor
![image](https://user-images.githubusercontent.com/3977442/54279787-3bab3e00-4596-11e9-9608-f8dba4a9efe7.png)
4. Not all fieldsets are closed, the fieldsets closed in step 2 are opened again.
5. When saving the metadata, all fieldsets are opened again regardless of the state of the 'Show/hide sections'-button:
![image](https://user-images.githubusercontent.com/3977442/54279787-3bab3e00-4596-11e9-9608-f8dba4a9efe7.png) ![image](https://user-images.githubusercontent.com/3977442/54281360-de18f080-4599-11e9-93f5-1b6abdda49a7.png)

**Expected behavior**
When closing the fieldsets with the 'Show/hide sections'-button, all fieldsets must be closed and the closed ones must stay closed.
When opening the fieldsets with the 'Show/hide sections'-button, all fieldsets must be opened and the opened ones must stay opened.
When saving the metadata, the 'Show/hide sections'-button must have the same state as before the save action.  Fieldsets must be closed or opened all depending on the state of the 'Show/hide sections'-button.

**Screenshots**
Not applicable.

**Log file**
Not applicable

**Desktop**
 - All browsers
 - GeoNetwork Version 3.6 and lower
 - Tomcat 8 with Java 8

**Additional context**
Not applicable

**Root cause**
The 'Show/hide sections'-button is toggling the fieldsets and not closing or opening the fieldsets.

**Proposed solution**
The proposed solution is resolving the fieldset toggling effect and will save the state of the 'Show/hide sections-button.  When fieldsets are closed by using the 'Show/hide sections-button and the metadata is saved, only the fieldsets defined in the config-editor.xml containing a isSupportingSlideToggle="true" will be closed again.

`
<fieldsWithFieldset>
    ...
    <name isSupportingSlideToggle="true">gmd:identificationInfo</name>
    ...
</fieldsWithFieldset>
`
