### PR TITLE
Improvements to the NoJS view

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -114,16 +114,17 @@
 
   <xsl:template mode="getOverviews" match="gmd:MD_Metadata">
     <section class="gn-md-side-overview">
-      <h4>
+      <h2>
         <i class="fa fa-fw fa-image"><xsl:comment select="'image'"/></i>
         <span><xsl:comment select="name()"/>
           <xsl:value-of select="$schemaStrings/overviews"/>
         </span>
-      </h4>
+      </h2>
 
       <xsl:for-each select="gmd:identificationInfo/*/gmd:graphicOverview/*">
         <img class="gn-img-thumbnail center-block" 
-             itemprop="thumbnailUrl" alt="thumbnail"
+             itemprop="thumbnailUrl"
+             alt="{$schemaStrings/overview}"
              src="{gmd:fileName/*}"/>
 
         <xsl:for-each select="gmd:fileDescription">
@@ -139,7 +140,7 @@
   </xsl:template>
 
   <xsl:template mode="getMetadataHeader" match="gmd:MD_Metadata">
-    <div class="alert alert-info" itemprop="description">
+    <div itemprop="description">
       <xsl:for-each select="gmd:identificationInfo/*/gmd:abstract">
         <xsl:variable name="txt">
           <xsl:call-template name="localised">
@@ -152,77 +153,69 @@
       </xsl:for-each>
     </div>
 
-
     <!-- Citation -->
-    <table class="table">
-      <tr class="active">
-        <td>
-          <div class="pull-left text-muted">
-            <i class="fa fa-quote-left fa-4x"><xsl:comment select="name()"/></i>
-          </div>
-        </td>
-        <td>
-          <em title="{$schemaStrings/citationProposal-help}"><xsl:comment select="name()"/>
-            <xsl:value-of select="$schemaStrings/citationProposal"/>
-          </em><br/>
+    <blockquote>
 
-          <!-- Custodians -->
-          <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
-                                  *[gmd:role/*/@codeListValue = ('custodian', 'author')]">
-            <xsl:variable name="name"
-                          select="normalize-space(gmd:individualName)"/>
+      <em title="{$schemaStrings/citationProposal-help}"><xsl:comment select="name()"/>
+        <xsl:value-of select="$schemaStrings/citationProposal"/>
+      </em><br/>
 
-            <xsl:value-of select="$name"/>
-            <xsl:if test="$name != ''">&#160;(</xsl:if>
-            <xsl:value-of select="gmd:organisationName/*"/>
-            <xsl:if test="$name">)</xsl:if>
-            <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
-          </xsl:for-each>
+      <!-- Custodians -->
+      <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
+                              *[gmd:role/*/@codeListValue = ('custodian', 'author')]">
+        <xsl:variable name="name"
+                      select="normalize-space(gmd:individualName)"/>
 
-          <!-- Publication year: use last publication date -->
-          <xsl:variable  name="publicationDate">
-            <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:date/*[
-                                    gmd:dateType/*/@codeListValue = 'publication']/
-                                      gmd:date/gco:*">
-              <xsl:sort select="." order="descending" />
+        <xsl:value-of select="$name"/>
+        <xsl:if test="$name != ''">&#160;(</xsl:if>
+        <xsl:value-of select="gmd:organisationName/*"/>
+        <xsl:if test="$name">)</xsl:if>
+        <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
+      </xsl:for-each>
 
-              <xsl:if test="position() = 1">
-                <xsl:value-of select="." />
-              </xsl:if>
-            </xsl:for-each>
-          </xsl:variable>
+      <!-- Publication year: use last publication date -->
+      <xsl:variable  name="publicationDate">
+        <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:date/*[
+                                gmd:dateType/*/@codeListValue = 'publication']/
+                                  gmd:date/gco:*">
+          <xsl:sort select="." order="descending" />
 
-          <xsl:if test="normalize-space($publicationDate) != ''">
-            (<xsl:value-of select="substring(normalize-space($publicationDate), 1, 4)"/>)
+          <xsl:if test="position() = 1">
+            <xsl:value-of select="." />
           </xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
 
-          <xsl:text>. </xsl:text>
+      <xsl:if test="normalize-space($publicationDate) != ''">
+        (<xsl:value-of select="substring(normalize-space($publicationDate), 1, 4)"/>)
+      </xsl:if>
 
-          <!-- Title -->
-          <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:title">
-            <xsl:call-template name="localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
+      <xsl:text>. </xsl:text>
 
-          <xsl:text>. </xsl:text>
+      <!-- Title -->
+      <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:title">
+        <xsl:call-template name="localised">
+          <xsl:with-param name="langId" select="$langId"/>
+        </xsl:call-template>
+      </xsl:for-each>
 
-          <!-- Publishers -->
-          <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
-                                  *[gmd:role/*/@codeListValue = 'publisher']">
-            <xsl:value-of select="gmd:organisationName/*"/>
-            <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
-          </xsl:for-each>
+      <xsl:text>. </xsl:text>
 
-          <!-- Link -->
-          <xsl:variable name="url"
-                        select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
-          <a href="{url}">
-            <xsl:value-of select="$url"/>
-          </a>
-        </td>
-      </tr>
-    </table>
+      <!-- Publishers -->
+      <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
+                              *[gmd:role/*/@codeListValue = 'publisher']">
+        <xsl:value-of select="gmd:organisationName/*"/>
+        <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
+      </xsl:for-each>
+
+      <!-- Link -->
+      <xsl:variable name="url"
+                    select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
+      <a href="{url}">
+        <xsl:value-of select="$url"/>
+      </a>
+    </blockquote>
+
   </xsl:template>
 
   <!-- Most of the elements are ... -->
