### PR TITLE
User searches / List of featured search as dropdown.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
@@ -31,7 +31,7 @@
    * Directive to display featured user searches in the home page.
    *
    */
-  module.directive('gnFeaturedUserSearchesHome', [
+  module.directive('gnUserSearchesList', [
     'gnUserSearchesService', 'gnConfigService', 'gnConfig', 'gnLangs',
     '$http', '$translate', '$location',
     function(gnUserSearchesService, gnConfigService, gnConfig, gnLangs,

--- a/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
@@ -39,12 +39,13 @@
       return {
         restrict: 'A',
         replace: true,
-        templateUrl:
-        '../../catalog/components/usersearches/partials/featuredusersearcheshome.html',
+        templateUrl: function(elem, attrs) {
+          return '../../catalog/components/usersearches/partials/featuredusersearches' +
+            (attrs['mode'] || 'cards') + '.html';
+        },
         link: function postLink(scope, element, attrs) {
           scope.lang = gnLangs.current;
-          scope.type = 'h';
-
+          scope.type = attrs['type'] || 'h';
           gnUserSearchesService.loadFeaturedUserSearches(scope.type).then(
             function(featuredSearchesCollection) {
               scope.featuredSearches = featuredSearchesCollection.data;

--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchesbutton.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchesbutton.html
@@ -1,0 +1,24 @@
+<div class="btn-group">
+  <button type="button"
+        class="btn btn-default btn-lg dropdown-toggle"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false"
+        title="{{'featuredUserSearches' | translate}}">
+  &nbsp;&nbsp;
+  <i class="fa fa-list fa-fw"></i>
+  <i class="fa fa-caret-down"></i>
+  <span class="sr-only" data-translate="">search</span>
+  </button>
+  <ul class="dropdown-menu">
+    <li data-ng-repeat="row in featuredSearches">
+      <a data-ng-click="search(row.url)">
+        {{row.names[lang] || row.names['eng'] || ('featuredSearch' | translate)}}
+
+        <img data-ng-if="row.logo"
+             data-ng-src="{{row.logo}}"
+             class="gn-source-logo"/>
+      </a>
+    </li>
+  </ul>
+</div>

--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchescards.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchescards.html
@@ -18,4 +18,3 @@
     </section>
   </li>
 </ul>
-

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -22,7 +22,7 @@
   }
 }
 
-ul.gn-resultview, [data-gn-featured-user-searches-home] {
+ul.gn-resultview, [data-gn-user-searches-list] {
   .gn-source-logo {
     z-index: 10;
     height: 20px;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -22,6 +22,14 @@
   }
 }
 
+ul.gn-resultview, [data-gn-featured-user-searches-home] {
+  .gn-source-logo {
+    z-index: 10;
+    height: 20px;
+    float: right;
+  }
+}
+
 // styling for all search results
 ul.gn-resultview {
   @thumbnail-width: 170px;
@@ -96,11 +104,6 @@ ul.gn-resultview {
         text-decoration: none;
       }
     }
-  }
-  .gn-source-logo {
-    z-index: 10;
-    height: 20px;
-    float: right;
   }
   .gn-md-abstract {
     background-color: #fff;

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -222,7 +222,7 @@
              role="tab"
              active="infoTabs.featuredSearches.active">
           <form class="form-horizontal">
-            <div data-gn-featured-user-searches-home></div>
+            <div data-gn-user-searches-list></div>
           </form>
         </tab>
         <tab heading="{{'Comments' | translate}}"

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -24,6 +24,7 @@
               <div class="input-group-btn">
                 <button type="button"
                         class="btn btn-default btn-lg"
+                        title="{{'advanced' | translate}}"
                         data-ng-model="searchObj.advancedMode"
                         btn-checkbox=""
                         btn-checkbox-true="1"
@@ -34,17 +35,22 @@
 
                 <button type="button"
                         data-ng-click="triggerSearch()"
+                        title="{{'search' | translate}}"
                         class="btn btn-primary btn-lg">
                   &nbsp;&nbsp;
                   <i class="fa fa-search"></i>
                   <span class="sr-only" data-translate="">search</span>
                   &nbsp;&nbsp;
                 </button>
+
+                <button data-gn-featured-user-searches-home=""
+                        data-mode="button"/>
+
                 <button type="button"
                         data-ng-click="resetSearch(searchObj.defaultParams);"
                         title="{{'ClearTitle' | translate}}"
-                        class="btn btn-link btn-lg">
-                  <i class="fa fa-times"></i>
+                        class="btn btn-default btn-lg">
+                  <i class="fa fa-times text-danger"></i>
                   <span class="sr-only" data-translate="">ClearTitle</span>
                 </button>
               </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -43,7 +43,7 @@
                   &nbsp;&nbsp;
                 </button>
 
-                <button data-gn-featured-user-searches-home=""
+                <button data-gn-user-searches-list=""
                         data-mode="button"/>
 
                 <button type="button"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1701393/56897257-4fe7c380-6a8e-11e9-8eac-6eea73f1d8dd.png)

Make featured search more visible to user (currently only displayed in home page). 

Adds a directive which can layout as cards view (form home page) or dropdown list (for search page). Also adding a type attribute for future usage for another type of search group.