### PR TITLE
Add thesaurus title as an Anchor when adding iso19139 in Anchor mode

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
@@ -241,12 +241,13 @@
       </xsl:if>
 
       <xsl:copy-of
-        select="geonet:add-thesaurus-info($currentThesaurus, $withThesaurusAnchor, /root/gui/thesaurus/thesauri, not(/root/request/keywordOnly))"/>
+        select="geonet:add-thesaurus-info($currentThesaurus, $withAnchor, $withThesaurusAnchor, /root/gui/thesaurus/thesauri, not(/root/request/keywordOnly))"/>
     </gmd:MD_Keywords>
   </xsl:template>
 
   <xsl:function name="geonet:add-thesaurus-info">
     <xsl:param name="currentThesaurus" as="xs:string"/>
+    <xsl:param name="withTitleAnchor" as="xs:boolean"/>
     <xsl:param name="withThesaurusAnchor" as="xs:boolean"/>
     <xsl:param name="thesauri" as="node()"/>
     <xsl:param name="thesaurusInfo" as="xs:boolean"/>
@@ -261,9 +262,18 @@
       <gmd:thesaurusName>
         <gmd:CI_Citation>
           <gmd:title>
-            <gco:CharacterString>
-              <xsl:value-of select="$thesauri/thesaurus[key = $currentThesaurus]/title"/>
-            </gco:CharacterString>
+            <xsl:choose>
+              <xsl:when test="$withTitleAnchor = true()">
+                <gmx:Anchor xlink:href="{$thesauri/thesaurus[key = $currentThesaurus]/defaultNamespace}">
+                  <xsl:value-of select="$thesauri/thesaurus[key = $currentThesaurus]/title"/>
+                </gmx:Anchor>
+              </xsl:when>
+              <xsl:otherwise>
+                <gco:CharacterString>
+                  <xsl:value-of select="$thesauri/thesaurus[key = $currentThesaurus]/title"/>
+                </gco:CharacterString>
+              </xsl:otherwise>
+            </xsl:choose>
           </gmd:title>
 
           <xsl:variable name="thesaurusDate"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -84,6 +84,13 @@
           <xsl:value-of select="$thesaurusTitleEl/gmd:PT_FreeText/gmd:textGroup/
                                   gmd:LocalisedCharacterString[normalize-space(text()) != ''][1]"/>
         </xsl:when>
+        <xsl:when test="normalize-space($thesaurusTitleEl/gmx:Anchor) != ''">
+          <xsl:value-of select="if ($overrideLabel != '')
+              then $overrideLabel
+              else concat(
+                      $iso19139strings/keywordFrom,
+                      normalize-space($thesaurusTitleEl/gmx:Anchor))"/>
+        </xsl:when>
         <xsl:otherwise>
           <xsl:value-of select="gmd:MD_Keywords/gmd:thesaurusName/
                                   gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code"/>
@@ -153,7 +160,7 @@
                   select="normalize-space(gmd:thesaurusName/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/*/text())"/>
 
     <xsl:variable name="thesaurusTitle"
-                  select="gmd:thesaurusName/gmd:CI_Citation/gmd:title/(gco:CharacterString|gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString)"/>
+                  select="gmd:thesaurusName/gmd:CI_Citation/gmd:title/(gco:CharacterString|gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString|gmx:Anchor)"/>
 
 
     <xsl:variable name="thesaurusConfig"

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-keywords.xsl
@@ -222,6 +222,7 @@
 
               <xsl:copy-of select="geonet:add-thesaurus-info(
                                               $thesaurusKey,
+                                              false(),
                                               true(),
                                               $root/root/env/thesauri,
                                               true())"/>


### PR DESCRIPTION
Use the namespace defined in the thesaurus file to add the title as an Anchor when the selected keywords mode in the editor is `anchor`:

```
<gmd:thesaurusName>
    <gmd:CI_Citation>
        <gmd:title>
            <gmx:Anchor
                    xlink:href="http://inspire.ec.europa.eu/theme#">
                GEMET - INSPIRE themes, version 1.0
            </gmx:Anchor>
        </gmd:title>
```

In other modes is added added as a `CharacterString` (as previously):

```
<gmd:thesaurusName>
    <gmd:CI_Citation>
        <gmd:title>
            <gco:CharacterString>
                GEMET - INSPIRE themes, version 1.0
            </gco:CharacterString>
        </gmd:title>
```

Required for INSPIRE related thesaurus.