### PR TITLE
Fix gmd:verticalCRS to display choices in advanced view

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/schema.xsd
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema.xsd
@@ -24,6 +24,9 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.isotc211.org/2005/gmd"
+           xmlns:gco="http://www.isotc211.org/2005/gco"
+           xmlns:gsr="http://www.isotc211.org/2005/gsr"
+           xmlns:gmx="http://www.isotc211.org/2005/gmx"
            elementFormDefault="qualified"
 >
   <xs:include schemaLocation="schema/gmd/metadataApplication.xsd"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/schema/gsr/gsr.xsd
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema/gsr/gsr.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.isotc211.org/2005/gsr"
+           xmlns:gsr="http://www.isotc211.org/2005/gsr"
            elementFormDefault="qualified" version="0.1"
 >
   <!-- ================================= Annotation ================================ -->

--- a/schemas/iso19139/src/main/plugin/iso19139/schema/gsr/spatialReferencing.xsd
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema/gsr/spatialReferencing.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml"
            xmlns:gco="http://www.isotc211.org/2005/gco" targetNamespace="http://www.isotc211.org/2005/gsr"
+           xmlns:gsr="http://www.isotc211.org/2005/gsr"
            elementFormDefault="qualified"
            version="0.1"
 >


### PR DESCRIPTION
Currently adding a vertical element, the `gmd:verticalCRS` is added to the xml, but not displayed in the metadata editor, due to missing namespace `gsr` in the related xsd files. 

![vertical-crs-1](https://user-images.githubusercontent.com/1695003/59756261-a9e45880-9289-11e9-9785-43e20aa7cd3c.png)

If not present, the types in the `gsr` xsd files are loaded without namespace prefix, but the backend code to add the element in the editor uses the namespace prefix to match it. This pull request adds the namespace to the required xsd files, being displayed properly now:

![vertical-crs-2](https://user-images.githubusercontent.com/1695003/59756493-1cedcf00-928a-11e9-8cd9-1509e1ab9bec.png)

