### PR TITLE
Fix labels not shown in Add button

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -341,6 +341,7 @@
           <xsl:if test="($nonExistingChildParent/* and not(@ifNotExist)) or
             ($nonExistingChildParent/* and count($nodes/*) = 0 and @ifNotExist)">
             <xsl:variable name="childName" select="@or"/>
+            <xsl:variable name="xpath" select="@xpath"/>
 
             <xsl:for-each select="$nonExistingChildParent/*/gn:child[@name = $childName]">
               <xsl:variable name="name" select="concat(@prefix, ':', @name)"/>
@@ -349,7 +350,7 @@
                             select="gn-fn-metadata:getFieldAddDirective($editorConfig, $name)"/>
 
               <xsl:variable name="labelConfig"
-                            select="gn-fn-metadata:getLabel($schema, $name, $labels)"/>
+                            select="gn-fn-metadata:getLabel($schema, $name, $labels, '', '', $xpath)"/>
               <xsl:call-template name="render-element-to-add">
                 <xsl:with-param name="label"
                                 select="if ($configName != '')


### PR DESCRIPTION
**Bug Description**
In the config editor, if a field is declared like following:
`<field name="$fieldNode" xpath="$xpath" or="name" in="parent-xpath"/>`
And a translation in the label.xml file like so:
`<element name="$fieldNode" context="$xpath"><btnLabel>My label</btnLabel></element>`
The generated + button for this field will not have "My label" displayed in it.

**Screenshots**
![image](https://user-images.githubusercontent.com/32705577/54525639-f3649500-4974-11e9-9972-437442e57d03.png)

**Expected behavior**
The content of the `<btnLabel>` tag should be displayed in the + button

**Log file**
No applicable

**Desktop (please complete the following information):**
 - GeoNetwork Version 3.6
 - Server Application Tomcat 8 with Java 8

**Additional context**
No applicable

**Root cause**
In the form-configurator.xml, in the template matching `<field>` tag, the function `gn-fn-metadata:getLabel` is called to retrieve the content of the `<btnLabel>` but the xpath is not sent as an argument.

**Proposed solution**
When the content of `<btnLabel>` is retrieved, the xpath attribute of the `<field>` tag is also taken in account by sending it in argument of `gn-fn-metadata:getLabel` function.

