### PR TITLE
Fix for untranslated categories in the Advanced Search panel

### DIFF
--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -124,7 +124,7 @@
                 for (var i = 0; i < data.length; i++) {
                   res.push({
                     id: data[i].name,
-                    name: data[i].label.eng
+                    name: data[i].label[$scope.lang]
                   });
                 }
                 res = orderByFilter(res,'name',false);


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/4092

The categories in the `Advanced Search` panel were not translated to the chosen language. This PR replaces the hardcoded English to the preferred, chosen language.

**Screenshot after the change**
![gn-advanced-categories-translated](https://user-images.githubusercontent.com/19608667/66568424-ae4ebd00-eb69-11e9-8c3e-68eb097ec137.png)
