### PR TITLE
group attributes with corresponding feature type / ISO19110 editor

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/layout/config-editor.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/config-editor.xml
@@ -50,6 +50,7 @@
 
   <fieldsWithFieldset>
     <name>gfc:producer</name>
+    <name>gfc:featureType</name>
     <name>gfc:carrierOfCharacteristics</name>
     <name>gfc:listedValue</name>
     <name>gfc:constrainedBy</name>
@@ -89,18 +90,10 @@
                  in="/gfc:FC_FeatureCatalogue"/>
           <field xpath="/gfc:FC_FeatureCatalogue/gfc:functionalLanguage" or="functionalLanguage"
                  in="/gfc:FC_FeatureCatalogue"/>
-          <field
-            xpath="/gfc:FC_FeatureCatalogue/gfc:featureType/gfc:FC_FeatureType/gfc:typeName"
-            or="typeName"
-            in="/gfc:FC_FeatureCatalogue/gfc:featureType/gfc:FC_FeatureType"/>
+          <field xpath="/gfc:FC_FeatureCatalogue/gfc:featureType" or="featureType" in="/gfc:FC_FeatureCatalogue"/>
 
           <action type="suggest"
                   process="add-columns-from-csv"/>
-
-          <field
-            xpath="/gfc:FC_FeatureCatalogue/gfc:featureType/gfc:FC_FeatureType/gfc:carrierOfCharacteristics"
-            or="carrierOfCharacteristics"
-            in="/gfc:FC_FeatureCatalogue/gfc:featureType/gfc:FC_FeatureType"/>
         </section>
       </tab>
       <flatModeExceptions>


### PR DESCRIPTION
Hello geonetwork community,

This is a fix for #3704. See link precise description of the bug.

After this fix, iso19110 editor simple view renders (3 printscreens below):
![image](https://user-images.githubusercontent.com/53038426/61457131-efb73e00-a967-11e9-8042-879c10b7241b.png)
and
![image](https://user-images.githubusercontent.com/53038426/61457231-23926380-a968-11e9-9f2d-112d88445c35.png)
and
![image](https://user-images.githubusercontent.com/53038426/61457279-40c73200-a968-11e9-8c47-adeb8ad149ae.png)

iso19110 editor full view renders:
![image](https://user-images.githubusercontent.com/53038426/61458063-0a8ab200-a96a-11e9-8bb7-7237cac4f281.png)


