### PR TITLE
Fix link to quartz crontrigger documentation in harvester schedule

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/schedule.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/schedule.html
@@ -35,7 +35,7 @@
           <li class="divider"/>
           <li>
             <a class="btn btn-link"
-               href="http://quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger"
+               href="http://www.quartz-scheduler.org/documentation/quartz-2.1.7/tutorials/crontrigger"
                target="_blank"
                data-translate="">moreExamples</a>
           </li>


### PR DESCRIPTION
Unfortunately Quartz project has change documentation urls to have the exact version number instead of generic ones as previously (http://quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger).

Updated to use `2.1.7` version that is the latest from `2.1.x` version we use in Geonetwork (http://www.quartz-scheduler.org/documentation/). Probably if they make a new minor release, with the change for documentation urls, will require to be updated this link.