### PR TITLE
Pr iso19110 fix responsibleparty indexing + add version identifier

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/default.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/default.xsl
@@ -27,6 +27,7 @@
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:gn-fn-index="http://geonetwork-opensource.org/xsl/functions/index"
                 version="1.0">
 
@@ -154,14 +155,13 @@
 
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
       <!-- === Responsible organization === -->
-      <xsl:for-each
-        select="/gfc:FC_FeatureCatalogue/gfc:producer/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString">
-        <xsl:variable name="role" select="../../gmd:role/*/@codeListValue"/>
-        <xsl:variable name="logo" select="descendant::*/gmx:FileName/@src"/>
-
-        <Field name="orgName" string="{string(.)}" store="false" index="true"/>
-        <Field name="responsibleParty" string="{concat($role, '|metadata|', ., '|', $logo)}"
-               store="true" index="false"/>
+      <xsl:for-each select="/gfc:FC_FeatureCatalogue/gfc:producer">
+        <xsl:apply-templates mode="index-contact"
+                             select="gmd:CI_ResponsibleParty|*[@gco:isoType = 'gmd:CI_ResponsibleParty']">
+          <xsl:with-param name="type" select="'resource'"/>
+          <xsl:with-param name="fieldPrefix" select="'responsibleParty'"/>
+          <xsl:with-param name="position" select="position()"/>
+        </xsl:apply-templates>
       </xsl:for-each>
 
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -193,6 +193,56 @@
     <xsl:param name="index" select="'true'"/>
 
     <Field name="{$name}" string="{string(.)}" store="{$store}" index="{$index}"/>
+  </xsl:template>
+
+  <xsl:template mode="index-contact" match="gmd:CI_ResponsibleParty|*[@gco:isoType = 'gmd:CI_ResponsibleParty']">
+    <xsl:param name="type"/>
+    <xsl:param name="fieldPrefix"/>
+    <xsl:param name="position" select="'0'"/>
+
+    <xsl:variable name="orgName" select="gmd:organisationName/(gco:CharacterString|gmx:Anchor)"/>
+
+    <Field name="orgName" string="{string($orgName)}" store="true" index="true"/>
+    <Field name="orgNameTree" string="{string($orgName)}" store="true" index="true"/>
+
+    <xsl:variable name="uuid" select="@uuid"/>
+    <xsl:variable name="role" select="gmd:role/*/@codeListValue"/>
+    <xsl:variable name="roleTranslation"
+                  select="util:getCodelistTranslation('gmd:CI_RoleCode', string($role), 'en')"/>
+    <xsl:variable name="logo" select=".//gmx:FileName/@src"/>
+    <xsl:variable name="email"
+                  select="gmd:contactInfo/*/gmd:address/*/gmd:electronicMailAddress/gco:CharacterString"/>
+    <xsl:variable name="phone"
+                  select="gmd:contactInfo/*/gmd:phone/*/gmd:voice[normalize-space(.) != '']/*/text()"/>
+    <xsl:variable name="individualName"
+                  select="gmd:individualName/gco:CharacterString/text()"/>
+    <xsl:variable name="positionName"
+                  select="gmd:positionName/gco:CharacterString/text()"/>
+    <xsl:variable name="address" select="string-join(gmd:contactInfo/*/gmd:address/*/(
+                                        gmd:deliveryPoint|gmd:postalCode|gmd:city|
+                                        gmd:administrativeArea|gmd:country)/gco:CharacterString/text(), ', ')"/>
+
+    <Field name="{$fieldPrefix}"
+           string="{concat($roleTranslation, '|', $type,'|',
+                             $orgName, '|',
+                             $logo, '|',
+                             string-join($email, ','), '|',
+                             $individualName, '|',
+                             $positionName, '|',
+                             $address, '|',
+                             string-join($phone, ','), '|',
+                             $uuid, '|',
+                             $position)}"
+           store="true" index="false"/>
+
+    <xsl:for-each select="$email">
+      <Field name="{$fieldPrefix}Email" string="{string(.)}" store="true" index="true"/>
+      <Field name="{$fieldPrefix}RoleAndEmail" string="{$role}|{string(.)}" store="true" index="true"/>
+    </xsl:for-each>
+    <xsl:for-each select="@uuid">
+      <Field name="{$fieldPrefix}Uuid" string="{string(.)}" store="true" index="true"/>
+      <Field name="{$fieldPrefix}RoleAndUuid" string="{$role}|{string(.)}" store="true" index="true"/>
+    </xsl:for-each>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/default.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/default.xsl
@@ -96,7 +96,7 @@
       <Field name="versionIdentifier"
              string="{string(/gfc:FC_FeatureCatalogue/gmx:versionNumber/gco:CharacterString|
         /gfc:FC_FeatureCatalogue/gfc:versionNumber/gco:CharacterString)}"
