### PR TITLE
Uniform styling for the status on the search results and metadata page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -80,19 +80,7 @@
              alt="{{md.title || md.defaultTitle}}"
              data-ng-src="{{md.getThumbnails().list[0].url}}"
              data-ng-if="md.getThumbnails().list[0].url"/>
-
-        <!-- Display the first metadata status (apply to ISO19139 record) -->
-        <div data-ng-if="md.status_text.length > 0"
-             title="{{md.status_text[0]}}"
-             class="gn-status gn-status-{{md.status[0]}}">{{md.status_text[0]}}
-        </div>
-        
-        <!-- Display the workflow status, if draft -->
-        <div data-ng-if="md.mdStatus == 1"
-             title="{{('status-' + md.mdStatus) | translate}}"
-             class="gn-workflow-status gn-workflow-status-{{md.mdStatus}}">
-                {{('status-' + md.mdStatus) | translate}}
-        </div>
+       
       </div>
       
 
@@ -121,9 +109,23 @@
 
     <!--start bottom row-->
     <div>
-      <div gn-grid-related gn-grid-related-uuid="::md.getUuid()"
-           template="../../catalog/views/default/templates/gridRelated.html"></div>
-      <gn-links-btn></gn-links-btn>
+      <!-- Display the first metadata status (apply to ISO19139 record) -->
+      <div data-ng-if="md.status_text.length > 0"
+           title="{{md.status_text[0]}}"
+           class="gn-status gn-status-{{md.status[0]}}">{{md.status_text[0]}}
+      </div> 
+      <div class="gn-toolbar">
+        <gn-links-btn class="pull-right"></gn-links-btn>
+        <div gn-grid-related gn-grid-related-uuid="::md.getUuid()"
+             class="pull-right"
+             template="../../catalog/views/default/templates/gridRelated.html"></div>
+        <div data-ng-if="md.draft == 'e'"
+             title="{{'workingCopy' | translate}}"
+             class="gn-workingcopy-status pull-right">
+          <i class="fa fa-pencil"></i>
+          <span>{{'workingCopy' | translate}}</span>
+        </div>
+      </div>
     </div>
 
     </div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -73,8 +73,9 @@
     <div title="{{(md.abstract || md.defaultAbstract) | striptags}}"
          data-ng-click="openRecord($index, md, searchResults.records)">
       <!-- Thumbnail -->
-      <div class="gn-md-thumbnail"
-            data-ng-class="{'gn-md-no-thumbnail': !md.getThumbnails().list[0].url}">
+      <div class="gn-md-thumbnail">
+        <div class="gn-md-no-thumbnail"
+             data-ng-if="!md.getThumbnails().list[0].url"></div>
         <img class="gn-img-thumbnail"
              alt="{{md.title || md.defaultTitle}}"
              data-ng-src="{{md.getThumbnails().list[0].url}}"

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -75,7 +75,7 @@
 
         <div class="row gn-md-links">
           <div class="btn-group" ng-if="::links.length > 0">
-            <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
               <span class="fa fa-link"></span>
               {{::links.length}}
               <ng-pluralize count="::links.length"
@@ -89,7 +89,7 @@
           </div>
 
           <div class="btn-group" ng-if="::downloads.length > 0">
-            <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
               <span class="fa fa-download"></span>
               {{::downloads.length}}
               <ng-pluralize count="::downloads.length"
@@ -105,7 +105,7 @@
           </div>
 
           <div class="btn-group" ng-if="layers.length > 0">
-            <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
               <span class="fa fa-globe"></span>
               {{::layers.length}}
               <ng-pluralize count="::layers.length"
@@ -127,13 +127,23 @@
               </li>
             </ul>
           </div>
-
+          <!-- Display the first metadata status (apply to ISO19139 record) -->
+          <div data-ng-if="md.status_text.length > 0"
+               title="{{md.status_text[0]}}"
+               class="gn-status gn-status-{{md.status[0]}} pull-right">{{md.status_text[0]}}
+          </div>
           <!--Edit button-->
