### PR TITLE
Formatter improvements

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -124,7 +124,8 @@
       </h2>
 
       <xsl:for-each select="gmd:identificationInfo/*/gmd:graphicOverview/*">
-        <img class="gn-img-thumbnail center-block" 
+        <img data-gn-img-modal="md"
+             class="gn-img-thumbnail center-block"
              alt="{$schemaStrings/overview}"
              src="{gmd:fileName/*}"/>
 
@@ -141,7 +142,7 @@
   </xsl:template>
 
   <xsl:template mode="getMetadataHeader" match="gmd:MD_Metadata">
-    <div>
+    <div class="gn-abstract">
       <xsl:for-each select="gmd:identificationInfo/*/gmd:abstract">
         <xsl:variable name="txt">
           <xsl:call-template name="localised">
@@ -160,70 +161,82 @@
                              select="$metadata"/>
       </script>
     </xsl:if>
+  </xsl:template>
 
+
+  <xsl:template mode="getMetadataCitation" match="gmd:MD_Metadata">
     <!-- Citation -->
     <blockquote>
-
-      <em title="{$schemaStrings/citationProposal-help}"><xsl:comment select="name()"/>
-        <xsl:value-of select="$schemaStrings/citationProposal"/>
-      </em><br/>
-
-      <!-- Custodians -->
-      <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
+      <div class="row">
+        <div class="col-md-3">
+          <i class="fa fa-quote-left pull-right"><xsl:comment select="'icon'"/></i>
+        </div>
+        <div class="col-md-9">
+          <h2 title="{$schemaStrings/citationProposal-help}"><xsl:comment select="name()"/>
+            <xsl:value-of select="$schemaStrings/citationProposal"/>
+            <i class="fa fa-info-circle"><xsl:comment select="'icon'"/></i>
+          </h2>
+          <br/>
+          <p>
+            <!-- Custodians -->
+            <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
                               *[gmd:role/*/@codeListValue = ('custodian', 'author')]">
-        <xsl:variable name="name"
-                      select="normalize-space(gmd:individualName)"/>
+              <xsl:variable name="name"
+                            select="normalize-space(gmd:individualName)"/>
 
-        <xsl:value-of select="$name"/>
-        <xsl:if test="$name != ''">&#160;(</xsl:if>
-        <xsl:value-of select="gmd:organisationName/*"/>
-        <xsl:if test="$name">)</xsl:if>
-        <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
-      </xsl:for-each>
+              <xsl:value-of select="$name"/>
+              <xsl:if test="$name != ''">&#160;(</xsl:if>
+              <xsl:value-of select="gmd:organisationName/*"/>
+              <xsl:if test="$name">)</xsl:if>
+              <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
+            </xsl:for-each>
 
-      <!-- Publication year: use last publication date -->
-      <xsl:variable  name="publicationDate">
-        <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:date/*[
+            <!-- Publication year: use last publication date -->
+            <xsl:variable  name="publicationDate">
+              <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:date/*[
                                 gmd:dateType/*/@codeListValue = 'publication']/
                                   gmd:date/gco:*">
-          <xsl:sort select="." order="descending" />
+                <xsl:sort select="." order="descending" />
 
-          <xsl:if test="position() = 1">
-            <xsl:value-of select="." />
-          </xsl:if>
-        </xsl:for-each>
-      </xsl:variable>
+                <xsl:if test="position() = 1">
+                  <xsl:value-of select="." />
+                </xsl:if>
+              </xsl:for-each>
+            </xsl:variable>
 
-      <xsl:if test="normalize-space($publicationDate) != ''">
-        (<xsl:value-of select="substring(normalize-space($publicationDate), 1, 4)"/>)
-      </xsl:if>
+            <xsl:if test="normalize-space($publicationDate) != ''">
+              (<xsl:value-of select="substring(normalize-space($publicationDate), 1, 4)"/>)
+            </xsl:if>
 
-      <xsl:text>. </xsl:text>
+            <xsl:text>. </xsl:text>
 
-      <!-- Title -->
-      <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:title">
-        <xsl:call-template name="localised">
-          <xsl:with-param name="langId" select="$langId"/>
-        </xsl:call-template>
-      </xsl:for-each>
+            <!-- Title -->
+            <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:title">
+              <xsl:call-template name="localised">
+                <xsl:with-param name="langId" select="$langId"/>
+              </xsl:call-template>
+            </xsl:for-each>
+            <xsl:text>. </xsl:text>
 
