### PR TITLE
Missing tooltip icon for date fields in templates

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -256,7 +256,12 @@
                } else if (element.is('legend')) {
                  element.contents().first().after(tooltipIconCompiled);
                } else if (isDatePicker) {
-                 element.closest(".gn-field").find("div.gn-control").append(tooltipIconCompiled);
+                // first check if it is in a template (inside a class="row"
+                var control = element.closest(".gn-multi-field .row").find("div.gn-control");
+                if (control.length == 0) {
+                  control = element.closest(".gn-field").find("div.gn-control").first();
+                }
+                control.append(tooltipIconCompiled);
                } else if (element.is('label')) {
                  if (tooltipAfterLabel) {
                    element.parent().children('div')


### PR DESCRIPTION
Fixes a problem that was adding the tooltip icon to multiple `gn-control` divs
when a template with more than one field is used.

![image](https://user-images.githubusercontent.com/826920/55392906-77557a00-553c-11e9-9339-91ba62f820bd.png)
