### PR TITLE
Add maven properties to set Jetty port

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -854,8 +854,11 @@
               <value>5000000</value>
             </systemProperty>
           </systemProperties>
+          <httpConnector>
+            <port>${jetty.port}</port>
+          </httpConnector>
           <stopKey>JETTY_TOP</stopKey>
-          <stopPort>8090</stopPort>
+          <stopPort>${jetty.stop.port}</stopPort>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Restore https://github.com/geonetwork/core-geonetwork/commit/ff23797410e7e69d68c6ff6afde2441401cd60e9 which has been partially dropped at some point.