### PR TITLE
New customization option to add online resources in editor

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
+++ b/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
@@ -37,6 +37,8 @@
         "name": {"param": "thumbnail_desc"}
       }
     }],
-    "multilingualFields": ["name", "desc"]
+    "multilingualFields": ["name", "desc"],
+    "listLayerNamesOrTitles": "title",
+    "addInspireDescription": false
   }
 }

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
@@ -140,10 +140,20 @@
             <applicationProfile>
               <xsl:value-of select="gmd:applicationProfile/gco:CharacterString"/>
             </applicationProfile>
-            <description>
-              <xsl:apply-templates mode="get-iso19139-localized-string"
-                                   select="gmd:description"/>
-            </description>
+	        <description>
+		      <xsl:choose>
+			    <xsl:when test="gmd:description/gco:CharacterString!=''">
+				  <xsl:apply-templates
+					   mode="get-iso19139-localized-string" select="gmd:description" />
+			    </xsl:when>
+			    <xsl:otherwise>
+				  <value lang="{$mainLanguage}">
+				    <xsl:value-of
+					     select="gmd:description/gmx:Anchor/text()" />
+				  </value>
+			    </xsl:otherwise>
+		      </xsl:choose>
+	        </description>
             <protocol>
               <xsl:value-of select="gn-fn-rel:translate(gmd:protocol, $langCode)"/>
             </protocol>

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSDirective.js
@@ -38,7 +38,9 @@
            scope: {
              selection: '=',
              layers: '=',
-             selectionMode: '=gnSelectionMode'
+             selectionMode: '=gnSelectionMode',
+             listLayerNamesOrTitles: '=gnListLayerNamesOrTitles',
+             addInspireDescription: '=gnAddInspireDescription'
            },
            link: function(scope, element, attrs) {
              // Manage layers selection

--- a/web-ui/src/main/resources/catalog/components/common/ows/partials/layersGrid.html
+++ b/web-ui/src/main/resources/catalog/components/common/ows/partials/layersGrid.html
@@ -11,11 +11,29 @@
       <td class="add col-first">
         <div class="icon-zoom-in"></div>
       </td>
-      <td>
-        {{layer.Title}}
-          <span data-ng-if="layer.Name">
-            ({{layer.Name}})
-          </span>
+      <td data-ng-if="listLayerNamesOrTitles=='title'">
+        <span data-ng-if="layer.Title">
+          {{layer.Title}}
+        </span>
+        <span data-ng-if="layer.Name">
+          ({{layer.Name}})
+        </span>
+      </td>
+      <td data-ng-if="listLayerNamesOrTitles=='name'">
+        <span data-ng-if="layer.Name">
+          {{layer.Name}}
+        </span>
+        <span data-ng-if="layer.Title">
+          ({{layer.Title}})
+        </span>
+      </td>
+      <td data-ng-if="!listLayerNamesOrTitles">
+        <span data-ng-if="layer.Title">
+          {{layer.Title}}
+        </span>
+        <span data-ng-if="layer.Name">
+          ({{layer.Name}})
+        </span>
       </td>
     </tr>
     </tbody>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -592,6 +592,16 @@
                       scope.params.desc= '';
                       initMultilingualFields();
                     }
