### PR TITLE
Harvester / Add option to append privileges in case of override

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -818,11 +818,6 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
      */
     protected abstract void doHarvest(Logger l) throws Exception;
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- Protected storage methods
-    //---
-    //---------------------------------------------------------------------------
 
     /**
      * Invoked from doAdd and doUpdate in sub class implementations.
@@ -859,6 +854,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
         harvesterSettingsManager.add(ID_PREFIX + optionsId, "every", params.getEvery());
         harvesterSettingsManager.add(ID_PREFIX + optionsId, "oneRunOnly", params.isOneRunOnly());
         harvesterSettingsManager.add(ID_PREFIX + optionsId, "overrideUUID", params.getOverrideUuid());
+        harvesterSettingsManager.add(ID_PREFIX + optionsId, "ifRecordExistAppendPrivileges", params.isIfRecordExistAppendPrivileges());
         harvesterSettingsManager.add(ID_PREFIX + optionsId, "status", status);
 
         //--- setup content node ---------------------------------------
@@ -941,6 +937,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
             add(res, "badFormat", result.badFormat);
             add(res, "collectionDatasetRecords", result.collectionDatasetRecords);
             add(res, "datasetUuidExist", result.datasetUuidExist);
+            add(res, "privilegesAppendedOnExistingRecord", result.privilegesAppendedOnExistingRecord);
             add(res, "doesNotValidate", result.doesNotValidate);
             add(res, "xpathFilterExcluded", result.xpathFilterExcluded);
             add(res, "duplicatedResource", result.duplicatedResource);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
@@ -57,7 +57,7 @@ import static org.quartz.JobBuilder.newJob;
 public abstract class AbstractParams {
     public static final String TRANSLATIONS = "translations";
     private static final long MAX_EVERY = Integer.MAX_VALUE;
-    
+
 
     public enum OverrideUuid {
         SKIP, OVERRIDE, RANDOM
@@ -85,25 +85,20 @@ public abstract class AbstractParams {
     private String ownerIdUser;
     private OverrideUuid overrideUuid;
 
+    /**
+     *  When more than one harvester harvest the same record, then record is usually rejected.
+     *  It can override existing, but the privileges are not preserved. This option
+     *  preserve privileges set in the different harvesters.
+     */
+    private boolean ifRecordExistAppendPrivileges;
+
 
     private List<Privileges> alPrivileges = new ArrayList<>();
     private List<String> alCategories = new ArrayList<>();
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- Constructor
-    //---
-    //---------------------------------------------------------------------------
-
     public AbstractParams(DataManager dm) {
         this.dm = dm;
     }
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- API methods
-    //---
-    //---------------------------------------------------------------------------
 
     private static HarvestValidationEnum readValidateFromParams(Element content) {
         String validationString = Util.getParam(content, "validate", HarvestValidationEnum.NOVALIDATION.toString());
@@ -188,6 +183,8 @@ public abstract class AbstractParams {
                 OverrideUuid.valueOf(
                         Util.getParam(opt, "overrideUuid",  OverrideUuid.SKIP.name())));
 
+        setIfRecordExistAppendPrivileges("true".equals(node.getChildTextTrim("ifRecordExistAppendPrivileges")));
+
         getTrigger();
 
         setImportXslt(Util.getParam(content, "importxslt", "none"));
@@ -244,7 +241,7 @@ public abstract class AbstractParams {
                 setOwnerIdUser(ownerIdUserE.getText());
             }
         }
