### PR TITLE
Language / Add support for ISO 639-2/T + ISO 3166-1 codes in language

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -178,6 +178,7 @@ public final class XslUtil {
 
     /**
      * Get the UI configuration. Return the JSON string.
+     *
      * @param key Optional key, if null, return a default configuration nammed 'srv'
      *            if exist. If not, empty config is returned.
      * @return
@@ -205,6 +206,7 @@ public final class XslUtil {
 
     /**
      * Get a precise value in the JSON UI configuration
+     *
      * @param key
      * @param path JSON path to the property
      * @return
@@ -509,17 +511,25 @@ public final class XslUtil {
             String iso2LangCode = null;
 
             try {
+                final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
+                /*if the language  is 2 characters long...*/
                 if (iso3LangCode.length() == 2) {
                     iso2LangCode = iso3LangCode;
+                    /*Catch language entries longer than 3 characters with a semicolon*/
+                } else if (iso3LangCode.length() > 3 && (iso3LangCode.indexOf(';') != -1)) {
+                    iso2LangCode = mapper.iso639_2_to_iso639_1(iso3LangCode.substring(0, 3));
+                    /** This final else works properly for languages with exactly three characters, so
+                     * an exception will occur if gmd:language has more than 3 characters but
+                     * does not have a semicolon.
+                     */
                 } else {
-                    final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
                     iso2LangCode = mapper.iso639_2_to_iso639_1(iso3LangCode);
                 }
             } catch (Exception ex) {
                 Log.error(Geonet.GEONETWORK, "Failed to get iso 2 language code for " + iso3LangCode + " caused by " + ex.getMessage());
 
             }
