### PR TITLE
ES / Index health check / Fix due to incompatibility between JEST 6.3.1 and ES 7.x

### DIFF
--- a/healthmonitor/src/main/java/org/fao/geonet/monitor/health/IndexHealthCheck.java
+++ b/healthmonitor/src/main/java/org/fao/geonet/monitor/health/IndexHealthCheck.java
@@ -55,7 +55,8 @@ public class IndexHealthCheck implements HealthCheckFactory {
 
                         if (result.isSucceeded()) {
                             return Result.healthy(String.format(
-                                "%s records indexed in remote index currently.", result.getTotal()
+                                "%s records indexed in remote index currently.",
+                                result.getHits(Object.class).size()
                             ));
                         } else {
                             return Result.unhealthy(


### PR DESCRIPTION
JEST has no update and ES 7 introduced a breaking change in the search result response. Workaround for now. Next step is moving to ES branch instead which removed JEST in favor of ES High level java client.