### PR TITLE
Update legacy services mapping

### DIFF
--- a/core/src/main/java/org/fao/geonet/services/thumbnail/Set.java
+++ b/core/src/main/java/org/fao/geonet/services/thumbnail/Set.java
@@ -82,7 +82,7 @@ public class Set {
     private static final String FNAME_PARAM = "fname=";
 
 
-    @RequestMapping(value = {"/{lang}/md.thumbnail.upload"}, produces = {
+    @RequestMapping(value = {"/{portal}/{lang}/md.thumbnail.upload"}, produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public Response serviceSpecificExec(HttpServletRequest request,

--- a/healthmonitor/src/main/java/org/fao/geonet/monitor/service/LogConfig.java
+++ b/healthmonitor/src/main/java/org/fao/geonet/monitor/service/LogConfig.java
@@ -98,7 +98,7 @@ public class LogConfig {
     /**
      * Download the log file in a ZIP.
      */
-    @RequestMapping(value = "/{lang}/log/file", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/log/file", produces = {
         MediaType.APPLICATION_OCTET_STREAM_VALUE})
     @ResponseBody
     public void getLog(HttpServletResponse response) throws IOException {
@@ -144,7 +144,7 @@ public class LogConfig {
      *
      * @param lines Number of lines to return. Default 2000. Max number of lines returned 20000.
      */
-    @RequestMapping(value = "/{lang}/log/activity", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/log/activity", produces = {
         MediaType.TEXT_PLAIN_VALUE})
     @ResponseBody
     public String activity(@RequestParam(value = "lines",

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -287,7 +287,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             formatType,
             request.getNativeRequest(HttpServletRequest.class));
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, servletRequest);
-        
+
         if(approved) {
         	metadata = context.getBean(MetadataRepository.class).findOneByUuid(metadataUuid);
         }
@@ -354,7 +354,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
      * @param mdPath   (optional) the xpath to the metadata node if it's not the root node of the
      *                 XML
      */
-    @RequestMapping(value = "/{lang}/xml.format.{type}")
+    @RequestMapping(value = "/{portal}/{lang}/xml.format.{type}")
     @ResponseBody
     @Deprecated
     public void execXml(
@@ -406,7 +406,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
      * This is a service to use if there is process to keep the cache at least periodically
      * up-to-date and if maximum performance is required.
      */
-    @RequestMapping(value = "/{lang}/md.format.public.{type}")
+    @RequestMapping(value = "/{portal}/{lang}/md.format.public.{type}")
     public HttpEntity<byte[]> getCachedPublicMetadata(
         @PathVariable final String lang,
         @PathVariable final String type,
@@ -442,7 +442,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
      *                       enum values: {@link org.fao.geonet.api.records.formatters.FormatterWidth}
      *                       The default is _100 (100% of the screen)
      */
-    @RequestMapping(value = "/{lang}/md.format.{type}")
+    @RequestMapping(value = "/{portal}/{lang}/md.format.{type}")
     @ResponseBody
     public void exec(
         @PathVariable final String lang,

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ListFormatters.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ListFormatters.java
@@ -103,7 +103,7 @@ public class ListFormatters extends AbstractFormatService {
         }
     }
 
-    @RequestMapping(value = "/{lang}/md.formatter.list", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/md.formatter.list", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public FormatterDataResponse exec(

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/Register.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/Register.java
@@ -75,7 +75,7 @@ import static org.fao.geonet.api.records.formatters.FormatterConstants.VIEW_XSL_
 public class Register extends AbstractFormatService {
 
 
-    @RequestMapping(value = {"/{lang}/md.formatter.register"}, produces = {MediaType.APPLICATION_JSON_VALUE})
+    @RequestMapping(value = {"/{portal}/{lang}/md.formatter.register"}, produces = {MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public JSONObject serviceSpecificExec(HttpServletRequest request,
                                           @PathVariable String lang,

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/Resource.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/Resource.java
@@ -50,7 +50,7 @@ import static com.google.common.io.Files.getFileExtension;
 @Controller("md.formatter.resource")
 public class Resource extends AbstractFormatService {
 
-    @RequestMapping(value = "/{lang}/md.formatter.resource")
+    @RequestMapping(value = "/{portal}/{lang}/md.formatter.resource")
     public void exec(
         @RequestParam(Params.ID) String xslid,
         @RequestParam(Params.FNAME) String fileName,

--- a/services/src/main/java/org/fao/geonet/guiservices/csw/virtual/Delete.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/csw/virtual/Delete.java
@@ -38,7 +38,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Deprecated
 public class Delete {
 
-    @RequestMapping(value = "/{lang}/admin.config.virtualcsw.remove", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.config.virtualcsw.remove", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/guiservices/csw/virtual/Get.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/csw/virtual/Get.java
@@ -40,7 +40,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Deprecated
 public class Get {
 
-    @RequestMapping(value = "/{lang}/admin.config.virtualcsw.get", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.config.virtualcsw.get", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/guiservices/csw/virtual/List.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/csw/virtual/List.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Controller("admin.config.virtualcsw.list")
 @Deprecated
 public class List {
-    @RequestMapping(value = "/{lang}/admin.config.virtualcsw.list", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.config.virtualcsw.list", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/guiservices/csw/virtual/Update.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/csw/virtual/Update.java
@@ -63,7 +63,7 @@ public class Update {
         "_content_type"
     };
 
-    @RequestMapping(value = "/{lang}/admin.config.virtualcsw.update", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.config.virtualcsw.update", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/guiservices/metadata/GetRelated.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/metadata/GetRelated.java
@@ -142,7 +142,7 @@ public class GetRelated implements Service, RelatedMetadata {
     /**
      * @param type List of comma or "|" separated types
      */
-    @RequestMapping(value = "/{lang}/xml.relation")
+    @RequestMapping(value = "/{portal}/{lang}/xml.relation")
     public HttpEntity<byte[]> exec(@PathVariable String lang,
                                    @RequestParam(required = false) Integer id,
                                    @RequestParam(required = false) String uuid,

--- a/services/src/main/java/org/fao/geonet/services/category/Remove.java
+++ b/services/src/main/java/org/fao/geonet/services/category/Remove.java
@@ -50,7 +50,7 @@ import jeeves.services.ReadWriteController;
 @ReadWriteController
 @Deprecated
 public class Remove {
-    @RequestMapping(value = "/{lang}/admin.category.remove", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.category.remove", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public CategoryUpdateResponse exec(

--- a/services/src/main/java/org/fao/geonet/services/category/Update.java
+++ b/services/src/main/java/org/fao/geonet/services/category/Update.java
@@ -49,7 +49,7 @@ import javax.annotation.Nonnull;
 @Deprecated
 public class Update {
 
-    @RequestMapping(value = "/{lang}/admin.category.update", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.category.update", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public CategoryUpdateResponse exec(

--- a/services/src/main/java/org/fao/geonet/services/category/XmlUpdate.java
+++ b/services/src/main/java/org/fao/geonet/services/category/XmlUpdate.java
@@ -50,7 +50,7 @@ import javax.xml.bind.annotation.XmlValue;
 @Deprecated
 public class XmlUpdate {
 
-    @RequestMapping(value = "/{lang}/admin.category.update.labels", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.category.update.labels", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public OkResponse serviceSpecificExec(@RequestBody String request) throws Exception {

--- a/services/src/main/java/org/fao/geonet/services/log/List.java
+++ b/services/src/main/java/org/fao/geonet/services/log/List.java
@@ -67,7 +67,7 @@ public class List {
     // ---
     // --------------------------------------------------------------------------
 
-    @RequestMapping(value = "/{lang}/admin.logfile.list", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.logfile.list", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     ListLogFilesResponse exec() throws Exception {

--- a/services/src/main/java/org/fao/geonet/services/logo/Add.java
+++ b/services/src/main/java/org/fao/geonet/services/logo/Add.java
@@ -54,7 +54,7 @@ public class Add implements ApplicationContextAware {
         this.context = context;
     }
 
-    @RequestMapping(value = "/{lang}/admin.logo.upload",
+    @RequestMapping(value = "/{portal}/{lang}/admin.logo.upload",
         consumes = {MediaType.ALL_VALUE},
         produces = {MediaType.APPLICATION_JSON_VALUE})
     public
@@ -64,7 +64,7 @@ public class Add implements ApplicationContextAware {
         return exec(fname);
     }
 
-    @RequestMapping(value = "/{lang}/admin.logo.upload", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.logo.upload", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/services/main/Select.java
+++ b/services/src/main/java/org/fao/geonet/services/main/Select.java
@@ -64,7 +64,7 @@ public class Select implements ApplicationContextAware {
      * @param type     Only metadata can be selected. Unused for now. Leave blank
      * @return The number of select records
      */
-    @RequestMapping(value = {"/{lang}/metadata.select", "/{lang}/md.select"},
+    @RequestMapping(value = {"/{portal}/{lang}/metadata.select", "/{portal}/{lang}/md.select"},
         produces = {MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody
@@ -88,7 +88,7 @@ public class Select implements ApplicationContextAware {
      * @return
      * @throws Exception
      */
-    @RequestMapping(value = "/{lang}/md.selected",
+    @RequestMapping(value = "/{portal}/{lang}/md.selected",
         produces = {MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody
@@ -108,7 +108,7 @@ public class Select implements ApplicationContextAware {
     /**
      * @deprecated Use the service with JSON format as output
      */
-    @RequestMapping(value = "/{lang}/metadata.select",
+    @RequestMapping(value = "/{portal}/{lang}/metadata.select",
         produces = {MediaType.APPLICATION_XML_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/services/metadata/BatchNewOwner.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/BatchNewOwner.java
@@ -64,7 +64,7 @@ import jeeves.services.ReadWriteController;
 @Deprecated
 public class BatchNewOwner {
 
-    @RequestMapping(value = "/{lang}/metadata.batch.newowner", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/metadata.batch.newowner", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public NewOwnerResult exec(

--- a/services/src/main/java/org/fao/geonet/services/metadata/ExtractServicesLayers.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/ExtractServicesLayers.java
@@ -58,7 +58,7 @@ import java.util.List;
 @Controller
 public class ExtractServicesLayers {
 
-    @RequestMapping(value = "/{lang}/selection.layers")
+    @RequestMapping(value = "/{portal}/{lang}/selection.layers")
     @ResponseBody
     public JSONObject getLayersFromSelectedMetadatas(
         @PathVariable String lang,

--- a/services/src/main/java/org/fao/geonet/services/metadata/MetadataIdentifierTemplatesController.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/MetadataIdentifierTemplatesController.java
@@ -45,7 +45,7 @@ import java.util.List;
 @Deprecated
 @Controller("metadataIdentifierTemplates")
 public class MetadataIdentifierTemplatesController {
-    @RequestMapping(value = "/{lang}/metadataIdentifierTemplates", method = RequestMethod.POST)
+    @RequestMapping(value = "/{portal}/{lang}/metadataIdentifierTemplates", method = RequestMethod.POST)
     @ResponseBody
     public OkResponse updateUrnTemplate(
         @RequestParam final Integer id,
@@ -78,7 +78,7 @@ public class MetadataIdentifierTemplatesController {
         return new OkResponse();
     }
 
-    @RequestMapping(value = "/{lang}/metadataIdentifierTemplates",
+    @RequestMapping(value = "/{portal}/{lang}/metadataIdentifierTemplates",
         method = RequestMethod.DELETE)
     @ResponseBody
     public OkResponse deleteMetadataURNTemplate(@RequestParam final Integer id) {
@@ -91,7 +91,7 @@ public class MetadataIdentifierTemplatesController {
         return new OkResponse();
     }
 
-    @RequestMapping(value = "/{lang}/metadataIdentifierTemplates",
+    @RequestMapping(value = "/{portal}/{lang}/metadataIdentifierTemplates",
         method = RequestMethod.GET, produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
@@ -92,7 +92,7 @@ public class Publish {
     boolean testing = false;
 
 
-    @RequestMapping(value = "/{lang}/md.publish", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/md.publish", produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     @ResponseBody
     public PublishReport publish(
@@ -108,7 +108,7 @@ public class Publish {
     }
 
 
-    @RequestMapping(value = "/{lang}/md.unpublish", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/md.unpublish", produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     @ResponseBody
     public PublishReport unpublish(

--- a/services/src/main/java/org/fao/geonet/services/metadata/ValidationService.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/ValidationService.java
@@ -74,7 +74,7 @@ public class ValidationService implements ApplicationContextAware {
      *
      * @param uuid One or more UUIDs to validate
      */
-    @RequestMapping(value = "/{lang}/md.validation",
+    @RequestMapping(value = "/{portal}/{lang}/md.validation",
         produces = {
             MediaType.APPLICATION_XML_VALUE,
             MediaType.APPLICATION_JSON_VALUE})
@@ -133,7 +133,7 @@ public class ValidationService implements ApplicationContextAware {
 	                    this.report.get("validRecords").add(record.getId());
 	                }
 	                this.report.get("records").add(record.getId());
-	
+
 	            }
             }
         }

--- a/services/src/main/java/org/fao/geonet/services/metadata/XslProcessing.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/XslProcessing.java
@@ -75,7 +75,7 @@ import jeeves.services.ReadWriteController;
 @Deprecated
 public class XslProcessing {
 
-    @RequestMapping(value = {"/{lang}/md.processing", "/{lang}/xml.metadata.processing", "/{lang}/metadata.processing.new"}, produces = {
+    @RequestMapping(value = {"/{portal}/{lang}/md.processing", "/{portal}/{lang}/xml.metadata.processing", "/{portal}/{lang}/metadata.processing.new"}, produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public XsltMetadataProcessingReport xmlProcessing(@RequestParam(value = Params.PROCESS) String process,

--- a/services/src/main/java/org/fao/geonet/services/metadata/XslProcessingReportGet.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/XslProcessingReportGet.java
@@ -89,7 +89,7 @@ public class XslProcessingReportGet {
     public void init(String appPath, ServiceConfig config) throws Exception {
     }
 
-    @RequestMapping(value = "/{lang}/md.processing.batch.report", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/md.processing.batch.report", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/services/region/List.java
+++ b/services/src/main/java/org/fao/geonet/services/region/List.java
@@ -142,7 +142,7 @@ public class List {
      * @param maxRecords limit the number of results returned - optional
      */
 
-    @RequestMapping(value = "/{lang}/regions.list", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/regions.list", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public ListRegionsResponse exec(@PathVariable String lang,

--- a/services/src/main/java/org/fao/geonet/services/resources/Download.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/Download.java
@@ -70,7 +70,7 @@ public class Download {
     @Autowired
     private ServiceManager serviceManager;
 
-    @RequestMapping(value = "/{lang}/resources.get")
+    @RequestMapping(value = "/{portal}/{lang}/resources.get")
     public HttpEntity<byte[]> exec(@PathVariable String lang,
                                    @RequestParam(value = Params.ID, required = false) String idParam,
                                    @RequestParam(value = Params.UUID, required = false) String uuidParam,

--- a/services/src/main/java/org/fao/geonet/services/resources/RemoveAndProcess.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/RemoveAndProcess.java
@@ -68,7 +68,7 @@ public class RemoveAndProcess {
     @Autowired
     private ServiceManager serviceManager;
 
-    @RequestMapping(value = {"/{lang}/resource.del.and.detach"}, produces = {
+    @RequestMapping(value = {"/{portal}/{lang}/resource.del.and.detach"}, produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/services/resources/UploadAndProcess.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/UploadAndProcess.java
@@ -69,7 +69,7 @@ public class UploadAndProcess {
     @Autowired
     private ServiceManager serviceManager;
 
-    @RequestMapping(value = {"/{lang}/resource.upload.and.link", "/{lang}/resource-onlinesrc-upload"}, produces = {
+    @RequestMapping(value = {"/{portal}/{lang}/resource.upload.and.link", "/{portal}/{lang}/resource-onlinesrc-upload"}, produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public IdResponse exec(HttpServletRequest request,

--- a/services/src/main/java/org/fao/geonet/services/sources/SourcesController.java
+++ b/services/src/main/java/org/fao/geonet/services/sources/SourcesController.java
@@ -72,7 +72,7 @@ public class SourcesController {
     @Autowired
     private HarvesterSettingRepository harvesterSettingRepository;
 
-    @RequestMapping("/{lang}/source/{uuid}")
+    @RequestMapping("/{portal}/{lang}/source/{uuid}")
     @ResponseBody
     public OkResponse updateTranslations(
         @PathVariable String lang,

--- a/services/src/main/java/org/fao/geonet/services/system/UpdateSystemInfo.java
+++ b/services/src/main/java/org/fao/geonet/services/system/UpdateSystemInfo.java
@@ -45,7 +45,7 @@ public class UpdateSystemInfo {
     @Autowired
     private SystemInfo info;
 
-    @RequestMapping(value = "/{lang}/systeminfo/staging", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/systeminfo/staging", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public OkResponse update(@RequestParam(required = true) String newProfile) {

--- a/services/src/main/java/org/fao/geonet/services/user/List.java
+++ b/services/src/main/java/org/fao/geonet/services/user/List.java
@@ -71,7 +71,7 @@ public class List {
     public void init(String appPath, ServiceConfig params) throws Exception {
     }
 
-    @RequestMapping(value = "/{lang}/admin.user.list", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.user.list", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/services/user/Remove.java
+++ b/services/src/main/java/org/fao/geonet/services/user/Remove.java
@@ -57,7 +57,7 @@ import static org.springframework.data.jpa.domain.Specifications.where;
 public class Remove {
 
 
-    @RequestMapping(value = "/{lang}/admin.user.remove", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.user.remove", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/services/user/Update.java
+++ b/services/src/main/java/org/fao/geonet/services/user/Update.java
@@ -65,7 +65,7 @@ import static org.fao.geonet.repository.specification.UserGroupSpecs.hasUserId;
 public class Update {
 
 
-    @RequestMapping(value = "/{lang}/admin.user.resetpassword", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.user.resetpassword", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody
@@ -87,7 +87,7 @@ public class Update {
         return new OkResponse();
     }
 
-    @RequestMapping(value = "/{lang}/admin.user.update", produces = {
+    @RequestMapping(value = "/{portal}/{lang}/admin.user.update", produces = {
         MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public
     @ResponseBody


### PR DESCRIPTION
Since introduction of the new concept of portals instead of node (PR #3475) some old services stopped to work. This commit updates the @RequestMapping annotation to match the new format of the URL for portals, adding an additional `/{portal}` segment to the RequestMapping URLs.