### PR TITLE
3.4.x - add support for ISO 639-2/T + ISO 3166-1 codes in language and correct node-label refs

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -446,17 +446,25 @@ public final class XslUtil {
             String iso2LangCode = null;
 
             try {
+				final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
+                /*if the language  is 2 characters long...*/
                 if (iso3LangCode.length() == 2) {
                     iso2LangCode = iso3LangCode;
-                } else {
-                    final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
+                    /*Catch language entries longer than 3 characters with a semicolon*/
+                } else if (iso3LangCode.length() > 3 && (iso3LangCode.indexOf(';')!=-1)){
+					iso2LangCode = mapper.iso639_2_to_iso639_1(iso3LangCode.substring(0,3));
+                    /** This final else works properly for languages with exactly three characters, so
+                    * an exception will occur if gmd:language has more than 3 characters but
+                    * does not have a semicolon.
+                    */
+				} else {
                     iso2LangCode = mapper.iso639_2_to_iso639_1(iso3LangCode);
                 }
             } catch (Exception ex) {
                 Log.error(Geonet.GEONETWORK, "Failed to get iso 2 language code for " + iso3LangCode + " caused by " + ex.getMessage());
 
             }
-
+            /* Triggers when the language can't be matched to a code */
             if (iso2LangCode == null) {
                 Log.error(Geonet.GEONETWORK, "Cannot convert " + iso3LangCode + " to 2 char iso lang code", new Error());
                 return iso3LangCode.substring(0, 2);

--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
@@ -29,7 +29,7 @@
                 xmlns:gn-fn-render="http://geonetwork-opensource.org/xsl/functions/render"
                 version="2.0"
                 exclude-result-prefixes="#all">
-
+ <!-- tr is defined at  core-geonetwork/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java -->
   <!-- Load the editor configuration to be able
   to render the different views -->
   <xsl:variable name="configuration"
@@ -72,7 +72,7 @@
       <dt>
         <xsl:value-of select="if ($fieldName)
                                 then $fieldName
-                                else tr:node-label(tr:create($schema), name(), null)"/>
+                                else tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value" select="."/>

--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -34,7 +34,7 @@
                 version="2.0"
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
-
+ <!-- tr is defined at  core-geonetwork/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java -->
   <!-- Load the editor configuration to be able
   to render the different views -->
   <xsl:variable name="configuration"
@@ -80,7 +80,7 @@
       <dt>
         <xsl:value-of select="if ($fieldName)
                                 then $fieldName
-                                else tr:node-label(tr:create($schema), name(), null)"/>
+                                else tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value" select="*|*/@codeListValue"/>
@@ -99,7 +99,7 @@
       *[$isFlatMode = false() and gmd:* and not(gco:CharacterString) and not(gmd:URL)]">
     <div class="entry name">
       <h3>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </h3>
       <div class="target">
         <xsl:apply-templates mode="render-field" select="*"/>
@@ -183,7 +183,7 @@
   <!-- ... Codelists -->
   <xsl:template mode="render-value" match="@codeListValue">
     <xsl:variable name="id" select="."/>
-    <!--<xsl:value-of select="tr:node-label(tr:create($schema), .)"/>-->
+    <!--<xsl:value-of select="tr:nodeLabel(tr:create($schema), .)"/>-->
     <xsl:variable name="codelistTranslation"
                   select="$schemaCodelists//entry[code = $id]/label"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -47,7 +47,7 @@
   3 levels of priority are defined: 100, 50, none
 
   -->
-
+ <!-- tr is defined at  core-geonetwork/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java -->
 
   <!-- Load the editor configuration to be able
   to render the different views -->
@@ -247,7 +247,7 @@
         <dt>
           <xsl:value-of select="if ($fieldName)
                                   then $fieldName
-                                  else tr:node-label(tr:create($schema), name(), null)"/>
+                                  else tr:nodeLabel(tr:create($schema), name(), null)"/>
         </dt>
         <dd>
           <xsl:apply-templates mode="render-value" select="*|*/@codeListValue"/>
@@ -266,7 +266,7 @@
       <dt>
         <xsl:value-of select="if ($fieldName)
                                 then $fieldName
-                                else tr:node-label(tr:create($schema), name(), null)"/>
+                                else tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value" select="."/>
@@ -300,7 +300,7 @@
 
     <div class="entry name">
       <h2>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
         <xsl:apply-templates mode="render-value"
                              select="@*"/>
       </h2>
@@ -484,7 +484,7 @@
                 priority="100">
     <dl>
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value" select="*"/>
@@ -506,7 +506,7 @@
         itemscope="itemscope"
         itemtype="http://schema.org/DataDownload">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:variable name="linkUrl"
@@ -549,7 +549,7 @@
                 priority="100">
     <dl class="gn-code">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
 
@@ -641,7 +641,7 @@
                 priority="100">
     <dl class="gn-format">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <ul>
@@ -674,7 +674,7 @@
                 priority="100">
     <dl class="gn-date">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
         <xsl:if test="*/gmd:dateType/*[@codeListValue != '']">
           (<xsl:apply-templates mode="render-value"
                                 select="*/gmd:dateType/*/@codeListValue"/>)
@@ -694,7 +694,7 @@
                 priority="100">
     <dl class="gn-date">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <ul>
@@ -728,7 +728,7 @@
     <xsl:if test="$isFirstOfItsKind">
       <dl class="gn-md-associated-resources">
         <dt>
-          <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+          <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
         </dt>
         <dd>
           <ul>

--- a/services/src/test/resources/org/fao/geonet/api/records/formatters/xsl-test-formatter/view.xsl
+++ b/services/src/test/resources/org/fao/geonet/api/records/formatters/xsl-test-formatter/view.xsl
@@ -28,12 +28,12 @@
                 exclude-result-prefixes="tr gnf">
 
   <xsl:include href="sharedFormatterDir/functions.xsl"/>
-
+  <!-- tr is defined at  core-geonetwork/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java -->
   <xsl:template match="/">
     <html>
       <body>
         <div class="tr">
-          <xsl:value-of select="tr:node-label(tr:create('iso19139'), 'gmd:title', 'gmd:parent')"/>
+          <xsl:value-of select="tr:nodeLabel(tr:create('iso19139'), 'gmd:title', 'gmd:parent')"/>
         </div>
         <xsl:copy-of select="gnf:p()"/>
       </body>


### PR DESCRIPTION
This pull request consists of two parts, which were identified during setup of a local GeoNetwork repository (at 3.4.4) - from looking at the 3.6.x branch these should also be applicable there.

**1. Remove references to node-label and replace with nodeLabel (bugfix)**
During testing we spotted errors related to view.xsl in our logs. From looking at schemaLocalizations (https://github.com/geonetwork/core-geonetwork/blob/3.4.x/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java) I discovered there was a nodeLabel function, but no such node-label function - nor did there appear to be any correction of node-label to nodeLabel during processing. Changing node-label to nodeLabel resolved our errors in our plugin - this pull request changes it throughout the core plugins as well.

**2. Add string parsing for gmd:language containing locality**
The North American Profile of ISO 19115 recommends that the gmd:language field be in the format of `<ISO639-2/T three letter language code><;><blank space><ISO3166-1 three letter country
code>`. However, GeoNetwork uses a hashmap `containsKey` function to convert three letter country codes to two letter country codes, which requires an exact match for the three letter country code. GeoNetwork also, by default, did not do any 'stripping' of gmd:language, so errors relating to 'undefined language' would occur when using records with gmd:language of `ENG; USA` or `FRA; CAN`. 

This adds a check for strings longer than three characters containing a semicolon, which most likely indicates the North American Profile rule has been followed, and if so strips the language field to the first three characters (which should represent the ISO 639-2/T three letter language code as expected) before passing them to the `containsKey` function. 