### PR TITLE
Access manager / Intranet group not found when using canDownload/Dynamic

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
@@ -366,7 +366,7 @@ public class AccessManager {
             return true;
         }
         int downloadId = ReservedOperation.download.getId();
-        Set<Operation> ops = getOperations(context, id, null);
+        Set<Operation> ops = getOperations(context, id, context.getIpAddress());
         for (Operation op : ops) {
             if (op.getId() == downloadId) {
                 return true;
@@ -380,7 +380,7 @@ public class AccessManager {
             return true;
         }
         int dynamicId = ReservedOperation.dynamic.getId();
-        Set<Operation> ops = getOperations(context, id, null);
+        Set<Operation> ops = getOperations(context, id, context.getIpAddress());
         for (Operation op : ops) {
             if (op.getId() == dynamicId) {
                 return true;


### PR DESCRIPTION
eg. this is used in schema filtered element.

For test, create a record with "WWW:DOWNLOAD-1.0-http--download" set download privilege on & off to intranet group = Errors. The element is always filtered.

See https://github.com/geonetwork/core-geonetwork/blob/master/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml#L88-L90