### PR TITLE
[BP] DatabaseMigration tasks doesn't save changes in the database. Fixes #3732

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/tools/migration/MigrationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/migration/MigrationApi.java
@@ -81,6 +81,7 @@ public class MigrationApi {
             if (DatabaseMigrationTask.class.isAssignableFrom(clazz)) {
                 DatabaseMigrationTask task =
                     (DatabaseMigrationTask) clazz.newInstance();
+                connection.setAutoCommit(true);
                 task.update(connection);
             } else if (ContextAwareTask.class.isAssignableFrom(clazz)) {
                 ContextAwareTask task = (ContextAwareTask) clazz.newInstance();


### PR DESCRIPTION
Sets auto commit in database connection to `True` as by default was `False` (tested with H2 and Postgres) causing the issue.
Fixes #3732.
Backport of #3733.