### PR TITLE
Small UI changes to Projection Switcher

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/partials/projectionSwitcher.html
@@ -1,11 +1,20 @@
-<ul class="list-group">
-	<li ng-repeat="p in (projections)" class="input-group"
-		data-ng-click="switchProjection(p.code)"
-		data-ng-class="map.getView().getProjection().getCode() == p.code ? 'active' : ''"
-		data-ng-if="map.getView().getProjection().getCode() == p.code || listOpen"><span
-		class="input-group-addon" data-ng-translate="">projection</span> <span
-		class="form-control clickable">{{p.label}} <span style="float: right"
-			class="fa clickable" data-ng-click="toggleList()"
-			data-ng-if="map.getView().getProjection().getCode() == p.code"
-			data-ng-class="listOpen? 'fa-caret-left' : 'fa-caret-down'"></span></span></li>
-</ul>
+<div class="input-group">
+	<span class="input-group-addon" data-ng-translate="">projection</span>
+	<ul>
+		<li ng-repeat="p in (projections)" 
+				class="form-control "
+				data-ng-click="switchProjection(p.code)"
+				data-ng-class="map.getView().getProjection().getCode() == p.code ? 'active' : ''"
+				data-ng-if="map.getView().getProjection().getCode() == p.code || listOpen">
+			<span	class="clickable">{{p.label}}</span>
+		</li>
+	</ul>
+	<span class="input-group-btn">
+		<button data-ng-click="toggleList()"
+					  type="button"
+						class="btn btn-default">
+			<span class="fa clickable"
+						data-ng-class="listOpen? 'fa-caret-left' : 'fa-caret-down'"></span>
+		</button>
+	</span>
+</div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -61,6 +61,44 @@
       }
     }
   }
+  [gn-projection-switcher] {
+    .input-group-addon {
+      width: 7em;
+      border-radius: 0;
+    }
+    ul {
+      margin: 0;
+      padding: 0;
+      position: absolute;
+      width: 16.5em;
+      border-radius: 0;
+      li {
+        width: calc(~"100% -30px");
+        border-radius: 0;
+        box-shadow: none;
+        cursor: pointer;
+        &.active {
+          font-weight: 500;
+          color: #000;
+        }
+        &:hover {
+          background-color: @dropdown-link-hover-bg;
+        }
+      }
+      li:not(:first-child) {
+        margin-top: -1px;
+      }
+    }
+    .btn {
+      width: 2.5em;
+      border-radius: 0;
+      border-left: 0;
+      &:active, &:focus {
+        background-color: @btn-default-bg;
+        border-color: @btn-default-border;
+      }
+    }
+  }
 }
 
 // minimap on search results


### PR DESCRIPTION
This PR changes the styling of the Projection Switcher on the map. The styling is now more like the search box on the map.

Changes:
- projection label shown once
- toggle button stays on first row
- toggle now has button styling
- current projection is highlighted
- background color on hover
- pointer cursor

**Old styling:**
![gn-projection-old](https://user-images.githubusercontent.com/19608667/54344880-27247f80-4642-11e9-8ea6-4757345bdb99.png)

**New styling:**
![gn-projection-new](https://user-images.githubusercontent.com/19608667/54345129-b3cf3d80-4642-11e9-9c87-9674b58408bd.png)

