### PR TITLE
Improvements in transfer ownership dialog usability

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -479,7 +479,7 @@
 
           scope.save = function() {
             if (!scope.selectedUserGroup) {
-              return
+              return;
             }
             var url = '../api/records/';
             if (bucket != 'null') {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -433,6 +433,9 @@
           var bucket = attrs['selectionBucket'];
           var mdUuid = attrs['gnTransferOwnership'];
           scope.selectedUserGroup = null;
+          scope.groupsLoaded = false;
+          scope.userGroupDefined = false;
+          scope.userGroups = null;
 
           scope.selectUser = function(user) {
             scope.selectedUser = user;
@@ -470,9 +473,14 @@
                 } else {
                   scope.userGroupDefined = false;
                 }
-              });
+              }).finally(function() {
+                scope.groupsLoaded = true;
+          });
 
           scope.save = function() {
+            if (!scope.selectedUserGroup) {
+              return
+            }
             var url = '../api/records/';
             if (bucket != 'null') {
               url += 'ownership?bucket=' + bucket + '&';

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
@@ -11,15 +11,22 @@
   <div class="btn-toolbar col-md-12" data-ng-show="userGroupDefined">
     <button type="button"
             class="btn btn-primary pull-right"
-            data-ng-class="selectedUserGroup ? '' : 'disabled'"
-            data-gn-click-and-spin="save()">
-      <i class="fa fa-save"></i>&nbsp;
+            data-gn-click-and-spin="save()"
+            data-ng-disabled="!selectedUserGroup">
+      <i class="fa fa-save"></i>&nbsp
       <span data-translate=""
             class="ng-scope">Save</span>
     </button>
   </div>
 
-  <div class="col-md-12" data-ng-hide="userGroupDefined">
+
+  <div class="col-md-12" data-ng-show="!groupsLoaded">
+    <p class="text-center">
+      <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
+      <span class="sr-only">Loading...</span>
+    </p>
+  </div>
+  <div class="col-md-12" data-ng-show="groupsLoaded && !userGroupDefined">
     <span data-translate="">noUsers</span>
   </div>
 </div>


### PR DESCRIPTION
Shows a loading spinner while the load groups request is not yet finished.
Actually disables the Save button instead of just add the class `disabled` to it
if not user is selected.

![image](https://user-images.githubusercontent.com/826920/57710513-620c5900-766d-11e9-8de2-6649cdf2931c.png)

![image](https://user-images.githubusercontent.com/826920/57710546-73edfc00-766d-11e9-931e-ec22c6ed54be.png)
