### PR TITLE
FIX: Remove lowercase in sortBy dropdown

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -187,7 +187,6 @@ span.gn-facet-label:first-letter {
 
 // fix sort-by combo case
 .gn-sort-by .btn.dropdown-toggle {
-  text-transform: lowercase;
   background-color: #fff;
   &:first-letter {
     text-transform: uppercase;


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/3966

The sort by field is not converted to `lowercase` via CSS anymore