### PR TITLE
Editor / Configuration / Add support for `@del` in codelist element

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -455,6 +455,7 @@
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="codelists" select="$iso19139codelists" required="no"/>
     <xsl:param name="overrideLabel" select="''" required="no"/>
+    <xsl:param name="refToDelete" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
@@ -484,7 +485,8 @@
       <xsl:with-param name="name"
                       select="if ($isEditing) then concat(*/gn:element/@ref, '_codeListValue') else ''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
-      <xsl:with-param name="parentEditInfo" select="gn:element"/>
+      <xsl:with-param name="parentEditInfo"
+                      select="if ($refToDelete) then $refToDelete else gn:element"/>
       <xsl:with-param name="listOfValues"
                       select="gn-fn-metadata:getCodeListValues($schema, name(*[@codeListValue]), $codelists, .)"/>
       <xsl:with-param name="isFirst"


### PR DESCRIPTION
Example of usage:
```
            <!--  Do not allow to remove the first maintenance
                  and update frequency grand parent
                  which also contains other elements elsewhere in the form -->
            <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:resourceMaintenance[1]/*/gmd:maintenanceAndUpdateFrequency"
                   name="cm-updateFrequency"/>
            <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:resourceMaintenance[position() > 1]/*/gmd:maintenanceAndUpdateFrequency"
                   name="cm-updateFrequency"
                   del="../.."/>
```

This allows to display a codelist element and to have the remove button acting on an ancestor element.