-
+            /* Triggers when the language can't be matched to a code */
             if (iso2LangCode == null) {
                 Log.error(Geonet.GEONETWORK, "Cannot convert " + iso3LangCode + " to 2 char iso lang code", new Error());
                 return iso3LangCode.substring(0, 2);
@@ -691,7 +701,6 @@ public final class XslUtil {
     }
 
 
-
     public static String geomToBbox(Object geom) {
         String ret = "";
         try {
@@ -780,7 +789,7 @@ public final class XslUtil {
         if (context != null) baseUrl = context.getBaseUrl();
 
         SettingInfo si = new SettingInfo();
-        return si.getSiteUrl() + (!baseUrl.startsWith("/")?"/":"") + baseUrl;
+        return si.getSiteUrl() + (!baseUrl.startsWith("/") ? "/" : "") + baseUrl;
     }
 
     public static String getLanguage() {
@@ -814,10 +823,11 @@ public final class XslUtil {
     }
 
     /**
-     *  To get the xml content of an url
-     *  It supports the usage of a proxy
-        * @param surl
-        * @return
+     * To get the xml content of an url
+     * It supports the usage of a proxy
+     *
+     * @param surl
+     * @return
      */
     public static Node getUrlContent(String surl) {
 
@@ -866,7 +876,7 @@ public final class XslUtil {
 
         for (int i = 0; i < strings.length; i++) {
             String val = strings[i];
-            if(val.compareTo(max) > 0) {
+            if (val.compareTo(max) > 0) {
                 max = val;
             }
         }
@@ -877,9 +887,9 @@ public final class XslUtil {
 
     static {
         URL_VALIDATION_CACHE = CacheBuilder.<String, Boolean>newBuilder().
-                maximumSize(100000).
-                expireAfterAccess(25, TimeUnit.HOURS).
-                build();
+            maximumSize(100000).
+            expireAfterAccess(25, TimeUnit.HOURS).
+            build();
     }
 
     public static boolean validateURL(final String urlString) throws ExecutionException {
@@ -898,15 +908,15 @@ public final class XslUtil {
 
     /**
      * Utility method to retrieve the thesaurus dir from xsl processes.
-     *
+     * <p>
      * Usage:
-     *
-     *    <xsl:stylesheet
-     *      xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
-     *      ...
-     *      xmlns:java="java:org.fao.geonet.util.XslUtil" ...>
-     *
-     *     <xsl:variable name="thesauriDir" select="java:getThesaurusDir()"/>
+     * <p>
+     * <xsl:stylesheet
+     * xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+     * ...
+     * xmlns:java="java:org.fao.geonet.util.XslUtil" ...>
+     * <p>
+     * <xsl:variable name="thesauriDir" select="java:getThesaurusDir()"/>
      *
      * @return Thesaurus directory
      */

--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
@@ -29,7 +29,7 @@
                 xmlns:gn-fn-render="http://geonetwork-opensource.org/xsl/functions/render"
                 version="2.0"
                 exclude-result-prefixes="#all">
-
+ <!-- tr is defined at  core-geonetwork/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java -->
   <!-- Load the editor configuration to be able
   to render the different views -->
   <xsl:variable name="configuration"
@@ -72,7 +72,7 @@
       <dt>
         <xsl:value-of select="if ($fieldName)
                                 then $fieldName
-                                else tr:node-label(tr:create($schema), name(), null)"/>
+                                else tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value" select="."/>

--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -34,7 +34,7 @@
                 version="2.0"
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
-
+ <!-- tr is defined at  core-geonetwork/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java -->
   <!-- Load the editor configuration to be able
   to render the different views -->
   <xsl:variable name="configuration"
@@ -80,7 +80,7 @@
       <dt>
         <xsl:value-of select="if ($fieldName)
                                 then $fieldName
-                                else tr:node-label(tr:create($schema), name(), null)"/>
+                                else tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value" select="*|*/@codeListValue"/>
@@ -99,7 +99,7 @@
       *[$isFlatMode = false() and gmd:* and not(gco:CharacterString) and not(gmd:URL)]">
     <div class="entry name">
       <h3>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </h3>
       <div class="target">
         <xsl:apply-templates mode="render-field" select="*"/>
@@ -183,7 +183,7 @@
   <!-- ... Codelists -->
   <xsl:template mode="render-value" match="@codeListValue">
     <xsl:variable name="id" select="."/>
-    <!--<xsl:value-of select="tr:node-label(tr:create($schema), .)"/>-->
+    <!--<xsl:value-of select="tr:nodeLabel(tr:create($schema), .)"/>-->
     <xsl:variable name="codelistTranslation"
                   select="$schemaCodelists//entry[code = $id]/label"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -49,7 +49,7 @@
   3 levels of priority are defined: 100, 50, none
 
   -->
-
+ <!-- tr is defined at  core-geonetwork/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java -->
 
   <!-- Load the editor configuration to be able
   to render the different views -->
@@ -241,7 +241,7 @@
         <dt>
           <xsl:value-of select="if ($fieldName)
                                   then $fieldName
-                                  else tr:node-label(tr:create($schema), name(), null)"/>
+                                  else tr:nodeLabel(tr:create($schema), name(), null)"/>
         </dt>
         <dd><xsl:comment select="name()"/>
           <xsl:apply-templates mode="render-value" select="*|*/@codeListValue"/>
@@ -278,7 +278,7 @@
       <dt>
         <xsl:value-of select="if ($fieldName)
                                 then $fieldName
-                                else tr:node-label(tr:create($schema), name(), null)"/>
+                                else tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:choose>
@@ -320,7 +320,7 @@
 
     <div class="entry name">
       <h2>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
         <xsl:apply-templates mode="render-value"
                              select="@*"/>
       </h2>
@@ -533,7 +533,7 @@
                 priority="100">
     <dl>
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value" select="*"/>
@@ -555,7 +555,7 @@
         itemscope="itemscope"
         itemtype="http://schema.org/DataDownload">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <xsl:variable name="linkUrl"
@@ -602,7 +602,7 @@
                 priority="100">
     <dl class="gn-code">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
 
@@ -694,7 +694,7 @@
                 priority="100">
     <dl class="gn-format">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <ul>
@@ -729,7 +729,7 @@
                 priority="100">
     <dl class="gn-date">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
         <xsl:if test="*/gmd:dateType/*[@codeListValue != '']">
           (<xsl:apply-templates mode="render-value"
                                 select="*/gmd:dateType/*/@codeListValue"/>)
@@ -757,7 +757,7 @@
                 priority="100">
     <dl class="gn-date">
       <dt>
-        <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </dt>
       <dd>
         <ul>
@@ -791,7 +791,7 @@
     <xsl:if test="$isFirstOfItsKind">
       <dl class="gn-md-associated-resources">
         <dt>
-          <xsl:value-of select="tr:node-label(tr:create($schema), name(), null)"/>
+          <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
         </dt>
         <dd>
           <ul>

--- a/services/src/test/resources/org/fao/geonet/api/records/formatters/xsl-test-formatter/view.xsl
+++ b/services/src/test/resources/org/fao/geonet/api/records/formatters/xsl-test-formatter/view.xsl
@@ -28,12 +28,12 @@
                 exclude-result-prefixes="tr gnf">
 
   <xsl:include href="sharedFormatterDir/functions.xsl"/>
-
+  <!-- tr is defined at  core-geonetwork/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java -->
   <xsl:template match="/">
     <html>
       <body>
         <div class="tr">
-          <xsl:value-of select="tr:node-label(tr:create('iso19139'), 'gmd:title', 'gmd:parent')"/>
+          <xsl:value-of select="tr:nodeLabel(tr:create('iso19139'), 'gmd:title', 'gmd:parent')"/>
         </div>
         <xsl:copy-of select="gnf:p()"/>
       </body>


### PR DESCRIPTION
ISO 19115 standards often suggest using a combination of an ISO 639-2/T three letter code and a ISO 3166-1 three letter code (separated by a semicolon) to identify language and locale, but strings longer than 3 characters were being rejected. This correction checks for the semicolon and for long languages (which probably means they are using the above format), then passes the first three characters into the already existing iso mapper.

See https://github.com/geonetwork/core-geonetwork/pull/3759