### PR TITLE
Dublin core / Record view / Keywords not displayed

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/default.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/default.xsl
@@ -232,7 +232,7 @@
         <xsl:if test="count($keywordWithNoThesaurus) > 0">
           'otherKeywords': [
           <xsl:for-each select="$keywordWithNoThesaurus">
-            {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>}
+            {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>, 'link': ''}
             <xsl:if test="position() != last()">,</xsl:if>
           </xsl:for-each>
           ]

--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/default.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/default.xsl
@@ -230,9 +230,9 @@
         <xsl:variable name="keywordWithNoThesaurus"
                       select="/simpledc/dc:subject[text() != '']"/>
         <xsl:if test="count($keywordWithNoThesaurus) > 0">
-          'keywords': [
+          'otherKeywords': [
           <xsl:for-each select="$keywordWithNoThesaurus">
-            <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>
+            {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>}
             <xsl:if test="position() != last()">,</xsl:if>
           </xsl:for-each>
           ]


### PR DESCRIPTION
Related to ISO19139 changes for keywords with anchor.

Before
![image](https://user-images.githubusercontent.com/1701393/56944282-190fbd00-6b23-11e9-8a95-75e1d88bf958.png)

After 
![image](https://user-images.githubusercontent.com/1701393/56944287-1c0aad80-6b23-11e9-95e3-615220269aa4.png)
