### PR TITLE
Uses function validateUrl in linked-data-checker.xsl process

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/process/linked-data-checker.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/linked-data-checker.xsl
@@ -33,9 +33,9 @@
 
   <!-- i18n information -->
   <xsl:variable name="linked-data-checker-loc">
-    <msg id="a" xml:lang="eng">return an error (</msg>
+    <msg id="a" xml:lang="eng"> return an error (</msg>
     <msg id="b" xml:lang="eng">). Run this task to remove it.</msg>
-    <msg id="a" xml:lang="fre">a retourné une erreur (</msg>
+    <msg id="a" xml:lang="fre"> a retourné une erreur (</msg>
     <msg id="b" xml:lang="fre">). Si l'erreur persiste, corriger le lien manuellement ou exécuter
       cette action pour le supprimer.
     </msg>
@@ -66,10 +66,10 @@
     <xsl:param name="url"/>
     <xsl:param name="type"/>
 
-    <xsl:variable name="status" select="java:getUrlStatus($url)"/>
+    <xsl:variable name="status" select="java:validateURL($url)"/>
     <!--    <xsl:message>Check:<xsl:value-of select="."/>|<xsl:value-of select="$status"/></xsl:message>
     -->
-    <xsl:if test="$status != '200'">
+    <xsl:if test="$status != true()">
       <suggestion process="linked-data-checker" id="{generate-id()}" category="links" target="all">
         <name xml:lang="en">
           <xsl:value-of select="$type"/>


### PR DESCRIPTION
Since the previous `getUrlStatus` can throw an exception and interrupt the suggestions request
this commit changes the `getUrlStatus` call to `validateURL` that only returns `true` or `false`
but doesn't throw any excaption if for example the URL is malformed.