### PR TITLE
Metadata selection pdf improvements

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -135,6 +135,12 @@
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>fop</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>fop-pdf-images</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.jcs</groupId>
       <artifactId>jcs</artifactId>

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -43,6 +43,7 @@ import jeeves.server.sources.ServiceRequest.InputMethod;
 import jeeves.server.sources.ServiceRequest.OutputMethod;
 import jeeves.server.sources.http.HttpServiceRequest;
 import jeeves.server.sources.http.JeevesServlet;
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.jetty.io.EofException;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
@@ -72,10 +73,8 @@ import javax.servlet.http.HttpSession;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import java.util.Map.Entry;
 
 //=============================================================================
@@ -702,7 +701,31 @@ public class ServiceManager {
                             } finally {
                                 timerContext.stop();
                             }
-                            response = BinaryFile.encode(200, file, "document.pdf", true).getElement();
+
+                            // Checks for a parameter documentFileName with the document file name,
+                            // otherwise uses a default value
+                            String documentName = guiElem.getChildText("documentFileName");
+                            if (StringUtils.isEmpty(documentName)) {
+                                documentName = "document.pdf";
+                            } else {
+                                if (!documentName.endsWith(".pdf")) {
+                                    documentName = documentName + ".pdf";
+                                }
+
+                                Calendar c = Calendar.getInstance();
+
+                                documentName = documentName.replace("{year}", c.get(Calendar.YEAR) + "");
+                                documentName = documentName.replace("{month}", c.get(Calendar.MONTH) + "");
+                                documentName = documentName.replace("{day}", c.get(Calendar.DAY_OF_MONTH) + "");
+
+                                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
+                                SimpleDateFormat datetimeFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+
+                                documentName = documentName.replace("{date}", dateFormat.format(c.getTime()));
+                                documentName = documentName.replace("{datetime}", datetimeFormat.format(c.getTime()));
+                            }
+
+                            response = BinaryFile.encode(200, file, documentName, true).getElement();
                         } catch (Exception e) {
                             error(" -> exception during XSL/FO transformation for : " + req.getService());
                             error(" -> (C) stylesheet : " + styleSheet);

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,12 @@
         <version>2.3</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>fop-pdf-images</artifactId>
+        <version>2.3</version>
+      </dependency>
+
       <!-- Jetty stuff -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -1097,6 +1103,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
         <version>1.2</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.pdfbox</groupId>
+        <artifactId>pdfbox</artifactId>
+        <version>2.0.7</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/services/src/main/java/org/fao/geonet/guiservices/util/GetSettingValue.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/util/GetSettingValue.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.guiservices.util;
 
 import jeeves.interfaces.Service;
@@ -9,6 +32,26 @@ import org.jdom.Element;
 
 import java.nio.file.Path;
 
+/**
+ * Service to retrieve a setting value to be used in internally by Jeeves services.
+ *
+ * Requires to use a parameter "settingValue" with the setting path to retrieve.
+ *
+ * Example:
+ *
+ * <service name="pdf.search">
+ *    ...
+ *    <output sheet="../xslt/services/pdf/portal-present-fop.xsl" file="true"
+ *               contentType="application/pdf">
+ *         ...
+ *         <call name="documentFileName" class=".guiservices.util.GetSettingValue">
+ *           <param name="setting" value="metadata/pdfReport/pdfName"/>
+ *         </call>
+ *    </output>
+ *     ...
+ * </service>
+ *
+ */
 public class GetSettingValue implements Service {
 
     private String setting;
@@ -35,5 +78,4 @@ public class GetSettingValue implements Service {
 
         return new Element("a").setText(settingValue);
     }
-
 }

--- a/services/src/main/java/org/fao/geonet/guiservices/util/GetSettingValue.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/util/GetSettingValue.java
@@ -1,0 +1,39 @@
+package org.fao.geonet.guiservices.util;
+
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.jdom.Element;
+
+import java.nio.file.Path;
+
+public class GetSettingValue implements Service {
+
+    private String setting;
+
+    public void init(Path appPath, ServiceConfig params) throws Exception {
+        setting = params.getValue("setting");
+    }
+
+    //--------------------------------------------------------------------------
+    //---
+    //--- Service
+    //---
+    //--------------------------------------------------------------------------
+
+    public Element exec(Element params, ServiceContext context) throws Exception {
+        String settingValue = "";
+
+        if (StringUtils.isNotEmpty(setting)) {
+            SettingManager settingManager = context.getBean(SettingManager.class);
+
+            settingValue = settingManager.getValue(setting);
+
+        }
+
+        return new Element("a").setText(settingValue);
+    }
+
+}

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1366,5 +1366,22 @@
     "ui-fluidLayout": "Fluid container for Home and Search",
     "ui-fluidLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container",
     "ui-fluidEditorLayout": "Fluid container for the Editor",
-    "ui-fluidEditorLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container"
+    "ui-fluidEditorLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container",
+    "metadata/pdfReport": "Metadata selection - pdf report",
+    "metadata/pdfReport/coverPdf": "Cover pdf",
+    "metadata/pdfReport/coverPdf-help": "URL of the cover pdf for the PDF report. If not defined, no cover page is added to the report.",
+    "metadata/pdfReport/introPdf": "Introduction pages pdf",
+    "metadata/pdfReport/introPdf-help": "URL of the pdf with the introduction pages for the PDF report. If not defined, no introduction pages are added to the report.",
+    "metadata/pdfReport/headerLeft": "Header text (left)",
+    "metadata/pdfReport/headerLeft-help": "The following template values are allowed: {date}, {siteInfo}.",
+    "metadata/pdfReport/headerRight": "Header text (right)",
+    "metadata/pdfReport/headerRight-help": "The following template values are allowed: {date}, {siteInfo}.",
+    "metadata/pdfReport/footerLeft": "Footer text (left)",
+    "metadata/pdfReport/footerLeft-help": "The following template values are allowed: {date}, {siteInfo}.",
+    "metadata/pdfReport/footerRight": "Footer text (right)",
+    "metadata/pdfReport/headerRight-help": "The following template values are allowed: {date}, {siteInfo}.",
+    "metadata/pdfReport/tocPage": "Add table of contents (TOC) page",
+    "metadata/pdfReport/pdfName": "Report file name",
+    "metadata/pdfReport/pdfName-help": "Report file name. The following template fields are allowed to be used: {year}, {month}, {day}, {date} and {datetime}. Template fields are replaced with the related date values. {date} uses 'yyyyMMdd' format and {datetime} uses 'yyyyMMddHHmmss' format."
+
 }

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -676,6 +676,16 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metada
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/workflow/forceValidationOnMdSave', 'false', 2, 100005, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/backuparchive/enable', 'false', 2, 12000, 'n');
 
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/coverPdf', '', 0, 12500, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/introPdf', '', 0, 12501, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/tocPage', 'false', 2, 12502, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/headerLeft', '{siteInfo}', 0, 12504, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/headerRight', '', 0, 12505, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/footerLeft', '', 0, 12506, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/footerRight', '{date}', 0, 12507, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/pdfName', 'metadata_{datetime}.pdf', 0, 12507, 'n');
+
+
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/ui/defaultView', 'default', 0, 10100, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userSelfRegistration/recaptcha/enable', 'false', 2, 1910, 'n');
@@ -689,6 +699,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipassword', '', 0, 194, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doikey', '', 0, 195, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doilandingpagetemplate', 'http://localhost:8080/geonetwork/srv/resources/records/{{uuid}}', 0, 195, 'n');
+
 
 INSERT INTO HarvesterSettings (id, parentid, name, value) VALUES  (1,NULL,'harvesting',NULL);
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v370/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v370/migrate-default.sql
@@ -2,5 +2,14 @@
 INSERT INTO Settings_ui (id, configuration) (SELECT 'srv', value FROM Settings WHERE name = 'ui/config');
 DELETE FROM Settings WHERE name = 'ui/config';
 
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/coverPdf', '', 0, 12500, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/introPdf', '', 0, 12501, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/tocPage', 'false', 2, 12502, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/headerLeft', '{siteInfo}', 0, 12504, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/headerRight', '', 0, 12505, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/footerLeft', '', 0, 12506, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/footerRight', '{date}', 0, 12507, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/pdfName', 'metadata_{datetime}.pdf', 0, 12507, 'n');
+
 UPDATE Settings SET value='3.7.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';

