### PR TITLE
Fix for the sidebar in the Admin (for Editor and Reviewer)

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/page-layout.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/page-layout.html
@@ -2,7 +2,7 @@
 
   <div class="sidebar">
 
-    <div class="sidebar-col-main">
+    <div class="sidebar-col-main" data-ng-if="user.isUserAdminOrMore()">
       <ul data-ng-if="user.isUserAdmin()" class="nav nav-sidebar" role="menu">
           <li>
             <a data-gn-active-tb-item="admin.console#/home">
@@ -35,7 +35,8 @@
         </ul>
     </div>
     <!-- /.sidebar-col-main -->
-    <div class="sidebar-col-sub">
+    <div class="sidebar-col-sub"
+        data-ng-class="!user.isUserAdminOrMore() ? 'sidebar-col-sub-editor' : ''">
        <ul class="nav nav-sidebar">
         <li data-ng-repeat="t in pageMenu.tabs"
             data-ng-class="(href === t.href && 'active') || (!href && t.href + '' === '#/' + pageMenu.folder + pageMenu.defaultTab && 'active')">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -60,6 +60,20 @@ ul.gn-resultview li.list-group-item {
         }
       }
     }
+    .username-dropdown {
+      .dropdown-menu {
+        > li {
+          &.active {
+            > a {
+              background-color: @dropdown-bg;
+              &:hover {
+                background-color: lighten(@brand-primary, 46.7%);
+              }
+            }
+          }
+        }
+      }
+    }
   }
   [data-ng-controller="GnAdminController"] {
     .sidebar {
@@ -102,6 +116,10 @@ ul.gn-resultview li.list-group-item {
         width: calc(~"100% - @{gn-col-main-width}");
         margin-left: @gn-col-main-width;
         float: left;
+      }
+      .sidebar-col-sub-editor {
+        width: @gn-sidebar-width;
+        margin-left: 0;
       }
       .sidebar-col-full {
         width: @gn-sidebar-width;


### PR DESCRIPTION
This PR fixes to the sidebar for `Editor` and `Reviewer`. The sidebar was also showing an 'empty' main sidebar because the `Editor` and `Reviewer` had no access to the items in this sidebar. This PR hides the main sidebar and extends the 'sub sidebar'

**Screenshot of before:**
![gn-admin-sidebar-before](https://user-images.githubusercontent.com/19608667/56729311-404a4100-6755-11e9-9a3e-37ba927985d5.png)

**Screenshot after the fix:**
![gn-admin-sidebar-after](https://user-images.githubusercontent.com/19608667/56729325-4809e580-6755-11e9-8fa0-1b039bbc291d.png)

This PR also fixes the background colour for active items in the `User` dropdown in the menubar.