### PR TITLE
FIX: Include all blocks in the Admin Scrollspy

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -47,15 +47,17 @@
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="gn-scroll-spy" data-gn-scroll-spy="gn-settings-spy-target"
-          data-watch="sectionsLevel1" data-depth="1"/>
+           data-watch="sectionsLevel1"
+           data-all-depth="true"/>
       <div class="panel-heading">
         <span data-translate="">settings</span>
       </div>
       <div class="panel-body">
         <form id="gn-settings" name="gnSettings" class="form-horizontal">
+          <div id="gn-settings-spy-target">
           <fieldset data-ng-repeat="(key, section1) in sectionsLevel1 | orderObjectBy:'position'"
-                    id="gn-settings-spy-target">
-            <h1>{{section1.name | translate}}</h1>
+                    id="gn-settings-spy-target-{{section1.name}}">
+            <legend>{{section1.name | translate}}</legend>
             <fieldset data-ng-repeat="section2 in section1.children | orderObjectBy:'position'"
                       id="{{section2.name.replace('/', '-')}}"
                       data-ng-show="section2.name">
@@ -401,6 +403,7 @@
               {{"saveSettings"|translate}}
             </button>
           </fieldset>
+          </div>
         </form>
 
         <div data-gn-need-help="administrator-guide/configuring-the-catalog/system-configuration.html"


### PR DESCRIPTION
The scrollspy in the settings page of the admin did not include all the sections. This was partly because of non-unique IDs. This PR fixes this and adds an extra, second level to the scrollspy

Related to (v 3.4) issue: https://github.com/geonetwork/core-geonetwork/issues/3926

Changes:
- introduced extra level to loop over
- unique IDs
- changed `<h1>` to `<legend>`

**Screenshot of the old situation:**

![gn-scrollspy-before](https://user-images.githubusercontent.com/19608667/62940092-146dcc80-bdd3-11e9-8547-857d696bd602.png)

**Screenshot after the changes:**

![gn-scrollspy-after](https://user-images.githubusercontent.com/19608667/62940112-20598e80-bdd3-11e9-963c-7a48916c548c.png)