-      <xsl:text>. </xsl:text>
-
-      <!-- Publishers -->
-      <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
+            <!-- Publishers -->
+            <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
                               *[gmd:role/*/@codeListValue = 'publisher']">
-        <xsl:value-of select="gmd:organisationName/*"/>
-        <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
-      </xsl:for-each>
+              <xsl:value-of select="gmd:organisationName/*"/>
+              <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
+            </xsl:for-each>
 
-      <!-- Link -->
-      <xsl:variable name="url"
-                    select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
-      <a href="{url}">
-        <xsl:value-of select="$url"/>
-      </a>
+            <br/>
+            <!-- Link -->
+            <xsl:variable name="url"
+                          select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
+            <a href="{url}">
+              <xsl:value-of select="$url"/>
+            </a>
+            <br/>
+          </p>
+        </div>
+      </div>
     </blockquote>
-
   </xsl:template>
 
   <!-- Most of the elements are ... -->
@@ -516,7 +529,7 @@
           <span><xsl:comment select="name()"/>
             <xsl:value-of select="$linkName"/>
           </span>
-        </a> 
+        </a>
         <xsl:if test="*/gmd:protocol[normalize-space(gco:CharacterString|gmx:Anchor) != '']">
         (<span><xsl:comment select="name()"/>
           <xsl:apply-templates mode="render-value"
@@ -768,7 +781,7 @@
             <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
           </a>
         </xsl:when>
-       
+
       </xsl:choose><xsl:comment select="name()"/>
       <xsl:call-template name="addLineBreaksAndHyperlinks">
         <xsl:with-param name="txt" select="$txt"/>
@@ -909,7 +922,7 @@
       <xsl:value-of select="."/>
     </span>
   </xsl:template>
-  
+
   <!-- ... Codelists -->
   <xsl:template mode="render-value"
                 match="@codeListValue">

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -181,12 +181,21 @@
             <!-- Custodians -->
             <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
                               *[gmd:role/*/@codeListValue = ('custodian', 'author')]">
-              <xsl:variable name="name"
-                            select="normalize-space(gmd:individualName)"/>
+              <xsl:variable name="name">
+                <xsl:for-each select="gmd:individualName">
+                  <xsl:call-template name="localised">
+                    <xsl:with-param name="langId" select="$langId"/>
+                  </xsl:call-template>
+                </xsl:for-each>
+              </xsl:variable>
 
               <xsl:value-of select="$name"/>
               <xsl:if test="$name != ''">&#160;(</xsl:if>
-              <xsl:value-of select="gmd:organisationName/*"/>
+              <xsl:for-each select="gmd:organisationName">
+                <xsl:call-template name="localised">
+                  <xsl:with-param name="langId" select="$langId"/>
+                </xsl:call-template>
+              </xsl:for-each>
               <xsl:if test="$name">)</xsl:if>
               <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
             </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -220,8 +220,10 @@
 
             <!-- Publishers -->
             <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
-                              *[gmd:role/*/@codeListValue = 'publisher']">
-              <xsl:value-of select="gmd:organisationName/*"/>
+                              *[gmd:role/*/@codeListValue = 'publisher']/gmd:organisationName">
+              <xsl:call-template name="localised">
+                <xsl:with-param name="langId" select="$langId"/>
+              </xsl:call-template>
               <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
             </xsl:for-each>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -408,11 +408,11 @@
     </xsl:variable>
 
     <div class="gn-contact">
-      <h2>
+      <strong>
         <i class="fa fa-envelope"><xsl:comment select="'email'"/></i>
         <xsl:apply-templates mode="render-value"
                              select="*/gmd:role/*/@codeListValue"/>
-      </h2>
+      </strong>
       <div class="row">
         <div class="col-md-6">
           <address>

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -116,7 +116,7 @@
 
           var addGeonames = !attrs['disableGeonames'];
           scope.regionTypes = [];
-         
+
           function setDefault() {
             var defaultThesaurus = attrs['default'];
             for (t in scope.regionTypes) {
@@ -1373,7 +1373,20 @@
         var modalElt;
 
         element.bind('click', function() {
-          var img = scope.$eval(attr['gnImgModal']);
+          var imgOrMd = scope.$eval(attr['gnImgModal']);
+          var img = undefined;
+          if(imgOrMd.getThumbnails) {
+            var imgs = imgOrMd.getThumbnails();
+            var url = $(element).attr('src');
+            for (var i = 0; i < imgs.list.length; i++) {
+              if (imgs.list[i].url === url) {
+                img = imgs.list[i];
+                break;
+              }
+            }
+          } else {
+            img = imgOrMd;
+          }
 
           // Toggle the modal if already displayed
           if (modalElt) {

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -4,6 +4,35 @@
   width: 100%;
 }
 
+blockquote {
+  padding: 0px;
+  margin: 20px 0px 0px 0px;
+  font-size: 100%;
+  border: none;
+
+  h2 {
+    font-size: 16px !important;
+    margin: 0px !important;
+  }
+  div.col-md-3 {
+    color: #ebecec;
+    font-size: 75px;
+  }
+  div.col-md-9 {
+    padding: 20px 20px;
+    background-color: #ebecec;
+  }
+}
+
+header div.gn-abstract {
+  border: solid 1px #ebecec;
+  border-radius: 2px;
+  background-color: mix(white, #ebecec, 50%);
+  padding: .5em;
+  margin-bottom: 1em;
+}
+
+
 /* Angular view */
 .gn-md-view {
   table {
@@ -445,7 +474,7 @@ ul.container-list {
             }
           }
         }
-       
+
       }
     }
   }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -91,19 +91,26 @@
             </header>
 
             <div>
