### PR TITLE
Splitting the large GN stylesheet into smaller ones and speed up loading

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1,18 +1,10 @@
 // GN Styles
 @import "../lib/style/font-awesome/less/font-awesome.less";
-@import "gn_bootstrap.less";
-
+@import "../lib/style/bootstrap/less/variables.less";
 @import (less) "../lib/ol.css";
 @import (less) "../lib/angular.ext/hotkeys/hotkeys.min.css";
-@import "../lib/bootstrap.ext/tagsinput/bootstrap-tagsinput.less";
-// import the css files as less files so they are included in the final output of wro4j
-@import "../lib/bootstrap.ext/datepicker/datepicker.less";
-@import (less) "../lib/style/datetimepicker.css";
 @import "gn_doc.less";
-@import "gn_icons.less";
-
 @import "ellipsis.less";
-@import "timeline.less";
 
 @fa-version: '4.3.0';
 @fa-font-path: '../catalog/lib/style/font-awesome/fonts';

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -1,10 +1,9 @@
+@import "gn_bootstrap.less";
+
 @import "../lib/bootstrap.ext/tagsinput/bootstrap-tagsinput.less";
 // import the css files as less files so they are included in the final output of wro4j
-@import (less) "../lib/style/ol.css";
-@import (less) "../lib/style/datetimepicker.css";
 @import (less) "../lib/jquery.ext/jquery.fileupload-ui.css";
 @import "gn.less";
-
 
 @import "../lib/style/bootstrap/less/glyphicons.less";
 

--- a/web-ui/src/main/resources/catalog/style/gn_fonts.less
+++ b/web-ui/src/main/resources/catalog/style/gn_fonts.less
@@ -1,0 +1,1 @@
+@import "../lib/style/font-awesome/less/font-awesome.less";

--- a/web-ui/src/main/resources/catalog/style/gn_inspire.less
+++ b/web-ui/src/main/resources/catalog/style/gn_inspire.less
@@ -1,0 +1,1 @@
+@import (less) "inspire/iti.css";

--- a/web-ui/src/main/resources/catalog/style/gn_pickers.less
+++ b/web-ui/src/main/resources/catalog/style/gn_pickers.less
@@ -1,0 +1,4 @@
+// import the css files as less files so they are included in the final output of wro4j
+@import (less) "../lib/bootstrap.ext/datepicker/datepicker.css";
+@import (less) "../lib/style/datetimepicker.css";
+@import (less) "../lib/angular.ext/colorpicker/angularjs-color-picker.min.css";

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -1,18 +1,7 @@
-// GN Styles
-@import "../lib/style/font-awesome/less/font-awesome.less";
-@import "gn_bootstrap.less";
 @import "gn_infolist.less";
 @import "gn_badge_categories.less";
 
 @import "../lib/bootstrap.ext/tagsinput/bootstrap-tagsinput.less";
-// import the css files as less files so they are included in the final output of wro4j
-@import (less) "../lib/bootstrap.ext/datepicker/datepicker.css";
-@import (less) "../lib/style/datetimepicker.css";
-@import (less) "../lib/angular.ext/colorpicker/angularjs-color-picker.min.css";
-
-@import (less) "inspire/iti.css";
-// Import this CSS to have INSPIRE themes translations
-//@import (less) "inspire/iti-i18n.css";
 
 @import "gn.less";
 @import "gn_viewer.less";
@@ -416,7 +405,7 @@ span.gn-facet-label:first-letter {
     font-size: 14px;
   }
   p {
-    font-size: .9em;
+    // font-size: .9em;
   }
   blockquote {
     padding: 6px 20px;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -27,13 +27,10 @@ html, body {
   background-attachment: fixed;
 }
 
-.container-fluid {
-   margin-right: auto;
-   margin-left: auto;
-   padding-left: 0;
-   padding-right: 0;
+.row {
+  margin-left: 0;
+  margin-right: 0;
 }
-
 .gn-row-main {
   margin: 2em 0 4em;
   .gn-form-any {

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -43,16 +43,26 @@
             TODO : less compilation
             <link href="style/app.css" rel="stylesheet" media="screen" />
 -->
-    <xsl:if test="$withD3">
-      <link href="{/root/gui/url}/static/nv.d3.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
-            media="screen"/>
-    </xsl:if>
+    <link href="{/root/gui/url}/static/gn_fonts.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+          media="screen"/>
 
     <link href="{/root/gui/url}/static/{$customFilename}.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
           media="screen"/>
 
     <link href="{/root/gui/url}/static/bootstrap-table.min.css?v={$buildNumber}" rel="stylesheet"
           media="screen"></link>
+
+    <link href="{/root/gui/url}/static/gn_pickers.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+          media="screen"/>
+
+    <link href="{/root/gui/url}/static/gn_inspire.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+          media="screen"/>
+
+    <xsl:if test="$withD3">
+      <link href="{/root/gui/url}/static/nv.d3.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+            media="screen"/>
+    </xsl:if>
+
     <link href="{/root/gui/url}/static/ng-skos.css?v={$buildNumber}" rel="stylesheet" media="screen"></link>
     <link href="{/root/gui/url}/static/{/root/gui/nodeId}_custom_style.css?v={$buildNumber}&amp;{$minimizedParam}"
           rel="stylesheet" media="screen"/>


### PR DESCRIPTION
This PR splits the large GeoNetwork stylesheet in smaller stylesheets. 

This is done in order to speed up the loading of the different files. A browser can load these smaller files simultaneously. The first styles needed to draw the opening page are accessible faster. The page doesn't have to wait until the one large stylesheet is loaded.

The new GN stylesheet is now (more or less) half the size of the old one.