### PR TITLE
Backport to 3.4.x - Allow to use gn-checkbox-with-nilreason directive for specific boolean fields. Related to #2437

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
@@ -137,6 +137,8 @@
     <xsl:variable name="added" select="parent::node()/parent::node()/@gn:addedObj"/>
     <xsl:variable name="container" select="parent::node()/parent::node()"/>
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <!-- Add view and edit template-->
     <xsl:call-template name="render-element">
       <xsl:with-param name="label" select="$labelConfig"/>
@@ -144,9 +146,9 @@
       <xsl:with-param name="cls" select="local-name()"/>
       <!--<xsl:with-param name="widget"/>
             <xsl:with-param name="widgetParams"/>-->
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
       <!--<xsl:with-param name="attributesSnippet" as="node()"/>-->
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo"
                       select="gn:element"/>
@@ -202,14 +204,15 @@
 
   <!-- Readonly elements -->
   <xsl:template mode="mode-dublin-core" priority="200" match="dc:identifier|dct:modified">
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
 
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
                       select="gn-fn-metadata:getLabel($schema, name(), $labels)"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout-custom-fields.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout-custom-fields.xsl
@@ -45,7 +45,7 @@
       <xsl:with-param name="value" select="*"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
-      <xsl:with-param name="type" select="gn-fn-iso19110:getFieldType(name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-iso19110:getFieldType(name(), '', $xpath)"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
@@ -175,7 +175,7 @@
       <xsl:with-param name="forceDisplayAttributes" select="true()" />
       <xsl:with-param name="type"
                       select="gn-fn-iso19110:getFieldType(name(),
-            name(gmx:Anchor))"/>
+            name(gmx:Anchor), $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then */gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>
@@ -244,7 +244,7 @@
                       select="gn-fn-iso19110:getFieldType(name(),
             name(gco:CharacterString|gco:Date|gco:DateTime|gco:Integer|gco:Decimal|
                 gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|
-                gco:Scale|gco:RecordType|gmx:MimeFileType|gmd:URL))"/>
+                gco:Scale|gco:RecordType|gmx:MimeFileType|gmd:URL), $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then */gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/utility-fn.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/utility-fn.xsl
@@ -41,14 +41,15 @@
     <xsl:param name="name" as="xs:string"/>
     <!-- The element containing the value eg. gco:Date -->
     <xsl:param name="childName" as="xs:string?"/>
+    <xsl:param name="xpath" as="xs:string?"/>
 
     <xsl:variable name="iso19110type"
-                  select="gn-fn-metadata:getFieldType($editorConfig, $name, $childName)"/>
+                  select="gn-fn-metadata:getFieldType($editorConfig, $name, $childName, $xpath)"/>
 
     <xsl:choose>
       <xsl:when test="$iso19110type = $defaultFieldType">
         <xsl:value-of
-          select="gn-fn-metadata:getFieldType($iso19139EditorConfig, $name, $childName)"/>
+          select="gn-fn-metadata:getFieldType($iso19139EditorConfig, $name, $childName, $xpath)"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$iso19110type"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/inflate-metadata.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/inflate-metadata.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                  xmlns:gco="http://www.isotc211.org/2005/gco"
+                  xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                  exclude-result-prefixes="#all">
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:template match="/root">
+    <xsl:apply-templates select="gmd:MD_Metadata"/>
+  </xsl:template>
+
+  <!-- Add gco:Boolean to gmd:pass with nilReason to work nicely in the editor,
+      update-fixed-info.xsl should removed if empty to avoid xsd errors  -->
+  <xsl:template match="gmd:pass[@gco:nilReason and not(gco:Boolean)]">
+    <xsl:copy>
+      <xsl:copy-of select="@*" />
+
+      <gco:Boolean></gco:Boolean>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/inflate-metadata.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/inflate-metadata.xsl
@@ -1,3 +1,4 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
                   xmlns:gco="http://www.isotc211.org/2005/gco"
@@ -7,7 +8,7 @@
   <xsl:output method="xml" indent="yes"/>
 
   <xsl:template match="/root">
-    <xsl:apply-templates select="gmd:MD_Metadata"/>
+    <xsl:apply-templates select="gmd:*"/>
   </xsl:template>
 
   <!-- Add gco:Boolean to gmd:pass with nilReason to work nicely in the editor,

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -59,6 +59,27 @@
     <for name="gco:Real" use="number"/>
     <for name="gco:Boolean" use="checkbox"/>
 
