### PR TITLE
Shibboleth: optional login form and new header

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
@@ -44,6 +44,8 @@ public class ShibbolethUserConfiguration {
     private boolean updateGroup;
     
     private String arraySeparator;
+    
+    private Boolean hideLogin;
 
     public String getUsernameKey() {
         return usernameKey;
@@ -144,6 +146,17 @@ public class ShibbolethUserConfiguration {
 			arraySeparator = ";";
 		}
 		this.arraySeparator = arraySeparator;
+	}
+
+	public Boolean getHideLogin() {
+		return hideLogin;
+	}
+
+	public void setHideLogin(Boolean hideLogin) {
+		if(hideLogin == null) {
+			hideLogin = true;
+		}
+		this.hideLogin = hideLogin;
 	}
 }
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
@@ -37,6 +37,7 @@ public class ShibbolethUserConfiguration {
     private String profileKey;
     private String groupKey;
     private String emailKey;
+    private String roleGroupKey;
 
     private String defaultGroup;
 
@@ -44,6 +45,7 @@ public class ShibbolethUserConfiguration {
     private boolean updateGroup;
     
     private String arraySeparator;
+    private String roleGroupSeparator;
     
     private Boolean hideLogin;
 
@@ -157,6 +159,25 @@ public class ShibbolethUserConfiguration {
 			hideLogin = true;
 		}
 		this.hideLogin = hideLogin;
+	}
+
+	public String getRoleGroupKey() {
+		return roleGroupKey;
+	}
+
+	public void setRoleGroupKey(String roleGroupKey) {
+		this.roleGroupKey = roleGroupKey;
+	}
+
+	public String getRoleGroupSeparator() {
+		return roleGroupSeparator;
+	}
+
+	public void setRoleGroupSeparator(String roleGroupSeparator) {
+		if(StringUtils.isEmpty(arraySeparator)) {
+			arraySeparator = ",";
+		}
+		this.roleGroupSeparator = roleGroupSeparator;
 	}
 }
 

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -298,16 +298,20 @@ public final class XslUtil {
         return ProfileManager.existsBean(beanId);
     }
 
