### PR TITLE
Use correct siteURL in sitemap urls

### DIFF
--- a/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
+++ b/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
@@ -77,11 +77,10 @@
               <xsl:if test="string($format)"><xsl:value-of select="$format"/>/
               </xsl:if>
             </xsl:variable>
-            <loc><xsl:value-of select="/root/gui/env/server/protocol"/>://<xsl:value-of
-              select="/root/gui/env/server/host"/>:<xsl:value-of
-              select="/root/gui/env/server/port"/><xsl:value-of select="/root/gui/url"/>/sitemap/<xsl:value-of
-              select="$formatParam"/><xsl:value-of select="$pStart"/>/<xsl:value-of
-              select="/root/gui/language"/>
+            <loc>
+              <xsl:value-of select="$siteURL"/><xsl:value-of select="/root/gui/url"/>/sitemap/<xsl:value-of
+                select="$formatParam"/><xsl:value-of select="$pStart"/>/<xsl:value-of
+                select="/root/gui/language"/>
             </loc>
             <lastmod>
               <xsl:value-of select="$changeDate"/>

--- a/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
+++ b/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
@@ -22,7 +22,9 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+				xmlns:util="java:org.fao.geonet.util.XslUtil"
+				version="2.0"
                 exclude-result-prefixes="#all">
 
   <xsl:include href="../../common/base-variables.xsl"/>
@@ -78,7 +80,7 @@
               </xsl:if>
             </xsl:variable>
             <loc>
-              <xsl:value-of select="$siteURL"/><xsl:value-of select="/root/gui/url"/>/sitemap/<xsl:value-of
+              <xsl:value-of select="util:getSiteUrl()"/><xsl:value-of select="/root/gui/url"/>/sitemap/<xsl:value-of
                 select="$formatParam"/><xsl:value-of select="$pStart"/>/<xsl:value-of
                 select="/root/gui/language"/>
             </loc>


### PR DESCRIPTION
This is to uniform to other URLs in GeoNetwork (basically is for avoiding to add port '80' to these URLs).

The URL affected is the one shown when the portal contains more than 2500 records and the sitemap is paginated.

http://localhost:8080/geonetwork/srv/eng/portal.sitemap