### PR TITLE
WFS Feature Harvester BUG fix

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/WfsFeaturesParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/WfsFeaturesParams.java
@@ -30,6 +30,8 @@ import org.fao.geonet.kernel.harvest.harvester.AbstractParams;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 import java.util.List;
 
 //=============================================================================
@@ -87,6 +89,10 @@ public class WfsFeaturesParams extends AbstractParams {
           List<Element> qu = q.getChildren();
           if (qu.size() == 1) {
             query = Xml.getString(qu.get(0));
+          } else {
+            // query string will be an escaped XML string as a result of 
+            // jdom Element.setText and XSLT processing, so fix it up
+            query = StringEscapeUtils.unescapeXml(q.getText());
           }
         }
         return query;


### PR DESCRIPTION
WFS Feature Harvester is the only(?) harvester that stores an XML query as a harvester parameter (GetFeature query). The harvester passes the query through JDOM, XSLT and converts it to JSON for display in the u/i. The only way this can be done safely is to keep the query in the form of an escaped XML string. But the query has to be in XML when it is sent to the WFS by the harvester. This fix adds logic to handle the case when the query is already an escaped XML string and needs to be converted to XML for the harvester to send to the WFS (the contrary case was already handled). Without this fix, the user would have to save the harvester to make sure the query was in XML format to send to the WFS, otherwise a cryptic error about parsing an empty WFS getfeature query would be returned.