### PR TITLE
[BUG] - Load schema related oasis-catalog in Resolver

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Resolver.java
+++ b/common/src/main/java/org/fao/geonet/utils/Resolver.java
@@ -28,6 +28,7 @@ import org.apache.xml.resolver.tools.CatalogResolver;
 import org.fao.geonet.Constants;
 import org.fao.geonet.utils.nio.NioPathAwareCatalogResolver;
 
+import java.nio.file.Path;
 import java.util.Vector;
 
 //=============================================================================
@@ -50,6 +51,7 @@ public final class Resolver implements ProxyInfoObserver {
     private ProxyInfo proxyInfo;
     private XmlResolver xmlResolver;
     private CatalogResolver catResolver;
+    private Path oasisCatalogPath;
     /**
      * When path is resolved to a non existing file, return this file.
      */
@@ -58,6 +60,17 @@ public final class Resolver implements ProxyInfoObserver {
     //--------------------------------------------------------------------------
 
     public Resolver() {
+        this.oasisCatalogPath = null;
+        beforeWrite();
+        try {
+            setUpXmlResolver();
+        } finally {
+            afterWrite();
+        }
+    }
+
+    public Resolver(Path oasisCatalogPath) {
+        this.oasisCatalogPath = oasisCatalogPath;
         beforeWrite();
         try {
             setUpXmlResolver();
@@ -72,8 +85,13 @@ public final class Resolver implements ProxyInfoObserver {
         CatalogManager catMan = new CatalogManager();
         catMan.setAllowOasisXMLCatalogPI(false);
         catMan.setCatalogClassName("org.apache.xml.resolver.Catalog");
-        String catFiles = System.getProperty(Constants.XML_CATALOG_FILES);
-        if (catFiles == null) catFiles = "";
+        String catFiles = null;
+        if(this.oasisCatalogPath == null) {
+            catFiles = System.getProperty(Constants.XML_CATALOG_FILES);
+            if (catFiles == null) catFiles = "";
+        } else {
+            catFiles = this.oasisCatalogPath.toString();
+        }
         if (Log.isDebugEnabled(Log.JEEVES))
             Log.debug(Log.JEEVES, "Using oasis catalog files " + catFiles);
 

--- a/common/src/main/java/org/fao/geonet/utils/ResolverWrapper.java
+++ b/common/src/main/java/org/fao/geonet/utils/ResolverWrapper.java
@@ -21,6 +21,11 @@
 
 package org.fao.geonet.utils;
 
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
 //=============================================================================
 
 /**
@@ -29,15 +34,34 @@ package org.fao.geonet.utils;
 
 public final class ResolverWrapper {
 
-    private static Resolver resolver = null;
+    // The map contains the reference to different resolvers initialized with schema specific oasis catalogs
+    private static Map<String, Resolver> resolverMap = new HashMap<String, Resolver>();
+    private static final String DEFAULT = "DEFAULT";
 
-    //--------------------------------------------------------------------------
+    // Initializes a schema specific resolver
+    public static synchronized void createResolverForSchema(String schemaName, Path oasisDirFile) {
+        if (!resolverMap.containsKey(schemaName)) resolverMap.put(schemaName, new Resolver(oasisDirFile));
+    }
 
+    // Returns a specific resolver OR a generic one when not possible
+    public static Resolver getInstance(String schemaName) {
+        if(schemaName==null) {
+            return getInstance();
+        } else if(!resolverMap.containsKey(schemaName)) {
+            Log.error(Log.JEEVES, "Oasis catalog files not available for " + schemaName);
+            return getInstance();
+        }
+        return resolverMap.get(schemaName);
+    }
+
+    public static Collection<Resolver> getResolvers() {
+        return resolverMap.values();
+    }
+
+    // Returns or initializes a generic resolver
     public static synchronized Resolver getInstance() {
-        if (resolver == null) resolver = new Resolver();
-        return resolver;
+        if (!resolverMap.containsKey(DEFAULT)) resolverMap.put(DEFAULT, new Resolver());
+        return resolverMap.get(DEFAULT);
     }
 }
-
-//=============================================================================
 

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -865,7 +865,7 @@ public final class Xml {
         }
         XmlErrorHandler eh = new XmlErrorHandler();
         Schema schema = factory().newSchema();
-        Element xsdErrors = validateRealGuts(schema, xml, eh);
+        Element xsdErrors = validateRealGuts(schema, xml, eh, null);
         if (xsdErrors != null) {
             throw new XSDValidationErrorEx("XSD Validation error(s):\n" + getString(xsdErrors), xsdErrors);
         }
@@ -879,7 +879,7 @@ public final class Xml {
     public static void validate(Path schemaPath, Element xml) throws Exception {
         XmlErrorHandler eh = new XmlErrorHandler();
         Schema schema = getSchemaFromPath(schemaPath);
-        Element xsdErrors = validateRealGuts(schema, xml, eh);
+        Element xsdErrors = validateRealGuts(schema, xml, eh, null);
         if (xsdErrors != null) {
             throw new XSDValidationErrorEx("XSD Validation error(s):\n" + getString(xsdErrors), xsdErrors);
         }
@@ -889,9 +889,9 @@ public final class Xml {
     /**
      * Validates an xml document with respect to schemaLocation hints using supplied error handler.
      */
-    public static Element validateInfo(Element xml, XmlErrorHandler eh) throws Exception {
+    public static Element validateInfo(Element xml, XmlErrorHandler eh, String schemaName) throws Exception {
         Schema schema = factory().newSchema();
-        return validateRealGuts(schema, xml, eh);
+        return validateRealGuts(schema, xml, eh, schemaName);
     }
 
 
@@ -900,9 +900,9 @@ public final class Xml {
      * Validates an xml document with respect to an xml schema described by .xsd file path using
      * supplied error handler.
      */
-    public static Element validateInfo(Path schemaPath, Element xml, XmlErrorHandler eh) throws Exception {
+    public static Element validateInfo(Path schemaPath, Element xml, XmlErrorHandler eh, String schemaName) throws Exception {
         Schema schema = getSchemaFromPath(schemaPath);
-        return validateRealGuts(schema, xml, eh);
+        return validateRealGuts(schema, xml, eh, schemaName);
     }
 
     //---------------------------------------------------------------------------
@@ -923,8 +923,8 @@ public final class Xml {
     /**
      * Called by all validation methods to do the real guts of the validation job.
      */
-    private static Element validateRealGuts(Schema schema, Element xml, XmlErrorHandler eh) throws JDOMException {
-        Resolver resolver = ResolverWrapper.getInstance();
+    private static Element validateRealGuts(Schema schema, Element xml, XmlErrorHandler eh, String schemaName) throws JDOMException {
+        Resolver resolver = ResolverWrapper.getInstance(schemaName);
 
         ValidatorHandler vh = schema.newValidatorHandler();
         vh.setResourceResolver(resolver.getXmlResolver());

--- a/core/src/main/java/jeeves/server/JeevesProxyInfo.java
+++ b/core/src/main/java/jeeves/server/JeevesProxyInfo.java
@@ -25,7 +25,10 @@
 
 package jeeves.server;
 
+import java.util.Collection;
+
 import org.fao.geonet.utils.ProxyInfo;
+import org.fao.geonet.utils.Resolver;
 import org.fao.geonet.utils.ResolverWrapper;
 
 /**
@@ -52,7 +55,11 @@ public class JeevesProxyInfo {
         if (proxyInfo == null) {
             proxyInfo = new ProxyInfo();
             // NOTE: Add new classes that observe ProxyInfo here
-            proxyInfo.addObserver(ResolverWrapper.getInstance());
+            // Resolvers
+            Collection<Resolver> resolvers = ResolverWrapper.getResolvers();
+            for (Resolver resolver : resolvers) {
+                proxyInfo.addObserver(resolver);
+            }
         }
         return proxyInfo;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -1293,6 +1293,7 @@ public class SchemaManager {
                 stage = "adding the schema information";
                 addSchema(applicationContext, schemasDir, schemaPluginCatRoot, schemaFile, suggestFile, substitutesFile,
                     idFile, oasisCatFile, conversionsFile);
+                ResolverWrapper.createResolverForSchema(schemasDir.getFileName().toString(), oasisCatFile);
             }
         } catch (Exception e) {
             String errStr = "Failed whilst " + stage + ". Exception message if any is " + e.getMessage();

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -252,9 +252,9 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
         boolean isSchemaLocationDefinedInMd = schemaLoc != null && schemaLoc != "";
 
         if (noChoiceButToUseSchemaLocation || isSchemaLocationDefinedInMd) {
-            return Xml.validateInfo(md, eh);
+            return Xml.validateInfo(md, eh, schema);
         } else {
-            return Xml.validateInfo(metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.SCHEMA), md, eh);
+            return Xml.validateInfo(metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.SCHEMA), md, eh, schema);
         }
     }
 


### PR DESCRIPTION
Each metadata schema contains a file oasis-catalog.xml with "schemaLocation hints to local schemas to make sure that GeoNetwork edits and validates against a schema it knows about.". When more schemas are used, during the validation all the oasis-catalog.xml are used together, creating undesired overrides when a namespace is present in more than one schema.
This PR creates specific **Resolver** for each schema available, to use during the validation. The centre of this change is ResolverWrapper that changes to be a Singleton, to be a map of resolvers, one per each schema.
The map is initialized at startup in SchemaManager, and used for each validation.
Note: It seems that the validation functions in Xml.java are used to validate also resources not specific for metadata schemas. These changes should be safe and retro compatible.