### PR TITLE
Fix: Remove padding in Admin page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -36,6 +36,10 @@ ul.gn-resultview li.list-group-item {
     padding-top: calc(~"@{gn-menubar-height} + 1px");
     background-color: #f7f7f7;
   }
+  .container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
   .gn-top-bar {
     position: fixed;
     width: 100%;


### PR DESCRIPTION
The `admin` page had a padding of 15px on both sides, but is designed to be full width. This PR removes the padding.

**Screenshot of old situation**
![gn-admin-padding-old](https://user-images.githubusercontent.com/19608667/65491951-5ac54980-deb0-11e9-856d-467d7a073650.png)

**The new situation**
![gn-admin-padding-new](https://user-images.githubusercontent.com/19608667/65491977-644eb180-deb0-11e9-8d26-3d02ca3ec658.png)
