### PR TITLE
Fix WMS default legend URL

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -899,10 +899,8 @@
               }
 
               if (!requestedStyle && this.containsStyles(getCapLayer)) {
-                legendUrl = (getCapLayer.Style[getCapLayer.
-                    Style.length - 1].LegendURL) ?
-                    getCapLayer.Style[getCapLayer.
-                        Style.length - 1].LegendURL[0] : undefined;
+                legendUrl = (getCapLayer.Style[0].LegendURL) ?
+                    getCapLayer.Style[0].LegendURL[0] : undefined;
               }
 
               if (legendUrl) {


### PR DESCRIPTION
When parsing WMS GetCapabilites, the default selected legend URL should be from the first `Style` object and not the last. This is to be consistent with the fact that the default selected style is the first too.

This can be tested with the following path:
http://localhost:8080/geonetwork/srv/fre/catalog.search#/map?wmsurl=http:%2F%2Fsdn.oceanbrowser.net%2Fweb-vis%2FPython%2Fweb%2Fwms&layername=Mediterranean%20Sea%2FTemperature.19002013.4Danl.nc*Temperature_L2

Result:
![image](https://user-images.githubusercontent.com/10629150/54540025-87475880-4997-11e9-837f-52457244f14c.png)
