### PR TITLE
Portal / Add message when a portal is empty.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -453,7 +453,7 @@ goog.require('gn_alert');
              gnViewerSettings, gnSearchSettings, $cookies,
              gnExternalViewer, gnAlertService) {
       $scope.version = '0.0.1';
-
+      var defaultNode = 'srv';
 
       // Links for social media
       $scope.socialMediaLink = $location.absUrl();
@@ -477,7 +477,7 @@ goog.require('gn_alert');
             return res[1];
           }
         }
-        return detector.default || 'srv';
+        return detector.default || defaultNode;
       }
 
 
@@ -501,6 +501,7 @@ goog.require('gn_alert');
         return detector.default || 'geonetwork';
       }
       $scope.nodeId = detectNode(gnGlobalSettings.gnCfg.nodeDetector);
+      $scope.isDefaultNode = $scope.nodeId === defaultNode;
       $scope.service = detectService(gnGlobalSettings.gnCfg.serviceDetector);
       $scope.redirectUrlAfterSign = window.location.href;
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -354,6 +354,7 @@
     "dublin-core-help": "The Dublin Core metadata standard",
     "dupNameWarning": "There is already a group with that name. Change the name.",
     "emailToSearch": "Email to search",
+    "emptyPortal": "Portal <strong>{{portal}}</strong> is empty. You can check its <a href='#/settings/sources'>configuration</a> or <a href='catalog.edit'>create or import records</a>.",
     "emptyCatalogShouldBeFilled": "The catalog is empty, you probably want to import new records or configure a harvester. You could also insert <a href='#/metadata/metadata-and-template/load-templates/all'>all templates</a>, <a href='#/metadata/metadata-and-template/load-samples/all'>all samples</a> or <a href='#/metadata/metadata-and-template/load-samples-and-templates/all'>both</a>.",
     "enable": "Enable",
     "enableAllowedCategories": "Enable Allowed Categories",

--- a/web-ui/src/main/resources/catalog/templates/admin/admin.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/admin.html
@@ -1,7 +1,7 @@
 <div class="row" data-ng-controller="GnAdminController">
 
     <div class="sidebar">
-  
+
       <div class="sidebar-col-main sidebar-col-full">
         <ul data-ng-if="user.isUserAdmin()" class="nav nav-sidebar" role="menu">
             <li>
@@ -89,8 +89,12 @@
 
 
         <div class="col-md-4 col-sm-8"
-             data-ng-show="searchInfo.count == 0"
+             data-ng-show="isDefaultNode && searchInfo.count == 0"
              data-translate=""> emptyCatalogShouldBeFilled
+        </div>
+        <div class="col-md-4 col-sm-8"
+             data-ng-show="!isDefaultNode && searchInfo.count == 0"
+             data-translate="" data-translate-values="{portal: nodeId}"> emptyPortal
         </div>
       </div>
       <!-- /.gn-row-admin-stats -->

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
@@ -11,9 +11,18 @@
                    placeholder="{{'filter' | translate}}"/>
             <a class="list-group-item"
                data-ng-class="s.uuid === source.uuid ? 'active' : ''"
+               title="{{::('source-' + s.type) | translate}}"
                data-ng-click="selectSource(s)"
                data-ng-repeat="s in sources | filter:sourcesSearch | orderBy:'name'">
-              {{s.name}} ({{('source-' + s.type) | translate}})
+              <i class="fa fa-fw"
+                 data-ng-class="{'fa-home': s.type === 'portal',
+                 'fa-folder': s.type === 'subportal',
+                 'fa-cloud': s.type === 'externalportal',
+                 'fa-cloud-download': s.type === 'harvester'}"></i>
+              {{::s.name}}
+              <img class="img-circle gn-source-logo"
+                   data-ng-src="{{'../../images/' + (s.type === 'subportal' ? 'harvesting/' +  s.logo : 'logos/' +  s.uuid + '.png')}}"/>
+
             </a>
           </ul>
         </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -40,6 +40,10 @@ ul.gn-resultview li.list-group-item {
     padding-left: 0;
     padding-right: 0;
   }
+  .gn-source-logo {
+    max-width: 20px;
+    max-height: 20px;
+  }
   .gn-top-bar {
     position: fixed;
     width: 100%;
@@ -189,7 +193,7 @@ ul.gn-resultview li.list-group-item {
               border-left-color: @brand-primary;
             }
           }
-    
+
         }
       }
     }
@@ -243,7 +247,7 @@ ul.gn-resultview li.list-group-item {
             }
           }
         }
-  
+
       }
       .gn-row-admin-stats {
         .panel {
@@ -260,7 +264,7 @@ ul.gn-resultview li.list-group-item {
           .panel-body {
             padding: 5px 15px;
             background: @gray-lighter;
-  
+
             h2 {
               margin: 0;
               padding: 10px 0;


### PR DESCRIPTION
Currently if a portal has no matching records, a message indicate that the catalogue is empty. This is not always true.

![image](https://user-images.githubusercontent.com/1701393/65869184-3bc82b00-e37a-11e9-84ec-a4aff596498f.png)

Add a specific message for empty portal:

![image](https://user-images.githubusercontent.com/1701393/65869180-3965d100-e37a-11e9-84cc-d91c8bc0d72d.png)

Also add icon and logo in list of sources
![image](https://user-images.githubusercontent.com/1701393/65872281-864ca600-e380-11e9-8d79-b780661a9757.png)

