### PR TITLE
FIX for menubar colours for when custom colours are set in the admin.

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/default.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/default.xsl
@@ -230,9 +230,9 @@
         <xsl:variable name="keywordWithNoThesaurus"
                       select="/simpledc/dc:subject[text() != '']"/>
         <xsl:if test="count($keywordWithNoThesaurus) > 0">
-          'keywords': [
+          'otherKeywords': [
           <xsl:for-each select="$keywordWithNoThesaurus">
-            <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>
+            {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>, 'link': ''}
             <xsl:if test="position() != last()">,</xsl:if>
           </xsl:for-each>
           ]

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
@@ -1,7 +1,7 @@
 <div>
   <form class="form-horizontal" role="form"
         data-ng-search-form="">
-              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+    <input type="hidden" name="_csrf" value="{{csrf}}"/>
     <div class="onlinesrc-container">
       <div class="form-group">
         <div class="col-sm-10">
@@ -41,10 +41,19 @@
            data-layers="layers"
            data-selection="srcParams.selectedLayers">
       </div>
+
+      <div>
+        <label>
+          <input type="checkbox"
+                 data-ng-model="addOnlineSrcInDataset"/>
+          <span data-translate="">addTheFollowingLinkInDataset</span>
+        </label>
+        <span>{{onlineSrcLink}}</span>
+      </div>
     </div>
     <div class="">
       <button type="button" class="btn navbar-btn btn-success"
-              data-gn-click-and-spin="linkTo()"
+              data-gn-click-and-spin="linkTo(addOnlineSrcInDataset)"
               data-ng-class="{'disabled': (stateObj.selectRecords.length < 1)}">
         <i class="fa gn-icon-service"/>&nbsp;
         <span data-translate="" data-ng-show="mode == 'service'">linkToService</span>

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -314,7 +314,9 @@
              }
              else {
                var params = {id: gnCurrentEdit.id};
-
+               if (gnCurrentEdit.tab) {
+                 params.currTab = gnCurrentEdit.tab;
+               }
                // If a new session, ask the server to save the original
                // record and update session start time
                if (startNewSession) {
@@ -322,7 +324,7 @@
                  gnCurrentEdit.sessionStartTime = moment();
                }
                $http.get('../api/records/' + gnCurrentEdit.id + '/editor',
-               params).then(function(data) {
+                 {params: params}).then(function(data) {
                  refreshForm($(data.data));
                });
              }

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1366,5 +1366,7 @@
     "ui-fluidLayout": "Fluid container for Home and Search",
     "ui-fluidLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container",
     "ui-fluidEditorLayout": "Fluid container for the Editor",
-    "ui-fluidEditorLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container"
+    "ui-fluidEditorLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container",
+    "styleVariable-gnMenubarBackgroundHover": "Background color on hover",
+    "styleVariable-gnMenubarColorActive": "Color when active"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -367,6 +367,7 @@
     "inputGeometryReadOnlyHint": "This geometry is read-only.",
     "selectKeyword": "Add keywords",
     "saveLinkToSibling": "Save link to other resource",
+    "addTheFollowingLinkInDataset": "Add the following link to the dataset (as an online source in the distribution section):",
     "confirmCloseInvalidTitle": "Confirm editor close",
     "confirmCloseInvalidMetadata": "The current metadata has been found to be invalid. Closing the editor will cause it to be unpublished (this can be changed in the application settings).<br><br>Are you sure you want to proceed?",
     "hotkeyDirectory": "Manage directories (eg. contact)",

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
@@ -84,8 +84,20 @@
                     color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
                 </div>
                 <div class="col-md-3">
+                    <label for="gnCssStyle.gn-menubarColorActive"
+                      data-translate="">styleVariable-gnMenubarColorActive</label>
+                    <color-picker
+                      data-ng-model="gnCssStyle.gnMenubarColorActive"
+                      color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                  </div>
+                <div class="col-md-3">
                   <label for="gnCssStyle.gnMenubarColor" data-translate="">styleVariable-gnMenubarColor</label>
                   <color-picker data-ng-model="gnCssStyle.gnMenubarColor"
+                    color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
+                </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnMenubarBackgroundHover" data-translate="">styleVariable-gnMenubarBackgroundHover</label>
+                  <color-picker data-ng-model="gnCssStyle.gnMenubarBackgroundHover"
                     color-picker-format="'hex'" color-picker-alpha="false"></color-picker>
                 </div>
                 <div class="col-md-3">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -47,6 +47,16 @@ ul.gn-resultview li.list-group-item {
     .navbar-collapse {
       background: #fff;
     }
+    .navbar-nav > li > a, .navbar-nav > .open > a, .navbar-nav > .active > a {
+      color: @navbar-default-link-color;
+      &:hover, &:focus {
+        color: @navbar-default-link-hover-color;
+        background-color: @navbar-default-link-hover-bg;
+      }
+    }
+    .navbar-nav > .active > a {
+      background-color: @navbar-default-link-active-bg;
+    }
     .dropdown-menu {
       > li {
         > a {
@@ -54,8 +64,17 @@ ul.gn-resultview li.list-group-item {
         }
         &.active, &:hover {
           > a {
-            color: @gn-menubar-color;
+            color: @navbar-default-link-color;
             background-color: lighten(@brand-primary, 46.7%);
+          }
+        }
+      }
+    }
+    @media (min-width: @screen-sm-min) {
+      li.dropdown-hover {
+        &.open:not(.active) > .dropdown-toggle {
+          &:hover, &:focus {
+            background: none;
           }
         }
       }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -9,13 +9,21 @@
 .navbar-default {
   background-color: @gn-menubar-background;
   border-color: @gn-menubar-border-color;
+  border-width: 0 0 1px 0;
   z-index: 100;
   .navbar-nav > li > a, .navbar-nav > .open > a, .navbar-nav > .active > a {
     height: @gn-menubar-height;
     color: @gn-menubar-color;
     &:hover, &:focus {
       color: @gn-menubar-color-hover;
+      background-color: @gn-menubar-background-hover;
     }
+  }
+  .navbar-nav li.dropdown-hover.open:not(.active) > .dropdown-toggle {
+    &:hover, &:focus {
+      background-color: @gn-menubar-background-hover;
+    }
+    
   }
   .dropdown-menu {
     > li {
@@ -27,6 +35,10 @@
       color: @gray;
       cursor: text !important;
     }
+  }
+  .navbar-nav > .active > a {
+    background-color: @gn-menubar-background-active;
+    color: @gn-menubar-color-active;
   }
   .gn-name.gn-truncate {
     @media (min-width: @screen-lg-min) {
@@ -43,6 +55,14 @@
     border-color: #f98258;
     &:focus {
       box-shadow: none; // inset 0 1px 1px rgba(0,0,0,.075), 0 0 4px rgb(250, 140, 99);
+    }
+  }
+  .gn-user-info {
+    .gn-user-role {
+      color: @gn-menubar-color;
+      &:hover {
+        color: @gn-menubar-color-hover;
+      }
     }
   }
   // more small screen oriented menu options
@@ -173,6 +193,15 @@
     .language-switcher {
       padding-left: 0;
       padding-right: 0;
+    }
+    @media (min-width: @screen-sm-min) {
+      li.dropdown-hover {
+        &.open:not(.active) > .dropdown-toggle {
+          &:hover, &:focus {
+            background-color: @gn-menubar-background-hover;
+          }
+        }
+      }
     }
   }
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -31,8 +31,10 @@
 @gn-menubar-height: 50px;
 @gn-menubar-background: @navbar-default-bg;
 @gn-menubar-background-active: @navbar-default-link-active-bg;
+@gn-menubar-color-active: @navbar-default-link-color;
 @gn-menubar-color: @navbar-default-link-color;
 @gn-menubar-color-hover: @navbar-default-link-hover-color;
+@gn-menubar-background-hover: @navbar-default-link-hover-bg;
 @gn-menubar-border-color: @navbar-default-border;
 
 // bottombar


### PR DESCRIPTION
Replaces PR: https://github.com/geonetwork/core-geonetwork/pull/3652

Fixes for menubar colours for when custom colours are set in the admin.

It is possible to adjust the colours of the navigation/menu in the admin. However, not all colours where correctly used which resulted in a default colour for an active menu  (colours in the screenshot are only for testing purposes :-) ).

![gn-menu-fix](https://user-images.githubusercontent.com/19608667/53959533-2b9de500-40e4-11e9-8c8b-efefdfce0abd.png)

Furthermore, some colours where also used in the admin menu which could result in menu items with the same background colour and text colour.

![gn-menu-fix-admin](https://user-images.githubusercontent.com/19608667/53959619-6dc72680-40e4-11e9-9c3f-48dc09ad086e.png)

This PR fixes the active menu colour, and adds default colours to the admin menu.

![gn-menu-admin-fixed](https://user-images.githubusercontent.com/19608667/53959746-cd253680-40e4-11e9-9099-4c20a2f39d52.png)

An extra setting is added for the background colour on hover and the active color