### PR TITLE
Editor / Anchor support / Improve layout

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -237,16 +237,22 @@
       current element and its children (eg. @uom in gco:Distance).
       A list of exception is defined in form-builder.xsl#render-for-field-for-attribute. -->
       <xsl:apply-templates mode="render-for-field-for-attribute"
-                           select="
-            @*|
-            gn:attribute[not(@name = parent::node()/@*/name())]">
+                           select="@*">
         <xsl:with-param name="ref" select="gn:element/@ref"/>
         <xsl:with-param name="insertRef" select="$theElement/gn:element/@ref"/>
       </xsl:apply-templates>
       <xsl:apply-templates mode="render-for-field-for-attribute"
-                           select="
-        */@*|
-        */gn:attribute[not(@name = parent::node()/@*/name())]">
+                           select="*/@*">
+        <xsl:with-param name="ref" select="$theElement/gn:element/@ref"/>
+        <xsl:with-param name="insertRef" select="$theElement/gn:element/@ref"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates mode="render-for-field-for-attribute"
+                           select="gn:attribute[not(@name = parent::node()/@*/name())]">
+        <xsl:with-param name="ref" select="gn:element/@ref"/>
+        <xsl:with-param name="insertRef" select="$theElement/gn:element/@ref"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates mode="render-for-field-for-attribute"
+                           select="*/gn:attribute[not(@name = parent::node()/@*/name())]">
         <xsl:with-param name="ref" select="$theElement/gn:element/@ref"/>
         <xsl:with-param name="insertRef" select="$theElement/gn:element/@ref"/>
       </xsl:apply-templates>

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -581,7 +581,10 @@
               // Could be in the case it was already encoded.
               var input = element.parent().parent().find('[name=' + scope.conceptIdElementName + ']');
 
-              var isFirstMultilingualElement = element.prev('div.gn-keyword-picker-concept-id').length === 0;
+              var insertionPoint = isMultilingualMode ?
+                element.closest('div[data-gn-multilingual-field]').find('div.well') : element;
+
+              var isFirstMultilingualElement = insertionPoint.siblings('div.gn-keyword-picker-concept-id').length === 0;
 
               if ((!isMultilingualMode && input.length === 0) ||
                 // Add an extra form element to store the value
@@ -591,13 +594,18 @@
                 (isMultilingualMode && isFirstMultilingualElement && input.length === 0)) {
 
                 var conceptIdElement =  angular.element(
-                  '<div class="well well-sm gn-keyword-picker-concept-id">' +
-                  '<label class="col-sm-4" data-translate>Link</label>' +
-                  '<input name="' + scope.conceptIdElementName + '" ' +
+                  '<div class="well well-sm gn-keyword-picker-concept-id row">' +
+                  '  <div class="form-group">' +
+                  '    <label class="col-sm-4"><i class="fa fa-link fa-fw"/><span data-translate>URL</span></label>' +
+                  '    <div class="col-sm-6"><input name="' + scope.conceptIdElementName + '" ' +
                   '       class="gn-field-link form-control"/>' +
+                  '    </div>' +
+                  '    <div class="col-sm-2"><a class="btn btn-link" title="{{\'resetUrl\' | translate}}" data-ng-click="resetUrl()"><i class="fa fa-times text-danger"/></a></div>' +
+                  '  </div>' +
                   '</div>');
-                element.after(conceptIdElement);
-                }
+                insertionPoint[isMultilingualMode ? 'before' : 'after'](
+                  $compile(conceptIdElement)(scope));
+              }
             }
 
             // Init typeahead
@@ -644,14 +652,24 @@
                   // This directive may depend on others and populate
                   // the same target input field for the attribute.
                   // Use a search instead of a scope element to cope with init order.
-                  var input = element.parent().parent().find('[name=' + scope.conceptIdElementName + ']');
+
+                  var insertionPoint = isMultilingualMode ?
+                    element.closest('div[data-gn-multilingual-field]') : element;
+                  var input = insertionPoint.find('[name=' + scope.conceptIdElementName + ']');
                   input.val(keywordKey);
                 }
               }, $(element))
             );
 
 
-
+            scope.resetUrl = function () {
+              if(scope.conceptIdElementName) {
+                var insertionPoint = isMultilingualMode ?
+                  element.closest('div[data-gn-multilingual-field]') : element;
+                var input = insertionPoint.find('[name=' + scope.conceptIdElementName + ']');
+                input.val('');
+              }
+            };
 
             // When clicking the element trigger input
             // to show autocompletion list.

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -654,7 +654,7 @@
                   // Use a search instead of a scope element to cope with init order.
 
                   var insertionPoint = isMultilingualMode ?
