### PR TITLE
Record link / Disable analyze button (only allowed for admin user)

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/record-links.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/record-links.html
@@ -13,6 +13,7 @@
   <div class="pull-right btn-toolbar">
     <button type="button" class="btn btn-primary"
             title="{{'analyzeLinks-help' | translate}}"
+            data-ng-disabled="!user.isAdministrator()"
             data-gn-click-and-spin="analyzeLinks()">
       <i class="fa fa-fw fa-cogs"/>&nbsp;
       <span data-translate="">analyzeLinks</span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1701393/67302298-fddda300-f4f0-11e9-9109-39e5ece34714.png)

Only admin can trigger analyze link task.

See https://github.com/geonetwork/core-geonetwork/blob/master/services/src/main/java/org/fao/geonet/api/links/LinksApi.java#L143-L151