### PR TITLE
Search / Add support to negative query on any fields

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryBuilder.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneQueryBuilder.java
@@ -525,8 +525,10 @@ public class LuceneQueryBuilder {
                 addNotRequiredTextField(fieldValue, LuceneIndexField.ANY, similarity, (criteriaIsASet ? bq : query));
             }
             // without
-            else if ("without".equals(fieldName)) {
-                addProhibitedTextField(fieldValue, LuceneIndexField.ANY, (criteriaIsASet ? bq : query));
+            else if (fieldName.startsWith("without")) {
+                addProhibitedTextField(fieldValue,
+                    fieldName.contains("-") ? fieldName.split("-")[1] : LuceneIndexField.ANY,
+                    (criteriaIsASet ? bq : query));
             }
             // phrase
             else if ("phrase".equals(fieldName)) {


### PR DESCRIPTION
Before that change, only `without=something` was building a negative full text query on `any` field.

This adds support to do negative query on all fields eg. `&without-_cat=geodatacore&` = Do not contain category geodatacore