### PR TITLE
Search results / PDF improvements

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/main/SelectionSearch.java
+++ b/services/src/main/java/org/fao/geonet/services/main/SelectionSearch.java
@@ -65,7 +65,9 @@ public class SelectionSearch implements Service {
         SearchManager searchMan = gc.getBean(SearchManager.class);
 
         String bucket = Util.getParam(params, SELECTION_BUCKET, SELECTION_METADATA);
+        String formatter = Util.getParam(params, "formatter", "");
         params.removeChild(SELECTION_BUCKET);
+        params.removeChild("formatter");
 
         // store or possibly close old searcher
         UserSession session = context.getUserSession();
@@ -115,6 +117,7 @@ public class SelectionSearch implements Service {
 
         Element summary = searcher.getSummary();
         summary.addContent(new Element(SELECTION_BUCKET).setText(bucket));
+        summary.addContent(new Element("formatter").setText(formatter));
         return summary;
 
     }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -80,7 +80,7 @@
 
       <img class="gn-img-extent"
            alt="{$schemaStrings/thumbnail}"
-           src="{$nodeUrl}/eng/region.getmap.png?mapsrs={if ($mapproj != '')
+           src="{$nodeUrl}eng/region.getmap.png?mapsrs={if ($mapproj != '')
                                          then $mapproj
                                          else 'EPSG:3857'}&amp;width={
                                          if ($width != '')

--- a/web/src/main/webapp/loc/ara/xml/strings.xml
+++ b/web/src/main/webapp/loc/ara/xml/strings.xml
@@ -1648,4 +1648,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/cat/xml/strings.xml
+++ b/web/src/main/webapp/loc/cat/xml/strings.xml
@@ -1714,4 +1714,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Continguts</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/chi/xml/strings.xml
+++ b/web/src/main/webapp/loc/chi/xml/strings.xml
@@ -1628,4 +1628,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/dut/xml/strings.xml
+++ b/web/src/main/webapp/loc/dut/xml/strings.xml
@@ -1696,4 +1696,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/eng/xml/strings.xml
+++ b/web/src/main/webapp/loc/eng/xml/strings.xml
@@ -1671,4 +1671,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/fin/xml/strings.xml
+++ b/web/src/main/webapp/loc/fin/xml/strings.xml
@@ -1704,4 +1704,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/fre/xml/strings.xml
+++ b/web/src/main/webapp/loc/fre/xml/strings.xml
@@ -1712,4 +1712,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <onTheWeb>Plus d'information</onTheWeb>
+  <format>Format</format>
+  <spatialRepresentationType>Type de donnée</spatialRepresentationType>
+  <updateFrequency>Fréquence de mise à jour</updateFrequency>
+  <lastUpdate>Fiche mise à jour</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/ger/xml/strings.xml
+++ b/web/src/main/webapp/loc/ger/xml/strings.xml
@@ -1813,4 +1813,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/ita/xml/strings.xml
+++ b/web/src/main/webapp/loc/ita/xml/strings.xml
@@ -1680,4 +1680,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/nor/xml/strings.xml
+++ b/web/src/main/webapp/loc/nor/xml/strings.xml
@@ -1658,4 +1658,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/pol/xml/strings.xml
+++ b/web/src/main/webapp/loc/pol/xml/strings.xml
@@ -1734,4 +1734,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/por/xml/strings.xml
+++ b/web/src/main/webapp/loc/por/xml/strings.xml
@@ -1688,4 +1688,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/rus/xml/strings.xml
+++ b/web/src/main/webapp/loc/rus/xml/strings.xml
@@ -1695,4 +1695,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/spa/xml/strings.xml
+++ b/web/src/main/webapp/loc/spa/xml/strings.xml
@@ -1700,4 +1700,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contenidos</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/loc/tur/xml/strings.xml
+++ b/web/src/main/webapp/loc/tur/xml/strings.xml
@@ -1607,4 +1607,9 @@
   <unknown>Unknown</unknown>
 
   <pdfReportTocTitle>Contents</pdfReportTocTitle>
+  <format>Format</format>
+  <onTheWeb>More online information</onTheWeb>
+  <spatialRepresentationType>Data type</spatialRepresentationType>
+  <updateFrequency>Update frequency</updateFrequency>
+  <lastUpdate>Record updated</lastUpdate>
 </strings>

--- a/web/src/main/webapp/xslt/services/pdf/metadata-fop.xsl
+++ b/web/src/main/webapp/xslt/services/pdf/metadata-fop.xsl
@@ -22,27 +22,30 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exslt="http://exslt.org/common"
-                xmlns:geonet="http://www.fao.org/geonetwork" xmlns:fo="http://www.w3.org/1999/XSL/Format"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 version="2.0"
-                exclude-result-prefixes="exslt">
+                exclude-result-prefixes="#all">
 
 
   <!-- Some colors -->
-  <xsl:variable name="background-color">#d6e2f7</xsl:variable>
-  <xsl:variable name="background-color-banner">#ffffff</xsl:variable>
-  <xsl:variable name="background-color-thumbnail">#f1f2f3</xsl:variable>
-  <xsl:variable name="border-color">#b3c6e6</xsl:variable>
+  <xsl:variable name="background-color">#DDDDDD</xsl:variable>
+  <xsl:variable name="background-color-banner">#333333</xsl:variable>
+  <xsl:variable name="background-color-thumbnail">#FFFFFF</xsl:variable>
+  <xsl:variable name="border-color">#333333</xsl:variable>
 
   <xsl:variable name="header-border">2pt solid #2e456b</xsl:variable>
 
   <!-- Some font properties -->
-  <xsl:variable name="font-color">#707070</xsl:variable>
+  <xsl:variable name="link-color">#428BCA</xsl:variable>
+  <xsl:variable name="font-color">#333333</xsl:variable>
   <xsl:variable name="font-size">8pt</xsl:variable>
-  <xsl:variable name="font-family">verdana</xsl:variable>
-  <xsl:variable name="title-color">#2e456b</xsl:variable>
+  <xsl:variable name="font-family">Helvetica</xsl:variable>
+  <xsl:variable name="title-color">#FFFFFF</xsl:variable>
   <xsl:variable name="title-size">12pt</xsl:variable>
   <xsl:variable name="title-weight">bold</xsl:variable>
+  <xsl:variable name="label-weight">bold</xsl:variable>
   <xsl:variable name="header-color">#2e456b</xsl:variable>
   <xsl:variable name="header-size">16pt</xsl:variable>
   <xsl:variable name="header-weight">bold</xsl:variable>
@@ -63,25 +66,23 @@
   <xsl:variable name="df">[Y0001]-[M01]-[D01]</xsl:variable>
 
 
-  <!-- ======================================================
-    FOP master configuration A4 with margins
-    -->
+  <!-- FOP master configuration A4 with margins -->
   <xsl:template name="fop-master">
     <fo:layout-master-set>
       <fo:simple-page-master master-name="simpleA4" page-height="29.7cm" page-width="21cm"
-                             margin-top="1.25cm" margin-bottom="1cm" margin-left="2cm"
+                             margin-top=".5cm" margin-bottom=".5cm" margin-left="2cm"
                              margin-right="2cm">
-        <fo:region-body margin-top="1.5cm" margin-bottom="3cm" />
-        <fo:region-before extent="0.8cm" />
-        <fo:region-after extent="0.8cm" />
+        <fo:region-body margin-top="1.4cm" margin-bottom=".4cm"/>
+        <fo:region-before extent=".4cm"/>
+        <fo:region-after extent=".4cm"/>
       </fo:simple-page-master>
 
       <fo:simple-page-master master-name="Intro" page-height="29.7cm" page-width="21cm"
-                             margin-top="1.25cm" margin-bottom="1cm" margin-left="2cm"
+                             margin-top=".5cm" margin-bottom=".5cm" margin-left="2cm"
                              margin-right="2cm">
-        <fo:region-body margin-top="1.5cm" margin-bottom="3cm" />
-        <fo:region-before extent="0.8cm" />
-        <fo:region-after extent="0.8cm"/>
+        <fo:region-body margin-top="1.4cm" margin-bottom=".4cm"/>
+        <fo:region-before extent=".4cm"/>
+        <fo:region-after extent=".4cm"/>
       </fo:simple-page-master>
 
       <fo:page-sequence-master master-name="PSM_Name">
@@ -91,9 +92,6 @@
   </xsl:template>
 
 
-  <!-- ======================================================
-        Page header
-  -->
   <xsl:template name="fop-header">
     <fo:static-content flow-name="xsl-region-before">
       <fo:block font-size="{$header-text-size}" color="{$font-color}">
@@ -106,7 +104,7 @@
                           padding-left="4pt"
                           text-align="left">
                   <xsl:call-template name="replacePlaceholders">
-                    <xsl:with-param name="value" select="$env/metadata/pdfReport/headerLeft" />
+                    <xsl:with-param name="value" select="$env/metadata/pdfReport/headerLeft"/>
                   </xsl:call-template>
                 </fo:block>
               </fo:table-cell>
@@ -114,15 +112,13 @@
               <fo:table-cell>
                 <fo:block padding-top="4pt" padding-right="4pt"
                           padding-left="4pt"
-                          text-align="right"
-                >
+                          text-align="right">
                   <xsl:call-template name="replacePlaceholders">
-                    <xsl:with-param name="value" select="$env/metadata/pdfReport/headerRight" />
+                    <xsl:with-param name="value" select="$env/metadata/pdfReport/headerRight"/>
                   </xsl:call-template>
                 </fo:block>
               </fo:table-cell>
             </fo:table-row>
-
           </fo:table-body>
         </fo:table>
       </fo:block>
@@ -130,16 +126,10 @@
   </xsl:template>
 
 
-  <!-- ======================================================
-        Page footer with node info, date and paging info
-  -->
+  <!-- Footer with catalogue name, org name and pagination -->
   <xsl:template name="fop-footer">
-
-    <!-- Footer with catalogue name, org name and pagination -->
     <fo:static-content flow-name="xsl-region-after">
-
       <fo:block font-size="{$header-text-size}" color="{$font-color}">
-
         <fo:table width="100%" table-layout="fixed">
           <fo:table-body>
             <fo:table-row height="8mm">
@@ -148,7 +138,7 @@
                           padding-left="4pt"
                           text-align="left">
                   <xsl:call-template name="replacePlaceholders">
-                    <xsl:with-param name="value" select="$env/metadata/pdfReport/footerLeft" />
+                    <xsl:with-param name="value" select="$env/metadata/pdfReport/footerLeft"/>
                   </xsl:call-template>
                 </fo:block>
               </fo:table-cell>
@@ -157,17 +147,15 @@
                 <!-- FIXME : align all text on top and capitalize ? -->
                 <fo:block padding-top="4pt" padding-right="4pt"
                           padding-left="4pt"
-                          text-align="right"
-                >
+                          text-align="right">
                   <xsl:call-template name="replacePlaceholders">
-                    <xsl:with-param name="value" select="$env/metadata/pdfReport/footerRight" />
+                    <xsl:with-param name="value" select="$env/metadata/pdfReport/footerRight"/>
                   </xsl:call-template>
                   <xsl:if test="string($env/metadata/pdfReport/footerRight)"> | </xsl:if>
-                  <fo:page-number/> / <fo:page-number-citation ref-id="terminator"/>
+                  <fo:page-number/>/<fo:page-number-citation ref-id="terminator"/>
                 </fo:block>
               </fo:table-cell>
             </fo:table-row>
-
           </fo:table-body>
         </fo:table>
       </fo:block>
@@ -176,40 +164,38 @@
 
 
   <xsl:template name="replacePlaceholders">
-    <xsl:param name="value" />
+    <xsl:param name="value"/>
 
-    <xsl:value-of select="replace(replace($value, '\{date\}', format-dateTime(current-dateTime(),$df)),
-                                  '\{siteInfo\}', concat($env/system/site/name, '-', $env/system/site/organization))" />
+    <xsl:value-of select="replace(replace(
+                                $value, '\{date\}',
+                                format-dateTime(current-dateTime(),$df)),
+                                  '\{siteInfo\}',
+                                  concat($env/system/site/name, '-',
+                                         $env/system/site/organization))"/>
   </xsl:template>
 
 
