### PR TITLE
Fixes typo in stylerurl property.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
@@ -164,7 +164,7 @@
                 });
               };
               scope.openStyler = function() {
-                window.open(scope.gsNode.stylerUrl +
+                window.open(scope.gsNode.stylerurl +
                     '?namespace=' + scope.gsNode.namespacePrefix +
                     '&layer=' + scope.wmsLayerName);
               };
@@ -200,7 +200,7 @@
                 if (n != o) {
                   scope.checkNode(scope.gsNode.id);
                   scope.hasStyler = !angular.isArray(
-                      scope.gsNode.stylerUrl);
+                      scope.gsNode.stylerurl);
                 }
               });
 


### PR DESCRIPTION
In Geopublisher control in the editor fixes a typo in the property `stylerUrl`.
The right value is `stylerurl`.