### PR TITLE
Editor / Validation / INSPIRE / Add support for TG2

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -23,27 +23,14 @@
 
 package org.fao.geonet.api.records;
 
-import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactoryConfigurationError;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import javassist.NotFoundException;
+import jeeves.server.context.ServiceContext;
+import jeeves.services.ReadWriteController;
 import org.apache.http.HttpStatus;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
@@ -57,7 +44,6 @@ import org.fao.geonet.api.records.formatters.cache.Key;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
-import org.fao.geonet.events.history.RecordProcessingChangeEvent;
 import org.fao.geonet.events.history.RecordValidationTriggeredEvent;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.EditLib;
@@ -78,102 +64,135 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import javassist.NotFoundException;
-import jeeves.server.context.ServiceContext;
-import jeeves.services.ReadWriteController;
 import org.springframework.web.context.request.NativeWebRequest;
 import springfox.documentation.annotations.ApiIgnore;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
+
 @RequestMapping(value = {
-        "/{portal}/api/records",
-        "/{portal}/api/" + API.VERSION_0_1 +
+    "/{portal}/api/records",
+    "/{portal}/api/" + API.VERSION_0_1 +
         "/records"
 })
 @Api(value = API_CLASS_RECORD_TAG,
-tags = API_CLASS_RECORD_TAG)
+    tags = API_CLASS_RECORD_TAG)
 @Controller("inspire")
 @PreAuthorize("hasRole('Editor')")
 @ReadWriteController
 public class InspireValidationApi {
 
     @Autowired
-    private SettingManager settingManager;
-
+    SettingManager settingManager;
+    @Autowired
+    InspireValidatorUtils inspireValidatorUtils;
+    @Autowired
+    LanguageUtils languageUtils;
+    String supportedSchemaRegex = "(iso19139|iso19115-3).*";
     @Autowired
     private SchemaManager schemaManager;
 
-    @Autowired
-    private DataManager dataManager;
-
-    String supportedSchemaRegex = "(iso19139|iso19115-3).*";
-
-    @Autowired
-    LanguageUtils languageUtils;
-
     @ApiOperation(
-            value = "Submit a record to the INSPIRE service for validation.",
-            notes = "User MUST be able to edit the record to validate it. "
-                    + "An INSPIRE endpoint must be configured in Settings. "
-                    + "This activates an asyncronous process, this method does not return any report. "
-                    + "This method returns an id to be used to get the report.",
-                    nickname = "submitValidate")
-    @RequestMapping(value = "/{metadataUuid}/validate/inspire",
-    method = RequestMethod.PUT,
-    produces = {
-            MediaType.TEXT_PLAIN_VALUE
-    }
-            )
+        value = "Get test suites available.",
+        notes = "TG13, TG2, ...",
+        nickname = "getTestSuites")
+    @RequestMapping(value = "/{metadataUuid}/validate/inspire/testsuites",
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.APPLICATION_JSON_VALUE
+        })
     @PreAuthorize("hasRole('Editor')")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Check status of the report."),
