### PR TITLE
iso19110 : move related to Associated Resources

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -161,7 +161,7 @@
 
             <div data-gn-related="mdView.current.record"
                 data-user="user"
-                data-types="parent|children|services|datasets"
+                data-types="parent|children|services|datasets|related"
                 data-title="{{'associatedResources' | translate}}">
             </div>
           </div>
@@ -169,7 +169,7 @@
           <div data-gn-related-observer>
             <div data-gn-related="mdView.current.record"
                 data-user="user"
-                data-types="fcats|related"
+                data-types="fcats"
                 data-title="{{'featureCatalog' | translate}}">
             </div>
             <div data-gn-related="mdView.current.record"


### PR DESCRIPTION
Hi Geonetwork community,

This pull request deals with the data-gn-related-observers of recordView. 

Current situation: data-types="related" are shown under the title 'featureCatalog'.
But looking at MetadataUtils.java, 'related' is about iso19139 & iso19115 refering to feature catalogs, not actual feature catalogs.

Impact: consulting an iso19110 recordView, the section "Feature Catalog" lists an iso19139.

Implemented solution here : move 'related' data-types to Associated Resources.