### PR TITLE
Update Apache Fop to 2.3 and MapFish print-map to 2.1.4

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -516,7 +516,7 @@ public final class Xml {
 
         // Step 1: Construct a FopFactory
         // (reuse if you plan to render multiple documents!)
-        FopFactory fopFactory = FopFactory.newInstance();
+        FopFactory fopFactory = FopFactory.newInstance(new File(".").toURI());
 
         // Step 2: Set up output stream.
         // Note: Using BufferedOutputStream for performance reasons

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -235,7 +235,7 @@
       <artifactId>pcj</artifactId>
     </dependency>
     <dependency>
-      <groupId>batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-ext</artifactId>
     </dependency>
     <dependency>
@@ -391,6 +391,10 @@
         <exclusion>
           <groupId>com.vividsolutions</groupId>
           <artifactId>jts</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.xmlgraphics</groupId>
+          <artifactId>batik-transcoder</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>fop</artifactId>
-        <version>0.95</version>
+        <version>2.3</version>
       </dependency>
 
       <!-- Jetty stuff -->
@@ -459,7 +459,7 @@
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>xmlgraphics-commons</artifactId>
-        <version>1.3.1</version>
+        <version>2.3</version>
       </dependency>
       <dependency>
         <groupId>avalon-framework</groupId>
@@ -482,9 +482,14 @@
         <version>4.3.1</version>
       </dependency>
       <dependency>
-        <groupId>batik</groupId>
+        <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-ext</artifactId>
-        <version>1.6-1</version>
+        <version>1.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-transcoder</artifactId>
+        <version>1.10</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -531,6 +536,12 @@
         <artifactId>xercesImpl</artifactId>
         <version>2.11.0</version>
       </dependency>
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>1.4.01</version>
+      </dependency>
+
       <!-- Patched XML Resolver 1.2 from apache xml-commons - fixes problems
                  with windows URLs -->
       <dependency>
@@ -1364,7 +1375,7 @@
     <node.version>v8.11.1</node.version>
     <npm.version>5.8.0</npm.version>
     <xmlunit.version>2.1.1</xmlunit.version>
-    <print-lib.version>2.1.1</print-lib.version>
+    <print-lib.version>2.1.4</print-lib.version>
     <flying-saucer>9.0.7</flying-saucer>
     <camel.version>2.14.4</camel.version>
     <log4j.version>1.2.17</log4j.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -221,7 +221,7 @@
       <artifactId>pcj</artifactId>
     </dependency>
     <dependency>
-      <groupId>batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-ext</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade `Apache FOP` from very old version`0.95` to latest `2.3` and minor upgrade of `Mapfish print-map` from `2.1.1` to `2.1.4`.

Tested the print of metadata selection that uses `Apache FOP` and map viewer printing that uses `Mapfish print-map` and looks working fine.

The upgrade for Apache FOP is done to be able to use https://xmlgraphics.apache.org/fop/fop-pdf-images.html for some improvements in the metadata printing to allow include in the output template PDF. The version of this library that was working with Apache FOP 0.95 seem no longer available in maven repositories.