### PR TITLE
Fix groupsCombo directive to select first group

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -301,8 +301,11 @@
 
                   // Select by default the first group.
                   if ((angular.isUndefined(scope.ownerGroup) ||
-                    scope.ownerGroup === '') && data) {
-                    scope.ownerGroup = scope.groups[0].id;
+                    scope.ownerGroup === '' ||
+                    scope.ownerGroup === null) && data) {
+                    // Requires to be converted to string, otherwise
+                    // angularjs adds empty non valid option
+                    scope.ownerGroup = scope.groups[0].id + "";
                   }
                   if (optional) {
                     scope.groups.unshift({


### PR DESCRIPTION
Fixes the check to initialise the group selected checking the value `null` that is used for example in the import controller: https://github.com/geonetwork/core-geonetwork/blob/master/web-ui/src/main/resources/catalog/js/edit/ImportController.js#L66

Also sets the selected value as string,otherwise angularjs adds empty option with the value of the group as a number as can't match it to the groups list, as expects a string.

As a side effect removes the empty group selection in the import metadata, what in my opinion was wrong as every metadata should be assigned to a group.

![import-groups](https://user-images.githubusercontent.com/1695003/58941573-5d265b00-877c-11e9-8724-a9b588ce53f4.png)
