### PR TITLE
Draft copy - As a reviewer or an Editor, it is impossible to open the editor on a record with a draft copy attached to it Fixes #3896

### DIFF
--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -165,10 +165,10 @@
   </bean>
 
 
-    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataIndexer"/>
-    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>
+    <!--<bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataIndexer"/>
+    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>-->
     <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataValidator"/>
-    <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>
+    <!--<bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>-->
     <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataOperations"/>
     <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataStatus"/>
     <bean class="org.fao.geonet.kernel.datamanager.base.BaseMetadataSchemaUtils"/>

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -167,6 +167,7 @@ public class MetadataEditingApi {
             el.setText("window.location.hash = decodeURIComponent(\"#/metadata/" + id2 + sb.toString() + "\")");
             String elStr = Xml.getString(el);
             response.getWriter().print(elStr);
+            return;
         }
         // End of start editing session
 


### PR DESCRIPTION
- Comment beans in `core` module that are "overridden" in `web` module using `primary` attribute, but during startup seem assigning the ones in the `core` module causing errors when trying to edit a published copy.

- Fixed also an error with the redirect to edit the draft copy, seem caused by the changes in https://github.com/geonetwork/core-geonetwork/pull/3622

After the redirect was written in the output stream, causing the following error when editing a metadata and being redirected to the draft version:

```
Caused by: java.lang.IllegalStateException: WRITER
    at org.eclipse.jetty.server.Response.getOutputStream (Response.java:917)
    at javax.servlet.ServletResponseWrapper.getOutputStream (ServletResponseWrapper.java:142)
    at javax.servlet.ServletResponseWrapper.getOutputStream (ServletResponseWrapper.java:142)
    at org.springframework.security.web.context.SaveContextOnUpdateOrErrorResponseWrapper.getOutputStream (SaveContextOnUpdateOrErrorResponseWrapper.java:116)
    at javax.servlet.ServletResponseWrapper.getOutputStream (ServletResponseWrapper.java:142)
    at javax.servlet.ServletResponseWrapper.getOutputStream (ServletResponseWrapper.java:142)
    at org.fao.geonet.api.records.editing.MetadataEditingApi.buildEditorForm (MetadataEditingApi.java:555)
```

Added a `return` statement after the redirect to avoid writing anything in the output stream.