### PR TITLE
Inspire validator proxy geonet

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -248,7 +248,7 @@ public class InspireValidationApi {
 
             InputStream metadataToTest = convertElement2InputStream(md);
 
-            String testId = inspireValidatorUtils.submitFile(URL, metadataToTest, testsuite, metadata.getUuid());
+            String testId = inspireValidatorUtils.submitFile(context, URL, metadataToTest, testsuite, metadata.getUuid());
 
             return testId;
         } catch (Exception e) {
@@ -306,12 +306,13 @@ public class InspireValidationApi {
     ) throws Exception {
 
         String URL = settingManager.getValue(Settings.SYSTEM_INSPIRE_REMOTE_VALIDATION_URL);
+        ServiceContext context = ApiUtils.createServiceContext(request);
 
         try {
-            if (inspireValidatorUtils.isReady(URL, testId)) {
+            if (inspireValidatorUtils.isReady(context, URL, testId)) {
                 Map<String, String> values = new HashMap<>();
 
-                values.put("status", inspireValidatorUtils.isPassed(URL, testId));
+                values.put("status", inspireValidatorUtils.isPassed(context, URL, testId));
                 values.put("report", inspireValidatorUtils.getReportUrl(URL, testId));
                 response.setStatus(HttpStatus.SC_OK);
 

--- a/services/src/main/java/org/fao/geonet/api/records/editing/InspireValidatorUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/InspireValidatorUtils.java
@@ -64,7 +64,7 @@ import com.google.common.io.CharStreams;
 
 import javassist.NotFoundException;
 
-// A static style interface for methods in Inspire Service.
+// Utility class to access methods in Inspire Service.
 // Based on ETF Web API v.2 BETA
 public class InspireValidatorUtils {
 
@@ -527,7 +527,12 @@ public class InspireValidatorUtils {
         }
     }
 
-    // Executes the HttpUriRequest
+    /**
+     *  Executes the HttpUriRequest
+        * @param request
+        * @return response of execute method
+        * @throws IOException
+     */
     private ClientHttpResponse execute(HttpUriRequest request) throws IOException {
 
         boolean useProxy = settingManager.getValueAsBool(Settings.SYSTEM_PROXY_USE, false);

--- a/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
@@ -1,14 +1,17 @@
 package org.fao.geonet.api.records.editing;
 
-import javassist.NotFoundException;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
+import javassist.NotFoundException;
+import jeeves.server.context.ServiceContext;
 
 public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
@@ -16,6 +19,13 @@ public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
     @Autowired
     InspireValidatorUtils inspireValidatorUtils;
+
+    private ServiceContext context;
+
+    @Before
+    public void setUp() throws Exception {
+        this.context = createServiceContext();
+    }
 
     @Test
     public void testGetReportUrl() {
@@ -37,15 +47,15 @@ public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
     @Ignore
     public void testLifeCycle() throws IOException {
 
-        assertEquals(inspireValidatorUtils.checkServiceStatus("http://wrong.url.eu"), false);
+        assertEquals(inspireValidatorUtils.checkServiceStatus(context, "http://wrong.url.eu"), false);
 
         // FIRST TEST IF OFFICIAL ETF IS AVAILABLE
         // Needed to avoid GN errors when ETF is not available
-        if (inspireValidatorUtils.checkServiceStatus(URL)) {
+        if (inspireValidatorUtils.checkServiceStatus(context, URL)) {
 
             try {
                 // No file
-                inspireValidatorUtils.submitFile(URL, null, "Metadata (TG version 1.3)", "GN UNIT TEST ");
+                inspireValidatorUtils.submitFile(context, URL, null, "Metadata (TG version 1.3)", "GN UNIT TEST ");
             } catch (IllegalArgumentException e) {
                 // RIGHT EXCEPTION
             } catch (Exception e) {
@@ -54,7 +64,7 @@ public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
             try {
                 // Valid but not found test ID
-                inspireValidatorUtils.isReady(URL, "IED123456789012345678901234567890123");
+                inspireValidatorUtils.isReady(context, URL, "IED123456789012345678901234567890123");
                 assertEquals("No exception!", "NotFoundException", "No Exception");
             } catch (NotFoundException e) {
                 // RIGHT EXCEPTION
@@ -64,7 +74,7 @@ public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
             try {
                 // Test ID in wrong format
-                assertEquals(inspireValidatorUtils.isPassed(URL, "1"), null);
+                assertEquals(inspireValidatorUtils.isPassed(context, URL, "1"), null);
             } catch (Exception e) {
                 assertEquals("Unexpected exception.", "Exception", "No Exception");
             }


### PR DESCRIPTION
My previous PR https://github.com/geonetwork/core-geonetwork/pull/3952 breaks the Inspire Validation services when a proxy is set. This is a fix for this.

I'm not sure if it's a good idea to apply this kind of fixes directly to GeonetHttpRequestFactory. What do you think?