### PR TITLE
OGC / GetCapabilities / Time out set to 1 min.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -86,6 +86,8 @@
   var unmarshaller110 = context110.createUnmarshaller();
   var unmarshaller20 = context20.createUnmarshaller();
   var cachedGetCapabilitiesUrls = {};
+  // var timeout = -1;
+  var timeout = 60 * 1000;
 
   module.provider('gnOwsCapabilities', function() {
     this.$get = ['$http', '$q', '$translate',
@@ -277,7 +279,7 @@
               if (true) {
                 $http.get(url, {
                   cache: true,
-                  timeout: 5000
+                  timeout: timeout
                 })
                     .success(function(data) {
                       try {
@@ -313,7 +315,7 @@
 
                 $http.get(url, {
                   cache: true,
-                  timeout: 5000
+                  timeout: timeout
                 })
                     .success(function(data, status, headers, config) {
                       if (data) {
@@ -345,7 +347,7 @@
               if (gnUrlUtils.isValid(url)) {
                 $http.get(url, {
                   cache: true,
-                  timeout: 5000
+                  timeout: timeout
                 })
                     .success(function(data, status, headers, config) {
                       var xfsCap = parseWFSCapabilities(data);
@@ -445,7 +447,7 @@
             return extent;
           },
 
-          
+
           getLayerInfoFromCap: function(layerName, capObj, uuid) {
             var needles = [];
             var layers = capObj.layers || capObj.Layer;
@@ -465,7 +467,7 @@
                 if (capObj.Request) {
                   layers[i].capRequest = capObj.Request;
                 }
-                
+
                 //check layername
                 var lId = layers[i].Identifier;
                 var capName = layers[i].Name ||
@@ -510,7 +512,7 @@
                 }
               }
             }
-            
+
             //FIXME: remove duplicates
             if (needles.length >= layerList.length) {
               if (capObj.version) {


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/commit/22a19736cff1a2438981956e1d66d6741adbebb2 which introduced a 5sec timeout

A too short timeout is also quite useless because then the direct query is cancelled on the browser, got -1 as status, then it goes to the proxy then is cancelled on the client side and the proxy continue ...