-        
+
         Element ownerIdGroupE = node.getChild("ownerGroup");
         if (ownerIdGroupE != null) {
             Element idE = ownerIdGroupE.getChild("id");
@@ -265,6 +262,7 @@ public abstract class AbstractParams {
         setOverrideUuid(
                 OverrideUuid.valueOf(
                         Util.getParam(opt, "overrideUuid", getOverrideUuid().name())));
+        setIfRecordExistAppendPrivileges("true".equals(node.getChildTextTrim("ifRecordExistAppendPrivileges")));
 
         getTrigger();
 
@@ -296,11 +294,6 @@ public abstract class AbstractParams {
         return alCategories;
     }
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- Protected methods
-    //---
-    //---------------------------------------------------------------------------
 
     /**
      * @param copy
@@ -320,6 +313,7 @@ public abstract class AbstractParams {
         copy.setEvery(getEvery());
         copy.setOneRunOnly(isOneRunOnly());
         copy.setOverrideUuid(getOverrideUuid());
+        copy.setIfRecordExistAppendPrivileges(isIfRecordExistAppendPrivileges());
 
         copy.setImportXslt(getImportXslt());
         copy.setValidate(getValidate());
@@ -595,4 +589,11 @@ public abstract class AbstractParams {
         this.overrideUuid = overrideUuid;
     }
 
+    public boolean isIfRecordExistAppendPrivileges() {
+        return ifRecordExistAppendPrivileges;
+    }
+
+    public void setIfRecordExistAppendPrivileges(boolean ifRecordExistAppendPrivileges) {
+        this.ifRecordExistAppendPrivileges = ifRecordExistAppendPrivileges;
+    }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvestResult.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/HarvestResult.java
@@ -30,6 +30,7 @@ public class HarvestResult {
     public int collectionDatasetRecords;    // = md for collection datasets
     public int couldNotInsert;
     public int datasetUuidExist;    // = uuid already in catalogue
+    public int privilegesAppendedOnExistingRecord;
     public int doesNotValidate;            // = 0 cos' not validated
     public int xpathFilterExcluded;
     public int duplicatedResource;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
@@ -33,7 +33,6 @@ import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.domain.Source;
 import org.fao.geonet.domain.SourceType;
 import org.fao.geonet.exceptions.BadInputEx;
@@ -379,7 +378,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 
         OperationAllowedRepository operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
         operationAllowedRepository.deleteAllByMetadataId(Integer.parseInt(id));
-        aligner.addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        aligner.addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         metadata.getCategories().clear();
         aligner.addCategories(metadata, params.getCategories(), localCateg, context, null, true);
@@ -434,7 +433,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 
         String id = String.valueOf(metadata.getId());
 
-        aligner.addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        aligner.addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         dataMan.indexMetadata(id, true, null);
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -23,24 +23,7 @@
 
 package org.fao.geonet.kernel.harvest.harvester.csw;
 
-import static org.fao.geonet.utils.AbstractHttpRequest.Method.GET;
-import static org.fao.geonet.utils.AbstractHttpRequest.Method.POST;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.transaction.Transactional;
-import javax.transaction.Transactional.TxType;
-
+import jeeves.server.context.ServiceContext;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
@@ -53,7 +36,6 @@ import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.kernel.DataManager;
@@ -77,7 +59,23 @@ import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.xpath.XPath;
 
-import jeeves.server.context.ServiceContext;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.fao.geonet.utils.AbstractHttpRequest.Method.GET;
+import static org.fao.geonet.utils.AbstractHttpRequest.Method.POST;
+
 
 public class Aligner extends BaseAligner<CswParams> {
 
@@ -181,7 +179,7 @@ public class Aligner extends BaseAligner<CswParams> {
         return result;
     }
 
-	private void insertOrUpdate(Collection<RecordInfo> records, Collection<HarvestError> errors) {
+    private void insertOrUpdate(Collection<RecordInfo> records, Collection<HarvestError> errors) {
         for (RecordInfo ri : records) {
 
             if (cancelMonitor.get()) {
@@ -189,7 +187,6 @@ public class Aligner extends BaseAligner<CswParams> {
             }
 
             try {
-
                 String id = metadataUtils.getMetadataId(ri.uuid);
 
                 if (id == null) {
@@ -205,6 +202,11 @@ public class Aligner extends BaseAligner<CswParams> {
                             updateMetadata(ri, Integer.toString(metadataUtils.findOneByUuid(ri.uuid).getId()), true);
                             log.debug("Overriding record with uuid " + ri.uuid);
                             result.updatedMetadata++;
+
+                            if (params.isIfRecordExistAppendPrivileges()) {
+                                addPrivileges(id, params.getPrivileges(), localGroups, context);
+                                result.privilegesAppendedOnExistingRecord++;
+                            }
                             break;
                         case RANDOM:
                             log.debug("Generating random uuid for remote record with uuid " + ri.uuid);
@@ -220,6 +222,10 @@ public class Aligner extends BaseAligner<CswParams> {
                     //record exists and belongs to this harvester
                     updateMetadata(ri, id, false);
 
+                    if (params.isIfRecordExistAppendPrivileges()) {
+                        addPrivileges(id, params.getPrivileges(), localGroups, context);
+                        result.privilegesAppendedOnExistingRecord++;
+                    }
                 }
 
                 context.getBean(LuceneIndexLanguageTracker.class).commit();
@@ -228,13 +234,13 @@ public class Aligner extends BaseAligner<CswParams> {
             } catch (Throwable t) {
                 errors.add(new HarvestError(this.context, t));
                 log.error("Unable to process record from csw (" + this.params.getName() + ")");
-                log.error("   Record failed: " +  ri.uuid + ". Error is: " + t.getMessage());
-				log.error(t);
+                log.error("   Record failed: " + ri.uuid + ". Error is: " + t.getMessage());
+                log.error(t);
             } finally {
                 result.originalMetadata++;
             }
         }
-	}
+    }
 
     /**
      * Remove records no longer on the remote CSW server
@@ -242,8 +248,8 @@ public class Aligner extends BaseAligner<CswParams> {
      * @param records
      * @throws Exception
      */
-	@Transactional(value=TxType.REQUIRES_NEW)
-	public HarvestResult cleanupRemovedRecords(Set<String> records) throws Exception {
+    @Transactional(value = TxType.REQUIRES_NEW)
+    public HarvestResult cleanupRemovedRecords(Set<String> records) throws Exception {
 
         if (cancelMonitor.get()) {
             return result;
@@ -260,7 +266,7 @@ public class Aligner extends BaseAligner<CswParams> {
         dataMan.forceIndexChanges();
 
         return result;
-	}
+    }
 
 
     private void addMetadata(RecordInfo ri, String uuid) throws Exception {
@@ -298,7 +304,7 @@ public class Aligner extends BaseAligner<CswParams> {
             md = processMetadata(context, md, processName, processParams);
             // Get new uuid if modified by XSLT process
             mdUuid = metadataUtils.extractUUID(schema, md);
-            if(mdUuid == null) {
+            if (mdUuid == null) {
                 mdUuid = ri.uuid;
             }
         }
@@ -331,17 +337,12 @@ public class Aligner extends BaseAligner<CswParams> {
 
         String id = String.valueOf(metadata.getId());
 
-        addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         metadataIndexer.indexMetadata(id, true, null);
         result.addedMetadata++;
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Private methods : updateMetadata
-    //---
-    //--------------------------------------------------------------------------
     private void updateMetadata(RecordInfo ri, String id, Boolean force) throws Exception {
         String date = localUuids.getChangeDate(ri.uuid);
 
@@ -353,55 +354,54 @@ public class Aligner extends BaseAligner<CswParams> {
                 result.unchangedMetadata++;
             } else {
                 log.debug("  - Updating local metadata for uuid:" + ri.uuid);
-                if(updatingLocalMetadata(ri, id, force)) {
-                	metadataIndexer.indexMetadata(id, true, null);
+                if (updatingLocalMetadata(ri, id, force)) {
+                    metadataIndexer.indexMetadata(id, true, null);
                     result.updatedMetadata++;
                 }
             }
         }
     }
+    @Transactional(value = TxType.REQUIRES_NEW)
+    private boolean updatingLocalMetadata(RecordInfo ri, String id, Boolean force) throws Exception {
+        Element md = retrieveMetadata(ri.uuid);
 
-    @Transactional(value=TxType.REQUIRES_NEW)
-	private boolean updatingLocalMetadata(RecordInfo ri, String id, Boolean force) throws Exception {
-		Element md = retrieveMetadata(ri.uuid);
+        if (md == null) {
+            result.unchangedMetadata++;
+            return false;
+        }
 
-		if (md == null) {
-		    result.unchangedMetadata++;
-		    return false;
-		}
+        if (!params.xslfilter.equals("")) {
+            md = processMetadata(context, md, processName, processParams);
+        }
 
-		if (!params.xslfilter.equals("")) {
-		    md = processMetadata(context, md, processName, processParams);
-		}
+        //
+        // update metadata
+        //
+        boolean validate = false;
+        boolean ufo = false;
+        boolean index = false;
+        String language = context.getLanguage();
 
-		//
-		// update metadata
-		//
-		boolean validate = false;
-		boolean ufo = false;
-		boolean index = false;
-		String language = context.getLanguage();
+        final AbstractMetadata metadata = metadataManager.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, true);
 
-		final AbstractMetadata metadata = metadataManager.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, true);
+        if (force) {
+            //change ownership of metadata to new harvester
+            metadata.getHarvestInfo().setUuid(params.getUuid());
+            metadata.getSourceInfo().setSourceId(params.getUuid());
 
-		if(force) {
-		    //change ownership of metadata to new harvester
-		    metadata.getHarvestInfo().setUuid(params.getUuid());
-		    metadata.getSourceInfo().setSourceId(params.getUuid());
+            metadataManager.save((Metadata) metadata);
+        }
 
-		    metadataManager.save((Metadata) metadata);
-		}
+        OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
+        repository.deleteAllByMetadataId(Integer.parseInt(id));
 
-		OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
-		repository.deleteAllByMetadataId(Integer.parseInt(id));
+        addPrivileges(id, params.getPrivileges(), localGroups, context);
 
-		addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        metadata.getCategories().clear();
+        addCategories(metadata, params.getCategories(), localCateg, context, null, true);
 
-		metadata.getCategories().clear();
-		addCategories(metadata, params.getCategories(), localCateg, context, null, true);
-
-		return true;
-	}
+        return true;
+    }
 
     /**
      * Does CSW GetRecordById request. If validation is requested and the metadata does not
@@ -452,7 +452,7 @@ public class Aligner extends BaseAligner<CswParams> {
 
             return response;
         } catch (Exception e) {
-            log.error("Raised exception while getting record : " +  e);
+            log.error("Raised exception while getting record : " + e);
             log.error(e);
             result.unretrievable++;
 
@@ -464,13 +464,13 @@ public class Aligner extends BaseAligner<CswParams> {
     /**
      * Check for metadata in the catalog having the same resource identifier as the harvested
      * record.
-     *
+     * <p>
      * If one dataset (same MD_metadata/../identificationInfo/../identifier/../code) (eg. a NMA
      * layer for roads) is described in 2 or more catalogs with different metadata uuids. The
      * metadata may be slightly different depending on the author, but the resource is the same.
      * When harvesting, some users would like to have the capability to exclude "duplicate"
      * description of the same dataset.
-     *
+     * <p>
      * The check is made searching the identifier field in the index using {@link
      * org.fao.geonet.kernel.search.LuceneSearcher#getAllMetadataFromIndexFor(String, String,
      * String, java.util.Set, boolean)}
@@ -527,7 +527,6 @@ public class Aligner extends BaseAligner<CswParams> {
     }
 
     /**
-     *
      * Filter the metadata if process parameter is set and corresponding XSL transformation
      * exists in xsl/conversion/import.
      *

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/fragment/FragmentHarvester.java
@@ -42,7 +42,6 @@ import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.exceptions.BadXmlResponseEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
@@ -407,9 +406,9 @@ public class FragmentHarvester extends BaseAligner {
 
         String id = String.valueOf(metadata.getId());
 
-        // Note: we use fragmentAllPrivs here because subtemplates need to be 
+        // Note: we use fragmentAllPrivs here because subtemplates need to be
         // visible/accessible to all
-        addPrivileges(id, fragmentAllPrivs, localGroups, dataMan, context);
+        addPrivileges(id, fragmentAllPrivs, localGroups, context);
         dataMan.indexMetadata(id, true, null);
 
         metadataManager.flush();
@@ -582,17 +581,17 @@ public class FragmentHarvester extends BaseAligner {
         repository.deleteAllByMetadataId(iId);
 
         if (isSubtemplate) {
-          // Note: we use fragmentAllPrivs here because subtemplates need to be 
+          // Note: we use fragmentAllPrivs here because subtemplates need to be
           // visible/accessible to all
-          addPrivileges(id, fragmentAllPrivs, localGroups, dataMan, context);
+          addPrivileges(id, fragmentAllPrivs, localGroups, context);
         } else {
-          addPrivileges(id, params.privileges, localGroups, dataMan, context);
+          addPrivileges(id, params.privileges, localGroups, context);
         }
 
         metadata.getCategories().clear();
         addCategories(metadata, params.categories, localCateg, context, null, true);
 
-        if (isSubtemplate) { 
+        if (isSubtemplate) {
             dataMan.setSubtemplateTypeAndTitleExt(iId, title);
         }
         dataMan.setHarvestedExt(iId, params.uuid, Optional.of(harvestUri));
@@ -644,7 +643,7 @@ public class FragmentHarvester extends BaseAligner {
         if (log.isDebugEnabled()) {
             log.debug("	- Set privileges, category, template and harvested");
         }
-        addPrivileges(id, params.privileges, localGroups, dataMan, context);
+        addPrivileges(id, params.privileges, localGroups, context);
 
         dataMan.indexMetadata(id, true, null);
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
@@ -36,7 +36,6 @@ import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
@@ -193,7 +192,7 @@ public class Aligner extends BaseAligner<GeoPRESTParams> {
 
         String id = String.valueOf(metadata.getId());
 
-        addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         dataMan.indexMetadata(id, Math.random() < 0.01, null);
         result.addedMetadata++;
@@ -234,7 +233,7 @@ public class Aligner extends BaseAligner<GeoPRESTParams> {
 
                 OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
                 repository.deleteAllByMetadataId(Integer.parseInt(id));
-                addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+                addPrivileges(id, params.getPrivileges(), localGroups, context);
 
                 metadata.getCategories().clear();
                 addCategories(metadata, params.getCategories(), localCateg, context, null, true);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -58,7 +58,6 @@ import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.utils.BinaryFile;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
@@ -151,8 +150,6 @@ public class Aligner extends BaseAligner<GeonetParams> {
         }
     }
 
-    //--------------------------------------------------------------------------
-
     public HarvestResult align(SortedSet<RecordInfo> records, List<HarvestError> errors) throws Exception {
         log.info("Start of alignment for : " + params.getName());
 
@@ -191,9 +188,8 @@ public class Aligner extends BaseAligner<GeonetParams> {
                 result.unchangedMetadata++;
             }
         }
-        //-----------------------------------------------------------------------
         //--- insert/update new metadata
-// Load preferred schema and set to iso19139 by default
+        // Load preferred schema and set to iso19139 by default
         preferredSchema = context.getBean(ServiceConfig.class).getMandatoryValue("preferredSchema");
         if (preferredSchema == null) {
             preferredSchema = "iso19139";
@@ -222,7 +218,6 @@ public class Aligner extends BaseAligner<GeonetParams> {
                     // look up value of localrating/enable
                     SettingManager settingManager = context.getBean(SettingManager.class);
                     String localRating = settingManager.getValue(Settings.SYSTEM_LOCALRATING_ENABLE);
-                    final MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
 
                     if (id == null) {
                         //record doesn't exist (so it doesn't belong to this harvester)
@@ -231,15 +226,21 @@ public class Aligner extends BaseAligner<GeonetParams> {
                     } else if (localUuids.getID(ri.uuid) == null) {
                         //record doesn't belong to this harvester but exists
                         result.datasetUuidExist++;
+
                         switch (params.getOverrideUuid()) {
                             case OVERRIDE:
                                 updateMetadata(ri,
-                                    Integer.toString(metadataRepository.findOneByUuid(ri.uuid).getId()),
+                                    id,
                                     localRating.equals(RatingsSetting.BASIC),
                                     params.useChangeDateForUpdate(),
                                     localUuids.getChangeDate(ri.uuid), true);
                                 log.info("Overriding record with uuid " + ri.uuid);
                                 result.updatedMetadata++;
+
+                                if (params.isIfRecordExistAppendPrivileges()) {
+                                    addPrivileges(id, params.getPrivileges(), localGroups, context);
+                                    result.privilegesAppendedOnExistingRecord++;
+                                }
                                 break;
                             case RANDOM:
                                 log.info("Generating random uuid for remote record with uuid " + ri.uuid);
@@ -258,6 +259,11 @@ public class Aligner extends BaseAligner<GeonetParams> {
                             localRating.equals(RatingsSetting.BASIC),
                             params.useChangeDateForUpdate(),
                             localUuids.getChangeDate(ri.uuid), false);
+
+                        if (params.isIfRecordExistAppendPrivileges()) {
+                            addPrivileges(id, params.getPrivileges(), localGroups, context);
+                            result.privilegesAppendedOnExistingRecord++;
+                        }
                     }
 
                 }
@@ -275,17 +281,6 @@ public class Aligner extends BaseAligner<GeonetParams> {
         return result;
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Private methods
-    //---
-    //--------------------------------------------------------------------------
-
-    //--------------------------------------------------------------------------
-    //---
-    //--- Private methods : addMetadata
-    //---
-    //--------------------------------------------------------------------------
     private Element extractValidMetadataForImport(DirectoryStream<Path> files, Element info) throws IOException, JDOMException {
         Element metadataValidForImport;
         final String finalPreferredSchema = preferredSchema;
@@ -375,8 +370,6 @@ public class Aligner extends BaseAligner<GeonetParams> {
 
         return metadataValidForImport;
     }
-
-    //--------------------------------------------------------------------------
 
     private void addMetadata(final RecordInfo ri, final boolean localRating, String uuid) throws Exception {
         final String id[] = {null};
@@ -481,12 +474,6 @@ public class Aligner extends BaseAligner<GeonetParams> {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Variables
-    //---
-    //--------------------------------------------------------------------------
-
     private String addMetadata(RecordInfo ri, Element md, Element info, boolean localRating, String uuid) throws Exception {
         Element general = info.getChild("general");
 
@@ -568,7 +555,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
             }
         }
         if (((ArrayList<Group>) params.getGroupCopyPolicy()).size() == 0) {
-            addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+            addPrivileges(id, params.getPrivileges(), localGroups, context);
         } else {
             addPrivilegesFromGroupPolicy(id, info.getChild("privileges"));
         }
@@ -850,11 +837,9 @@ public class Aligner extends BaseAligner<GeonetParams> {
             }
         }
 
-        OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
-        repository.deleteAllByMetadataId(Integer.parseInt(id));
         if (((ArrayList<Group>) params.getGroupCopyPolicy()).size() == 0) {
-            addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
-        } else {
+            addPrivileges(id, params.getPrivileges(), localGroups, context);
+        } else if (info != null){
             addPrivilegesFromGroupPolicy(id, info.getChild("privileges"));
         }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
@@ -38,35 +38,16 @@ import org.jdom.Element;
 import java.sql.SQLException;
 import java.util.UUID;
 
-//=============================================================================
-
 public class GeonetHarvester extends AbstractHarvester<HarvestResult> {
     public static final String TYPE = "geonetwork";
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Init
-    //---
-    //--------------------------------------------------------------------------
     private GeonetParams params;
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Add
-    //---
-    //---------------------------------------------------------------------------
 
     protected void doInit(Element node, ServiceContext context) throws BadInputEx {
         params = new GeonetParams(dataMan);
         super.setParams(params);
         params.create(node);
     }
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Update
-    //---
-    //---------------------------------------------------------------------------
 
     protected String doAdd(Element node) throws BadInputEx, SQLException {
         params = new GeonetParams(dataMan);
@@ -86,8 +67,6 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult> {
 
         return id;
     }
-
-    //---------------------------------------------------------------------------
 
     protected void doUpdate(String id, Element node) throws BadInputEx, SQLException {
         GeonetParams copy = params.copy();
@@ -113,12 +92,6 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult> {
         super.setParams(params);
 
     }
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- addHarvestInfo
-    //---
-    //---------------------------------------------------------------------------
 
     protected void storeNodeExtra(AbstractParams p, String path,
                                   String siteId, String optionsId) throws SQLException {
@@ -159,12 +132,6 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult> {
         }
     }
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- Harvest
-    //---
-    //---------------------------------------------------------------------------
-
     public void addHarvestInfo(Element info, String id, String uuid) {
         super.addHarvestInfo(info, id, uuid);
 
@@ -177,12 +144,6 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult> {
         info.addContent(new Element("smallThumbnail").setText(small));
         info.addContent(new Element("largeThumbnail").setText(large));
     }
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Variables
-    //---
-    //---------------------------------------------------------------------------
 
     public void doHarvest(Logger log) throws Exception {
         Harvester h = new Harvester(cancelMonitor, log, context, params);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetParams.java
@@ -36,37 +36,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 
-//=============================================================================
-
 public class GeonetParams extends AbstractParams {
-    //--------------------------------------------------------------------------
-    //---
-    //--- Constructor
-    //---
-    //--------------------------------------------------------------------------
-
     public String host;
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- Create : called when a new entry must be added. Reads values from the
-    //---          provided entry, providing default values
-    //---
-    //---------------------------------------------------------------------------
     public boolean createRemoteCategory;
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- Update : called when an entry has changed and variables must be updated
-    //---
-    //---------------------------------------------------------------------------
     public boolean mefFormatFull;
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- Other API methods
-    //---
-    //---------------------------------------------------------------------------
     /**
      * The filter is a process (see schema/process folder) which depends on the schema. It could be
      * composed of parameter which will be sent to XSL transformation using the following syntax :
@@ -75,26 +51,18 @@ public class GeonetParams extends AbstractParams {
      * </pre>
      */
     public String xslfilter;
+
     private String node;
+
     private Boolean useChangeDateForUpdate;
 
-    //---------------------------------------------------------------------------
     private ArrayList<Search> alSearches = new ArrayList<Search>();
 
-    //---------------------------------------------------------------------------
     private ArrayList<Group> alCopyPolicy = new ArrayList<Group>();
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Private methods
-    //---
-    //---------------------------------------------------------------------------
 
     public GeonetParams(DataManager dm) {
         super(dm);
     }
-
-    //---------------------------------------------------------------------------
 
     public void create(Element node) throws BadInputEx {
         super.create(node);
@@ -116,12 +84,6 @@ public class GeonetParams extends AbstractParams {
         addSearches(searches);
         addCopyPolicy(policy);
     }
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Variables
-    //---
-    //---------------------------------------------------------------------------
 
     public void update(Element node) throws BadInputEx {
         super.update(node);
@@ -245,7 +207,3 @@ public class GeonetParams extends AbstractParams {
         this.useChangeDateForUpdate = useChangeDateForUpdate;
     }
 }
-
-//=============================================================================
-
-

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
@@ -67,31 +67,13 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-//=============================================================================
-
 class Harvester implements IHarvester<HarvestResult> {
     private final AtomicBoolean cancelMonitor;
-    //--------------------------------------------------------------------------
-    //---
-    //--- Constructor
-    //---
-    //--------------------------------------------------------------------------
-    //---------------------------------------------------------------------------
-    //---
-    //--- Variables
-    //---
-    //---------------------------------------------------------------------------
     private Logger log;
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- API methods
-    //---
-    //--------------------------------------------------------------------------
     private GeonetParams params;
     private ServiceContext context;
 
-    //---------------------------------------------------------------------------
     /**
      * Contains a list of accumulated errors during the executing of this harvest.
      */
@@ -105,12 +87,6 @@ class Harvester implements IHarvester<HarvestResult> {
         this.context = context;
         this.params = params;
     }
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Sources update
-    //---
-    //---------------------------------------------------------------------------
 
     public HarvestResult harvest(Logger log) throws Exception {
         this.log = log;
@@ -168,7 +144,7 @@ class Harvester implements IHarvester<HarvestResult> {
         SortedSet<RecordInfo> records = new TreeSet<>(Comparator.comparing(RecordInfo::getUuid));
 
         // Do a search and set from=1 and to=2, try to find out maxPageSize
-        // xml.search service returns maxPageSize in 3.8.x onwards, if not set then 
+        // xml.search service returns maxPageSize in 3.8.x onwards, if not set then
         // use 100. If set but is greater than the one defined by client use the client one.
         int pageSize = 100;
 
@@ -456,7 +432,3 @@ class Harvester implements IHarvester<HarvestResult> {
         return errors;
     }
 }
-
-//=============================================================================
-
-

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -39,7 +39,6 @@ import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.domain.Source;
 import org.fao.geonet.domain.SourceType;
 import org.fao.geonet.exceptions.BadInputEx;
@@ -178,7 +177,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 
         OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
         repository.deleteAllByMetadataId(Integer.parseInt(id));
-        aligner.addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        aligner.addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         metadata.getCategories().clear();
         aligner.addCategories(metadata, params.getCategories(), localCateg, context, null, true);
@@ -215,7 +214,7 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult> {
 
         String id = String.valueOf(metadata.getId());
 
-        aligner.addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        aligner.addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         metadataManager.flush();
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
@@ -295,7 +295,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
                        metadata.getSourceInfo().setOwner(aligner.getOwner());
                     }
                 });
-                aligner.addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+                aligner.addPrivileges(id, params.getPrivileges(), localGroups, context);
                 listOfRecordsToIndex.add(Integer.valueOf(id));
                 listOfRecords.add(Integer.valueOf(id));
                 result.addedMetadata++;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -44,7 +44,6 @@ import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.kernel.DataManager;
@@ -367,7 +366,7 @@ class Harvester extends BaseAligner<OaiPmhParams> implements IHarvester<HarvestR
 
         String id = String.valueOf(metadata.getId());
 
-        addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         metadataManager.flush();
 
@@ -498,7 +497,7 @@ class Harvester extends BaseAligner<OaiPmhParams> implements IHarvester<HarvestR
 
             OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
             repository.deleteAllByMetadataId(Integer.parseInt(id));
-            addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+            addPrivileges(id, params.getPrivileges(), localGroups, context);
 
             metadata.getCategories().clear();
             addCategories(metadata, params.getCategories(), localCateg, context, null, true);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +75,6 @@ import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.services.thumbnail.Set;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.util.Sha1Encoder;
 import org.fao.geonet.utils.BinaryFile;
@@ -91,27 +89,6 @@ import org.jdom.Namespace;
 import org.jdom.xpath.XPath;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
-import jeeves.server.context.ServiceContext;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 
 //=============================================================================
@@ -461,7 +438,7 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
         String id = String.valueOf(metadata.getId());
         uuids.add(uuid);
 
-        addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         return uuids;
     }
@@ -866,7 +843,7 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
             if (log.isDebugEnabled()) log.debug("    - Layer loaded in DB.");
 
             if (log.isDebugEnabled()) log.debug("    - Set Privileges and category.");
-            addPrivileges(reg.id, params.getPrivileges(), localGroups, dataMan, context);
+            addPrivileges(reg.id, params.getPrivileges(), localGroups, context);
 
             if (log.isDebugEnabled()) log.debug("    - Set Harvested.");
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
@@ -54,14 +54,12 @@ import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
 import org.fao.geonet.kernel.harvest.harvester.IHarvester;
 import org.fao.geonet.kernel.harvest.harvester.RecordInfo;
 import org.fao.geonet.kernel.harvest.harvester.UriMapper;
-import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.MetadataCategoryRepository;
 import org.fao.geonet.util.Sha1Encoder;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.Xml;
 import org.fao.geonet.utils.XmlRequest;
-import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
@@ -72,12 +70,10 @@ import thredds.catalog.InvCatalogImpl;
 import thredds.catalog.InvCatalogRef;
 import thredds.catalog.InvDataset;
 import thredds.catalog.InvDocumentation;
-import thredds.catalog.InvMetadata;
 import thredds.catalog.InvService;
 import thredds.catalog.ThreddsMetadata;
 import thredds.catalog.ServiceType;
 import ucar.nc2.units.DateRange;
-import ucar.nc2.units.DateType;
 import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.util.StringUtil2;
@@ -90,13 +86,11 @@ import java.io.UnsupportedEncodingException;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -111,16 +105,16 @@ import javax.net.ssl.SSLHandshakeException;
 
 /**
  * A ThreddsHarvester is able to generate metadata for datasets and services from a Thredds
- * catalogue. Thredds datasets can be laid out in one of two ways: 
+ * catalogue. Thredds datasets can be laid out in one of two ways:
  *
- * 1. by variable: individual datasets contain a single variable. If one directory for each variable, then thredds     
- * catalog metadata could be held about each variable at the directory level. Otherwise all datasets have to be 
+ * 1. by variable: individual datasets contain a single variable. If one directory for each variable, then thredds
+ * catalog metadata could be held about each variable at the directory level. Otherwise all datasets have to be
  * traversed and metadata collected.
  *
  * 2. by time/geospatial domain: could have thredds catalog metadata in the top directory or any sub directories
  * This harvester can be pointed at the directory
  * and it will query each dataset using WMS to retrieve the spatial and temporal extents plus variables
- * (each one is a wms layer). A single metadata record with these variables and the union of the extents will 
+ * (each one is a wms layer). A single metadata record with these variables and the union of the extents will
  * be then created by running an XSLT on the information collected from the datasets in the directory.
  *
  * Metadata produced are : <ul> <li>ISO19119 for service metadata (all services in the catalog)</li>
@@ -213,7 +207,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
     private IMetadataOperations mdOperations;
     private IMetadataIndexer mdIndexer;
     private DataManager dataMan;
-    
+
     //---------------------------------------------------------------------------
     //---
     //--- API methods
@@ -336,7 +330,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
     /**
      * Add metadata to GN for the services and datasets in a thredds catalog.
      *
-     * 1. Open Catalog Document 
+     * 1. Open Catalog Document
      * 2. Crawl the catalog processing datasets as ISO19139 records and
      * request WMS GetCapabilities for each dataset
      * 3. Accumulate union of extents and other info
@@ -373,10 +367,10 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
         //--- get service and dataset style sheets, try schema first
        	Path serviceStyleSheet = schemaDir.
-            resolve(Geonet.Path.TDS_19119_19139_STYLESHEETS). 
+            resolve(Geonet.Path.TDS_19119_19139_STYLESHEETS).
             resolve("ThreddsCatalog-to-19119.xsl");
        	Path datasetStyleSheet = schemaDir.
-            resolve(Geonet.Path.TDS_19119_19139_STYLESHEETS). 
+            resolve(Geonet.Path.TDS_19119_19139_STYLESHEETS).
             resolve("ThreddsCatalog-to-19139.xsl");
         if (!Files.exists(serviceStyleSheet)) {
         	serviceStyleSheet = context.getAppPath().
@@ -390,7 +384,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 				}
 
 				Path dataParamsNCSSStylesheet = null;
-        // -- This is schema dependent 
+        // -- This is schema dependent
         if (schemaDir.toString().contains("iso19139.mcp")) {
             dataParamsNCSSStylesheet = schemaDir.
 							resolve(Geonet.Path.TDS_19119_19139_STYLESHEETS).
@@ -481,7 +475,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
 		private void extractThreddsMetadata(InvDataset ds) {
 			log.info("Trying to find ThreddsMetadata for dataset "+ds.getName());
- 
+
 			ThreddsMetadata.GeospatialCoverage gsC = ds.getGeospatialCoverage();
 			if (gsC != null) {
 				log.info("Found ThreddsMetadata geospatialcoverage");
@@ -502,9 +496,9 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 					}
 				}
 			}
-			
+
       if (gsC != null && dr != null && gridVariables.size() > 0) metadataObtained = true;
-	
+
 			// record any documentation so that it can be passed to metadata records
 	    docs = ds.getDocumentation();
 			if (docs != null && docs.size() > 0) {
@@ -526,7 +520,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
       log.debug("ThreddsMetadata: "+gsC+" : "+dr+" : "+vars.size()+" : "+docs);
 			return (gsC != null || dr != null || vars.size() > 0 || docs != null);
 		}
-			
+
     //---------------------------------------------------------------------------
 
     /**
@@ -574,7 +568,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 				if (!isService) {
         	if (params.datasetCategory != null && !params.datasetCategory.equals("")) {
            	MetadataCategory metadataCategory = context.getBean(MetadataCategoryRepository.class).findOne(Integer.parseInt(params.datasetCategory));
-	
+
            	if (metadataCategory == null) {
              	throw new IllegalArgumentException("No category found with name: " + params.datasetCategory);
            	}
@@ -589,7 +583,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
         String id = String.valueOf(metadata.getId());
 
-        addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context);
+        addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         mdIndexer.indexMetadata(id, true, null);
 
@@ -597,7 +591,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
     }
 
     /**
-     * Examine one dataset getting metadata including variables, extents and 
+     * Examine one dataset getting metadata including variables, extents and
      * service urls.
      * Note: collection datasets are not processes here.
      *
@@ -612,7 +606,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
         harvestUris.add(getUri(ds));
 
         //--- Record service URL for the dataset so that it can be added to the service
-        //--- if required 
+        //--- if required
         List<InvAccess> accesses = ds.getAccess();
         for (InvAccess access : accesses) {
             processService(access.getService(), getUuid(ds), ds);
@@ -843,7 +837,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
     /**
      * Try the different THREDDS services until we find one that gives us the extents and
-     * variables in the dataset supplied as a parameter. 
+     * variables in the dataset supplied as a parameter.
      *
      * @param ds the dataset to be processed
      */
@@ -855,11 +849,11 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 						datasetMetadataObtained = false;
 						if (hasWMSService(ds)) {
 					  	extractMetadataFromWMS(ds);
-						} 
+						}
 
             if (!datasetMetadataObtained && hasNetcdfSubsetService(ds)) {
 					  	extractMetadataFromNetcdfSubsetService(ds);
-						} 
+						}
 
             if (!datasetMetadataObtained && hasISOService(ds)) {
 					  	extractMetadataFromISO(ds);
@@ -901,37 +895,37 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
           log.debug("ISO url is "+url);
 
 					// record response in global var isoResponse as we may use it to add some other metadata eg. contacts
-          isoResponse = getXMLResponse(url); 
+          isoResponse = getXMLResponse(url);
 
 					log.debug("Name of root element in response is "+isoResponse.getName());
 					if (isoResponse.getName().equals("MI_Metadata")) {
-						Element latLonBox = Xml.selectElement(isoResponse, 
+						Element latLonBox = Xml.selectElement(isoResponse,
 																		"*//gmd:MD_DataIdentification//gmd:EX_GeographicBoundingBox", iso191152NamespaceList);
 						if (latLonBox == null) {
 						  log.error("Cannot find ISO19115-2 EX_GeographicBoundingBox element!");
 						  return;
 						}
-						
+
             Element timeSpan = Xml.selectElement(isoResponse, "*//gmd:MD_DataIdentification//gml:TimePeriod",
 																								iso191152NamespaceList);
 						if (timeSpan == null) {
 						  log.error("Cannot find ISO19115-2 TimePeriod element!");
 						  return;
 						}
-						
-            List<?> contentInfo = Xml.selectNodes(isoResponse, 
+
+            List<?> contentInfo = Xml.selectNodes(isoResponse,
 								"gmd:contentInfo/gmi:MI_CoverageDescription/gmd:dimension/gmd:MD_Band", iso191152NamespaceList);
 						if (contentInfo == null) {
 							log.error("Cannot find ISO19115-2 contentInfo element!");
 							return;
 						}
 
-          	if (log.isDebugEnabled()) 
+          	if (log.isDebugEnabled())
           		log.debug("Bounding box is:\n"+Xml.getString(latLonBox)+"\n Time span is:\n"+Xml.getString(timeSpan)+
 												"\nContent Info has "+contentInfo.size()+" bands");
 
 						// extend global bbox and textent and add variables using what we found
-            datasetMetadataObtained = (addISOLatLonBox(latLonBox) && addISOTimeSpan(timeSpan) && 
+            datasetMetadataObtained = (addISOLatLonBox(latLonBox) && addISOTimeSpan(timeSpan) &&
 																	extractISOVariables(contentInfo));
 					}
 				}
@@ -943,13 +937,13 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
   	/**
    	 * Extract ISO bounding box info.
-   	 * 
+   	 *
    	 * @param bbox EX_GeographicBoundingBox from THREDDS ISO metadata
    	 */
 
 		private boolean addISOLatLonBox(Element bbox) {
 			boolean result = false;
-	
+
 			try {
 				Element westE = bbox.getChild("westBoundLongitude", gmd);
         Element eastE = bbox.getChild("eastBoundLongitude", gmd);
@@ -973,7 +967,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
   	/**
    	 * Extract ISO temporal extent info.
-   	 * 
+   	 *
    	 * @param dimension gml:TimePeriod from THREDDS ISO metadata
    	 */
 
@@ -988,14 +982,14 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
         DateRange thisDateRange = new DateRange(st.toDate(), et.toDate());
 				addTimeSpan(thisDateRange);
         result = true;
-      } 
+      }
 
 			return result;
 		}
 
   	/**
    	 * Extract ISO variable info.
-   	 * 
+   	 *
    	 * @param bands List of gmd:MD_Band elements from contentInfo of ISO metadata
    	 */
 
@@ -1076,7 +1070,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
           url += "?request=GetCapabilities&version=1.3.0&service=WMS";
 
 					// record response in global var wmsResponse as we may use it to add some other metadata eg. contacts
-          wmsResponse = getXMLResponse(url); 
+          wmsResponse = getXMLResponse(url);
 
 					if (wmsResponse.getName().equals("WMS_Capabilities")) {
 						List<Element> layers = findLayers(wmsResponse);
@@ -1093,7 +1087,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 						    return;
 							}
 
-          		if (log.isDebugEnabled()) 
+          		if (log.isDebugEnabled())
           			log.debug("Bounding box is:\n"+Xml.getString(bbox)+"\n Time span is:\n"+Xml.getString(dimension));
 
 							// extend global bbox and textent and add variables using what we found
@@ -1109,7 +1103,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
    /**
    	 * Find queryable layers in a WMS getcapabilities statement.
-   	 * 
+   	 *
    	 * @param datasetXml JDOM xml of wms getcapabilities statement
    	 */
 
@@ -1120,7 +1114,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
       	Object o = iter.next();
       	if (o instanceof Element) {
         	Element layer = (Element)o;
-        	if (layer.getName().equals("Layer") && layer.getAttributeValue("queryable","0").equals("1") && 
+        	if (layer.getName().equals("Layer") && layer.getAttributeValue("queryable","0").equals("1") &&
               layer.getChild("BoundingBox", wms) != null && layer.getChild("Dimension", wms) != null) {
           	layers.add(layer);
         	}
@@ -1131,13 +1125,13 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
   	/**
    	 * Extract wms bounding box info.
-   	 * 
+   	 *
    	 * @param bbox BoundingBox element from WMS GetCapabilities
    	 */
 
 		private boolean addWMSLatLonBox(Element bbox) {
 			boolean result = false;
-	
+
 			try {
 				double west = Double.parseDouble(bbox.getAttributeValue("minx"));
       	double east = Double.parseDouble(bbox.getAttributeValue("maxx"));
@@ -1155,7 +1149,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
   	/**
    	 * Extract wms temporal Dimension info.
-   	 * 
+   	 *
    	 * @param dimension Dimension element from WMS GetCapabilities
    	 */
 
@@ -1163,7 +1157,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 			boolean result = false;
 
 			String[] times = dimension.getText().split(",");
-			
+
       String startTime = times[0].trim();
       String endTime = times[times.length-1].trim();
 			if (startTime != null && endTime != null && startTime.length() > 0 && endTime.length() > 0) {
@@ -1172,14 +1166,14 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
         DateRange thisDateRange = new DateRange(st.toDate(), et.toDate());
 				addTimeSpan(thisDateRange);
         result = true;
-      } 
+      }
 
 			return result;
 		}
 
   	/**
    	 * Extract wms layer names and use as variables.
-   	 * 
+   	 *
    	 * @param layers List of Layer elements from WMS GetCapabilities
    	 */
 
@@ -1207,22 +1201,22 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 // NCSS Routines
 
     /**
-     * Extract extents and variables from NCSS (Netcdf subset service) call on dataset. 
+     * Extract extents and variables from NCSS (Netcdf subset service) call on dataset.
      *
      * @param ds the dataset to be queried via the NCSS service
      */
 
 		private void extractMetadataFromNetcdfSubsetService(InvDataset ds) {
         try {
-          // go to the subset service and get the 
+          // go to the subset service and get the
           // dataset.xml file as it contains bbox and textent
           InvAccess access = ds.getAccess(ServiceType.NetcdfSubset);
           String url = access.getStandardUrlName();
           log.info("NCSS url is "+url);
           url += "/dataset.xml";
-            
+
           Element xml = getXMLResponse(url);
-					/* Looking for: 
+					/* Looking for:
                        ....
                          <LatLonBox>
                               <west>65.0000</west>
@@ -1233,7 +1227,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
                          <TimeSpan>
                               <begin>2017-07-22T06:00:00Z</begin>
                               <end>2017-07-22T06:00:00Z</end>
-                         </TimeSpan>	
+                         </TimeSpan>
                        ....
              	If we don't find then we skip this dataset
           */
@@ -1242,19 +1236,19 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 						log.error("Cannot find LatLonBox element!, skipping dataset");
 						return;
           }
-	
-          Element timeSpan = xml.getChild("TimeSpan"); 
+
+          Element timeSpan = xml.getChild("TimeSpan");
           if (timeSpan == null) {
 						log.error("Cannot find TimeSpan element!, skipping dataset");
 						return;
           }
-	
-          if (log.isDebugEnabled()) 
+
+          if (log.isDebugEnabled())
           	log.debug("Bounding box is:\n"+Xml.getString(latLonBox)+"\n Time span is:\n"+Xml.getString(timeSpan));
-	
+
 					// extend global bbox and textent and add variables using what we found
           datasetMetadataObtained = (addNCSSLatLonBox(latLonBox) && addNCSSTimeSpan(timeSpan) && extractNCSSVariables(xml));
-	
+
         } catch (Exception e) {
           log.error("Thrown Exception " + e + " during dataset processing");
           e.printStackTrace();
@@ -1262,9 +1256,9 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 		}
 
     /**
-     * Extend global bounding box (globalLatLonBox) using latLonBox from NCSS xml. 
+     * Extend global bounding box (globalLatLonBox) using latLonBox from NCSS xml.
      *
-     * @param    latLonBox           bounding box from NCSS xml to add to globalLatLonBox 
+     * @param    latLonBox           bounding box from NCSS xml to add to globalLatLonBox
      **/
 
     private boolean addNCSSLatLonBox(Element latLonBox) {
@@ -1285,9 +1279,9 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 		}
 
     /**
-     * Extend global date range (globalDateRange) using timeSpan from NCSS xml. 
+     * Extend global date range (globalDateRange) using timeSpan from NCSS xml.
      *
-     * @param    timeSpan           time span from NCSS xml to add to globalDateRange 
+     * @param    timeSpan           time span from NCSS xml to add to globalDateRange
      **/
 
     private boolean addNCSSTimeSpan(Element timeSpan) {
@@ -1308,7 +1302,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 		}
 
     /**
-     * Extract variables from NCSS (netcdf subset service) call on dataset. 
+     * Extract variables from NCSS (netcdf subset service) call on dataset.
      *
      * @param xml The XML returned from a NCSS call
      */
@@ -1335,7 +1329,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 									} else if (attrName.equals("units")) {
 										var.setUnits(attr.getAttributeValue("value"));
 									}
-								}	
+								}
 							}
             	gridVariables.put(name, var);
             	result = true;
@@ -1354,7 +1348,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
     /**
      * Extract metadata from DDX (Opendap ddx service) call on dataset. This is really a last ditch attempt to
-     * get something about the variables in the dataset because the ddx doesn't contain any info about the 
+     * get something about the variables in the dataset because the ddx doesn't contain any info about the
      * extents etc. So this gets called when we don't have NCSS, WMS, ISO etc which is only for very old THREDDS
      * services nowadays though even some of those will fail here as they don't even support ddx calls!
      *
@@ -1363,17 +1357,17 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
 		private void extractMetadataFromOpendapDDX(InvDataset ds) {
         try {
-          // go to the subset service and get the 
+          // go to the subset service and get the
           // dataset.xml file as it contains bbox and textent
           InvAccess access = ds.getAccess(ServiceType.OPENDAP);
           String url = access.getStandardUrlName();
           log.info("Opendap url is "+url);
           url += ".ddx";
-            
+
           Element xml = getXMLResponse(url);
-	
+
           // add variables to gridVariables
-					if (extractDDXVariables(xml)) datasetMetadataObtained = true; 
+					if (extractDDXVariables(xml)) datasetMetadataObtained = true;
 
         } catch (Exception e) {
           log.error("Thrown Exception " + e + " during dataset processing");
@@ -1382,7 +1376,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 		}
 
     /**
-     * Extract variables from DDX (Opendap ddx service) call on dataset. 
+     * Extract variables from DDX (Opendap ddx service) call on dataset.
      *
      * @param xml The XML returned from a DDX call
      */
@@ -1403,7 +1397,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 							if (oa instanceof Element) {
 								Element attr = (Element)oa;
 								String attrName = attr.getAttributeValue("name");
-            		if (attrName.equals("long_name")) {	
+            		if (attrName.equals("long_name")) {
 						  	  var.setDescription(attr.getChildText("value"));
 								} else if (attrName.equals("units")) {
 						  	  var.setUnits(attr.getChildText("value"));
@@ -1420,7 +1414,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 // End DDX Stuff
 
     /**
-     * Extend global bounding box (globalLatLonBox) using supplied LatLonRect. 
+     * Extend global bounding box (globalLatLonBox) using supplied LatLonRect.
      *
      * @param    thisBox           bounding box supplied as LatLonRect
      **/
@@ -1434,21 +1428,21 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
     }
 
     /**
-     * Extend global date range (globalDateRange) using supplied DateRange. 
+     * Extend global date range (globalDateRange) using supplied DateRange.
      *
      * @param    thisDateRange      date range supplied as DateRange
      **/
 
 		private void addTimeSpan(DateRange thisDateRange) {
       if (globalDateRange == null) {
-      	globalDateRange = thisDateRange; 
+      	globalDateRange = thisDateRange;
       } else {
         globalDateRange.extend(thisDateRange);
       }
     }
 
     /**
-     * Process all services that serve datasets in the thredds catalog. 
+     * Process all services that serve datasets in the thredds catalog.
      *
      * @param    cata                the XML of the catalog
      * @param    styleSheet    name of the stylesheet to produce 19119
@@ -1468,7 +1462,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
             String urls = StringUtils.join(ts.datasetUrls,"^^^");
 
             	//---	pass info to stylesheet which will create a 19119 record
-	
+
             if (log.isDebugEnabled())
                 log.debug("  - XSLT transformation using " + styleSheet);
 
@@ -1485,21 +1479,21 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
             param.put("serverops", ts.ops);
             param.put("bbox", globalLatLonBox.getLatMin()+"^^^"+globalLatLonBox.getLatMax()+"^^^"+globalLatLonBox.getLonMin()+"^^^"+globalLatLonBox.getLonMax());
             param.put("textent", globalDateRange.getStart().toDateTimeStringISO()+"^^^"+globalDateRange.getEnd().toDateTimeStringISO());
-	
+
             Element md = Xml.transform(cata, styleSheet, param);
-	
+
             String schema = mdSchemaUtils.autodetectSchema(md, null);
             if (schema == null) {
                	log.warning("Skipping metadata with unknown schema.");
                	result.unknownSchema++;
             } else {
-	
+
                	//--- Now add to geonetwork
                 boolean isService = true;
                	saveMetadata(md, sUuid, sUrl, isService);
-	
+
                	harvestUris.add(sUrl);
-	
+
                	result.serviceRecords++;
             }
         }
@@ -1514,7 +1508,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
      * @param    dataParamsStyleSheet    stylesheet to produce mcp:dataParameters from subset service xml
      **/
 
-    private void createDatasetMetadata(Element cata, Path styleSheet, 
+    private void createDatasetMetadata(Element cata, Path styleSheet,
 																				Path dataParamsNCSSStylesheet) throws Exception {
 
         String sUuid = Sha1Encoder.encodeString(params.url);
@@ -1546,9 +1540,9 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 				if (globalDateRange != null) {
         	param.put("textent", globalDateRange.getStart().toDateTimeStringISO()+"^^^"+globalDateRange.getEnd().toDateTimeStringISO());
 				}
-	
+
         Element md = Xml.transform(wmsResponse, styleSheet, param);
-	
+
         String schema = mdSchemaUtils.autodetectSchema(md, null);
         if (schema == null) {
           log.warning("Skipping metadata with unknown schema.");
@@ -1562,14 +1556,14 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 						}
           	if (dps != null) addDataParameters(md, dps);
 					}
-	
+
  	        //--- Now add to geonetwork
         	boolean isService = false;
 					log.debug("Will save metadata "+Xml.getString(md));
         	saveMetadata(md, sUuid, params.url, isService);
-	
+
         	harvestUris.add(params.url);
-	
+
         	result.collectionDatasetRecords++;
 				}
     }

--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/privileges.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/privileges.html
@@ -1,5 +1,18 @@
 <fieldset>
   <legend id="gn-harvest-settings-gn-priviliges-title" data-translate="">harvestedRecordPrivileges</legend>
+
+
+  <div id="gn-harvest-settings-gn-priviliges-ifRecordExistAppendPrivileges"
+       data-ng-show="harvester['@type'] == 'webdav' || harvester['@type'] == 'geonetwork' || harvester['@type'] == 'csw' ">
+    <label class="control-label">
+      <input type="checkbox"
+             data-ng-model="harvester.ifRecordExistAppendPrivileges"/>
+      <span data-translate="">ifRecordExistAppendPrivileges</span>
+    </label>
+    <p class="help-block" data-translate="">ifRecordExistAppendPrivilegesHelp</p>
+  </div>
+
+
   <ul id="gn-harvest-settings-gn-priviliges-list" class="list-group">
     <li class="list-group-item">
       <div>

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -234,7 +234,8 @@
           groups +=
               '<group id="' + p['@id'] + '">' + ops + '</group>';
         });
-        return '<privileges>' + groups + '</privileges>';
+        return '<privileges>' + groups + '</privileges>' +
+          '<ifRecordExistAppendPrivileges>' + h.ifRecordExistAppendPrivileges + '</ifRecordExistAppendPrivileges>';
       };
       $scope.buildResponseCategory = function(h) {
         var cats = '';

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -363,6 +363,8 @@
     "exportLogAsZIP": "Export (ZIP)",
     "facetIndicatorHelp": "Statistics by records are defined based on facets configuration and may represent only the most frequent values.",
     "fees": "Fees",
+    "ifRecordExistAppendPrivileges": "If record exist (eg. already harvested from another source), append privileges defined below.",
+    "ifRecordExistAppendPrivilegesHelp": "Only applies on update and if action on UUID collision is set to overwrite record. If enabled, privileges are not removed on update. So if you want to reset privileges, you need to remove those records first and trigger the harvester again.",
     "filesystem-beforeScript": "Script to run before harvesting",
     "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "filesystem-checkFileLastModifiedForUpdate": "Update catalog record only if file was updated",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
@@ -34,6 +34,7 @@ var gnHarvestercsw = {
         "overrideUuid": "SKIP",
         "status" : "active"
       },
+      "ifRecordExistAppendPrivileges": false,
       "privileges" : [ {
         "@id" : "1",
         "operation" : [ {

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork.js
@@ -47,6 +47,7 @@ var gnHarvestergeonetwork = {
           "name": []
         }
       }],
+      "ifRecordExistAppendPrivileges": false,
       "privileges": [{
         "@id": "1",
         "operation":     [
@@ -66,7 +67,7 @@ var gnHarvestergeonetwork = {
     var body = '<node id="' + h['@id'] + '" '
       + '    type="' + h['@type'] + '">'
       + '  <ownerGroup><id>' + h.ownerGroup[0] + '</id></ownerGroup>'
-      + '  <ownerUser><id>' + h.ownerUser[0] + '</id></ownerUser>' 
+      + '  <ownerUser><id>' + h.ownerUser[0] + '</id></ownerUser>'
       + '  <site>'
       + '    <name>' + h.site.name + '</name>'
       + '    <host>' + h.site.host.replace(/&/g, '&amp;') + '</host>'

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/webdav.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/webdav.js
@@ -31,6 +31,7 @@ var gnHarvesterwebdav = {
                 "overrideUuid" : "SKIP",
                 "subtype" : "waf"
             },
+            "ifRecordExistAppendPrivileges": false,
             "privileges" : [ {
                 "@id" : "1",
                 "operation" : [ {
@@ -50,7 +51,7 @@ var gnHarvesterwebdav = {
         var body = '<node id="' + h['@id'] + '" '
                 + '    type="' + h['@type'] + '">'
                 + '  <ownerGroup><id>' + h.ownerGroup[0] + '</id></ownerGroup>'
-                + '  <ownerUser><id>' + h.ownerUser[0] + '</id></ownerUser>' 
+                + '  <ownerUser><id>' + h.ownerUser[0] + '</id></ownerUser>'
                 + '  <site>'
                 + '    <name>' + h.site.name + '</name>'
                 + '    <url>' + h.site.url.replace(/&/g, '&amp;') + '</url>'

--- a/web/src/main/webapp/xsl/xml/harvesting/common.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/common.xsl
@@ -84,6 +84,9 @@
 
       <xsl:apply-templates select="." mode="searches"/>
       <xsl:apply-templates select="$priv" mode="privileges"/>
+      <ifRecordExistAppendPrivileges>
+        <xsl:value-of select="$opt/ifRecordExistAppendPrivileges/value"/>
+      </ifRecordExistAppendPrivileges>
       <xsl:apply-templates select="$categ" mode="categories"/>
       <xsl:apply-templates select="." mode="other"/>
 

--- a/web/src/main/webapp/xsl/xml/harvesting/geonetwork.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/geonetwork.xsl
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-  <!-- ============================================================================================= -->
-
   <xsl:import href="common.xsl"/>
-
-  <!-- ============================================================================================= -->
-  <!-- === Geonetwork harvesting node -->
-  <!-- ============================================================================================= -->
 
   <xsl:template match="*" mode="site">
     <host>
@@ -30,8 +23,6 @@
       <xsl:value-of select="xslfilter"/>
     </xslfilter>
   </xsl:template>
-
-  <!-- ============================================================================================= -->
 
   <xsl:template match="*" mode="searches">
     <searches>
@@ -74,8 +65,6 @@
     </searches>
   </xsl:template>
 
-  <!-- ============================================================================================= -->
-
   <xsl:template match="*" mode="other">
     <groupsCopyPolicy>
       <xsl:for-each select="children/groupCopyPolicy">
@@ -83,7 +72,5 @@
       </xsl:for-each>
     </groupsCopyPolicy>
   </xsl:template>
-
-  <!-- ============================================================================================= -->
 
 </xsl:stylesheet>


### PR DESCRIPTION
When more than one harvester harvest the same record, then record is usually rejected or overriden.
It can override existing, but the privileges are not preserved. This option preserve privileges set in the different harvesters.

This can happen when you have user admins not aware of other harvesters and duplicates are created and different set of privileges need to be combined. 

![image](https://user-images.githubusercontent.com/1701393/65958676-3dfcb900-e450-11e9-8f9f-179cc706ceac.png)


It applies to GeoNetwork, CSW and Webdav protocol.




Also do some cleanup of useless comment and unused method.