### PR TITLE
Editor / Link to dataset / Init uuid correctly, Add support for WFS and ATOM services

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1103,14 +1103,12 @@
                       // editor to get URL or current record.
                       var links = [];
                       links = links.concat(
-                          gnCurrentEdit.metadata.getLinksByType('OGC:WMS'));
-                      links = links.concat(
-                          gnCurrentEdit.metadata.getLinksByType('wms'));
+                          gnCurrentEdit.metadata.getLinksByType('ogc', 'atom'));
                       if (links.length > 0) {
                         scope.onlineSrcLink = links[0].url;
+                        scope.srcParams.protocol = links[0].protocol || '';
                         scope.loadCurrentLink(scope.onlineSrcLink);
                         scope.srcParams.url = scope.onlineSrcLink;
-                        scope.srcParams.protocol = links[0].protocol || '';
                         scope.srcParams.uuidSrv = gnCurrentEdit.uuid;
 
                         scope.addOnlineSrcInDataset = true;
@@ -1145,16 +1143,21 @@
                   scope.loadCurrentLink = function(url) {
                     scope.alertMsg = null;
 
-                    return gnOwsCapabilities.getWMSCapabilities(url)
-                        .then(function(capabilities) {
-                          scope.layers = [];
-                          scope.srcParams.selectedLayers = [];
-                          scope.layers.push(capabilities.Layer[0]);
-                          angular.forEach(scope.layers[0].Layer, function(l) {
-                            scope.layers.push(l);
-                            // TODO: We may have more than one level
+                    var serviceType = scope.srcParams.protocol.toLowerCase();
+                    if (serviceType.indexOf('ogc') !== -1) {
+                      return gnOwsCapabilities[
+                        serviceType.indexOf('wfs') !== -1 ?
+                          'getWFSCapabilities' : 'getWMSCapabilities'](url)
+                          .then(function(capabilities) {
+                            scope.layers = [];
+                            scope.srcParams.selectedLayers = [];
+                            scope.layers.push(capabilities.Layer[0]);
+                            angular.forEach(scope.layers[0].Layer, function(l) {
+                              scope.layers.push(l);
+                              // TODO: We may have more than one level
+                            });
                           });
-                        });
+                    }
                   };
 
                   /**
@@ -1190,8 +1193,8 @@
 
                         if (links.length > 0) {
                           scope.onlineSrcLink = links[0].url;
-                          scope.loadCurrentLink(scope.onlineSrcLink);
                           scope.srcParams.protocol = links[0].protocol || 'OGC:WMS';
+                          scope.loadCurrentLink(scope.onlineSrcLink);
                           scope.srcParams.url = scope.onlineSrcLink;
                           scope.addOnlineSrcInDataset = true;
                         } else {
@@ -1222,7 +1225,6 @@
                    * Hide modal on success.
                    */
                   scope.linkTo = function(addOnlineSrcInDataset) {
-                    scope.onlineSrcLink = '';
                     if (scope.mode === 'service') {
                       return gnOnlinesrc.
                           linkToService(scope.srcParams, scope.popupid, addOnlineSrcInDataset);
@@ -1236,6 +1238,7 @@
             }
           };
         }])
+
 
       /**
      * @ngdoc directive

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1151,11 +1151,24 @@
                           .then(function(capabilities) {
                             scope.layers = [];
                             scope.srcParams.selectedLayers = [];
-                            scope.layers.push(capabilities.Layer[0]);
-                            angular.forEach(scope.layers[0].Layer, function(l) {
-                              scope.layers.push(l);
-                              // TODO: We may have more than one level
-                            });
+                            if (capabilities.Layer) {
+                              scope.layers.push(capabilities.Layer[0]);
+                              angular.forEach(scope.layers[0].Layer, function(l) {
+                                scope.layers.push(l);
+                                // TODO: We may have more than one level
+                              });
+                            } else if (capabilities.featureTypeList) {
+                              angular.forEach(capabilities.featureTypeList.featureType, function(l) {
+                                var name = l.name.prefix + ":" + l.name.localPart;
+                                var layer = {
+                                  'Name': name,
+                                  'Title': l.title || name,
+                                  'abstract': l.abstract || ''
+                                };
+
+                                scope.layers.push(layer);
+                              });
+                            }
                           });
                     }
                   };
@@ -1178,10 +1191,7 @@
                         scope.layers = [];
                         scope.srcParams.selectedLayers = [];
 
-                        // Search a WMS link in the service metadata record
-                        // TODO: WFS ?
-                        links = links.concat(md.getLinksByType('OGC:WMS'));
-                        links = links.concat(md.getLinksByType('wms'));
+                        links = links.concat(md.getLinksByType('ogc', 'atom'));
                         scope.srcParams.uuidSrv = md.getUuid();
                         scope.srcParams.identifier =
                           (gnCurrentEdit.metadata.identifier && gnCurrentEdit.metadata.identifier[0]) ?

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1203,7 +1203,7 @@
                           scope.srcParams.url = scope.onlineSrcLink;
                           scope.addOnlineSrcInDataset = false;
                         }
-                      } else if (scope.addOnlineSrcInDataset) {
+                      } else {
                         scope.srcParams.uuidDS = md.getUuid();
                         scope.srcParams.name = gnCurrentEdit.mdTitle;
                         scope.srcParams.desc = gnCurrentEdit.mdTitle;


### PR DESCRIPTION
Fix an issue when linking to a dataset without adding the service link in the target.

When linking to a WFS or ATOM, use the correct service URL to be added to the dataset (instead of the formatter):

![image](https://user-images.githubusercontent.com/1701393/58002438-a9b43a00-7ade-11e9-8fb1-4d650e948a81.png)
