### PR TITLE
Sign in/out / Add option to sign in in a third party app like GeoServer.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -37,12 +37,13 @@ goog.require('gn_saved_selections');
 goog.require('gn_search_manager');
 goog.require('gn_session_service');
 goog.require('gn_alert');
+goog.require('gn_login_service');
 
 
   var module = angular.module('gn_cat_controller',
       ['gn_search_manager', 'gn_session_service',
         'gn_admin_menu', 'gn_saved_selections',
-        'gn_external_viewer', 'gn_history', 'gn_alert']);
+        'gn_external_viewer', 'gn_history', 'gn_alert', 'gn_login_service']);
 
 
   module.constant('gnSearchSettings', {});
@@ -419,13 +420,13 @@ goog.require('gn_alert');
     'gnGlobalSettings', '$location', 'gnUtilityService',
     'gnSessionService', 'gnLangs', 'gnAdminMenu',
     'gnViewerSettings', 'gnSearchSettings', '$cookies',
-    'gnExternalViewer', 'gnAlertService',
+    'gnExternalViewer', 'gnAlertService', 'gnLoginService',
     function($scope, $http, $q, $rootScope, $translate,
              gnSearchManagerService, gnConfigService, gnConfig,
              gnGlobalSettings, $location, gnUtilityService,
              gnSessionService, gnLangs, gnAdminMenu,
              gnViewerSettings, gnSearchSettings, $cookies,
-             gnExternalViewer, gnAlertService) {
+             gnExternalViewer, gnAlertService, gnLoginService) {
       $scope.version = '0.0.1';
 
 
@@ -736,6 +737,9 @@ goog.require('gn_alert');
       $http.get('../../warninghealthcheck')
         .success(healthCheckStatus)
         .error(healthCheckStatus);
+
+      $scope.signin = gnLoginService.signin;
+      $scope.signout = gnLoginService.signout;
     }]);
 
 })();

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -28,11 +28,13 @@
 
   goog.require('gn_catalog_service');
   goog.require('gn_utility');
+  goog.require('gn_login_service');
 
   var module = angular.module('gn_login_controller', [
     'gn_utility',
     'gn_catalog_service',
-    'vcRecaptcha'
+    'vcRecaptcha',
+    'gn_login_service'
   ]);
 
   /**
@@ -42,11 +44,11 @@
       ['$scope', '$http', '$rootScope', '$translate',
        '$location', '$window', '$timeout',
        'gnUtilityService', 'gnConfig', 'gnGlobalSettings',
-       'vcRecaptchaService', '$q',
+       'vcRecaptchaService', '$q', 'gnLoginService',
        function($scope, $http, $rootScope, $translate,
            $location, $window, $timeout,
                gnUtilityService, gnConfig, gnGlobalSettings,
-               vcRecaptchaService, $q) {
+               vcRecaptchaService, $q, gnLoginService) {
           $scope.formAction = '../../signin#' +
          $location.path();
           $scope.registrationStatus = null;
@@ -188,6 +190,8 @@
                   window.location.href = redirectTo;
            });
          };
+
+         $scope.signin = gnLoginService.signin;
 
          initForm();
 

--- a/web-ui/src/main/resources/catalog/js/LoginService.js
+++ b/web-ui/src/main/resources/catalog/js/LoginService.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+(function() {
+
+  goog.provide('gn_login_service');
+
+  var module = angular.module('gn_login_service', []);
+
+  /**
+   * Take care of sign in/out
+   */
+  module.factory('gnLoginService',
+      ['$http',
+       function($http) {
+
+          // Enable login in third party app. eg. geoserver
+          // var thirdPartyAuthApp = {
+          //   signin: '/geoserver/j_spring_security_check',
+          //   signout: '/geoserver/j_spring_security_logout'
+          // };
+          var thirdPartyAuthApp = undefined;
+
+          return {
+            /**
+             * Sign in first in the thirdparty app if one provided,
+             * and then in the catalogue.
+             *
+             * @param formId
+             * @param u
+             * @param p
+             */
+            signin: function(formId, u, p) {
+              formId = '#' + formId;
+              if (thirdPartyAuthApp) {
+                $http.post(window.location.origin + thirdPartyAuthApp.signin,
+                  $.param({
+                    username: u,
+                    password: p
+                  }), {
+                    headers: {
+                      'Content-Type':
+                        'application/x-www-form-urlencoded'
+                    }
+                  }).then(function (r) {
+                  $(formId).get(0).submit()
+                }, function (r) {
+                    console.warn(
+                      "Failed to authenticate on third party app using URL "
+                      + thirdPartyAuthApp.signin
+                      + ". Response status is " + r.status);
+                  $(formId).get(0).submit()
+                });
+              } else {
+                $(formId).get(0).submit()
+              }
+            },
+            /**
+             * Sign out in third party app first if any, then sign out from the catalogue.
+             * @param url
+             */
+            signout: function(url) {
+              if (thirdPartyAuthApp) {
+                $http.get(window.location.origin + thirdPartyAuthApp.signout).then(
+                  function (r) {
+                    window.location = url;
+                  },
+                  function (r) {
+                    window.location = url;
+                  }
+                );
+              } else {
+                window.location = url;
+              }
+            }
+          };
+       }]);
+
+})();