--- a/web/src/main/webapp/WEB-INF/config/config-service-pdf.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-service-pdf.xml
@@ -41,6 +41,9 @@
           <param name="range" value="1000" /> <!-\- too many causes problems -\->
         </call>-->
         <call name="siteURL" class=".guiservices.util.GetSiteURL"/>
+        <call name="documentFileName" class=".guiservices.util.GetSettingValue">
+          <param name="setting" value="metadata/pdfReport/pdfName"/>
+        </call>
       </output>
 
       <error id="search-error" sheet="../xslt/common/error/error-xml.xsl" statusCode="500"/>
@@ -68,6 +71,9 @@
       <output sheet="../xslt/services/pdf/portal-present-fop.xsl" file="true"
               contentType="application/pdf">
         <call name="siteURL" class=".guiservices.util.GetSiteURL"/>
+        <call name="documentFileName" class=".guiservices.util.GetSettingValue">
+          <param name="setting" value="metadata/pdfReport/pdfName"/>
+        </call>
       </output>
       <error id="search-error" sheet="../xslt/common/error/error-xml.xsl" statusCode="500"/>
     </service>

--- a/web/src/main/webapp/loc/ara/xml/strings.xml
+++ b/web/src/main/webapp/loc/ara/xml/strings.xml
@@ -1646,4 +1646,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/cat/xml/strings.xml
+++ b/web/src/main/webapp/loc/cat/xml/strings.xml
@@ -1712,4 +1712,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Continguts</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/chi/xml/strings.xml
+++ b/web/src/main/webapp/loc/chi/xml/strings.xml
@@ -1626,4 +1626,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/dut/xml/strings.xml
+++ b/web/src/main/webapp/loc/dut/xml/strings.xml
@@ -1694,4 +1694,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/eng/xml/strings.xml
+++ b/web/src/main/webapp/loc/eng/xml/strings.xml
@@ -1669,4 +1669,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/fin/xml/strings.xml
+++ b/web/src/main/webapp/loc/fin/xml/strings.xml
@@ -1702,4 +1702,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/fre/xml/strings.xml
+++ b/web/src/main/webapp/loc/fre/xml/strings.xml
@@ -1710,4 +1710,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Carte</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/ger/xml/strings.xml
+++ b/web/src/main/webapp/loc/ger/xml/strings.xml
@@ -1811,4 +1811,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/ita/xml/strings.xml
+++ b/web/src/main/webapp/loc/ita/xml/strings.xml
@@ -1678,4 +1678,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/nor/xml/strings.xml
+++ b/web/src/main/webapp/loc/nor/xml/strings.xml
@@ -1656,4 +1656,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/pol/xml/strings.xml
+++ b/web/src/main/webapp/loc/pol/xml/strings.xml
@@ -1732,4 +1732,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/por/xml/strings.xml
+++ b/web/src/main/webapp/loc/por/xml/strings.xml
@@ -1686,4 +1686,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/rus/xml/strings.xml
+++ b/web/src/main/webapp/loc/rus/xml/strings.xml
@@ -1693,4 +1693,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/spa/xml/strings.xml
+++ b/web/src/main/webapp/loc/spa/xml/strings.xml
@@ -1698,4 +1698,6 @@
   <tag_label>TAGS</tag_label>
   <map_label>Mapa</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contenidos</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/loc/tur/xml/strings.xml
