### PR TITLE
Set threads in maven-surefire-plugin based on number of cores.

### DIFF
--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -197,6 +197,22 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>get-cpu-count</id>
+                <goals>
+                  <goal>cpu-count</goal>
+                </goals>
+                <configuration>
+                  <cpuCount>system.numCores</cpuCount>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
@@ -204,7 +220,7 @@
                 <postgresqlPerformanceTest>true</postgresqlPerformanceTest>
               </systemPropertyVariables>
               <runOrder>alphabetical</runOrder>
-              <forkCount>4</forkCount>
+              <forkCount>${system.numCores}</forkCount>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -289,13 +289,29 @@
       </plugin>
       <!-- run integration tests after unit tests -->
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>get-cpu-count</id>
+            <goals>
+              <goal>cpu-count</goal>
+            </goals>
+            <configuration>
+              <cpuCount>system.numCores</cpuCount>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>-Dfile.encoding=UTF-8 -Xmx1G</argLine>
           <!--<rerunFailingTestsCount>5</rerunFailingTestsCount>-->
           <runOrder>alphabetical</runOrder>
-          <forkCount>4</forkCount>
+          <forkCount>${system.numCores}</forkCount>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <excludes>
             <exclude>**/*PerformanceTest.java</exclude>


### PR DESCRIPTION
We recently updated from 3.6 to 3.8.1 however after the upgrade, we started having build issues.  

Prior to the upgrade, the build would take approx 15 - 20 minutes. After the upgrade it was taking 70 minutes or more.

Our build platform is a 2 core 4GB Ram system in the Azure.  We are using Azure devops pipeline for doing the build. The build run all the tests.

After some testing, we could see that the 2.6 build would run without using any swap space (So it did not require more than 4GB of ram).  But the 3.8.1 build was using 3+GB of swap at some points in the testing.  It almost looks like there are some memory leaks in some of the tests - but I did not find the cause so this is only a guess?

If we update the system to use 8GB of ram, then the build would take between 20 and 30 minutes - but to upgrade to 8GB of ram in Azure is twice the price of the existing build system so that was not really an option for us.

The other option that we found was to reduce the number of forks during the test.  The forks are hard coded to 4.  As our system only had 2 cores it seemed to make more sense to only use 2 forks.  By setting the forks to 2, the builds now take approx 27 minutes.

This pull request is to adjust the fork count so that it is calculated based on the number of cores available on the system - this helped with our build times.
I have not tested this on system with lots of cores - not sure if it would cause any issues?
