### PR TITLE
Harvester / Avoid to set empty XSL transformation

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/importxsl/ImportXSLDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/importxsl/ImportXSLDirective.js
@@ -47,7 +47,9 @@
               .success(function(data) {
                 scope.stylesheets = data;
                 scope.stylesheets.unshift('');
-                scope.element = scope.stylesheets[0];
+                if (angular.isUndefined(scope.element) || angular.isObject(scope.element)) {
+                  scope.element = scope.stylesheets[0];
+                }
               });
         }
       };


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/commit/4193933ea0f19daae75c2050f8bf679d582ab086

In some cases, the element is an object and the empty line was added in such case.

Only setup the element value to the first transformation if it is not set to avoid a reset. In debug mode, it was working but not in prod mode.

Cache the call to get the list of transformation.