### PR TITLE
[WIP] csw harvester encountering an empty page has to continue harvesting

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -389,13 +389,6 @@ class Harvester implements IHarvester<HarvestResult> {
                 break;
             }
 
-            // Another way to escape from an infinite loop
-
-            if (returnedCount == 0) {
-                log.warning("Forcing harvest end since numberOfRecordsReturned = 0");
-                break;
-            }
-
             // Start position of next record.
             // Note that some servers may return less records than requested (it's ok for CSW protocol)
             start += returnedCount;


### PR DESCRIPTION
condition on next record not changing should suffice avoiding infinite
loop. furthermore, empty page condition induce an random behaviour,
harvesting will stop on a fully empty page, incomplete page are accepted,
this depending on page size and records order.