### PR TITLE
Support gmx:Anchor in extract relations xslt process

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
@@ -30,6 +30,8 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:gn-fn-rel="http://geonetwork-opensource.org/xsl/functions/relations"
                 version="2.0"
@@ -75,6 +77,12 @@
                   else if ($mainLanguage) then $mainLanguage else $lang}">
         <xsl:value-of select="."/>
       </value>
+
+      <xsl:if test="gmx:Anchor">
+        <value lang="{if ($mainLanguage) then $mainLanguage else $lang}" href="{gmx:Anchor/@xlink:href}">
+          <xsl:value-of select="gmx:Anchor"/>
+        </value>
+      </xsl:if>
     </xsl:for-each>
   </xsl:template>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
@@ -67,7 +67,7 @@
                             gmd:language/gco:CharacterString|ancestor::metadata/*[@gco:isoType='gmd:MD_Metadata' or name()='gmd:MD_Metadata']/
                             gmd:language/gmd:LanguageCode/@codeListValue)"/>
 
-    <xsl:for-each select="gco:CharacterString|
+    <xsl:for-each select="gco:CharacterString|gmx:Anchor|
                           gmd:PT_FreeText/*/gmd:LocalisedCharacterString">
       <xsl:variable name="localeId"
                     select="substring-after(@locale, '#')"/>
@@ -75,14 +75,9 @@
       <value lang="{if (@locale)
                   then ancestor::metadata/*[@gco:isoType='gmd:MD_Metadata' or name()='gmd:MD_Metadata']/gmd:locale/*[@id = $localeId]/gmd:languageCode/*/@codeListValue
                   else if ($mainLanguage) then $mainLanguage else $lang}">
+        <xsl:copy-of select="@xlink:href"/>
         <xsl:value-of select="."/>
       </value>
-
-      <xsl:if test="gmx:Anchor">
-        <value lang="{if ($mainLanguage) then $mainLanguage else $lang}" href="{gmx:Anchor/@xlink:href}">
-          <xsl:value-of select="gmx:Anchor"/>
-        </value>
-      </xsl:if>
     </xsl:for-each>
   </xsl:template>
 

--- a/services/src/main/java/org/fao/geonet/api/records/model/related/LocalizedString.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/related/LocalizedString.java
@@ -20,6 +20,7 @@ import javax.xml.bind.annotation.XmlValue;
  *   &lt;simpleContent>
  *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema>string">
  *       &lt;attribute name="lang" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="href" type="{http://www.w3.org/2001/XMLSchema}string" />
  *     &lt;/extension>
  *   &lt;/simpleContent>
  * &lt;/complexType>
@@ -35,6 +36,8 @@ public class LocalizedString {
     protected String value;
     @XmlAttribute(name = "lang")
     protected String lang;
+    @XmlAttribute(name = "href")
+    protected String href;
 
     /**
      * Gets the value of the value property.
@@ -72,4 +75,21 @@ public class LocalizedString {
         this.lang = value;
     }
 
+    /**
+     * Gets the value of the href property.
+     *
+     * @return possible object is {@link String }
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * Sets the value of the href property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    public void setHref(String value) {
+        this.href = value;
+    }
 }


### PR DESCRIPTION
Currently the Associated resources panel doesn't display the values in elements that use Anchors, for example for INSPIRE the description should use an Anchor like:

```
<gmd:description>
  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint">
    accessPoint
  </gmx:Anchor>
</gmd:description>
```

The Associated resource panel UI requires additional work to support the Anchors properly allowing to edit also the `xlink:href` attribute as with this change only the text value can be edited. 

This is a change in the related service to process Anchors and return the value and also the `xlink:href` attribute. Example response for an online resource with previous `gmd:description`:

```
<related>
  <onlines>
    <item>
      ...
      <description>
        <value lang="dut" href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint">accessPoint</value>
    ...
</description>
```