### PR TITLE
Settings to switch between fluid and fixed width container/layout

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -835,6 +835,32 @@
         </div>
       </div>
 
+      <div data-ng-switch-when="fluidLayout">
+
+        <input type="checkbox"
+               id="{{key}}-checkbox"
+               data-ng-model="mCfg[key]"/>&nbsp;
+        <label class="control-label"
+               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
+      <div data-ng-switch-when="fluidEditorLayout">
+
+        <input type="checkbox"
+               id="{{key}}-checkbox"
+               data-ng-model="mCfg[key]"/>&nbsp;
+        <label class="control-label"
+               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
       <div data-ng-switch-default>
         <label class="control-label">{{('ui-' + key) | translate}}</label>
         <input type="text"

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -91,7 +91,8 @@ goog.require('gn_alert');
         'home': {
           'enabled': true,
           'appUrl': '../../srv/{{lang}}/catalog.search#/home',
-          'showSocialBarInFooter': true
+          'showSocialBarInFooter': true,
+          'fluidLayout': true
         },
         'search': {
           'enabled': true,
@@ -235,6 +236,7 @@ goog.require('gn_alert');
           'appUrl': '../../srv/{{lang}}/catalog.edit',
           'isUserRecordsOnly': false,
           'isFilterTagsDisplayed': false,
+          'fluidEditorLayout': true,
           'createPageTpl':
               '../../catalog/templates/editor/new-metadata-horizontal.html',
           'editorIndentType': ''
@@ -433,6 +435,7 @@ goog.require('gn_alert');
       // Links for social media
       $scope.socialMediaLink = $location.absUrl();
       $scope.getPermalink = gnUtilityService.getPermalink;
+      $scope.fluidEditorLayout = gnGlobalSettings.gnCfg.mods.editor.fluidEditorLayout;
 
       // If gnLangs current already set by config, do not use URL
       $scope.langs = gnGlobalSettings.gnCfg.mods.header.languages;

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1359,5 +1359,9 @@
     "hopCount": "Hop count",
     "hopCountHelp": "Control the maximum number of message hops (default to 2) before the search is terminated in a distributed search.",
     "ui-showSocialBarInFooter": "Show Socialbar",
-    "ui-showSocialBarInFooter-help": "Show the button bar with all the social buttons (facebook, twitter, etc.) in the footer of GeoNetwork"
+    "ui-showSocialBarInFooter-help": "Show the button bar with all the social buttons (facebook, twitter, etc.) in the footer of GeoNetwork",
+    "ui-fluidLayout": "Fluid container for Home and Search",
+    "ui-fluidLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container",
+    "ui-fluidEditorLayout": "Fluid container for the Editor",
+    "ui-fluidEditorLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container"
 }

--- a/web-ui/src/main/resources/catalog/templates/editor/editor.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editor.html
@@ -20,8 +20,9 @@
       unsupportedSchemaAlert
     </div>
 
-
-    <div id="gn-editor-container-{{id}}"></div>
+    <div data-ng-class="fluidEditorLayout ? 'container-fluid' : 'container'">
+      <div id="gn-editor-container-{{id}}"></div>
+    </div>
 
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -1,18 +1,19 @@
 <div class="gn-editor-board"
      data-ng-controller="GnSearchController">
   <div class="row" data-ng-controller="GnEditorBoardSearchController">
-    <div class="col-sm-12"
-         data-ng-search-form=""
-         data-runSearch="true"
-         data-wait-for-user="true" >
+    <div data-ng-class="fluidEditorLayout ? 'container-fluid' : 'container'">
+      <div class="col-sm-12"
+          data-ng-search-form=""
+          data-runSearch="true"
+          data-wait-for-user="true" >
 
