### PR TITLE
API / Translation should never be null

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
@@ -22,33 +22,12 @@
  */
 
 package org.fao.geonet.api.tools.i18n;
-//==============================================================================
-//===	Copyright (C) 2001-2015 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.IsoLanguage;
+import org.fao.geonet.domain.Localized;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.domain.Operation;
 import org.fao.geonet.domain.Schematron;
@@ -157,7 +136,8 @@ public class TranslationApi implements ApplicationContextAware {
             Iterator<StatusValue> valueIterator = valueList.iterator();
             while (valueIterator.hasNext()) {
                 StatusValue entity = valueIterator.next();
-                response.put("status-" + entity.getId() + "", entity.getLabel(language));
+                response.put("status-" + entity.getId() + "",
+                    getLabelOrKey(entity, language, entity.getId() + ""));
             }
         }
 
@@ -166,7 +146,8 @@ public class TranslationApi implements ApplicationContextAware {
             Iterator<MetadataCategory> metadataCategoryIterator = metadataCategoryList.iterator();
             while (metadataCategoryIterator.hasNext()) {
                 MetadataCategory entity = metadataCategoryIterator.next();
-                response.put("cat-" + entity.getName() + "", entity.getLabel(language));
+                response.put("cat-" + entity.getName() + "",
+                    getLabelOrKey(entity, language, entity.getName()));
             }
         }
 
@@ -175,7 +156,8 @@ public class TranslationApi implements ApplicationContextAware {
             Iterator<Group> groupIterator = groupList.iterator();
             while (groupIterator.hasNext()) {
                 Group entity = groupIterator.next();
-                response.put("group-" + entity.getId() + "", entity.getLabel(language));
+                response.put("group-" + entity.getId() + "",
+                    getLabelOrKey(entity, language, entity.getName()));
             }
         }
 
@@ -184,8 +166,10 @@ public class TranslationApi implements ApplicationContextAware {
             Iterator<Operation> operationIterator = operationList.iterator();
             while (operationIterator.hasNext()) {
                 Operation entity = operationIterator.next();
-                response.put("op-" + entity.getId() + "", entity.getLabel(language));
-                response.put("op-" + entity.getName() + "", entity.getLabel(language));
+                response.put("op-" + entity.getId() + "",
+                             getLabelOrKey(entity, language, entity.getId() + ""));
+                response.put("op-" + entity.getName() + "",
+                             getLabelOrKey(entity, language, entity.getName()));
             }
         }
 
@@ -194,7 +178,8 @@ public class TranslationApi implements ApplicationContextAware {
             Iterator<Source> sourceIterator = sourceList.iterator();
             while (sourceIterator.hasNext()) {
                 Source entity = sourceIterator.next();
-                response.put("source-" + entity.getUuid() + "", entity.getLabel(language));
+                response.put("source-" + entity.getUuid() + "",
+                             getLabelOrKey(entity, language, entity.getUuid()));
             }
         }
 
@@ -203,7 +188,8 @@ public class TranslationApi implements ApplicationContextAware {
             Iterator<Schematron> schematronIterator = schematronList.iterator();
             while (schematronIterator.hasNext()) {
                 Schematron entity = schematronIterator.next();
-                response.put("sch-" + entity.getRuleName() + "", entity.getLabel(language));
+                response.put("sch-" + entity.getRuleName() + "",
+                             getLabelOrKey(entity, language, entity.getRuleName()));
             }
         }
 
@@ -212,10 +198,16 @@ public class TranslationApi implements ApplicationContextAware {
             Iterator<IsoLanguage> isoLanguageIterator = isoLanguageList.iterator();
             while (isoLanguageIterator.hasNext()) {
                 IsoLanguage entity = isoLanguageIterator.next();
-                response.put("lang-" + entity.getCode() + "", entity.getLabel(language));
+                response.put("lang-" + entity.getCode() + "",
+                             getLabelOrKey(entity, language, entity.getCode()));
             }
         }
         return response;
+    }
+
+    private String getLabelOrKey(Localized entity, String language, String defaultValue) {
+        String value = entity.getLabel(language);
+        return value != null ? value : defaultValue;
     }
 
 


### PR DESCRIPTION
When moving from older version, translations may be incomplete (depending on language setup changes). JSON can then contains null which make translate directive to fail with errors and it breaks the UI in some places:
```

TypeError: Cannot read property 'substr' of null
    at ha (lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:390)
    at Function.V.instant (lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:390)
    at c (lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:390)
    at fn (eval at compile (lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:237), <anonymous>:4:199)
    at lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:135
    at m.$digest (lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:150)
    at m.$apply (lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:154)
    at lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:166
    at e (lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:57)
    at lib.js?v=ff50cfc1dea2dbd6a7f1c491fbd3e91405026a32:60
```

![image](https://user-images.githubusercontent.com/1701393/67461672-2a530580-f63e-11e9-85e7-c79f68e336f1.png)


The API op affected is:
http://localhost:8080/geonetwork/srv/api/0.1/tools/i18n/db?type=StatusValue&type=Operation&type=Group

Response causing issue is due to `null` value:
```
{
status-0: "Inconnu",
status-1: "Brouillon",
status-2: "Validé",
status-3: "Retiré",
status-4: "A valider",
status-5: "Rejeté",
group--1: null,
group-0: null,
group-1: "all",
```

Always set a default non empty value in the response.

From the catalog admin point of view, the complete fix in such case is to update the database missing translations.