### PR TITLE
Fixed editor sidebar with validation panel on top

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
@@ -52,9 +52,9 @@
   <views>
     <view name="default" upAndDownControlHidden="true">
       <sidePanel>
+        <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""
                    data-types="onlines"/>
-        <directive data-gn-validation-report=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="default" default="true" mode="flat">
@@ -66,9 +66,9 @@
     </view>
     <view name="advanced">
       <sidePanel>
+        <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""
                    data-types="onlines"/>
-        <directive data-gn-validation-report=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="advanced" default="true">
@@ -77,9 +77,9 @@
     </view>
     <view name="xml">
       <sidePanel>
+        <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""
                    data-types="onlines"/>
-        <directive data-gn-validation-report=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="xml" default="true"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -464,12 +464,12 @@
     -->
     <view name="inspire" upAndDownControlHidden="true" displayIfServiceInfo="/settings/system/inspire/enable='true'">
       <sidePanel>
+        <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""/>
         <directive gn-geo-publisher=""
                    data-ng-if="gnCurrentEdit.geoPublisherConfig"
                    data-config="{{gnCurrentEdit.geoPublisherConfig}}"
                    data-lang="lang"/>
-        <directive data-gn-validation-report=""/>
         <directive data-gn-suggestion-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
@@ -3132,6 +3132,7 @@
         In the full view, editor can access and manage the file store and
         thumbnail name and description not supported by the overview manager.
         -->
+        <directive data-gn-validation-report=""/>
         <directive data-gn-overview-manager=""/>
         <directive data-gn-onlinesrc-list=""
                    data-types="onlinesrc|parent|dataset|service|source|sibling|associated|fcats"/>
@@ -3140,7 +3141,7 @@
                    data-ng-if="gnCurrentEdit.geoPublisherConfig"
                    data-config="{{gnCurrentEdit.geoPublisherConfig}}"
                    data-lang="lang"/>
-        <directive data-gn-validation-report=""/>
+        
         <directive data-gn-suggestion-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
@@ -3213,12 +3214,12 @@
     </view>
     <view name="advanced">
       <sidePanel>
+        <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""/>
         <directive gn-geo-publisher=""
                    data-ng-if="gnCurrentEdit.geoPublisherConfig"
                    data-config="{{gnCurrentEdit.geoPublisherConfig}}"
                    data-lang="lang"/>
-        <directive data-gn-validation-report=""/>
         <directive data-gn-suggestion-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
@@ -3289,12 +3290,12 @@
     </view>
     <view name="xml">
       <sidePanel>
+        <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""/>
         <directive gn-geo-publisher=""
                    data-ng-if="gnCurrentEdit.geoPublisherConfig"
                    data-config="{{gnCurrentEdit.geoPublisherConfig}}"
                    data-lang="lang"/>
-        <directive data-gn-validation-report=""/>
         <directive data-gn-suggestion-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -121,16 +121,6 @@
                 }
               };
 
