### PR TITLE
Portal list / Force content type to text/html

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
@@ -115,19 +115,12 @@ public class SourcesApi {
     @ResponseBody
     public void getSubPortal(
         @ApiIgnore
-            HttpServletRequest request,
-        @ApiIgnore
-            HttpServletResponse response,
-        @ApiIgnore
-        @RequestHeader(
-            value = "Accept",
-            defaultValue = MediaType.APPLICATION_JSON_VALUE
-        )
-            String accept
+            HttpServletResponse response
     ) throws Exception {
         final List<Source> sources = sourceRepository.findAll(SortUtils.createSort(Source_.name));
         Element sourcesList = new Element("sources");
         sources.stream().map(GeonetEntity::asXml).forEach(sourcesList::addContent);
+        response.setContentType(MediaType.TEXT_HTML_VALUE);
         response.getWriter().write(
             new XsltResponseWriter()
                 .withJson("catalog/locales/en-core.json")


### PR DESCRIPTION
On some tomcat installation, it looks like content type is sometimes set to text/html. Not sure if related to Spring.