### PR TITLE
API / Related / Errors in case a feature catalogue is linked but not found

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -67,6 +67,8 @@ import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.jdom.Content;
 import org.jdom.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 
@@ -82,6 +84,7 @@ import jeeves.server.context.ServiceContext;
 public class MetadataUtils {
     public static final boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = false;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Geonet.SEARCH_ENGINE);
 
     public static Element getRelated(ServiceContext context, int iId, String uuid,
                                      RelatedItemType[] type,
@@ -203,7 +206,11 @@ public class MetadataUtils {
                         Element metadata = new Element("metadata");
                         Element response = new Element("response");
                         Element current = getRecord(fcat_uuid, context, dm);
-                        metadata.addContent(current);
+                        if (current != null) {
+                            metadata.addContent(current);
+                        } else {
+                            LOGGER.error("Feature catalogue with UUID {} referenced in {} was not found.", fcat_uuid, uuid);
+                        }
                         response.addContent(metadata);
                         fcat.addContent(response);
                     }


### PR DESCRIPTION
Error is:
```xml
<apiError>
<code>unsatisfied_request_parameter</code>
<description>Cannot add null object</description>
<message>IllegalAddException</message>
</apiError>
```

This is related to a record having a reference to a non existing feature catalogue eg.
```xml
<gmd:contentInfo >
<gmd:MD_FeatureCatalogueDescription>
<gmd:includedWithDataset>
<gco:Boolean>false</gco:Boolean>
</gmd:includedWithDataset>
<gmd:featureCatalogueCitation uuidref="fr-120066022-ca-jdd-36d391b9-8b55-4eb3-b891-c02b706ad97a" xlink:href="http://localhost:8080/geonetwork/srv/fre/csw?service=CSW&request=GetRecordById&version=2.0.2&outputSchema=http://www.isotc211.org/2005/gmd&elementSetName=full&id=fr-120066022-ca-jdd-36d391b9-8b55-4eb3-b891-c02b706ad97a"/>
</gmd:MD_FeatureCatalogueDescription>
</gmd:contentInfo>
```

When this happens, calls to the related API is returning exception and does not display any related objects (eg. thumbnails).