### PR TITLE
Fixes how the total feature count is computed with ElasticSearch

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -433,13 +433,13 @@
         return JSON.stringify(queryObject);
       }.bind(this),
       responseHandler: function(res) {
-        this.count = res.hits.total;
+        this.count = res.hits.total.value;
         var rows = [];
         for (var i = 0; i < res.hits.hits.length; i++) {
           rows.push(res.hits.hits[i]._source);
         }
         return {
-          total: res.hits.total,
+          total: res.hits.total.value,
           rows: rows
         };
       }.bind(this),


### PR DESCRIPTION
The `hits.total` property on the ES responses used to be an integer but it is now an object, which broke the features table rendering with a layer using ES-indexed data.