### PR TITLE
Directive for switching between Anchor and CharacterString

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -78,6 +78,14 @@
     </for>
     -->
 
+    <!-- Example configuration to use the anchor switcher directive
+    <for name="gmd:code" xpath="/gmd:MD_Metadata/gmd:identifier/gmd:MD_Identifier/gmd:code" use="data-gn-anchor-switcher"/>
+    <for name="gmd:supplementalInformation" use="data-gn-anchor-switcher"/>
+    <for name="gmd:organisationName" use="data-gn-anchor-switcher"/>
+    -->
+
+
+
     <for name="gts:TM_PeriodDuration" use="data-gn-field-duration-div"/>
     <for name="gml:duration" use="data-gn-field-duration-div"/>
 

--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -188,6 +188,7 @@
              element.is('input') ||
              element.is('textarea') ||
              element.is('select');
+             var isDiv = element.is('div');
              var tooltipTarget = element;
              var iconMode = gnCurrentEdit.displayTooltipsMode === 'icon';
              var isDatePicker = 'gnDatePicker' in attrs;
@@ -269,6 +270,8 @@
                  } else {
                    element.after(tooltipIconCompiled);
                  }
+               } else if (isDiv) {
+                 element.closest(".gn-field").find("div.gn-control").append(tooltipIconCompiled);
                }
 
                // close tooltips on click in editor container

--- a/web-ui/src/main/resources/catalog/components/edit/FieldsModule.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsModule.js
@@ -27,79 +27,6 @@
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   goog.require('gn_batch_process_button');
   goog.require('gn_bounding');
   goog.require('gn_checkbox_with_nilreason');
@@ -115,6 +42,7 @@
   goog.require('gn_organisation_entry_selector');
   goog.require('gn_record_fragment_selector');
   goog.require('gn_template_field_directive');
+  goog.require('gn_anchor_switcher_directive')
 
 
 
@@ -133,6 +61,7 @@
     'gn_record_fragment_selector',
     'gn_checkbox_with_nilreason',
     'gn_md_validation_tools_directive',
-    'gn_bounding'
+    'gn_bounding',
+    'gn_anchor_switcher_directive'
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/components/edit/anchorswitcher/AnchorSwitcher.js
+++ b/web-ui/src/main/resources/catalog/components/edit/anchorswitcher/AnchorSwitcher.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_anchor_switcher_directive');
+
+  var module = angular.module('gn_anchor_switcher_directive', []);
+
+  module.directive('gnAnchorSwitcher',
+      ['gnEditor', 'gnCurrentEdit', '$compile', '$q',
+       function(gnEditor, gnCurrentEdit, $compile, $q) {
+         return {
+           restrict: 'A',
+           replace: true,
+           transclude: true,
+           scope: {
+             id: '@',
+             textValue: '@value',
+             elementRef: '@name',
+             gnFieldTooltip: '@'
+           },
+           templateUrl: '../../catalog/components/edit/anchorswitcher/partials/' +
+           'anchorswitcher.html',
+           link: function(scope, element, attrs) {
+             var attributeHtmlTemplate = _.template(
+             '<div class="form-group" id="gn-attr-<%= id %>_xlinkCOLONhref">' +
+             '<label class="col-sm-4" data-translate>url</label>' +
+             '<div class="col-sm-7">' +
+             '<input type="text" class="" ' +
+             'name="<%= id %>_xlinkCOLONhref" value="">' +
+             '</div>' +
+             '<div class="col-sm-1">' +
+             '<a class="btn pull-right" ' +
+             'data-gn-click-and-spin="removeAttribute(\'<%= id %>_xlinkCOLONhref\')" ' +
+             'data-toggle="tooltip" data-placement="top" ' +
+             'title="{{\'deleteField\' |translate}}" style="visibility: hidden;">' +
+             '<i class="fa fa-times text-danger"></i>' +
+             '</a>' +
+             '</div>' +
+             '</div>'
+             );
+
+
+             scope.checkMode = function() {
+               var xlinkHrefDomEl = $('[name="' + scope.elementRef +
+               '_xlinkCOLONhref' + '"]');
+               if (xlinkHrefDomEl.length > 0) {
+                 scope.mode = 'anchor';
+               } else {
+                 scope.mode = 'characterString';
+               }
+               return scope.mode;
+             };
+
+             scope.setAttributesVisibility = function(mode, newAttributes) {
+               var visibility = newAttributes ||
+               gnCurrentEdit.displayAttributes;
+
+               if (mode === 'anchor') {
+                 visibility = true;
+               }
+               var attributesDiv = $('#gn-attr-div' + scope.elementRef);
+               // Toggle class on all gn-attr widgets
+               if (visibility) {
+                 attributesDiv.removeClass('hidden');
+               } else {
+                 attributesDiv.addClass('hidden');
+               }
+             };
+
+             scope.$watch('getDisplayAttributes()', function(newAttributes) {
+               scope.setAttributesVisibility(scope.mode, newAttributes);
+             });
+
+             scope.getDisplayAttributes = function() {
+               return gnCurrentEdit.displayAttributes;
+             };
+
+             scope.$watch('mode', function(newMode) {
+               var xlinkInput = $('[name="' + scope.elementRef +
+               '_xlinkCOLONhref' + '"]');
+               if (newMode === 'anchor') {
+                 if (xlinkInput.length === 0) {
+                   addXlinkHrefElement();
+                 }
+
+               } else if (newMode === 'characterString') {
+
+               }
+               scope.setAttributesVisibility(newMode);
+             });
+
+             var addXlinkHrefElement = function() {
+               var snippedDiv = $('#gn-attr-div' + scope.elementRef);
+               var xlinkDivTemplate = attributeHtmlTemplate({
+                 id: scope.elementRef
+               });
+               var xlinkDiv = $(xlinkDivTemplate);
+               var compiledAngularDiv = $compile(xlinkDiv)(scope);
+               snippedDiv.append(compiledAngularDiv);
+             };
+
+             scope.setMode = function(newMode) {
+               scope.mode = newMode;
+             };
+
+             scope.removeAttribute = function(ref) {
+               var defer = $q.defer();
+               gnEditor.removeAttribute(gnCurrentEdit.id, ref).then(function() {
+                 defer.resolve();
+               }, function() {
+                 defer.reject();
+               });
+               return defer.promise;
+             };
+
+             scope.$on('attributeRemoved', function(event, ref) {
+               if (ref === scope.elementRef + '_xlinkCOLONhref') {
+                 scope.setMode('characterString');
+               }
+             });
+
+
+             // init
+             element.removeClass('form-control');
+             scope.initialMode = scope.checkMode();
+           }
+         };
+       }]);
+})();

