### PR TITLE
New CSS variables for the Search Box

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1385,6 +1385,9 @@
     "metadata/pdfReport/headerRight-help": "The following template values are allowed: {date}, {siteInfo}.",
     "metadata/pdfReport/tocPage": "Add table of contents (TOC) page",
     "metadata/pdfReport/pdfName": "Report file name",
-    "metadata/pdfReport/pdfName-help": "Report file name. The following template fields are allowed to be used: {year}, {month}, {day}, {date} and {datetime}. Template fields are replaced with the related date values. {date} uses 'yyyyMMdd' format and {datetime} uses 'yyyyMMddHHmmss' format."
-
+    "metadata/pdfReport/pdfName-help": "Report file name. The following template fields are allowed to be used: {year}, {month}, {day}, {date} and {datetime}. Template fields are replaced with the related date values. {date} uses 'yyyyMMdd' format and {datetime} uses 'yyyyMMddHHmmss' format.",
+    "gnSearchCss": "Search Box",
+    "styleVariable-gnSearchOutlineColor": "Border color for when the search box has the focus",
+    "styleVariable-gnSearchButtonBackgroundColor": "Background color for the search button",
+    "styleVariable-gnSearchButtonColor": "Text color for the search button"
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
@@ -31,7 +31,7 @@
             <div class="row">
               <p data-translate="">gnCssStyleIntroMessage</p>
             </div>
-            <div class="row">
+            <div class="row gn-margin-bottom">
               <div class="col-md-12">
                 <legend >
                   <span data-translate="">gnBackgroundCss</span>
@@ -50,7 +50,7 @@
                 </div>
               </div>
             </div>
-            <div class="row">
+            <div class="row gn-margin-bottom">
               <div class="col-md-12">
                 <legend>
                   <span data-translate="">gnHeaderCss</span>
@@ -64,7 +64,7 @@
                 </div>
               </div>
             </div>
-            <div class="row">
+            <div class="row gn-margin-bottom">
               <div class="col-md-12">
                 <legend>
                   <span data-translate="">gnMenubarCss</span>
@@ -100,7 +100,31 @@
                 </div>
               </div>
             </div>
-            <div class="row">
+            <div class="row gn-margin-bottom">
+              <div class="col-md-12">
+                <legend>
+                  <span data-translate="">gnSearchCss</span>
+                </legend>
+              </div>
+              <div class="form-row">
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnSearchOutlineColor" data-translate="">styleVariable-gnSearchOutlineColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnSearchOutlineColor"
+                    color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnSearchButtonBackgroundColor" data-translate="">styleVariable-gnSearchButtonBackgroundColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnSearchButtonBackgroundColor"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnSearchButtonColor" data-translate="">styleVariable-gnSearchButtonColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnSearchButtonColor"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+              </div>
+            </div>
+            <div class="row gn-margin-bottom">
               <div class="col-md-12">
                 <legend>
                   <span data-translate="">gnBottombarCss</span>
@@ -129,7 +153,7 @@
                 </div>
               </div>
             </div>
-            <div class="row">
+            <div class="row gn-margin-bottom">
               <div class="col-md-6">
                 <legend>
                   <span data-translate="">gnTopicsCss</span>
@@ -156,7 +180,7 @@
                 </div>
               </div>
             </div>
-            <div class="row">
+            <div class="row gn-margin-bottom">
               <div class="col-md-6">
                 <legend>
                   <span data-translate="">gnResultcardsCss</span>
@@ -193,7 +217,7 @@
                 </div>
               </div>
             </div>
-            <div class="row">
+            <div class="row gn-margin-bottom">
               <div class="col-md-12">
                 <legend>
                   <span data-translate="">gnMdViewCss</span>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -36,6 +36,23 @@ html, body {
 
 .gn-row-main {
   margin: 2em 0 4em;
+  .gn-form-any {
+    .input-lg {
+      &:focus {
+        border-color: @gn-search-outline-color;
+        box-shadow: rgba(0, 0, 0, 0.075) 0px 1px 1px inset, rgba(@gn-search-outline-color-red, @gn-search-outline-color-green, @gn-search-outline-color-blue, 0.6) 0px 0px 8px;
+      }
+    }
+    .btn {
+      background-color: @gn-search-button-background-color;
+      border-color: darken(@gn-search-button-background-color, 5%);
+      color: @gn-search-button-color;
+      &:hover {
+        background-color: darken(@gn-search-button-background-color, 10%);
+        border-color: darken(@gn-search-button-background-color, 15%);
+      }
+    }
+  }
 }
 
 .gn-row-info {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -92,6 +92,25 @@
       button.btn-lg, input[type="text"].input-lg {
         height: 46px;
       }
+      input[type="text"].input-lg {
+        &:focus {
+          border-color: @gn-search-outline-color;
+          box-shadow: rgba(0, 0, 0, 0.075) 0px 1px 1px inset, rgba(@gn-search-outline-color-red, @gn-search-outline-color-green, @gn-search-outline-color-blue, 0.6) 0px 0px 8px;
+        }
+      }
+      button.btn-primary.btn-lg {
+        background-color: @gn-search-button-background-color;
+        border-color: darken(@gn-search-button-background-color, 5%);
+        color: @gn-search-button-color;
+        &:hover {
+          background-color: darken(@gn-search-button-background-color, 10%);
+          border-color: darken(@gn-search-button-background-color, 15%);
+        }
+      }
+      .dropdown-menu > .active > a {
+        background-color: @gn-search-button-background-color;
+        color: @gn-search-button-color;
+      }
     }
   }
   .loading {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -44,6 +44,14 @@
 
 // home page
 //
+// ----- search input
+@gn-search-outline-color: @brand-primary;
+@gn-search-button-background-color: @brand-primary;
+@gn-search-button-color: @btn-primary-color;
+
+@gn-search-outline-color-red: red(@gn-search-outline-color);
+@gn-search-outline-color-green: green(@gn-search-outline-color);
+@gn-search-outline-color-blue: blue(@gn-search-outline-color);
 // ----- topics block
 @gn-topics-background-color: @well-bg;
 // ----- info block


### PR DESCRIPTION
This PR adds new CSS variables for the search box on the `Home` and `Search` page.

The following variables have been added:
- outline for search box
- background-color for the search button
- color for search button

![gn-searchbox-variables](https://user-images.githubusercontent.com/19608667/56725166-a088b500-674c-11e9-95bf-3a3f024fe35e.png)

These 3 variables can be set in the admin pages in the `CSS & Style` section:

![gn-searchbox-admin](https://user-images.githubusercontent.com/19608667/56725152-9a92d400-674c-11e9-8904-29726ba44013.png)
