### PR TITLE
New metadata / Force to set groupOwner when user is not an administrator

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
@@ -64,8 +64,13 @@
           <strong>{{(ownerGroup.label[lang] || '...') | translate}}</strong>
         </div>
         <div class="panel-body">
-          <div data-groups-combo="" data-owner-group="ownerGroup" lang="lang"
-               data-groups="groups" data-profile="Editor" data-exclude-special-groups="true"/>
+          <div data-groups-combo=""
+               data-optional="{{user.isAdministrator()}}"
+               data-owner-group="ownerGroup"
+               lang="lang"
+               data-groups="groups"
+               data-profile="Editor"
+               data-exclude-special-groups="true"/>
         </div>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
@@ -62,9 +62,13 @@
       <strong>{{(ownerGroup.label[lang] || '...') | translate}}</strong>
     </div>
     <div class="col-sm-8">
-      <div data-groups-combo="" data-owner-group="ownerGroup" lang="lang"
-           data-groups="groups" data-profile="Editor" data-exclude-special-groups="true">
-      </div>
+      <div data-groups-combo=""
+         data-optional="{{user.isAdministrator()}}"
+         data-owner-group="ownerGroup"
+         lang="lang"
+         data-groups="groups"
+         data-profile="Editor"
+         data-exclude-special-groups="true"/>
     </div>
   </div>
   <div class="row" data-ng-show="hasTemplates && !generateUuid">


### PR DESCRIPTION
Currently gourp owner can be left empty if user is Editor, Reviewer or UserAdmin.
Force to set the value (like when harvesting) to attach record to one of the user group. 
Only admin can leave it blank.

When user is member of one group, then the UI is simple and the group owner is set automatically

![image](https://user-images.githubusercontent.com/1701393/67301679-0681a980-f4f0-11e9-8fd0-922c8413493d.png)