--- a/web-ui/src/main/resources/catalog/components/edit/anchorswitcher/partials/anchorswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/edit/anchorswitcher/partials/anchorswitcher.html
@@ -1,0 +1,32 @@
+<div class="">
+
+  <div class="gn-characterString gn-value"
+       data-ng-if="mode === 'characterString'">
+    <input type="hidden" data-ng-attr-name="{{elementRef + '_xlinkCOLONhref'}}" />
+    <div class="input-group">
+      <input class="form-control"
+             data-ng-model="textValue"
+             data-ng-attr-id="{{'gn-' + elementRef + '-charStringValue'}}"
+             data-ng-attr-name="{{elementRef}}"
+             data-ng-attr-value="{{textValue}}"
+      />
+      <span class="input-group-btn">
+        <button type="button" class="btn btn-default" data-ng-click="setMode('anchor')">
+          <i class="fa fa-link">&nbsp;</i>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div class="gn-characterString gn-value"
+       data-ng-if="mode === 'anchor'">
+    <input class="form-control"
+           data-ng-model="textValue"
+           data-ng-attr-id="{{'gn-' + elementRef + '-charStringValue'}}"
+           data-ng-attr-name="{{elementRef}}"
+           data-ng-attr-value="{{textValue}}"
+    />
+  </div>
+
+
+</div>
+

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -37,15 +37,17 @@
   module.value('gnCurrentEdit', {});
 
   module.factory('gnEditor',
-      ['$q',
-       '$http',
-       '$translate',
-       '$compile',
-       'gnUrlUtils',
-       'gnXmlTemplates',
-       'gnHttp',
-       'gnCurrentEdit',
-       function($q, $http, $translate, $compile,
+      [
+        '$rootScope',
+        '$q',
+        '$http',
+        '$translate',
+        '$compile',
+        'gnUrlUtils',
+        'gnXmlTemplates',
+        'gnHttp',
+        'gnCurrentEdit',
+       function($rootScope, $q, $http, $translate, $compile,
                gnUrlUtils, gnXmlTemplates,
                gnHttp, gnCurrentEdit) {
 
@@ -545,10 +547,14 @@
              var defer = $q.defer();
              $http.delete('../api/records/' + gnCurrentEdit.id +
              '/editor/attributes?ref=' + ref.replace('COLON', ':'))
-              .success(function(data) {
+              .then(function(data) {
                var target = $('#gn-attr-' + ref);
                target.slideUp(duration, function() { $(this).remove();});
-             });
+               defer.resolve();
+               $rootScope.$broadcast('attributeRemoved', ref);
+             }, function(errorData) {
+                defer.reject(errorData);
+              });
              return defer.promise;
            },
            /**

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -278,6 +278,7 @@
               <div class="{$cssDefaultClass}
                 {if ($forceDisplayAttributes) then 'gn-attr-mandatory' else 'gn-attr'}
                 {if ($isDisplayingAttributes = true() or $forceDisplayAttributes = true()) then '' else 'hidden'}">
+                <xsl:attribute name="id">gn-attr-div_<xsl:value-of select="$editInfo/@ref"/></xsl:attribute>
                 <xsl:copy-of select="$attributesSnippet"/>
 
               </div>


### PR DESCRIPTION
Directive `gnAnchorSwitcher` for switching between `gmx:Anchor` and `gco:CharacterString`

CharacterString mode:
![image](https://user-images.githubusercontent.com/826920/55412692-35dac400-5568-11e9-98f7-d63ecd75a959.png)

This mode produces a snippet like:
```xml
<element>
  <gco:CharacterString>Sample text</gco:CharacterString>
</element>
```

When clicking in the button with the link icon it sets the Anchor mode:
![image](https://user-images.githubusercontent.com/826920/55413528-c5cd3d80-5569-11e9-8b8e-5d6411a8beeb.png)

In this mode the component produces:
```xml
<element>
<gmx:Anchor xlink:href="Url in URL field">Sample text</gmx:Anchor>
</element>
```

Clicking in the :x: button sets the CharacterString mode again.


The directive can be use defining it in `config-editor.xml` for specific fields, for example:
```xml
    <for name="gmd:code" xpath="/gmd:MD_Metadata/gmd:identifier/gmd:MD_Identifier/gmd:code" use="data-gn-anchor-switcher"/>
    <for name="gmd:supplementalInformation" use="data-gn-anchor-switcher"/>
    <for name="gmd:organisationName" use="data-gn-anchor-switcher"/>
```

Related to #2867.