### PR TITLE
Fix for long harvester names

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -16,16 +16,15 @@
                placeholder="{{'filter' | translate}}"/>
 
         <div id="gn-harvest-select-saved-row" class="list-group" data-ng-hide="$parent.isLoadingHarvester">
-          <a href="" class="list-group-item"
+          <a href="" class="list-group-item gn-harvester-list-group"
              data-ng-repeat="h in pageItems()"
              data-ng-class="[h['@id'] === harvesterSelected['@id'] ? 'active' : '', h.error ? 'list-group-item-danger' : '']"
              data-ng-click="selectHarvester(h)"
              title="{{h.error ? ('selectForError' | translate) : (h.info.lastRun.length === 0 ? '' : ('lastRun' | translate) + (h.info.lastRun | gnFromNow))}}">
-            <!-- TODO : Add a tooltip with last run info -->
-
             <i data-ng-show="h.options.status === 'active'" class="fa fa-play"/>
-            <i data-ng-show="h.options.status === 'inactive'" class="fa fa-pause"/> {{h.site.name}}
-            ({{('harvester-' + h['@type']) | translate}}) <span class="badge">{{h.info.result.total}}</span>
+            <i data-ng-show="h.options.status === 'inactive'" class="fa fa-pause"/>
+            <span class="gn-harvester-name"> {{h.site.name}}
+            ({{('harvester-' + h['@type']) | translate}})</span> <span class="badge">{{h.info.result.total}}</span>
             <i data-ng-show="h.info.running" class="fa fa-spinner fa-spin"/>
           </a>
           <span data-gn-pagination-list=""

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -284,7 +284,6 @@ ul.gn-resultview li.list-group-item {
             float: right;
           }
         }
-    
       }
       .thumbnail {
         padding: 0;
@@ -301,6 +300,16 @@ ul.gn-resultview li.list-group-item {
               text-decoration: none;
             }
           }
+        }
+      }
+      .gn-harvester-list-group {
+        i {
+          vertical-align: top;
+          margin-top: 3px;
+        }
+        .gn-harvester-name {
+          display: inline-block;
+          width: 80%;
         }
       }
     }


### PR DESCRIPTION
When harvester names in the list with harvesters are too long the count badge is partly hidden. This PR displays a longer name on more than one line, so the counter is visible.

**Before:**
![gn-harvester-before](https://user-images.githubusercontent.com/19608667/59605441-18e97200-910f-11e9-82c1-a99f08161854.png)

**After:**
![gn-harvester-after](https://user-images.githubusercontent.com/19608667/59605457-2272da00-910f-11e9-8bfd-d3186751c393.png)
