### PR TITLE
Fix the localisation style for Chrome 78

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/localisation/partials/localisation.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/localisation/partials/localisation.html
@@ -5,7 +5,7 @@
         title="{{'clear'|translate}}"></span>
   <div class="input-group">
     <span class="input-group-addon">
-      <i class="fa fa-map-signs"/>&nbsp;
+      <i class="fa fa-map-signs"/>
     </span>
     <input data-ng-model="query"
            data-ng-model-options="modelOptions"


### PR DESCRIPTION
The update to Chrome 78 "broke" the styling for the `localisation` search on the map. This PR fixes it.

**Before**
![gn-map-before](https://user-images.githubusercontent.com/19608667/67491110-a9633080-f674-11e9-978b-bb2a275af25a.png)

**After**
![gn-map-after](https://user-images.githubusercontent.com/19608667/67491128-b122d500-f674-11e9-8b33-8534176ea95d.png)

I guess this is the smallest PR ever 😄 