+++ b/web/src/main/webapp/loc/tur/xml/strings.xml
@@ -1605,4 +1605,6 @@
   <tag_label>Tags</tag_label>
   <map_label>Map</map_label>
   <unknown>Unknown</unknown>
+
+  <pdfReportTocTitle>Contents</pdfReportTocTitle>
 </strings>

--- a/web/src/main/webapp/xslt/services/pdf/metadata-fop.xsl
+++ b/web/src/main/webapp/xslt/services/pdf/metadata-fop.xsl
@@ -48,6 +48,17 @@
   <xsl:variable name="header-weight">bold</xsl:variable>
   <xsl:variable name="note-size">6pt</xsl:variable>
 
+  <xsl:variable name="heading1-text-size">16pt</xsl:variable>
+  <xsl:variable name="heading1-text-weight">bold</xsl:variable>
+
+  <xsl:variable name="heading2-text-size">12pt</xsl:variable>
+  <xsl:variable name="heading2-text-weight">bold</xsl:variable>
+
+  <xsl:variable name="toc-text-size">10pt</xsl:variable>
+
+  <xsl:variable name="header-text-size">9pt</xsl:variable>
+  <xsl:variable name="footer-text-size">11pt</xsl:variable>
+
   <!-- Date format for footer information -->
   <xsl:variable name="df">[Y0001]-[M01]-[D01]</xsl:variable>
 
