### PR TITLE
Fix for #3517: Hide the button and dropdown when VCS (Version Control System) in not enabled

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -21,7 +21,7 @@
     <div data-gn-metadata-group-updater="groupOwner"
          data-metadata-id="gnCurrentEdit.id" title="{{'group'|translate}}"/>
 
-    <div class="btn-group">
+    <div class="btn-group" data-ng-if="gnConfig.metadata.vcs.enable">
       <button class="btn btn-default navbar-btn dropdown-toggle"
               type="button"
               data-toggle="dropdown"


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/3517

Hide the button and dropdown when VCS (Version Control System) in not enabled. This PR hides the dropdown toggle button because the versioning item is the only item in the dropdown