-  <!-- ======================================================
-      TOC page
-  -->
   <xsl:template name="toc-page">
     <xsl:param name="res"/>
 
     <fo:block break-after="page">
-
-      <fo:block font-size="{$heading1-text-size}" font-weight="{$heading1-text-weight}" text-align="center" margin-bottom="10pt">
-        <xsl:value-of select="/root/gui/strings/pdfReportTocTitle" />
+      <fo:block font-size="{$heading1-text-size}"
+                font-weight="{$heading1-text-weight}"
+                text-align="center"
+                margin-bottom="10pt">
+        <xsl:value-of select="/root/gui/strings/pdfReportTocTitle"/>
       </fo:block>
 
 
-      <xsl:for-each select="$res/*[name() != 'summary' and name() != 'from' and name() != 'to']" >
-        <xsl:variable name="md">
-          <!--<xsl:apply-templates mode="briefPdf" select="."/>-->
-          <!-- Using search service with fast=index to retrieve the information directly from the index -->
-          <xsl:copy-of select="."/>
-        </xsl:variable>
-
-        <xsl:variable name="metadata" select="exslt:node-set($md)/*[1]"/>
-
-        <fo:block text-align-last="justify" font-size="{$toc-text-size}" color="{$title-color}">
-          <fo:basic-link internal-destination="section-{$metadata/geonet:info/id}">
-            <xsl:value-of select="$metadata/title" />
-            <fo:leader leader-pattern="space" />
-            <fo:page-number-citation ref-id="section-{$metadata/geonet:info/id}" />
+      <xsl:for-each select="$res/*[name() != 'summary' and name() != 'from' and name() != 'to']">
+        <fo:block text-align-last="justify"
+                  font-size="{$toc-text-size}"
+                  font-weight="{$label-weight}"
+                  color="{$font-color}">
+          <fo:basic-link internal-destination="section-{geonet:info/uuid}">
+            <xsl:value-of select="defaultTitle"/>
+            <fo:leader leader-pattern="space"/>
+            <fo:page-number-citation ref-id="section-{geonet:info/uuid}"/>
           </fo:basic-link>
         </fo:block>
       </xsl:for-each>
