### PR TITLE
Adding slave mode.

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/HarvesterSetting.java
+++ b/domain/src/main/java/org/fao/geonet/domain/HarvesterSetting.java
@@ -111,7 +111,7 @@ public class HarvesterSetting extends GeonetEntity {
     /**
      * Get the parent setting object. This is a nullable property.
      */
-    @OneToOne(optional = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(optional = true, fetch = FetchType.LAZY, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "parentid")
     @OnDelete(action=OnDeleteAction.CASCADE)
     public

--- a/events/src/main/java/org/fao/geonet/events/server/ServerStartup.java
+++ b/events/src/main/java/org/fao/geonet/events/server/ServerStartup.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+/**
+ *
+ */
+package org.fao.geonet.events.server;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Event launched when GeoNetwork finishes startup
+ *
+ * @author delawen
+ */
+public class ServerStartup extends ApplicationEvent {
+
+	private static final long serialVersionUID = 5217757141175170179L;
+
+	public ServerStartup(ConfigurableApplicationContext event) {
+		super(event);
+	}
+	
+	public ConfigurableApplicationContext getContext() {
+		return (ConfigurableApplicationContext) super.getSource();
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1241,6 +1241,7 @@
         </file>
       </activation>
       <modules>
+	<module>slave</module>
         <module>schemas-test</module>
         <module>web-ui</module>
         <module>web-ui-docs</module>

--- a/slave/Readme.md
+++ b/slave/Readme.md
@@ -1,0 +1,13 @@
+This project gets included on GeoNetwork when compiled with the profile "slave":
+
+mvn clean package install -P slave
+
+When a GeoNetwork is compiled as read only:
+
+ * Does not allow any login (intercepts all logins)
+ * Does not allow adding or updating any users (intercepts all database changes)
+ * [Optional] Remove all users except admin user, which is still used for internal GeoNetwork tasks. Admin user will not be available for login either.
+ * [Optional] Remove all harvesters from the database
+ * Create and run a harvester pointing to the master instance
+ 
+ Configuration options are on file src/main/resources/slave.properties

--- a/slave/pom.xml
+++ b/slave/pom.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>geonetwork</artifactId>
+    <groupId>org.geonetwork-opensource</groupId>
+    <version>3.7.0-SNAPSHOT</version>
+  </parent>
+
+  <name>GeoNetwork Events</name>
+  <packaging>jar</packaging>
+  <artifactId>slave</artifactId>
+  <description>Converts the instance on a slave instance</description>
+  <url>http://geonetwork-opensource.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>harvesters</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/slave/pom.xml
+++ b/slave/pom.xml
@@ -31,7 +31,7 @@
     <version>3.7.0-SNAPSHOT</version>
   </parent>
 
-  <name>GeoNetwork Events</name>
+  <name>GeoNetwork Slave</name>
   <packaging>jar</packaging>
   <artifactId>slave</artifactId>
   <description>Converts the instance on a slave instance</description>

--- a/slave/src/main/java/org/fao/geonet/readonly/InterceptsStartup.java
+++ b/slave/src/main/java/org/fao/geonet/readonly/InterceptsStartup.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.readonly;
+
+import java.util.List;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.HarvesterSetting;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.domain.User_;
+import org.fao.geonet.events.server.ServerStartup;
+import org.fao.geonet.kernel.harvest.HarvestManager;
+import org.fao.geonet.repository.HarvesterSettingRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.jdom.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+/**
+ * 
+ * This instance is a slave, which means: No user login (no filter configured
+ * to authenticate) and no user creation {@link InterceptsUserAdd}
+ * {@link InterceptsUserUpdate}
+ * 
+ * On this class we will load a harvester defined by an url on a source file, if
+ * not already added, and remove all users except the admin user, just in case.
+ * 
+ * @author delawen
+ *
+ */
+@Component
+public class InterceptsStartup implements ApplicationListener<ServerStartup> {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	private @Value("${slave.removeHarvesters:true}") boolean removeHarvesters;
+	private @Value("${slave.removeUsers:true}") boolean removeUsers;
+	private @Value("${slave.masterURL}") String masterURL;
+	private @Value("${slave.masterNode}") String masterNode;
+	private @Value("${slave.frequency}") String frequency;
+
+	private final String key = "MASTER";
+	private final Logger log = LoggerFactory.getLogger(Geonet.GEONETWORK);
+
+	public void onApplicationEvent(ServerStartup arg0) {
+		removeHarvesters(arg0);
+		addHarvester(arg0);
+		removeUsers(arg0);
+	}
+
+	/**
+	 * Remove all harvesters that don't have the name "MASTER"
+	 * 
+	 * @param arg0
+	 */
+	@Transactional(value = TxType.REQUIRES_NEW)
+	private void removeHarvesters(ServerStartup arg0) {
+		if (removeHarvesters) {
+			HarvesterSettingRepository settingsRepo = arg0.getContext().getBean(HarvesterSettingRepository.class);
+
+			List<HarvesterSetting> harvesters = settingsRepo.findAllChildren(1);
+			for (HarvesterSetting h : harvesters) {
+				for (HarvesterSetting hs : settingsRepo.findAllChildren(h.getId())) {
+					if (hs.getName().equals("site")) {
+						for (HarvesterSetting s : settingsRepo.findAllChildren(hs.getId())) {
+							if (s.getName().equals("name") && !s.getValue().equals(key)) {
+								try {
+									HarvestManager hm = arg0.getContext().getBean(HarvestManager.class);
+									hm.remove(String.valueOf(h.getId()));
+								} catch (Exception e) {
+									log.error("Error removing old harvester in readonly instance: " + h, e);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Remove all users with an ID above 1 (the default admin user we need to run
+	 * GeoNetwork).
+	 * 
+	 * @param arg0
+	 */
+	@Transactional(value = TxType.REQUIRES_NEW)
+	private void removeUsers(ServerStartup arg0) {
+		if (removeUsers) {
+			userRepository.deleteAll(new Specification<User>() {
+				@Override
+				public Predicate toPredicate(Root<User> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+					Path<Integer> userIdAttributePath = root.get(User_.id);
+					Predicate userIdEqualPredicate = cb.gt(userIdAttributePath, cb.literal(1));
+					return userIdEqualPredicate;
+				}
+			});
+		}
+	}
+
+	/**
+	 * Create the "MASTER" harvester to replicate all content
+	 * 
+	 * @param arg0
+	 */
+	private void addHarvester(ServerStartup arg0) {
+		int id = harvesterAlreadyCreated(arg0);
+		
+		if (id < 0) {
+
+			Element harvester = new Element("node");
+			harvester.setAttribute("id", "");
+			harvester.setAttribute("type", "geonetwork");
+
+			Element ownerGroup = new Element("ownerGroup");
+			addElementWithContentString(ownerGroup, "id", "2");
+			harvester.addContent(ownerGroup);
+
+			Element ownerUser = new Element("ownerUser");
+			addElementWithContentString(ownerUser, "id", "undefined");
+			harvester.addContent(ownerUser);
+
+			harvester.addContent(createSite());
+			harvester.addContent(createEmptySearches());
+			harvester.addContent(createOptions());
+			harvester.addContent(createContent());
+			harvester.addContent(createPrivileges());
+			Element categories = new Element("categories");
+			addElementWithAttribute(categories, "category", "id", "");
+			harvester.addContent(categories);
+
+			id = addMasterHarvester(arg0, harvester);
+		}
+		
+		try {
+			HarvestManager hm = arg0.getContext().getBean(HarvestManager.class);
+			hm.run(String.valueOf(id));
+		} catch (Exception e) {
+			log.error("Error running MASTER harvester in readonly instance", e);
+		}
+	}
+
+	private int harvesterAlreadyCreated(ServerStartup arg0) {
+		HarvesterSettingRepository settingsRepo = arg0.getContext().getBean(HarvesterSettingRepository.class);
+
+		List<HarvesterSetting> harvesters = settingsRepo.findAllChildren(1);
+		for (HarvesterSetting h : harvesters) {
+			for (HarvesterSetting hs : settingsRepo.findAllChildren(h.getId())) {
+				if (hs.getName().equals("site")) {
+					for (HarvesterSetting s : settingsRepo.findAllChildren(hs.getId())) {
+						if (s.getName().equals("name") && s.getValue().equals(key)) {
+							return h.getId();
+						}
+					}
+				}
+			}
+		}
+		return -1;
+	}
+
+	@Transactional(value = TxType.REQUIRES_NEW)
+	private int addMasterHarvester(ServerStartup arg0, Element harvester) {
+		try {
+			HarvestManager hm = arg0.getContext().getBean(HarvestManager.class);
+			return Integer.valueOf(hm.addHarvesterReturnId(harvester, "1"));
+		} catch (Exception e) {
+			log.error("Error initializing MASTER harvester in readonly instance", e);
+		}
+		return -1;
+	}
+
+	private Element createPrivileges() {
+		Element privileges = new Element("privileges");
+		Element group = new Element("group");
+		group.setAttribute("id", "1");
+		addElementWithAttribute(group, "operation", "name", "view");
+		addElementWithAttribute(group, "operation", "name", "dynamic");
+		addElementWithAttribute(group, "operation", "name", "download");
+		privileges.addContent(group);
+		return privileges;
+	}
+
+	private void addElementWithAttribute(Element group, String name, String attribute, String value) {
+		Element operation = new Element(name);
+		operation.setAttribute(attribute, value);
+		group.addContent(operation);
+	}
+
+	private Element createContent() {
+		Element content = new Element("content");
+		addElementWithContentString(content, "validate", "NOVALIDATION");
+		addElementWithContentString(content, "importxslt", "none");
+		return content;
+	}
+
+	private Element createOptions() {
+		Element options = new Element("options");
+		addElementWithContentString(options, "oneRunOnly", "false");
+		addElementWithContentString(options, "overrideUuid", "OVERRIDE");
+		addElementWithContentString(options, "every", frequency);
+		addElementEmpty(options, "status");
+		return options;
+	}
+
+	private Element createSite() {
+		Element site = new Element("site");
+		addElementWithContentString(site, "name", key);
+		addElementWithContentString(site, "host", masterURL);
+		addElementWithContentString(site, "node", masterNode);
+		addElementWithContentString(site, "useChangeDateForUpdate", "true");
+		addElementWithContentString(site, "createRemoteCategory", "true");
+		addElementWithContentString(site, "icon", "undefined");
+		addElementWithContentString(site, "mefFormatFull", "false");
+		addElementEmpty(site, "xslfilter");
+		Element account = new Element("account");
+		addElementWithContentString(account, "use", "false");
+		addElementEmpty(account, "username");
+		addElementEmpty(account, "password");
+		site.addContent(account);
+		return site;
+	}
+
+	private Element createEmptySearches() {
+		Element searches = new Element("searches");
+		Element search = new Element("search");
+		addElementEmpty(search, "freeText");
+		addElementEmpty(search, "title");
+		addElementEmpty(search, "abstract");
+		addElementEmpty(search, "keywords");
+		addElementEmpty(search, "digital");
+		addElementEmpty(search, "hardcopy");
+		addElementEmpty(search, "anyField");
+		addElementEmpty(search, "anyValue");
+		Element source = new Element("source");
+		addElementEmpty(source, "uuid");
+		addElementEmpty(source, "name");
+		search.addContent(source);
+		searches.addContent(search);
+		return searches;
+	}
+
+	private void addElementEmpty(Element parent, String name) {
+		Element el = new Element(name);
+		parent.addContent(el);
+	}
+
+	private void addElementWithContentString(Element parent, String name, String value) {
+		Element el = new Element(name);
+		el.addContent(value);
+		parent.addContent(el);
+	}
+}

--- a/slave/src/main/java/org/fao/geonet/readonly/InterceptsUserAdd.java
+++ b/slave/src/main/java/org/fao/geonet/readonly/InterceptsUserAdd.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.readonly;
+
+import org.fao.geonet.events.user.UserCreated;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 
+ * Don't allow user creation
+ * 
+ * @author delawen
+ *
+ */
+@Component
+public class InterceptsUserAdd {
+
+	@TransactionalEventListener(phase=TransactionPhase.BEFORE_COMMIT)
+	public void doAfterCommit(UserCreated event) {
+		throw new RuntimeException("Users can't be added to this readonly instance.");
+	}
+}

--- a/slave/src/main/java/org/fao/geonet/readonly/InterceptsUserUpdate.java
+++ b/slave/src/main/java/org/fao/geonet/readonly/InterceptsUserUpdate.java
@@ -40,6 +40,8 @@ public class InterceptsUserUpdate {
 
 	@TransactionalEventListener(phase=TransactionPhase.BEFORE_COMMIT)
 	public void doAfterCommit(UserUpdated event) {
-		throw new RuntimeException("Users can't be updated to this readonly instance.");
+		if(event.getUser().getId() != 1) {
+			throw new RuntimeException("Users can't be updated to this readonly instance.");
+		}
 	}
 }

--- a/slave/src/main/java/org/fao/geonet/readonly/InterceptsUserUpdate.java
+++ b/slave/src/main/java/org/fao/geonet/readonly/InterceptsUserUpdate.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.readonly;
+
+import org.fao.geonet.events.user.UserUpdated;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 
+ * Don't allow user creation
+ * 
+ * @author delawen
+ *
+ */
+@Component
+public class InterceptsUserUpdate {
+
+	@TransactionalEventListener(phase=TransactionPhase.BEFORE_COMMIT)
+	public void doAfterCommit(UserUpdated event) {
+		throw new RuntimeException("Users can't be updated to this readonly instance.");
+	}
+}

--- a/slave/src/main/resources/config-spring-geonetwork-parent.xml
+++ b/slave/src/main/resources/config-spring-geonetwork-parent.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<beans
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.springframework.org/schema/beans"
+  xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    ">
+
+</beans>

--- a/slave/src/main/resources/config-spring-geonetwork.xml
+++ b/slave/src/main/resources/config-spring-geonetwork.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the ~ 
+	United Nations (FAO-UN), United Nations World Food Programme (WFP) ~ and 
+	United Nations Environment Programme (UNEP) ~ ~ This program is free software; 
+	you can redistribute it and/or modify ~ it under the terms of the GNU General 
+	Public License as published by ~ the Free Software Foundation; either version 
+	2 of the License, or (at ~ your option) any later version. ~ ~ This program 
+	is distributed in the hope that it will be useful, but ~ WITHOUT ANY WARRANTY; 
+	without even the implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+	PURPOSE. See the GNU ~ General Public License for more details. ~ ~ You should 
+	have received a copy of the GNU General Public License ~ along with this 
+	program; if not, write to the Free Software ~ Foundation, Inc., 51 Franklin 
+	St, Fifth Floor, Boston, MA 02110-1301, USA ~ ~ Contact: Jeroen Ticheler 
+	- FAO - Viale delle Terme di Caracalla 2, ~ Rome - Italy. email: geonetwork@osgeo.org -->
+
+<beans
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://www.springframework.org/schema/beans"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context
+		http://www.springframework.org/schema/context/spring-context.xsd">
+
+	<context:component-scan
+		base-package="org.fao.geonet.readonly" />
+
+	<bean id="filterChainFilters" class="java.util.ArrayList">
+		<constructor-arg>
+			<list>
+				<ref bean="securityContextPersistenceFilter" />
+				<ref bean="csrfFilter" />
+				<ref bean="logoutFilter" />
+				<ref bean="requestCacheFilter" />
+				<ref bean="anonymousFilter" />
+				<ref bean="sessionMgmtFilter" />
+				<ref bean="exceptionTranslationFilter" />
+				<ref bean="filterSecurityInterceptor" />
+			</list>
+		</constructor-arg>
+	</bean>
+
+	<bean
+		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="locations">
+			<list>
+				<value>classpath:slave.properties</value>
+			</list>
+		</property>
+	</bean>
+</beans>

--- a/slave/src/main/resources/config-spring-geonetwork.xml
+++ b/slave/src/main/resources/config-spring-geonetwork.xml
@@ -41,12 +41,16 @@
 		</constructor-arg>
 	</bean>
 
-	<bean
-		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="ignoreUnresolvablePlaceholders" value="true" />
+		<property name="ignoreResourceNotFound" value="true" />
 		<property name="locations">
 			<list>
-				<value>classpath:slave.properties</value>
+				<value>classpath*:slave.properties</value>
+				<value>/WEB-INF/slave.properties</value>
 			</list>
 		</property>
 	</bean>
+
 </beans>

--- a/slave/src/main/resources/slave.properties
+++ b/slave/src/main/resources/slave.properties
@@ -1,0 +1,13 @@
+# Url of the master we want to replicate
+slave.masterURL=https://..../geonetwork
+slave.masterNode=srv
+
+# If there are other harvesters already in our database, should we cleanup them?
+slave.removeHarvesters=true
+
+# If there are users in our database, should we cleanup them?
+slave.removeUsers=true
+
+# Frequency to run the MASTER harvester
+# If this frequency is too short, only one harvester will run at a time
+slave.frequency=0 0/30 * * * ?

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -949,6 +949,16 @@
       </properties>
     </profile>
 
+    <profile>
+      <id>slave</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geonetwork-opensource</groupId>
+          <artifactId>slave</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <properties>

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.entitylistener.AbstractEntityListenerManager;
+import org.fao.geonet.events.server.ServerStartup;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.inspireatom.InspireAtomType;
 import org.fao.geonet.inspireatom.harvester.InspireAtomHarvesterScheduler;
@@ -410,6 +411,9 @@ public class Geonetwork implements ApplicationHandler {
         fillCaches(context);
 
         AbstractEntityListenerManager.setSystemRunning(true);
+        
+        this._applicationContext.publishEvent(new ServerStartup(this._applicationContext));
+        
         return gnContext;
     }
 


### PR DESCRIPTION
Usage: "mvn clean package install -P slave" to generate the war file or "mvn jetty:run -P slave" to run jetty (on web folder).

To run this instance you have to configure the master URL first. Configuration options are on file slave/src/main/resources/slave.properties 

masterURL is on https://github.com/geonetwork/core-geonetwork/pull/3712/files#diff-38229dfbdddf6cb469c704fa9b3ee403R2

With this profile active, GeoNetwork:
 * Does not allow any login (intercepts all logins)
 * Does not allow adding or updating any users (intercepts all database changes)
 * [Optional] Remove all users except admin user, which is still used for internal GeoNetwork tasks. Admin user will not be available for login either.
 * [Optional] Remove all harvesters from the database
 * Create and run a harvester pointing to the master instance

To cleanly develop this, I also added a new event that is fired after the server starts up: org.fao.geonet.events.server.ServerStartup

If the profile is not active, GeoNetwork will act as usual, the source code of the slave jar will not be added. (Remember to "mvn clean" after testing the slave mode to cleanup the jar from the WEB-INF/lib).
