### PR TITLE
Portal / Add portal filter to CSW queries.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -1498,7 +1498,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
                 LOGGER.debug("Lucene query: {}", _query);
 
 
-                appendPortalFilter();
+                _query = appendPortalFilter(_query, _luceneConfig);
 
 
                 try {
@@ -1582,7 +1582,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
 
     }
 
-    private void appendPortalFilter() throws ParseException, QueryNodeException {
+    public static Query appendPortalFilter(Query q, LuceneConfig luceneConfig) throws ParseException, QueryNodeException {
         // If the requested portal define a filter
         // Add it to the request.
         NodeInfo node = ApplicationContextHolder.get().getBean(NodeInfo.class);
@@ -1595,20 +1595,21 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
             else if (StringUtils.isNotEmpty(portal.getFilter())) {
                 Query portalFilterQuery = null;
                 // Parse Lucene query
-                portalFilterQuery = parseLuceneQuery(portal.getFilter(), _luceneConfig);
+                portalFilterQuery = parseLuceneQuery(portal.getFilter(), luceneConfig);
                 LOGGER.info("Portal filter is :\n" + portalFilterQuery);
 
                 BooleanQuery query = new BooleanQuery();
                 BooleanClause.Occur occur = LuceneUtils.convertRequiredAndProhibitedToOccur(true, false);
-                query.add(_query, occur);
+                query.add(q, occur);
 
                 if (portalFilterQuery != null) {
                     query.add(portalFilterQuery, occur);
                 }
-                _query = query;
-                LOGGER.debug("Lucene query (with portal filter): {}", _query);
+                q = query;
+                LOGGER.debug("Lucene query (with portal filter): {}", q);
             }
         }
+        return q;
     }
 
     /**

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/CatalogSearcher.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/CatalogSearcher.java
@@ -535,7 +535,7 @@ public class CatalogSearcher implements MetadataRecordSelector {
         ServiceConfig config = new ServiceConfig();
         String geomWkt = null;
 
-
+        _query = LuceneSearcher.appendPortalFilter(_query, luceneConfig);
         Pair<TopDocs, Element> searchResults = LuceneSearcher.doSearchAndMakeSummary(numHits, startPosition - 1,
             maxRecords + startPosition - 1, _lang.presentationLanguage,
             luceneConfig.getSummaryTypes().get(resultType.toString()), luceneConfig,


### PR DESCRIPTION
When creating a portal eg. `copernicus` with filter `+any:copernicus` from admin > source, the filter was not applied to csw queries

Request
http://localhost:8080/geonetwork/copernicus/eng/csw?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetRecords&typeNames=gmd:MD_Metadata
should return the subset of records corresponding to the portal.