### PR TITLE
Fix metadata text node saving

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -342,8 +342,13 @@ public class EditLib {
                     if (replaceExisting) {
                         @SuppressWarnings("unchecked")
                         List<Element> children = node.getChildren();
-                        for (Element child: children) {
-                            el.addContent((Element) child.clone());
+                        if(children.size() > 0) {
+                            for (Element child: children) {
+                                el.addContent((Element) child.clone());
+                            }
+                        } else {
+                            String textContent = node.getText();
+                            el.addContent(textContent);
                         }
                         List<Attribute> attributes = node.getAttributes();
                         for (Attribute a : attributes) {


### PR DESCRIPTION
**Bug Description**
For our Dcat-ap plugin, we encountered a issue where some fields in the editor are not saved at all. Filling-up those inputs with some text then saving the editor does not modify the record. When the editor reload, those inputs fields are emptied.

**Expected behavior**
When saving the editor, the modifications made for those fields should be saved in the database and when the editor reloads, the fields should be pre-filled with the value previously encoded in it.

**Screenshots**
![image](https://user-images.githubusercontent.com/32705577/54594269-9af2cd80-4a30-11e9-9386-314ca3b6fb22.png)

**Log file**
Not applicable.

**Desktop**
- All browsers
- GeoNetwork Version 3.6 and lower
- Tomcat 8 with Java 8

**Additional context**
Not applicable.

**Root cause**
When saving the editor, multiple xml fragments are sent in the back-end to be applied to the edited record.
If an XML fragment is sent with a "replace" flag, GeoNetwork will try to it iterate over all the child nodes of this fragment and add each child to the content of the record. When the XML fragment is a text node, the iteration will not happen even once and the fragment will not be added to the record.

**Proposed solution**
The proposed solution is to check before looping over all the child nodes of an XML fragment if the XML fragment is a text node. If it is the case, the fragment is directly applied without trying to loop over its child.