### PR TITLE
INSPIRE ATOM - Beans not in context + AtomPredefineFeed endpoints not mounted correctly

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
@@ -88,6 +88,7 @@ import jeeves.server.sources.http.ServletPathFinder;
  */
 
 @Controller
+@RequestMapping(value = "/{portal}")
 public class AtomPredefinedFeed {
 
     /**

--- a/inspire-atom/src/main/resources/config-spring-geonetwork.xml
+++ b/inspire-atom/src/main/resources/config-spring-geonetwork.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<beans
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns="http://www.springframework.org/schema/beans"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		                  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+  <context:component-scan base-package="org.fao.geonet.inspireatom"/>
+</beans>


### PR DESCRIPTION
This pull request fix two issue in one.

### First Issue

**Describe the bug**
Beans from package org.fao.geonet.inspireatom are not scanned by Spring. 

**To Reproduce**
Example with [http://localhost:8080/geonetwork/srv/eng/atom.download?...](http://localhost:8080/geonetwork/srv/eng/atom.download)

**Log file**
```
2019-09-13 09:43:47,087 ERROR [jeeves.service] - Exception when executing service
2019-09-13 09:43:47,087 ERROR [jeeves.service] -  (C) Exc : org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type [org.fao.geonet.inspireatom.InspireAtomService] is defined
2019-09-13 09:43:47,153 ERROR [jeeves] - Error occurred within a transaction
org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type [org.fao.geonet.inspireatom.InspireAtomService] is defined
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:372)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:369)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:332)
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1066)
	at jeeves.server.context.BasicContext.getBean(BasicContext.java:118)
	at org.fao.geonet.services.inspireatom.AtomGetData.exec(AtomGetData.java:96)
	at jeeves.server.dispatchers.ServiceInfo.execService(ServiceInfo.java:227)
	at jeeves.server.dispatchers.ServiceInfo.noTransactionExec(ServiceInfo.java:142)
	at jeeves.server.dispatchers.ServiceInfo.access$000(ServiceInfo.java:46)
	at jeeves.server.dispatchers.ServiceInfo$1.doInTransaction(ServiceInfo.java:121)
	at jeeves.server.dispatchers.ServiceInfo$1.doInTransaction(ServiceInfo.java:118)
	at jeeves.transaction.TransactionManager.runInTransaction(TransactionManager.java:73)
	...
```

**Root cause**
This is due to the change of scanned component in the file services/src/main/resources/config-spring-geonetwork.xml in [this commit](https://github.com/geonetwork/core-geonetwork/commit/7c426728287065580a6aaa3a215c0edea97e8845)

### Second Issue

**Describe the bug**
Requests Mapping in class AtomPredefinedFeed are not mounted correctly. Accessing them will result in a HTTP 404 error.

**To Reproduce**
Example with the following endpoint: [http://localhost:8080/geonetwork/srv/atom/describe/service?uuid={service_record_uuid}](http://localhost:8080/geonetwork/srv/atom/describe/service?uuid={service_record_uuid})

**Root cause**
When the change to [replace multinode by sub portal](https://github.com/geonetwork/core-geonetwork/commit/70c2afba48f9a2a4c797b674a1b2d1a916b871b6) has been done, the `{portal}` variable was not added to those endpoints.
