### PR TITLE
Use tranformation parameter in Keyword API service to retrieve a keyword xml snippet

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
@@ -229,7 +229,40 @@
       <!-- If no keyword, add one to avoid invalid metadata -->
       <xsl:if test="count(//keyword[thesaurus/key = $currentThesaurus]) = 0">
         <gmd:keyword gco:nilReason="missing">
-          <gco:CharacterString></gco:CharacterString>
+          <!-- Multilingual output if more than one requested language -->
+          <xsl:choose>
+            <xsl:when test="count($listOfLanguage) > 1">
+              <xsl:attribute name="xsi:type" select="'gmd:PT_FreeText_PropertyType'"/>
+
+              <xsl:if test="not($textgroupOnly)">
+                <gco:CharacterString />
+              </xsl:if>
+
+              <gmd:PT_FreeText>
+                <xsl:for-each select="$listOfLanguage">
+                  <xsl:variable name="lang" select="."/>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString
+                      locale="#{upper-case(util:twoCharLangCode($lang))}" />
+                  </gmd:textGroup>
+                </xsl:for-each>
+              </gmd:PT_FreeText>
+            </xsl:when>
+            <xsl:otherwise>
+
+              <!-- ... default mode -->
+              <xsl:choose>
+                <xsl:when test="$withAnchor">
+                  <!-- TODO multilingual Anchor ?
+                  -->
+                  <gmx:Anchor xlink:href="" />
+                </xsl:when>
+                <xsl:otherwise>
+                  <gco:CharacterString />
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:otherwise>
+          </xsl:choose>
         </gmd:keyword>
       </xsl:if>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
@@ -229,38 +229,12 @@
       <!-- If no keyword, add one to avoid invalid metadata -->
       <xsl:if test="count(//keyword[thesaurus/key = $currentThesaurus]) = 0">
         <gmd:keyword gco:nilReason="missing">
-          <!-- Multilingual output if more than one requested language -->
           <xsl:choose>
-            <xsl:when test="count($listOfLanguage) > 1">
-              <xsl:attribute name="xsi:type" select="'gmd:PT_FreeText_PropertyType'"/>
-
-              <xsl:if test="not($textgroupOnly)">
-                <gco:CharacterString />
-              </xsl:if>
-
-              <gmd:PT_FreeText>
-                <xsl:for-each select="$listOfLanguage">
-                  <xsl:variable name="lang" select="."/>
-                  <gmd:textGroup>
-                    <gmd:LocalisedCharacterString
-                      locale="#{upper-case(util:twoCharLangCode($lang))}" />
-                  </gmd:textGroup>
-                </xsl:for-each>
-              </gmd:PT_FreeText>
+            <xsl:when test="$withAnchor">
+              <gmx:Anchor xlink:href="" />
             </xsl:when>
             <xsl:otherwise>
-
-              <!-- ... default mode -->
-              <xsl:choose>
-                <xsl:when test="$withAnchor">
-                  <!-- TODO multilingual Anchor ?
-                  -->
-                  <gmx:Anchor xlink:href="" />
-                </xsl:when>
-                <xsl:otherwise>
-                  <gco:CharacterString />
-                </xsl:otherwise>
-              </xsl:choose>
+              <gco:CharacterString />
             </xsl:otherwise>
           </xsl:choose>
         </gmd:keyword>

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -443,6 +443,11 @@ public class KeywordsApi {
                 requestParams.addContent(new Element(e.getKey()).setText(e.getValue()));
             }
         }
+
+        if (StringUtils.isNotEmpty(transformation)) {
+            requestParams.addContent(new Element("transformation", transformation));
+        }
+
         root.addContent(requestParams);
         root.addContent(descKeys);
         root.addContent(gui);

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -444,10 +444,6 @@ public class KeywordsApi {
             }
         }
 
-        if (StringUtils.isNotEmpty(transformation)) {
-            requestParams.addContent(new Element("transformation", transformation));
-        }
-
         root.addContent(requestParams);
         root.addContent(descKeys);
         root.addContent(gui);


### PR DESCRIPTION
This is used in `config-editor.xml` when defining the attribute for `data-transformation` for the directive `data-gn-thesaurus-selector`, previously was send, but not used in the backend service:

```
<for name="gmd:descriptiveKeywords" addDirective="data-gn-thesaurus-selector">
      <directiveAttributes data-transformation="to-iso19139-keyword-with-anchor" />
</for>
```