@@ -219,244 +205,197 @@
 
 
   <!--
-    gui to show a complex element
-  -->
-  <xsl:template name="complexElementFop">
-    <xsl:param name="title"/>
-    <xsl:param name="text"/>
-    <xsl:param name="content"/>
-
-    <!-- used as do*ElementAction url anchor to go back to the same position after editing operations -->
-    <xsl:param name="anchor">
-      <xsl:choose>
-
-        <!-- current node is an element -->
-        <xsl:when test="geonet:element/@ref">_
-          <xsl:value-of select="geonet:element/@ref"/>
-        </xsl:when>
-
-        <!-- current node is a new child: create anchor to parent -->
-        <xsl:when test="../geonet:element/@ref">_
-          <xsl:value-of select="../geonet:element/@ref"/>
-        </xsl:when>
-
-      </xsl:choose>
-    </xsl:param>
-
-    <fo:table-row>
-      <fo:table-cell>
-        <fo:block>
-          <fo:table width="100%" table-layout="fixed">
-            <fo:table-column column-width="3cm"/>
-            <fo:table-column column-width="12cm"/>
-            <fo:table-column column-width="1cm"/>
-            <fo:table-body>
-              <fo:table-row border-top-style="solid" border-right-style="solid"
-                            border-left-style="solid" border-top-color="{$background-color}"
-                            border-right-color="{$background-color}"
-                            border-left-color="{$background-color}">
-                <fo:table-cell padding-left="4pt" padding-right="4pt" padding-top="4pt"
-                               margin-top="4pt" number-columns-spanned="3">
-                  <fo:block border-top="2pt solid black">
-                    <fo:inline>
-                      <xsl:text>::</xsl:text>
-                      <xsl:value-of select="$title"/>
-                    </fo:inline>
-                  </fo:block>
-                </fo:table-cell>
-              </fo:table-row>
-              <fo:table-row>
-                <fo:table-cell>
-                  <fo:block/>
-                </fo:table-cell>
-                <fo:table-cell>
-                  <fo:block>
-                    <xsl:variable name="n" select="exslt:node-set($content)"/>
-                    <xsl:if test="$n/node()">
-                      <fo:table table-layout="fixed" width="100%" border-collapse="separate">
-                        <fo:table-body>
-                          <xsl:copy-of select="$content"/>
-                        </fo:table-body>
-                      </fo:table>
-                    </xsl:if>
-                  </fo:block>
-                </fo:table-cell>
-              </fo:table-row>
-            </fo:table-body>
-          </fo:table>
-        </fo:block>
-      </fo:table-cell>
-    </fo:table-row>
-
-  </xsl:template>
-
-
-  <!--
-   gui to show a block element
- -->
-  <xsl:template name="blockElementFop">
-    <xsl:param name="block"/>
-    <xsl:param name="label"/>
-    <xsl:param name="color">blue</xsl:param>
-
-    <fo:table-row>
-      <fo:table-cell padding-left="4pt" padding-right="4pt" padding-top="4pt" margin-top="4pt"
-                     number-columns-spanned="2">
-        <fo:block>
-          <xsl:if test="$block != ''">
-            <xsl:if test="$label!=''">
-              <fo:inline font-size="{$title-size}" font-weight="{$title-weight}"
-                         color="{$title-color}" margin="8pt">
-                <xsl:value-of select="$label"/>
-              </fo:inline>
-            </xsl:if>
-            <fo:table width="100%" table-layout="fixed">
-              <fo:table-column column-width="5cm"/>
-              <fo:table-column column-width="15cm"/>
-              <fo:table-body>
-                <xsl:copy-of select="$block"/>
-              </fo:table-body>
-            </fo:table>
-          </xsl:if>
-        </fo:block>
-      </fo:table-cell>
-    </fo:table-row>
-  </xsl:template>
-
-  <!-- ===========================================
-    metadata result to fop
+    Print search results as PDF
   -->
   <xsl:template name="fo">
     <xsl:param name="res"/>
 