@@ -420,12 +413,12 @@
 	</xsl:choose>
 	</xsl:attribute>
 
-    
-      <h3>
+    <div class="gn-contact">
+      <h2>
         <i class="fa fa-envelope"><xsl:comment select="'email'"/></i>
         <xsl:apply-templates mode="render-value"
                              select="*/gmd:role/*/@codeListValue"/>
-      </h3>
+      </h2>
       <div class="row">
         <div class="col-md-6">
           <address>
@@ -538,7 +531,7 @@
       <dd>
         <xsl:apply-templates mode="render-value" select="*"/>
         <xsl:apply-templates mode="render-value" select="@*"/>
-        <a class="btn btn-link" href="{$nodeUrl}api/records/{$metadataId}/formatters/xml">
+        <a class="btn btn-default" href="{$nodeUrl}api/records/{$metadataId}/formatters/xml">
           <i class="fa fa-file-code-o fa-2x"><xsl:comment select="'file'"/></i>
           <span><xsl:value-of select="$schemaStrings/metadataInXML"/></span>
         </a>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -393,27 +393,26 @@
 
     <div class="gn-contact" itemscope="itemscope"
            itemtype="http://schema.org/Organization">
-	<!-- schema.org:  provider,         provider,   copyrightHolder,  -,        publisher,   sourceOrganization,  provider,       producer,              provider,  publisher, author       (creator, contributor, funder, sponsor, translator)
-	     iso19139:     resourceProvider, custodian,  owner,            user,     distributor, originator,          pointOfContact, principalInvestigator, processor, publisher, author
-	-->
-	<xsl:attribute name="itemprop">
-	<xsl:choose>
-	  <xsl:when test="$role='resourceProvider'">provider</xsl:when>
-	  <xsl:when test="$role='custodian'">provider</xsl:when>
-	  <xsl:when test="$role='owner'">copyrightHolder</xsl:when>
-	  <xsl:when test="$role='user'">user</xsl:when>
-	  <xsl:when test="$role='distributor'">publisher</xsl:when>
-	  <xsl:when test="$role='originator'">sourceOrganization</xsl:when>
-	  <xsl:when test="$role='pointOfContact'">provider</xsl:when>
-	  <xsl:when test="$role='principalInvestigator'">producer</xsl:when>
-	  <xsl:when test="$role='processor'">provider</xsl:when>
-	  <xsl:when test="$role='publisher'">publisher</xsl:when>
-	  <xsl:when test="$role='author'">author</xsl:when>
-	  <xsl:otherwise>provider</xsl:otherwise>
-	</xsl:choose>
-	</xsl:attribute>
+      <!-- schema.org:  provider,         provider,   copyrightHolder,  -,        publisher,   sourceOrganization,  provider,       producer,              provider,  publisher, author       (creator, contributor, funder, sponsor, translator)
+          iso19139:     resourceProvider, custodian,  owner,            user,     distributor, originator,          pointOfContact, principalInvestigator, processor, publisher, author
+      -->
+      <xsl:attribute name="itemprop">
+      <xsl:choose>
+        <xsl:when test="$role='resourceProvider'">provider</xsl:when>
+        <xsl:when test="$role='custodian'">provider</xsl:when>
+        <xsl:when test="$role='owner'">copyrightHolder</xsl:when>
+        <xsl:when test="$role='user'">user</xsl:when>
+        <xsl:when test="$role='distributor'">publisher</xsl:when>
+        <xsl:when test="$role='originator'">sourceOrganization</xsl:when>
+        <xsl:when test="$role='pointOfContact'">provider</xsl:when>
+        <xsl:when test="$role='principalInvestigator'">producer</xsl:when>
+        <xsl:when test="$role='processor'">provider</xsl:when>
+        <xsl:when test="$role='publisher'">publisher</xsl:when>
+        <xsl:when test="$role='author'">author</xsl:when>
+        <xsl:otherwise>provider</xsl:otherwise>
+      </xsl:choose>
+      </xsl:attribute>
 
-    <div class="gn-contact">
       <h2>
         <i class="fa fa-envelope"><xsl:comment select="'email'"/></i>
         <xsl:apply-templates mode="render-value"
@@ -532,7 +531,7 @@
         <xsl:apply-templates mode="render-value" select="*"/>
         <xsl:apply-templates mode="render-value" select="@*"/>
         <a class="btn btn-default" href="{$nodeUrl}api/records/{$metadataId}/formatters/xml">
-          <i class="fa fa-file-code-o fa-2x"><xsl:comment select="'file'"/></i>
+          <i class="fa fa-file-code-o"><xsl:comment select="'file'"/></i>
           <span><xsl:value-of select="$schemaStrings/metadataInXML"/></span>
         </a>
       </dd>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
@@ -232,4 +232,11 @@
   <trueValue>Yes</trueValue>
   <falseValue>No</falseValue>
   <nilValue>Undefined</nilValue>
