### PR TITLE
WFS Feature / Zoom to filtered results.

### DIFF
--- a/es/config/records.json
+++ b/es/config/records.json
@@ -1078,6 +1078,18 @@
         "location": {
           "type": "geo_point"
         },
+        "bbox_xmin": {
+          "type": "double"
+        },
+        "bbox_xmax": {
+          "type": "double"
+        },
+        "bbox_ymin": {
+          "type": "double"
+        },
+        "bbox_ymax": {
+          "type": "double"
+        },
         "harvesterId": {
           "type": "keyword"
         },

--- a/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
+++ b/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
@@ -1019,15 +1019,15 @@
         fieldsQ.push('+*' + v + '*');
       });
     }
+    if (this.initialParams.filter) {
+      fieldsQ.push(this.initialParams.filter);
+    }
 
     // Search for all if no filter defined
     if (fieldsQ.length === 0) {
       fieldsQ.push('*:*');
     }
 
-    if (this.initialParams.filter != '') {
-      fieldsQ.push(this.initialParams.filter);
-    }
 
     var filter = fieldsQ.join(' ');
     qParam += filter;

--- a/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
+++ b/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
@@ -494,6 +494,7 @@
     var fields = [];
     for (var fieldId in response.aggregations) {
       if (fieldId.indexOf('_stats') > 0) break;
+      if (fieldId.indexOf('bbox_') === 0) continue;
       var respAgg = response.aggregations[fieldId];
       var reqAgg = requestParam.aggs[fieldId];
 

--- a/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
+++ b/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
@@ -432,6 +432,12 @@
                       field.isTree ? FACET_TREE_ROWS : ROWS
             }
           };
+          // if (!field.isDateTime) {
+          if (field.idxName.match(/^ft_.*_s$/)) {
+            // ignore empty strings
+            // include/exclude settings as they can only be applied to string fields
+            facetParams[field.idxName].terms['exclude'] = '';
+          }
         }
       }
       else {

--- a/web-ui/src/main/resources/catalog/components/index/IndexRequestConfig.js
+++ b/web-ui/src/main/resources/catalog/components/index/IndexRequestConfig.js
@@ -39,8 +39,10 @@
       },
       facets: true,
       stats: true,
-      excludedFields: ['geom', 'the_geom', 'ms_geometry',
-        'msgeometry', 'id_s', '_version_', 'featuretypeid', 'doctype']
+      excludedFields: [
+        'geom', 'the_geom', 'ms_geometry', 'msgeometry',
+        'bbox_xmin', 'bbox_ymin', 'bbox_xmax', 'bbox_ymax',
+        'id_s', '_version_', 'featuretypeid', 'doctype']
     };
   }]);
 

--- a/web-ui/src/main/resources/catalog/components/viewer/heatmap/HeatmapService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/heatmap/HeatmapService.js
@@ -86,7 +86,7 @@
               }, {
                 match_phrase: {
                   featureTypeId: {
-                    query: featureType
+                    query: encodeURIComponent(featureType)
                   }
                 }
               }, {

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
@@ -463,8 +463,16 @@
             if (scope.autoZoomToExtent
               && agg.bbox_xmin.value && agg.bbox_ymin.value
               && agg.bbox_xmax.value && agg.bbox_ymax.value) {
-              var extent = [agg.bbox_xmin.value, agg.bbox_ymin.value,
-                agg.bbox_xmax.value, agg.bbox_ymax.value];
+              var isPoint = agg.bbox_xmin.value === agg.bbox_xmax.value
+                            && agg.bbox_ymin.value === agg.bbox_ymax.value,
+                  radius = .05,
+                  extent = [agg.bbox_xmin.value, agg.bbox_ymin.value,
+                            agg.bbox_xmax.value, agg.bbox_ymax.value];
+
+              if (isPoint) {
+                var point = new ol.geom.Point([agg.bbox_xmin.value, agg.bbox_ymin.value]);
+                extent = new ol.extent.buffer(point.getExtent(), radius);
+              }
               scope.featureExtent = ol.extent.applyTransform(extent,
                 ol.proj.getTransform("EPSG:4326", scope.map.getView().getProjection()));
             }

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
@@ -410,6 +410,8 @@
               };
             });
 