-    <xsl:for-each select="$res/*[name() != 'summary' and name() != 'from' and name() != 'to']">
+    <fo:table>
+      <fo:table-column column-width="17cm"/>
+      <fo:table-body>
+        <xsl:for-each select="$res/*[name() != 'summary' and name() != 'from' and name() != 'to']">
 
-      <xsl:variable name="md">
-        <!--<xsl:apply-templates mode="briefPdf" select="."/>-->
-        <!-- Using search service with fast=index to retrieve the information directly from the index -->
-        <xsl:copy-of select="."/>
-      </xsl:variable>
-      <xsl:variable name="metadata" select="exslt:node-set($md)/*[1]"/>
-      <xsl:variable name="source" select="string($metadata/geonet:info/source)"/>
+          <xsl:variable name="source" select="string(geonet:info/source)"/>
 
+          <xsl:if test="geonet:info/id != ''">
+            <fo:table-row border-top-style="solid"
+                          border-right-style="solid"
+                          border-left-style="solid"
+                          border-top-color="{$background-color}"
+                          border-right-color="{$background-color}"
+                          border-left-color="{$background-color}"
+                          page-break-inside="avoid">
+              <fo:table-cell display-align="center"
+                             background-color="{$background-color-banner}">
+                <fo:block text-align="center"
+                          font-weight="{$title-weight}"
+                          font-size="{$title-size}" color="{$title-color}"
+                          padding-top="4pt" padding-bottom="4pt"
+                          padding-left="4pt" padding-right="4pt"
+                          id="section-{geonet:info/uuid}">
+                  <xsl:value-of select="defaultTitle"/>
+                </fo:block>
+              </fo:table-cell>
+            </fo:table-row>
+            <fo:table-row keep-with-previous.within-page="always"
+                          page-break-inside="avoid">
+              <fo:table-cell>
+                <fo:block margin-left="0pt" margin-right="0pt"
+                          margin-top="4pt" margin-bottom="4pt">
 
