### PR TITLE
Fixes empty owner select in admin's batch process

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
@@ -145,12 +145,11 @@
       $scope.batchSearchTemplateY = true;
       $scope.batchSearchTemplateN = true;
       $scope.batchSearchTemplateS = false;
-      $scope.batchSearchGroups = {};
-      $scope.batchSearchUsers = {};
-      $scope.batchSearchCategories = {};
+      $scope.batchSearchGroups = [];
+      $scope.batchSearchUsers = [];
+      $scope.batchSearchCategories = [];
 
-      $scope.editors = {};
-      $scope.groupinfo = {};
+      $scope.editors = [];
       $scope.editorSelectedId = null;
       $scope.editorGroups = {};
 

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/batch.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/batch.html
@@ -71,7 +71,7 @@
                     <select class="form-control" id="gn-batchSearchGroupOwner"
                             data-ng-model="searchObj.params.group">
                       <option></option>
-                      <option data-ng-repeat="g in batchSearchGroups" value="{{g.id}}"
+                      <option data-ng-repeat="g in batchSearchGroups | orderBy:'name' " value="{{g.id}}"
                       >{{g.label[lang]|empty:g.name}}
                       </option>
                     </select>
@@ -83,9 +83,8 @@
                     <select class="form-control" id="gn-batchSearchOwner"
                             data-ng-model="searchObj.params._owner">
                       <option></option>
-                      <option data-ng-repeat="u in batchSearchUsers.users"
-                              value="{{u.value.id}}">{{u.value.name}}
-                        {{u.value.surname}}
+                      <option data-ng-repeat="u in batchSearchUsers | orderBy: 'username'"
+                              value="{{u.id}}">{{u.name}} {{u.surname}} ({{u.username}})
                       </option>
                     </select>
                   </div>


### PR DESCRIPTION
In Batch processes admin tool the _Owner_ list of users is empty. This PR fixes that:
![image](https://user-images.githubusercontent.com/826920/56227459-d2778880-6075-11e9-9452-f6699b6ed33b.png)


