### PR TITLE
Associated panel / When there is no layer, coupledResource should not be added

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -468,7 +468,11 @@
             var qParams = setParams('dataset-add', params);
 
             return runProcess(scope, {
-              scopedName: qParams.name,
+              // names are equal if no selected layers
+              // See #setLayersParams
+              // In this case, dataset-add.xsl MUST not add coupledResource
+              // So setting it to empty
+              scopedName: params.name === qParams.name ? '' : qParams.name,
               uuidref: qParams.uuidDS,
               uuid: qParams.uuidSrv,
               source: qParams.identifier || '',


### PR DESCRIPTION
Currenlty if no layer selected (when the service does not provide valid URL for listing layers), coupledResource is populated with the service name.