### PR TITLE
WIP - Update mockito version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/harvesters/pom.xml
+++ b/harvesters/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -875,8 +875,8 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>1.10.19</version>
+        <artifactId>mockito-core</artifactId>
+        <version>2.28.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -887,8 +887,8 @@
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito</artifactId>
-        <version>1.6.4</version>
+        <artifactId>powermock-api-mockito2</artifactId>
+        <version>2.0.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/schemas-test/pom.xml
+++ b/schemas-test/pom.xml
@@ -74,7 +74,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -82,7 +82,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -184,7 +184,7 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- Apache commons csv -->


### PR DESCRIPTION
Replaces https://github.com/geonetwork/core-geonetwork/pull/3203 to use `mockito-core` instead of `mockito-all` that seem not maintained anymore.