### PR TITLE
Portal id / Exclude webapp root folders

### DIFF
--- a/common/src/main/java/org/fao/geonet/NodeInfo.java
+++ b/common/src/main/java/org/fao/geonet/NodeInfo.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.io.Serializable;
 
 /**
@@ -32,6 +34,26 @@ import java.io.Serializable;
  */
 public class NodeInfo implements Serializable {
     public static final String DEFAULT_NODE = "srv";
+
+    /**
+     * The webapp based folder can not be used as a portal identifier.
+     */
+    public static ImmutableSet<String> EXCLUDED_NODE_IDS;
+    static {
+        EXCLUDED_NODE_IDS = ImmutableSet.<String>builder()
+            .add("catalog")
+            .add("conversion")
+            .add("doc")
+            .add("htmlCache")
+            .add("images")
+            .add("loc")
+            .add("resources")
+            .add("xml")
+            .add("xsl")
+            .add("xslt")
+            .build();
+    }
+
     private String id = "srv";
     private boolean defaultNode = true;
     private boolean readOnly = false;

--- a/core/src/main/java/jeeves/config/springutil/JeevesDispatcherServlet.java
+++ b/core/src/main/java/jeeves/config/springutil/JeevesDispatcherServlet.java
@@ -76,7 +76,8 @@ public class JeevesDispatcherServlet extends DispatcherServlet {
         // eg. /srv/eng/catalogue.search or /srv/api/...
         String path = request.getPathInfo();
         if (path != null && path.length() > 1 && path.contains("/")) {
-            node.setId(request.getPathInfo().split("/")[1]);
+            String id = request.getPathInfo().split("/")[1];
+            node.setId(NodeInfo.EXCLUDED_NODE_IDS.contains(id) ? NodeInfo.DEFAULT_NODE : id);
         } else {
             // eg. when accessing /
             node.setId(NodeInfo.DEFAULT_NODE);


### PR DESCRIPTION
Depending on the last resource retrieved, the portal id was sometimes set
to a webapp root folder name which was not matching any portals.

Exclude those folders.

Problem was random, but for example, signin with the popup with wrong
password was most of the time redirecting to a non existing node (ie.
catalog).