### PR TITLE
ISO19139 / Multilingual record / Fix online source name editing

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
@@ -138,8 +138,7 @@ Insert is made in first transferOptions found.
                         normalize-space($updateKey) = concat(
                         gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
                         gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString,
-                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString,
-                        gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'])
+                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString)
                         ]">
     <xsl:call-template name="createOnlineSrc"/>
   </xsl:template>
@@ -415,7 +414,6 @@ Insert is made in first transferOptions found.
               <xsl:if test="$name != ''">
                 <gmd:name>
                   <xsl:choose>
-
                     <!--Multilingual-->
                     <xsl:when test="contains($name, '#')">
                       <xsl:for-each select="tokenize($name, $separator)">
@@ -423,6 +421,7 @@ Insert is made in first transferOptions found.
                                       select="substring-before(., '#')"></xsl:variable>
                         <xsl:variable name="nameValue"
                                       select="substring-after(., '#')"></xsl:variable>
+
                         <xsl:if
                           test="$useOnlyPTFreeText = 'false' and $nameLang = $mainLang">
                           <gco:CharacterString>


### PR DESCRIPTION
* remove MimeFileType detection which breaks multilingual editing in associated resource panel (values always removed)
* remove geocat.ch hardcoded ref to DE generating invalid updatekey in some cases
* xlink clean link without trailing commas
* populate-free-text already check if textgroup local was present. Cleaning
* quicker selection of the main language free text


@sppigot, @josegar74  , would like your opinion on the MimeFileType removal ? or should we add an option to allow activation of this ?