### PR TITLE
Disable InspireValidatorUtilsTest#testLifeCycle test

### DIFF
--- a/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -32,6 +33,7 @@ public class InspireValidatorUtilsTest {
     }
 
     @Test
+    @Ignore
     public void testLifeCycle() {
 
         sm.setValue(Settings.SYSTEM_PROXY_USE, false);


### PR DESCRIPTION
It is hanging up the test processes waiting for a response from the upstream remote server.