### PR TITLE
Record view / Prevent mutating the index record when clicking on 'view WMS'

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -261,19 +261,21 @@
             url: $filter('gnLocalized')(link.url) || link.url
           };
 
+          var title = link.title;
+          var name = link.name;
           if (angular.isObject(link.title)) {
-            link.title = $filter('gnLocalized')(link.title);
+            title = $filter('gnLocalized')(link.title);
           }
           if (angular.isObject(link.name)) {
-            link.name = $filter('gnLocalized')(link.name);
+            name = $filter('gnLocalized')(link.name);
           }
 
-          if (link.name && link.name !== '') {
-            config.name = link.name;
+          if (name && name !== '') {
+            config.name = name;
             config.group = link.group;
             // Related service return a property title for the name
-          } else if (link.title) {
-            config.name = link.title;
+          } else if (title) {
+            config.name = title;
           }
 
           // if an external viewer is defined, use it here
@@ -285,7 +287,7 @@
               type: config.type,
               url: config.url,
               name: config.name,
-              title: link.title
+              title: title
             });
             return;
           }


### PR DESCRIPTION
This fixes a bug where on the record view clicking on "View WMS" would mutate the corresponding `link` and break the WMS service info. Can be reproduced here:
https://www.geograndest.fr/geonetwork/srv/fre/catalog.search?t=1555485535#/metadata/FR-180067019_IGNF_ORTHOHR_RVB_CIGAL_2015

Before clicking:
![image](https://user-images.githubusercontent.com/10629150/67759184-4f30e980-fa3f-11e9-9657-06a5ae10c67d.png)


After clicking:
![image](https://user-images.githubusercontent.com/10629150/67759148-3de7dd00-fa3f-11e9-99c4-5d9231aebc93.png)

This is still present on master.

Note: this is only noticeable when using an external viewer.