### PR TITLE
Styling improvements to the search toolbar

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -6,6 +6,18 @@
   padding-top: 15px;
   background-color: @gn-results-background-color;
 }
+.gn-row-tools {
+  .btn-default, .pagination > li > a, .pagination > li > span {
+    border-color: @panel-default-border !important;
+    &:hover, &:active, &:focus {
+      background-color: @panel-default-heading-bg !important;
+      border-color: @btn-default-border !important;
+      span {
+        background: transparent;
+      }
+    }
+  }
+}
 // search terms
 .searchterm {
   margin: 0 5px 5px 0;

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -38,7 +38,7 @@
           </div>
         </div>
       </div>
-      <div class="row">
+      <div class="row gn-row-tools">
         <div class="col-xs-12 col-md-9"
             data-gn-facet-dimension-list="searchResults.dimension"
             data-params="searchObj.params"


### PR DESCRIPTION
This PR improves the styling for the toolbar in the search results page.

![gn-search-toolbar](https://user-images.githubusercontent.com/19608667/61633548-9dd82600-ac8f-11e9-8d7e-7a76474c4798.png)

Changes:
- uniform colours for `hover` and `active` state
- no white background for text in dropdown

**Background for text in dropdown:**
![gn-search-dropdown](https://user-images.githubusercontent.com/19608667/61633501-7ed99400-ac8f-11e9-806a-993d7ab0d5b5.png)

**After:**
![gn-search-dropdown-after](https://user-images.githubusercontent.com/19608667/61633557-a597ca80-ac8f-11e9-99a2-370a84cbb2e3.png)

