### PR TITLE
Inspire Validator calls now use directly GeonetHttpRequestFactory

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -308,10 +308,10 @@ public class InspireValidationApi {
         String URL = settingManager.getValue(Settings.SYSTEM_INSPIRE_REMOTE_VALIDATION_URL);
 
         try {
-            if (inspireValidatorUtils.isReady(URL, testId, null)) {
+            if (inspireValidatorUtils.isReady(URL, testId)) {
                 Map<String, String> values = new HashMap<>();
 
-                values.put("status", inspireValidatorUtils.isPassed(URL, testId, null));
+                values.put("status", inspireValidatorUtils.isPassed(URL, testId));
                 values.put("report", inspireValidatorUtils.getReportUrl(URL, testId));
                 response.setStatus(HttpStatus.SC_OK);
 

--- a/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
+
 public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
     private static String URL = "http://inspire-sandbox.jrc.ec.europa.eu/etf-webapp";
@@ -33,13 +35,13 @@ public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
     @Test
     @Ignore
-    public void testLifeCycle() {
+    public void testLifeCycle() throws IOException {
 
-        assertEquals(inspireValidatorUtils.checkServiceStatus("http://wrong.url.eu", null), false);
+        assertEquals(inspireValidatorUtils.checkServiceStatus("http://wrong.url.eu"), false);
 
         // FIRST TEST IF OFFICIAL ETF IS AVAILABLE
         // Needed to avoid GN errors when ETF is not available
-        if (inspireValidatorUtils.checkServiceStatus(URL, null)) {
+        if (inspireValidatorUtils.checkServiceStatus(URL)) {
 
             try {
                 // No file
@@ -52,7 +54,7 @@ public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
             try {
                 // Valid but not found test ID
-                inspireValidatorUtils.isReady(URL, "IED123456789012345678901234567890123", null);
+                inspireValidatorUtils.isReady(URL, "IED123456789012345678901234567890123");
                 assertEquals("No exception!", "NotFoundException", "No Exception");
             } catch (NotFoundException e) {
                 // RIGHT EXCEPTION
@@ -62,7 +64,7 @@ public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
             try {
                 // Test ID in wrong format
-                assertEquals(inspireValidatorUtils.isPassed(URL, "1", null), null);
+                assertEquals(inspireValidatorUtils.isPassed(URL, "1"), null);
             } catch (Exception e) {
                 assertEquals("Unexpected exception.", "Exception", "No Exception");
             }


### PR DESCRIPTION
Inspire Validator calls now use directly GeonetHttpRequestFactory instead of the HttpClient in it. This to avoid issues with the pool of connection managed by it. 