### PR TITLE
Fix for #4123: "Breaking" dropdowns in Chrome 78 and missing icons

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -4,6 +4,7 @@
 @import (less) "../lib/ol.css";
 @import (less) "../lib/angular.ext/hotkeys/hotkeys.min.css";
 @import "gn_doc.less";
+@import "gn_icons.less";
 @import "ellipsis.less";
 
 @fa-version: '4.3.0';
@@ -317,6 +318,11 @@ div.gn-scroll-spy {
   li.disabled {
     a {
       pointer-events: none;
+    }
+  }
+  li {
+    a {
+      min-width: max-content;
     }
   }
 }


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/4123

After updating to Chrome 78 the dropdown items with a `&nbsp;` (in combination with the `min-width` of the dropdown) were sometimes displayed on 2 lines.

This PR also brings back icons (in dropdowns) that were lost after PR https://github.com/geonetwork/core-geonetwork/pull/4044

**Before**
![gn-dropdown-menu-chrome](https://user-images.githubusercontent.com/19608667/67476723-dc97c680-f658-11e9-808e-b3aa6d69124f.png)

**After the change**
![gn-dropdown-menu](https://user-images.githubusercontent.com/19608667/67476731-e02b4d80-f658-11e9-83d4-dfe93feaa6ae.png)