### PR TITLE
FIX: Increase the navbar z-index to display the menus over the editor content

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -110,7 +110,7 @@ div[gn-transfer-ownership] * .list-group {
     top: 0;
     left: 0;
     right: 0;
-    z-index: 30;
+    z-index: 100;
     height: 52px;
   }
   .gn-sub-bar {


### PR DESCRIPTION
Increase the z-index of the navbar in the editor to display the menus over the editor content

**Before:**
![gn-menu-z-before](https://user-images.githubusercontent.com/19608667/58861069-defb8300-86ad-11e9-9a88-7827085a0511.png)

**After:**
![gn-menu-z-after](https://user-images.githubusercontent.com/19608667/58861089-e6229100-86ad-11e9-985e-a6eaecdbadf7.png)