### PR TITLE
Fix error when sch:assert/@see attribute contains a URL

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
+++ b/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
@@ -271,6 +271,7 @@
 
     <xsl:variable name="ref">
       <xsl:choose>
+        <xsl:when test="string-length( $see ) &gt; 0 and (starts-with($see, 'http') or starts-with($see, 'https'))"><xsl:value-of select="'geonet:element/@ref'"/></xsl:when>
         <xsl:when test="string-length( $see ) &gt; 0"><xsl:value-of select="concat('(',$see,')[1]')"/></xsl:when>
         <xsl:otherwise><xsl:value-of select="'geonet:element/@ref'"/></xsl:otherwise>
       </xsl:choose>


### PR DESCRIPTION
Since commit https://github.com/fxprunayre/core-geonetwork/commit/514c9b5ab4319dbb0b9a2278e6888b82e7c8c110 in PR #3298 the schematron throws an error when the `<sch:assert>` `see` attribute contains a URL. For example

``` 
Error at svrl:failed-assert on line 320 column 56 of schematron-rules-nl-19115-basis.xsl:
  XPST0003: XPath syntax error at char 10 on line 320 in {...https://docs.geostandaarden...}:
    QName cannot end with colon: {https:}
Error at svrl:failed-assert on line 353 column 52 of schematron-rules-nl-19115-basis.xsl:
  XPST0003: XPath syntax error at char 10 on line 353 in {...https://docs.geostandaarden...}:
    QName cannot end with colon: {https:}
Error at svrl:failed-assert on line 384 column 56 of schematron-rules-nl-19115-basis.xsl:
  XPST0003: XPath syntax error at char 10 on line 384 in {...https://docs.geostandaarden...}:
    QName cannot end with colon: {https:}
Error at svrl:failed-assert on line 2239 column 54 of schematron-rules-nl-19115-basis.xsl:
  XPST0003: XPath syntax error at char 10 on line 2239 in {...https://docs.geostandaarden...}:
    QName cannot end with colon: {https:}
```

The `sch:assert` elements  in `schematron-rules-nl-19115-basis.sch` look like this:
```xml
<sch:assert id="Metadata_ID" 
  etf_name="Metadata ID" 
  test="$fileIdentifier" 
  see="https://docs.geostandaarden.nl/md/mdprofiel-iso19115/#metadata-unieke-identifier">
Er is geen Metadata ID (https://docs.geostandaarden.nl/md/mdprofiel-iso19115/#metadata-unieke-identifier) opgegeven.
</sch:assert>
```

This is the code causing the error:
https://github.com/geonetwork/core-geonetwork/blob/901fcb23b10dedda3e6222f45c71a90b23b59d4f/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl#L272-L280


In #3298 `see` attribute was used to point to the element where the error should be shown. From the PR text:
>in Schematron, a rule is checked in a context that is defined on a per rule basis. eg. Resource identifier is checked in the Identification info context. An extra attribute see is added in order to show the schematron error near the element pointed by the see attribute. This is an xpath pointing to an element in the metadata or in the metadocument (ie. `geonet:*` elements). Example, for a check on is a link defined made in the context of the distribution section, add a see attribute in order to make the error appear next to the linkage element (instead of the top of the distribution section).

However, the Schematron specification published by ISO/IEC in  [ISO/IEC 19757-3:2016(E)](https://standards.iso.org/ittf/PubliclyAvailableStandards/c055982_ISO_IEC_19757-3_2016.zip) standard, point `5.5.12` says that the `see` attribute must be an URI.
> **5.5.12 `see` attribute**
> The URI [IRI] of external information of interest to maintainers and users of the schema.

The change introduced in #3289 makes GN incompatible with Schematron standard. This PR tries to fix that allowing the `see` attribute to be an URL.
