### PR TITLE
ISO19139 / Format / nilReason is set to unknown when missing

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -246,7 +246,16 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- ================================================================= -->
+  <!-- INSPIRE / TG2 / Require nilReason attribute to be
+    innaplicable or unknown when version is empty.
+    Instead of the default missing -->
+  <xsl:template match="gmd:distributionInfo/*/gmd:distributionFormat/*/gmd:version[gco:CharacterString = '']"
+                priority="10">
+    <gmd:version gco:nilReason="unknown">
+      <gco:CharacterString/>
+    </gmd:version>
+  </xsl:template>
+
 
   <xsl:template match="*[gco:CharacterString|gmx:Anchor|gmd:PT_FreeText]">
     <xsl:copy>

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v370/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v370/migrate-default.sql
@@ -15,6 +15,9 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metada
 
 UPDATE Settings SET internal='n' WHERE name='system/server/securePort';
 
+
+UPDATE metadata SET data = replace(data, '<gmd:version gco:nilReason="missing">', '<gmd:version gco:nilReason="unknown">') WHERE  data LIKE '%<gmd:version gco:nilReason="missing">%';
+
 UPDATE Settings SET value='3.7.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 


### PR DESCRIPTION
This is an INSPIRE requirement and should be ok for other ISO19139 profiles