-      <div class="gn-sub-bar">
-        <form class="form-horizontal"
-              role="form">
-          <input type="hidden" name="_csrf" value="{{csrf}}"/>
-          <div class="row gn-top-search">
-            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-5">
-              <div class="input-group gn-form-any">
+        <div class="gn-sub-bar">
+          <form class="form-horizontal"
+                role="form">
+            <input type="hidden" name="_csrf" value="{{csrf}}"/>
+            <div class="row gn-top-search">
+              <div class="col-xs-12 col-sm-6 col-md-6 col-lg-5">
+                <div class="input-group gn-form-any">
 
                 <span class="input-group-addon">
                   <label>
@@ -45,87 +46,88 @@
                   </button>
                 </div>
 
+                </div>
+              </div>
+              <div class="col-xs-12 col-sm-6 col-md-6 col-lg-7 text-right">
+                <a href="#/create" class="btn btn-primary">
+                  <i class="fa fa-fw fa-plus"/><span data-translate="">addRecord</span>
+                </a>
+                <a href="#/import" class="btn btn-default">
+                  <i class="fa fa-fw fa-upload"/><span class="hidden-xs hidden-sm" data-translate="">ImportRecord</span>
+                </a>
+                <a href="#/directory" class="btn btn-default"
+                  ng-if="user.isEditorOrMore()">
+                  <i class="fa fa-fw fa-bookmark"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">directoryManager</span>
+                </a>
+                <a href="#/batchedit" class="btn btn-default"
+                  ng-if="user.isEditorOrMore()">
+                  <i class="fa fa-fw fa-pencil"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
+                </a>
+                <a href="#/accessManager" class="btn btn-default"
+                  ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
+                  <i class="fa fa-fw fa-lock"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
+                </a>
               </div>
             </div>
-            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-7 text-right">
-              <a href="#/create" class="btn btn-primary">
-                <i class="fa fa-fw fa-plus"/><span data-translate="">addRecord</span>
-              </a>
-              <a href="#/import" class="btn btn-default">
-                <i class="fa fa-fw fa-upload"/><span class="hidden-xs hidden-sm" data-translate="">ImportRecord</span>
-              </a>
-              <a href="#/directory" class="btn btn-default"
-                 ng-if="user.isEditorOrMore()">
-                <i class="fa fa-fw fa-bookmark"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">directoryManager</span>
-              </a>
-              <a href="#/batchedit" class="btn btn-default"
-                 ng-if="user.isEditorOrMore()">
-                <i class="fa fa-fw fa-pencil"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
-              </a>
-              <a href="#/accessManager" class="btn btn-default"
-                 ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
-                <i class="fa fa-fw fa-lock"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
-              </a>
-            </div>
-          </div>
-        </form>
-      </div>
-
-      <div class="row">
-        <div class="gn-results-heading col-md-offset-3">
-          <div data-search-filter-tags data-use-location-parameters="false"
-               data-ng-show="isFilterTagsDisplayed"></div>
+          </form>
         </div>
-      </div>
 
-
-
-      <div class="row">
-        <div class="col-sm-3 col-md-3 gn-search-facet">
-
-          <!-- Hierachical facet mode -->
-          <div data-ng-show="searchResults.records.length > 0"
-               data-gn-facet-dimension-list="searchResults.dimension"
-               data-params="searchObj.params"
-               data-facet-type="facetsSummaryType"
-               data-current-facets="currentFacets">
+        <div class="row">
+          <div class="gn-results-heading col-md-offset-3">
+            <div data-search-filter-tags data-use-location-parameters="false"
+                data-ng-show="isFilterTagsDisplayed"></div>
           </div>
         </div>
-        <div class="col-sm-9 col-md-9">
 
-          <span class="loading fa fa-spinner fa-spin"
-                data-ng-show="searching"></span>
 
-          <div class="alert alert-warning" role="alert"
-               ng-if="!searching && searchResults.count == 0">
-            <i class="fa fa-frown-o"></i>
-            <span data-translate="">zarooResult</span>
-          </div>
 