+            addBboxAggregation(aggs);
+
             //indexObject is only available if Elastic is configured
             if (indexObject) {
               indexObject.searchWithFacets({
@@ -419,6 +421,9 @@
                   then(function(resp) {
                     indexObject.pushState();
                     scope.fields = resp.facets;
+                    resp.indexData.aggregations &&
+                      scope.zoomToResults(resp.indexData.aggregations);
+
                     scope.count = resp.count;
                     angular.forEach(scope.fields, function(f) {
                       if (expandedFields.indexOf(f.name) >= 0) {
@@ -428,6 +433,40 @@
                   });
             }
           };
+
+
+          // Compute bbox of returned object
+          // At some point we may be able to use geo_bounds aggregation
+          // when it is supported for geo_shape type
+          // See https://github.com/elastic/elasticsearch/issues/7574
+          // Eg.
+          // "viewport" : {
+          //   "geo_bounds" : {
+          //     "field" : "location",
+          //     "wrap_longitude" : true
+          //   }
+          // }
+          function addBboxAggregation(aggs) {
+            aggs['bbox_xmin'] = {'min': {'field': 'bbox_xmin'}};
+            aggs['bbox_ymin'] = {'min': {'field': 'bbox_ymin'}};
+            aggs['bbox_xmax'] = {'max': {'field': 'bbox_xmax'}};
+            aggs['bbox_ymax'] = {'max': {'field': 'bbox_ymax'}};
+          };
+
+          scope.zoomToResults = function (agg) {
+            scope.autoZoomToExtent = true;
+            if (scope.autoZoomToExtent
+                && agg.bbox_xmin && agg.bbox_ymin
+                && agg.bbox_xmax && agg.bbox_ymax) {
+              var extent = [agg.bbox_xmin.value, agg.bbox_ymin.value,
+                            agg.bbox_xmax.value, agg.bbox_ymax.value];
+              extent = ol.extent.applyTransform(extent,
+                        ol.proj.getTransform("EPSG:4326", scope.map.getView().getProjection()));
+              scope.map.getView().fit(extent, scope.map.getSize());
+            }
+          };
+
+
 
           scope.getMore = function(field) {
             indexObject.getFacetMoreResults(field).then(function(response) {
@@ -453,13 +492,21 @@
             scope.layer.set('esConfig', null);
             scope.$broadcast('FiltersChanged');
 
+            // reset text search in facets
+            scope.facetFilters = {};
+
+            var aggs = {};
+            addBboxAggregation(aggs);
+
             // load all facet and fill ui structure for the list
-            return indexObject.searchWithFacets({}).
+            return indexObject.searchWithFacets({}, aggs).
                 then(function(resp) {
                   indexObject.pushState();
                   scope.fields = resp.facets;
                   scope.count = resp.count;
-                });
+                  resp.indexData.aggregations &&
+                    scope.zoomToResults(resp.indexData.aggregations);
+            });
           };
 
           /**
@@ -484,11 +531,14 @@
                   initialFilters.geometry[0][1];
             }
 
+            var aggs = {};
+            addBboxAggregation(aggs);
+
             // resend a search with initial filters to alter the facets
             return indexObject.searchWithFacets({
               params: initialFilters.qParams,
               geometry: initialFilters.geometry
-            }).then(function(resp) {
+            }, aggs).then(function(resp) {
               indexObject.pushState();
               scope.fields = resp.facets;
               scope.count = resp.count;

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
@@ -164,6 +164,9 @@
           var indexObject, extentFilter;
           scope.filterGeometry = undefined;
 
+          // Extent of current features matching the filter.
+          scope.featureExtent = undefined;
+
           /**
            * Init the directive when the scope.layer has changed.
            * If the layer is given through the isolate scope object, the init
@@ -421,8 +424,9 @@
                   then(function(resp) {
                     indexObject.pushState();
                     scope.fields = resp.facets;
-                    resp.indexData.aggregations &&
-                      scope.zoomToResults(resp.indexData.aggregations);
+                    
+	            resp.indexData.aggregations &&
+                        setFeatureExtent(resp.indexData.aggregations);
 
                     scope.count = resp.count;
                     angular.forEach(scope.fields, function(f) {
@@ -453,18 +457,27 @@
             aggs['bbox_ymax'] = {'max': {'field': 'bbox_ymax'}};
           };
 
-          scope.zoomToResults = function (agg) {
+          function setFeatureExtent(agg) {
             scope.autoZoomToExtent = true;
             if (scope.autoZoomToExtent
-                && agg.bbox_xmin && agg.bbox_ymin
-                && agg.bbox_xmax && agg.bbox_ymax) {
+              && agg.bbox_xmin && agg.bbox_ymin
+              && agg.bbox_xmax && agg.bbox_ymax) {
               var extent = [agg.bbox_xmin.value, agg.bbox_ymin.value,
-                            agg.bbox_xmax.value, agg.bbox_ymax.value];
-              extent = ol.extent.applyTransform(extent,
-                        ol.proj.getTransform("EPSG:4326", scope.map.getView().getProjection()));
-              scope.map.getView().fit(extent, scope.map.getSize());
+                agg.bbox_xmax.value, agg.bbox_ymax.value];
+              scope.featureExtent = ol.extent.applyTransform(extent,
+                ol.proj.getTransform("EPSG:4326", scope.map.getView().getProjection()));
             }
           };
+
+          scope.zoomToResults = function () {
+            scope.map.getView().fit(scope.featureExtent, scope.map.getSize());
+          };
+
+          scope.$watch('featureExtent', function(n, o) {
+            if (n && n !== o) {
+              scope.zoomToResults();
+            }
+          });
 
 
 
@@ -505,7 +518,7 @@
                   scope.fields = resp.facets;
                   scope.count = resp.count;
                   resp.indexData.aggregations &&
-                    scope.zoomToResults(resp.indexData.aggregations);
+                    setFeatureExtent(resp.indexData.aggregations);
             });
           };
 
@@ -569,6 +582,8 @@
             // save this filter state for future comparison
             scope.previousFilterState.params = angular.merge({}, scope.output);
             scope.previousFilterState.geometry = scope.ctrl.searchGeometry;
+
+            scope.zoomToResults();
 
             var defer = $q.defer();
             var sldConfig = wfsFilterService.createSLDConfig(scope.output);

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
@@ -54,6 +54,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.geometry.BoundingBox;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -312,6 +313,15 @@ public class EsWFSFeatureIndexer {
                             } else {
                                 report.setPointOnlyForGeomsFalse();
                             }
+
+                            // Populate bbox coordinates to be able to compute
+                            // global bbox of search results
+                            final BoundingBox bbox = feature.getBounds();
+                            rootNode.put("bbox_xmin", bbox.getMinX());
+                            rootNode.put("bbox_ymin", bbox.getMinY());
+                            rootNode.put("bbox_xmax", bbox.getMaxX());
+                            rootNode.put("bbox_ymax", bbox.getMaxY());
+
                         } else {
                             String value = attributeValue.toString();
                             rootNode.put(getDocumentFieldName(attributeName),


### PR DESCRIPTION
    When indexing features, add 4 fields to store the coordinate of the
    bounding box of each features. On client side use min/max aggregations
    to retrieve the bounding box of all features matching filter.

    When ES support for geo_bounds aggregation will be implemented for geo_shape type
    See https://github.com/elastic/elasticsearch/issues/7574
    The following would be better probably:

    ```
     "viewport" : {
       "geo_bounds" : {
         "field" : "location",
         "wrap_longitude" : true
       }
     }
    ```

See in action https://youtu.be/SKwnwN5RPKA