### PR TITLE
Fix for #4142: Maximum height for image thumbnail in 'Add Online resource' dialog

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -4,6 +4,7 @@
 @import (less) "../lib/ol.css";
 @import (less) "../lib/angular.ext/hotkeys/hotkeys.min.css";
 @import "gn_doc.less";
+@import "gn_icons.less";
 @import "ellipsis.less";
 
 @fa-version: '4.3.0';
@@ -339,13 +340,16 @@ div.gn-scroll-spy {
     width: 90vw;
     max-height: 90vh;
     .modal-body {
-      max-height: 76vh;
+      max-height: 80vh;
       overflow: auto;
       min-height: 500px;
       .gn-modal-content {
         // height of modal body - 2 * padding - height of button(s)
-        max-height: calc(~"76vh - 30px - 30px");
+        max-height: calc(~"76vh - 30px - 28px");
         overflow: auto;
+        .img-thumbnail {
+          max-height: 250px;
+        }
       }
     }
   }


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/4142

Add a maximum height to the thumbnail image. This prevents form elements to be pushed out of sight. 

Extra: Try to minimize the amount of scrollbars.

**The 'Add Online resource' dialog after the changes**
![gn-add-online-resource](https://user-images.githubusercontent.com/19608667/67685652-c447e480-f995-11e9-9f00-58f4317bfd1e.png)