+                    if(scope.config.listLayerNamesOrTitles !== undefined) {
+                      scope.listLayerNamesOrTitles = scope.config.listLayerNamesOrTitles;
+                    } else {
+                      scope.listLayerNamesOrTitles = 'title';
+                    }
+                    if(scope.config.addInspireDescription !== undefined) {
+                      scope.addInspireDescription = scope.config.addInspireDescription;
+                    } else {
+                      scope.addInspireDescription = false;
+                    }
                   };
                   function loadConfigAndInit(withInit) {
                     gnSchemaManagerService.getEditorAssociationPanelConfig(
@@ -913,19 +923,29 @@
                     angular.forEach(scope.params.selectedLayers,
                         function(layer) {
                           names.push(layer.Name || layer.name);
-                          descs.push(layer.Title || layer.title);
+                          if(!scope.addInspireDescription) {
+                            descs.push(layer.Title || layer.title);
+                          }
                         });
 
                     if (scope.isMdMultilingual) {
                       var langCode = scope.mdLangs[scope.mdLang];
                       scope.params.name[langCode] = names.join(',');
-                      scope.params.desc[langCode] = descs.join(',');
+                      if(!scope.addInspireDescription) {
+                        scope.params.desc[langCode] = descs.join(',');
+                      }
                     }
                     else {
-                      angular.extend(scope.params, {
-                        name: names.join(','),
-                        desc: descs.join(',')
-                      });
+                      if(!scope.addInspireDescription) {
+                        angular.extend(scope.params, {
+                          name: names.join(','),
+                          desc: descs.join(',')
+                        });
+                      } else {
+                        angular.extend(scope.params, {
+                          name: names.join(',')
+                        });
+                      }
                     }
                   }
                 });

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -115,7 +115,7 @@
 
           angular.forEach(params.selectedLayers, function(layer) {
             names.push(layer.Name || layer.name);
-            descs.push(layer.Title || layer.title);
+            descs.push(params.desc);
           });
 
           angular.extend(params, {

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -153,6 +153,8 @@
                    id="gn-addonlinesrc-layers-row"
                    data-ng-show="OGCProtocol != null"
                    data-gn-selection-mode="isEditing ? 'single' : 'multiple'"
+                   data-gn-list-layer-names-or-titles="listLayerNamesOrTitles"
+                   data-gn-add-inspire-description="addInspireDescription"
                    data-layers="layers"
                    data-selection="params.selectedLayers">
               </div>
@@ -207,9 +209,12 @@
                         id="gn-addonlinesrc-description-single-textarea"
                         data-gn-autogrow=""
                         data-ng-model="params.desc"
+                        data-ng-if="addInspireDescription===false"
                         class="form-control input-sm"
                         placeholder="description"
                         name="description"/>
+              <input type="text" name="description"  data-ng-model="params.desc" data-ng-if="addInspireDescription"
+              data-typeahead="accessp for accessp in ['accessPoint','endPoint']" data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"/>
               </div>
               <div id="gn-addonlinesrc-description-multilingual-row"
                    class="col-sm-10"
@@ -217,7 +222,7 @@
                    gn-multilingual-field="{{mdOtherLanguages}}"
                    data-main-language="{{mdLang}}"
                    expanded="false">
-              <textarea data-ng-repeat="(key, val) in mdLangs"
+                <textarea data-ng-repeat="(key, val) in mdLangs"
                         id="gn-addonlinesrc-description-multilingual-{{val}}"
                         rows="3"
                         lang="{{val}}"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
@@ -38,6 +38,8 @@
       </h4>
       <div data-gn-layers-grid
            data-gn-selection-mode="layerSelectionMode"
+           data-gn-list-layer-names-or-titles="listLayerNamesOrTitles"
+           data-gn-add-inspire-description="addInspireDescription"
            data-layers="layers"
            data-selection="srcParams.selectedLayers">
       </div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -146,7 +146,10 @@
                 <!-- For OGC resources, the description contains the label
                 and the title the layer name which in some cases eg. ESRI
                 is a number only. -->
-                {{(resource[resource.protocol && resource.protocol.indexOf('OGC') !== -1 ? 'description' : 'title'] | gnLocalized: lang) || resource.lUrl}}
+                {{(resource[resource.protocol && resource.protocol.indexOf('OGC') !== -1 &&
+                resource.description && resource.description.indexOf('accessPoint') === -1  &&
+                resource.description.indexOf('endPoint') === -1 ?
+                'description' : 'title'] | gnLocalized: lang) || resource.lUrl}}
               </a>
               <span data-ng-if="resource.lUrl.match('^http|ftp') === null">
                 {{(resource.title | gnLocalized: lang) || resource.lUrl}}


### PR DESCRIPTION
Starting from this https://github.com/geonetwork/core-geonetwork/pull/3720 This adds two new options:

listLayerNamesOrTitles: can be "title" or "name" to show layer names instead of titles in add WMS resources (as discussed here https://github.com/geonetwork/core-geonetwork/issues/3813). "title" is the default (current behaviour)

addInspireDescription: true o false (default). When true it shows a typehead text field, with two options "accessPoint" and "endPoint", as required from INSPIRE regulation, or free text, for others cases.