-          <div class="row gn-margin-bottom"
-               data-ng-show="searchResults.records.length > 0">
-            <div class="col-xs-12 col-sm-5 col-md-3 relative gn-nopadding-left">
-              <div data-gn-selection-widget=""
-                   data-results="searchResults"></div>
-            </div>
-            <div class="col-xs-12 col-sm-7 col-md-5 gn-nopadding-left gn-nopadding-right text-right">
-              <div class="pull-right"
-                   data-gn-pagination="paginationInfo"
-                   data-hits-values="searchObj.hitsperpageValues"></div>
-            </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 gn-nopadding-right text-right">
-              <div class="pull-right"
-                   data-sortby-combo=""
-                   data-params="searchObj.params"
-                   data-gn-sortby-values="searchObj.sortbyValues"></div>
-            </div>
-          </div>
-          <div class="row">
+        <div class="row">
+          <div class="col-sm-3 col-md-3 gn-search-facet">
+
+            <!-- Hierachical facet mode -->
             <div data-ng-show="searchResults.records.length > 0"
-                data-gn-results-container=""
-                data-search-results="searchResults"
-                data-template-url="resultTemplate"></div>
+                data-gn-facet-dimension-list="searchResults.dimension"
+                data-params="searchObj.params"
+                data-facet-type="facetsSummaryType"
+                data-current-facets="currentFacets">
             </div>
+          </div>
+          <div class="col-sm-9 col-md-9">
+
+            <span class="loading fa fa-spinner fa-spin"
+                  data-ng-show="searching"></span>
+
+            <div class="alert alert-warning" role="alert"
+                ng-if="!searching && searchResults.count == 0">
+              <i class="fa fa-frown-o"></i>
+              <span data-translate="">zarooResult</span>
+            </div>
+
+            <div class="row gn-margin-bottom"
+                data-ng-show="searchResults.records.length > 0">
+              <div class="col-xs-12 col-sm-5 col-md-3 relative gn-nopadding-left">
+                <div data-gn-selection-widget=""
+                    data-results="searchResults"></div>
+              </div>
+              <div class="col-xs-12 col-sm-7 col-md-5 gn-nopadding-left gn-nopadding-right text-right">
+                <div class="pull-right"
+                    data-gn-pagination="paginationInfo"
+                    data-hits-values="searchObj.hitsperpageValues"></div>
+              </div>
+              <div class="col-xs-12 col-sm-12 col-md-4 gn-nopadding-right text-right">
+                <div class="pull-right"
+                    data-sortby-combo=""
+                    data-params="searchObj.params"
+                    data-gn-sortby-values="searchObj.sortbyValues"></div>
+              </div>
+            </div>
+            <div class="row">
+              <div data-ng-show="searchResults.records.length > 0"
+                  data-gn-results-container=""
+                  data-search-results="searchResults"
+                  data-template-url="resultTemplate"></div>
+              </div>
+          </div>
         </div>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -137,6 +137,8 @@
       $scope.facetConfig = gnSearchSettings.facetConfig;
       $scope.facetTabField = gnSearchSettings.facetTabField;
       $scope.location = gnSearchLocation;
