### PR TITLE
Position 'Source Dataset' block in detailview under 'Technical Information' table

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -364,11 +364,9 @@
               </tr>
               </tbody>
             </table>
-
           </div>
 
-
-          <table class="table table-striped">
+          <table class="table table-striped t">
             <tbody>
             <tr data-ng-if="mdView.current.record.updateFrequency">
               <th data-translate="">updateFrequency</th>
@@ -419,29 +417,23 @@
                 <p data-ng-bind-html="mdView.current.record.lineage | linky | newlines"/>
               </td>
             </tr>
-            <tr>
-              <th></th>
-              <td>
-                <div data-gn-related-observer>
-                  <div data-gn-related="mdView.current.record"
-                      data-user="user"
-                      data-types="sources"
-                      data-has-results="hasRelations.sources"
-                      data-title="{{'sourceDatasets' | translate}}">
-                  </div>
-
-
-                  <div data-gn-related="mdView.current.record"
-                      data-user="user"
-                      data-types="hassources"
-                      data-has-results="hasRelations.hassources"
-                      data-title="{{'isSourceOfDatasets' | translate}}">
-                  </div>
-                </div>
-              </td>
-            </tr>
             </tbody>
           </table>
+
+          <div data-gn-related-observer>
+            <div data-gn-related="mdView.current.record"
+                data-user="user"
+                data-types="sources"
+                data-has-results="hasRelations.sources"
+                data-title="{{'sourceDatasets' | translate}}">
+            </div>
+            <div data-gn-related="mdView.current.record"
+                data-user="user"
+                data-types="hassources"
+                data-has-results="hasRelations.hassources"
+                data-title="{{'isSourceOfDatasets' | translate}}">
+            </div>
+          </div>
 
           <h2 data-translate="">metadataInformation</h2>
 


### PR DESCRIPTION
In the current situation the `Source Dataset` block in the detailview is in the table of the `Technical Information`. This means that the content is put in just one column and the text of the button doesn't fit.

![gn-detail-sourcedataset-before](https://user-images.githubusercontent.com/19608667/67482692-75800f00-f664-11e9-8364-790251f8d089.png)

This PR takes the `Source Dataset` block out of the table and positions it under this table. This results in a more balanced view and solves the button text problem.

After the change
![gn-detail-sourcedataset-after](https://user-images.githubusercontent.com/19608667/67482700-787aff80-f664-11e9-9848-7396b00a106d.png)

