### PR TITLE
Fix for #3862: Fit content in Privileges dialog

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -78,6 +78,12 @@
     padding-top: 55px;
     padding-bottom: 15px;
   }
+  // modal dialog (wider for for multilingual)
+  @media (min-width: @screen-sm-min) {
+    .modal-dialog {
+      width: 760px;
+    }
+  }
   form.gn-editor {
     // tabs above editor
     .nav {


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/3862

The content of the privileges dialog didn't fit in all languages. This PR makes the modal dialog a bit wider in the editor (but it still fits the screen) so all languages will fit in the window. 

**Screenshot after the change**
![gn-privileges-dialog](https://user-images.githubusercontent.com/19608667/67383249-27e5a280-f58f-11e9-9ee1-68016fd7469e.png)
