### PR TITLE
Editor / Associated resources / Set default value to action

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -482,7 +482,16 @@
                   return scope.config.types[0];
                 }
 
-                gnOnlinesrc.register('onlinesrc', function(linkToEdit) {
+                gnOnlinesrc.register('onlinesrc', function(linkToEditOrType) {
+                  var linkToEdit = undefined, linkType = undefined;
+                  if (angular.isDefined(linkToEditOrType)) {
+                    if (angular.isObject(linkToEditOrType)) {
+                        linkToEdit = linkToEditOrType;
+                      } else if (angular.isString(linkToEditOrType)) {
+                        linkType = linkToEditOrType;
+                      }
+                  }
+
                   scope.isEditing = angular.isDefined(linkToEdit);
                   scope.codelistFilter = scope.gnCurrentEdit && scope.gnCurrentEdit.codelistFilter;
 
@@ -490,9 +499,19 @@
                   scope.schema = gnCurrentEdit.schema;
 
                   var init = function() {
+                    function getType(linkType) {
+                      for (var i = 0; i < scope.config.types.length; i++) {
+                          var t = scope.config.types[i];
+                          if (t.label === linkType) {
+                              return t;
+                            }
+                        }
+                      return scope.config.types[0];
+                    };
+
                     var typeConfig = linkToEdit ?
                       getTypeConfig(linkToEdit) :
-                      scope.config.types[0];
+                      getType(linkType);
                     scope.config.multilingualFields = [];
                     angular.forEach(typeConfig.fields, function(f, k) {
                     if (scope.isMdMultilingual &&
@@ -596,9 +615,9 @@
                         selectedLayers: []
                       };
                     } else {
-                      scope.editingKey= null;
-                      scope.params.linkType= scope.config.types[0];
-                      scope.params.protocol= null;
+                      scope.editingKey = null;
+                      scope.params.linkType = typeConfig;
+                      scope.params.protocol = null;
                       scope.params.name= '';
                       scope.params.desc= '';
                       initMultilingualFields();
@@ -1421,7 +1440,22 @@
                    * Register a method on popup open to reset
                    * the search form and trigger a search.
                    */
-                  gnOnlinesrc.register('sibling', function() {
+                  gnOnlinesrc.register('sibling', function(config) {
+                    if (config && !angular.isObject(config)) {
+                      config = angular.fromJson(config);
+                    }
+
+                    scope.config = {
+                      associationTypeForced:
+                        angular.isDefined(config && config.associationType),
+                      associationType:
+                        (config && config.associationType) || null,
+                      initiativeTypeForced:
+                        angular.isDefined(config && config.initiativeType),
+                      initiativeType:
+                        (config && config.initiativeType) || null
+                    };
+
                     $(scope.popupid).modal('show');
 
                     scope.$broadcast('resetSearch');

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1551,12 +1551,13 @@
   <!-- Render associated resource action -->
   <xsl:template name="render-associated-resource-button">
     <xsl:param name="type"/>
+    <xsl:param name="options"/>
     <xsl:param name="label"/>
 
     <div class="row form-group gn-field gn-extra-field">
       <div class="col-xs-10 col-xs-offset-2">
         <a class="btn gn-associated-resource-btn"
-           data-ng-click="gnOnlinesrc.onOpenPopup('{$type}')">
+           data-ng-click="gnOnlinesrc.onOpenPopup('{$type}'{if ($options != '') then concat(', ''', $options, '''') else ''})">
           <i class="fa gn-icon-{$type}"></i>&#160;
           <span data-translate="">
             <xsl:choose>

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -151,6 +151,7 @@
           <xsl:variable name="label" select="$strings/*[name() = $labelKey]"/>
           <xsl:call-template name="render-associated-resource-button">
             <xsl:with-param name="type" select="@process"/>
+            <xsl:with-param name="options" select="directiveAttributes"/>
             <xsl:with-param name="label" select="if ($label != '') then $label else $labelKey"/>
           </xsl:call-template>
         </xsl:when>


### PR DESCRIPTION
Example configuration to make a button to add thumbnail and to add an
aggregation to a source/mission type:

```xml
          <action type="associatedResource"
                  name="add-thumbnail"
                  process="onlinesrc">
            <directiveAttributes>addThumbnail</directiveAttributes>
          </action>

          <action type="associatedResource"
                  name="add-ref-to-source-mission"
                  process="sibling">
            <directiveAttributes>{"associationType": "source", "initiativeType": "mission"}</directiveAttributes>
          </action>
```


Allows to create custom button pointing directly to a specific type of online resource or aggregation:

![image](https://user-images.githubusercontent.com/1701393/63601347-88735600-c5c5-11e9-9c63-0e51f17c85aa.png)

![image](https://user-images.githubusercontent.com/1701393/63601357-8ad5b000-c5c5-11e9-82f9-df498fae9c63.png)

