### PR TITLE
Editor / Keywords / Simple layout in flat mode

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -124,7 +124,7 @@
                           else $listOfThesaurus/thesaurus[title=$thesaurusTitle]"/>
 
     <xsl:choose>
-      <xsl:when test="$thesaurusConfig/@fieldset = 'false'">
+      <xsl:when test="($isFlatMode and not($thesaurusConfig/@fieldset)) or $thesaurusConfig/@fieldset = 'false'">
         <xsl:apply-templates mode="mode-iso19139" select="*">
           <xsl:with-param name="schema" select="$schema"/>
           <xsl:with-param name="labels" select="$labels"/>
@@ -253,7 +253,7 @@
         <div data-gn-keyword-selector="{$widgetMode}"
              data-metadata-id="{$metadataId}"
              data-element-ref="{concat('_X', ../gn:element/@ref, '_replace')}"
-             data-thesaurus-title="{if ($thesaurusConfig/@fieldset = 'false') then $thesaurusTitle else ''}"
+             data-thesaurus-title="{if (($isFlatMode and not($thesaurusConfig/@fieldset)) or $thesaurusConfig/@fieldset = 'false') then $thesaurusTitle else ''}"
              data-thesaurus-key="{$thesaurusKey}"
              data-keywords="{$keywords}"
              data-transformations="{$transformations}"


### PR DESCRIPTION
In simple (more precisely "flat" mode) views, keywords are displayed by default with a fieldset. This can be customized per thesaurus using the `fieldset` config:

```
        <thesaurus key="external.theme.NVS.L05POS"
                   fieldset="false"
                   transformations="to-iso19139-keyword"/>
```

The idea is to keep flat mode view as simple as possible.

But in this case all other thesaurus are displayed using a fieldset - and the editor config can't configure for all thesaurus in a record. Below, INSPIRE, theme sextant and ISO topics are known but others no:

![image](https://user-images.githubusercontent.com/1701393/59501148-31515680-8e9b-11e9-853d-7aef057698d9.png)


This change use the no fieldset mode when the view is flat:

![image](https://user-images.githubusercontent.com/1701393/59501227-61005e80-8e9b-11e9-9c4b-ba311f6f96c7.png)

But config-editor can still force usage of fieldset mode by declaring the thesaurus.


Advanced view is using the fieldset mode:

![image](https://user-images.githubusercontent.com/1701393/59501249-69589980-8e9b-11e9-8fa0-8011c958a10d.png)


