### PR TITLE
[BP 3.6.x] Fix thubmnail-add parameter names for ISO 19115-3

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -295,8 +295,13 @@
                       fileStoreFilter: '*.{jpg,JPG,png,PNG,gif,GIF}',
                       process: 'thumbnail-add',
                       fields: {
-                        'url': {isMultilingual: false},
-                        'name': {param: 'desc'}
+                        'url': {
+                          param: 'thumbnail_url',
+                          isMultilingual: false
+                        },
+                        'name': {
+                          param: 'thumbnail_desc'
+                        }
                       }
                     }, {
                       group: 'onlineDiscover',


### PR DESCRIPTION
In branch `3.4.x` of https://github.com/metadata101/iso19115-3 the parameters
of the process `thumbnail_add.xsl` are `thumbnail_url`, `thumbnail_desc` and
`thumbnail_type` (https://github.com/metadata101/iso19115-3/blob/2f484b053aabe8939c48bbeb0018824c1bbd724b/src/main/plugin/iso19115-3/process/thumbnail-add.xsl#L18-L21)

This commit fixes the names of these parameters in the
_Add online resource_ panel configuration to match the names in the schema
process. This also should fix the part of metadata101/iso19115-3#35 about
the overview not being added to the XML.

Backport of #3852.