### PR TITLE
Schematron / Add criteria to filter on user main profile.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/schematron/criteria-type.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/schematron/criteria-type.xml
@@ -47,6 +47,12 @@
   </type>
   <type>
     <value>@@value@@</value>
+    <type>USER_MAIN_PROFILE</type>
+    <name>UserMainProfile</name>
+    <allowArbitraryValue>true</allowArbitraryValue>
+  </type>
+  <type>
+    <value>@@value@@</value>
     <type>GROUP</type>
     <name>Group</name>
     <allowArbitraryValue>true</allowArbitraryValue>


### PR DESCRIPTION
This adds the possibility to trigger a validation rule only for user with some profiles. The use case here is that we have some editors populating the main information with some basic level of validation and then catalogue administrator are reviewing records with an extra set of rules.

![image](https://user-images.githubusercontent.com/1701393/54991858-208cf500-4fbe-11e9-831e-b6fd19b79d19.png)

One issue with that criteria is that a record may be valid for some users and invalid for some others but if used in the context of a workflow with clear profiles and persons in charge of the final validation that is useful.