### PR TITLE
Report about failed schematron executions

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/SchematronValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchematronValidator.java
@@ -77,7 +77,7 @@ public class SchematronValidator {
             }
         } catch (Throwable e) {
             Element errorReport = new Element("schematronVerificationError", Edit.NAMESPACE);
-            errorReport.addContent("Schematron error ocurred, rules could not be verified: " + e.getMessage());
+            errorReport.addContent("Schematron error occurred, rules could not be verified: " + e.getMessage());
             schemaTronXmlOut.addContent(errorReport);
         }
 
@@ -200,7 +200,7 @@ public class SchematronValidator {
 
             // If an error occurs that prevents to verify schematron rules, add to show in report
             Element errorReport = new Element("schematronVerificationError", Edit.NAMESPACE);
-            errorReport.addContent("Schematron error ocurred, rules could not be verified: " + e.getMessage());
+            errorReport.addContent("Schematron error occurred, rules could not be verified: " + e.getMessage());
             report.addContent(errorReport);
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -127,32 +127,38 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
                 Iterator reports = schemaTronReport.getDescendants(ReportFinder);
                 while (reports.hasNext()) {
                     Element report = (Element) reports.next();
+                    Element schematronVerificationError = report.getChild("schematronVerificationError", Edit.NAMESPACE);
 
-                    Iterator errors = report.getDescendants(ErrorFinder);
-                    while (errors.hasNext()) {
-                        Element err = (Element) errors.next();
 
-                        StringBuilder msg = new StringBuilder();
-                        String reportType;
-                        if (err.getName().equals("failed-assert")) {
-                            reportType = report.getAttributeValue("rule", Edit.NAMESPACE);
-                            reportType = reportType == null ? "No name for rule" : reportType;
+                    if (schematronVerificationError != null) {
+                        errorReport.append("schematronVerificationError: " + schematronVerificationError.getTextTrim());
+                    } else {
+                        Iterator errors = report.getDescendants(ErrorFinder);
+                        while (errors.hasNext()) {
+                            Element err = (Element) errors.next();
 
-                            Iterator descendants = err.getDescendants();
-                            while (descendants.hasNext()) {
-                                Object node = descendants.next();
-                                if (node instanceof Element) {
-                                    String textTrim = ((Element) node).getTextTrim();
-                                    msg.append(textTrim).append(" \n");
+                            StringBuilder msg = new StringBuilder();
+                            String reportType;
+                            if (err.getName().equals("failed-assert")) {
+                                reportType = report.getAttributeValue("rule", Edit.NAMESPACE);
+                                reportType = reportType == null ? "No name for rule" : reportType;
+
+                                Iterator descendants = err.getDescendants();
+                                while (descendants.hasNext()) {
+                                    Object node = descendants.next();
+                                    if (node instanceof Element) {
+                                        String textTrim = ((Element) node).getTextTrim();
+                                        msg.append(textTrim).append(" \n");
+                                    }
                                 }
+                            } else {
+                                reportType = "Xsd Error";
+                                msg.append(err.getChildText("message", Edit.NAMESPACE));
                             }
-                        } else {
-                            reportType = "Xsd Error";
-                            msg.append(err.getChildText("message", Edit.NAMESPACE));
-                        }
 
-                        if (msg.length() > 0) {
-                            errorReport.append(reportType).append(':').append(msg);
+                            if (msg.length() > 0) {
+                                errorReport.append(reportType).append(':').append(msg);
+                            }
                         }
                     }
                 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -332,7 +332,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
 
                     // If an error occurs that prevents to verify schematron rules, add to show in report
                     Element errorReport = new Element("schematronVerificationError", Edit.NAMESPACE);
-                    errorReport.addContent("Schematron error ocurred, rules could not be verified: " + e.getMessage());
+                    errorReport.addContent("Schematron error occurred, rules could not be verified: " + e.getMessage());
                     report.addContent(errorReport);
                     LOGGER.error("schematron xslt failed, exception", e);
                 }

--- a/services/src/main/java/org/fao/geonet/api/records/model/validation/Report.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/validation/Report.java
@@ -1,6 +1,8 @@
 
 package org.fao.geonet.api.records.model.validation;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.math.BigInteger;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -30,6 +32,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *         &lt;element ref="{}total"/>
  *         &lt;element ref="{}requirement"/>
  *         &lt;element ref="{}patterns"/>
+ *         &lt;element ref="{}schematronVerificationError"/>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
@@ -47,7 +50,8 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
     "success",
     "total",
     "requirement",
-    "patterns"
+    "patterns",
+    "schematronVerificationError"
 })
 @XmlRootElement(name = "report")
 public class Report {
@@ -72,6 +76,9 @@ public class Report {
     protected String requirement;
     @XmlElement(required = true)
     protected Patterns patterns;
+    @XmlElement(required = false)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    protected String schematronVerificationError;
 
     /**
      * Gets the value of the id property.
@@ -263,6 +270,23 @@ public class Report {
      */
     public void setPatterns(Patterns value) {
         this.patterns = value;
+    }
+
+    /**
+     * Gets the value of schematronVerificationError. This is set when a failure occurred while a schematron run.
+     *
+     * @return the schematronVerificationError property.
+     */
+    public String getSchematronVerificationError() {
+        return schematronVerificationError;
+    }
+
+    /**
+     * Sets the value of schematronVerificationError property.
+     * @param schematronVerificationError the error message.
+     */
+    public void setSchematronVerificationError(String schematronVerificationError) {
+        this.schematronVerificationError = schematronVerificationError;
     }
 
 }

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -1,7 +1,7 @@
 <div id="gn-editor-validation-panel" class="panel panel-default" data-ng-class="getClass()">
   <div class="panel-heading"
        data-gn-slide-toggle="">
-    <i class="fa" data-ng-class="getClass('icon')"></i>&nbsp;
+    <i class="fa fa-fw" data-ng-class="getClass('icon')"></i>&nbsp;
     <span data-translate="">validationReport</span>
 
     <button type="button" class="btn btn-default pull-right btn-xs gn-btn-fix"
@@ -46,7 +46,7 @@
         <div data-gn-slide-toggle="" class="panel-heading clearfix">
           <div class="col-md-9">
             <h2 class="gn-schematron-title"><span data-ng-if="type.schematronVerificationError">
-              <i class="fa fa-exclamation-triangle text-danger"></i>&nbsp;</span>{{(type.label || type.id) | translate}}</h2>
+              <i class="fa fa-exclamation-triangle fa-fw text-danger"></i>&nbsp;</span>{{(type.label || type.id) | translate}}</h2>
           </div>
           <div class="col-md-3 gn-nopadding-right" data-ng-if="!type.schematronVerificationError">
 
@@ -65,7 +65,7 @@
           </div>
           <div class="col-md-3 gn-nopadding-right" data-ng-if="type.schematronVerificationError">
             <span class="label pull-right label-danger" data-translate="">
-              runServiceError
+              validationServiceError
             </span>
           </div>
         </div>
@@ -73,6 +73,7 @@
           <ul class="list-group">
             <li class="list-group-item text-danger">
               <p>{{type.schematronVerificationError}}</p>
+              <p data-translate="">validationServiceErrorDetail</p>
             </li>
           </ul>
         </div>

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -45,9 +45,11 @@
            data-ng-class="'schematron-result-list-' + labelImportanceClass(type)">
         <div data-gn-slide-toggle="" class="panel-heading clearfix">
           <div class="col-md-9">
-            <h2 class="gn-schematron-title">{{(type.label || type.id) | translate}}</h2>
+            <h2 class="gn-schematron-title"><span data-ng-if="type.schematronVerificationError">
+              <i class="fa fa-exclamation-triangle text-danger"></i>&nbsp;</span>{{(type.label || type.id) | translate}}</h2>
           </div>
-          <div class="col-md-3 gn-nopadding-right">
+          <div class="col-md-3 gn-nopadding-right" data-ng-if="!type.schematronVerificationError">
+
             <span class="label pull-right"
                   data-ng-class="labelImportanceClass(type)"
                   data-ng-if="type.total === '?'">
@@ -61,8 +63,20 @@
                   data-ng-class="labelImportanceClass(type)"
                   data-ng-if="type.total !== '?'">{{type.success}} / {{type.total}}</span>
           </div>
+          <div class="col-md-3 gn-nopadding-right" data-ng-if="type.schematronVerificationError">
+            <span class="label pull-right label-danger" data-translate="">
+              runServiceError
+            </span>
+          </div>
         </div>
-        <div class="panel-body">
+        <div class="panel-body" data-ng-if="type.schematronVerificationError">
+          <ul class="list-group">
+            <li class="list-group-item text-danger">
+              <p>{{type.schematronVerificationError}}</p>
+            </li>
+          </ul>
+        </div>
+        <div class="panel-body" data-ng-if="!type.schematronVerificationError">
           <ul class="list-group" data-ng-repeat="pattern in type.patterns.pattern">
             <li class="list-group-item" data-ng-repeat="rule in pattern.rules.rule"
                 title="{{rule.details}}"

--- a/web-ui/src/main/resources/catalog/components/utility/partials/batchreport.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/batchreport.html
@@ -52,7 +52,7 @@
       <h2 data-translate="">metadataErrorReport</h2>
       <table class="table table-striped">
         <tr>
-          <th data-transalte="">identifier</th>
+          <th data-translate="">identifier</th>
           <th data-translate="">error</th>
         </tr>
         <tr data-ng-repeat="(key, errors) in processReport.metadataErrors">

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -298,6 +298,8 @@
     "validate-inspire-help": "Check record against inspire validation rules",
     "validationReport": "Validation",
     "runValidation": "Run validation check",
+    "validationServiceError": "Server error",
+    "validationServiceErrorDetail": "Please check server's log files for more information.",
     "fixedOnTop": "Always on top",
     "whoCanAccess": "Who has access",
     "wmsServiceUrl": "Service URL",

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -232,7 +232,7 @@
     "other": "Other",
     "onlineResourceName": "Resource name",
     "protocol": "Protocol",
-    "runServiceError": "Error happens while calling service",
+    "runServiceError": "Error happened while calling service",
     "overwriteFile": "Overwrite file if existing",
     "overview": "Overview",
     "overviews": "Overviews",

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/batch-replacer-report.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/batch-replacer-report.html
@@ -71,7 +71,7 @@
         <h2 data-translate="">metadataErrorReport</h2>
         <table class="table table-striped">
           <tr>
-            <th data-transalte="">identifier</th>
+            <th data-translate="">identifier</th>
             <th data-translate="">error</th>
           </tr>
           <tr data-ng-repeat="(key, value) in processReport.metadataErrors">

--- a/web/src/main/webapp/xslt/services/metadata/validate.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/validate.xsl
@@ -125,6 +125,13 @@
     <xsl:variable name="rulename" select="string(@geonet:rule)"/>
     <xsl:variable name="errors" select="count(.//svrl:failed-assert)"/>
     <xsl:variable name="successes" select="count(.//svrl:successful-report)"/>
+    <xsl:variable name="schematronVerificationError" select="./geonet:schematronVerificationError"/>
+
+    <xsl:message>
+      ===============
+      schematronVerificationError:
+      <xsl:copy-of select="$schematronVerificationError"/>
+    </xsl:message>
 
     <report>
       <id>
@@ -150,6 +157,12 @@
           </xsl:otherwise>
         </xsl:choose>
       </label>
+      <!-- If the schematron failed to compile or during the validation it should have a `geonet:schematronVerificationError` element -->
+      <xsl:if test="$schematronVerificationError">
+        <schematronVerificationError>
+          <xsl:value-of select="$schematronVerificationError"/>
+        </schematronVerificationError>
+      </xsl:if>
       <error>
         <xsl:value-of select="$errors"/>
       </error>

--- a/web/src/main/webapp/xslt/services/metadata/validate.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/validate.xsl
@@ -126,13 +126,7 @@
     <xsl:variable name="errors" select="count(.//svrl:failed-assert)"/>
     <xsl:variable name="successes" select="count(.//svrl:successful-report)"/>
     <xsl:variable name="schematronVerificationError" select="./geonet:schematronVerificationError"/>
-
-    <xsl:message>
-      ===============
-      schematronVerificationError:
-      <xsl:copy-of select="$schematronVerificationError"/>
-    </xsl:message>
-
+    
     <report>
       <id>
         <xsl:value-of select="$rulename"/>


### PR DESCRIPTION
If a schematron fails when it is running causing an exception now the user can know that an error has happened instead of see a successful 0/0 errors message.

Fixes #3594.

See warning:
![image](https://user-images.githubusercontent.com/826920/55010510-960bbc00-4fe4-11e9-9208-9dfdf706d34a.png)