-      <xsl:if test="$metadata/geonet:info/id != ''">
-        <fo:table-row border-top-style="solid" border-right-style="solid" border-left-style="solid"
-                      border-top-color="{$background-color}"
-                      border-right-color="{$background-color}"
-                      border-left-color="{$background-color}"
-                      page-break-inside="avoid">
-          <fo:table-cell padding-left="4pt" padding-right="4pt" padding-top="4pt" margin-top="4pt">
-            <fo:block>
-              <fo:external-graphic content-width="35pt">
-                <xsl:attribute name="src">url('<xsl:value-of
-                  select="concat($baseURL, '/images/logos/', $source , '.gif')"
-                />')"
-                </xsl:attribute>
-              </fo:external-graphic>
-            </fo:block>
-          </fo:table-cell>
-          <fo:table-cell display-align="center">
-            <fo:block font-weight="{$title-weight}" font-size="{$title-size}" color="{$title-color}"
-                      padding-top="4pt" padding-bottom="4pt" padding-left="4pt" padding-right="4pt"
-                      id="section-{$metadata/geonet:info/id}">
-              <xsl:value-of select="$metadata/title"/>
-            </fo:block>
-          </fo:table-cell>
-        </fo:table-row>
-        <fo:table-row border-bottom-style="solid" border-right-style="solid"
-                      border-left-style="solid" border-bottom-color="{$background-color}"
-                      border-right-color="{$background-color}"
-                      border-left-color="{$background-color}"
-                      keep-with-previous.within-page="always"
-                      page-break-inside="avoid">
-          <fo:table-cell number-columns-spanned="2">
-            <fo:block margin-left="2pt" margin-right="4pt" margin-top="4pt" margin-bottom="4pt">
-              <fo:table>
-                <fo:table-column column-width="11.8cm"/>
-                <fo:table-column column-width="4.8cm"/>
-                <fo:table-body>
-                  <fo:table-row>
-                    <fo:table-cell>
-                      <fo:block>
+                  <fo:table>
+                    <fo:table-column column-width="3cm"/>
+                    <fo:table-column column-width="13cm"/>
+                    <fo:table-body>
 
-                        <!-- Labels and values-->
-                        <fo:table>
-                          <fo:table-column column-width="2.5cm"/>
-                          <fo:table-column column-width="9.3cm"/>
-
-                          <fo:table-body>
-                            <xsl:call-template name="info-rows">
-                              <xsl:with-param name="label" select="$oldGuiStrings/uuid"/>
-                              <xsl:with-param name="value" select="$metadata/geonet:info/uuid"/>
-                            </xsl:call-template>
-
-
-                            <xsl:call-template name="info-rows">
-                              <xsl:with-param name="label" select="$oldGuiStrings/abstract"/>
-                              <xsl:with-param name="value" select="$metadata/abstract"/>
-                            </xsl:call-template>
-
-
-                            <xsl:call-template name="info-rows">
-                              <xsl:with-param name="label" select="$oldGuiStrings/keywords"/>
-                              <xsl:with-param name="value"
-                                              select="string-join($metadata/keyword, ', ')"/>
-                            </xsl:call-template>
-
-
-                            <xsl:call-template name="info-rows">
-                              <xsl:with-param name="label" select="$oldGuiStrings/schema"/>
-                              <xsl:with-param name="value" select="$metadata/geonet:info/schema"/>
-                            </xsl:call-template>
-
-                            <xsl:call-template name="metadata-resources">
-                              <xsl:with-param name="gui" select="$oldGuiStrings"/>
-                              <xsl:with-param name="metadata" select="$metadata"/>
-                            </xsl:call-template>
-
-                          </fo:table-body>
-                        </fo:table>
-
-                      </fo:block>
-                    </fo:table-cell>
-                    <fo:table-cell background-color="{$background-color-thumbnail}">
-                      <xsl:call-template name="metadata-thumbnail-block">
-                        <xsl:with-param name="metadata" select="$metadata"/>
+                      <xsl:call-template name="info-rows">
+                        <xsl:with-param name="label" select="$oldGuiStrings/abstract"/>
+                        <xsl:with-param name="value" select="abstract"/>
                       </xsl:call-template>
-                    </fo:table-cell>
-                  </fo:table-row>
-                </fo:table-body>
-              </fo:table>
-            </fo:block>
-          </fo:table-cell>
-        </fo:table-row>
-        <fo:table-row height=".3cm">
-          <fo:table-cell>
-            <fo:block/>
-          </fo:table-cell>
-        </fo:table-row>
-      </xsl:if>
-    </xsl:for-each>
+
+                      <xsl:call-template name="info-rows">
+                        <xsl:with-param name="label" select="$oldGuiStrings/extent"/>
+                        <xsl:with-param name="content">
+                          <xsl:for-each select="geoBox[. != '']">
+                            <xsl:variable name="coords"
+                                          select="tokenize(normalize-space(.), '\|')"/>
+                            <xsl:variable name="url"
+                                          select="concat($nodeUrl, 'eng/region.getmap.png?mapsrs=EPSG:3857&amp;width=300&amp;background=settings&amp;geomsrs=EPSG:4326&amp;geom=Polygon((', $coords[1], ' ', $coords[2], ',', $coords[1], ' ', $coords[4], ',', $coords[3], ' ', $coords[4], ',', $coords[3], ' ', $coords[2], ',', $coords[1], ' ', $coords[2], '))')"/>
+                            <fo:basic-link text-decoration="underline"
+                                           color="$link-color"
+                                           external-destination="{$url}">
+                              <fo:external-graphic padding-left="4pt"
+                                                   content-width="100%">
+                                <xsl:attribute name="src">url('<xsl:value-of
+                                  select="$url"
+                                />')"
+                                </xsl:attribute>
+                              </fo:external-graphic>
+                            </fo:basic-link>
+                          </xsl:for-each>
+                        </xsl:with-param>
+                      </xsl:call-template>
+
+
+                      <xsl:call-template name="info-rows">
+                        <xsl:with-param name="label" select="$oldGuiStrings/keywords"/>
+                        <xsl:with-param name="value"
+                                        select="string-join(keyword, ', ')"/>
+                      </xsl:call-template>
+
+                      <xsl:if test="spatialRepresentationType_text">
+                        <xsl:call-template name="info-rows">
+                          <xsl:with-param name="label" select="$oldGuiStrings/spatialRepresentationType"/>
+                          <xsl:with-param name="value"
+                                          select="string-join(spatialRepresentationType_text, ', ')"/>
+                        </xsl:call-template>
+                      </xsl:if>
+
+                      <xsl:if test="format">
+                        <xsl:call-template name="info-rows">
+                          <xsl:with-param name="label" select="$oldGuiStrings/format"/>
+                          <xsl:with-param name="value"
+                                          select="string-join(format, ', ')"/>
+                        </xsl:call-template>
+                      </xsl:if>
+
+                      <xsl:if test="maintenanceAndUpdateFrequency_text">
+                        <xsl:call-template name="info-rows">
+                          <xsl:with-param name="label" select="$oldGuiStrings/updateFrequency"/>
+                          <xsl:with-param name="value"
+                                          select="string-join(maintenanceAndUpdateFrequency_text, ', ')"/>
+                        </xsl:call-template>
+                      </xsl:if>
+
+                      <xsl:call-template name="info-rows">
+                        <xsl:with-param name="label" select="$oldGuiStrings/uuid"/>
+                        <xsl:with-param name="value" select="geonet:info/uuid"/>
+                        <xsl:with-param name="content">
+                          <fo:external-graphic padding-left="4pt"
+                                               content-width="9pt">
+                            <xsl:attribute name="src">url('<xsl:value-of
+                              select="concat($baseURL, 'images/logos/', $source , '.png')"
+                            />')"
+                            </xsl:attribute>
+                          </fo:external-graphic>
+                        </xsl:with-param>
+                      </xsl:call-template>
+
+                      <xsl:call-template name="info-rows">
+                        <xsl:with-param name="label" select="$oldGuiStrings/lastUpdate"/>
+                        <xsl:with-param name="value"
+                                        select="geonet:info/changeDate"/>
+                      </xsl:call-template>
+
+                      <xsl:call-template name="metadata-resources">
+                        <xsl:with-param name="gui" select="$oldGuiStrings"/>
+                        <xsl:with-param name="metadata" select="."/>
+                      </xsl:call-template>
+
+                      <xsl:call-template name="info-rows">
+                        <xsl:with-param name="label" select="$oldGuiStrings/onTheWeb"/>
+                        <xsl:with-param name="content">
+                          <fo:inline>
+                            <xsl:value-of select="$oldGuiStrings/show"/>
+                            <xsl:text> </xsl:text>
+                            <fo:basic-link text-decoration="underline" color="$link-color">
+                              <xsl:attribute name="external-destination">url('<xsl:value-of
+                                select="concat($nodeUrl, 'api/records/', geonet:info/uuid)"
+                              />')
+                              </xsl:attribute>HTML
+                            </fo:basic-link>
+                            <fo:basic-link text-decoration="underline" color="$link-color">
+                              <xsl:attribute name="external-destination">url('<xsl:value-of
+                                select="concat($nodeUrl, 'api/records/', geonet:info/uuid, '/formatters/xsl-view?view=advanced&amp;output=pdf')"/>')
+                              </xsl:attribute>PDF
+                            </fo:basic-link>
+                            <fo:basic-link text-decoration="underline" color="$link-color">
+                              <xsl:attribute name="external-destination">url('<xsl:value-of
+                                select="concat($nodeUrl, 'api/records/', geonet:info/uuid, '/formatters/xml')"
+                              />')
+                              </xsl:attribute>XML (<xsl:value-of select="if (standardName != '') then standardName else geonet:info/schema"/>)
+                            </fo:basic-link>
+                          </fo:inline>
+
+                        </xsl:with-param>
+                      </xsl:call-template>
+                    </fo:table-body>
+                  </fo:table>
+                </fo:block>
+              </fo:table-cell>
+            </fo:table-row>
+            <fo:table-row>
+              <fo:table-cell background-color="{$background-color-thumbnail}">
+                <xsl:call-template name="metadata-thumbnail-block">
+                  <xsl:with-param name="metadata" select="."/>
+                </xsl:call-template>
+              </fo:table-cell>
+            </fo:table-row>
+          </xsl:if>
+        </xsl:for-each>
+      </fo:table-body>
+    </fo:table>
   </xsl:template>
 
 
-  <!-- Metadata thumbnail -->
+
+
   <xsl:template name="metadata-thumbnail-block">
     <xsl:param name="metadata"/>
 
-    <fo:block padding-top="4pt" padding-bottom="4pt" padding-right="4pt" padding-left="4pt">
+    <fo:block display-align="center"
+              padding-top="4pt" padding-bottom="4pt" padding-right="4pt" padding-left="4pt">
       <!-- Format:
          <image>thumbnail|resources.get?uuid=da165110-88fd-11da-a88f-000d939bc5d8&fname=thumbnail_s.gif&access=public</image>
       -->
 
       <!-- Thumbnails - Use the first one only -->
-      <xsl:if test="$metadata/image">
-        <xsl:variable name="image" select="tokenize($metadata/image[1], '\|')[2]"/>
+      <xsl:for-each select="$metadata/image">
+        <xsl:variable name="image" select="tokenize(., '\|')[2]"/>
 
         <xsl:choose>
           <xsl:when test="contains($image ,'://')">
-            <fo:external-graphic content-width="4.6cm">
+            <fo:external-graphic content-width="15cm">
               <xsl:attribute name="src">
                 <xsl:text>url('</xsl:text>
                 <xsl:value-of select="$image"/>
@@ -465,7 +404,7 @@
             </fo:external-graphic>
           </xsl:when>
           <xsl:otherwise>
-            <fo:external-graphic content-width="4.6cm">
+            <fo:external-graphic content-width="15cm">
               <xsl:attribute name="src">
                 <xsl:text>url('</xsl:text>
                 <xsl:value-of
@@ -475,7 +414,8 @@
             </fo:external-graphic>
           </xsl:otherwise>
         </xsl:choose>
-      </xsl:if>
+        <fo:block/>
+      </xsl:for-each>
     </fo:block>
   </xsl:template>
 
@@ -493,43 +433,15 @@
     <xsl:call-template name="info-rows">
       <xsl:with-param name="label" select="if ($title) then $oldGuiStrings/resources else ''"/>
       <xsl:with-param name="content">
-        <xsl:choose>
-          <xsl:when test="$remote=false()">
-            <fo:basic-link text-decoration="underline" color="blue">
-              <xsl:attribute name="external-destination">url('<xsl:value-of
-                select="concat($baseURL, '?uuid=', $metadata/geonet:info/uuid)"
-              />')
-              </xsl:attribute>
-              <xsl:value-of select="$oldGuiStrings/show"/>
-            </fo:basic-link>
-            <fo:block/>
-            <fo:basic-link text-decoration="underline" color="blue">
-              <xsl:attribute name="external-destination">url('<xsl:value-of
-                select="concat($baseURL, '/srv/', $lang, '/xml.metadata.get?uuid=', $metadata/geonet:info/uuid)"
-              />')
-              </xsl:attribute>
-              <xsl:value-of select="$oldGuiStrings/show"/> (XML)
-            </fo:basic-link>
-            <fo:block/>
-          </xsl:when>
-          <xsl:otherwise>
-            <fo:block text-align="left" font-style="italic">
-              <xsl:text>Z3950: </xsl:text>
-              <xsl:value-of select="$metadata/geonet:info/server"/>
-              <xsl:text> </xsl:text>
-            </fo:block>
-          </xsl:otherwise>
-        </xsl:choose>
-
         <xsl:if test="$metadata/geonet:info/download='true'">
           <!-- Format:
           <link>phy.zip|Physiography of North and Central Eurasia Landform (Gif Format)|http://localhost:8080/geonetwork/srv/en/resources.get?uuid=78f93047-74f8-4419-ac3d-fc62e4b0477b&fname=phy.zip&access=private|WWW:DOWNLOAD-1.0-http- -download|application/zip</link>
           -->
 
-          <xsl:for-each select="$metadata/link[contains(., 'WWW:DOWNLOAD-1.0-http--download')]">
+          <xsl:for-each select="$metadata/link[contains(., 'WWW:DOWNLOAD')]">
             <xsl:variable name="link" select="tokenize(., '\|')[3]"/>
 
-            <fo:basic-link text-decoration="underline" color="blue">
+            <fo:basic-link text-decoration="underline" color="$link-color">
               <xsl:attribute name="external-destination">url('<xsl:value-of select="$link"/>')
               </xsl:attribute>
               <xsl:value-of select="$oldGuiStrings/download"/>
@@ -547,7 +459,7 @@
             <xsl:variable name="title" select="tokenize(., '\|')[2]"/>
             <xsl:variable name="link" select="tokenize(., '\|')[3]"/>
 
-            <fo:basic-link text-decoration="underline" color="blue">
+            <fo:basic-link text-decoration="underline" color="$link-color">
               <xsl:attribute name="external-destination">url('<xsl:value-of select="$link"/>')
               </xsl:attribute>
               <xsl:value-of select="$oldGuiStrings/visualizationService"/> (<xsl:value-of
@@ -562,61 +474,27 @@
   </xsl:template>
 
 
-  <!--
-    main pdf banner
-  -->
-  <xsl:template name="banner">
-    <fo:table table-layout="fixed" width="100%">
-      <fo:table-column column-width="20cm"/>
-      <!--<fo:table-column column-width="4cm"/>-->
-      <fo:table-body>
-        <fo:table-row border-bottom-style="solid" border-bottom-color="{$header-color}"
-                      border-bottom-width="1pt">
-          <fo:table-cell display-align="center" background-color="{$background-color-banner}">
-            <!-- FIXME : align all text on top and capitalize ? -->
-            <fo:block font-family="{$font-family}" font-size="{$header-size}" color="{$title-color}"
-                      font-weight="{$header-weight}" padding-top="4pt" padding-right="4pt"
-                      padding-left="4pt">
-              <fo:external-graphic padding-right="4pt">
-                <xsl:attribute name="src">url('<xsl:value-of
-                  select="concat($baseURL, '/images/logos/', $env/system/site/siteId, '.gif')"
-                />')"
-                </xsl:attribute>
-              </fo:external-graphic>
-              <xsl:value-of select="upper-case($env/system/site/name)"/> (<xsl:value-of
-              select="upper-case($env/system/site/organization)"/>)
-            </fo:block>
-          </fo:table-cell>
-          <!-- <fo:table-cell display-align="right" text-align="top"
-            background-color="{$background-color-banner}">
-            <fo:block text-align="right" font-family="{$font-family}" font-size="{$header-size}"
-              color="{$header-color}" font-weight="{$header-weight}"
-              padding-top="4pt" padding-bottom="4pt" padding-right="4pt" padding-left="4pt">
-              <xsl:value-of select="upper-case(/root/gui/strings/searchResult)"/>
-            </fo:block>
-          </fo:table-cell>-->
-        </fo:table-row>
-      </fo:table-body>
-    </fo:table>
-  </xsl:template>
-
   <xsl:template name="info-rows">
     <xsl:param name="label"/>
     <xsl:param name="value"/>
     <xsl:param name="content"/>
-    <fo:table-row border-bottom-style="solid" border-top-style="solid"
-                  border-top-color="{$title-color}" border-top-width=".1pt"
-                  border-bottom-color="{$title-color}"
-                  border-bottom-width=".1pt">
+    <fo:table-row>
       <fo:table-cell background-color="{if ($label != '') then $background-color else ''}"
-                     color="{$title-color}" padding-top="4pt" padding-bottom="4pt"
-                     padding-right="4pt"
-                     padding-left="4pt">
-        <fo:block linefeed-treatment="preserve">
+                     border-top-style="solid"
+                     border-top-color="{$title-color}" border-top-width=".1pt"
+                     color="{$font-color}"
+                     padding-top="4pt" padding-bottom="4pt"
+                     padding-right="4pt" padding-left="4pt">
+        <fo:block linefeed-treatment="preserve"
+                  font-weight="{$label-weight}"
+                  font-family="{$font-family}" >
           <xsl:value-of select="$label"/>
         </fo:block>
       </fo:table-cell>
-      <fo:table-cell color="{$font-color}" padding-top="4pt" padding-bottom="4pt"
+      <fo:table-cell color="{$font-color}"
+                     border-top-style="solid"
+                     border-top-color="{$font-color}" border-top-width=".1pt"
+                     padding-top="4pt" padding-bottom="4pt"
                      padding-right="4pt" padding-left="4pt">
         <fo:block linefeed-treatment="preserve">
           <xsl:value-of select="$value"/>

--- a/web/src/main/webapp/xslt/services/pdf/portal-present-fop.xsl
+++ b/web/src/main/webapp/xslt/services/pdf/portal-present-fop.xsl
@@ -21,17 +21,14 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
-
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:geonet="http://www.fao.org/geonetwork"
-                version="2.0" exclude-result-prefixes="xsl geonet">
-
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                version="2.0"
+                exclude-result-prefixes="#all">
 
   <xsl:include href="../../common/profiles-loader-tpl-brief.xsl"/>
   <xsl:include href="metadata-fop.xsl"/>
 
-  <!--
-    Start FOP layout
-  -->
   <xsl:template match="/root">
     <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format"
              xmlns:fox="http://xmlgraphics.apache.org/fop/extensions">
@@ -63,52 +60,38 @@
         <fox:external-document content-type="pdf" src="{$env/metadata/pdfReport/introPdf}" />
       </xsl:if>
 
-      <fo:page-sequence master-reference="simpleA4" initial-page-number="1">
+      <xsl:variable name="formatter"
+                    select="/root/request/formatter"/>
 
-        <xsl:call-template name="fop-header"/>
-        <xsl:call-template name="fop-footer"/>
+      <xsl:choose>
+        <xsl:when test="$formatter != ''">
+          <!-- Experimental / Combine all record using a dedicated formatter.
+          This does not work for private record as fox is using HTTP call
+          without authentication. Also paging will not work and link from
+          toc does not. -->
+          <xsl:for-each select="/root/response/*[name() != 'summary' and name() != 'from' and name() != 'to']" >
+            <fox:external-document content-type="pdf"
+                                   src="{concat($nodeUrl, 'api/records/', geonet:info/uuid, '/formatters/', $formatter)}" />
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <fo:page-sequence master-reference="simpleA4" initial-page-number="1">
 
-        <fo:flow flow-name="xsl-region-body">
+            <xsl:call-template name="fop-header"/>
+            <xsl:call-template name="fop-footer"/>
 
-          <fo:block font-size="{$font-size}">
+            <fo:flow flow-name="xsl-region-body">
+              <fo:block font-size="{$font-size}">
+                    <xsl:call-template name="fo">
+                      <xsl:with-param name="res" select="/root/response"/>
+                    </xsl:call-template>
+              </fo:block>
+              <fo:block id="terminator"/>
+            </fo:flow>
+          </fo:page-sequence>
+        </xsl:otherwise>
+      </xsl:choose>
 
-            <fo:table width="100%" table-layout="fixed">
-              <fo:table-column column-width="1.8cm"/>
-              <fo:table-column column-width="15.2cm"/>
-              <fo:table-body>
-                <fo:table-row height="8mm">
-                  <fo:table-cell display-align="center" number-columns-spanned="2">
-                    <fo:block text-align="center" color="{$font-color}">
-                      <xsl:value-of select="/root/response/summary/@count"/>
-                      <xsl:text> </xsl:text>
-                      <xsl:value-of select="/root/gui/strings/ress"/>
-                      <xsl:if test="/root/response/summary/@count &gt; 1">s</xsl:if>
-                    </fo:block>
-                  </fo:table-cell>
-                </fo:table-row>
-
-                <xsl:call-template name="fo">
-                  <xsl:with-param name="res" select="/root/response"/>
-                </xsl:call-template>
-
-              </fo:table-body>
-            </fo:table>
-          </fo:block>
-
-          <fo:block id="terminator"/>
-        </fo:flow>
-      </fo:page-sequence>
     </fo:root>
   </xsl:template>
-
-  <!-- ============================================================== -->
-
-  <xsl:template match="geonet:info/title" mode="strip"/>
-
-  <xsl:template match="@*|node()" mode="strip">
-    <xsl:copy>
-      <xsl:apply-templates select="@*|node()" mode="strip"/>
-    </xsl:copy>
-  </xsl:template>
-
 </xsl:stylesheet>


### PR DESCRIPTION
* Remove unused code
* Style PDF with same colors as in angular view (no more old 2.10 blue)

![image](https://user-images.githubusercontent.com/1701393/60876991-3a84d780-a23d-11e9-9e9a-7b7d7a824b3d.png)

* Add extent, resource type, last update, all overviews
* Create section for metadata link in HTML/PDF/XML with proper link to
formatters
* (Experimental) Add option to use a formatter (only works for public record, looks to be quite slow and memory consuming) - it would be better to use iText in Java directly


Examples
* Default
[apur_catalogue_20190709111725.pdf](https://github.com/geonetwork/core-geonetwork/files/3372273/apur_catalogue_20190709111725.pdf)

* With formatter
[apur_catalogue_20190709112639.pdf](https://github.com/geonetwork/core-geonetwork/files/3372277/apur_catalogue_20190709112639.pdf)