--- a/web-ui/src/main/resources/catalog/templates/signin.html
+++ b/web-ui/src/main/resources/catalog/templates/signin.html
@@ -7,7 +7,7 @@
         </div>
         <div class="panel-body">
           <p data-translate="">loginText</p>
-          <form class="form-horizontal" name="gnSigninForm" action="{{formAction}}"
+          <form class="form-horizontal" name="gnSigninForm" id="gnSigninForm" action="{{formAction}}"
                 method="post" role="form" data-ng-if="::user" data-ng-show="!shibbolethEnabled">
             <input type="hidden" name="_csrf" value="{{csrf}}"/>
   
@@ -52,13 +52,12 @@
                           <input type="checkbox"/><span translate>rememberMe</span>
                       </label>
                   </div>-->
-  
-            <button type="submit"
+            <a data-ng-click="signin('gnSigninForm', signinUsername, signinPassword)"
                     class="btn btn-primary btn-block"
                     data-ng-disabled="!gnSigninForm.$valid">
               <i class="fa fa-fw fa-sign-in"/>
               <span data-translate="">signIn</span>
-            </button>
+            </a>
           </form>
   
           <p class="text-danger"

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -188,8 +188,8 @@
           </li>
           <li role="separator" class="divider hidden-xs"></li>
           <li role="menuitem">
-            <a href="{{gnCfg.mods.signout.appUrl}}"
-               title="{{'signout' | translate}}">
+            <a data-ng-click="signout(gnCfg.mods.signout.appUrl)"
+                   title="{{'signout' | translate}}">
               <i class="fa fa-sign-out"></i>&nbsp;
               {{'signout' | translate}}
             </a>
@@ -208,7 +208,7 @@
         </a>
         <ul class="dropdown-menu" role="menu">
           <li role="menuitem">
-            <form name="gnSigninForm" class="navbar-form flex-row"
+            <form name="gnSigninForm" id="gnSigninForm" class="navbar-form flex-row"
               action="{{signInFormAction}}" method="post" role="form">
               <input type="hidden" name="_csrf" value="{{csrf}}"/>
               <div class="form-group form-group-sm">
@@ -236,11 +236,11 @@
                 </div>
               </div>
               <div class="flex-spacer hidden-xs"></div>
-              <button type="submit" class="btn btn-primary btn-sm pull-right"
-                      aria-label="{{'signIn' | translate}}"
-                      data-ng-disabled="!gnSigninForm.$valid">
-                <i class="fa fa-sign-in"></i>
-              </button>
+              <a data-ng-click="signin('gnSigninForm', signinUsername, signinPassword)"
+                 class="btn btn-primary btn-sm pull-right"
+                 data-ng-disabled="!gnSigninForm.$valid">
+                <i class="fa fa-fw fa-sign-in"/>
+              </a>
             </form>
           </li>
         </ul>


### PR DESCRIPTION
Sometimes, users have a GeoServer instance next to GeoNetwork which use
same accounts. When SSO system is not setup, then it requires to sign in
in both apps to access secured layers in the map viewer.

This introduce the possibility to trigger a sign in and sign out action
in a third party before connecting to the catalogue.

If user does not exist in third party app, then authentication is only made in the catalogue.


![image](https://user-images.githubusercontent.com/1701393/54430948-58c24700-4725-11e9-8c78-17cd5a89479a.png)