@@ -58,10 +69,19 @@
   <xsl:template name="fop-master">
     <fo:layout-master-set>
       <fo:simple-page-master master-name="simpleA4" page-height="29.7cm" page-width="21cm"
-                             margin-top=".2cm" margin-bottom=".2cm" margin-left=".6cm"
-                             margin-right=".2cm">
-        <fo:region-body margin-top="0cm"/>
-        <fo:region-after extent=".2cm"/>
+                             margin-top="1.25cm" margin-bottom="1cm" margin-left="2cm"
+                             margin-right="2cm">
+        <fo:region-body margin-top="1.5cm" margin-bottom="3cm" />
+        <fo:region-before extent="0.8cm" />
+        <fo:region-after extent="0.8cm" />
+      </fo:simple-page-master>
+
+      <fo:simple-page-master master-name="Intro" page-height="29.7cm" page-width="21cm"
+                             margin-top="1.25cm" margin-bottom="1cm" margin-left="2cm"
+                             margin-right="2cm">
+        <fo:region-body margin-top="1.5cm" margin-bottom="3cm" />
+        <fo:region-before extent="0.8cm" />
+        <fo:region-after extent="0.8cm"/>
       </fo:simple-page-master>
 
       <fo:page-sequence-master master-name="PSM_Name">
@@ -70,24 +90,131 @@
     </fo:layout-master-set>
   </xsl:template>
 
+
+  <!-- ======================================================
+        Page header
+  -->
+  <xsl:template name="fop-header">
+    <fo:static-content flow-name="xsl-region-before">
+      <fo:block font-size="{$header-text-size}" color="{$font-color}">
+
+        <fo:table width="100%" table-layout="fixed">
+          <fo:table-body>
+            <fo:table-row height="8mm">
+              <fo:table-cell>
+                <fo:block padding-top="4pt" padding-right="4pt"
+                          padding-left="4pt"
+                          text-align="left">
+                  <xsl:call-template name="replacePlaceholders">
+                    <xsl:with-param name="value" select="$env/metadata/pdfReport/headerLeft" />
+                  </xsl:call-template>
+                </fo:block>
+              </fo:table-cell>
+
+              <fo:table-cell>
+                <fo:block padding-top="4pt" padding-right="4pt"
+                          padding-left="4pt"
+                          text-align="right"
+                >
+                  <xsl:call-template name="replacePlaceholders">
+                    <xsl:with-param name="value" select="$env/metadata/pdfReport/headerRight" />
+                  </xsl:call-template>
+                </fo:block>
+              </fo:table-cell>
+            </fo:table-row>
+
+          </fo:table-body>
+        </fo:table>
+      </fo:block>
+    </fo:static-content>
+  </xsl:template>
+
+
   <!-- ======================================================
         Page footer with node info, date and paging info
   -->
   <xsl:template name="fop-footer">
+
     <!-- Footer with catalogue name, org name and pagination -->
     <fo:static-content flow-name="xsl-region-after">
-      <fo:block text-align="end" font-family="{$font-family}" font-size="{$note-size}"
-                color="{$font-color}">
-        <xsl:value-of select="$env/system/site/name"/> -
-        <xsl:value-of
-          select="$env/system/site/organization"/>
-        | <!-- TODO : set date format according to locale -->
-        <xsl:value-of select="format-dateTime(current-dateTime(),$df)"/> |
-        <fo:page-number/>
-        /
-        <fo:page-number-citation ref-id="terminator"/>
+
+      <fo:block font-size="{$header-text-size}" color="{$font-color}">
+
+        <fo:table width="100%" table-layout="fixed">
+          <fo:table-body>
+            <fo:table-row height="8mm">
+              <fo:table-cell>
+                <fo:block padding-top="4pt" padding-right="4pt"
+                          padding-left="4pt"
+                          text-align="left">
+                  <xsl:call-template name="replacePlaceholders">
+                    <xsl:with-param name="value" select="$env/metadata/pdfReport/footerLeft" />
+                  </xsl:call-template>
+                </fo:block>
+              </fo:table-cell>
+
+              <fo:table-cell>
+                <!-- FIXME : align all text on top and capitalize ? -->
+                <fo:block padding-top="4pt" padding-right="4pt"
+                          padding-left="4pt"
+                          text-align="right"
+                >
+                  <xsl:call-template name="replacePlaceholders">
+                    <xsl:with-param name="value" select="$env/metadata/pdfReport/footerRight" />
+                  </xsl:call-template>
+                  <xsl:if test="string($env/metadata/pdfReport/footerRight)"> | </xsl:if>
+                  <fo:page-number/> / <fo:page-number-citation ref-id="terminator"/>
+                </fo:block>
+              </fo:table-cell>
+            </fo:table-row>
+
+          </fo:table-body>
+        </fo:table>
       </fo:block>
     </fo:static-content>
