### PR TITLE
Editor / Helper & codelist / Add support to displayIf constraint in associated resource panel.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/schemamanager/SchemaManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/common/schemamanager/SchemaManagerService.js
@@ -116,9 +116,10 @@
             *
             * Return a promise.
             */
-           getElementInfo: function(config) {
+           getElementInfo: function(config, displayIf) {
              var defer = $q.defer();
-             var fromCache = infoCache.get(config);
+             var cacheKey = config + (displayIf || '');
+             var fromCache = infoCache.get(cacheKey);
              if (fromCache) {
                defer.resolve(fromCache);
              } else {
@@ -130,9 +131,10 @@
                  '/descriptors/' + info[1] + '/details?' +
                  'parent=' + (info[2] || '') +
                  '&xpath=' + (info[3] || '') +
-                 '&isoType=' + (info[4] || '')).
+                 '&isoType=' + (info[4] || '') +
+                 '&displayIf=' + (encodeURIComponent(displayIf) || '')).
                  success(function(data) {
-                   infoCache.put(config, data);
+                   infoCache.put(cacheKey, data);
                    defer.resolve(data);
                  });
                }

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -210,6 +210,7 @@
               scope.lang = scope.$parent.lang;
               scope.readonly = attrs['readonly'] || false;
               scope.relations = {};
+              scope.gnCurrentEdit.codelistFilter  = attrs['codelistFilter'];
 
               /**
                * Calls service 'relations.get' to load
@@ -1047,6 +1048,7 @@
 
                 gnOnlinesrc.register('onlinesrc', function(linkToEdit) {
                   scope.isEditing = angular.isDefined(linkToEdit);
+                  scope.codelistFilter = scope.gnCurrentEdit && scope.gnCurrentEdit.codelistFilter;
 
                   scope.metadataId = gnCurrentEdit.id;
                   scope.schema = gnCurrentEdit.schema;

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -618,6 +618,14 @@
                     }
                   });
 
+              scope.codelistFilter = '';
+              scope.$watch('gnCurrentEdit.codelistFilter',
+                function(n, o) {
+                  if (n && n !== o) {
+                    scope.codelistFilter = n;
+                    init();
+                  }
+                });
               var init = function() {
                 var schema = attrs['schema'] ||
                     gnCurrentEdit.schema || 'iso19139';
@@ -625,14 +633,14 @@
 
                 scope.type = attrs['schemaInfoCombo'];
                 if (scope.type == 'codelist') {
-                  gnSchemaManagerService.getCodelist(config).then(
+                  gnSchemaManagerService.getCodelist(config, scope.codelistFilter).then(
                       function(data) {
                         scope.infos = angular.copy(data.entry);
                         addBlankValueAndSetDefault();
                       });
                 }
                 else if (scope.type == 'element') {
-                  gnSchemaManagerService.getElementInfo(config).then(
+                  gnSchemaManagerService.getElementInfo(config, scope.codelistFilter).then(
                       function(data) {
                         scope.infos = data.helper ? data.helper.option : null;
                         addBlankValueAndSetDefault();

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -239,6 +239,7 @@
                   formScope: $scope.$new(),
                   sessionStartTime: moment(),
                   formLoadExtraFn: formLoadExtraFunctions,
+                  codelistFilter: '',
                   working: false
                 });
 


### PR DESCRIPTION
In labels and codelist.xml, we have the possibility to constraint list of values using a display if attribute.

This filter can not be set in the associated resource panel according to the metadata record currently on edition. This PR add support for that.

eg. if you have 2 configs for protocol

```
  <element name="gmd:protocol" id="398.0" alias="protocol"
           displayIf="ancestor::node()[name()='gmd:MD_Metadata' and contains(gmd:metadataStandardName/*/gco:CharacterString, 'ISO 19139, MyOcean profile')]">
    <label>Protocol</label>
    <description>Connection protocol to be used</description>
    <helper>
      <option value="WWW:FTP">FTP</option>
      <option value="WWW:MAIL">Mail</option>
      <option value="WWW:LINK">Web link</option>
      <option value="OGC:WMS">Web Map Service (OGC)</option>
      <option value="OGC:WCS">Web Coverage Service (OGC)</option>
      <option value="OGC:SOS:getCapabilities">Sensor Observation Service - getCapabilities (OGC)</option>
      <option value="WWW:OPENDAP">OPeNDAP</option>
      <option value="MYO:MOTU-SUB">MOTU (SUB)</option>
      <option value="MYO:MOTU-DGF">MOTU (DGF)</option>
    </helper>
  </element>
  <element name="gmd:protocol" id="398.0" alias="protocol">
    <label>Protocol</label>
    <description>Connection protocol to be used</description>
    <helper>
      <option value="WWW:LINK">Web link (URL)</option>
      <option value="WWW:LINK-1.0-http--publication-URL">Main publication link</option>
      <option value="WWW:LINK-1.0-http--metadata-URL">Point of truth URL of this metadata record</option>
      <option value="FILE">Download (file)</option>
      <option value="COPYFILE">Download (copy)</option>
      <option value="DB">Download (database)</option>
      <option value="WWW:DOWNLOAD-1.0-link--download">Download (link)</option>
      <option value="NETWORK:LINK">Download (visible path)</option>
      <option value="OGC:WFS">Download (WFS)</option>
      <option value="OGC:WCS">Download (WCS)</option>
      <option value="OGC:WMS">View (WMS)</option>
      <option value="OGC:WMTS">View (WMTS)</option>
      <option value="OGC:WPS">OGC-WPS Web Processing Service</option>
      <option value="OGC:OWS-C">View (OWS Context)</option>
    </helper>
  </element>
```

Then you can create a view with a custom panel
```

        <directive data-gn-onlinesrc-list=""
                   data-types="onlinesrc|sibling"
                   data-codelist-filter="ancestor::node()[name()='gmd:MD_Metadata' and contains(gmd:metadataStandardName/*/gco:CharacterString, 'ISO 19139, MyOcean profile')]"/>
```


![image](https://user-images.githubusercontent.com/1701393/55219135-60ddb480-5204-11e9-85f1-a273ff101d6b.png)



This is a follow up of https://github.com/geonetwork/core-geonetwork/pull/3188

