### PR TITLE
Editor / Using thesaurus on element with same name does not work.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -353,7 +353,7 @@
             </xsl:element>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:copy-of select="gn-fn-metadata:getFieldDirective($editorConfig, name())"/>
+            <xsl:copy-of select="gn-fn-metadata:getFieldDirective($editorConfig, name(), $xpath)"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:with-param>

--- a/web/src/main/webapp/xslt/common/functions-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/functions-metadata.xsl
@@ -398,10 +398,19 @@
   <xsl:function name="gn-fn-metadata:getFieldDirective" as="node()">
     <xsl:param name="configuration" as="node()"/>
     <xsl:param name="name" as="xs:string"/>
+    <xsl:param name="xpath" as="xs:string?"/>
 
     <xsl:variable name="type"
-                  select="$configuration/editor/fields/for[@name = $name and starts-with(@use, 'data-')]"/>
+                  select="$configuration/editor/fields/for[@name = $name and starts-with(@use, 'data-') and not(@xpath)]"/>
+    <xsl:variable name="typeWithXpath"
+                  select="$configuration/editor/fields/for[@name = $name and starts-with(@use, 'data-') and @xpath = $xpath]"/>
     <xsl:choose>
+      <xsl:when test="$typeWithXpath">
+        <xsl:element name="directive">
+          <xsl:attribute name="data-directive-name" select="$typeWithXpath/@use"/>
+          <xsl:copy-of select="$typeWithXpath/directiveAttributes/@*"/>
+        </xsl:element>
+      </xsl:when>
       <xsl:when test="$type">
         <xsl:element name="directive">
           <xsl:attribute name="data-directive-name" select="$type/@use"/>


### PR DESCRIPTION
Add xpath to make it more strict on the matching element. Currently the first one is used.

eg. configuration to populate format and specification based on
thesaurus

```xml

    <for name="cit:title"
         xpath="/mdb:MD_Metadata/mdb:distributionInfo/mrd:MD_Distribution/mrd:distributionFormat/mrd:MD_Format/mrd:formatSpecificationCitation/cit:CI_Citation/cit:title"
         use="data-gn-keyword-picker">
      <directiveAttributes data-thesaurus-key="external.theme.httpregistrymetawalcodelistmediatypes-media-types"
                           data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
    </for>

    <for name="cit:title"
         xpath="/mdb:MD_Metadata/mdb:dataQualityInfo/mdq:DQ_DataQuality/mdq:report/mdq:DQ_DomainConsistency/mdq:result/mdq:DQ_ConformanceResult/mdq:specification/cit:CI_Citation/cit:title"
         use="data-gn-keyword-picker">
      <directiveAttributes data-thesaurus-key="external.theme.inspire-technical-guidelines"
                           data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
    </for>

```


![image](https://user-images.githubusercontent.com/1701393/62863024-ed969400-bd07-11e9-88c3-04fb51bb0d99.png)