+  <logo>logo</logo>
+  <overview>overview</overview>
+  <thumbnail>thumbnail</thumbnail>
+  <north>north</north>
+  <east>east</east>
+  <south>south</south>
+  <west>west</west>
 </strings>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_facets_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_facets_default.less
@@ -1,8 +1,8 @@
 /* Facet / this is a hack to hide a facet
- not to be displayed because used to get complex
- field for rendering properly INSPIRE theme icons
- only. It may be more relevant to have this at the
- facetsConfigService ? */
+not to be displayed because used to get complex
+field for rendering properly INSPIRE theme icons
+only. It may be more relevant to have this at the
+facetsConfigService ? */
 [data-facet=inspireThemesWithAc] {
   display: none;
 }
@@ -19,4 +19,27 @@
 .gn-facet-toggle-btn {
   line-height: 1em;
   margin: -4px 0px 4px 0px;
+}
+
+// nojs styles
+.gn-nojs {
+  .gn-facet {
+    summary {
+      text-transform: uppercase;
+      padding: 5px 0;
+      outline: 0;
+      width: 250px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    details { 
+      ul {
+        padding-left: 2.5em;
+      }
+      a {
+        font-weight: normal;
+      }
+    }
+  }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_facets_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_facets_default.less
@@ -24,6 +24,15 @@ facetsConfigService ? */
 // nojs styles
 .gn-nojs {
   .gn-facet {
+    background-color: #fff;
+    h2 {
+      font-size: 20px;
+      margin-top: 10px;
+      margin-right: 5px;
+    }
+    .badge {
+      background-color: #707070;
+    }
     summary {
       text-transform: uppercase;
       padding: 5px 0;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -179,3 +179,11 @@
     margin: 0;
   }
 }
+
+// nojs styles
+.gn-nojs {
+  .gn-logo {
+    max-height: 28px;
+    margin: -8px 0px;
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_pagination_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_pagination_default.less
@@ -50,3 +50,11 @@
     color: @btn-default-color;
   }
 }
+
+// nojs styles
+.gn-nojs {
+  .gn-pages {
+    padding-bottom: 20px;
+    background: #fff;
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -122,3 +122,95 @@
     table-layout: fixed;
   }
 }
+
+// nojs styles
+.gn-nojs {
+  .gn-md-view {
+    h1 {
+      i {
+        display: none;
+      }
+    }
+    blockquote {
+      font-size: 15px;
+      line-height: 1.5em;
+    }
+    .gn-md-side {
+      h2 {
+        font-size: 16px;
+      }
+      .gn-img-thumbnail {
+        line-height: 1.42857;
+        background-color: rgb(255, 255, 255);
+        display: inline-block;
+        max-width: 100%;
+        height: auto;
+        padding: 4px;
+        border-width: 1px;
+        border-style: solid;
+        border-color: rgb(221, 221, 221);
+        border-image: initial;
+        border-radius: 4px;
+        transition: all 0.2s ease-in-out 0s;
+      }
+    } 
+    h2 {
+      font-size: 18px;
+      margin-bottom: 20px;
+    }
+    .gn-contact {
+      padding: 8px;
+      border-top: 1px solid #ddd;
+      h2 {
+        font-size: 14px;
+        margin: 0 0 15px 0;
+      }
+    }
+    dl {
+      .clearfix();
+      border-top: 1px solid #ddd;
+      margin-bottom: 0;
+      padding-bottom: 0;
+      dt {
+        float:left;
+        width: 35%;
+        padding: 8px;
+        font-weight: 500;
+      }
+      dd {
+        float: left;
+        padding: 8px;
+        width: 65%;
+        ul {
+          padding-left: 1.2em;
+        }
+      }
+    }
+    .view-header {
+      border-bottom: 0;
+    }
+    .entry {
+      margin-left: 0 !important;
+      padding-left: 0;
+      border-left: 0;
+    }
+    .extent {
+      display: inline-block;
+      position: relative;
+      margin: 2em 0px 0px 90px;
+      display: inline-block;
+      position: relative;
+      margin: 2em 0px 0px 90px;
+      border-width: 1px;
+      border-style: solid;
+      border-color: rgb(204, 204, 204);
+      border-image: initial;
+    }
+    // tabs
+    .tab-content {
+      .view-header {
+        display: none;
+      }
+    }
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -127,6 +127,8 @@
 .gn-nojs {
   .gn-md-view {
     h1 {
+      margin: 15px 0 25px 0;
+      font-size: 22px;
       i {
         display: none;
       }
@@ -156,7 +158,6 @@
     } 
     h2 {
       font-size: 18px;
-      margin-bottom: 20px;
     }
     .gn-contact {
       padding: 8px;
@@ -186,13 +187,17 @@
         }
       }
     }
-    .view-header {
+    h2.view-header, h5.view-header {
       border-bottom: 0;
     }
     .entry {
       margin-left: 0 !important;
       padding-left: 0;
       border-left: 0;
+      h2 {
+        font-weight: 400;
+        margin: 15px 0;
+      }
     }
     .extent {
       display: inline-block;
@@ -207,10 +212,26 @@
       border-image: initial;
     }
     // tabs
+    .nav-tabs {
+      border: 0;
+      > li {
+        a {
+          border: 1px solid @nav-tabs-border-color;
+          border-radius: @border-radius-base;
+          margin: 0 5px 5px 0;
+        }
+      } 
+    }
     .tab-content {
-      .view-header {
-        display: none;
+      #gn-tab-default {
+        h1.view-header {
+          display: none;
+        }
       }
+      .tab-pane {
+        display: block;
+      }
+
     }
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -26,7 +26,7 @@
 ul.gn-resultview {
   @thumbnail-width: 170px;
   margin-right: -15px;
-
+  
   .metadata {
     position: absolute;
     top: 0;
@@ -47,7 +47,7 @@ ul.gn-resultview {
     .row:first-of-type {
       padding-left: 3px;
     }
-
+    
     .gn-md-thumbnail {
       .gn-img-thumbnail {
         max-width: @thumbnail-width;
@@ -60,7 +60,7 @@ ul.gn-resultview {
         &.gn-md-edit-btn {
           width: 12px;
           margin-left: 10px;
-
+          
         }
       }
       h4 {
@@ -72,13 +72,13 @@ ul.gn-resultview {
       }
     }
   }
-
+  
   .gn-md-title {
     margin-top: 2px;
     overflow: hidden;
     cursor: pointer;
     h3 {
-
+      
       /* Leave space for selection checkbox */
       //padding-left: 20px;
       margin-top: 0px;
@@ -109,10 +109,10 @@ ul.gn-resultview {
   .gn-md-abstract.ellipsis:after {
     background: none;
   }
-
+  
   li.gn-grid {
     @grid-bottom-margin: 2px;
-
+    
     float: left;
     border: 1px solid @list-group-border;
     //box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.4);
@@ -153,7 +153,7 @@ ul.gn-resultview {
       right: 0px;
       padding: 5px;
     }
-
+    
     .gn-md-thumbnail {
       //position: absolute;
       //top: 82px;
@@ -168,7 +168,7 @@ ul.gn-resultview {
         height: auto;
       }
     }
-
+    
     .gn-md-category {
       display: block;
       float: left;
@@ -279,7 +279,7 @@ ul.gn-resultview {
 
 /* Medium devices (desktops, 992px and up) */
 @media (min-width: @screen-md-min) {
-
+  
   ul.gn-resultview li.gn-grid {
     width: calc(~"50% - 15px");
   }
@@ -287,8 +287,51 @@ ul.gn-resultview {
 
 /* Large devices (large desktops, 1200px and up) */
 @media (min-width: @screen-lg-min) {
-
+  
   ul.gn-resultview li.gn-grid {
     //width: calc(~"33% - 15px");
+  }
+}
+
+// nojs styles
+.gn-nojs {
+  .gn-resultview {
+    .list-group-item.gn-grid {
+      border: 0;
+      border-bottom: 1px solid #ddd;
+      margin-bottom: 0;
+      width: 100%;
+      max-width: none;
+      height: auto;
+      border-radius: 0;
+      .gn-md-title {
+        min-height: 0;
+        max-height: none;
+      }
+      h1 {
+        margin: 0 0 20px 0;
+        font-size: 20px;
+        a {
+          color: #333;
+        }
+        &.view-header {
+          margin: 5px 0 15px 0;
+        }
+      }
+      .gn-md-thumbnail {
+        border: 1px solid #ddd;
+        margin-right: 10px;
+        height: auto;
+        margin-top: 5px;
+        border-radius: 2px;
+        img {
+          max-width: 200px;
+        }
+      }
+      p {
+        line-height: 1.6em;
+        font-size: 1em;
+      }
+    }
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -296,6 +296,8 @@ ul.gn-resultview {
 // nojs styles
 .gn-nojs {
   .gn-resultview {
+    .clearfix();
+    padding-bottom: 50px;
     .list-group-item.gn-grid {
       border: 0;
       border-bottom: 1px solid #ddd;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -311,3 +311,14 @@ li.list-group-item.gn-map-item {
     }
   }
 }
+
+// nojs styles
+.gn-nojs {
+  .gn-top-search {
+    padding: 30px 0;
+    margin-bottom: 30px;
+    .btn-lg {
+      padding: 13px 16px;
+    }
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -317,6 +317,9 @@ li.list-group-item.gn-map-item {
   .gn-top-search {
     padding: 30px 0;
     margin-bottom: 30px;
+    .gn-form-any input.input-lg {
+      height: 46px;
+    }
     .btn-lg {
       padding: 13px 16px;
     }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -44,21 +44,25 @@
             itemtype="http://schema.org/geoShape">
         <div class="input-group coord coord-north">
           <input type="text" class="form-control"
+                 aria-label="{$schemaStrings/north}"
                  value="{format-number($north, $numberFormat)}" readonly=""/>
           <span class="input-group-addon">N</span>
         </div>
         <div class="input-group coord coord-south">
           <input type="text" class="form-control"
+                 aria-label="{$schemaStrings/south}"
                  value="{format-number($south, $numberFormat)}" readonly=""/>
           <span class="input-group-addon">S</span>
         </div>
         <div class="input-group coord coord-east">
           <input type="text" class="form-control"
+                aria-label="{$schemaStrings/east}"
                  value="{format-number($east, $numberFormat)}" readonly=""/>
           <span class="input-group-addon">E</span>
         </div>
         <div class="input-group coord coord-west">
           <input type="text" class="form-control"
+                 aria-label="{$schemaStrings/west}"
                  value="{format-number($west, $numberFormat)}" readonly=""/>
           <span class="input-group-addon">W</span>
         </div>
@@ -85,6 +89,7 @@
                     select="util:getSettingValue('region/getmap/mapproj')"/>
 
       <img class="gn-img-extent"
+           alt="{$schemaStrings/thumbnail}"
            src="{$nodeUrl}/eng/region.getmap.png?mapsrs={if ($mapproj != '')
                                          then $mapproj
                                          else 'EPSG:3857'}&amp;width={

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -115,38 +115,43 @@
             <xsl:apply-templates mode="getOverviews" select="$metadata"/>
 
             <section class="gn-md-side-providedby">
-              <h4>
+              <h2>
                 <i class="fa fa-fw fa-cog"><xsl:comment select="'icon'"/></i>
                 <span><xsl:value-of select="$schemaStrings/providedBy"/></span>
-              </h4>
+              </h2>
               <img class="gn-source-logo"
+                   alt="{$schemaStrings/logo}"
                    src="{$nodeUrl}../images/logos/{$source}.png" />
             </section>
 
             <xsl:if test="$isSocialbarEnabled">
               <section class="gn-md-side-social">
-                <h4>
+                <h2>
                   <i class="fa fa-fw fa-share-square-o"><xsl:comment select="'icon'"/></i>
                   <span><xsl:value-of select="$schemaStrings/shareOnSocialSite"/></span>
-                </h4>
+                </h2>
                 <a href="https://twitter.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
-                  target="_blank" class="btn btn-default">
+                   target="_blank"
+                   aria-label="Twitter"
+                   class="btn btn-default">
                   <i class="fa fa-fw fa-twitter"><xsl:comment select="'icon'"/></i>
                 </a>
-                <a href="https://plus.google.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
-                  target="_blank" class="btn btn-default">
-                  <i class="fa fa-fw fa-google-plus"><xsl:comment select="'icon'"/></i>
-                </a>
                 <a href="https://www.facebook.com/sharer.php?u={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
-                  target="_blank" class="btn btn-default">
+                   target="_blank"
+                   aria-label="Facebook"
+                   class="btn btn-default">
                   <i class="fa fa-fw fa-facebook"><xsl:comment select="'icon'"/></i>
                 </a>
                 <a href="http://www.linkedin.com/shareArticle?mini=true&amp;summary=&amp;url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
-                  target="_blank" class="btn btn-default">
+                   target="_blank"
+                   aria-label="LinkedIn"
+                   class="btn btn-default">
                   <i class="fa fa-fw fa-linkedin"><xsl:comment select="'icon'"/></i>
                 </a>
                 <a href="mailto:?subject={$title}&amp;body={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
-                  target="_blank" class="btn btn-default">
+                   target="_blank"
+                   aria-label="Email"
+                   class="btn btn-default">
                   <i class="fa fa-fw fa-envelope-o"><xsl:comment select="'icon'"/></i>
                 </a>
               </section>
@@ -156,10 +161,10 @@
             when in pure HTML mode. -->
             <xsl:if test="$root != 'div'">
               <section class="gn-md-side-viewmode">
-                <h4>
+                <h2>
                   <i class="fa fa-fw fa-eye"><xsl:comment select="'icon'"/></i>
                   <span><xsl:value-of select="$schemaStrings/viewMode"/></span>
-                </h4>
+                </h2>
                 <xsl:for-each select="$configuration/editor/views/view[not(@disabled)]">
                   <ul>
                     <li>
@@ -198,10 +203,10 @@
             </xsl:if>
 
             <section class="gn-md-side-associated">
-              <h4>
+              <h2>
                 <i class="fa fa-fw fa-link"><xsl:comment select="'icon'"/></i>
                 <span><xsl:value-of select="$schemaStrings/associatedResources"/></span>
-              </h4>
+              </h2>
               <div gn-related="md"
                    data-user="user"
                    data-types="parent|children|services|datasets|hassources|sources|fcats|siblings|associated">
@@ -283,7 +288,8 @@
                 match="section[@xpath]">
     <div id="gn-view-{generate-id()}" class="gn-tab-content">
       <xsl:apply-templates mode="render-view" select="@xpath"/>
-    <xsl:comment select="'icon'"/></div>
+      <xsl:comment select="'icon'"/>
+    </div>
   </xsl:template>
 
 
@@ -294,7 +300,7 @@
         <xsl:variable name="title"
                       select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
 
-        <xsl:element name="h{3 + count(ancestor-or-self::*[name(.) = 'section'])}">
+        <xsl:element name="h{1 + count(ancestor-or-self::*[name(.) = 'section'])}">
           <xsl:attribute name="class" select="'view-header'"/>
           <xsl:value-of select="$title"/>
         </xsl:element>

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -58,6 +58,11 @@
           rel="stylesheet" media="screen"/>
   </xsl:template>
 
+  <xsl:template name="css-load-nojs">
+    <link href="{/root/gui/url}/static/{$customFilename}.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+          media="screen"/>
+  </xsl:template>
+
 
   <xsl:template name="javascript-load">
 

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -46,7 +46,7 @@
                select="'dataset'"/>
 
 
-    <html>
+    <html ng-app="{$angularModule}" lang="{$lang2chars}" id="ng-app">
       <head>
         <title><xsl:value-of select="$title"/></title>
         <meta charset="utf-8"/>
@@ -81,13 +81,14 @@
               type="application/opensearchdescription+xml"
               title="{$title}"/>
 
-        <xsl:call-template name="css-load"/>
+        <xsl:call-template name="css-load-nojs"/>
+
       </head>
 
-      <body>
+      <body class="gn-nojs">
         <div class="gn-full">
           <xsl:call-template name="header"/>
-          <div class="container">
+          <div class="container" role="main">
             <xsl:copy-of select="$content"/>
           </div>
           <xsl:call-template name="footer"/>
@@ -108,15 +109,15 @@
         </script>
 
         <script type="text/javascript">
-          //show elements that require js
+          <!-- //show elements that require js -->
           $(".hidden-nojs").removeClass('hidden-nojs');
 
-          // attach click to tab
+          <!-- // attach click to tab -->
           $('.nav-tabs-advanced a').click(function (e) {
             e.preventDefault();
             $(this).tab('show');
           });
-          // hide empty tab
+          <!-- // hide empty tab -->
           $('.nav-tabs-advanced a').each(function() {
 
             var tabLink = $(this).attr('href');
@@ -127,10 +128,9 @@
               }
             }
           });
-          // show the first tab
+          <!-- // show the first tab -->
           $('.nav-tabs-advanced a:first').tab('show');
         </script>
-        <xsl:call-template name="css-load"/>
       </body>
     </html>
   </xsl:template>

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -94,43 +94,6 @@
           <xsl:call-template name="footer"/>
         </div>
 
-        <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-        <script src="//code.jquery.com/jquery-1.12.4.min.js"
-                integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-                crossorigin="anonymous">
-          &#160;
-        </script>
-
-        <!-- Latest compiled and minified JavaScript -->
-        <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
-                integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
-                crossorigin="anonymous">
-          &#160;
-        </script>
-
-        <script type="text/javascript">
-          <!-- //show elements that require js -->
-          $(".hidden-nojs").removeClass('hidden-nojs');
-
-          <!-- // attach click to tab -->
-          $('.nav-tabs-advanced a').click(function (e) {
-            e.preventDefault();
-            $(this).tab('show');
-          });
-          <!-- // hide empty tab -->
-          $('.nav-tabs-advanced a').each(function() {
-
-            var tabLink = $(this).attr('href');
-
-            if (tabLink) {
-              if ($(tabLink).length === 0) {
-                $(this).parent().hide();
-              }
-            }
-          });
-          <!-- // show the first tab -->
-          $('.nav-tabs-advanced a:first').tab('show');
-        </script>
       </body>
     </html>
   </xsl:template>

--- a/web/src/main/webapp/xslt/skin/default/skin.xsl
+++ b/web/src/main/webapp/xslt/skin/default/skin.xsl
@@ -8,7 +8,7 @@
                 exclude-result-prefixes="#all">
 
   <xsl:template name="header">
-    <div class="navbar navbar-default gn-top-bar">
+    <div class="navbar navbar-default gn-top-bar" role="navigation">
       <div class="container">
         <div class="navbar-header">
           <button type="button"
@@ -66,36 +66,31 @@
     <xsl:if test="/root/search/response">
       <form action="{$nodeUrl}search"
             class="form-horizontal" role="form">
-        <div class="row gn-top-search" style="margin:15px auto">
-          <div class="col-md-12">
-            <div class="row">
-              <div class="col-md-offset-4 col-md-4 relative">
-                <div class="gn-form-any input-group">
-                  <input type="text"
-                         name="any"
-                         id="gn-any-field"
-                         placeholder="{$t/anyPlaceHolder}"
-                         value="{/root/request/any}"
-                         class="form-control input-lg"
-                         autofocus=""/>
-                  <div class="input-group-btn">
-                    <button type="submit"
-                            class="btn btn-primary btn-lg"
-                            title="{$t/search}">
-                      &#160;&#160;
-                      <i class="fa fa-search">&#160;</i>
-                      &#160;&#160;
-                    </button>
-                    <a href="{$nodeUrl}search"
-                       class="btn btn-link btn-lg"
-                       title="{$t/reset}">
-                      <i class="fa fa-times">&#160;</i>
-                    </a>
-                  </div>
-                </div>
-                <input type="hidden" name="fast" value="index"/>
+        <div class="row gn-top-search">
+          <div class="col-md-offset-3 col-md-6 relative">
+            <div class="gn-form-any input-group">
+              <input type="text"
+                      name="any"
+                      id="gn-any-field"
+                      aria-label="{$t/anyPlaceHolder}"
+                      placeholder="{$t/anyPlaceHolder}"
+                      value="{/root/request/any}"
+                      class="form-control input-lg"
+                      autofocus=""/>
+              <div class="input-group-btn">
+                <button type="submit"
+                        class="btn btn-default btn-lg"
+                        title="{$t/search}">
+                  <i class="fa fa-search">&#160;</i>
+                </button>
+                <a href="{$nodeUrl}search"
+                    class="btn btn-default btn-lg"
+                    title="{$t/reset}">
+                  <i class="fa fa-times">&#160;</i>
+                </a>
               </div>
             </div>
+            <input type="hidden" name="fast" value="index"/>
           </div>
         </div>
       </form>
@@ -104,7 +99,7 @@
 
   <xsl:template name="footer">
 
-    <div class="navbar navbar-default gn-bottom-bar">
+    <div class="navbar navbar-default gn-bottom-bar" role="navigation">
       <ul class="nav navbar-nav">
         <li class="gn-footer-text">
 
@@ -122,7 +117,7 @@
           </a>
         </li>
         <li>
-          <a href="{/root/gui/url}/doc/api" title="{$t/learnTheApi}"><xsl:value-of select="$t/api"/></a>
+          <a href="{/root/gui/url}/doc/api" title="{$t/learnTheApi}"><xsl:value-of select="$t/api"/>&#160;</a>
         </li>
       </ul>
     </div>

--- a/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
+++ b/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
@@ -209,14 +209,14 @@
                  </div>
 
                   <div class="clearfix">
-                    <div class="gn-md-thumbnail pull-left">
-                      <xsl:for-each select="image[1]">
+                    <xsl:for-each select="image[1]">
+                      <div class="gn-md-thumbnail pull-left">
                         <img class="gn-img-thumbnail"
                              itemprop="thumbnailUrl"
                              alt="{thumbnail}"
-                             src="{tokenize(., '\|')[2]}"></img>
-                      </xsl:for-each>
-                    </div>
+                             src="{tokenize(., '\|')[2]}" />
+                      </div>
+                    </xsl:for-each>
                     <p itemprop="description">
                       <xsl:value-of select="abstract"/>
                     </p>

--- a/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
+++ b/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
@@ -60,7 +60,7 @@
           for this criteria. For contact, source catalog, an extra panel
           is added with some details about this resource. -->
           <xsl:if test="count($parameters) = 1">
-            <div class="thumbnail text-center">
+            <div class="text-center">
               <xsl:variable name="parameterName"
                             select="$parameters[1]/name()"/>
               <xsl:variable name="parameterLabel"
@@ -68,9 +68,9 @@
 
               <xsl:variable name="parameterValue"
                             select="$parameters[1]/text()"/>
-              <h4>
+              <b>
                 <xsl:value-of select="$parameterLabel"/>
-              </h4>
+              </b>
               <!-- Illustration -->
               <xsl:choose>
                 <xsl:when test="$parameterName = '_groupPublished'">
@@ -101,9 +101,9 @@
                   </h2>
                 </xsl:otherwise>
               </xsl:choose>
-              <h4>
+              <span class="badge">
                 <xsl:value-of select="concat($count, ' ', $t/records)"/>
-              </h4>
+              </span>
             </div>
           </xsl:if>
           &#160;
@@ -112,7 +112,8 @@
         <xsl:if test="$count > 0">
           <xsl:for-each select="/root/search/response[1]/summary">
             <xsl:for-each select="dimension[category]">
-              <h4><xsl:value-of select="gn-fn-core:translate(@label, $t)"/></h4>
+            <details>
+              <summary><xsl:value-of select="gn-fn-core:translate(@label, $t)"/></summary>
 
               <xsl:variable name="field" select="@name"/>
               <ul>
@@ -136,13 +137,15 @@
                     </label>
                   </li>
                 </xsl:for-each>
-              </ul>
+              </ul></details>
             </xsl:for-each>
+            
           </xsl:for-each>
         </xsl:if>
       </div>
       <xsl:if test="$count > 0">
         <div class="col-md-9">
+        
           <xsl:for-each select="/root/search/response[@from]">
 
             <div class="row" style="padding-bottom:20px">
@@ -186,11 +189,11 @@
                    </xsl:if>
                  </div>
 
-                 <div class="row gn-md-title">
-                   <h3 itemprop="name">
+                 <div class="gn-md-title">
+                   <h1 itemprop="name">
                      <a href="{$nodeUrl}api/records/{*[name()='geonet:info']/uuid}"
                         itemprop="url">
-                       <i class="fa gn-icon-{type}" title="{type}">&#160;</i>
+                       <!-- <i class="fa gn-icon-{type}" title="{type}">&#160;</i> -->
                        <xsl:choose>
                          <xsl:when test="title != ''">
                            <xsl:value-of select="title"/>
@@ -200,26 +203,20 @@
                          </xsl:otherwise>
                        </xsl:choose>
                      </a>
-                   </h3>
+                   </h1>
                  </div>
 
-                 <div>
-                   <div class="gn-md-thumbnail">
-                     <xsl:for-each select="image[1]">
-                       <img class="gn-img-thumbnail" itemprop="thumbnailUrl"
-                            src="{tokenize(., '\|')[2]}"></img>
-                     </xsl:for-each>
-                   </div>
-                   <div style="float:left; display:block; width: calc(100% - 162px)">
-                     <div class="text-justify gn-md-abstract ellipsis">
-                       <div>
-                         <p itemprop="description">
-                           <xsl:value-of select="abstract"/>
-                         </p>
-                       </div>
-                     </div>
-                   </div>
-                 </div>
+                  <div class="clearfix">
+                    <div class="gn-md-thumbnail pull-left">
+                      <xsl:for-each select="image[1]">
+                        <img class="gn-img-thumbnail" itemprop="thumbnailUrl"
+                              src="{tokenize(., '\|')[2]}"></img>
+                      </xsl:for-each>
+                    </div>
+                    <p itemprop="description">
+                      <xsl:value-of select="abstract"/>
+                    </p>
+                  </div>
                 </li>
               </xsl:for-each>
             </ul>

--- a/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
+++ b/web/src/main/webapp/xslt/ui-search/search-nojs.xsl
@@ -60,7 +60,7 @@
           for this criteria. For contact, source catalog, an extra panel
           is added with some details about this resource. -->
           <xsl:if test="count($parameters) = 1">
-            <div class="text-center">
+            <div class="clearfix">
               <xsl:variable name="parameterName"
                             select="$parameters[1]/name()"/>
               <xsl:variable name="parameterLabel"
@@ -68,39 +68,41 @@
 
               <xsl:variable name="parameterValue"
                             select="$parameters[1]/text()"/>
-              <b>
-                <xsl:value-of select="$parameterLabel"/>
-              </b>
+              <div class="gn-margin-bottom">
+                <strong><xsl:value-of select="$parameterLabel"/></strong>
+              </div>
               <!-- Illustration -->
-              <xsl:choose>
-                <xsl:when test="$parameterName = '_groupPublished'">
-                  <img  class="gn-logo-lg"
-                        src="{nodeUrl}../images/harvesting/{$parameterValue}.png"/>
-                </xsl:when>
-                <xsl:when test="$parameterName = '_source'">
-                  <img  class="gn-logo-lg"
-                        src="{nodeUrl}../images/logos/{$parameterValue}.png"/>
-                </xsl:when>
-                <xsl:when test="$parameterName = 'responsiblePartyEmail'">
-                  <img src="//gravatar.com/avatar/{util:md5Hex($parameterValue)}?s=200"/>
-                  <h2>
-                    <xsl:value-of select="$parameterValue"/>
-                  </h2>
-                </xsl:when>
-                <xsl:when test="$parameterName = 'topicCat' or $parameterName = 'type'">
-                  <span class="">
-                    <i class="fa fa-3x gn-icon gn-icon-{$parameterValue}">&#160;</i>
-                  </span>
-                  <h2>
-                    <xsl:value-of select="$parameterValue"/>
-                  </h2>
-                </xsl:when>
-                <xsl:otherwise>
-                  <h2>
-                    <xsl:value-of select="$parameterValue"/>
-                  </h2>
-                </xsl:otherwise>
-              </xsl:choose>
+              <div class="pull-left">
+                <xsl:choose>
+                  <xsl:when test="$parameterName = '_groupPublished'">
+                    <img  class="gn-logo-lg"
+                          src="{nodeUrl}../images/harvesting/{$parameterValue}.png"/>
+                  </xsl:when>
+                  <xsl:when test="$parameterName = '_source'">
+                    <img  class="gn-logo-lg"
+                          src="{nodeUrl}../images/logos/{$parameterValue}.png"/>
+                  </xsl:when>
+                  <xsl:when test="$parameterName = 'responsiblePartyEmail'">
+                    <img src="//gravatar.com/avatar/{util:md5Hex($parameterValue)}?s=200"/>
+                    <h2>
+                      <xsl:value-of select="$parameterValue"/>
+                    </h2>
+                  </xsl:when>
+                  <xsl:when test="$parameterName = 'topicCat' or $parameterName = 'type'">
+                    <span class="">
+                      <i class="fa fa-3x gn-icon gn-icon-{$parameterValue}">&#160;</i>
+                    </span>
+                    <h2>
+                      <xsl:value-of select="$parameterValue"/>
+                    </h2>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <h2>
+                      <xsl:value-of select="$parameterValue"/>
+                    </h2>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </div>
               <span class="badge">
                 <xsl:value-of select="concat($count, ' ', $t/records)"/>
               </span>
@@ -148,7 +150,7 @@
         
           <xsl:for-each select="/root/search/response[@from]">
 
-            <div class="row" style="padding-bottom:20px">
+            <div class="row gn-pages">
               <div class="col-xs-12">
                 <xsl:value-of select="$t/from"/>
                 <b>
@@ -209,8 +211,10 @@
                   <div class="clearfix">
                     <div class="gn-md-thumbnail pull-left">
                       <xsl:for-each select="image[1]">
-                        <img class="gn-img-thumbnail" itemprop="thumbnailUrl"
-                              src="{tokenize(., '\|')[2]}"></img>
+                        <img class="gn-img-thumbnail"
+                             itemprop="thumbnailUrl"
+                             alt="{thumbnail}"
+                             src="{tokenize(., '\|')[2]}"></img>
                       </xsl:for-each>
                     </div>
                     <p itemprop="description">


### PR DESCRIPTION
Replaces PR: https://github.com/geonetwork/core-geonetwork/pull/3645

This PR brings the layout of the NoJS view closer to the default views. A new class is introduced: gn-nojs to target styling for the NoJS views.

Changes to the styling
- use of `<blockquote>` for the filter options

Together with the styling some accessibility issues are addressed:

- added aria-roles
- better headings (`<h2>` follows `<h1>`)
- improved colour contrast

**Screenshots after the restyling**
![gn-nojs-list](https://user-images.githubusercontent.com/19608667/53804836-d1b4e800-3f48-11e9-8401-29742be5d27b.png)

![gn-nojs-detail](https://user-images.githubusercontent.com/19608667/53804873-ed1ff300-3f48-11e9-9396-bd4517e3f10b.png)