### PR TITLE
Fix for #3967: Order the categories by the translated label

### DIFF
--- a/web-ui/src/main/resources/catalog/components/category/CategoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/category/CategoryDirective.js
@@ -50,7 +50,12 @@
               success(function(data) {
                 scope.categories = data;
               });
+
+          scope.sortByLabel = function(c) {
+            return c.label[scope.lang];
+          };
         }
+        
       };
     }]);
 

--- a/web-ui/src/main/resources/catalog/components/category/partials/category.html
+++ b/web-ui/src/main/resources/catalog/components/category/partials/category.html
@@ -3,7 +3,7 @@
          data-ng-show="label">{{label | translate}}</label>
   <select class="form-control" data-ng-model="element">
     <option></option>
-    <option data-ng-repeat="c in categories" value="{{c.id}}"
+    <option data-ng-repeat="c in categories | orderBy:sortByLabel" value="{{c.id}}"
             data-ng-selected="c.id == element">
       <span class="fa gn-icon-{{c.name}}"></span>
       {{c.label[lang] | translate}}

--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -53,8 +53,9 @@
     'gnSearchSettings',
     'gnGlobalSettings',
     'gnConfig',
+    'orderByFilter',
     function($scope, $q, $http, suggestService, gnAlertService,
-             gnSearchSettings, gnGlobalSettings, gnConfig) {
+             gnSearchSettings, gnGlobalSettings, gnConfig, orderByFilter) {
 
       /** Object to be shared through directives and controllers */
       $scope.searchObj = {
@@ -126,6 +127,7 @@
                     name: data[i].label.eng
                   });
                 }
+                res = orderByFilter(res,'name',false);
                 defer.resolve(res);
               });
           return defer.promise;


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/3967

Order the categories by the translated label for the `advanced search ` and `harvester setting`.