-          <a class="btn btn-xs btn-default"
+          <a class="btn btn-default pull-left"
              ng-href="catalog.edit#/metadata/{{md['geonet:info'].id}}">
             <i class="fa fa-pencil"></i>
             <span data-translate="" class="sr-only">edit</span>
           </a>
+          <div data-ng-if="md.draft == 'e'"
+               title="{{'workingCopy' | translate}}"
+               class="gn-workingcopy-status pull-left">
+            <i class="fa fa-pencil"></i>
+            <span>{{'workingCopy' | translate}}</span>
+          </div>
         </div>
       </div>
       <div class="col-md-2 clearfix">
@@ -147,11 +157,7 @@
                data-ng-if="md.getThumbnails().list[0].url"/>
 
         </div>
-        <!-- Display the first metadata status (apply to ISO19139 record) -->
-        <div data-ng-if="md.status_text.length > 0"
-             title="{{md.status_text[0]}}"
-             class="gn-status gn-status-{{md.status[0]}}">{{md.status_text[0]}}
-       </div>
+
       </div>
     </div>
   </li>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -138,8 +138,9 @@
       </div>
       <div class="col-md-2 clearfix">
         <!-- Thumbnail -->
-        <div class="gn-md-thumbnail"
-             data-ng-class="{'gn-md-no-thumbnail': !md.getThumbnails().list[0].url}">
+        <div class="gn-md-thumbnail">
+          <div class="gn-md-no-thumbnail"
+               data-ng-if="!md.getThumbnails().list[0].url"></div>
           <img class="gn-img-thumbnail"
                alt="{{md.title || md.defaultTitle}}"
                data-ng-src="{{md.getThumbnails().list[0].url}}"

--- a/web-ui/src/main/resources/catalog/components/utility/partials/draftvalidationwidget.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/draftvalidationwidget.html
@@ -6,7 +6,7 @@
 	  title="{{(('draft') | translate)}}: {{(('validStatus-' + draft.valid) | translate)}}"
 	  ng-switch="draft.isTemplate">
 	  <i class="fa fa-fw fa-file" ng-switch-when="y" />
