### PR TITLE
Use transform for harvested metadata format (GeoNetwork harvester) (master)

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -511,7 +511,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
         }
 
         if (!params.xslfilter.equals("")) {
-            md = HarvesterUtil.processMetadata(dataMan.getSchema(ri.schema),
+            md = HarvesterUtil.processMetadata(dataMan.getSchema(schema),
                 md, processName, processParams);
         }
         // insert metadata


### PR DESCRIPTION
GeoNetwork supports harvesting unsupported iso19139 profile records from another GeoNetwork harvester by falling back to the core iso19139 metadata record included in the mef by the other GeoNetwork instance.

However, when harvesting these records, it's not possible to apply a transform as GeoNetwork incorrectly tries to source the transform from the process directory for the unsupported profile which of course doesn't exist and aborts harvesting the record.

Fix this by sourcing the transform to be applied from the process directory of the harvested metadata format.