-              <xsl:apply-templates mode="render-toc" select="$viewConfig"/>
-              <!-- Tab panes -->
-              <div>
-                <xsl:if test="$tabs = 'true'">
-                  <xsl:attribute name="class" select="'tab-content'"/>
-                </xsl:if>
-                <xsl:for-each select="$viewConfig/*">
-                  <xsl:sort select="@formatter-order"
-                            data-type="number"/>
-                  <xsl:apply-templates mode="render-view"
-                                       select="."/>
-                </xsl:for-each>
-              </div>
+              <xsl:choose>
+                <xsl:when test="$template != ''">
+                  <saxon:call-template name="{$template}"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:apply-templates mode="render-toc" select="$viewConfig"/>
+                  <!-- Tab panes -->
+                  <div>
+                    <xsl:if test="$tabs = 'true'">
+                      <xsl:attribute name="class" select="'tab-content'"/>
+                    </xsl:if>
+                    <xsl:for-each select="$viewConfig/*">
+                      <xsl:sort select="@formatter-order"
+                                data-type="number"/>
+                      <xsl:apply-templates mode="render-view"
+                                           select="."/>
+                    </xsl:for-each>
+                  </div>
+                </xsl:otherwise>
+              </xsl:choose>
             </div>
 
             <xsl:apply-templates mode="getMetadataCitation" select="$metadata"/>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -24,8 +24,9 @@
   <xsl:template mode="getOverviews" match="*"/>
   <xsl:template mode="getMetadataThumbnail" match="*"/>
   <xsl:template mode="getMetadataHeader" match="*"/>
+  <xsl:template mode="getMetadataCitation" match="*"/>
   <xsl:template mode="getJsonLD" match="*"/>
-  <!-- Those templates should be overriden in the schema plugin - end -->
+  <!-- Those templates should be overridden in the schema plugin - end -->
 
   <!-- Starting point -->
   <xsl:template match="/">
@@ -82,9 +83,11 @@
 
               <xsl:apply-templates mode="getMetadataHeader" select="$metadata"/>
 
-              <div gn-related="md"
-                   data-user="user"
-                   data-types="onlines"><xsl:comment select="'icon'"/></div>
+              <xsl:if test="$related != ''">
+                <div gn-related="md"
+                     data-user="user"
+                     data-types="{$related}"><xsl:comment select="'icon'"/></div>
+              </xsl:if>
             </header>
 
             <div>
@@ -102,6 +105,8 @@
                 </xsl:for-each>
               </div>
             </div>
+
+            <xsl:apply-templates mode="getMetadataCitation" select="$metadata"/>
           </div>
           <div class="gn-md-side gn-md-side-advanced col-md-4">
             <xsl:apply-templates mode="getOverviews" select="$metadata"/>
@@ -151,7 +156,7 @@
 
             <!-- Display link to portal and other view only
             when in pure HTML mode. -->
-            <xsl:if test="$root != 'div'">
+            <xsl:if test="$viewMenu = 'true'">
               <section class="gn-md-side-viewmode">
                 <h2>
                   <i class="fa fa-fw fa-eye"><xsl:comment select="'icon'"/></i>
@@ -180,30 +185,32 @@
               </section>
 
               <section class="gn-md-side-access">
