### PR TITLE
Formatter / XSL / Do not repeat tab as header as it is already displayed in the tab itself

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -264,6 +264,11 @@
           <xsl:attribute name="class" select="'tab-pane'"/>
         </xsl:if>
         <h1 class="view-header">
+          <!-- If in tab mode, do not repeat the tab name as header
+          as it is already displayed in the tab itself. -->
+          <xsl:if test="$tabs = 'true'">
+            <xsl:attribute name="class" select="'hidden'"/>
+          </xsl:if>
           <xsl:value-of select="$title"/>
         </h1>
         <xsl:choose>


### PR DESCRIPTION
To avoid identification > identification for example

![image](https://user-images.githubusercontent.com/1701393/58266520-19961f00-7d82-11e9-83fe-19317dc4a251.png)
