### PR TITLE
Harvesters check permissions before overwrite

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
@@ -26,6 +26,7 @@ package org.fao.geonet.kernel.harvest;
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
@@ -133,4 +134,16 @@ public abstract class BaseAligner<P extends AbstractParams> extends AbstractAlig
             }
         }
     }
+    
+    
+    /**
+     *  To check if the user/group associated with the harvester
+     *  is the current owner/group owner of the existing record
+     * @param recordToOverwrite
+     * @return true if the owner is the same
+     */
+    protected boolean canOverwriteRecord(Metadata recordToOverwrite) {
+        return Integer.compare(recordToOverwrite.getSourceInfo().getOwner(), getOwnerId(params)) == 0 && Integer.compare(recordToOverwrite.getSourceInfo().getGroupOwner(), getOwnerGroupId(params)) == 0;
+    }
+
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
@@ -143,7 +143,7 @@ public abstract class BaseAligner<P extends AbstractParams> extends AbstractAlig
      * @return true if the owner is the same
      */
     protected boolean canOverwriteRecord(Metadata recordToOverwrite) {
-        return Integer.compare(recordToOverwrite.getSourceInfo().getOwner(), getOwnerId(params)) == 0 && Integer.compare(recordToOverwrite.getSourceInfo().getGroupOwner(), getOwnerGroupId(params)) == 0;
+        return Integer.compare(recordToOverwrite.getSourceInfo().getOwner(), getOwner()) == 0 && Integer.compare(recordToOverwrite.getSourceInfo().getGroupOwner(), getGroupOwner()) == 0;
     }
 
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -954,6 +954,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
             add(res, "subtemplatesUpdated", result.subtemplatesUpdated);
             add(res, "total", result.totalMetadata);
             add(res, "unchanged", result.unchangedMetadata);
+            add(res, "permissionDenied", result.permissionDenied);
             add(res, "unknownSchema", result.unknownSchema);
             add(res, "unretrievable", result.unretrievable);
             add(res, "updated", result.updatedMetadata);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvestResult.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvestResult.java
@@ -61,4 +61,5 @@ public class HarvestResult {
     public int thumbnailsFailed;        // = number of thumbnail creation which failed
     /** Number of metadata managed by other harvester. */
     public int managedByOtherHarvester;
+    public int permissionDenied;        // = the harvester does not belong to the current owner of metadata
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -240,6 +240,7 @@ class Harvester extends BaseAligner<WebDavParams> implements IHarvester<HarvestR
             case OVERRIDE:
                 Metadata existingMetadata = metadataRepository.findOneByUuid(uuid);
                 RecordInfo existingRecordInfo = new RecordInfo(existingMetadata);
+
                 updateMetadata(rf, existingRecordInfo, true);
                 log.info("Overriding record with uuid " + uuid);
                 result.updatedMetadata++;


### PR DESCRIPTION
This could be a solution to the issue described here with overwrite option https://github.com/geonetwork/core-geonetwork/issues/2613
When a harvester finds a record on the origin with a UUID already in the catalog, if the overwrite option is active, the record is considered only if the owner/group owner of the harvester is the same of the record in the catalog. Otherwise, if a record is skipped because of this, a new counter, permissionDenied, is shown in the final report, counting the records not overwritten because of this.