-            @ApiResponse(code = 404, message = "Metdata not found."),
-            @ApiResponse(code = 500, message = "Service unavailable."),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+        @ApiResponse(code = 200, message = "List of testsuites available."),
+        @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+    })
+    public
+    @ResponseBody
+    Map<String, String[]> getTestSuites(
+        @ApiParam(
+            value = API_PARAM_RECORD_UUID,
+            required = true)
+        @PathVariable
+            String metadataUuid) {
+        // TODO: We may at some point propose only testsuite which applies to a record ?
+        return inspireValidatorUtils.getTestsuites();
+    }
+
+    @ApiOperation(
+        value = "Submit a record to the INSPIRE service for validation.",
+        notes = "User MUST be able to edit the record to validate it. "
+            + "An INSPIRE endpoint must be configured in Settings. "
+            + "This activates an asyncronous process, this method does not return any report. "
+            + "This method returns an id to be used to get the report.",
+        nickname = "submitValidate")
+    @RequestMapping(value = "/{metadataUuid}/validate/inspire",
+        method = RequestMethod.PUT,
+        produces = {
+            MediaType.TEXT_PLAIN_VALUE
+        })
+    @PreAuthorize("hasRole('Editor')")
+    @ApiResponses(value = {
+        @ApiResponse(code = 201, message = "Check status of the report."),
+        @ApiResponse(code = 404, message = "Metadata not found."),
+        @ApiResponse(code = 500, message = "Service unavailable."),
+        @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
     })
     public
     @ResponseBody
     String validateRecord(
-            @ApiParam(
-                    value = API_PARAM_RECORD_UUID,
-                    required = true)
-            @PathVariable
+        @ApiParam(
+            value = API_PARAM_RECORD_UUID,
+            required = true)
+        @PathVariable
             String metadataUuid,
-            HttpServletResponse response,
-            @ApiParam(hidden = true)
-            @ApiIgnore
+        @ApiParam(
+            value = "Test suite to run",
+            required = false)
+        @RequestParam
+            String testsuite,
+        HttpServletResponse response,
+        @ApiParam(hidden = true)
+        @ApiIgnore
             HttpServletRequest request,
-            @ApiParam(hidden = true)
-            @ApiIgnore
-            final NativeWebRequest nativeRequest,
-            @ApiParam(hidden = true)
-            @ApiIgnore
+        @ApiParam(hidden = true)
+        @ApiIgnore
+        final NativeWebRequest nativeRequest,
+        @ApiParam(hidden = true)
+        @ApiIgnore
             HttpSession session
-            ) throws Exception {
+    ) throws Exception {
 
         ApplicationContext appContext = ApplicationContextHolder.get();
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
 
         new RecordValidationTriggeredEvent(metadata.getId(), ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(), null).publish(appContext);
 
-        if(metadata == null) {
+        if (metadata == null) {
             response.setStatus(HttpStatus.SC_NOT_FOUND);
             return "";
         }
 
         String schema = metadata.getDataInfo().getSchemaId();
-        if(!schema.matches(supportedSchemaRegex)) {
+        if (!schema.matches(supportedSchemaRegex)) {
             response.setStatus(HttpStatus.SC_NOT_ACCEPTABLE);
             return String.format("INSPIRE validator does not support records in schema '%'. Schema must match expression '%' and have an ISO19139 formatter.",
                 schema, supportedSchemaRegex);
         }
-
 
         String id = String.valueOf(metadata.getId());
 
@@ -204,21 +223,20 @@ public class InspireValidationApi {
             } else {
                 // Cleanup metadocument elements
                 EditLib editLib = appContext.getBean(DataManager.class).getEditLib();
-
                 editLib.removeEditingInfo(md);
                 editLib.contractElements(md);
             }
 
+
             md.detach();
             ServiceContext context = ApiUtils.createServiceContext(request);
-            Attribute schemaLocAtt =  schemaManager.getSchemaLocation(
+            Attribute schemaLocAtt = schemaManager.getSchemaLocation(
                 "iso19139", context);
-
 
             if (schemaLocAtt != null) {
                 if (md.getAttribute(
-                        schemaLocAtt.getName(),
-                        schemaLocAtt.getNamespace()) == null) {
+                    schemaLocAtt.getName(),
+                    schemaLocAtt.getNamespace()) == null) {
                     md.setAttribute(schemaLocAtt);
                     // make sure namespace declaration for schemalocation is present -
                     // remove it first (does nothing if not there) then add it
@@ -227,9 +245,10 @@ public class InspireValidationApi {
                 }
             }
 
+
             InputStream metadataToTest = convertElement2InputStream(md);
 
-            String testId = InspireValidatorUtils.submitFile(URL, metadataToTest, metadata.getUuid(), settingManager);
+            String testId = inspireValidatorUtils.submitFile(URL, metadataToTest, testsuite, metadata.getUuid());
 
             return testId;
         } catch (Exception e) {
@@ -239,7 +258,7 @@ public class InspireValidationApi {
     }
 
     private InputStream convertElement2InputStream(Element md)
-            throws TransformerConfigurationException, TransformerFactoryConfigurationError, TransformerException {
+        throws TransformerFactoryConfigurationError, TransformerException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         XMLOutputter xmlOutput = new XMLOutputter();
         try {
@@ -251,49 +270,49 @@ public class InspireValidationApi {
     }
 
     @ApiOperation(
-            value = "Check the status of validation with the INSPIRE service.",
-            notes = "User MUST be able to edit the record to validate it. "
-                    + "An INSPIRE endpoint must be configured in Settings. "
-                    + "If the process is complete an object with status is returned. ",
-                    nickname = "checkValidateStatus")
+        value = "Check the status of validation with the INSPIRE service.",
+        notes = "User MUST be able to edit the record to validate it. "
+            + "An INSPIRE endpoint must be configured in Settings. "
+            + "If the process is complete an object with status is returned. ",
+        nickname = "checkValidateStatus")
     @RequestMapping(value = "/{testId}/validate/inspire",
-    method = RequestMethod.GET,
-    produces = {
+        method = RequestMethod.GET,
+        produces = {
             MediaType.APPLICATION_JSON_VALUE
-    }
-            )
+        }
+    )
     @PreAuthorize("hasRole('Editor')")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Report ready."),
-            @ApiResponse(code = 201, message = "Report not ready."),
-            @ApiResponse(code = 404, message = "Report id not found."),
-            @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+        @ApiResponse(code = 200, message = "Report ready."),
+        @ApiResponse(code = 201, message = "Report not ready."),
+        @ApiResponse(code = 404, message = "Report id not found."),
+        @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
     })
     public
     @ResponseBody
     Map<String, String> checkValidation(
-            @ApiParam(
-                    value = "Test identifier",
-                    required = true)
-            @PathVariable
+        @ApiParam(
+            value = "Test identifier",
+            required = true)
+        @PathVariable
             String testId,
-            HttpServletRequest request,
-            @ApiParam(hidden = true)
-            @ApiIgnore
+        HttpServletRequest request,
+        @ApiParam(hidden = true)
+        @ApiIgnore
             HttpServletResponse response,
-            @ApiParam(hidden = true)
-            @ApiIgnore
+        @ApiParam(hidden = true)
+        @ApiIgnore
             HttpSession session
-            ) throws Exception {
+    ) throws Exception {
 
         String URL = settingManager.getValue(Settings.SYSTEM_INSPIRE_REMOTE_VALIDATION_URL);
 
         try {
-            if (InspireValidatorUtils.isReady(URL, testId, null, settingManager)) {
+            if (inspireValidatorUtils.isReady(URL, testId, null)) {
                 Map<String, String> values = new HashMap<>();
 
-                values.put("status", InspireValidatorUtils.isPassed(URL, testId, null, settingManager));
-                values.put("report", InspireValidatorUtils.getReportUrl(URL, testId));
+                values.put("status", inspireValidatorUtils.isPassed(URL, testId, null));
+                values.put("report", inspireValidatorUtils.getReportUrl(URL, testId));
                 response.setStatus(HttpStatus.SC_OK);
 
                 return values;

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -34,12 +34,10 @@
   <context:property-placeholder location="${app.properties}"
                                 file-encoding="UTF-8"
                                 ignore-unresolvable="true" />
-
   <context:component-scan base-package="org.fao.geonet.api"/>
   <context:component-scan base-package="org.fao.geonet.guiapi"/>
   <context:component-scan base-package="org.fao.geonet.guiservices"/>
   <context:component-scan base-package="org.fao.geonet.services"/>
-
 
   <bean id="defaultLanguage" class="java.lang.String">
     <constructor-arg index="0" value="\${language.default}"/>
@@ -55,8 +53,44 @@
     <property name="cacheAllRegionsInMemory" value="true"/>
     <property name="thesaurusName" value="external.place.regions"/>
   </bean>
+
   <bean id="MetadataRegionsDAO" class="org.fao.geonet.services.region.MetadataRegionDAO">
     <property name="cacheAllRegionsInMemory" value="false"/>
+  </bean>
+
+  <bean id="InspireValidatorUtils"
+        class="org.fao.geonet.api.records.editing.InspireValidatorUtils"
+        scope="singleton">
+    <property name="testsuites">
+      <map>
+        <entry key="TG version 1.3">
+          <array>
+            <value>Conformance class: INSPIRE Profile based on EN ISO 19115 and EN ISO 19119</value>
+            <value>Conformance class: XML encoding of ISO 19115/19119 metadata</value>
+          </array>
+        </entry>
+        <entry key="TG version 2.0 - Data sets and series">
+          <array>
+            <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
+            <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
+            <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
+          </array>
+        </entry>
+        <entry key="TG version 2.0 - Spatial data service">
+          <array>
+            <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
+            <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
+            <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
+            <value>Conformance Class 3: INSPIRE Spatial Data Service baseline metadata.</value>
+            <!--<value>Conformance Class 4: INSPIRE Network Services metadata.</value>
+            <value>Conformance Class 5: INSPIRE Invocable Spatial Data Services metadata.</value>
+            <value>Conformance Class 6: INSPIRE Interoperable Spatial Data Services metadata.</value>
+            <value>Conformance Class 7: INSPIRE Harmonised Spatial Data Services metadata.</value>-->
+          </array>
+        </entry>
+      </map>
+    </property>
+    <property name="defaultTestSuite" value="TG version 1.3"/>
   </bean>
 
   <bean id="resourceUploadHandler"

--- a/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
@@ -2,24 +2,23 @@ package org.fao.geonet.api.records.editing;
 
 import static org.junit.Assert.assertEquals;
 
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.kernel.setting.Settings;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import javassist.NotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class InspireValidatorUtilsTest {
 
-    private SettingManager sm = Mockito.mock(SettingManager.class);
+    private static String URL = "http://inspire-sandbox.jrc.ec.europa.eu/etf-webapp";
 
-    private static String URL = "http://inspire-sandbox.jrc.ec.europa.eu/etf-webapp/";
+    @Autowired
+    InspireValidatorUtils inspireValidatorUtils;
 
     @Test
     public void testGetReportUrl() {
 
-        String reportUrl = InspireValidatorUtils.getReportUrl(URL, "123");
+        String reportUrl = inspireValidatorUtils.getReportUrl(URL, "123");
 
         assertEquals(URL + "/v2/TestRuns/123.html", reportUrl);
     }
@@ -27,7 +26,7 @@ public class InspireValidatorUtilsTest {
     @Test
     public void testGetReportUrlJSON() {
 
-        String reportUrl = InspireValidatorUtils.getReportUrlJSON(URL, "123");
+        String reportUrl = inspireValidatorUtils.getReportUrlJSON(URL, "123");
 
         assertEquals(URL + "/v2/TestRuns/123.json", reportUrl);
     }
@@ -36,17 +35,15 @@ public class InspireValidatorUtilsTest {
     @Ignore
     public void testLifeCycle() {
 
-        sm.setValue(Settings.SYSTEM_PROXY_USE, false);
-
-        // assertEquals(InspireValidatorUtils.checkServiceStatus("http://wrong.url.eu", null, sm), false);
+        assertEquals(inspireValidatorUtils.checkServiceStatus("http://wrong.url.eu", null), false);
 
         // FIRST TEST IF OFFICIAL ETF IS AVAILABLE
         // Needed to avoid GN errors when ETF is not available
-        if (InspireValidatorUtils.checkServiceStatus(URL, null, sm)) {
+        if(inspireValidatorUtils.checkServiceStatus(URL, null)) {
 
             try {
                 // No file
-                InspireValidatorUtils.submitFile(URL, null, "GN UNIT TEST ", sm);
+                inspireValidatorUtils.submitFile(URL, null, "Metadata (TG version 1.3)", "GN UNIT TEST ");
             } catch (IllegalArgumentException e) {
                 // RIGHT EXCEPTION
             } catch (Exception e) {
@@ -55,7 +52,7 @@ public class InspireValidatorUtilsTest {
 
             try {
                 // Valid but not found test ID
-                InspireValidatorUtils.isReady(URL, "IED123456789012345678901234567890123", null, sm);
+                inspireValidatorUtils.isReady(URL, "IED123456789012345678901234567890123", null);
                 assertEquals("No exception!", "NotFoundException", "No Exception");
             } catch (NotFoundException e) {
                 // RIGHT EXCEPTION
@@ -65,7 +62,7 @@ public class InspireValidatorUtilsTest {
 
             try {
                 // Test ID in wrong format
-                assertEquals(InspireValidatorUtils.isPassed(URL, "1", null, sm), null);
+                assertEquals(inspireValidatorUtils.isPassed(URL, "1", null), null);
             } catch (Exception e) {
                 assertEquals("Unexpected exception.", "Exception", "No Exception");
             }
@@ -76,4 +73,6 @@ public class InspireValidatorUtilsTest {
 
     }
 
+
 }
+

--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -41,10 +41,23 @@
               scope.isDownloadingRecord = false;
               scope.isDownloadedRecord = false;
               scope.isEnabled = false;
+              scope.testSuites = {}
+
+
 
               scope.$watch('gnCurrentEdit.uuid', function(newValue, oldValue) {
+                if (newValue == undefined) {
+                  return;
+                }
                 scope.isEnabled = true;
                 scope.inspMdUuid = newValue;
+                $http({
+                  method: 'GET',
+                  url: '../api/records/' + scope.inspMdUuid +
+                    '/validate/inspire/testsuites'
+                }).then(function(r) {
+                  scope.testsuites = r.data;
+                });
 
                 gnConfigService.load().then(function(c) {
                   // INSPIRE validator only support ISO19139/115-3 records.
@@ -57,7 +70,7 @@
                 });
               });
 
-              scope.validateInspire = function() {
+              scope.validateInspire = function(test) {
 
                 if (scope.isEnabled) {
 
@@ -67,7 +80,7 @@
                   $http({
                     method: 'PUT',
                     url: '../api/records/' + scope.inspMdUuid +
-                    '/validate/inspire'
+                    '/validate/inspire?testsuite=' + test
                   }).then(function mySucces(response) {
                     if (angular.isDefined(response.data) && response.data != null) {
                       scope.checkInBackgroud(response.data);

--- a/web-ui/src/main/resources/catalog/components/validationtools/partials/mdValidationTools.html
+++ b/web-ui/src/main/resources/catalog/components/validationtools/partials/mdValidationTools.html
@@ -1,44 +1,69 @@
 <span>
-  <button type="button" class="btn btn-default navbar-btn" data-ng-show="!isInspireValidationEnabled"
-    title="{{'validate'|translate}}" data-gn-click-and-spin="save(true, true)">
-    <i class="fa fa-check" />&nbsp; <span class="visible-lg" data-translate=""
-            title="{{'validate-help' | translate}}">validate</span>
+  <button type="button" class="btn btn-default navbar-btn"
+          data-ng-show="!isInspireValidationEnabled"
+          title="{{'validate'|translate}}"
+          data-gn-click-and-spin="save(true, true)">
+    <i class="fa fa-check"/>&nbsp;
+    <span class="visible-lg" data-translate=""
+          title="{{'validate-help' | translate}}">validate</span>
   </button>
 
 
   <div class="btn-group" data-ng-show="isInspireValidationEnabled">
     <button class="btn btn-default dropdown-toggle" type="button"
-      data-toggle="dropdown" aria-expanded="true">
-      <i data-ng-show="!isDownloadingRecord" class="fa fa-check" /><i
-        data-ng-show="isDownloadingRecord" class="fa fa-spinner fa-spin" />
+            data-toggle="dropdown" aria-expanded="true">
+      <i data-ng-show="!isDownloadingRecord" class="fa fa-check"/>
+      <i
+        data-ng-show="isDownloadingRecord" class="fa fa-spinner fa-spin"/>
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">
       <li role="presentation"><a role="menuitem" tabindex="-1"
-        data-gn-click-and-spin="save(true, true)"
-        title="{{'validate-help' | translate}}"> <i class="fa fa-check" />&nbsp;
+                                 data-gn-click-and-spin="save(true, true)"
+                                 title="{{'validate-help' | translate}}">
+        <i class="fa fa-check"/>&nbsp;
           <span
-            class="visible-lg" data-translate="">validate</span></a></li>
-      <li role="presentation" data-ng-show="!isDownloadingRecord"><a
-        role="menuitem" tabindex="-1"
-        data-gn-click-and-spin="validateInspire()"
-        title="{{'validate-inspire-help' | translate}}"> <i
-          class="fa fa-check-square" />&nbsp; <span class="visible-lg"
-          data-translate="">validate-inspire</span>
-      </a></li>
-      <li role="presentation" data-ng-show="isDownloadingRecord"><a
-        role="menuitem" tabindex="-1"
-        data-gn-click-and-spin="validateInspire()"
-        title="{{'validate-inspire-help' | translate}}"> <i
-          class="fa fa-spinner fa-spin" />&nbsp; <span class="visible-lg"
-          data-translate="">reportGeneration</span>
-      </a></li>
-      <li role="presentation" data-ng-show="isDownloadedRecord"><a
-        role="menuitem" tabindex="-1" target="_blank" href="{{reportURL}}"
-        title="{{'validate-inspire-help' | translate}}"> <i
-          class="fa gn-icon-maps" />&nbsp; <span class="visible-lg"
-          data-translate="">reportLink</span> - {{reportStatus}}
-      </a></li>
+            class="visible-lg" data-translate="">validate</span>
+      </a>
+      </li>
+      <li class="divider"></li>
+      <li class="dropdown-header">
+        <span class="visible-lg"
+              data-translate="">validate-inspire</span></li>
+      <li role="presentation" data-ng-show="!isDownloadingRecord"
+          data-ng-repeat="(key,value) in testsuites">
+        <a
+          role="menuitem" tabindex="-1"
+          data-gn-click-and-spin="validateInspire(key)"
+          title="{{'validate-inspire-help' | translate}} {{value.join(', ')}}">
+          <i
+            class="fa fa-chevron-right"/>&nbsp;
+
+          <span>{{key}}</span>
+      </a>
+      </li>
+
+      <li role="presentation" data-ng-show="isDownloadingRecord">
+        <a
+          role="menuitem" tabindex="-1"
+          data-gn-click-and-spin="validateInspire()"
+          title="{{'validate-inspire-help' | translate}}">
+        <i
+          class="fa fa-spinner fa-spin"/>&nbsp;
+          <span class="visible-lg"
+                data-translate="">reportGeneration</span>
+      </a>
+      </li>
+      <li role="presentation" data-ng-show="isDownloadedRecord">
+        <a
+          role="menuitem" tabindex="-1" target="_blank" href="{{reportURL}}"
+          title="{{'validate-inspire-help' | translate}}">
+          <i
+            class="fa gn-icon-maps"/>&nbsp;
+          <span class="visible-lg"
+                data-translate="">reportLink</span> - {{reportStatus}}
+      </a>
+      </li>
     </ul>
   </div>
 </span>

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1306,6 +1306,7 @@
     "registryChooseType": "Choose registry item class",
     "registryChooseItem": "Choose registry collection",
     "registryUseInspireOne": "Use INSPIRE registry",
+    "validatorUseInspireOne": "Use INSPIRE validator",
     "registryFailedToLoadItem": "Failed to load item collection.",
     "registryNoItemFound": "No collection found. Choose another item class.",
     "registryNoLanguage": "One language is required.",

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -347,8 +347,18 @@
                             data-ng-change="processRecommended('siteIdChange', s['name'])"/>
                     </div>
 
-                    <input data-ng-switch-when="system/inspire/remotevalidation/url" type="text" class="form-control"
-                          id="{{s['name']}}" name="{{s.name}}" value="{{s.value}}" placeholder="{{'system/inspire/remotevalidation/url-placeholder' | translate}}" />
+                    <div class="input-group"
+                         data-ng-switch-when="system/inspire/remotevalidation/url" >
+                      <input type="text" class="form-control"
+                             id="{{s['name']}}" name="{{s.name}}" value="{{s.value}}"
+                             placeholder="{{'system/inspire/remotevalidation/url-placeholder' | translate}}" />
+                      <span class="input-group-btn">
+                      <div class="btn btn-default"
+                           onClick="document.getElementById('system/inspire/remotevalidation/url').value = 'http://inspire.ec.europa.eu/validator/';"
+                           data-translate="">validatorUseInspireOne</div>
+                    </span>
+                    </div>
+
 
                     <!-- Default -->
                     <input data-ng-switch-default="" type="text" class="form-control"


### PR DESCRIPTION

* Default validator to use is now http://inspire.ec.europa.eu/validator/

![image](https://user-images.githubusercontent.com/1701393/61052361-85dce880-a3eb-11e9-8c12-7dd1e4c00cb2.png)

* Add configurable levels of validation (now TG13, TG2 DS, TG2 SDS) - can be customized in bean configuration


* API / Add operation to return available testsuites.

![image](https://user-images.githubusercontent.com/1701393/61052373-8d03f680-a3eb-11e9-8440-aecb1177f3d4.png)

* Admin / Add option to set the INSPIRE validator URL to the default one

![image](https://user-images.githubusercontent.com/1701393/61052369-8a090600-a3eb-11e9-81d0-6774c1974a53.png)



@pvgenuchten, I'm not sure which conformance class we have to use for service from class 1 to 7. Do you know how we should configure that ?
