### PR TITLE
INSPIRE / Validation / Convert non ISO19139 records in order to do remote validation

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -812,7 +812,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         return context.getApplicationContext().getBean(SystemInfo.class).isDevMode();
     }
 
-    private class FormatMetadata implements Callable<StoreInfoAndDataLoadResult> {
+    public class FormatMetadata implements Callable<StoreInfoAndDataLoadResult> {
         private final Key key;
         private final NativeWebRequest request;
         private final ServiceContext serviceContext;

--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -47,13 +47,13 @@
                 scope.inspMdUuid = newValue;
 
                 gnConfigService.load().then(function(c) {
-                  // INSPIRE validator only support ISO19139 records.
-                  // TODO: For other schema support we may need to convert the record
-                  // to ISO19139 first. eg. ISO19115-3
+                  // INSPIRE validator only support ISO19139/115-3 records.
+                  // This assume that those schema have and ISO19139 formatter
+                  // which is the format supported by the validator
                   scope.isInspireValidationEnabled =
                     gnConfig[gnConfig.key.isInspireEnabled] &&
                     angular.isString(gnConfig['system.inspire.remotevalidation.url']) &&
-                    (gnCurrentEdit.schema === 'iso19139');
+                    gnCurrentEdit.schema.match(/iso19139|iso19115-3/) != null;
                 });
               });
 


### PR DESCRIPTION
Schema is supported if an extension of iso19139 or iso19115-3 and provides a formatter nammed iso19139.

Example with an ISO19115-3 record:

![image](https://user-images.githubusercontent.com/1701393/56433862-b7ee1b00-62d2-11e9-869e-479d6e672f6c.png)


Funded by metawal