-	  <i class="fa fa-fw fa-file-text" ng-switch-when="n" />
+	  <i class="fa fa-fw fa-pencil" ng-switch-when="n" />
 	  <i class="fa fa-fw fa-bookmark" ng-switch-when="s" />
 	  <i class="fa fa-fw fa-bookmark-o" ng-switch-when="t" />
 	  <i class="fa fa-fw fa-question" ng-switch-default />

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -446,5 +446,6 @@
     "categoriesUpdated": "Categories updated.",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "canceWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?"
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "workingCopy": "Working copy"
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -598,10 +598,11 @@ i.fa-times.delete:hover {
 
 
 .gn-search-page {
-  .gn-status {
+  .gn-status, .gn-workflow-status {
     border: 2px solid @brand-primary;
-    position: absolute;
-    margin-top: 15px;
+    display: inline-block;
+    margin-top: 5px;
+    margin-right: 5px;
     border-radius: 20px;
     padding: 5px 8px;
     color: @brand-primary;
@@ -609,11 +610,9 @@ i.fa-times.delete:hover {
     font-size: 80%;
     background-color: #fff;
   }
-  .gn-status-mdview {
+  .gn-status-mdview, .gn-workflow-status-mdview {
     position: relative;
     margin-top: 0;
-    display: inline-block;
-    border-radius: 20px;
     padding: 8px 12px;
     font-weight: 500;
     font-size: 90%;
@@ -632,36 +631,12 @@ i.fa-times.delete:hover {
     border-color: darken(@brand-danger, 5%);
     color: @brand-danger;
   }
-
-// Same as before but with workflow statuses
   .gn-workflow-status {
-    border: 2px solid darken(@brand-info, 5%);
-    position: absolute;
-    top: 95px;
-    left: 115px;
-    border-radius: 6px;
-    padding: 2px;
-    -ms-transform: rotate(30deg);
-    -webkit-transform: rotate(30deg);
-    transform: rotate(30deg);
-    color: @brand-info;
-    font-weight: bold;
-    font-size: 80%;
     background-color: rgba(255, 255, 255 , 0.7);
     border-color: darken(@brand-success, 5%);
     color: @brand-success;
   }
   .gn-workflow-status-mdview {
-    position: relative;
-    top: 0;
-    left: 0;
-    display: inline-block;
-    font-size: 100%;
-    border-radius: 20px;
-    padding: 8px 12px;
-    font-weight: normal;
-    font-size: 80%;
-    transform: none;
     border-color: darken(@brand-success, 5%);
     color: @brand-success;
   }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -645,6 +645,37 @@ i.fa-times.delete:hover {
   .gn-workflow-status-1 {
     border-color: darken(@brand-danger, 5%);
     color: @brand-danger;
+
+
+  }
+  .gn-workingcopy-status {
+    border: 1px solid @btn-default-border;
+    background-color: #fff;
+    border-radius: 20px;
+    padding: 0 15px 0 0;
+    font-size: 12px;
+    margin-top: 7px;
+    display: block;
+    cursor: pointer;
+    color: @gray-dark;
+    .fa {
+      border-radius: 1000px;
+      width: 32px;
+      height: 32px;
+      line-height: 32px;
+      text-align: center;
+      font-size: 14px;
+      color: #fff;
+      margin-bottom: -0.3em;
+      background-color: #777;
+      overflow: hidden;
+    }
+    span {
+      line-height: 30px;
+      display: block;
+      float: right;
+      margin-left: 10px;
+    }
   }
 }
 

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -402,7 +402,6 @@ span.gn-facet-label:first-letter {
     line-height: 3em;
     font-size: 90%;
     margin: 0;
-    //margin-left: 6em;
     .dropdown-menu {
       max-width: 500px;
       li a {
@@ -437,18 +436,20 @@ span.gn-facet-label:first-letter {
   .gn-md-thumbnail {
     float:left;
     width: 140px;
-    max-height: 140px;
     height: auto;
     margin-right: 15px;
-    border: 1px solid #ddd;
     border-radius: 4px;
     overflow: hidden;
     .gn-img-thumbnail {
+      border: 1px solid #ddd;
       margin: 0;
       min-height: 100%;
     }
   }
   .gn-md-no-thumbnail {
+    width: 140px;
+    height: 140px;
+    background-size: 140px 140px;
     background-image: url(../catalog/views/default/images/no-thumbnail.png);
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -32,7 +32,7 @@ ul.gn-resultview, [data-gn-user-searches-list] {
 
 // styling for all search results
 ul.gn-resultview {
-  @thumbnail-width: 170px;
+  @thumbnail-width: 140px;
   margin-right: -15px;
   
   .metadata {
@@ -106,12 +106,8 @@ ul.gn-resultview {
     }
   }
   .gn-md-abstract {
-    background-color: #fff;
     cursor: pointer;
     color: @gray-darker;
-    p {
-      background-color: #fff;
-    }
   }
   .gn-md-abstract.ellipsis:after {
     background: none;
@@ -152,8 +148,6 @@ ul.gn-resultview {
       float: left;
     }
     .gn-md-links {
-      //position: absolute;
-      //bottom: @grid-bottom-margin;
       background: none;
       position: absolute;
       bottom: 0px;
@@ -162,16 +156,12 @@ ul.gn-resultview {
     }
     
     .gn-md-thumbnail {
-      //position: absolute;
-      //top: 82px;
-      //opacity: .8;
       overflow: hidden;
       cursor: pointer;
       .gn-img-thumbnail {
         max-width: @thumbnail-width;
         max-height: 140px;
         min-height: 40px;
-        //margin: @grid-bottom-margin;
         height: auto;
       }
     }
@@ -217,17 +207,8 @@ ul.gn-resultview {
       border-radius: 0;
       margin-top: 5px;
     }
-    .gn-status {
+    .gn-status, .gn-workflow-status {
       position: relative;
-      border: 0;
-      padding: 0;
-      margin-top: 5px;
-      top: auto;
-      left: auto;
-      transform: none;
-      font-weight: 400;
-      font-size: 95%;
-      text-transform: uppercase;
       float: left;
       color: darken(@brand-info, 25%);
     }
@@ -240,36 +221,10 @@ ul.gn-resultview {
     .gn-status-obsolete {
       color: darken(@brand-danger, 20%);
     }
-    
-    // Same as before but with workflow statuses
     .gn-workflow-status {
-      border: 2px solid darken(@brand-info, 5%);
-      position: absolute;
-      top: 95px;
-      left: 115px;
-      border-radius: 6px;
-      padding: 2px;
-      -ms-transform: rotate(30deg);
-      -webkit-transform: rotate(30deg);
-      transform: rotate(30deg);
-      color: @brand-info;
-      font-weight: bold;
-      font-size: 80%;
       background-color: rgba(255, 255, 255 , 0.7);
       border-color: darken(@brand-success, 5%);
       color: @brand-success;
-    }
-    .gn-workflow-status-mdview {
-      position: relative;
-      top: 0;
-      left: 0;
-      display: inline-block;
-      font-size: 100%;
-      border-radius: 20px;
-      padding: 8px 12px;
-      font-weight: normal;
-      font-size: 80%;
-      transform: none;
     }
     /* Decide here which status should be displayed
     or not and with which colors */

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -24,6 +24,7 @@
 
 ul.gn-resultview, [data-gn-user-searches-list] {
   .gn-source-logo {
+    margin-left: 5px;
     z-index: 10;
     height: 20px;
     float: right;
@@ -82,22 +83,21 @@ ul.gn-resultview {
   }
   
   .gn-md-title {
-    margin-top: 2px;
+    margin-top: 10px;
     overflow: hidden;
     cursor: pointer;
     h3 {
-      
-      /* Leave space for selection checkbox */
-      //padding-left: 20px;
-      margin-top: 0px;
+      margin-top: 0;
+      line-height: 1.1em;
       a {
-        //text-transform: uppercase;
         font-weight: normal;
         font-size: 80%;
         color: #333333;
         text-overflow: ellipsis;
         overflow: hidden;
         display: block;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
       }
       a:hover {
         color: #428bca;
@@ -118,14 +118,12 @@ ul.gn-resultview {
     
     float: left;
     border: 1px solid @list-group-border;
-    //box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.4);
     min-width: 300px;
     max-width: 500px;
     width: calc(~"100% - 15px");
-    height: 20.5em;
+    height: 24em;
     padding: 14px;
     .gn-md-details {
-      //margin-left: @thumbnail-width;
       color: #6a6a6a;
       max-height: 50px;
       overflow: hidden;
@@ -136,25 +134,22 @@ ul.gn-resultview {
       vertical-align: text-bottom;
     }
     .gn-md-title {
-      min-height: 3.5em;
-      max-height: 3.5em;
-      h3{
-        a{
-          max-height: 82px;
-        }
-      }
+      margin-bottom: 5px;
+      min-height: 4em;
+      max-height: 4em;
     }
     input {
       float: left;
     }
     .gn-md-links {
       background: none;
+      padding: 5px;
+    }
+    .gn-toolbar {
       position: absolute;
       bottom: 0px;
       right: 0px;
-      padding: 5px;
     }
-    
     .gn-md-thumbnail {
       overflow: hidden;
       cursor: pointer;
@@ -228,9 +223,13 @@ ul.gn-resultview {
     }
     /* Decide here which status should be displayed
     or not and with which colors */
-    .gn-workflow-status-1 {
-      border-color: darken(@brand-danger, 5%);
-      color: @brand-danger;
+    .gn-workingcopy-status {
+      margin-top: 0;
+      i {
+        height: 34px;
+        width: 34px;
+        margin-top: -1px;
+      }
     }
     .gn-md-abstract {
       p {


### PR DESCRIPTION
Fix for: https://github.com/geonetwork/core-geonetwork/issues/3869

Uniform styling for the status on the search results and metadata page. The `no thumbnail` image is now in a separate `<div>`, otherwise the status badges would be displayed on top of the `no thumbnail` image.

The changes are made for both the `grid` and `list` search results.

**Screenshot after the changes:**
![gn-status-after](https://user-images.githubusercontent.com/19608667/59766218-fa66b080-929f-11e9-96b8-5a92d3d34da0.png)

Changes:
- new way to display no thumbnail image
- remove duplicate styles
- cleanup unused styles
- fix for background colour on hover for cards on the results list