### PR TITLE
Formatter / Add parameter to override language header.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -58,6 +58,7 @@ import io.swagger.annotations.ApiParam;
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.ServiceManager;
 import jeeves.xlink.Processor;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.fao.geonet.ApplicationContextHolder;
@@ -273,6 +274,13 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         @RequestParam(
             value = "mdpath",
             required = false) final String mdPath,
+        @ApiParam(
+            value = "Optional language ISO 3 letters code to override HTTP Accept-language header.",
+            required = false
+        )
+        @RequestParam(
+            value = "language",
+            required = false) final String iso3lang,
         @RequestParam(
             value = "output",
             required = false)
@@ -300,7 +308,11 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             formatType = FormatType.xml;
         }
 
-        final String language = LanguageUtils.locale2gnCode(locale.getISO3Language());
+        String language = LanguageUtils.locale2gnCode(locale.getISO3Language());
+        if (StringUtils.isNotEmpty(iso3lang)) {
+            language = LanguageUtils.locale2gnCode(iso3lang);
+        }
+
         final ServiceContext context = createServiceContext(
             language,
             formatType,

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -135,7 +135,7 @@
         </a>
       </li>
       <li role="menuitem">
-        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xsl-view?root=div&output=pdf"
+        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xsl-view?root=div&output=pdf&language={{lang}}"
            target="_blank">
           <i class="fa fa-fw fa-file-pdf-o"></i>&nbsp;
           <span data-translate="">exportPDF</span>


### PR DESCRIPTION
Fix issue when multilingual record is browsed in french and click on PDF
link return the document in browser language which may be different.

Related to https://github.com/geonetwork/core-geonetwork/issues/3782