### PR TITLE
Formatter / fix pdf generation from full view, flying saucer trouble with float left

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_metadata_pdf.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata_pdf.less
@@ -32,7 +32,6 @@
   }
   dt {
     clear: left;
-    float: left;
     width: 160px;
     font-style: italic;
     font-size: 13px;


### PR DESCRIPTION
…left

If one plan to use alternate pdf formatter, the one usin flying-saucer, "float: left" can't be processed.

(following diff illustrating pdf formatter switch)

```
web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -103,7 +103,7 @@
        <i class="fa fa-file-zip-o"></i>&nbsp;
        <span data-translate="">exportMEF</span>
      </a></li>
-      <li><a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xsl-view?root=div&output=pdf"
+     <li><a data-ng-href="../api/records/{{md.getUuid()}}/formatters/full_view?output=pdf"
             target="_blank">
        <i class="fa fa-file-pdf-o"></i>&nbsp;
        <span data-translate="">exportPDF</span>
```