### PR TITLE
ES / Add option to populate an index with only public records.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -80,11 +80,21 @@ public class EsSearchManager implements ISearchManager {
     @Value("${es.index.records:gn-records}")
     private String index = "records";
 
+    /**
+     * Index containing only public records.
+     */
+    @Value("${es.index.records_public:gn-records-public}")
+    private String publicIndex = "records";
+
     @Value("${es.index.records.type:records}")
     private String indexType = "records";
 
     public String getIndex() {
         return index;
+    }
+
+    public String getPublicIndex() {
+        return publicIndex;
     }
 
     public String getIndexType() {
@@ -201,6 +211,7 @@ public class EsSearchManager implements ISearchManager {
 
     private int commitInterval = 200;
     private Map<String, String> listOfDocumentsToIndex = new HashMap<>();
+    private Map<String, String> listOfPublicDocumentsToIndex = new HashMap<>();
 
     @Override
     public void index(Path schemaDir, Element metadata, String id, List<Element> moreFields,
@@ -227,9 +238,11 @@ public class EsSearchManager implements ISearchManager {
         doc.put("scope", settingManager.getSiteName());
         doc.put("harvesterUuid", settingManager.getSiteId());
         doc.put("harvesterId", settingManager.getNodeURL());
-        Map<String, String> docListToIndex = new HashMap<>();
-        docListToIndex.put(id, mapper.writeValueAsString(doc));
-        listOfDocumentsToIndex.put(id, mapper.writeValueAsString(doc));
+        String json = mapper.writeValueAsString(doc);
+        if (doc.get("isPublishedToAll").asBoolean()) {
+            listOfPublicDocumentsToIndex.put(id, json);
+        }
+        listOfDocumentsToIndex.put(id, json);
         if (listOfDocumentsToIndex.size() == commitInterval) {
             sendDocumentsToIndex();
         }
@@ -239,6 +252,10 @@ public class EsSearchManager implements ISearchManager {
         synchronized (this) {
             if (listOfDocumentsToIndex.size() > 0) {
                 client.bulkRequest(index, listOfDocumentsToIndex);
+                if (StringUtils.isNotEmpty(publicIndex)) {
+                    client.bulkRequest(publicIndex, listOfPublicDocumentsToIndex);
+                    listOfPublicDocumentsToIndex.clear();
+                }
                 listOfDocumentsToIndex.clear();
             }
         }
@@ -402,8 +419,8 @@ public class EsSearchManager implements ISearchManager {
                     String uuid = (String) iter.next();
                     for (AbstractMetadata metadata : metadataRepository.findAllByUuid(uuid)) {
                         listOfIdsToIndex.add(metadata.getId() + "");
-                    } 
-                    
+                    }
+
                     if(!metadataRepository.existsMetadataUuid(uuid)) {
                         Log.warning(Geonet.INDEX_ENGINE, String.format(
                             "Selection contains uuid '%s' not found in database", uuid));
@@ -434,6 +451,10 @@ public class EsSearchManager implements ISearchManager {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
         client.deleteByQuery(index,
             "harvesterUuid:\\\"" + settingManager.getSiteId() + "\\\"");
+        if (StringUtils.isNotEmpty(publicIndex)) {
+            client.deleteByQuery(publicIndex,
+                "harvesterUuid:\\\"" + settingManager.getSiteId() + "\\\"");
+        }
     }
 
 //    public void iterateQuery(SolrQuery params, final Consumer<SolrDocument> callback) throws IOException, SolrServerException {

--- a/pom.xml
+++ b/pom.xml
@@ -1367,6 +1367,7 @@
     <es.index.features></es.index.features>
     <es.index.features.type></es.index.features.type>
     <es.index.records></es.index.records>
+    <es.index.records_public></es.index.records_public>
     <es.index.records.type></es.index.records.type>
     <es.index.searchlogs></es.index.searchlogs>
     <es.index.searchlogs.type></es.index.searchlogs.type>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -957,6 +957,7 @@
         <es.index.features>gn-features</es.index.features>
         <es.index.features.type>features</es.index.features.type>
         <es.index.records>gn-records</es.index.records>
+        <es.index.records_public>gn-records-public</es.index.records_public>
         <es.index.records.type>records</es.index.records.type>
         <es.index.searchlogs>gn-searchlogs</es.index.searchlogs>
         <es.index.searchlogs.type>searchlogs</es.index.searchlogs.type>

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -26,6 +26,7 @@ es.index.features.applyPrecisionModel=true
 es.index.features.featureCommitInterval=250
 es.index.records=${es.index.records}
 es.index.records.type=${es.index.records.type}
+es.index.records_public=${es.index.records.records_public}
 es.index.searchlogs=${es.index.searchlogs}
 es.index.searchlogs.type=${es.index.searchlogs.type}
 

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -420,13 +420,13 @@
     <url-pattern>/index/records</url-pattern>
   </servlet-mapping>
 
-<!--
+
   <servlet>
-    <servlet-name>ESProxy</servlet-name>
-    <servlet-class>org.mitre.dsmiley.httpproxy.ProxyServlet</servlet-class>
+    <servlet-name>ESPublicRecordsProxy</servlet-name>
+    <servlet-class>org.mitre.dsmiley.httpproxy.URITemplateProxyServlet</servlet-class>
     <init-param>
       <param-name>targetUri</param-name>
-      <param-value>${es.url}</param-value>
+      <param-value>${es.url}/${es.index.records_public}/{_}</param-value>
     </init-param>
     <init-param>
       <param-name>log</param-name>
@@ -434,12 +434,9 @@
     </init-param>
   </servlet>
   <servlet-mapping>
-    <servlet-name>ESProxy</servlet-name>
-    <url-pattern>/index/all</url-pattern>
+    <servlet-name>ESPublicRecordsProxy</servlet-name>
+    <url-pattern>/index/records_public</url-pattern>
   </servlet-mapping>
--->
-
-
 
   <servlet>
     <servlet-name>HttpDashboardProxy</servlet-name>


### PR DESCRIPTION
For security reason, it may be relevant to populate one index with all
records with restricted access (to be configured on elastic side) and
another public index with only public records. This allows to create
Kibana dashboard with no restricted access.