+  </xsl:template>
+
+
+  <xsl:template name="replacePlaceholders">
+    <xsl:param name="value" />
+
+    <xsl:value-of select="replace(replace($value, '\{date\}', format-dateTime(current-dateTime(),$df)),
+                                  '\{siteInfo\}', concat($env/system/site/name, '-', $env/system/site/organization))" />
+  </xsl:template>
+
+
+  <!-- ======================================================
+      TOC page
+  -->
+  <xsl:template name="toc-page">
+    <xsl:param name="res"/>
+
+    <fo:block break-after="page">
+
+      <fo:block font-size="{$heading1-text-size}" font-weight="{$heading1-text-weight}" text-align="center" margin-bottom="10pt">
+        <xsl:value-of select="/root/gui/strings/pdfReportTocTitle" />
+      </fo:block>
+
+
+      <xsl:for-each select="$res/*[name() != 'summary' and name() != 'from' and name() != 'to']" >
+        <xsl:variable name="md">
+          <!--<xsl:apply-templates mode="briefPdf" select="."/>-->
+          <!-- Using search service with fast=index to retrieve the information directly from the index -->
+          <xsl:copy-of select="."/>
+        </xsl:variable>
+
+        <xsl:variable name="metadata" select="exslt:node-set($md)/*[1]"/>
+
+        <fo:block text-align-last="justify" font-size="{$toc-text-size}" color="{$title-color}">
+          <fo:basic-link internal-destination="section-{$metadata/geonet:info/id}">
+            <xsl:value-of select="$metadata/title" />
+            <fo:leader leader-pattern="space" />
+            <fo:page-number-citation ref-id="section-{$metadata/geonet:info/id}" />
+          </fo:basic-link>
+        </fo:block>
+      </xsl:for-each>
+
+    </fo:block>
   </xsl:template>
 
 
@@ -231,7 +358,8 @@
           </fo:table-cell>
           <fo:table-cell display-align="center">
             <fo:block font-weight="{$title-weight}" font-size="{$title-size}" color="{$title-color}"
-                      padding-top="4pt" padding-bottom="4pt" padding-left="4pt" padding-right="4pt">
+                      padding-top="4pt" padding-bottom="4pt" padding-left="4pt" padding-right="4pt"
+                      id="section-{$metadata/geonet:info/id}">
               <xsl:value-of select="$metadata/title"/>
             </fo:block>
           </fo:table-cell>
@@ -245,7 +373,7 @@
           <fo:table-cell number-columns-spanned="2">
             <fo:block margin-left="2pt" margin-right="4pt" margin-top="4pt" margin-bottom="4pt">
               <fo:table>
-                <fo:table-column column-width="14.8cm"/>
+                <fo:table-column column-width="11.8cm"/>
                 <fo:table-column column-width="4.8cm"/>
                 <fo:table-body>
                   <fo:table-row>
@@ -254,8 +382,8 @@
 
                         <!-- Labels and values-->
                         <fo:table>
-                          <fo:table-column column-width="3cm"/>
-                          <fo:table-column column-width="11.4cm"/>
+                          <fo:table-column column-width="2.5cm"/>
+                          <fo:table-column column-width="9.3cm"/>
 
                           <fo:table-body>
                             <xsl:call-template name="info-rows">
@@ -374,7 +502,7 @@
               </xsl:attribute>
               <xsl:value-of select="$oldGuiStrings/show"/>
             </fo:basic-link>