-              // scope.toggleAlwaysOnTop = function() {
-              //   scope.alwaysOnTop = !scope.alwaysOnTop;
-              //   var element = angular.element( document.querySelector( '#gn-editor-validation-panel' ) );
-              //   if(scope.alwaysOnTop) {
-              //     element.addClass('gn-fixed-scroll');
-              //   } else {
-              //     element.removeClass('gn-fixed-scroll');
-              //   }
-              // };
-
               // When saving is done, refresh validation report
               scope.$watch('gnCurrentEdit.saving', function(newValue) {
                 if (newValue === false && gnCurrentEdit.showValidationErrors) {

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -121,15 +121,15 @@
                 }
               };
 
-              scope.toggleAlwaysOnTop = function() {
-                scope.alwaysOnTop = !scope.alwaysOnTop;
-                var element = angular.element( document.querySelector( '#gn-editor-validation-panel' ) );
-                if(scope.alwaysOnTop) {
-                  element.addClass('gn-fixed-scroll');
-                } else {
-                  element.removeClass('gn-fixed-scroll');
-                }
-              };
+              // scope.toggleAlwaysOnTop = function() {
+              //   scope.alwaysOnTop = !scope.alwaysOnTop;
+              //   var element = angular.element( document.querySelector( '#gn-editor-validation-panel' ) );
+              //   if(scope.alwaysOnTop) {
+              //     element.addClass('gn-fixed-scroll');
+              //   } else {
+              //     element.removeClass('gn-fixed-scroll');
+              //   }
+              // };
 
               // When saving is done, refresh validation report
               scope.$watch('gnCurrentEdit.saving', function(newValue) {

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -4,13 +4,13 @@
     <i class="fa fa-fw" data-ng-class="getClass('icon')"></i>&nbsp;
     <span data-translate="">validationReport</span>
 
-    <button type="button" class="btn btn-default pull-right btn-xs gn-btn-fix"
+    <!-- <button type="button" class="btn btn-default pull-right btn-xs gn-btn-fix"
             data-ng-click="toggleAlwaysOnTop();$event.stopPropagation();"
             data-toggle="tooltip"
             data-placement="top"
             title="{{'fixedOnTop' | translate}}">
       <i class="fa fa-thumb-tack"></i>
-    </button>
+    </button> -->
   </div>
   <!-- /.panel-heading -->
   <div class="panel-body" data-ng-show="ruleTypes.length !== 0">

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -3,14 +3,6 @@
        data-gn-slide-toggle="">
     <i class="fa fa-fw" data-ng-class="getClass('icon')"></i>&nbsp;
     <span data-translate="">validationReport</span>
-
-    <!-- <button type="button" class="btn btn-default pull-right btn-xs gn-btn-fix"
-            data-ng-click="toggleAlwaysOnTop();$event.stopPropagation();"
-            data-toggle="tooltip"
-            data-placement="top"
-            title="{{'fixedOnTop' | translate}}">
-      <i class="fa fa-thumb-tack"></i>
-    </button> -->
   </div>
   <!-- /.panel-heading -->
   <div class="panel-body" data-ng-show="ruleTypes.length !== 0">

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -522,6 +522,12 @@ form.gn-editor {
       top: 2px;
     }
   }
+  .gn-validation-report {
+    .list-group-item {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
+  }
 }
 
 .gn-autocomplete-list {
@@ -976,23 +982,29 @@ gn-draft-validation-widget {
   }
 }
 
-.gn-fixed-scroll {
-  position:fixed;
-  top: 70px;
-  margin-right: 15px;
-  z-index: 10;
-  .gn-btn-fix {
-    color: #333;
-    background-color: #e6e6e6;
-    border-color: #adadad;
-    outline: 0;
-    background-image: none;
-    -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+.gn-editor-sidebar {
+  margin-top: 15px;
+  padding-bottom: 150px;
+}
+@media (min-width: @screen-md-min) {
+  .scrollbar-white() {
+    &::-webkit-scrollbar-track, &::-webkit-scrollbar-thumb {
+      -webkit-box-shadow: inset 0 0 6px #fff; 
+    }
+    &::-webkit-scrollbar-thumb:window-inactive {
+      background: #fff; 
+    }
+  }
+  .gn-editor-sidebar {
+    margin-top: 0;
+    position: fixed;
+    right: 0;
+    overflow: auto;
+    max-height: 100%;
+    padding-bottom: 110px;
+    .scrollbar-white();
   }
 }
-
-
 
 gn-bounding-polygon {
   label {
@@ -1006,3 +1018,10 @@ gn-bounding-polygon {
     font-size: 0.9em;
   }
 }
+
+ // scrollspy
+  .gn-scroll-spy {
+    .btn.btn-round {
+      border-radius: 50% !important;
+    }
+  }

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
@@ -150,7 +150,7 @@
           </xsl:choose>
         </form>
       </div>
-      <div class="col-md-{if ($hasSidePanel) then '4' else '0'}">
+      <div class="col-md-{if ($hasSidePanel) then '4' else '0'} gn-editor-sidebar">
         <div class="gn-editor-tools-container">
           <xsl:apply-templates mode="form-builder"
                                select="$viewConfig/sidePanel/*"/>


### PR DESCRIPTION
This PR moves the validation to the top of the editor sidebar and fixes the sidebar. This enables the user to scroll through the content with the validation results staying in place. The sidebar in itself is also scrollable when there is a lot of content.

The `pin` button that used to fix only the validation panel has been removed.

![gn-editor-pin-validation](https://user-images.githubusercontent.com/19608667/64595035-6f361c00-d3b1-11e9-9867-a6e469e45fc1.png)

