### PR TITLE
Search results / Add template to display related record as list instead of dropdown

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/gridRelated.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/gridRelated.js
@@ -78,6 +78,8 @@
         },
         link: function(scope, element, attrs) {
           scope.location = window.location;
+          scope.max = attrs['max'] || 5;
+          scope.displayState = {};
           gnGridRelatedList.promise.then(function() {
             var related = gnGridRelatedList.list[scope.uuid];
             if (related) {

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -126,10 +126,6 @@
           <span>{{'workingCopy' | translate}}</span>
         </div>
       </div>
-      <div gn-grid-related
-           gn-grid-related-uuid="::md.getUuid()"
-           template="../../catalog/views/default/templates/gridRelated.html"></div>
-      <gn-links-btn></gn-links-btn>
     </div>
 
     </div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -126,6 +126,10 @@
           <span>{{'workingCopy' | translate}}</span>
         </div>
       </div>
+      <div gn-grid-related
+           gn-grid-related-uuid="::md.getUuid()"
+           template="../../catalog/views/default/templates/gridRelated.html"></div>
+      <gn-links-btn></gn-links-btn>
     </div>
 
     </div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -73,6 +73,10 @@
           <address ng-if="md.getContacts().resource">{{::md.getContacts().resource}}</address>
         </div>
 
+        <div gn-grid-related
+             gn-grid-related-uuid="::md.getUuid()"
+             template="../../catalog/views/default/templates/gridRelatedList.html"></div>
+
         <div class="row gn-md-links">
           <div class="btn-group" ng-if="::links.length > 0">
             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -144,6 +144,11 @@ goog.require('gn_alert');
                 'search/resultsview/partials/viewtemplates/grid.html',
             'tooltip': 'Grid',
             'icon': 'fa-th'
+          },{
+            'tplUrl': '../../catalog/components/' +
+              'search/resultsview/partials/viewtemplates/list.html',
+            'tooltip': 'List',
+            'icon': 'fa-bars'
           }],
           'resultTemplate': '../../catalog/components/' +
               'search/resultsview/partials/viewtemplates/grid.html',

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -451,6 +451,7 @@ span.gn-facet-label:first-letter {
     height: 140px;
     background-size: 140px 140px;
     background-image: url(../catalog/views/default/images/no-thumbnail.png);
+    height: 140px;
   }
 }
 
@@ -688,7 +689,7 @@ button.active [role=tooltip] {
   padding: 0;
   list-style: none;
   > li {
-    padding-left: 25px;
+    padding-left: 15px;
     &:hover {
       text-decoration: none;
       color: #262626;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -145,6 +145,10 @@ ul.gn-resultview {
       background: none;
       padding: 5px;
     }
+    [gn-grid-related] {
+      padding: 5px;
+      margin: 2px;
+    }
     .gn-toolbar {
       position: absolute;
       bottom: 0px;

--- a/web-ui/src/main/resources/catalog/views/default/templates/gridRelatedList.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/gridRelatedList.html
@@ -1,0 +1,14 @@
+<ul class="list-group" ng-if="::relations">
+    <ul ng-repeat="type in ::types"
+        ng-if="::relations[type]"
+        class="gn-related-list">
+      <li class="gn-related-type">{{type | translate}}</li>
+      <li ng-repeat="r in ::relations[type]" >
+        <a href="{{location.origin}}{{location.pathname}}#/metadata/{{r.id}}"
+           title="{{r.title | gnLocalized: lang}}">
+          {{r.title | gnLocalized: lang}}
+        </a>
+      </li>
+    </ul>
+  </ul>
+</ul>

--- a/web-ui/src/main/resources/catalog/views/default/templates/gridRelatedList.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/gridRelatedList.html
@@ -1,14 +1,22 @@
 <ul class="list-group" ng-if="::relations">
-    <ul ng-repeat="type in ::types"
-        ng-if="::relations[type]"
-        class="gn-related-list">
-      <li class="gn-related-type">{{type | translate}}</li>
-      <li ng-repeat="r in ::relations[type]" >
-        <a href="{{location.origin}}{{location.pathname}}#/metadata/{{r.id}}"
-           title="{{r.title | gnLocalized: lang}}">
-          {{r.title | gnLocalized: lang}}
-        </a>
-      </li>
-    </ul>
+  <ul ng-repeat="type in ::types"
+      ng-if="::relations[type]"
+      ng-init="displayState[type] = false;"
+      class="gn-related-list">
+    <li class="gn-related-type">
+      {{::relations[type].length}}&nbsp;{{type | translate}}
+    </li>
+    <li ng-repeat="r in ::relations[type]" >
+      <a ng-show="$index < max || displayState[type]"
+         href="{{location.origin}}{{location.pathname}}#/metadata/{{r.id}}"
+         title="{{r.title | gnLocalized: lang}}">
+        {{r.title | gnLocalized: lang}}
+      </a>
+    </li>
+    <li ng-if="relations[type].length > max && !display">
+      <a ng-click="displayState[type] = !displayState[type]">
+        {{relations[type].length - max}}&nbsp;{{(displayState[type] ? 'less' : 'more') | translate}} ...
+      </a>
+    </li>
   </ul>
 </ul>


### PR DESCRIPTION
Currently related records are displayed in a dropdown
![image](https://user-images.githubusercontent.com/1701393/60574339-bb455e80-9d79-11e9-8625-f8b53aa60c27.png)

In grid mode, it is probably good as we don't want to have variable height depending on number of related. When using row mode, this template is useful:

![image](https://user-images.githubusercontent.com/1701393/60574303-a8328e80-9d79-11e9-9c3b-2bca020f316e.png)
