### PR TITLE
Hide complete panel when filtering settings in the admin

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -348,6 +348,8 @@
           } else {
             $(this).hide();
           }
+          // check parent
+          $scope.filterParent($(this));
         });
       };
       $scope.resetFilter = function(formId) {
@@ -360,6 +362,47 @@
           // show the fieldsets
           $(formId + ' fieldset').show();
         });
+
+      };
+
+      // check the parent for visible children
+      $scope.filterParent = function(element) {
+
+        var doFilterMain = true;
+        // go back to the fieldset
+        var fieldsetParent = element.parent().parent();
+        // check for UI settings
+        if (fieldsetParent.prop('nodeName').toLowerCase() != 'fieldset') {
+          fieldsetParent = element.parent();
+          doFilterMain = false;
+        }
+        // reset
+        fieldsetParent.show();
+        fieldsetParent.parent().show();
+        // count visible elements
+        var counter = fieldsetParent.children('div').children(':visible').length;
+
+        if (counter > 0) {
+          fieldsetParent.show();
+        } else {
+          fieldsetParent.hide();
+        }
+        if (doFilterMain) {
+          $scope.filterMain(fieldsetParent);
+        }
+      };
+      
+      // filter the main parent (for Settings)
+      $scope.filterMain = function(element) {
+
+        var parentMain = element.parent();
+        var counter = parentMain.children('fieldset:visible').length;
+
+        if (counter > 0) {
+          parentMain.show();
+        } else {
+          parentMain.hide();
+        }
 
       };
 

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -50,7 +50,6 @@
           data-watch="sectionsLevel1" data-depth="1"/>
       <div class="panel-heading">
         <span data-translate="">settings</span>
-
       </div>
       <div class="panel-body">
         <form id="gn-settings" name="gnSettings" class="form-horizontal">
@@ -58,7 +57,8 @@
                     id="gn-settings-spy-target">
             <h1>{{section1.name | translate}}</h1>
             <fieldset data-ng-repeat="section2 in section1.children | orderObjectBy:'position'"
-                      id="{{section2.name.replace('/', '-')}}">
+                      id="{{section2.name.replace('/', '-')}}"
+                      data-ng-show="section2.name">
               <legend>{{section2.name | translate}}</legend>
               <!-- According to data type -->
               <div data-ng-repeat="s in section2.children | hideLanguages | hideGeoNetworkInternalSettings | orderObjectBy:'position'"


### PR DESCRIPTION
You can filter on settings in the `Settings` and `User Interface` pages in the admin. Until now only the line with the settings was hidden, which could result in empty blocks (parent) where all lines (children) were hidden.

This PR also checks on the parents. If the parent has no visible children it will be hidden.

An extra change has been made to **not** show a fieldset when it's empty

**Screenshot of only one block (parent) shown:**
![gn-editor-filter](https://user-images.githubusercontent.com/19608667/55082639-55727800-50a2-11e9-9db0-3be46d0d6858.png)