-    /**
-     * Check if Shibboleth should show login
-     *
-     * @param beanId id of the bean to look up
-     */
-    public static boolean shibbolethHideLogin() {
-        ServiceContext serviceContext = ServiceContext.get();
-        ShibbolethUserConfiguration shib = serviceContext.getBean(ShibbolethUserConfiguration.class);
-        return shib.getHideLogin();
-    }
+	/**
+	 * Check if Shibboleth should show login
+	 *
+	 * @param beanId
+	 *            id of the bean to look up
+	 */
+	public static boolean shibbolethHideLogin() {
+		if (existsBean("shibbolethConfiguration")) {
+			ServiceContext serviceContext = ServiceContext.get();
+			ShibbolethUserConfiguration shib = serviceContext.getBean(ShibbolethUserConfiguration.class);
+			return shib.getHideLogin();
+		}
+		return false;
+	}
 
     /**
      * Optimistically check if user can access a given url.  If not possible to determine then the

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -64,6 +64,8 @@ import org.fao.geonet.kernel.ThesaurusManager;
 import org.fao.geonet.kernel.search.CodeListTranslator;
 import org.fao.geonet.kernel.search.LuceneSearcher;
 import org.fao.geonet.kernel.search.Translator;
+import org.fao.geonet.kernel.security.shibboleth.ShibbolethUserConfiguration;
+import org.fao.geonet.kernel.security.shibboleth.ShibbolethUserUtils;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
@@ -294,6 +296,17 @@ public final class XslUtil {
      */
     public static boolean existsBean(String beanId) {
         return ProfileManager.existsBean(beanId);
+    }
+
+    /**
+     * Check if Shibboleth should show login
+     *
+     * @param beanId id of the bean to look up
+     */
+    public static boolean shibbolethHideLogin() {
+        ServiceContext serviceContext = ServiceContext.get();
+        ShibbolethUserConfiguration shib = serviceContext.getBean(ShibbolethUserConfiguration.class);
+        return shib.getHideLogin();
     }
 
     /**

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -281,6 +281,7 @@ goog.require('gn_alert');
       },
       current: null,
       shibbolethEnabled: false,
+      shibbolethHideLogin: true,
       init: function(config, gnUrl, gnViewerSettings, gnSearchSettings) {
         // start from the default config to make sure every field is present
         // and override with config arg if required
@@ -502,6 +503,7 @@ goog.require('gn_alert');
       $scope.isMapViewerEnabled = gnGlobalSettings.isMapViewerEnabled;
       $scope.isDebug = window.location.search.indexOf('debug') !== -1;
       $scope.shibbolethEnabled = gnGlobalSettings.shibbolethEnabled;
+      $scope.shibbolethHideLogin = gnGlobalSettings.shibbolethHideLogin;
       $scope.isExternalViewerEnabled = gnExternalViewer.isEnabled();
       $scope.externalViewerUrl = gnExternalViewer.getBaseUrl();
 

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -66,6 +66,7 @@
           $scope.signinFailure = gnUtilityService.getUrlParameter('failure');
           $scope.gnConfig = gnConfig;
           $scope.shibbolethEnabled = gnGlobalSettings.shibbolethEnabled;
+          $scope.shibbolethHideLogin = gnGlobalSettings.shibbolethHideLogin;
 
           function initForm() {
            if ($window.location.pathname.indexOf('new.password') !== -1) {

--- a/web-ui/src/main/resources/catalog/templates/signin.html
+++ b/web-ui/src/main/resources/catalog/templates/signin.html
@@ -8,7 +8,7 @@
         <div class="panel-body">
           <p data-translate="">loginText</p>
           <form class="form-horizontal" name="gnSigninForm" action="{{formAction}}"
-                method="post" role="form" data-ng-if="::user" data-ng-show="!shibbolethEnabled">
+                method="post" role="form" data-ng-if="::user" data-ng-show="!shibbolethHideLogin">
             <input type="hidden" name="_csrf" value="{{csrf}}"/>
   
             <!-- username -->

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -140,7 +140,7 @@
 
     <form class="navbar-form navbar-right language-switcher">
       <span class="gn-menuheader-xs visible-xs"
-            data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !shibbolethEnabled"
+            data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !shibbolethHideLogin"
             data-translate="">language</span>
       <div class="form-group"
            data-gn-language-switcher="lang"
@@ -197,7 +197,7 @@
         </ul>
       </li>
       <li class="dropdown dropdown-hover open signin-dropdown"
-        data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !shibbolethEnabled">
+        data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !shibbolethHideLogin">
         <a href="{{gnCfg.mods.signin.appUrl | signInLink}}"
            title="{{'signIn'|translate}}"
            class="dropdown-toggle gn-menuheader-xs"

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth-overrides.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth-overrides.properties
@@ -38,3 +38,5 @@ shibbolethConfiguration.updateProfile=false
 shibbolethConfiguration.updateGroup=false
 
 shibbolethConfiguration.arraySeparator=;
+
+shibbolethConfiguration.hideLogin=true

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth-overrides.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth-overrides.properties
@@ -26,10 +26,11 @@ shibbolethConfiguration.usernameKey=REMOTE_USER
 shibbolethConfiguration.surnameKey=Shib-Person-surname
 shibbolethConfiguration.firstnameKey=Shib-InetOrgPerson-givenName
 shibbolethConfiguration.profileKey=Shib-EP-Entitlement
-shibbolethConfiguration.groupKey=
-shibbolethConfiguration.emailKey=
+shibbolethConfiguration.groupKey=Shib-EP-Groups
+shibbolethConfiguration.emailKey=Shib-EP-Email
+shibbolethConfiguration.roleGroupKey=Shib-EP-GroupsRoles
 
-shibbolethConfiguration.defaultGroup=
+shibbolethConfiguration.defaultGroup=sample
 
 #Tell if the profile should be updated whenever the user login.
 #This info is needed when the authentication provider 
@@ -38,5 +39,6 @@ shibbolethConfiguration.updateProfile=false
 shibbolethConfiguration.updateGroup=false
 
 shibbolethConfiguration.arraySeparator=;
+shibbolethConfiguration.roleGroupSeparator=,
 
 shibbolethConfiguration.hideLogin=true

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
@@ -62,6 +62,7 @@
     <property name="profileKey" value="${shibbolethConfiguration.profileKey}"/>
     <property name="groupKey" value="${shibbolethConfiguration.groupKey}"/>
     <property name="emailKey" value="${shibbolethConfiguration.emailKey}"/>
+    <property name="roleGroupKey" value="${shibbolethConfiguration.roleGroupKey}"/>
     
     <property name="defaultGroup" value="${shibbolethConfiguration.defaultGroup}"/>
 
@@ -69,6 +70,7 @@
     <property name="updateGroup" value="${shibbolethConfiguration.updateGroup}"/>
    
     <property name="arraySeparator" value="${shibbolethConfiguration.arraySeparator}"/>
+    <property name="roleGroupSeparator" value="${shibbolethConfiguration.roleGroupSeparator}"/>
  
 		<property name="hideLogin"
 			value="${shibbolethConfiguration.hideLogin}" />

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml
@@ -26,11 +26,14 @@
 <beans
   xmlns:ctx="http://www.springframework.org/schema/context"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:util="http://www.springframework.org/schema/util"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
           http://www.springframework.org/schema/context
-          http://www.springframework.org/schema/context/spring-context-3.0.xsd"
-  xmlns="http://www.springframework.org/schema/beans">
+          http://www.springframework.org/schema/context/spring-context-3.0.xsd
+          http://www.springframework.org/schema/util
+          http://www.springframework.org/schema/util/spring-util.xsd"
+	xmlns="http://www.springframework.org/schema/beans">
 
 
   <ctx:property-override
@@ -66,20 +69,46 @@
     <property name="updateGroup" value="${shibbolethConfiguration.updateGroup}"/>
    
     <property name="arraySeparator" value="${shibbolethConfiguration.arraySeparator}"/>
-  </bean>
-  
-  <bean id="filterChainFilters" class="java.util.ArrayList">
-    <constructor-arg>
-      <list>
-        <ref bean="securityContextPersistenceFilter"/>
-        <ref bean="logoutFilter"/>
-        <ref bean="shibbolethPreAuthFilter"/>
-        <ref bean="requestCacheFilter"/>
-        <ref bean="anonymousFilter"/>
-        <ref bean="sessionMgmtFilter"/>
-        <ref bean="exceptionTranslationFilter"/>
-        <ref bean="filterSecurityInterceptor"/>
-      </list>
-    </constructor-arg>
-  </bean>
+ 
+		<property name="hideLogin"
+			value="${shibbolethConfiguration.hideLogin}" />
+	</bean>
+
+	<bean id="filterChainFilters" class="java.util.ArrayList">
+		<constructor-arg
+			ref="#{ '${shibbolethConfiguration.hideLogin}' == 'true' ? 'shibbolethFilterChanFiltersExclusive' : 'shibbolethFilterChanFiltersInclusive' }">
+		</constructor-arg>
+	</bean>
+
+	<util:list id="shibbolethFilterChanFiltersExclusive">
+		<ref bean="securityContextPersistenceFilter" />
+		<ref bean="logoutFilter" />
+		<ref bean="shibbolethPreAuthFilter" />
+		<ref bean="requestCacheFilter" />
+		<ref bean="anonymousFilter" />
+		<ref bean="sessionMgmtFilter" />
+		<ref bean="exceptionTranslationFilter" />
+		<ref bean="filterSecurityInterceptor" />
+	</util:list>
+
+	<!-- This list should be kept updated based on the one on config-security-core.xml -->
+	<util:list id="shibbolethFilterChanFiltersInclusive">
+		<ref bean="securityContextPersistenceFilter" />
+		<!-- To disable csrf security (not recommended) comment the following line -->
+		<ref bean="csrfFilter" />
+		<!-- To disable csrf security (not recommended) comment the upper line -->
+		<ref bean="logoutFilter" />
+		<!-- A filter that check if an external service already authenticated user 
+			(default implementation does nothing but can be overridden) -->
+		<ref bean="multiNodeAuthenticationFilter" />
+		<ref bean="preAuthenticationFilter" />
+		<ref bean="shibbolethPreAuthFilter" />
+		<ref bean="basicAuthenticationFilter" />
+		<ref bean="formLoginFilter" />
+		<ref bean="requestCacheFilter" />
+		<ref bean="anonymousFilter" />
+		<ref bean="sessionMgmtFilter" />
+		<ref bean="exceptionTranslationFilter" />
+		<ref bean="filterSecurityInterceptor" />
+	</util:list>
 </beans>

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -209,6 +209,7 @@
         module.config(['gnGlobalSettings',
         function(gnGlobalSettings) {
         gnGlobalSettings.shibbolethEnabled = <xsl:value-of select="$shibbolethOn"/>;
+        gnGlobalSettings.shibbolethHideLogin = <xsl:value-of select="$shibbolethHideLogin and $shibbolethOn"/>;
         }]);
       </script>
     </xsl:if>

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -67,6 +67,9 @@
 
   <xsl:variable name="shibbolethOn"
                 select="util:existsBean('shibbolethConfiguration')"/>
+                
+  <xsl:variable name="shibbolethHideLogin"
+                select="util:shibbolethHideLogin()"/>
 
   <!-- Define which JS module to load using Closure -->
   <xsl:variable name="angularApp" select="


### PR DESCRIPTION
New properties in web/src/main/webapp/WEB-INF/config-security/config-security-shibboleth.xml.

1.- We can choose if we want an exclusive Shibboleth login or if we want to have other types of authentication too (basic authentication, form or whatever):
`shibbolethConfiguration.hideLogin=true`

2.- Instead of having two different headers to define groups and profiles, use a combined header:
```
shibbolethConfiguration.roleGroupKey=Shib-EP-GroupsRoles
shibbolethConfiguration.roleGroupSeparator=,
```
Example:
Shib-EP-GroupsRoles=group1,Editor;group2,Guest;group3:UserAdmin

means that the user will be Editor on group1, Guest on group2 and UserAdmin in group3. As usual, the highest profile in the list is the profile set in` user.setProfile`.

This header can be used in combination with the ones defined in #3785. All groups and profiles defined on the three headers will be used.

Remember to enable the `updateProfile` and `updateGroup` properties to have this profiles and groups added to your user:
```
shibbolethConfiguration.updateProfile=false
 shibbolethConfiguration.updateGroup=false
```