### PR TITLE
Associated resources / Clarify links added when linking service and datasets

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1218,6 +1218,7 @@
                    * Hide modal on success.
                    */
                   scope.linkTo = function(addOnlineSrcInDataset) {
+                    scope.onlineSrcLink = '';
                     if (scope.mode === 'service') {
                       return gnOnlinesrc.
                           linkToService(scope.srcParams, scope.popupid, addOnlineSrcInDataset);

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1069,6 +1069,8 @@
                   scope.popupid = '#linkto' + scope.mode + '-popup';
                   scope.alertMsg = null;
                   scope.layerSelectionMode = 'multiple';
+                  scope.onlineSrcLink = '';
+                  scope.addOnlineSrcInDataset = true;
 
                   gnOnlinesrc.register(scope.mode, function() {
                     $(scope.popupid).modal('show');
@@ -1076,15 +1078,23 @@
                     // parameters of the online resource form
                     scope.srcParams = {selectedLayers: []};
 
-                    var searchParams = {
-                      type: scope.mode
-                    };
+                    var searchParams = {};
+                    if (scope.mode === 'service') {
+                      searchParams.type = scope.mode;
+                    } else {
+                      // Any records which are not services
+                      // ie. dataset, series, ...
+                      searchParams['without-type'] = 'service';
+                    }
                     scope.$broadcast('resetSearch', searchParams);
                     scope.layers = [];
+
                     // Load service layers on load
                     if (scope.mode !== 'service') {
-                      // TODO: Check the appropriate WMS service
-                      // or list URLs if many
+                      // If linking a dataset and the service is a WMS
+                      // List all layers. The service WMS link can be added
+                      // as online source in the target dataset.
+                      // TODO: list all URLs if many
                       // TODO: If service URL is added, user need to reload
                       // editor to get URL or current record.
                       var links = [];
@@ -1092,15 +1102,25 @@
                           gnCurrentEdit.metadata.getLinksByType('OGC:WMS'));
                       links = links.concat(
                           gnCurrentEdit.metadata.getLinksByType('wms'));
-                      if (angular.isArray(links) && links.length === 1) {
-                        var serviceUrl = links[0].url;
-                        scope.loadCurrentLink(serviceUrl);
-                        scope.srcParams.url = serviceUrl;
+                      if (links.length > 0) {
+                        scope.onlineSrcLink = links[0].url;
+                        scope.loadCurrentLink(scope.onlineSrcLink);
+                        scope.srcParams.url = scope.onlineSrcLink;
                         scope.srcParams.protocol = links[0].protocol || '';
                         scope.srcParams.uuidSrv = gnCurrentEdit.uuid;
+
+                        scope.addOnlineSrcInDataset = true;
                       } else {
                         scope.alertMsg =
                             $translate.instant('linkToServiceWithoutURLError');
+
+                        // If no WMS found, suggest to add a link to the service landing page
+                        // Default is false.
+                        // Build a link to the service metadata record
+                        scope.onlineSrcLink = gnConfigService.getServiceURL() +
+                          "api/records/" + gnCurrentEdit.uuid;
+
+                        scope.addOnlineSrcInDataset = false;
                       }
                     }
                   });
@@ -1150,6 +1170,8 @@
                         var links = [];
                         scope.layers = [];
                         scope.srcParams.selectedLayers = [];
+
+                        // Search a WMS link in the service metadata record
                         // TODO: WFS ?
                         links = links.concat(md.getLinksByType('OGC:WMS'));
                         links = links.concat(md.getLinksByType('wms'));
@@ -1162,26 +1184,27 @@
                         scope.srcParams.source = gnCurrentEdit.metadata.source;
 
 
-                        if (angular.isArray(links) && links.length === 1) {
-                          scope.loadCurrentLink(links[0].url);
-                          scope.srcParams.url = links[0].url;
+                        if (links.length > 0) {
+                          scope.onlineSrcLink = links[0].url;
+                          scope.loadCurrentLink(scope.onlineSrcLink);
+                          scope.srcParams.protocol = links[0].protocol || 'OGC:WMS';
+                          scope.srcParams.url = scope.onlineSrcLink;
+                          scope.addOnlineSrcInDataset = true;
                         } else {
                           scope.srcParams.name = scope.currentMdTitle;
                           scope.srcParams.desc = scope.currentMdTitle;
                           scope.srcParams.protocol = "WWW:LINK-1.0-http--link";
-                          scope.srcParams.url =  gnConfigService.getServiceURL() +
-                            "api/records/" +
-                            md.getUuid() + "/formatters/xml";
+                          scope.onlineSrcLink = gnConfigService.getServiceURL() +
+                            "api/records/" + md.getUuid();
+                          scope.srcParams.url = scope.onlineSrcLink;
+                          scope.addOnlineSrcInDataset = false;
                         }
-                      } else {
-                        // dataset
+                      } else if (scope.addOnlineSrcInDataset) {
                         scope.srcParams.uuidDS = md.getUuid();
                         scope.srcParams.name = gnCurrentEdit.mdTitle;
                         scope.srcParams.desc = gnCurrentEdit.mdTitle;
                         scope.srcParams.protocol = "WWW:LINK-1.0-http--link";
-                        scope.srcParams.url =  gnConfigService.getServiceURL() +
-                          "api/records/" +
-                          md.getUuid() + "/formatters/xml";
+                        scope.srcParams.url = scope.onlineSrcLink;
                         scope.srcParams.identifier = (md.identifier && md.identifier[0]) ? md.identifier[0] : '';
                         scope.srcParams.source = md.source;
                       }
@@ -1194,13 +1217,13 @@
                    *  - link a service to a dataset
                    * Hide modal on success.
                    */
-                  scope.linkTo = function() {
+                  scope.linkTo = function(addOnlineSrcInDataset) {
                     if (scope.mode === 'service') {
                       return gnOnlinesrc.
-                          linkToService(scope.srcParams, scope.popupid);
+                          linkToService(scope.srcParams, scope.popupid, addOnlineSrcInDataset);
                     } else {
                       return gnOnlinesrc.
-                          linkToDataset(scope.srcParams, scope.popupid);
+                          linkToDataset(scope.srcParams, scope.popupid, addOnlineSrcInDataset);
                     }
                   };
                 }

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
@@ -1,7 +1,7 @@
 <div>
   <form class="form-horizontal" role="form"
         data-ng-search-form="">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+    <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="onlinesrc-container">
       <div class="form-group">
         <div class="col-sm-10">
@@ -41,10 +41,19 @@
            data-layers="layers"
            data-selection="srcParams.selectedLayers">
       </div>
+
+      <div>
+        <label>
+          <input type="checkbox"
+                 data-ng-model="addOnlineSrcInDataset"/>
+          <span data-translate="">addTheFollowingLinkInDataset</span>
+        </label>
+        <span>{{onlineSrcLink}}</span>
+      </div>
     </div>
     <div class="">
       <button type="button" class="btn navbar-btn btn-success"
-              data-gn-click-and-spin="linkTo()"
+              data-gn-click-and-spin="linkTo(addOnlineSrcInDataset)"
               data-ng-class="{'disabled': (stateObj.selectRecords.length < 1)}">
         <i class="fa gn-icon-service"/>&nbsp;
         <span data-translate="" data-ng-show="mode == 'service'">linkToService</span>

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -314,7 +314,9 @@
              }
              else {
                var params = {id: gnCurrentEdit.id};
-
+               if (gnCurrentEdit.tab) {
+                 params.currTab = gnCurrentEdit.tab;
+               }
                // If a new session, ask the server to save the original
                // record and update session start time
                if (startNewSession) {
@@ -322,7 +324,7 @@
                  gnCurrentEdit.sessionStartTime = moment();
                }
                $http.get('../api/records/' + gnCurrentEdit.id + '/editor',
-               params).then(function(data) {
+                 {params: params}).then(function(data) {
                  refreshForm($(data.data));
                });
              }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -367,6 +367,7 @@
     "inputGeometryReadOnlyHint": "This geometry is read-only.",
     "selectKeyword": "Add keywords",
     "saveLinkToSibling": "Save link to other resource",
+    "addTheFollowingLinkInDataset": "Add the following link to the dataset (as an online source in the distribution section):",
     "confirmCloseInvalidTitle": "Confirm editor close",
     "confirmCloseInvalidMetadata": "The current metadata has been found to be invalid. Closing the editor will cause it to be unpublished (this can be changed in the application settings).<br><br>Are you sure you want to proceed?",
     "hotkeyDirectory": "Manage directories (eg. contact)",


### PR DESCRIPTION


When linking a service to a dataset, the service will be modified with a coupledResource + operatesOn (as before) and the dataset can be optionally modified with the following link added:

* a service with a WMS endpoint - a link to the WMS + layer name can be added to the dataset record

![image](https://user-images.githubusercontent.com/1701393/57028819-60d83680-6c40-11e9-9de6-8b313a0da48c.png)

* a service with no URL - a link to the metadata record (main landing page in HTML) can be added to the dataset record

![image](https://user-images.githubusercontent.com/1701393/57028879-85341300-6c40-11e9-95fb-6a9015c7745f.png)



Related to https://github.com/geonetwork/core-geonetwork/commit/00bd2de0cf74fc429ba96d74cda632cc4ca4f670



Also fix the search which was only listing datasets (and for example not series) - replaced by search for all which is not a service.