### PR TITLE
Added extra classes to related resources

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -5,7 +5,7 @@
   <div class=""
        data-ng-repeat="(type, items) in relations track by $index"
        data-ng-if="type && type !== 'thumbnails'">
-    <div class="row list-group-item gn-related-item"
+    <div class="row list-group-item gn-related-item gn-related-{{type}}"
          data-ng-repeat="r in items track by $index"
          data-ng-init="mainType = config.getType(r, type);">
       <div class="col-xs-1 col-sm-1">
@@ -165,11 +165,15 @@
           <div data-ng-switch-default>
             <p class="text-muted"
                data-ng-if="mainType.indexOf('MD') == 0 && r.id">
-              <a href="#/metadata/{{r.id}}">
-                {{(r.title | gnLocalized: lang) }}
-              </a> ({{(config.getLabel(mainType, type)) | translate}})<br/>
-              {{ (r.description | gnLocalized: lang | striptags | words:35)}} <a href="#/metadata/{{r.id}}">{{'more' |
-              translate}}...</a>
+              <span class="gn-related-title">
+                <a href="#/metadata/{{r.id}}">
+                  {{(r.title | gnLocalized: lang) }}
+                </a> ({{(config.getLabel(mainType, type)) | translate}})
+              </span>
+              <span class="gn-related-description">
+                {{ (r.description | gnLocalized: lang | striptags | words:35)}} <a href="#/metadata/{{r.id}}">{{'more' |
+                translate}}...</a>
+              </span>
             </p>
 
             <p class="text-muted"

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -306,6 +306,9 @@
       }
     }
   }
+  .gn-related-title {
+    display: block;
+  }
   p {
     word-wrap: break-word;
   }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -68,12 +68,6 @@
     text-overflow: ellipsis;
     overflow: hidden;
     max-width: 150px;
-    //@media (min-width: @screen-md-min) {
-    //  max-width: 125px;
-    //}
-    //@media (min-width: @screen-lg-min) {
-    //  max-width: 115px;
-    //}
   }
 }
 


### PR DESCRIPTION
This PR adds extra classes to the related items in the metadata page. These classes make it easier to manipulate the look and feel of the related items via a custom view/styling

Classes added to:
- `.gn-related-..type..` to the related item itself
- title (`gn-related-title`)
- description (`gn-related-description`)