### PR TITLE
Select default option in admin UI in pages using tabs

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/AdminController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminController.js
@@ -330,13 +330,21 @@
       $scope.getTpl = function(pageMenu) {
         $scope.type = pageMenu.defaultTab;
         $.each(pageMenu.tabs, function(index, value) {
-          if ((angular.isUndefined($routeParams.dashboard) &&
-              value.type === $routeParams.tab) || (
-              angular.isDefined($routeParams.dashboard) &&
-              value.href.indexOf(
-              encodeURIComponent($routeParams.dashboard)) !== -1)
-          ) {
-            $scope.type = $routeParams.tab;
+          var isMatch = false;
+
+          if (angular.isUndefined($routeParams.dashboard)) {
+            // If no $routeParams.tab, check if the option is the default one,
+            // otherwise  compare the option with $routeParams.tab
+            isMatch = ($routeParams.tab === undefined &&
+              value.type === pageMenu.defaultTab) ||
+              (value.type === $routeParams.tab);
+          } else {
+            isMatch = value.href.indexOf(
+              encodeURIComponent($routeParams.dashboard)) !== -1;
+          }
+
+          if (isMatch) {
+            $scope.type = ($routeParams.tab !== undefined)?$routeParams.tab:pageMenu.defaultTab;
             $scope.href = value.href;
           }
         });


### PR DESCRIPTION
Currently when accessing a page with tabs the default tab is displayed, but not selected in the tabs controls. For example, when accessing `Users and groups` in the Administration panel the url opened  is the following http://localhost:8080/geonetwork/srv/eng/admin.console#/organization, that display the users page (the default one), but doesn't show the option selected in the tab list:

![default-option-1](https://user-images.githubusercontent.com/1695003/59029455-a353eb00-885e-11e9-8194-6afe4cd511e0.png)

With the changes:

![default-option-2](https://user-images.githubusercontent.com/1695003/59029482-b070da00-885e-11e9-8300-6bf6878aa3cc.png)

