### PR TITLE
Wro4j / More detailed error when a lib is not found.

### DIFF
--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetWroModelFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetWroModelFactory.java
@@ -713,6 +713,14 @@ public class GeonetWroModelFactory implements WroModelFactory {
 
                 @Override
                 public Iterator<File> iterator() {
+                    // More detailed error about 
+                    // Parameter 'directory' is not a directory 
+                    // when a missing lib is not found by wro4j when geonetwork initialized.
+                    // It may happen when submodules are not loaded properly.
+                    if (!root.isDirectory()) {
+                        throw new IllegalArgumentException(
+                            String.format("Directory '%s' is not a directory. It could be a missing library. Check the source if you have all dependency files required.", root));
+                    }
                     return FileUtils.iterateFiles(root, extToCollect, true);
                 }
             };


### PR DESCRIPTION
The error "Parameter 'directory' is not a directory" thrown by FileUtils is not really helpful. 
Explain a bit more why it is failing.

It has been raised on different places already:
* https://sourceforge.net/p/geonetwork/mailman/message/35527805/
* https://github.com/georchestra/georchestra/issues/1120

Exception is now:

```
[INFO] Started Jetty Server
java.lang.IllegalArgumentException: Directory '/data/dev/gn/sextant/web-client/src/main/resources/catalog/lib/bootstrap-table/dist' is not a directory. It could be a missing library. Check the source if you have all dependency files required.
	at org.fao.geonet.wro4j.GeonetWroModelFactory$ResourceDesc$1.iterator(GeonetWroModelFactory.java:719)
	at org.fao.geonet.wro4j.GeonetWroModelFactory.addCssGroupsByRequireDependencies(GeonetWroModelFactory.java:455)
	at org.fao.geonet.wro4j.GeonetWroModelFactory.loadGroupsUsingRequireDependencyManagement(GeonetWroModelFactory.java:386)
	at org.fao.geonet.wro4j.GeonetWroModelF
```