### PR TITLE
Styling changes for the attribute table for ISO19110 in the recordView

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -429,6 +429,24 @@ ul.container-list {
       ul {
         padding-left: 0;
       }
+      &.gn-table-attribute {
+        padding-left: 8px;
+        table {
+          th {
+            border-top: 0;
+            border-bottom: 2px solid @table-border-color;
+          }
+          td {
+            padding-left: 8px;
+            table {
+              th {
+                background-color: @table-bg-accent;
+              }
+            }
+          }
+        }
+       
+      }
     }
   }
   .gn-contact img {

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/attributetable.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/attributetable.html
@@ -1,4 +1,4 @@
-<table class="table table-striped">
+<table class="table">
   <tr>
     <th data-translate="">attributeName</th>
     <th data-translate="" data-ng-show="showCodeColumn">attributeCode</th>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -352,7 +352,7 @@
                 <td colspan="2" class="gn-noborder-top gn-nopadding-top gn-nopadding-bottom"/>
               </tr>
               <tr data-ng-if="featureType.attributeTable">
-                <td colspan="2" class="gn-noborder-top">
+                <td colspan="2" class="gn-noborder-top gn-table-attribute">
                   <div data-ng-if="featureType.attributeTable"
                        data-gn-attribute-table-renderer="featureType.attributeTable">
                   </div>


### PR DESCRIPTION
Small styling changes for the attribute table for ISO19110 in the recordView

Related to https://github.com/geonetwork/core-geonetwork/pull/3951

Changes made:
- new class `gn-table-attribute`
- less padding in table cell
- different styling for the table in table