### PR TITLE
[BP 3.6.x] Editor / Missing asterisk on + action when cardinality is 1..n

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl
@@ -181,7 +181,7 @@
     <xsl:variable name="dateTypeElementRef"
                   select="gn:element/@ref"/>
 
-    <xsl:variable name="isRequired" select="gn:element/@min = 1 and gn:element/@max = 1"/>
+    <xsl:variable name="isRequired" select="gn:element/@min = 1"/>
 
     <div class="form-group gn-field gn-date {if ($isRequired) then 'gn-required' else ''}"
          id="gn-el-{$dateTypeElementRef}"

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -789,7 +789,7 @@
                     select="concat($childEditInfo/@prefix, ':', $childEditInfo/@name)"/>
       <xsl:variable name="parentName"
                     select="name(ancestor::*[not(contains(name(), 'CHOICE_ELEMENT'))][1])"/>
-      <xsl:variable name="isRequired" select="$childEditInfo/@min = 1 and $childEditInfo/@max = 1"/>
+      <xsl:variable name="isRequired" select="$childEditInfo/@min = 1"/>
 
       <!-- This element is replaced by the content received when clicking add -->
       <div


### PR DESCRIPTION
This is the backporting to 3.6.x of https://github.com/geonetwork/core-geonetwork/pull/3620 from @fxprunayre 