### PR TITLE
Fix for overlapping buttons on contribute dashboard on medium sized screens

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -17,8 +17,8 @@
 
                 <span class="input-group-addon">
                   <label>
-                    <input type="checkbox" data-ng-model="onlyMyRecord.is">
-                    <span data-translate="" class="hidden-xs">onlyMyRecord</span>
+                    <input type="checkbox" title="{{'onlyMyRecord' | translate}}" data-ng-model="onlyMyRecord.is">
+                    <span data-translate="" class="hidden-xs hidden-sm">onlyMyRecord</span>
                   </label>
                 </span>
                 <input type="text"
@@ -49,21 +49,21 @@
                 </div>
               </div>
               <div class="col-xs-12 col-sm-6 col-md-6 col-lg-7 text-right">
-                <a href="#/create" class="btn btn-primary">
-                  <i class="fa fa-fw fa-plus"/><span data-translate="">addRecord</span>
+                <a href="#/create" class="btn btn-primary btn-truncate" title="{{'addRecord' | translate}}">
+                  <i class="fa fa-fw fa-plus"/><span class=" hidden-sm" data-translate="">addRecord</span>
                 </a>
-                <a href="#/import" class="btn btn-default">
+                <a href="#/import" class="btn btn-default btn-truncate" title="{{'ImportRecord' | translate}}">
                   <i class="fa fa-fw fa-upload"/><span class="hidden-xs hidden-sm" data-translate="">ImportRecord</span>
                 </a>
-                <a href="#/directory" class="btn btn-default"
+                <a href="#/directory" class="btn btn-default btn-truncate" title="{{'directoryManager' | translate}}"
                   ng-if="user.isEditorOrMore()">
-                  <i class="fa fa-fw fa-bookmark"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">directoryManager</span>
+                  <i class="fa fa-fw fa-bookmark"/><span class="hidden-xs hidden-sm hidden-md btn-truncate-lg" data-translate="">directoryManager</span>
                 </a>
-                <a href="#/batchedit" class="btn btn-default"
+                <a href="#/batchedit" class="btn btn-default btn-truncate" title="{{'batchEditing' | translate}}"
                   ng-if="user.isEditorOrMore()">
                   <i class="fa fa-fw fa-pencil"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
                 </a>
-                <a href="#/accessManager" class="btn btn-default"
+                <a href="#/accessManager" class="btn btn-default" title="{{'accessManager' | translate}}"
                   ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
                   <i class="fa fa-fw fa-lock"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
                 </a>
@@ -109,12 +109,12 @@
                 <div data-gn-selection-widget=""
                     data-results="searchResults"></div>
               </div>
-              <div class="col-xs-12 col-sm-7 col-md-5 gn-nopadding-left gn-nopadding-right text-right">
+              <div class="col-xs-12 col-sm-7 col-md-4 gn-nopadding-left gn-nopadding-right text-right">
                 <div class="pull-right"
                     data-gn-pagination="paginationInfo"
                     data-hits-values="searchObj.hitsperpageValues"></div>
               </div>
-              <div class="col-xs-12 col-sm-12 col-md-4 gn-nopadding-right text-right">
+              <div class="col-xs-12 col-sm-12 col-md-5 gn-nopadding-right text-right">
                 <div class="pull-right"
                     data-sortby-combo=""
                     data-params="searchObj.params"

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -105,16 +105,16 @@
 
             <div class="row gn-margin-bottom"
                 data-ng-show="searchResults.records.length > 0">
-              <div class="col-xs-12 col-sm-5 col-md-3 relative gn-nopadding-left">
+              <div class="col-xs-12 col-sm-5 col-md-5 col-lg-4 relative gn-nopadding-left">
                 <div data-gn-selection-widget=""
                     data-results="searchResults"></div>
               </div>
-              <div class="col-xs-12 col-sm-7 col-md-4 gn-nopadding-left gn-nopadding-right text-right">
+              <div class="col-xs-12 col-sm-7 col-md-7 col-lg-4 gn-nopadding-left gn-nopadding-right text-right">
                 <div class="pull-right"
                     data-gn-pagination="paginationInfo"
                     data-hits-values="searchObj.hitsperpageValues"></div>
               </div>
-              <div class="col-xs-12 col-sm-12 col-md-5 gn-nopadding-right text-right">
+              <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 gn-nopadding-right text-right">
                 <div class="pull-right"
                     data-sortby-combo=""
                     data-params="searchObj.params"
@@ -126,7 +126,7 @@
                   data-gn-results-container=""
                   data-search-results="searchResults"
                   data-template-url="resultTemplate"></div>
-              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -32,7 +32,7 @@
                 alt="{{'siteLogo' | translate}}"
                 data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
         </a>
-        <a class="pull-left"
+        <a class="pull-left hidden-sm"
            data-ng-class="gnCfg.mods.header.isLogoInHeader ? '' : 'gn-nopadding-left'"
            data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
           <span class="gn-name"
@@ -159,7 +159,7 @@
           <img class="img-circle"
             alt="{{'avatar' | translate}}"
             data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=18"/>
-          <div class="gn-user-info hidden-sm">
+          <div class="gn-user-info hidden-sm hidden-md">
             {{user.name}} {{user.surname}}<br>
             <span class="gn-user-role">{{user.profile | lowercase | translate}}</span>
           </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -61,4 +61,19 @@
   border-radius: 50%;
   padding: 11px 15px;
 }
+.btn-truncate {
+  span {
+    display: inline-block;
+    float: left;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 150px;
+    @media (min-width: @screen-md-min) {
+      max-width: 125px;
+    }
+    @media (min-width: @screen-lg-min) {
+      max-width: 115px;
+    }
+  }
+}
 


### PR DESCRIPTION
This PR optimises the toolbars of the contribute dashboard on medium sized screens, paying extra attention to languages with long button labels (e.g. German).

Furthermore, this PR takes care of overlapping `sort` and `pagination` options.

Changes made:
* max width for buttons and truncate labels
* hide some labels on medium sized screens
* add `title` attribute to buttons

**Screenshot of truncated buttons**

![gn-overlapping-buttons](https://user-images.githubusercontent.com/19608667/64341205-244e8a00-cfe8-11e9-97d7-13616c2f4faa.png)