+      $scope.fluidLayout = gnGlobalSettings.gnCfg.mods.home.fluidLayout;
+      $scope.fluidEditorLayout = gnGlobalSettings.gnCfg.mods.editor.fluidEditorLayout;
       $scope.toggleMap = function () {
         $(searchMap.getTargetElement()).toggle();
         $('button.gn-minimap-toggle > i').toggleClass('fa-angle-double-left fa-angle-double-right');

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -1,34 +1,37 @@
-<div class="container-fluid">
+<!-- <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'"> -->
   <div class="row gn-row-main">
-    <div class="col-sm-8 col-sm-offset-2">
+    <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
+      <div class="col-sm-8 col-sm-offset-2">
 
-      <div class="input-group gn-form-any">
-        <input type="text"
-               class="form-control input-lg"
-               autofocus=""
-               data-ng-model="homeAnyField"
-               data-ng-model-options="modelOptions"
-               placeholder="{{'anyPlaceHolder' | translate}}"
-               aria-label="{{'anyPlaceHolder' | translate}}"
-               data-ng-keyup="$event.keyCode == 13 && goToSearch(homeAnyField)"
-               data-typeahead="address for address in getAnySuggestions($viewValue)"
-               data-typeahead-loading="anyLoading"
-               data-typeahead-min-length="1"/>
-        <span class="input-group-btn">
-          <a class="btn btn-primary btn-lg"
-             type="button"
-             data-ng-href="#/search?any={{homeAnyField}}">
-            <i class="fa fa-search"></i>
-            <span class="sr-only" data-translate="">search</span>
-          </a>
-        </span>
+        <div class="input-group gn-form-any">
+          <input type="text"
+                class="form-control input-lg"
+                autofocus=""
+                data-ng-model="homeAnyField"
+                data-ng-model-options="modelOptions"
+                placeholder="{{'anyPlaceHolder' | translate}}"
+                aria-label="{{'anyPlaceHolder' | translate}}"
+                data-ng-keyup="$event.keyCode == 13 && goToSearch(homeAnyField)"
+                data-typeahead="address for address in getAnySuggestions($viewValue)"
+                data-typeahead-loading="anyLoading"
+                data-typeahead-min-length="1"/>
+          <span class="input-group-btn">
+            <a class="btn btn-primary btn-lg"
+              type="button"
+              data-ng-href="#/search?any={{homeAnyField}}">
+              <i class="fa fa-search"></i>
+              <span class="sr-only" data-translate="">search</span>
+            </a>
+          </span>
+        </div>
+
+        <div data-translate="" class="search-over"
+            data-translate-values="{records: '{{searchInfo.count}}'}">searchOver</div>
+
       </div>
-
-      <div data-translate="" class="search-over"
-           data-translate-values="{records: '{{searchInfo.count}}'}">searchOver</div>
-
     </div>
   </div>
+  <!-- /.gn-row-main -->
 
   <form class="form-horizontal"
         role="grid"
@@ -37,7 +40,8 @@
         data-runSearch="true"
         data-ng-show="searchResults.records.length > 0">
     <div class="row gn-top-records" role="row">
-      <h4 data-translate="">topMaps</h4>
+      <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
+        <h4 data-translate="">topMaps</h4>
 
         <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
@@ -45,95 +49,59 @@
              data-gn-results-container=""
              data-search-results="searchResults"
              data-template-url="resultTemplate"></div>
+      </div>
     </div>
+    <!-- /.gn-top-records -->
   </form>
 
   <div class="row" data-ng-show="searchInfo.count == 0">
-    <div data-ng-show="searchInfo.count == 0"
-         class="col-md-offset-4 col-md-4 alert alert-warning">
-      <span data-translate="">noDataInCatalog</span>
-      <div data-gn-need-help="user-guide/quick-start/index.html"></div>
+    <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
+      <div data-ng-show="searchInfo.count == 0"
+          class="col-md-offset-2 col-md-8 alert alert-warning">
+        <span data-translate="">noDataInCatalog</span>
+        <div data-gn-need-help="user-guide/quick-start/index.html"></div>
+      </div>
     </div>
   </div>
 
 
   <div class="row gn-row-topics" data-ng-show="searchInfo.count > 0">
-    <div class="col-sm-12 col-md-9" data-ng-show="browse !== ''">
-      <h4>
-        <span data-translate="">browseBy</span>
-        <span
-          data-ng-show="searchInfo.facet['inspireThemes'].length > 0 && searchInfo.facet['topicCats'].length > 0">
-          <label data-ng-show="searchInfo.facet['inspireThemes'].length > 0">
-            <input type="radio" name="browse" value="inspire" data-ng-model="browse"/>
-            <span data-translate="">inspireThemes</span>
-          </label>
-          <label data-ng-show="searchInfo.facet['topicCats'].length > 0">
-            <input type="radio" name="browse" value="topics" data-ng-model="browse"/>
-            <span data-translate="">topics</span>
-          </label>
-        </span>
-        <label
-          data-ng-show="searchInfo.facet['inspireThemes'].length > 0 && searchInfo.facet['topicCats'].length == 0"><span
-          data-translate="">inspireThemes</span></label>
-        <label
-          data-ng-show="searchInfo.facet['topicCats'].length > 0 && searchInfo.facet['inspireThemes'].length == 0"><span
-          data-translate="">topics</span></label>
-      </h4>
+    <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
+      <div class="col-sm-12 col-md-9" data-ng-show="browse !== ''">
+        <h4>
+          <span data-translate="">browseBy</span>
+          <span
+            data-ng-show="searchInfo.facet['inspireThemes'].length > 0 && searchInfo.facet['topicCats'].length > 0">
+            <label data-ng-show="searchInfo.facet['inspireThemes'].length > 0">
+              <input type="radio" name="browse" value="inspire" data-ng-model="browse"/>
+              <span data-translate="">inspireThemes</span>
+            </label>
+            <label data-ng-show="searchInfo.facet['topicCats'].length > 0">
+              <input type="radio" name="browse" value="topics" data-ng-model="browse"/>
+              <span data-translate="">topics</span>
+            </label>
+          </span>
+          <label
+            data-ng-show="searchInfo.facet['inspireThemes'].length > 0 && searchInfo.facet['topicCats'].length == 0"><span
+            data-translate="">inspireThemes</span></label>
+          <label
+            data-ng-show="searchInfo.facet['topicCats'].length > 0 && searchInfo.facet['inspireThemes'].length == 0"><span
+            data-translate="">topics</span></label>
+        </h4>
 
-<!--       <div class="row">
-        <span id="chips-card" data-ng-repeat="(key, facet) in searchInfo.facet['topicCats']"
-              class="col-xs-6 col-sm-4 col-lg-3" data-ng-show="browse === 'topics'"> -->
-      <div class="row">
-        <span data-ng-repeat="(key, facet) in searchInfo.facet['topicCats']"
-              data-ng-show="browse === 'topics'"
-              class="col-xs-12 col-sm-6 col-md-4 chips-card">
-          <div class="badge-result badge-result-topic clearfix">
-            <a class="pull-left clearfix"
-               title="{{facet['@label']}}"
-               role="link"
-               data-ng-href="#/search?facet.q=topicCat%2F{{facet['@name']}}">
-              <span class="badge-icon badge-result-topic pull-left">
-                <i class="fa fa-3x fa-table gn-icon gn-icon-{{facet['@name']}}"></i>
-              </span>
-              <span class="badge-text pull-left">
-                <span class="gn-icon-label">{{facet['@label']}}</span>
-              </span>
-            </a>
-            <span class="badge pull-left">{{facet['@count']}}</span>
-          </div>
-        </span>
-        <span data-ng-repeat="(key, facet) in searchInfo.facet['inspireThemesURI'] track by $index"
-              data-ng-show="browse === 'inspire'"
-              class="col-xs-12 col-sm-6 col-md-4 chips-card">
-          <div class="badge-result badge-result-inspire clearfix">
-            <a class="pull-left clearfix bg-iti-{{facet['@name'].slice(facet['@name'].lastIndexOf('/')+1)}}"
-               title="{{facet['@label']}}"
-               data-ng-href="#/search?facet.q=inspireThemeURI%2F{{facet['@name'] | encodeURIComponent | encodeURIComponent}}">
-              <span class="badge-icon pull-left">
-                 <i class="fa fa-3x gn-icon iti-{{facet['@name'].slice(facet['@name'].lastIndexOf('/')+1)}}"></i>
-              </span>
-              <span class="badge-text pull-left">
-                <span class="gn-icon-label">{{facet['@label']}}</span>
-              </span>
-            </a>
-            <span class="badge pull-left">{{facet['@count']}}</span>
-          </div>
-        </span>
-      </div>
-    </div>
-    <div class="col-sm-12 col-md-3" data-ng-show="searchInfo.facet['types'].length > 0">
-      <h4>
-        <span data-translate="">browseTypes</span>
-      </h4>
-      <div class="row">
-          <span data-ng-repeat="(key, facet) in searchInfo.facet['types']"
-                data-ng-show="facet['@label']"
-                class="col-xs-12 col-sm-6 col-md-12 chips-card">
-            <div class="badge-result badge-result-type pull-left">
-              <a title="{{facet['@label']}}"
-                 class="pull-left clearfix"
-                 data-ng-href="#/search?facet.q=type%2F{{facet['@name']}}">
-                <span class="badge-icon pull-left">
+  <!--       <div class="row">
+          <span id="chips-card" data-ng-repeat="(key, facet) in searchInfo.facet['topicCats']"
+                class="col-xs-6 col-sm-4 col-lg-3" data-ng-show="browse === 'topics'"> -->
+        <div class="row">
+          <span data-ng-repeat="(key, facet) in searchInfo.facet['topicCats']"
+                data-ng-show="browse === 'topics'"
+                class="col-xs-12 col-sm-6 col-md-4 chips-card">
+            <div class="badge-result badge-result-topic clearfix">
+              <a class="pull-left clearfix"
+                title="{{facet['@label']}}"
+                role="link"
+                data-ng-href="#/search?facet.q=topicCat%2F{{facet['@name']}}">
+                <span class="badge-icon badge-result-topic pull-left">
                   <i class="fa fa-3x fa-table gn-icon gn-icon-{{facet['@name']}}"></i>
                 </span>
                 <span class="badge-text pull-left">
@@ -143,14 +111,58 @@
               <span class="badge pull-left">{{facet['@count']}}</span>
             </div>
           </span>
+          <span data-ng-repeat="(key, facet) in searchInfo.facet['inspireThemesURI'] track by $index"
+                data-ng-show="browse === 'inspire'"
+                class="col-xs-12 col-sm-6 col-md-4 chips-card">
+            <div class="badge-result badge-result-inspire clearfix">
+              <a class="pull-left clearfix bg-iti-{{facet['@name'].slice(facet['@name'].lastIndexOf('/')+1)}}"
+                title="{{facet['@label']}}"
+                data-ng-href="#/search?facet.q=inspireThemeURI%2F{{facet['@name'] | encodeURIComponent | encodeURIComponent}}">
+                <span class="badge-icon pull-left">
+                  <i class="fa fa-3x gn-icon iti-{{facet['@name'].slice(facet['@name'].lastIndexOf('/')+1)}}"></i>
+                </span>
+                <span class="badge-text pull-left">
+                  <span class="gn-icon-label">{{facet['@label']}}</span>
+                </span>
+              </a>
+              <span class="badge pull-left">{{facet['@count']}}</span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <div class="col-sm-12 col-md-3" data-ng-show="searchInfo.facet['types'].length > 0">
+        <h4>
+          <span data-translate="">browseTypes</span>
+        </h4>
+        <div class="row">
+            <span data-ng-repeat="(key, facet) in searchInfo.facet['types']"
+                  data-ng-show="facet['@label']"
+                  class="col-xs-12 col-sm-6 col-md-12 chips-card">
+              <div class="badge-result badge-result-type pull-left">
+                <a title="{{facet['@label']}}"
+                  class="pull-left clearfix"
+                  data-ng-href="#/search?facet.q=type%2F{{facet['@name']}}">
+                  <span class="badge-icon pull-left">
+                    <i class="fa fa-3x fa-table gn-icon gn-icon-{{facet['@name']}}"></i>
+                  </span>
+                  <span class="badge-text pull-left">
+                    <span class="gn-icon-label">{{facet['@label']}}</span>
+                  </span>
+                </a>
+                <span class="badge pull-left">{{facet['@count']}}</span>
+              </div>
+            </span>
+        </div>
       </div>
     </div>
   </div>
+  <!-- /.gn-row-topics -->
   
   <div class="row gn-row-info"
        data-ng-show="searchInfo.count > 0"
        data-ng-class="{'gn-info-list-blocks': type === 'blocks' || type === undefined, 'gn-info-list-large': type === 'large', 'gn-info-list-small': type === 'small'}">
-    <div class="col-sm-12">
+    <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
+      <div class="col-sm-12">
 
       <!-- toggle buttons -->
       <div id="info-toggle-buttons" class="btn-group pull-right" data-toggle="buttons">
@@ -215,8 +227,9 @@
           </form>
         </tab>
       </tabset>
+      </div>
     </div>
   </div>
   <!-- /.gn-row-info -->
 
-</div>
+<!-- </div> -->

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -1,34 +1,34 @@
-<div class="container-fluid"
-     data-ng-search-form=""
+<div data-ng-search-form=""
      data-runSearch="true">
   <div data-ng-include="'../../catalog/views/default/templates/searchForm.html'"></div>
 
   <div gn-grid-related-query="searchResults.records"></div>
-  <div class="row gn-row-results">
-    <div class="col-md-3 gn-search-facet">
+  <div class="row gn-row-results" style="background-color:red;">
+    <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
+      <div class="col-md-3 gn-search-facet">
 
-      <div data-ng-show="searchResults.records.length > 0"
-           data-gn-saved-selections-panel="user"></div>
+        <div data-ng-show="searchResults.records.length > 0"
+            data-gn-saved-selections-panel="user"></div>
 
-      <!-- Hierachical facet mode -->
-      <div class="panel panel-default"
-           data-ng-show="searchResults.records.length > 0">
-        <div class="panel-heading" data-gn-slide-toggle="">
-          <i class="fa fa-search"/>&nbsp;
-          <span data-translate="">filter</span>
-        </div>
-        <div class="panel-body">
-          <div data-gn-facet-dimension-list="searchResults.dimension"
-               data-params="searchObj.params"
-               data-facet-type="facetsSummaryType"
-               data-facet-list="facetConfig"
-               data-current-facets="currentFacets">
+        <!-- Hierachical facet mode -->
+        <div class="panel panel-default"
+            data-ng-show="searchResults.records.length > 0">
+          <div class="panel-heading" data-gn-slide-toggle="">
+            <i class="fa fa-search"/>&nbsp;
+            <span data-translate="">filter</span>
+          </div>
+          <div class="panel-body">
+            <div data-gn-facet-dimension-list="searchResults.dimension"
+                data-params="searchObj.params"
+                data-facet-type="facetsSummaryType"
+                data-facet-list="facetConfig"
+                data-current-facets="currentFacets">
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="col-md-9 container-fluid">
+      <div class="col-md-9 container-fluid">
       <div class="row" data-ng-show="isFilterTagsDisplayedInSearch">
         <div class="col-xs-12">
           <div data-search-filter-tags="">
@@ -102,6 +102,9 @@
       </div>
     </div>
     <br>
+  
+  
+    </div>
   </div>
 
   <div data-gn-map-field="searchObj.searchMap"

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -1,61 +1,63 @@
 <form class="form-horizontal"
       role="form">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+  <input type="hidden" name="_csrf" value="{{csrf}}"/>
   <!--ANY full text search input-->
   <div class="row gn-top-search">
-    <div class="col-md-12">
-      <div class="row">
-        <div class="col-md-offset-3 col-md-6 relative">
-          <div class="input-group gn-form-any">
-            <input type="text"
-                   class="form-control input-lg"
-                   id="gn-any-field"
-                   data-ng-model="searchObj.params.any"
-                   placeholder="{{'anyPlaceHolder' | translate}}"
-                   aria-label="{{'anyPlaceHolder' | translate}}"
-                   data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
-                   data-typeahead="address for address in getAnySuggestions($viewValue)"
-                   data-typeahead-loading="anyLoading" class="form-control"
-                   data-typeahead-min-length="1"
-                   data-typeahead-focus-first="false"
-                   data-typeahead-wait-ms="300">
+    <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
+      <div class="col-md-12">
+        <div class="row">
+          <div class="col-md-offset-3 col-md-6 relative">
+            <div class="input-group gn-form-any">
+              <input type="text"
+                    class="form-control input-lg"
+                    id="gn-any-field"
+                    data-ng-model="searchObj.params.any"
+                    placeholder="{{'anyPlaceHolder' | translate}}"
+                    aria-label="{{'anyPlaceHolder' | translate}}"
+                    data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
+                    data-typeahead="address for address in getAnySuggestions($viewValue)"
+                    data-typeahead-loading="anyLoading" class="form-control"
+                    data-typeahead-min-length="1"
+                    data-typeahead-focus-first="false"
+                    data-typeahead-wait-ms="300">
 
-            <div class="input-group-btn">
-              <button type="button"
-                      class="btn btn-default btn-lg"
-                      data-ng-model="searchObj.advancedMode"
-                      btn-checkbox=""
-                      btn-checkbox-true="1"
-                      btn-checkbox-false="0">
-                <i class="fa fa-ellipsis-v"></i>
-                <span class="sr-only" data-translate="">advanced</span>
-              </button>
+              <div class="input-group-btn">
+                <button type="button"
+                        class="btn btn-default btn-lg"
+                        data-ng-model="searchObj.advancedMode"
+                        btn-checkbox=""
+                        btn-checkbox-true="1"
+                        btn-checkbox-false="0">
+                  <i class="fa fa-ellipsis-v"></i>
+                  <span class="sr-only" data-translate="">advanced</span>
+                </button>
 
-              <button type="button"
-                      data-ng-click="triggerSearch()"
-                      class="btn btn-primary btn-lg">
-                &nbsp;&nbsp;
-                <i class="fa fa-search"></i>
-                <span class="sr-only" data-translate="">search</span>
-                &nbsp;&nbsp;
-              </button>
-              <button type="button"
-                      data-ng-click="resetSearch(searchObj.defaultParams);"
-                      title="{{'ClearTitle' | translate}}"
-                      class="btn btn-link btn-lg">
-                <i class="fa fa-times"></i>
-                <span class="sr-only" data-translate="">ClearTitle</span>
-              </button>
+                <button type="button"
+                        data-ng-click="triggerSearch()"
+                        class="btn btn-primary btn-lg">
+                  &nbsp;&nbsp;
+                  <i class="fa fa-search"></i>
+                  <span class="sr-only" data-translate="">search</span>
+                  &nbsp;&nbsp;
+                </button>
+                <button type="button"
+                        data-ng-click="resetSearch(searchObj.defaultParams);"
+                        title="{{'ClearTitle' | translate}}"
+                        class="btn btn-link btn-lg">
+                  <i class="fa fa-times"></i>
+                  <span class="sr-only" data-translate="">ClearTitle</span>
+                </button>
+              </div>
             </div>
           </div>
+          <div class="col-lg-3">
+          </div>
         </div>
-        <div class="col-lg-3">
-        </div>
-      </div>
-      <div class="row" data-ng-show="searchObj.advancedMode">
-        <!--Advanced search form-->
-        <div data-ng-include="advancedSearchTemplate"></div>
+        <div class="row" data-ng-show="searchObj.advancedMode">
+          <!--Advanced search form-->
+          <div data-ng-include="advancedSearchTemplate"></div>
 
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Replaces PR: https://github.com/geonetwork/core-geonetwork/pull/3662

The layout of GeoNetwork can have a fluid (full width) or fixed (centered) container. These classes were hard-coded in the templates. Now 2 variables are introduced that can be changed in the admin module, so hard-coded classes aren't needed anymore.

There is a setting for the home and search page, and a setting for the contribute and edit pages. So it is possible to have a homepage with a fixed and centered width while the editor has a full width layout.

The layout of some templates has been reordered a little in order to have parts/blocks on the page with a full page width (even when the layout has a fixed width, see the `topics` in the screenshot).

**Screenshot of the homepage**

![gn-fixedwidth-home](https://user-images.githubusercontent.com/19608667/54128737-fc9db100-440c-11e9-878e-077ae8f6d2cf.png)

**Screenshot of the editor**

![gn-fixedwidth-editor](https://user-images.githubusercontent.com/19608667/54128753-06271900-440d-11e9-9171-1f2e09cb6db3.png)
