### PR TITLE
ISO19139 / Schematron / Check only http urls

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-url-check.sch
+++ b/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-url-check.sch
@@ -13,7 +13,7 @@
     <sch:pattern>
         <sch:title>$loc/strings/invalidURLCheck</sch:title>
         <!-- Check specification names and status -->
-        <sch:rule context="//gmd:linkage//gmd:URL">
+        <sch:rule context="//gmd:linkage//gmd:URL[starts-with(text(), 'http')]">
 
             <sch:let name="isValidUrl" value="xslutil:validateURL(text())" />
             <sch:assert test="$isValidUrl = true()">


### PR DESCRIPTION
To avoid reporting errors on protocol the validation method in XslUtil does not handle.