-            |
+            <fo:block/>
             <fo:basic-link text-decoration="underline" color="blue">
               <xsl:attribute name="external-destination">url('<xsl:value-of
                 select="concat($baseURL, '/srv/', $lang, '/xml.metadata.get?uuid=', $metadata/geonet:info/uuid)"
@@ -382,7 +510,7 @@
               </xsl:attribute>
               <xsl:value-of select="$oldGuiStrings/show"/> (XML)
             </fo:basic-link>
-            |
+            <fo:block/>
           </xsl:when>
           <xsl:otherwise>
             <fo:block text-align="left" font-style="italic">
@@ -406,7 +534,7 @@
               </xsl:attribute>
               <xsl:value-of select="$oldGuiStrings/download"/>
             </fo:basic-link>
-            |
+            <fo:block/>
           </xsl:for-each>
         </xsl:if>
 
@@ -425,7 +553,7 @@
               <xsl:value-of select="$oldGuiStrings/visualizationService"/> (<xsl:value-of
               select="$title"/>)
             </fo:basic-link>
-            |
+            <fo:block/>
           </xsl:for-each>
         </xsl:if>
 

--- a/web/src/main/webapp/xslt/services/pdf/portal-present-fop.xsl
+++ b/web/src/main/webapp/xslt/services/pdf/portal-present-fop.xsl
@@ -33,24 +33,48 @@
     Start FOP layout
   -->
   <xsl:template match="/root">
-    <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format">
+    <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format"
+             xmlns:fox="http://xmlgraphics.apache.org/fop/extensions">
       <xsl:call-template name="fop-master"/>
+
+      <!-- Cover page -->
+      <xsl:if test="string($env/metadata/pdfReport/coverPdf)">
+        <fox:external-document content-type="pdf" src="{$env/metadata/pdfReport/coverPdf}" />
+      </xsl:if>
+
+      <!-- TOC page -->
+      <xsl:if test="$env/metadata/pdfReport/tocPage = 'true'">
+        <fo:page-sequence master-reference="Intro" force-page-count="no-force">
+          <xsl:call-template name="fop-header"/>
+
+          <fo:flow flow-name="xsl-region-body">
+            <!-- TOC page -->
+            <xsl:if test="$env/metadata/pdfReport/tocPage = 'true'">
+              <xsl:call-template name="toc-page">
+                <xsl:with-param name="res" select="/root/response"/>
+              </xsl:call-template>
+            </xsl:if>
+          </fo:flow>
+        </fo:page-sequence>
+      </xsl:if>
+
+      <!-- Intro page -->
+      <xsl:if test="string($env/metadata/pdfReport/introPdf)">
+        <fox:external-document content-type="pdf" src="{$env/metadata/pdfReport/introPdf}" />
+      </xsl:if>
 
       <fo:page-sequence master-reference="simpleA4" initial-page-number="1">
 
+        <xsl:call-template name="fop-header"/>
         <xsl:call-template name="fop-footer"/>
 
         <fo:flow flow-name="xsl-region-body">
-
-          <!-- Banner level -->
-          <xsl:call-template name="banner"/>
-
 
           <fo:block font-size="{$font-size}">
 
             <fo:table width="100%" table-layout="fixed">
               <fo:table-column column-width="1.8cm"/>
-              <fo:table-column column-width="18.2cm"/>
+              <fo:table-column column-width="15.2cm"/>
               <fo:table-body>
                 <fo:table-row height="8mm">
                   <fo:table-cell display-align="center" number-columns-spanned="2">


### PR DESCRIPTION
This pull request adds the following enhancements for the metadata selection pdf to create a report having a more professional look and feel:

- TOC page
- Configurable texts for header/footer
- Support to include external cover and intro pages
- Customise the pdf name
- Improve margins for printing

The different options can be customised in the Administration settings:

![metadata-pdf-selection-settings](https://user-images.githubusercontent.com/1695003/57306606-6c65aa80-70e3-11e9-82a9-a78330cf7e2d.png)

Attached a sample PDF including cover, toc and intro pages:

[metadata_20190507160221.pdf](https://github.com/geonetwork/core-geonetwork/files/3153051/metadata_20190507160221.pdf)

Old report, to compare differences:

[old-report.pdf](https://github.com/geonetwork/core-geonetwork/files/3153070/old-report.pdf)