-             store="false" index="true"/>
+             store="true" index="true"/>
 
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
       <!-- === Revision date === -->

--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/default.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/default.xsl
@@ -92,6 +92,13 @@
       </xsl:apply-templates>
 
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+      <!-- === Version identifier === -->
+      <Field name="versionIdentifier"
+             string="{string(/gfc:FC_FeatureCatalogue/gmx:versionNumber/gco:CharacterString|
+        /gfc:FC_FeatureCatalogue/gfc:versionNumber/gco:CharacterString)}"
+             store="false" index="true"/>
+
+      <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
       <!-- === Revision date === -->
       <xsl:for-each select="/gfc:FC_FeatureCatalogue/gmx:versionDate/gco:Date|
         /gfc:FC_FeatureCatalogue/gfc:versionDate/gco:Date">

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -104,6 +104,7 @@
   "defaultView": "Default view",
   "full": "Full view",
   "securityConstraints": "Security constraints",
+  "versionIdentifier": "Version identifier",
   "otherConstraints": "Other constraints",
   "resourceConstraints": "Resource constraints",
   "maintenanceAndUpdateFrequencies": "Update frequencies",

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -11,7 +11,7 @@
       data-ng-show="user.canEditRecord(mdView.current.record)">
       {{'seeDraft' | translate}}
     </a>
-    
+
     <!-- If approved exists, show a link -->
     <a data-ng-if="mdView.current.record.draft == 'y'"
       class="see-draft see-draft-approved"
@@ -21,7 +21,7 @@
       {{'seeNoDraft' | translate}}
     </a>
   </div>
-  
+
   <div class="container">
     <div class="alert alert-warning"
         data-ng-hide="!mdView.loadDetailsFinished || mdView.current.record"
@@ -38,7 +38,7 @@
         data-ng-show="mdView.current.record">
 
       <div class="btn-toolbar" role="toolbar">
-        
+
         <div class="btn-group" role="group">
           <button class="btn btn-default"
                   data-ng-click="closeRecord(mdView.current.record)">
@@ -99,7 +99,7 @@
 
         <div class="gn-md-actions-btn pull-right"
             data-gn-md-actions-menu="mdView.current.record"/>
-        
+
         <div class="btn-group pull-right" role="group">
           <a class="btn btn-default"
             data-ng-show="user.canEditRecord(mdView.current.record) && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
@@ -150,7 +150,7 @@
               class="gn-status gn-status-mdview gn-status-{{mdView.current.record.status[0]}}">
             {{mdView.current.record.status_text[0]}}
           </div>
-          
+
           <div data-gn-related-observer>
             <div data-gn-related="mdView.current.record"
                 data-user="user"
@@ -309,6 +309,10 @@
                 </ul>
               </td>
             </tr>
+            <tr data-ng-if="mdView.current.record.versionIdentifier">
+              <th data-translate="">versionIdentifier</th>
+              <td>{{mdView.current.record.versionIdentifier}}</td>
+            </tr>
             </tbody>
           </table>
 
@@ -449,7 +453,7 @@
 
           <table class="table table-striped">
             <tbody>
-            <tr data-ng-if="mdView.current.record.getAllContacts()">
+            <tr data-ng-if="mdView.current.record.getAllContacts().metadata && mdView.current.record.getAllContacts().metadata.length > 0">
               <th data-translate="">contact</th>
               <td>
                 <div data-gn-metadata-contacts="mdView.current.record.getAllContacts().metadata" data-gn-mode="org-role" />

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -183,6 +183,7 @@
       <field name="standardName" tagName="standardName"/>
       <field name="_groupWebsite" tagName="groupWebsite"/>
       <field name="featureTypes" tagName="featureTypes"/>
+      <field name="versionIdentifier" tagName="versionIdentifier"/>
       <field name="_draft" tagName="draft"/>
     </dumpFields>
   </search>


### PR DESCRIPTION
Hi geonetwork community,

This pull requests does two things:

1. Fix the indexing and display in recordView of iso19110 gfc:producer/md:CI_ResponsibleParty. It uses to display only the company name in "Metadata information" section. Now it shows all fields of the contact (address, phone number, etc.) in the section "About this resource". 

2. Add to indexes and recordView a new field : versionIdentifier (mapped to versionNumber of iso19110)

Both changes endup with the following rendering of iso19110 recordView (only "About this resource" section shown):
![image](https://user-images.githubusercontent.com/53038426/63653684-56eabe00-c770-11e9-9d2a-f0a3f93b5b23.png)

