### PR TITLE
Set context as thread local when it is created in ApiUtils

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -193,7 +193,9 @@ public class ApiUtils {
 
     static public ServiceContext createServiceContext(HttpServletRequest request, String iso3langCode) {
         ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
-        return serviceManager.createServiceContext("Api", iso3langCode, request);
+        ServiceContext serviceContext = serviceManager.createServiceContext("Api", iso3langCode, request);
+        serviceContext.setAsThreadLocal();
+        return serviceContext;
     }
 
     public static long sizeOfDirectory(Path lDir) throws IOException {

--- a/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
@@ -529,7 +529,6 @@ public class MapServersApi {
 
 
         ServiceContext context = ApiUtils.createServiceContext(request);
-        context.setAsThreadLocal();
 
         String baseUrl = settingManager.getSiteURL(context);
         GeoServerRest gs = new GeoServerRest(requestFactory, g.getUrl(),


### PR DESCRIPTION
Sometimes LuceneSearcher throws this exception:
`java.lang.IllegalStateException: There needs to be a ServiceContext in the thread local for this thread`
when it's used from the API service. This commits sets the service
context created in `ApiUtils.createServiceContext` as thread local allowing
LuceneSearcher to find it in the thread local store.