### PR TITLE
Set `system/server/securePort` setting as public instead of internal

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -511,16 +511,20 @@
          */
         getServiceURL: function() {
           var port = '';
-          if(gnConfig['system.server.protocol']==='http' &&
+          if (gnConfig['system.server.protocol'] === 'http' &&
              gnConfig['system.server.port'] &&
-             gnConfig['system.server.port']!=null &&
-             gnConfig['system.server.port']!=80) {
-            port = ':'+gnConfig['system.server.port'];
-          } else if(gnConfig['system.server.protocol']==='https' &&
-             gnConfig['system.server.port'] &&
-             gnConfig['system.server.port']!=null &&
-             gnConfig['system.server.port']!=443) {
-            port = ':'+gnConfig['system.server.port'];
+             gnConfig['system.server.port'] != null &&
+             gnConfig['system.server.port'] != 80) {
+
+            port = ':' + gnConfig['system.server.port'];
+
+          } else if (gnConfig['system.server.protocol'] === 'https' &&
+             gnConfig['system.server.securePort'] &&
+             gnConfig['system.server.securePort'] != null &&
+             gnConfig['system.server.securePort'] != 443) {
+
+            port = ':' + gnConfig['system.server.securePort'];
+
           }
 
           var url = gnConfig['system.server.protocol'] + '://' +

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -575,7 +575,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/host', 'localhost', 0, 210, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/protocol', 'http', 0, 220, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/port', '8080', 1, 230, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/securePort', '8443', 1, 240, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/securePort', '8443', 1, 240, 'n');
 INSERT INTO settings (name, value, datatype, position, internal) VALUES ('system/server/log','log4j.xml',0,250,'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/network', '127.0.0.1', 0, 310, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/netmask', '255.0.0.0', 0, 320, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v370/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v370/migrate-default.sql
@@ -11,5 +11,9 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metada
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/footerRight', '{date}', 0, 12507, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/pdfReport/pdfName', 'metadata_{datetime}.pdf', 0, 12507, 'n');
 
+UPDATE Settings SET internal='n' WHERE name='system/server/securePort';
+
 UPDATE Settings SET value='3.7.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
+
+


### PR DESCRIPTION
Fixes a bug in `getServiceURL` that was returning the wrong port when HTTPS is used.
For example it returned `https://www.example.com:80/geonetwork/srv/` instead of
`https://www.example.com/geonetwork/srv`.