### PR TITLE
Migration API - NullPointerException when executing a database migration task. Fixes #3729

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/tools/migration/MigrationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/migration/MigrationApi.java
@@ -81,6 +81,7 @@ public class MigrationApi {
             if (DatabaseMigrationTask.class.isAssignableFrom(clazz)) {
                 DatabaseMigrationTask task =
                     (DatabaseMigrationTask) clazz.newInstance();
+                task.setContext(appContext);
                 task.update(connection);
             } else if (ContextAwareTask.class.isAssignableFrom(clazz)) {
                 ContextAwareTask task = (ContextAwareTask) clazz.newInstance();


### PR DESCRIPTION
Fixes #3729.