### PR TITLE
ES / Return the synonym found.

### DIFF
--- a/es/es-core/src/main/java/org/fao/geonet/es/EsClient.java
+++ b/es/es-core/src/main/java/org/fao/geonet/es/EsClient.java
@@ -265,7 +265,7 @@ public class EsClient implements InitializingBean {
                     JsonObject token = tokens.get(0).getAsJsonObject();
                     String type = token.get("type").getAsString();
                     if ("SYNONYM".equals(type) || "word".equals(type)) {
-                        analyzedValue = token.get("token").getAsString();
+                        return token.get("token").getAsString();
                     }
                 }
                 return "";


### PR DESCRIPTION
Currently it always return empty text. 