### PR TITLE
Allow subtemplates to specify uuid and title as attributes on root element

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
@@ -267,6 +267,20 @@ public class MetadataSampleApi {
                             isTemplate = templateName.startsWith(templateOfSubTemplatePrefix) ?
                                 "t" : "s";
                         }
+                        if (isTemplate.equals("s")) {
+                            // subtemplates loaded here can have a title or uuid attribute
+                            String tryUuid = xml.getAttributeValue("uuid");
+                            if (tryUuid != null && tryUuid.length() > 0) uuid = tryUuid;
+                            title = xml.getAttributeValue("title");
+                            if (title == null || title.length() == 0) {
+                              title = templateName.substring(prefixLength,
+                                templateName.length() - prefixLength);
+                            }
+                            // throw away the uuid and title attributes if present as they
+                            // cause problems for validation
+                            xml.removeAttribute("uuid");
+                            xml.removeAttribute("title");
+                        }
                         //
                         // insert metadata
                         //
@@ -275,7 +289,8 @@ public class MetadataSampleApi {
                         metadata.getDataInfo().
                             setSchemaId(schemaName).
                             setRoot(xml.getQualifiedName()).
-                            setType(MetadataType.lookup(isTemplate));
+                            setType(MetadataType.lookup(isTemplate)).
+                            setTitle(title);
                         metadata.getSourceInfo().
                             setSourceId(siteId).
                             setOwner(owner).


### PR DESCRIPTION
Sometimes necessary to be able to load subtemplates/fragments from the schema templates directory with a known uuid so that templates and other records can  refer to them with xlinks.

eg. templates/sub-cc-by-4.0.xml:

`
<mco:MD_LegalConstraints xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" title="Creative Commons CC-BY-4.0" uuid="urn:csiro:marlin:license:cc-by-4">
  ...
</mco:MD_LegalConstraints>
`

The uuid and title attributes are read and then removed when the subtemplate is loaded to ensure validity. 