### PR TITLE
Small styling changes for the alert messages

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_alerts_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_alerts_default.less
@@ -1,0 +1,50 @@
+.gn-alerts {
+  left: 0;
+  @media (min-width: @screen-md-min) {
+    max-width: 75%;
+  }
+  .alert {
+    min-width: 300px;
+    min-height: 50px;
+    border-radius: 0px 3px 3px 0px;
+    border-left: 5px solid #d4edda;
+    padding-left: 50px;
+    line-height: 1.5em;
+    margin-right: 5px;
+    margin-bottom: 0;
+    .close {
+      opacity: 0.5;
+    }
+    &:before {
+      font: normal normal normal 14px/1 FontAwesome;
+      font-size: inherit;
+      text-rendering: auto;
+      -webkit-font-smoothing: antialiased;
+      float: left;
+      font-size: 24px;
+      margin-left: -35px;
+      margin-top: -2px;
+    }
+    .btn {
+      margin-top: 10px;
+    }
+  }
+  .alert-success {
+    color: #3c864d;
+    background-color: #c7f0d1;
+    border-color: #c3e6cb;
+    border-left: 5px solid #3c864d;
+    &:before {
+      content: "\f05d";
+    }
+  }
+  .alert-danger {
+    color: #d9534f;
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+    border-left: 5px solid #e44f5e;
+    &:before {
+      content: "\f071";
+    }
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_alerts_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_alerts_default.less
@@ -1,3 +1,5 @@
+@import "../../../style/gn_bootstrap.less";
+
 .gn-alerts {
   left: 0;
   @media (min-width: @screen-md-min) {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
@@ -1,5 +1,7 @@
 @import "../../../style/gn_login";
 @import "gn_view.less";
+// alert messages
+@import "gn_alerts_default.less";
 // variables for manipulating the theme
 @import "gn_variables_default.less"; // must be last
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -19,6 +19,8 @@
 @import "gn_footer_default.less";
 // infolists on the homepage
 @import "gn_infolist_default.less";
+// alert messages
+@import "gn_alerts_default.less";
 // variables for manipulating the theme
 @import "gn_variables_default.less"; // must be last
 


### PR DESCRIPTION
This PR has some small improvements for the alert messages to make them more visible and stand out and to have a more uniform style. 

**Changes**:
- new, separate stylesheet for the alerts
- `max-width` and `min-width` for the alerts
- added an icon
- slightly changed green for the success messages (better visibility for a smaller message in the upper left corner)
- added a border on the left side (like the messages in the admin)

Two screenshot of the new messages:
![gn-alert-success](https://user-images.githubusercontent.com/19608667/55072692-0ae60100-508c-11e9-8d62-0644a125e591.png)

![gn-alert-error](https://user-images.githubusercontent.com/19608667/55072711-16d1c300-508c-11e9-928b-a3048b2ccbd3.png)