-                    element.closest('div[data-gn-multilingual-field]') : element;
+                    element.closest('div[data-gn-multilingual-field]') : element.parent().parent();
                   var input = insertionPoint.find('[name=' + scope.conceptIdElementName + ']');
                   input.val(keywordKey);
                 }

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -246,6 +246,7 @@
     "upload": "Upload",
     "uuid": "Identifier",
     "url": "URL",
+    "resetUrl": "Reset URL",
     "records": "record(s)",
     "responsiblePartyEmail": "Contact",
     "call": "Call",

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -440,6 +440,16 @@ form.gn-editor.gn-label-above-input {
     width: 100%;
     text-align: left;
   }
+  // But do not for section in a well (eg. remove action)
+  // which are in one line label/control mode
+  .well {
+    .col-sm-2 {
+      width: 16.666%;
+    }
+    .col-sm-6 {
+      width: 50%;
+    }
+  }
   // Form field on a second row
   .col-sm-9 {
     width: 90%;

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1414,8 +1414,11 @@
     <xsl:variable name="fieldName"
                   select="concat('_', $ref, '_', replace($attributeName, ':', 'COLON'))"/>
 
-    <div class="form-group" id="gn-attr-{$fieldName}">
+    <div class="form-group gn-attr-{replace($attributeName, ':', '_')}" id="gn-attr-{$fieldName}">
       <label class="col-sm-4">
+        <xsl:if test="$attributeName = 'xlink:href'">
+          <i class="fa fa-link fa-fw"/>
+        </xsl:if>
         <xsl:value-of select="gn-fn-metadata:getLabel($schema, $attributeName, $labels)/label"/>
       </label>
       <div class="col-sm-7">
@@ -1500,7 +1503,7 @@
     <xsl:variable name="attributeLabel" select="gn-fn-metadata:getLabel($schema, @name, $labels)"/>
     <xsl:variable name="fieldName"
                   select="concat(replace(@name, ':', 'COLON'), '_', $insertRef)"/>
-    <button type="button" class="btn btn-default btn-xs btn-attr"
+    <button type="button" class="btn btn-default btn-xs btn-attr btn-xs gn-attr-{replace(@name, ':', '_')}"
             id="gn-attr-add-button-{$fieldName}"
             data-gn-click-and-spin="add('{$ref}', '{@name}', '{$insertRef}', null, true)"
             title="{$attributeLabel/description}">


### PR DESCRIPTION
Applies when using a thesaurus to populate the input text and keyword if to set the xlink:href of the Anchor.

Example configuration:
```xml
  <for name="gmd:useLimitation"
         use="data-gn-keyword-picker">
    <directiveAttributes
      data-thesaurus-key="external.theme.httpinspireeceuropaeumetadatacodelistLimitationsOnPublicAccess-LimitationsOnPublicAccess"
      data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
  </for>
```

Depending on the presence or not of the Anchor link, the UI was different when initializing the editor (URL above or below input depending if the record is multilingual or not). This was related to the fact that the keyword directive if not present add a new input after the element with JS and if the xlink:href attribute is present, then the XSL build the input.


After:
* Simple view (gn-label-above-input for multilingual record)

![image](https://user-images.githubusercontent.com/1701393/60822179-3f964800-a1a5-11e9-86c7-4369f49f4e7a.png)

* Simple view once URL is set

![image](https://user-images.githubusercontent.com/1701393/60822026-f645f880-a1a4-11e9-90cb-5d1846185b4b.png)

* Advanced view

![image](https://user-images.githubusercontent.com/1701393/60821652-42dd0400-a1a4-11e9-8c41-3d93cdfe3217.png)



This fix the layout by:
* Appending the URL element in the same position as if it was present in the XML
* Display first attributes with values and then + action for non existing attributes
* Use same label
* Add an icon for URL
* Add an action to reset the URL (~equivalent to the remove attribute action)
* Fix alignement if using the `form.gn-editor.gn-label-above-input` mode


Related to https://github.com/geonetwork/core-geonetwork/pull/3078 and https://github.com/geonetwork/core-geonetwork/issues/3120 but not that easy to fix when we have to support all standards and multilingual or not records.
