### PR TITLE
Remove duplicate index form locale also

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -205,12 +205,6 @@ public class EsSearchManager implements ISearchManager {
     public void end() throws Exception {
     }
 
-    @Override
-    public MetaSearcher newSearcher(String stylesheetName) throws Exception {
-        //TODO
-        return null;
-    }
-
     private int commitInterval = 200;
     private Map<String, String> listOfDocumentsToIndex = new HashMap<>();
     private Map<String, String> listOfPublicDocumentsToIndex = new HashMap<>();

--- a/core/src/main/java/org/fao/geonet/kernel/search/ISearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/ISearchManager.java
@@ -45,8 +45,6 @@ public interface ISearchManager {
 
     void end() throws Exception;
 
-    MetaSearcher newSearcher(String stylesheetName) throws Exception;
-
     /**
      * Indexes a metadata record.
      *

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -173,6 +173,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
     private long _versionToken = -1;
     private SummaryType _summaryConfig;
     private boolean _logSearch = true;
+    private SettingInfo settingInfo;
 
     /**
      * constructor TODO javadoc.
@@ -185,6 +186,8 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         _luceneConfig = luceneConfig;
         _boostQueryClass = _luceneConfig.getBoostQueryClass();
         _tokenizedFieldSet = luceneConfig.getTokenizedField();
+
+        settingInfo =  ApplicationContextHolder.get().getBean(SettingInfo.class);
     }
 
     //
@@ -930,9 +933,11 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         final SearchManager searchmanager;
         ServiceContext context = ServiceContext.get();
         GeonetworkMultiReader reader;
+        SettingInfo si;
         if (context != null) {
             GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
             searchmanager = gc.getBean(SearchManager.class);
+            si = gc.getBean(SettingInfo.class);
             indexAndTaxonomy = searchmanager.getNewIndexReader(priorityLang);
             reader = indexAndTaxonomy.indexReader;
         } else {
@@ -944,8 +949,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         try {
             IndexSearcher searcher = new IndexSearcher(reader);
             TermQuery query = new TermQuery(new Term(field, value));
-            SettingInfo settingInfo = searchmanager.getSettingInfo();
-            boolean sortRequestedLanguageOnTop = settingInfo.getRequestedLanguageOnTop();
+            boolean sortRequestedLanguageOnTop = si.getRequestedLanguageOnTop();
             LOGGER.debug("sortRequestedLanguageOnTop: {}", sortRequestedLanguageOnTop);
 
             int numberOfHits = 1;
@@ -1447,7 +1451,6 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
             if (LOGGER.isDebugEnabled())
                 LOGGER.debug("CRITERIA: {}\n", Xml.getString(request));
 
-            SettingInfo settingInfo = _sm.getSettingInfo();
             SettingInfo.SearchRequestLanguage requestedLanguageOnly = settingInfo.getRequestedLanguageOnly();
             LOGGER.debug("requestedLanguageOnly: {}", requestedLanguageOnly);
 
@@ -1575,7 +1578,6 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         boolean sortOrder = (Util.getParam(request, Geonet.SearchResult.SORT_ORDER, "").equals(""));
         LOGGER.debug("Sorting by : {}", sortBy);
 
-        SettingInfo settingInfo = _sm.getSettingInfo();
         boolean sortRequestedLanguageOnTop = settingInfo.getRequestedLanguageOnTop();
         LOGGER.debug("sortRequestedLanguageOnTop: {}", sortRequestedLanguageOnTop);
         _sort = LuceneSearcher.makeSort(Collections.singletonList(Pair.read(sortBy, sortOrder)), _language.presentationLanguage, sortRequestedLanguageOnTop);

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -290,8 +290,8 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
      */
     public static LanguageSelection determineLanguage(
         @Nullable ServiceContext srvContext,
-        @Nonnull Element request,
-        @Nonnull SettingInfo settingInfo) {
+        @Nonnull Element request) {
+        SettingInfo settingInfo = srvContext.getBean(SettingInfo.class);
         String finalDetectedLanguage = null;
         if (settingInfo != null && settingInfo.getRequestedLanguageOnly() == SettingInfo.SearchRequestLanguage.OFF) {
             LOGGER.debug("requestedlanguage ignored, using default one ");
@@ -1100,7 +1100,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
 
         String sBuildSummary = request.getChildText(Geonet.SearchResult.BUILD_SUMMARY);
         boolean buildSummary = sBuildSummary == null || sBuildSummary.equals("true");
-        _language = determineLanguage(srvContext, request, _sm.getSettingInfo());
+        _language = determineLanguage(srvContext, request);
 
         LOGGER.debug("LuceneSearcher initializing search range");
         initSearchRange(srvContext);
@@ -1252,7 +1252,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         // To count the number of values added and stop if maxNumberOfTerms reach
         if (_language == null) {
             final Element request = new Element("request").addContent(new Element("any").setText(searchValue));
-            _language = determineLanguage(srvContext, request, _sm.getSettingInfo());
+            _language = determineLanguage(srvContext, request);
         }
 
         _logSearch = false;

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -1170,6 +1170,16 @@ public class SearchManager implements ISearchManager {
 
         defaultLang.removeContent();
         defaultLang.addContent(toInclude);
+
+        for (Element element : otherLanguages) {
+            toInclude.clear();
+            for (Element index : (List<Element>) element.getChildren()) {
+                toInclude.add(index);
+            }
+            element.removeContent();
+            element.addContent(toInclude);
+        }
+
     }
 
     // utilities

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -967,7 +967,7 @@ public class SearchManager implements ISearchManager {
         String searchValueWithoutWildcard = searchValue.replaceAll("[*?]", "");
 
         final Element request = new Element("request").addContent(new Element(Geonet.IndexFieldNames.ANY).setText(searchValue));
-        String language = LuceneSearcher.determineLanguage(context, request, context.getBean(SettingInfo.class)).analyzerLanguage;
+        String language = LuceneSearcher.determineLanguage(context, request).analyzerLanguage;
         final PerFieldAnalyzerWrapper analyzer = SearchManager.getAnalyzer(language, true);
         String analyzedSearchValue = LuceneSearcher.analyzeText(fieldName, searchValueWithoutWildcard, analyzer);
         boolean startsWithOnly = !searchValue.startsWith("*") && searchValue.endsWith("*");

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -1093,7 +1093,7 @@ public class SearchManager implements ISearchManager {
      * otherlanguages and merge the fields with those in defaultLang.
      */
     @SuppressWarnings(value = "unchecked")
-    private void mergeDefaultLang(Element defaultLang, List<Element> otherLanguages) {
+    protected void mergeDefaultLang(Element defaultLang, List<Element> otherLanguages) {
         final String langCode;
         if (defaultLang.getAttribute(Geonet.IndexFieldNames.LOCALE) == null) {
             langCode = "";
@@ -1154,19 +1154,21 @@ public class SearchManager implements ISearchManager {
             }
         });
 
+        for (Element element : (List<Element>) defaultLang.getChildren()) {
+            toInclude.add(element);
+        }
+
         if (toMerge != null) {
             toMerge.detach();
             otherLanguages.remove(toMerge);
-            for (Element element : (List<Element>) defaultLang.getChildren()) {
-                toInclude.add(element);
-            }
             for (Element element : (List<Element>) toMerge.getChildren()) {
                 toInclude.add(element);
             }
             toMerge.removeContent();
-            defaultLang.removeContent();
-            defaultLang.addContent(toInclude);
         }
+
+        defaultLang.removeContent();
+        defaultLang.addContent(toInclude);
     }
 
     // utilities

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -515,11 +515,6 @@ public class SearchManager implements ISearchManager {
         _luceneOptimizerManager.shutdown();
     }
 
-    @Override
-    public MetaSearcher newSearcher(String stylesheetName) throws Exception {
-        return null;
-    }
-
     private void createDocumentBoost() {
         ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         LuceneConfig luceneConfig = applicationContext.getBean(LuceneConfig.class);

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -141,6 +141,41 @@ import static org.fao.geonet.constants.Geonet.IndexFieldNames.DATABASE_CHANGE_DA
  * Indexes metadata using Lucene.
  */
 public class SearchManager implements ISearchManager {
+    public static final Comparator<Element> INDEX_COMPARATOR = new Comparator<Element>() {
+        public int compare(Element o1, Element o2) {
+            // <Field name="_locale" string="{string($iso3LangId)}" store="true" index="true" token="false"/>
+            int name = compare(o1, o2, "name");
+            int string = compare(o1, o2, "string");
+            int store = compare(o1, o2, "store");
+            int index = compare(o1, o2, "index");
+            if (name != 0) {
+                return name;
+            }
+            if (string != 0) {
+                return string;
+            }
+            if (store != 0) {
+                return store;
+            }
+            if (index != 0) {
+                return index;
+            }
+            return 0;
+        }
+
+        private int compare(Element o1, Element o2, String attName) {
+            return safeGet(o1, attName).compareTo(safeGet(o2, attName));
+        }
+
+        public String safeGet(Element e, String attName) {
+            String att = e.getAttributeValue(attName);
+            if (att == null) {
+                return "";
+            } else {
+                return att;
+            }
+        }
+    };
     private static Logger SE_LOGGER = LoggerFactory.getLogger(Geonet.SEARCH_ENGINE);
     private static Logger LU_LOGGER = LoggerFactory.getLogger(Geonet.LUCENE);
     private static Logger IE_LOGGER = LoggerFactory.getLogger(Geonet.INDEX_ENGINE);
@@ -1118,41 +1153,7 @@ public class SearchManager implements ISearchManager {
             }
         }
 
-        SortedSet<Element> toInclude = new TreeSet<Element>(new Comparator<Element>() {
-            public int compare(Element o1, Element o2) {
-                // <Field name="_locale" string="{string($iso3LangId)}" store="true" index="true" token="false"/>
-                int name = compare(o1, o2, "name");
-                int string = compare(o1, o2, "string");
-                int store = compare(o1, o2, "store");
-                int index = compare(o1, o2, "index");
-                if (name != 0) {
-                    return name;
-                }
-                if (string != 0) {
-                    return string;
-                }
-                if (store != 0) {
-                    return store;
-                }
-                if (index != 0) {
-                    return index;
-                }
-                return 0;
-            }
-
-            private int compare(Element o1, Element o2, String attName) {
-                return safeGet(o1, attName).compareTo(safeGet(o2, attName));
-            }
-
-            public String safeGet(Element e, String attName) {
-                String att = e.getAttributeValue(attName);
-                if (att == null) {
-                    return "";
-                } else {
-                    return att;
-                }
-            }
-        });
+        SortedSet<Element> toInclude = new TreeSet<Element>(INDEX_COMPARATOR);
 
         for (Element element : (List<Element>) defaultLang.getChildren()) {
             toInclude.add(element);

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -213,10 +213,6 @@ public class SearchManager implements ISearchManager {
         return _analyzer;
     }
 
-    public static PerFieldAnalyzerWrapper getSearchAnalyzer() {
-        return _searchAnalyzer;
-    }
-
     /**
      * Retrieve per field analyzer according to language and for searching or indexing time.
      *

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -297,12 +297,6 @@ public class SearchManager implements ISearchManager {
         return clazz.getConstructor(org.apache.lucene.search.Query.class, int.class, Geometry.class, Pair.class);
     }
 
-    public SettingInfo getSettingInfo() {
-
-        ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
-        return applicationContext.getBean(SettingInfo.class);
-    }
-
     /**
      * Creates an analyzer based on its definition in the Lucene config.
      *

--- a/core/src/test/java/org/fao/geonet/kernel/search/LuceneSearcher_FastEqualsFullLoad_OrderIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/LuceneSearcher_FastEqualsFullLoad_OrderIntegrationTest.java
@@ -48,8 +48,7 @@ public class LuceneSearcher_FastEqualsFullLoad_OrderIntegrationTest extends Abst
         final List<Namespace> theNSs = Arrays.asList(Geonet.Namespaces.GMD);
         final List<Element> nodes = (List<Element>) Xml.selectNodes(result, xpath, theNSs);
 
-        final SettingInfo settingInfo = _serviceContext.getBean(SearchManager.class).getSettingInfo();
-        final LuceneSearcher.LanguageSelection language = LuceneSearcher.determineLanguage(_serviceContext, request, settingInfo);
+        final LuceneSearcher.LanguageSelection language = LuceneSearcher.determineLanguage(_serviceContext, request);
 
         String[] titles = new String[nodes.size()];
         final String langCode;

--- a/core/src/test/java/org/fao/geonet/kernel/search/SearchManagerTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/SearchManagerTest.java
@@ -74,6 +74,27 @@ public class SearchManagerTest {
         assertEquals(1, indexFromDefault.getContentSize());
     }
 
+    @Test
+    public void mergeDefinedTwiceForDefaultAtLocalSide() {
+        SearchManager toTest = new SearchManager();
+        Element indexFromDefault = singletonIndexList("indexedTwice", "fre");
+        indexFromDefault.removeContent();
+        Element indexFromFreLocale = singletonIndexList("indexedTwice", "fre");
+        indexFromFreLocale.addContent(indexFromFreLocale.cloneContent());
+        Element indexFromEngLocale = singletonIndexList("locale", "eng");
+        Element indexFromGerLocale = singletonIndexList("locale", "ger");
+        List<Element> indexFromLocales= new ArrayList<>();
+        indexFromLocales.add(indexFromFreLocale);
+        indexFromLocales.add(indexFromEngLocale);
+        indexFromLocales.add(indexFromGerLocale);
+
+        toTest.mergeDefaultLang(indexFromDefault, indexFromLocales);
+
+        assertNotNull(indexFromDefault.getChild("momo_from_indexedTwice_fre"));
+        assertEquals(1, indexFromDefault.getContentSize());
+    }
+
+
     private Element singletonIndexList(String source, String language) {
         String elementName = "momo_from_" + source + "_" + language;
         Element indexFromDefault = new Element("Document").setAttribute(Geonet.IndexFieldNames.LOCALE, language);

--- a/core/src/test/java/org/fao/geonet/kernel/search/SearchManagerTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/SearchManagerTest.java
@@ -95,6 +95,27 @@ public class SearchManagerTest {
     }
 
 
+    @Test
+    public void mergeDefinedTwiceInLocal() {
+        SearchManager toTest = new SearchManager();
+        Element indexFromDefault = singletonIndexList("default", "fre");
+        Element indexFromFreLocale = singletonIndexList("locale", "fre");
+        Element indexFromEngLocale = singletonIndexList("indexedTwice", "eng");
+        indexFromEngLocale.addContent(indexFromEngLocale.cloneContent());
+        Element indexFromGerLocale = singletonIndexList("locale", "ger");
+        List<Element> indexFromLocales= new ArrayList<>();
+        indexFromLocales.add(indexFromFreLocale);
+        indexFromLocales.add(indexFromEngLocale);
+        indexFromLocales.add(indexFromGerLocale);
+
+        toTest.mergeDefaultLang(indexFromDefault, indexFromLocales);
+
+        assertNotNull(indexFromEngLocale.getChild("momo_from_indexedTwice_eng"));
+        assertEquals(2, indexFromDefault.getContentSize());
+        assertEquals(1, indexFromEngLocale.getContentSize());
+
+    }
+
     private Element singletonIndexList(String source, String language) {
         String elementName = "momo_from_" + source + "_" + language;
         Element indexFromDefault = new Element("Document").setAttribute(Geonet.IndexFieldNames.LOCALE, language);

--- a/core/src/test/java/org/fao/geonet/kernel/search/SearchManagerTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/SearchManagerTest.java
@@ -1,0 +1,84 @@
+package org.fao.geonet.kernel.search;
+
+
+import org.fao.geonet.constants.Geonet;
+import org.jdom.Element;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SearchManagerTest {
+
+    @Test
+    public void mergeNominal() {
+        SearchManager toTest = new SearchManager();
+        Element indexFromDefault = singletonIndexList("default", "fre");
+        Element indexFromFreLocale = singletonIndexList("locale", "fre");
+        Element indexFromEngLocale = singletonIndexList("locale", "eng");
+        Element indexFromGerLocale = singletonIndexList("locale", "ger");
+        List<Element> indexFromLocales= new ArrayList<>();
+        indexFromLocales.add(indexFromFreLocale);
+        indexFromLocales.add(indexFromEngLocale);
+        indexFromLocales.add(indexFromGerLocale);
+
+       toTest.mergeDefaultLang(indexFromDefault, indexFromLocales);
+
+       assertTrue(indexFromLocales.contains(indexFromEngLocale));
+       assertTrue(indexFromLocales.contains(indexFromGerLocale));
+       assertFalse(indexFromLocales.contains(indexFromFreLocale));
+       assertNotNull(indexFromDefault.getChild("momo_from_default_fre"));
+       assertNotNull(indexFromDefault.getChild("momo_from_locale_fre"));
+    }
+
+    @Test
+    public void mergeDefinedTwiceForDefaultAtBothSide() {
+        SearchManager toTest = new SearchManager();
+        Element indexFromDefault = singletonIndexList("indexedTwice", "fre");
+        Element indexFromFreLocale = singletonIndexList("indexedTwice", "fre");
+        Element indexFromEngLocale = singletonIndexList("locale", "eng");
+        Element indexFromGerLocale = singletonIndexList("locale", "ger");
+        List<Element> indexFromLocales= new ArrayList<>();
+        indexFromLocales.add(indexFromFreLocale);
+        indexFromLocales.add(indexFromEngLocale);
+        indexFromLocales.add(indexFromGerLocale);
+
+        toTest.mergeDefaultLang(indexFromDefault, indexFromLocales);
+
+        assertTrue(indexFromLocales.contains(indexFromEngLocale));
+        assertTrue(indexFromLocales.contains(indexFromGerLocale));
+        assertFalse(indexFromLocales.contains(indexFromFreLocale));
+        assertNotNull(indexFromDefault.getChild("momo_from_indexedTwice_fre"));
+        assertEquals(1, indexFromDefault.getContentSize());
+    }
+
+    @Test
+    public void mergeDefinedTwiceForDefaultAtDefaultSide() {
+        SearchManager toTest = new SearchManager();
+        Element indexFromDefault = singletonIndexList("indexedTwice", "fre");
+        indexFromDefault.addContent(indexFromDefault.cloneContent());
+        Element indexFromEngLocale = singletonIndexList("locale", "eng");
+        Element indexFromGerLocale = singletonIndexList("locale", "ger");
+        List<Element> indexFromLocales= new ArrayList<>();
+        indexFromLocales.add(indexFromEngLocale);
+        indexFromLocales.add(indexFromGerLocale);
+
+        toTest.mergeDefaultLang(indexFromDefault, indexFromLocales);
+
+        assertNotNull(indexFromDefault.getChild("momo_from_indexedTwice_fre"));
+        assertEquals(1, indexFromDefault.getContentSize());
+    }
+
+    private Element singletonIndexList(String source, String language) {
+        String elementName = "momo_from_" + source + "_" + language;
+        Element indexFromDefault = new Element("Document").setAttribute(Geonet.IndexFieldNames.LOCALE, language);
+        indexFromDefault.addContent(new Element(elementName).setAttribute("name", elementName));
+        return indexFromDefault;
+    }
+
+}

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecordById.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecordById.java
@@ -162,8 +162,7 @@ public class GetRecordById extends AbstractOperation implements CatalogService {
                 // to the requested MD
                 Lib.resource.checkPrivilege(context, id, ReservedOperation.view);
 
-                final SettingInfo settingInfo = gc.getBean(SearchManager.class).getSettingInfo();
-                final String displayLanguage = LuceneSearcher.determineLanguage(context, request, settingInfo).presentationLanguage;
+                final String displayLanguage = LuceneSearcher.determineLanguage(context, request).presentationLanguage;
                 Element md = SearchController.retrieveMetadata(context, id, setName, outSchema, null, null, ResultType.RESULTS, null,
                     displayLanguage);
 

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecords.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecords.java
@@ -98,6 +98,9 @@ public class GetRecords extends AbstractOperation implements CatalogService {
     private SchemaManager _schemaManager;
 
     @Autowired
+    private SettingInfo settingInfo;
+
+    @Autowired
     public GetRecords(ApplicationContext context) {
         _searchController = new SearchController(context);
     }
@@ -180,7 +183,6 @@ public class GetRecords extends AbstractOperation implements CatalogService {
         // a comma separated list (such as GN's own CSW Harvesting Client), the check assumes a comma-separated list,
         // and checks whether its values are not other than csw:Record or gmd:MD_Metadata. If both are sent,
         // gmd:MD_Metadata is preferred.
-        final SettingInfo settingInfo = context.getBean(SearchManager.class).getSettingInfo();
         String typeName = checkTypenames(query, settingInfo.getInspireEnabled());
 
         // set of elementnames or null
@@ -759,9 +761,9 @@ public class GetRecords extends AbstractOperation implements CatalogService {
 
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
         SearchManager sm = gc.getBean(SearchManager.class);
-        boolean requestedLanguageOnTop = sm.getSettingInfo().getRequestedLanguageOnTop();
+        boolean requestedLanguageOnTop = settingInfo.getRequestedLanguageOnTop();
 
-        String preferredLanguage = LuceneSearcher.determineLanguage(context, request, sm.getSettingInfo()).presentationLanguage;
+        String preferredLanguage = LuceneSearcher.determineLanguage(context, request).presentationLanguage;
 
         // we always want to keep the relevancy as part of the sorting mechanism
         return LuceneSearcher.makeSort(sortFields, preferredLanguage, requestedLanguageOnTop);

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/CatalogSearcher.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/CatalogSearcher.java
@@ -118,6 +118,8 @@ public class CatalogSearcher implements MetadataRecordSelector {
     private LuceneSearcher.LanguageSelection _lang;
     private long _searchToken;
     private ApplicationContext _applicationContext;
+    private SettingInfo settingInfo;
+
     public CatalogSearcher(GMLConfiguration configuration,
                            Set<String> selector, Set<String> uuidselector, ApplicationContext applicationContext) {
 //		_tokenizedFieldSet = luceneConfig.getTokenizedField();
@@ -125,8 +127,8 @@ public class CatalogSearcher implements MetadataRecordSelector {
         _configuration = configuration;
         this._applicationContext = applicationContext;
         _uuidselector = uuidselector;
-        _searchToken = -1L;  // means we will get a new IndexSearcher when we
-        // ask for it first time
+        _searchToken = -1L;  // means we will get a new IndexSearcher when we ask for it first time
+        settingInfo = applicationContext.getBean(SettingInfo.class);
     }
 
     /**
@@ -210,7 +212,7 @@ public class CatalogSearcher implements MetadataRecordSelector {
                 if (Log.isDebugEnabled(Geonet.CSW_SEARCH))
                     Log.debug(Geonet.CSW_SEARCH, "after convertphrases:\n" + Xml.getString(luceneExpr));
             }
-            _lang = LuceneSearcher.determineLanguage(context, filterExpr, sm.getSettingInfo());
+            _lang = LuceneSearcher.determineLanguage(context, filterExpr);
 
             indexAndTaxonomy = sm.getIndexReader(_lang.presentationLanguage, _searchToken);
             Log.debug(Geonet.CSW_SEARCH, "Found searcher with " + indexAndTaxonomy.version + " comparing with " + _searchToken);
@@ -464,7 +466,7 @@ public class CatalogSearcher implements MetadataRecordSelector {
         }
 
 
-        boolean requestedLanguageOnTop = sm.getSettingInfo().getRequestedLanguageOnTop();
+        boolean requestedLanguageOnTop = settingInfo.getRequestedLanguageOnTop();
 
         Query data;
         LuceneConfig luceneConfig = getLuceneConfig();
@@ -473,7 +475,7 @@ public class CatalogSearcher implements MetadataRecordSelector {
             Log.info(Geonet.CSW_SEARCH, "LuceneSearcher made null query");
         } else {
             PerFieldAnalyzerWrapper analyzer = SearchManager.getAnalyzer(_lang.analyzerLanguage, true);
-            SettingInfo.SearchRequestLanguage requestedLanguageOnly = sm.getSettingInfo().getRequestedLanguageOnly();
+            SettingInfo.SearchRequestLanguage requestedLanguageOnly = settingInfo.getRequestedLanguageOnly();
             data = LuceneSearcher.makeLocalisedQuery(luceneExpr,
                 analyzer, luceneConfig, _lang.presentationLanguage, requestedLanguageOnly);
             Log.info(Geonet.CSW_SEARCH, "LuceneSearcher made query:\n" + data.toString());

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -441,8 +441,7 @@ public class SearchController {
         }
 
 
-        final SettingInfo settingInfo = context.getBean(SearchManager.class).getSettingInfo();
-        String displayLanguage = LuceneSearcher.determineLanguage(context, filterExpr, settingInfo).presentationLanguage;
+        String displayLanguage = LuceneSearcher.determineLanguage(context, filterExpr).presentationLanguage;
         // retrieve actual metadata for results
         int counter = retrieveMetadataMatchingResults(context, results, summaryAndSearchResults, maxRecords, setName,
             outSchema, elemNames, typeName, resultType, strategy, displayLanguage);


### PR DESCRIPTION
* Apply same strategy (ie. remove duplicates) to local index fields as the one for the main index (see https://github.com/geonetwork/core-geonetwork/pull/4090/commits/f34de46cd985ef593fa436f2e8b3e0155b401812) 


![avoid_duplicate](https://user-images.githubusercontent.com/18677090/76398171-b01ce680-637c-11ea-8a5c-c89dcf0878db.png)

For example, this screenshot metadata language is french, five locales are defined, user language is Rumantsch, and on simple view locales are displayed once and only once.

* Refactor access to SettingInfo and cleaning
