### PR TITLE
Map / Add map or layer from records / Search on focus and info when none found

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
@@ -7,6 +7,7 @@
           class="fa fa-search"/></span>
         <input class="form-control"
                data-ng-change="triggerSearch()"
+               data-ng-focus="triggerSearch()"
                type="text"
                data-ng-model="searchObj.params.any"
                data-ng-model-options="modelOptions"
@@ -28,6 +29,11 @@
     -->
 
 
+    <div data-ng-show="searchResults.count >= 0 && searchResults.records.length === 0"
+         class="alert alert-warning"
+         data-translate="">
+        {{('noRecordFoundWithResourceRegistered' + mode) | translate}}
+    </div>
     <div data-ng-show="searchResults.records.length > 0">
       <div class="pull-right"
            data-gn-pagination="paginationInfo"

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -50,6 +50,8 @@
   "refresh": "Refresh",
   "mapLegend": "Legend",
   "kmlFile": "{{layer}} (KML)",
+  "noRecordFoundWithResourceRegistered": "No record found with one or more WMS layers registered.",
+  "noRecordFoundWithResourceRegisteredmap": "No record found with one or more maps registered.",
   "tmsLinkDetails":"This dataset is published in the view service (TMS) available at <a href='{{url}}' target='_blank'>{{url}}</a> with identifier <strong>{{layer}}</strong>.",
   "wmsLinkDetails": "This dataset is published in the view service (WMS) available at <a href='{{url}}' target='_blank'>{{url}}</a> with layer name <strong>{{layer}}</strong>.",
   "wmsServiceLinkDetails": "This dataset is published in the view service (WMS) available at <a href='{{url}}' target='_blank'>{{url}}</a>.",


### PR DESCRIPTION
When user focus on search field this trigger an empty search. Currently user would have to focus and type "*" to trigger search for example.

![image](https://user-images.githubusercontent.com/1701393/58955500-78a15e00-879c-11e9-8735-894a1101f81a.png)

if no record are returned a comprehensive message indicates that there is no record with reference to a map 

![image](https://user-images.githubusercontent.com/1701393/58955477-61fb0700-879c-11e9-8fd9-5ed4d6469824.png)

or to a WMS layer

![image](https://user-images.githubusercontent.com/1701393/58955533-8f47b500-879c-11e9-99e7-ebeb5eba44b5.png)
