### PR TITLE
Improving Shibboleth authorization

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
@@ -20,12 +20,15 @@
 
 package org.fao.geonet.kernel.security.shibboleth;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Some basic configuration info for Shibboleth logins.
  *
  * Mainly header names mapping to attributes.
  *
  * @author ETj (etj at geo-solutions.it)
+ * @author María Arias de Reyna (delawen)
  */
 public class ShibbolethUserConfiguration {
     private String usernameKey;
@@ -39,6 +42,8 @@ public class ShibbolethUserConfiguration {
 
     private boolean updateProfile;
     private boolean updateGroup;
+    
+    private String arraySeparator;
 
     public String getUsernameKey() {
         return usernameKey;
@@ -53,7 +58,7 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setSurnameKey(String surnameKey) {
-        if (surnameKey == null) {
+		if(StringUtils.isEmpty(surnameKey)) {
             surnameKey = "";
         }
         this.surnameKey = surnameKey;
@@ -64,7 +69,7 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setFirstnameKey(String firstnameKey) {
-        if (firstnameKey == null) {
+		if(StringUtils.isEmpty(firstnameKey)) {
             firstnameKey = "";
         }
         this.firstnameKey = firstnameKey;
@@ -75,7 +80,7 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setProfileKey(String profileKey) {
-        if (profileKey == null) {
+		if(StringUtils.isEmpty(profileKey)) {
             profileKey = "";
         }
         this.profileKey = profileKey;
@@ -86,7 +91,7 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setGroupKey(String groupKey) {
-        if (groupKey == null) {
+		if(StringUtils.isEmpty(groupKey)) {
             groupKey = "";
         }
         this.groupKey = groupKey;
@@ -97,18 +102,12 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setDefaultGroup(String defaultGroup) {
-        if (defaultGroup == null) {
+		if(StringUtils.isEmpty(defaultGroup)) {
             defaultGroup = "";
         }
         this.defaultGroup = defaultGroup;
     }
-
-    /**
-     * Tell if the profile should be updated whenever the user login.
-     *
-     * This info is needed when the identificatian provider provides no real mean to tell the user
-     * profile.
-     */
+    
     public boolean isUpdateProfile() {
         return updateProfile;
     }
@@ -130,11 +129,22 @@ public class ShibbolethUserConfiguration {
     }
 
     public void setEmailKey(String emailKey) {
-        if (emailKey == null) {
+		if(StringUtils.isEmpty(emailKey)) {
             emailKey = "";
         }
         this.emailKey = emailKey;
     }
+
+	public String getArraySeparator() {
+		return arraySeparator;
+	}
+
+	public void setArraySeparator(String arraySeparator) {
+		if(StringUtils.isEmpty(arraySeparator)) {
+			arraySeparator = ";";
+		}
+		this.arraySeparator = arraySeparator;
+	}
 }
 
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
@@ -194,6 +194,12 @@ public class ShibbolethUserUtils {
 
 		for (String group : groups) {
 			Group g = groupRepository.findByName(group);
+			
+			if(g == null) {
+				g = new Group();
+				g.setName(group);
+				groupRepository.save(g);
+			}
 
 			UserGroup usergroup = new UserGroup();
 			usergroup.setGroup(g);

--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
@@ -20,219 +20,281 @@
 
 package org.fao.geonet.kernel.security.shibboleth;
 
-import jeeves.component.ProfileManager;
-
-import org.apache.batik.util.resources.ResourceManager;
-import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.domain.LDAPUser;
-import org.fao.geonet.domain.Profile;
-import org.fao.geonet.domain.User;
-import org.fao.geonet.kernel.security.GeonetworkAuthenticationProvider;
-import org.fao.geonet.kernel.security.WritableUserDetailsContextMapper;
-import org.fao.geonet.repository.UserRepository;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.provisioning.UserDetailsManager;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
+import java.util.HashSet;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+import org.apache.batik.util.resources.ResourceManager;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.LDAPUser;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.kernel.security.GeonetworkAuthenticationProvider;
+import org.fao.geonet.kernel.security.WritableUserDetailsContextMapper;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.UserGroupRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.specification.UserGroupSpecs;
+import org.hsqldb.lib.Set;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.util.StringUtils;
+
+import jeeves.component.ProfileManager;
 
 /**
  * @author ETj (etj at geo-solutions.it)
+ * @author María Arias de Reyna (delawen)
  */
 public class ShibbolethUserUtils {
-    private UserDetailsManager userDetailsManager;
-    private WritableUserDetailsContextMapper udetailsmapper;
+	private UserDetailsManager userDetailsManager;
+	private WritableUserDetailsContextMapper udetailsmapper;
 
+	static MinimalUser parseUser(ServletRequest request, ResourceManager resourceManager, ProfileManager profileManager,
+			ShibbolethUserConfiguration config) {
+		return MinimalUser.create(request, config);
+	}
 
-    static MinimalUser parseUser(ServletRequest request,
-                                 ResourceManager resourceManager, ProfileManager profileManager,
-                                 ShibbolethUserConfiguration config) {
-        return MinimalUser.create(request, config);
-    }
+	protected static String getHeader(HttpServletRequest req, String name, String defValue) {
 
-    protected static String getHeader(HttpServletRequest req, String name,
-                                      String defValue) {
+		if (name == null || name.trim().isEmpty()) {
+			return defValue;
+		}
 
-        if (name == null || name.trim().isEmpty()) {
-            return defValue;
-        }
+		String value = req.getHeader(name);
 
-        String value = req.getHeader(name);
+		if (value == null)
+			return defValue;
 
-        if (value == null)
-            return defValue;
+		if (value.length() == 0)
+			return defValue;
 
-        if (value.length() == 0)
-            return defValue;
+		return value;
+	}
 
-        return value;
-    }
+	/**
+	 * @return the inserted/updated user or null if no valid user found or any error
+	 *         happened
+	 */
+	@Transactional(value = TxType.REQUIRES_NEW)
+	protected UserDetails setupUser(ServletRequest request, ShibbolethUserConfiguration config) throws Exception {
+		UserRepository userRepository = ApplicationContextHolder.get().getBean(UserRepository.class);
+		GroupRepository groupRepository = ApplicationContextHolder.get().getBean(GroupRepository.class);
+		UserGroupRepository userGroupRepository = ApplicationContextHolder.get().getBean(UserGroupRepository.class);
+		GeonetworkAuthenticationProvider authProvider = ApplicationContextHolder.get()
+				.getBean(GeonetworkAuthenticationProvider.class);
 
-    /**
-     * @return the inserted/updated user or null if no valid user found or any error happened
-     */
-    @Transactional
-    protected UserDetails setupUser(ServletRequest request,
-                                    ShibbolethUserConfiguration config) throws Exception {
-        UserRepository userRepository = ApplicationContextHolder.get().getBean(UserRepository.class);
-        GeonetworkAuthenticationProvider authProvider = ApplicationContextHolder.get().getBean(GeonetworkAuthenticationProvider.class);
+		// Read in the data from the headers
+		HttpServletRequest req = (HttpServletRequest) request;
 
-        // Read in the data from the headers
-        HttpServletRequest req = (HttpServletRequest) request;
+		String username = getHeader(req, config.getUsernameKey(), "");
+		String surname = getHeader(req, config.getSurnameKey(), "");
+		String firstname = getHeader(req, config.getFirstnameKey(), "");
+		String email = getHeader(req, config.getEmailKey(), "");
+		String arraySeparator = config.getArraySeparator();
 
-        String username = getHeader(req, config.getUsernameKey(), "");
-        String surname = getHeader(req, config.getSurnameKey(), "");
-        String firstname = getHeader(req, config.getFirstnameKey(), "");
-        String email = getHeader(req, config.getEmailKey(), "");
-        Profile profile = Profile.findProfileIgnoreCase(getHeader(req,
-            config.getProfileKey(), ""));
-        // TODO add group to user
-        //String group = getHeader(req, config.getGroupKey(), "");
+		String profile_header = getHeader(req, config.getProfileKey(), Profile.Guest.name());
+		String[] profiles = new String[0];
+		if (!StringUtils.isEmpty(profile_header)) {
+			profiles = profile_header.split(arraySeparator);
+		}
 
-        if (username != null && username.trim().length() > 0) { // ....add other
-            // cnstraints to
-            // be sure it's
-            // a real
-            // shibbolet
-            // login and not
-            // fake
+		String group_header = getHeader(req, config.getGroupKey(), config.getDefaultGroup());
+		String[] groups = new String[0];
+		if (!StringUtils.isEmpty(group_header)) {
+			groups = group_header.split(arraySeparator);
+		}
 
+		if (!StringUtils.isEmpty(username)) {
 
-            // Make sure the profile name is an exact match
-            if (profile == null) {
-                profile = Profile.Guest;
-            }
+			// FIXME: needed? only accept the first 256 chars
+			if (username.length() > 256) {
+				username = username.substring(0, 256);
+			}
 
-            // TODO add group to user
-            //if (group.equals("")) {
-            //	group = config.getDefaultGroup();
-            //}
+			// Create or update the user
+			User user = null;
+			try {
+				user = (User) authProvider.loadUserByUsername(username);
 
+				if (config.isUpdateGroup()) {
+					// First we remove all previous groups
+					userGroupRepository.deleteAll(UserGroupSpecs.hasUserId(user.getId()));
 
-            // FIXME: needed? only accept the first 256 chars
-            if (username.length() > 256) {
-                username = username.substring(0, 256);
-            }
+					// Now we add the groups
+					assignGroups(groupRepository, userGroupRepository, profiles, groups, user);
+				}
 
-            // Create or update the user
-            User user = new User();
-            try {
-                user = (User) authProvider.loadUserByUsername(username);
-            } catch (UsernameNotFoundException e) {
-                user.setUsername(username);
-                user.setSurname(surname);
-                user.setName(firstname);
-                user.setProfile(profile);
+				//Assign the highest profile available
+				if (config.isUpdateProfile()) {
+					assignProfile(profiles, user);
+					userRepository.save(user);
+				}
 
-                // TODO add group to user
-                // Group g = _groupRepository.findByName(group);
+			} catch (UsernameNotFoundException e) {
+				user = new User();
+				user.setUsername(username);
+				user.setSurname(surname);
+				user.setName(firstname);
 
-            }
+				// Add email
+				if (!StringUtils.isEmpty(email)) {
+					user.getEmailAddresses().add(email);
+				}
+				
+				assignProfile(profiles, user);
+				userRepository.save(user);
+				
+				assignGroups(groupRepository, userGroupRepository, profiles, groups, user);
+			}
 
+			if (udetailsmapper != null) {
+				// If is not null, we may want to write to ldap if user does not exist
+				LDAPUser ldapUserDetails = null;
+				try {
+					ldapUserDetails = (LDAPUser) userDetailsManager.loadUserByUsername(username);
+				} catch (Throwable t) {
+					t.printStackTrace();
+				}
 
-            if (udetailsmapper != null) {
-                //If is not null, we may want to write to ldap if user does not exist
-                LDAPUser ldapUserDetails = null;
-                try {
-                    ldapUserDetails = (LDAPUser) userDetailsManager
-                        .loadUserByUsername(username);
-                } catch (Throwable t) {
-                    t.printStackTrace();
-                }
+				if (ldapUserDetails == null) {
+					ldapUserDetails = new LDAPUser(username);
+					ldapUserDetails.getUser().setName(firstname).setSurname(surname);
 
-                if (ldapUserDetails == null) {
-                    ldapUserDetails = new LDAPUser(username);
-                    ldapUserDetails.getUser().setName(firstname)
-                        .setSurname(surname);
+					ldapUserDetails.getUser().setProfile(user.getProfile());
+					ldapUserDetails.getUser().getEmailAddresses().clear();
+					if (StringUtils.isEmpty(email)) {
+						ldapUserDetails.getUser().getEmailAddresses().add(username + "@unknownIdp");
+					} else {
+						ldapUserDetails.getUser().getEmailAddresses().add(email);
+					}
+				}
 
-                    ldapUserDetails.getUser().setProfile(profile);
-                    ldapUserDetails.getUser().getEmailAddresses().clear();
-                    if (StringUtils.isEmpty(email)) {
-                        ldapUserDetails.getUser().getEmailAddresses().add(username + "@unknownIdp");
-                    } else {
-                        ldapUserDetails.getUser().getEmailAddresses().add(email);
-                    }
-                }
+				udetailsmapper.saveUser(ldapUserDetails);
 
-                udetailsmapper.saveUser(ldapUserDetails);
+				user = ldapUserDetails.getUser();
+			}
 
-                user = ldapUserDetails.getUser();
-            } else {
-                userRepository.saveAndFlush(user);
-            }
+			return user;
+		}
 
-            return user;
-        }
+		return null;
+	}
 
-        return null;
-    }
+	private void assignGroups(GroupRepository groupRepository, UserGroupRepository userGroupRepository,
+			String[] profiles, String[] groups, User user) {
+		// Assign groups
+		int i = 0;
 
-    public static class MinimalUser {
+		for (String group : groups) {
+			Group g = groupRepository.findByName(group);
 
-        private String username;
-        private String name;
-        private String surname;
-        private String profile;
+			UserGroup usergroup = new UserGroup();
+			usergroup.setGroup(g);
+			usergroup.setUser(user);
+			if (profiles.length > i) {
+				Profile profile = Profile.findProfileIgnoreCase(profiles[i]);
+				if(profile.equals(Profile.Administrator)) {
+					//As we are assigning to a group, it is UserAdmin instead
+					profile = Profile.UserAdmin;
+				}
+				usergroup.setProfile(profile);
+			} else {
+				//Failback if no profile
+				usergroup.setProfile(Profile.Guest);
+			}
+			userGroupRepository.save(usergroup);
+			i++;
+		}
+	}
 
-        static MinimalUser create(ServletRequest request,
-                                  ShibbolethUserConfiguration config) {
+	private void assignProfile(String[] profiles, User user) {
+		// Assign the highest profile to the user
+		user.setProfile(null);
+		
+		for (String profile : profiles) {
+			Profile p = Profile.findProfileIgnoreCase(profile);
+			if (p != null && user.getProfile() == null) {
+				user.setProfile(p);
+			} else if (p != null && user.getProfile().compareTo(p) >= 0) {
+				user.setProfile(p);
+			} 
+		}
+		
+		//Failback if no profile
+		if(user.getProfile() == null) {
+			user.setProfile(Profile.Guest);
+		}
+	}
 
-            // Read in the data from the headers
-            HttpServletRequest req = (HttpServletRequest) request;
+	public static class MinimalUser {
 
-            String username = getHeader(req, config.getUsernameKey(), "");
-            String surname = getHeader(req, config.getSurnameKey(), "");
-            String firstname = getHeader(req, config.getFirstnameKey(), "");
-            String profile = getHeader(req, config.getProfileKey(), "");
+		private String username;
+		private String name;
+		private String surname;
+		private String profile;
 
-            if (username.trim().length() > 0) {
+		static MinimalUser create(ServletRequest request, ShibbolethUserConfiguration config) {
 
-                MinimalUser user = new MinimalUser();
-                user.setUsername(username);
-                user.setName(firstname);
-                user.setSurname(surname);
-                user.setProfile(profile);
-                return user;
+			// Read in the data from the headers
+			HttpServletRequest req = (HttpServletRequest) request;
 
-            } else {
-                return null;
-            }
-        }
+			String username = getHeader(req, config.getUsernameKey(), "");
+			String surname = getHeader(req, config.getSurnameKey(), "");
+			String firstname = getHeader(req, config.getFirstnameKey(), "");
+			String profile = getHeader(req, config.getProfileKey(), "");
 
-        public String getUsername() {
-            return username;
-        }
+			if (username.trim().length() > 0) {
 
-        public void setUsername(String username) {
-            this.username = username;
-        }
+				MinimalUser user = new MinimalUser();
+				user.setUsername(username);
+				user.setName(firstname);
+				user.setSurname(surname);
+				user.setProfile(profile);
+				return user;
 
-        public String getName() {
-            return name;
-        }
+			} else {
+				return null;
+			}
+		}
 
-        public void setName(String name) {
-            this.name = name;
-        }
+		public String getUsername() {
+			return username;
+		}
 
-        public String getSurname() {
-            return surname;
-        }
+		public void setUsername(String username) {
+			this.username = username;
+		}
 
-        public void setSurname(String surname) {
-            this.surname = surname;
-        }
+		public String getName() {
+			return name;
+		}
 
-        public String getProfile() {
-            return profile;
-        }
+		public void setName(String name) {
+			this.name = name;
+		}
 
-        public void setProfile(String profile) {
-            this.profile = profile;
-        }
-    }
+		public String getSurname() {
+			return surname;
+		}
+
+		public void setSurname(String surname) {
+			this.surname = surname;
+		}
+
+		public String getProfile() {
+			return profile;
+		}
+
+		public void setProfile(String profile) {
+			this.profile = profile;
+		}
+	}
 
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
@@ -20,8 +20,6 @@
 
 package org.fao.geonet.kernel.security.shibboleth;
 
-import java.util.HashSet;
-
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
@@ -40,7 +38,6 @@ import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.UserRepository;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
-import org.hsqldb.lib.Set;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.provisioning.UserDetailsManager;
@@ -211,6 +208,14 @@ public class ShibbolethUserUtils {
 					profile = Profile.UserAdmin;
 				}
 				usergroup.setProfile(profile);
+				
+				if(profile.equals(Profile.Reviewer)) {
+					UserGroup ug = new UserGroup();
+					ug.setGroup(g);
+					ug.setUser(user);
+					ug.setProfile(Profile.Editor);
+					userGroupRepository.save(ug);
+				}
 			} else {
 				//Failback if no profile
 				usergroup.setProfile(Profile.Guest);

--- a/core/src/test/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtilsTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtilsTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.kernel.security.shibboleth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.fao.geonet.AbstractCoreIntegrationTest;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.UserGroupRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.specification.UserGroupSpecs;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class ShibbolethUserUtilsTest extends AbstractCoreIntegrationTest {
+
+	private ShibbolethUserUtils utils;
+	private ShibbolethUserConfiguration config;
+
+	@Autowired
+	private UserRepository userRepo;
+	@Autowired
+	private GroupRepository groupRepo;
+	@Autowired
+	private UserGroupRepository userGroupRepo;
+
+	// Default values
+	private String surname = "Sur Name";
+	private String username = "shibbolethtest";
+	private String email = "blabla@bleble.bli";
+	private String firstname = "First of her name";
+	private String groupname = "ShibTestGroup";
+
+	@Before
+	public void setUp() {
+		utils = new ShibbolethUserUtils();
+		config = new ShibbolethUserConfiguration();
+
+		config.setArraySeparator(";");
+		config.setDefaultGroup(groupname + "1");
+		config.setEmailKey("EMAIL_KEY");
+		config.setFirstnameKey("FIRSTNAME_KEY");
+		config.setGroupKey("GROUP_KEY");
+		config.setProfileKey("PROFILE_KEY");
+		config.setSurnameKey("SURNAME_KEY");
+		config.setUpdateGroup(true);
+		config.setUpdateProfile(true);
+		config.setUsernameKey("USERNAME_KEY");
+
+		for (int i = 1; i < 5; i++) {
+			Group group = new Group();
+			group.setName(groupname + i);
+			groupRepo.save(group);
+		}
+	}
+
+	@After
+	public void cleanUp() {
+		User user = userRepo.findOneByUsername(username);
+		userRepo.delete(user.getId());
+
+		for (int i = 1; i < 5; i++) {
+			Group group = groupRepo.findByName(groupname + i);
+			groupRepo.delete(group);
+		}
+	}
+
+	@Test
+	public void twoConsecutiveLogins() throws Exception {
+		User user = userRepo.findOneByUsername(username);
+		assertNull("User already exists", user);
+
+		String group = groupname + "1";
+		String profile = Profile.UserAdmin.name() + config.getArraySeparator() + Profile.Administrator.name();
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(this.config.getEmailKey(), email);
+		request.addHeader(this.config.getFirstnameKey(), firstname);
+		request.addHeader(this.config.getGroupKey(), group);
+		request.addHeader(this.config.getProfileKey(), profile);
+		request.addHeader(this.config.getSurnameKey(), surname);
+		request.addHeader(this.config.getUsernameKey(), username);
+		utils.setupUser(request, this.config);
+
+		// Checks
+		user = userRepo.findOneByUsername(username);
+		assertNotNull("User was not created", user);
+		assertSame("The profile should be the highest in the list", Profile.Administrator, user.getProfile());
+
+		List<Integer> idGroups = userGroupRepo.findGroupIds(UserGroupSpecs.hasUserId(user.getId()));
+		assertSame("Groups size is wrong", idGroups.size(), 1);
+		assertEquals("The group assigned is wrong", Integer.valueOf(groupRepo.findByName(group).getId()),
+				idGroups.get(0));
+
+		// Second round, same user different authorization
+		group = groupname + "3";
+		profile = Profile.Guest.name() + config.getArraySeparator() + Profile.Editor.name();
+		request = new MockHttpServletRequest();
+		request.addHeader(this.config.getEmailKey(), email);
+		request.addHeader(this.config.getFirstnameKey(), firstname);
+		request.addHeader(this.config.getGroupKey(), group);
+		request.addHeader(this.config.getProfileKey(), profile);
+		request.addHeader(this.config.getSurnameKey(), surname);
+		request.addHeader(this.config.getUsernameKey(), username);
+		utils.setupUser(request, this.config);
+
+		// Checks
+		user = userRepo.findOneByUsername(username);
+		assertNotNull("User was removed", user);
+
+		idGroups = userGroupRepo.findGroupIds(UserGroupSpecs.hasUserId(user.getId()));
+		assertSame("The profile should be the highest in the list", Profile.Editor, user.getProfile());
+		assertSame("Groups size is wrong", idGroups.size(), 1);
+		assertEquals("The group assigned is wrong", Integer.valueOf(groupRepo.findByName(group).getId()),
+				idGroups.get(0));
+	}
+
+	@Test
+	public void twoConsecutiveLoginsNoAuthorization() throws Exception {
+
+		config.setUpdateGroup(false);
+		config.setUpdateProfile(false);
+
+		User user = userRepo.findOneByUsername(username);
+		assertNull("User already exists", user);
+
+		String group = groupname + "1";
+		String profile = Profile.UserAdmin.name() + config.getArraySeparator() + Profile.Administrator.name();
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(this.config.getEmailKey(), email);
+		request.addHeader(this.config.getFirstnameKey(), firstname);
+		request.addHeader(this.config.getGroupKey(), group);
+		request.addHeader(this.config.getProfileKey(), profile);
+		request.addHeader(this.config.getSurnameKey(), surname);
+		request.addHeader(this.config.getUsernameKey(), username);
+		utils.setupUser(request, this.config);
+
+		// Checks
+		user = userRepo.findOneByUsername(username);
+		assertNotNull("User was not created", user);
+		assertSame("The profile should be the highest in the list", Profile.Administrator, user.getProfile());
+
+		List<Integer> idGroups = userGroupRepo.findGroupIds(UserGroupSpecs.hasUserId(user.getId()));
+		assertSame("Groups size is wrong", idGroups.size(), 1);
+		assertEquals("The group assigned is wrong", Integer.valueOf(groupRepo.findByName(group).getId()),
+				idGroups.get(0));
+
+		// Second round, same user different authorization but the original
+		// authorization should be kept (no updateProfile, updateGroups)
+		request = new MockHttpServletRequest();
+		request.addHeader(this.config.getEmailKey(), email);
+		request.addHeader(this.config.getFirstnameKey(), firstname);
+		request.addHeader(this.config.getGroupKey(), groupname + "3");
+		request.addHeader(this.config.getProfileKey(),
+				Profile.Guest.name() + config.getArraySeparator() + Profile.Editor.name());
+		request.addHeader(this.config.getSurnameKey(), surname);
+		request.addHeader(this.config.getUsernameKey(), username);
+		utils.setupUser(request, this.config);
+
+		// Checks
+		user = userRepo.findOneByUsername(username);
+		assertNotNull("User was removed", user);
+
+		idGroups = userGroupRepo.findGroupIds(UserGroupSpecs.hasUserId(user.getId()));
+		assertSame("The profile should be the highest in the list", Profile.Administrator, user.getProfile());
+		assertSame("Groups size is wrong", idGroups.size(), 1);
+		assertEquals("The group assigned is wrong", Integer.valueOf(groupRepo.findByName(group).getId()),
+				idGroups.get(0));
+	}
+
+	@Test
+	public void groupLengthNotMatchProfileLength() throws Exception {
+
+		User user = userRepo.findOneByUsername(username);
+		assertNull("User already exists", user);
+
+		String group = groupname + "1" + config.getArraySeparator() + groupname + "2" + config.getArraySeparator()
+				+ groupname + "3";
+		String profile = Profile.Editor.name();
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(this.config.getEmailKey(), email);
+		request.addHeader(this.config.getFirstnameKey(), firstname);
+		request.addHeader(this.config.getGroupKey(), group);
+		request.addHeader(this.config.getProfileKey(), profile);
+		request.addHeader(this.config.getSurnameKey(), surname);
+		request.addHeader(this.config.getUsernameKey(), username);
+
+		utils.setupUser(request, this.config);
+
+		// Checks
+		user = userRepo.findOneByUsername(username);
+		assertNotNull("User was not created", user);
+		assertSame("The profile should be the highest in the list", Profile.Editor, user.getProfile());
+		List<Integer> idGroups = userGroupRepo.findGroupIds(UserGroupSpecs.hasUserId(user.getId()));
+		assertSame("Groups size is wrong", idGroups.size(), 3);
+
+		List<UserGroup> groups = userGroupRepo.findAll(UserGroupSpecs.hasUserId(user.getId()));
+		for (UserGroup ug : groups) {
+			if (ug.getProfile().equals(Profile.Editor)) {
+				assertTrue(ug.getGroup().getName().equalsIgnoreCase(groupname + "1"));
+			} else if (ug.getProfile().equals(Profile.Guest)) {
+				assertTrue(ug.getGroup().getName().equalsIgnoreCase(groupname + "2")
+						|| ug.getGroup().getName().equalsIgnoreCase(groupname + "3"));
+			} else {
+				assertTrue("We have a usergroup we shouldn't have", false);
+			}
+		}
+
+	}
+
+	@Test
+	public void severalGroups() throws Exception {
+
+		User user = userRepo.findOneByUsername(username);
+		assertNull("User already exists", user);
+
+		String group = groupname + "1";
+		String profile = Profile.Reviewer.name();
+
+		for (int i = 2; i < 5; i++) {
+			group = group + config.getArraySeparator() + groupname + i;
+			profile = profile + config.getArraySeparator() + Profile.Editor.name();
+		}
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(this.config.getEmailKey(), email);
+		request.addHeader(this.config.getFirstnameKey(), firstname);
+		request.addHeader(this.config.getGroupKey(), group);
+		request.addHeader(this.config.getProfileKey(), profile);
+		request.addHeader(this.config.getSurnameKey(), surname);
+		request.addHeader(this.config.getUsernameKey(), username);
+
+		utils.setupUser(request, this.config);
+
+		// Checks
+		user = userRepo.findOneByUsername(username);
+		assertNotNull("User was not created", user);
+		assertSame("The profile should be the highest in the list", Profile.Reviewer, user.getProfile());
+
+		List<Integer> idGroups = userGroupRepo.findGroupIds(UserGroupSpecs.hasUserId(user.getId()));
+		assertSame("Groups size is wrong", idGroups.size(), 4);
+
+		List<UserGroup> groups = userGroupRepo.findAll(UserGroupSpecs.hasUserId(user.getId()));
+		for (UserGroup ug : groups) {
+			assertNotSame("No profile can be guest as we have defined a role for all groups.", Profile.Guest,
+					ug.getProfile());
+		}
+	}
+
+}

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth-overrides.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth-overrides.properties
@@ -22,11 +22,19 @@
 # Rome - Italy. email: geonetwork@osgeo.org
 #
 
-shibbolethConfiguration.firstnameKey=Shib-InetOrgPerson-givenName
-shibbolethConfiguration.surnameKey=Shib-Person-surname
 shibbolethConfiguration.usernameKey=REMOTE_USER
+shibbolethConfiguration.surnameKey=Shib-Person-surname
+shibbolethConfiguration.firstnameKey=Shib-InetOrgPerson-givenName
 shibbolethConfiguration.profileKey=Shib-EP-Entitlement
 shibbolethConfiguration.groupKey=
+shibbolethConfiguration.emailKey=
 
-shibbolethConfiguration.updateGroup=false
+shibbolethConfiguration.defaultGroup=
+
+#Tell if the profile should be updated whenever the user login.
+#This info is needed when the authentication provider 
+#does not provide authorization information
 shibbolethConfiguration.updateProfile=false
+shibbolethConfiguration.updateGroup=false
+
+shibbolethConfiguration.arraySeparator=;

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
@@ -53,14 +53,19 @@
   <!-- You may customize the following values by editing the file config-security-shibboleth-overrides.properties -->
   <bean id="shibbolethConfiguration"
         class="org.fao.geonet.kernel.security.shibboleth.ShibbolethUserConfiguration">
-    <property name="firstnameKey" value="${shibbolethConfiguration.firstnameKey}"/>
-    <property name="surnameKey" value="${shibbolethConfiguration.surnameKey}"/>
     <property name="usernameKey" value="${shibbolethConfiguration.usernameKey}"/>
+    <property name="surnameKey" value="${shibbolethConfiguration.surnameKey}"/>
+    <property name="firstnameKey" value="${shibbolethConfiguration.firstnameKey}"/>
     <property name="profileKey" value="${shibbolethConfiguration.profileKey}"/>
     <property name="groupKey" value="${shibbolethConfiguration.groupKey}"/>
+    <property name="emailKey" value="${shibbolethConfiguration.emailKey}"/>
+    
+    <property name="defaultGroup" value="${shibbolethConfiguration.defaultGroup}"/>
 
-    <property name="updateGroup" value="${shibbolethConfiguration.updateGroup}"/>
     <property name="updateProfile" value="${shibbolethConfiguration.updateProfile}"/>
+    <property name="updateGroup" value="${shibbolethConfiguration.updateGroup}"/>
+   
+    <property name="arraySeparator" value="${shibbolethConfiguration.arraySeparator}"/>
   </bean>
   
   <bean id="filterChainFilters" class="java.util.ArrayList">


### PR DESCRIPTION
Now we accept a list of groups and profiles to assign to the user.

Also, keys "updateProfile" and "updateGroups" were ignored. Now we can handle authorization safely.
Also, key "email" was ignored. Now we can setup an email using shibboleth.
Unit Tests added to explore corner cases.

I had added the missing keys on the config files. Also reordered the keys to match the same as in xml file and the same as in java config class, to make sure in the future no keys are lost.

To test this I used a browser extension to add HTTP headers manually.

The groups and profile headers now allow a list (separated by https://github.com/geonetwork/core-geonetwork/pull/3785/files#diff-1dcd473586cb00240bdfbcf814e536f9R40 ) to assign several groups with different profiles to the same user, as in the user interface.

For example:

HEADER_PROFILE: "Guest;Editor;UserAdmin;Reviewer"
HEADER_GROUPS: "group1;group2;group3;group4"

which means: group1 as Guest, group2 as Editor, group3 as UserAdmin, group4 as Reviewer
Groups with no matching profile will use the "Guest" profile.
If some group has the Administrator profile, it will be changed for UserAdmin, although the main profile of the user (user.setProfile()) will be Administrator. Corner weird case.

The Profile assigned to the user (user.setProfile) will be as in the user interface: the highest of all profiles in the list of profiles.