### PR TITLE
Editor / Table mode / Add option to not to have a fieldset around the table

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -327,6 +327,11 @@ Element to match for creating the table.
                 <xs:documentation>Table header label (from strings.xml), if not defined is used the value of attribute 'for' use the related element label from labels.xml</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="fieldset" type="xs:string" use="optional" fixed="false">
+              <xs:annotation>
+                <xs:documentation>To not to add an extra section around the table. This means that editor can't remove the element targeted by the table.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:sequence>
               <xs:element maxOccurs="1" ref="header"/>
               <xs:element maxOccurs="1" ref="row"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-tpl.xsl
@@ -134,7 +134,7 @@
 
     <!-- Return only the new row in embed mode. -->
     <xsl:choose>
-      <xsl:when test="$isEmbeddedMode and not($isFirstOfItsKind)">
+      <xsl:when test="$tableConfig/@fieldset = 'false' or ($isEmbeddedMode and not($isFirstOfItsKind))">
         <xsl:call-template name="render-table">
           <xsl:with-param name="values" select="$values"/>
         </xsl:call-template>


### PR DESCRIPTION

Sample configuration:

```xml

 <table fieldset="false" for="mac:MI_Instrument">
      <header>
        <col label="mac:MI_Instrument"/>
        <col label="mac:MI_Platform"/>
        <col/>
      </header>
      <row>
        <col xpath="mac:identifier/*/mcc:code"/>
        <col xpath="mac:mountedOn/*/mac:identifier/*/mcc:code"/>
        <col del=".."/>
      </row>
    </table>

```


![image](https://user-images.githubusercontent.com/1701393/63578215-47148380-c590-11e9-99fa-eb4c504ad5bf.png)


Needs an update in ISO19115-3.2018