### PR TITLE
Paginate GeoNetwork type harvester

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/RecordInfo.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/RecordInfo.java
@@ -137,6 +137,10 @@ public class RecordInfo {
         return false;
     }
 
+    public String getUuid() {
+        return uuid;
+    }
+
 }
 
 //=============================================================================

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -23,24 +23,6 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geonet;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.commons.lang.StringUtils;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.GeonetContext;
@@ -86,7 +68,6 @@ import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -101,6 +82,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -170,7 +152,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
 
     //--------------------------------------------------------------------------
 
-    public HarvestResult align(Set<RecordInfo> records, List<HarvestError> errors) throws Exception {
+    public HarvestResult align(SortedSet<RecordInfo> records, List<HarvestError> errors) throws Exception {
         log.info("Start of alignment for : " + params.getName());
 
         //-----------------------------------------------------------------------
@@ -965,12 +947,12 @@ public class Aligner extends BaseAligner<GeonetParams> {
      * Return true if the uuid is present in the remote node
      */
 
-    private boolean exists(Set<RecordInfo> records, String uuid) {
-        for (RecordInfo ri : records)
-            if (uuid.equals(ri.uuid))
-                return true;
-
-        return false;
+    private boolean exists(SortedSet<RecordInfo> records, String uuid) {
+        // Records is a TreeSet sorted by uuid attribute.
+        // Method equals of RecordInfo only checks equality using `uuid` attribute.
+        // TreeSet.contains can be used more efficiently instead of doing a loop over all the recordInfo elements.
+        RecordInfo recordToTest = new RecordInfo(uuid, null);
+        return records.contains(recordToTest);
     }
 
     private Path retrieveMEF(String uuid) throws IOException {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
@@ -23,7 +23,9 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geonet;
 
+import com.google.common.collect.Lists;
 import jeeves.server.context.ServiceContext;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
@@ -53,12 +55,15 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 //=============================================================================
@@ -158,16 +163,64 @@ class Harvester implements IHarvester<HarvestResult> {
 
         //--- perform all searches
 
-        Set<RecordInfo> records = new HashSet<RecordInfo>();
+        // Use a TreeSet because in the align phase we need to check if a given UUID is already in the set..
+        SortedSet<RecordInfo> records = new TreeSet<>(Comparator.comparing(RecordInfo::getUuid));
+
+        // Do a search and set from=1 and to=2, try to find out maxPageSize
+        // xml.search service returns maxPageSize in 3.8.x onwards, if not set then
+        // use 100. If set but is greater than the one defined by client use the client one.
+        int pageSize = 100;
+
+        try {
+            Element getPageSizeSearch = doSearch(req, Search.createEmptySearch(1, 2));
+            String sPageSize = getPageSizeSearch.getAttributeValue("maxPageSize");
+            if (!StringUtils.isBlank(sPageSize)) {
+                int clientPageSize = Integer.parseInt(sPageSize);
+                log.info("Client said maximum page size is " + clientPageSize);
+                if (clientPageSize < pageSize) {
+                    pageSize = clientPageSize;
+                    log.info("Page size returned by the server is smaller than the default one for the harvester. Using the remote server one.");
+                } else {
+                    log.info("Page size returned by the server is greater than the default one for the harvester. " +
+                        "Using the client harvester default page size (" + pageSize + ")");
+
+                }
+            } else {
+                log.info("Client didn't respond with page size so using page size of " + pageSize);
+            }
+        } catch (NumberFormatException nfe) {
+            log.error("Invalid maxPageSize attribute value, using " + pageSize);
+        } catch (Exception e) {
+            log.error("Unable to determine pagesize, this could be fatal");
+        }
 
         boolean error = false;
-        for (Search s : params.getSearches()) {
+        List<Search> searches = Lists.newArrayList(params.getSearches());
+        if (params.isSearchEmpty()) {
+            searches.add(Search.createEmptySearch(1, 2));
+        }
+
+        for (Search s : searches) {
             if (cancelMonitor.get()) {
                 return new HarvestResult();
             }
+            log.info(String.format("Processing search with these parameters %s", s.toString()));
+            int from = 1;
+            int to = from + (pageSize - 1);
+            s.setRange(from, to);
 
+            int resultCount = Integer.MAX_VALUE;
+            log.info("Searching on : " + params.getName());
+
+            while (from < resultCount && !error) {
             try {
-                records.addAll(search(req, s));
+                    Element searchResult = doSearch(req, s);
+                    Element summary = searchResult.getChild(Geonet.Elem.SUMMARY);
+                    resultCount = Integer.valueOf(summary.getAttributeValue("count"));
+
+                    @SuppressWarnings("unchecked")
+                    List<Element> metadataResultList = searchResult.getChildren("metadata");
+                    records.addAll(processSearchResult(metadataResultList));
             } catch (Exception t) {
                 error = true;
                 log.error("Unknown error trying to harvest");
@@ -178,31 +231,19 @@ class Harvester implements IHarvester<HarvestResult> {
                 error = true;
                 log.fatal("Something unknown and terrible happened while harvesting");
                 log.fatal(t.getMessage());
-                t.printStackTrace();
-                errors.add(new HarvestError(context, t));
-            }
-        }
-
-        if (params.isSearchEmpty()) {
-            try {
-                log.debug("Doing an empty search");
-                records.addAll(search(req, Search.createEmptySearch()));
-            } catch (Exception t) {
-                error = true;
-                log.error("Unknown error trying to harvest");
-                log.error(t.getMessage());
                 log.error(t);
                 errors.add(new HarvestError(context, t));
-            } catch (Throwable t) {
-                error = true;
-                log.fatal("Something unknown and terrible happened while harvesting");
-                log.fatal(t.getMessage());
-                t.printStackTrace();
-                errors.add(new HarvestError(context, t));
+                }
+
+                from = from + pageSize;
+                to = to + pageSize;
+                s.setRange(from, to);
+
             }
         }
 
-        log.info("Total records processed in all searches :" + records.size());
+
+        log.info("Total records processed from this search :" + records.size());
 
         //--- align local node
         HarvestResult result = new HarvestResult();
@@ -231,6 +272,38 @@ class Harvester implements IHarvester<HarvestResult> {
         return result;
     }
 
+    private Set<RecordInfo> processSearchResult(List<Element> metadataResultList) {
+        Set<RecordInfo> records = new HashSet<>(metadataResultList.size());
+        for (Element md : metadataResultList) {
+            if (cancelMonitor.get()) {
+                return Collections.emptySet();
+            }
+
+            try {
+                Element info = md.getChild("info", Edit.NAMESPACE);
+
+                if (info == null)
+                    log.warning("Missing 'geonet:info' element in 'metadata' element");
+                else {
+                    String uuid = info.getChildText("uuid");
+                    String schema = info.getChildText("schema");
+                    String changeDate = info.getChildText("changeDate");
+                    String source = info.getChildText("source");
+
+                    records.add(new RecordInfo(uuid, changeDate, schema, source));
+                }
+            } catch (Exception e) {
+                HarvestError harvestError = new HarvestError(context, e);
+                harvestError.setDescription("Malformed element '"
+                    + md.toString() + "'");
+                harvestError
+                    .setHint("It seems that there was some malformed element. Check with your administrator.");
+                this.errors.add(harvestError);
+            }
+
+        }
+        return records;
+    }
     //---------------------------------------------------------------------------
 
     private void pre29Login(XmlRequest req) throws IOException, BadXmlResponseEx, BadSoapResponseEx, UserNotFoundEx {
@@ -247,53 +320,19 @@ class Harvester implements IHarvester<HarvestResult> {
         }
     }
 
-    private Set<RecordInfo> search(XmlRequest request, Search s) throws OperationAbortedEx {
-        Set<RecordInfo> records = new HashSet<RecordInfo>();
-
-        for (Object o : doSearch(request, s).getChildren("metadata")) {
-
-            if (cancelMonitor.get()) {
-                return Collections.emptySet();
-            }
-
-            try {
-                Element md = (Element) o;
-                Element info = md.getChild("info", Edit.NAMESPACE);
-
-                if (info == null)
-                    log.warning("Missing 'geonet:info' element in 'metadata' element");
-                else {
-                    String uuid = info.getChildText("uuid");
-                    String schema = info.getChildText("schema");
-                    String changeDate = info.getChildText("changeDate");
-                    String source = info.getChildText("source");
-
-                    records.add(new RecordInfo(uuid, changeDate, schema, source));
-                }
-            } catch (Exception e) {
-                HarvestError harvestError = new HarvestError(context, e);
-                harvestError.setDescription("Malformed element '"
-                    + o.toString() + "'");
-                harvestError
-                    .setHint("It seems that there was some malformed element. Check with your administrator.");
-                this.errors.add(harvestError);
-            }
-        }
-
-        log.info("Records added to result list : " + records.size());
-
-        return records;
-    }
-    //---------------------------------------------------------------------------
 
     private Element doSearch(XmlRequest request, Search s) throws OperationAbortedEx {
         request.setAddress(params.getServletPath() + "/" + params.getNode()
             + "/eng/" + Geonet.Service.XML_SEARCH);
         request.clearParams();
         try {
-            log.info("Searching on : " + params.getName());
+            log.info(String.format("Searching on %s. From %d to %d.", params.getName(), s.from, s.to));
+
             Element response = request.execute(s.createRequest());
-            if (log.isDebugEnabled()) log.debug("Search results:\n" + Xml.getString(response));
+
+            if (log.isDebugEnabled()) {
+                log.debug("Search results:\n" + Xml.getString(response));
+            }
 
             return response;
         } catch (BadSoapResponseEx e) {
@@ -322,7 +361,7 @@ class Harvester implements IHarvester<HarvestResult> {
             harvestError.setHint("Check with your administrator.");
             this.errors.add(harvestError);
             log.warning("Raised exception when searching : " + e);
-            return new Element("response");
+            throw new OperationAbortedEx("raised exception when searching", e);
         }
     }
 
@@ -332,7 +371,7 @@ class Harvester implements IHarvester<HarvestResult> {
         if (sources == null)
             throw new BadServerResponseEx(info);
 
-        Map<String, Source> map = new HashMap<String, Source>();
+        Map<String, Source> map = new HashMap<>();
 
         for (Object o : sources.getChildren()) {
             Element sourceEl = (Element) o;
@@ -340,7 +379,7 @@ class Harvester implements IHarvester<HarvestResult> {
             String uuid = sourceEl.getChildText("uuid");
             String name = sourceEl.getChildText("name");
 
-            Source source = new Source(uuid, name, new HashMap<String, String>(), false);
+            Source source = new Source(uuid, name, new HashMap<>(), false);
             // If translation element provided and has values, use it.
             // Otherwise use the default ones from the name of the source
             if ((sourceEl.getChild("label") != null) &&
@@ -353,13 +392,13 @@ class Harvester implements IHarvester<HarvestResult> {
         return map;
     }
 
-    private void updateSources(Set<RecordInfo> records,
+    private void updateSources(SortedSet<RecordInfo> records,
                                Map<String, Source> remoteSources) throws SQLException, MalformedURLException {
         log.info("Aligning source logos from for : " + params.getName());
 
         //--- collect all different sources that have been harvested
 
-        Set<String> sources = new HashSet<String>();
+        Set<String> sources = new HashSet<>();
 
         for (RecordInfo ri : records) {
             sources.add(ri.source);
@@ -377,7 +416,7 @@ class Harvester implements IHarvester<HarvestResult> {
                     retrieveLogo(context, params.host, sourceUuid);
                 } else {
                     String sourceName = "(unknown)";
-                    source = new Source(sourceUuid, sourceName, new HashMap<String, String>(), false);
+                    source = new Source(sourceUuid, sourceName, new HashMap<>(), false);
                     Resources.copyUnknownLogo(context, sourceUuid);
                 }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Search.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Search.java
@@ -23,19 +23,24 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geonet;
 
-import java.util.Iterator;
-
+import com.google.common.base.Splitter;
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.fao.geonet.Util;
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
-import com.google.common.base.Splitter;
+import java.util.Iterator;
 
 //=============================================================================
 
 class Search {
+    public int from;
+    public int to;
     public String freeText;
 
     //---------------------------------------------------------------------------
@@ -93,8 +98,10 @@ class Search {
         sourceName = Util.getParam(source, "name", "");
     }
 
-    public static Search createEmptySearch() throws BadParameterEx {
-        return new Search(new Element("search"));
+    public static Search createEmptySearch(int from, int to) throws BadParameterEx {
+        Search s = new Search(new Element("search"));
+        s.setRange(from, to);
+        return s;
     }
 
     public Search copy() {
@@ -110,13 +117,16 @@ class Search {
         s.sourceName = sourceName;
         s.anyField = anyField;
         s.anyValue = anyValue;
+        s.from = from;
+        s.to = to;
 
         return s;
     }
 
     public Element createRequest() {
         Element req = new Element("request");
-
+        add(req, "from", Integer.toString(from));
+        add(req, "to", Integer.toString(to));
         add(req, "any", freeText);
         add(req, "title", title);
         add(req, "abstract", abstrac);
@@ -147,6 +157,10 @@ class Search {
         if (hardcopy)
             Lib.element.add(req, "paper", "on");
 
+        if (Log.isDebugEnabled(Geonet.HARVEST_MAN)) {
+            Log.debug(Geonet.HARVEST_MAN, "Search request is " + Xml.getString(req));
+        }
+
         return req;
     }
 
@@ -154,8 +168,29 @@ class Search {
         if (value.length() != 0)
             req.addContent(new Element(name).setText(value));
     }
-}
 
-//=============================================================================
+    public void setRange(int from, int to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("from", from)
+            .append("to", to)
+            .append("freeText", freeText)
+            .append("title", title)
+            .append("abstrac", abstrac)
+            .append("keywords", keywords)
+            .append("digital", digital)
+            .append("hardcopy", hardcopy)
+            .append("sourceUuid", sourceUuid)
+            .append("sourceName", sourceName)
+            .append("anyField", anyField)
+            .append("anyValue", anyValue)
+            .toString();
+    }
+}
 
 


### PR DESCRIPTION
Backport of #3916. Only the client part, not the `search.xml` service. With this PR
the client GN will be able of harvesting new v3.8.0 GNs and to use paginated requests,
avoiding timeouts with big catalogs.