### PR TITLE
Editor - extend template to apply angularjs directives to fields to send 'required' flag. Update directives for topic categories and field duration to use 'required' flag

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/fieldduration/FieldDurationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/fieldduration/FieldDurationDirective.js
@@ -51,7 +51,8 @@
         scope: {
           value: '@gnFieldDurationDiv',
           label: '@label',
-          ref: '@ref'
+          ref: '@ref',
+          required: '@required'
         },
         templateUrl: '../../catalog/components/edit/fieldduration/partials/' +
             'fieldduration.html',

--- a/web-ui/src/main/resources/catalog/components/edit/fieldduration/partials/fieldduration.html
+++ b/web-ui/src/main/resources/catalog/components/edit/fieldduration/partials/fieldduration.html
@@ -1,4 +1,4 @@
-<span>
+<span data-ng-class="required ? 'gn-required' : ''">
   <label class="control-label col-xs-2">{{label}}</label>
   <div class="col-xs-9">
     <!-- The hidden field with the value. -->

--- a/web-ui/src/main/resources/catalog/components/edit/topiccategory/TopicCategoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/topiccategory/TopicCategoryDirective.js
@@ -52,7 +52,8 @@
            scope: {
              values: '@gnTopiccategorySelectorDiv',
              label: '@label',
-             ref: '@ref'
+             ref: '@ref',
+             required: '@required'
            },
            templateUrl: '../../catalog/components/edit/topiccategory/partials/' +
            'topiccategory.html',

--- a/web-ui/src/main/resources/catalog/components/edit/topiccategory/partials/topiccategory.html
+++ b/web-ui/src/main/resources/catalog/components/edit/topiccategory/partials/topiccategory.html
@@ -1,4 +1,4 @@
-<span>
+<span data-ng-class="required ? 'gn-required' : ''">
   <label class="col-sm-2 control-label">
     {{label}}
   </label>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -157,6 +157,7 @@
 
             <xsl:attribute name="data-ref" select="concat('_', $editInfo/@ref)"/>
             <xsl:attribute name="data-label" select="$label/label"/>
+            <xsl:attribute name="data-required" select="$isRequired"/>
           </span>
           <div class="col-sm-1 gn-control">
             <xsl:if test="not($isDisabled)">


### PR DESCRIPTION
With this change the xslt template that applies directives to fields provides a `data-required` attribute that can be used in the directives to display the field mandatory element in the label.

Example for topic categories:

![topic-categories-mandatory](https://user-images.githubusercontent.com/1695003/58792844-3be73280-85f5-11e9-9054-e551992727a6.png)
