### PR TITLE
Import record / Generate UUID return ResourceNotFoundException

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -838,7 +838,8 @@ public class MetadataInsertDeleteApi {
             throw ex;
         }
         int iId = Integer.parseInt(id.get(0));
-
+        uuid = dataManager.getMetadataUuid(iId + "");
+        
         // Set template
         dataManager.setTemplate(iId, metadataType, null);
 


### PR DESCRIPTION
Records is inserted but in the process, the generated UUID is not used and report an error:
```
Record with UUID 'daa-b311-41db-a638-b309ceeba98e' not found in this catalog
```