-                <div class="well text-center">
-                  <a class="btn btn-block btn-primary"
-                     href="{if ($portalLink != '')
-                            then replace($portalLink, '\$\{uuid\}', $metadataUuid)
-                            else concat($nodeUrl, $language, '/catalog.search#/metadata/', $metadataUuid)}">
-                    <i class="fa fa-fw fa-link"><xsl:comment select="'icon'"/></i>
-                    <xsl:value-of select="$schemaStrings/linkToPortal"/>
-                  </a>
+                <a class="btn btn-block btn-primary"
+                   href="{if ($portalLink != '')
+                          then replace($portalLink, '\$\{uuid\}', $metadataUuid)
+                          else concat($nodeUrl, $language, '/catalog.search#/metadata/', $metadataUuid)}">
+                  <i class="fa fa-fw fa-link"><xsl:comment select="'icon'"/></i>
+                  <xsl:value-of select="$schemaStrings/linkToPortal"/>
+                </a>
+                <div class="hidden-xs hidden-sm">
                   <xsl:value-of select="$schemaStrings/linkToPortal-help"/>
                 </div>
               </section>
             </xsl:if>
 
-            <section class="gn-md-side-associated">
-              <h2>
-                <i class="fa fa-fw fa-link"><xsl:comment select="'icon'"/></i>
-                <span><xsl:value-of select="$schemaStrings/associatedResources"/></span>
-              </h2>
-              <div gn-related="md"
-                   data-user="user"
-                   data-types="parent|children|services|datasets|hassources|sources|fcats|siblings|associated">
-                Not available
-              </div>
-            </section>
+            <xsl:if test="$sideRelated != ''">
+              <section class="gn-md-side-associated">
+                <h2>
+                  <i class="fa fa-fw fa-link"><xsl:comment select="'icon'"/></i>
+                  <span><xsl:value-of select="$schemaStrings/associatedResources"/></span>
+                </h2>
+                <div gn-related="md"
+                     data-user="user"
+                     data-types="{$sideRelated}">
+                  Not available
+                </div>
+              </section>
+            </xsl:if>
           </div>
         </div>
 

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
@@ -16,12 +16,22 @@
   <!-- Enable tab view mode or not -->
   <xsl:param name="tabs" select="'true'"/>
 
+  <!-- List of related items to display on top. By default only online links. -->
+  <xsl:param name="related" select="'onlines'"/>
+
+  <!-- List of related items to display on the side panel. By default all except links. -->
+  <xsl:param name="sideRelated" select="'parent|children|services|datasets|hassources|sources|fcats|siblings|associated'"/>
+
+
   <!-- Define the full portal link. By default, it will link
   to the catalog.search main page of the catalog. To configure a custom
   use {{uuid}} to be replaced by the record UUID.
   eg. http://another.portal.org/${uuid}
   -->
   <xsl:param name="portalLink" select="''"/>
+
+  <!-- To display all views defined in config-editor.xml -->
+  <xsl:param name="viewMenu" select="'false'"/>
 
   <!-- Define if the formatter output also the record as JSON-LD. -->
   <xsl:param name="withJsonLd" select="'true'"/>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
@@ -22,6 +22,17 @@
   <!-- List of related items to display on the side panel. By default all except links. -->
   <xsl:param name="sideRelated" select="'parent|children|services|datasets|hassources|sources|fcats|siblings|associated'"/>
 
+  <!-- Define a specific XSL template to be used for the content of the formatter.
+  This is useful to create a custom view not based on config-editor.xml.
+
+  In ISO19139/formatter/xsl-view/view.xsl, import a new XSL like
+    <xsl:include href="sextant.xsl"/>
+  which then define the view with the template corresponding to this parameter:
+  <xsl:template name="sextant-summary-view">
+    <table class="table">
+    ....
+  -->
+  <xsl:param name="template" select="''"/>
 
   <!-- Define the full portal link. By default, it will link
   to the catalog.search main page of the catalog. To configure a custom


### PR DESCRIPTION
* Add `related` and `sideRelated` variables to control which related item to display in top header and in side panel
* Add `template` variable to use a custom XSL template to use
* Add `viewMenu` variable to display or not view menu switcher

![image](https://user-images.githubusercontent.com/1701393/63937560-f951bc80-ca62-11e9-855e-04c0fd4577b0.png)

* Citation is in footer

![image](https://user-images.githubusercontent.com/1701393/63937504-dde6b180-ca62-11e9-875d-3b30b72c9060.png)

* Add CSS for abstract in header

![image](https://user-images.githubusercontent.com/1701393/63937474-cf989580-ca62-11e9-8d8b-c578fee3e077.png)

* Make modal popup work in both angular view and formatter view
* Avoid duplicated org name.


Related work : https://github.com/metadata101/iso19115-3.2018/pull/9
