### PR TITLE
Fix legends for map layers

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -519,10 +519,9 @@
                 needles[0].version = capObj.version;
               }
               // Multiple layers from the same service
-              if (layerName.indexOf(',')) {
-                needles[0].Name = layerName;
+              if (layerName.indexOf(',') !== -1) {
                 // Parameters 'styles' and 'layers' should have the same number of values.
-                //needles[0].Style = new Array(layerList.length).join(',');
+                needles[0].Style = new Array(layerList.length).join(',');
               }
               return needles[0];
             }

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -522,7 +522,7 @@
               if (layerName.indexOf(',')) {
                 needles[0].Name = layerName;
                 // Parameters 'styles' and 'layers' should have the same number of values.
-                needles[0].Style = new Array(layerList.length).join(',');
+                //needles[0].Style = new Array(layerList.length).join(',');
               }
               return needles[0];
             }


### PR DESCRIPTION
The `Style` property of the layer in the getcapabilities document was modified and as such some code that relied on it would break. This was the case for legend rendering.

Note: this is not a final fix as this code was probably necessary for some other features (such as https://github.com/geonetwork/core-geonetwork/pull/3859). This PR is open for discussion, thanks.