### PR TITLE
Allow table column mandatory fields

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
@@ -182,9 +182,11 @@
       <xsl:if test="not($isEmbeddedMode) or ($isEmbeddedMode and $isFirstOfItsKind)">
         <header>
           <col>
+            <xsl:copy-of select="@*"/>
             <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'uuidref', $labels, '', $isoType, $xpath)/label"/>
           </col>
           <col>
+            <xsl:copy-of select="@*"/>
             <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'xlink:href', $labels, '', $isoType, $xpath)/label"/>
           </col>
         </header>

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -504,6 +504,18 @@ form.gn-editor {
   }
 
 
+  .th-inner.gn-required {
+    &:after {
+      content: "*";
+      font-size: 1.8em;
+      margin: -7px 0 0 7px;
+      position: absolute;
+      color: #a94442;
+      font-weight: normal;
+    }
+  }
+
+
   .form-horizontal .form-group {
       margin-left: 0px;
       margin-right: 0px;

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1558,6 +1558,9 @@
                   <xsl:attribute name="class" select="@class"/>
                 </xsl:if>
                 <div class="th-inner ">
+                  <xsl:if test="@required">
+                    <xsl:attribute name="class" select="'th-inner gn-required'"/>
+                  </xsl:if>
                   <xsl:value-of select="."/>
                 </div>
               </th>


### PR DESCRIPTION
This PR makes effective the attribute "_required=true_" also on **<col>** elements inside **<header>** in _config-editor.xml_. Like:

```
<header>
...
<col required="true">...</col>
...
</header>

```

To test:
In ISO19139 change  _/schema-iso19139/src/main/plugin/iso19139/layout/config-editor.xml_ and add required to some col like _gmd:organisationName_ to have:

![Untitled](https://user-images.githubusercontent.com/1323093/56271991-07c5ba00-60fa-11e9-80f6-a9c1e427bd93.png)

Related feature request https://github.com/geonetwork/core-geonetwork/issues/3740

