### PR TITLE
WMS / Add support for group of layers when searching in capabilities 

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -450,19 +450,20 @@
 
             // Layer name may be a list of comma separated layers
             layerList = layerName.split(',');
+            layersLoop:
             for (var j = 0; j < layerList.length; j ++) {
               var name = layerList[j];
-
               //non namespaced lowercase name
               nameNoNamespace = name.split(':')[
                   name.split(':').length - 1].toLowerCase();
 
+              capabilityLayers:
               for (var i = 0; i < layers.length; i++) {
                 //Add Info for Requests:
                 if (capObj.Request) {
                   layers[i].capRequest = capObj.Request;
                 }
-
+                
                 //check layername
                 var lId = layers[i].Identifier;
                 var capName = layers[i].Name ||
@@ -481,7 +482,7 @@
                     layers[i].version = capObj.version;
                   }
                   needles.push(layers[i]);
-                  continue;
+                  break capabilityLayers;
                 }
 
                 //check dataset identifer match
@@ -490,7 +491,7 @@
                     for (var c = 0; c < layers[i].Identifier.length; c++) {
                       if (layers[i].Identifier[c] == uuid) {
                         needles.push(layers[i]);
-                        continue;
+                        break capabilityLayers;
                       }
                     }
                   }
@@ -500,7 +501,7 @@
                       if (mdu && mdu.OnlineResource &&
                         mdu.OnlineResource.indexOf(uuid) > 0) {
                         needles.push(layers[i]);
-                        continue;
+                        break capabilityLayers;
                       }
                     }
                   }


### PR DESCRIPTION

When using a background map which is using multiple layers from the same service, the layer name may be like `layer1,layer2`.

Currently, this function does not found the layer. 
Check if all layer in the list are defined in the capabilities.

eg.
```
  <ows-context:ResourceList>
    <ows-context:Layer name="3,2,1,7,12,13,4,5,6,8,9,10" group="Background layers" hidden="false" opacity="1">
      <ows-context:Server service="urn:ogc:serviceType:WMS" version="1.3.0">
        <ows-context:OnlineResource
          xlink:href="https://land.discomap.eea.europa.eu/arcgis/services/Background/Background_Cashed_WGS84/MapServer/WmsServer"/>
      </ows-context:Server>
      <ows:Title>EEA discomap background</ows:Title>
    </ows-context:Layer>
```