### PR TITLE
Editing / Update-fixed-info applies to template

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -946,13 +946,6 @@ public class BaseMetadataManager implements IMetadataManager {
             AbstractMetadata metadata = null;
             if (metadataId.isPresent()) {
                 metadata = metadataUtils.findOne(metadataId.get());
-                boolean isTemplate = metadata != null && metadata.getDataInfo().getType() == MetadataType.TEMPLATE;
-
-                // don't process templates
-                if (isTemplate) {
-                    LOGGER_DATA_MANAGER.debug("Not applying update-fixed-info for a template");
-                    return md;
-                }
             }
 
             String currentUuid = metadata != null ? metadata.getUuid() : null;


### PR DESCRIPTION
From historical reason ?, update-fixed-info (ufo) was not applied to templates. But now, this is causing issue as ufo is making important changes which also applies to template. eg. all thesaurus handling, nilReason, codelist updates, gml@id, ... When editors try to validate template they are facing issues that they don't have with records. So it does not make much sense to not apply ufo to template.