+    <!-- Use data-gn-checkbox-with-nilreason for INSPIRE conformity, using xpath attribute.Similar configuration can be
+             applied to other boolean fields that require to handle nilreason value.
+             And additional change is required in inflate-metadata.xsl, for the elements to handle with this directive to add gco:Boolean
+             when missing due to nilreason attribute and work nicely with the metadata editor.
+             Example with gmd:pass:
+               <xsl:template match="gmd:pass[@gco:nilReason and not(gco:Boolean)]">
+                <xsl:copy>
+                  <xsl:copy-of select="@*" />
+                  <gco:Boolean></gco:Boolean>
+                </xsl:copy>
+              </xsl:template>
+              Update-fixed-info.xsl already removes gco:Boolean when empty due to nilreason attribute, to avoid xsd errors. No need to change it.
+        -->
+    <!--<for name="gco:Boolean"
+         xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:pass"
+         use="data-gn-checkbox-with-nilreason">
+      <directiveAttributes
+        data-tag-name="gmd:pass"
+        data-nilreason="eval#@gco:nilReason"
+        data-labels='{"true": "conformant", "false": "notConformant", "unknown": "notEvaluated"}'/>
+    </for>-->
 
     <for name="gco:Date" use="data-gn-date-picker"/>
     <for name="gco:DateTime" use="data-gn-date-picker"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -54,7 +54,7 @@
       <xsl:with-param name="value" select="*"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -235,7 +235,7 @@
       <xsl:with-param name="forceDisplayAttributes" select="true()" />
       <xsl:with-param name="type"
                       select="gn-fn-metadata:getFieldType($editorConfig, name(),
-            name(gmx:Anchor))"/>
+            name(gmx:Anchor), $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then */gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo"
@@ -403,7 +403,10 @@
       <xsl:with-param name="attributesSnippet" select="$attributes"/>
       <xsl:with-param name="type"
                       select="gn-fn-metadata:getFieldType($editorConfig, name(),
-        name($theElement))"/>
+        name($theElement), $xpath)"/>
+      <xsl:with-param name="directiveAttributes">
+        <xsl:copy-of select="gn-fn-metadata:getFieldDirective($editorConfig, name(), name($theElement), $xpath)"/>
+      </xsl:with-param>
       <xsl:with-param name="name" select="$theElement/gn:element/@ref"/>
       <xsl:with-param name="editInfo" select="$theElement/gn:element"/>
       <xsl:with-param name="parentEditInfo"
@@ -422,13 +425,15 @@
    as read only. The associated resource panel is used to edit
     those values. -->
   <xsl:template mode="mode-iso19139" match="@uuidref" priority="2000">
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
                       select="gn-fn-metadata:getLabel($schema, name(..), $labels)"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="../gn:element"/>
       <xsl:with-param name="parentEditInfo" select="../gn:element"/>
@@ -439,13 +444,15 @@
 
 
   <xsl:template mode="mode-iso19139" match="gco:ScopedName|gco:LocalName">
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
                       select="gn-fn-metadata:getLabel($schema, name(.), $labels)"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="gn:element/@ref"/>
       <xsl:with-param name="editInfo" select="gn:element"/>
       <xsl:with-param name="parentEditInfo" select="../gn:element"/>
@@ -580,12 +587,14 @@
 
     <xsl:variable name="added" select="parent::node()/parent::node()/@gn:addedObj"/>
 
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+
     <xsl:call-template name="render-element">
       <xsl:with-param name="label" select="$labelConfig"/>
       <xsl:with-param name="value" select="."/>
       <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '')"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo"
                       select="gn:element"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -627,4 +627,20 @@
     </xsl:if>
   </xsl:template>
 
+  <!-- Remove empty boolean  and set gco:nilReason='unknown' -->
+  <xsl:template match="*[gco:Boolean and not(string(gco:Boolean))]">
+    <xsl:copy>
+      <xsl:copy-of select="@*[name() != 'gco:nilReason']" />
+      <xsl:attribute name="gco:nilReason">unknown</xsl:attribute>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove gco:nilReason if not empty boolean -->
+  <xsl:template match="*[string(gco:Boolean)]">
+    <xsl:copy>
+      <xsl:copy-of select="@*[name() != 'gco:nilReason']" />
+      <xsl:apply-templates select="*" />
+    </xsl:copy>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/3569

Not intended to be merged, but to be used by customers in `3.4.x` branch