### PR TITLE
Harvester / Add batch edit parameter.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/BatchEditParameter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/BatchEditParameter.java
@@ -51,7 +51,7 @@ public class BatchEditParameter implements Serializable {
         this.condition = condition;
     }
     public BatchEditParameter(String xpath, String value) {
-        new BatchEditParameter(xpath, value, null);
+        this(xpath, value, null);
     }
 
     @XmlElement(required = true)

--- a/core/src/main/java/org/fao/geonet/kernel/BatchEditParameter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/BatchEditParameter.java
@@ -20,7 +20,7 @@
  * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
  * Rome - Italy. email: geonetwork@osgeo.org
  */
-package org.fao.geonet.api.records.model;
+package org.fao.geonet.kernel;
 
 import org.apache.commons.lang.StringUtils;
 

--- a/core/src/main/java/org/fao/geonet/kernel/BatchEditParameter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/BatchEditParameter.java
@@ -36,17 +36,22 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class BatchEditParameter implements Serializable {
     private String xpath;
     private String value;
+    private String condition;
 
     public BatchEditParameter() {
     }
 
-    public BatchEditParameter(String xpath, String value) {
+    public BatchEditParameter(String xpath, String value, String condition) {
         if (StringUtils.isEmpty(xpath)) {
             throw new IllegalArgumentException(
                 "Parameter xpath is not set. It should be not empty and define the XPath of the element to update.");
         }
         this.xpath = xpath;
         this.value = value;
+        this.condition = condition;
+    }
+    public BatchEditParameter(String xpath, String value) {
+        new BatchEditParameter(xpath, value, null);
     }
 
     @XmlElement(required = true)
@@ -67,6 +72,15 @@ public class BatchEditParameter implements Serializable {
         this.value = value;
     }
 
+    @XmlElement(required = false)
+    public String getCondition() {
+        return condition;
+    }
+
+    public void setCondition(String condition) {
+        this.condition = condition;
+    }
+
     public String toString() {
         StringBuffer sb = new StringBuffer("Editing xpath ");
         sb.append(this.xpath);
@@ -75,6 +89,8 @@ public class BatchEditParameter implements Serializable {
             sb.append(this.value);
         }
         sb.append(".");
+        sb.append(" Check expression: ");
+        sb.append(this.condition);
         return sb.toString();
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -91,7 +91,7 @@ public class EditLib {
 
     private SchemaManager scm;
     private static final Map<String, Integer> htVersions = new ConcurrentHashMap<String, Integer>();
-    
+
     public EditLib(SchemaManager scm) {
         this.scm = scm;
         htVersions.clear();
@@ -537,24 +537,27 @@ public class EditLib {
                 if (indexOfRequiredPortion > 0) {
                     final String requiredXPath =
                         xpathProperty.substring(0, indexOfRequiredPortion);
-                    Object elem = trySelectNode(metadataRecord,
+                    final SelectResult selectResult = trySelectNode(metadataRecord,
                         metadataSchema,
                         requiredXPath,
-                        false).result;
-                    if (elem == null) {
-                        isUpdated = createAndAddFromXPath(metadataRecord,
-                            metadataSchema,
-                            requiredXPath,
-                            value);
-                    } else if (elem instanceof Element) {
-                        Element element = (Element) elem;
+                        false);
+                    if (selectResult != null) {
+                        Object elem = selectResult.result;
+                        if (elem == null) {
+                            isUpdated = createAndAddFromXPath(metadataRecord,
+                                metadataSchema,
+                                requiredXPath,
+                                value);
+                        } else if (elem instanceof Element) {
+                            Element element = (Element) elem;
 
-                        isUpdated = createAndAddFromXPath(element,
-                            metadataSchema,
-                            xpathProperty.substring(indexOfRequiredPortion),
-                            value);
-                    } else {
-                        isUpdated = false;
+                            isUpdated = createAndAddFromXPath(element,
+                                metadataSchema,
+                                xpathProperty.substring(indexOfRequiredPortion),
+                                value);
+                        } else {
+                            isUpdated = false;
+                        }
                     }
                 } else {
                     isUpdated = createAndAddFromXPath(metadataRecord,

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -860,6 +860,7 @@ public abstract class AbstractHarvester<T extends HarvestResult> {
         //--- setup content node ---------------------------------------
 
         harvesterSettingsManager.add(ID_PREFIX + contentId, "importxslt", params.getImportXslt());
+        harvesterSettingsManager.add(ID_PREFIX + contentId, "batchEdits", params.getBatchEdits());
         harvesterSettingsManager.add(ID_PREFIX + contentId, "validate", params.getValidate());
 
         //--- setup stats node ----------------------------------------

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
@@ -92,6 +92,7 @@ public abstract class AbstractParams {
      */
     private boolean ifRecordExistAppendPrivileges;
 
+    private String batchEdits;
 
     private List<Privileges> alPrivileges = new ArrayList<>();
     private List<String> alCategories = new ArrayList<>();
@@ -188,6 +189,7 @@ public abstract class AbstractParams {
         getTrigger();
 
         setImportXslt(Util.getParam(content, "importxslt", "none"));
+        setBatchEdits(Util.getParam(content, "batchEdits", ""));
 
         this.setValidate(readValidateFromParams(content));
 
@@ -267,6 +269,7 @@ public abstract class AbstractParams {
         getTrigger();
 
         setImportXslt(Util.getParam(content, "importxslt", getImportXslt()));
+        setBatchEdits(Util.getParam(content, "batchEdits", getBatchEdits()));
         this.setValidate(readValidateFromParams(content));
 
         if (privil != null) {
@@ -316,6 +319,7 @@ public abstract class AbstractParams {
         copy.setIfRecordExistAppendPrivileges(isIfRecordExistAppendPrivileges());
 
         copy.setImportXslt(getImportXslt());
+        copy.setBatchEdits(getBatchEdits());
         copy.setValidate(getValidate());
 
         for (Privileges p : alPrivileges) {
@@ -595,5 +599,13 @@ public abstract class AbstractParams {
 
     public void setIfRecordExistAppendPrivileges(boolean ifRecordExistAppendPrivileges) {
         this.ifRecordExistAppendPrivileges = ifRecordExistAppendPrivileges;
+    }
+
+    public String getBatchEdits() {
+        return batchEdits;
+    }
+
+    public void setBatchEdits(String batchEdits) {
+        this.batchEdits = batchEdits;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel.harvest.harvester.csw;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.GeonetContext;
@@ -38,6 +39,7 @@ import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.exceptions.OperationAbortedEx;
+import org.fao.geonet.kernel.BatchEditParameter;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
 import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
@@ -64,6 +66,7 @@ import javax.transaction.Transactional.TxType;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -309,6 +312,16 @@ public class Aligner extends BaseAligner<CswParams> {
             }
         }
 
+        if (StringUtils.isNotEmpty(params.getBatchEdits())) {
+            String batchEditsConfig = params.getBatchEdits();
+            ObjectMapper mapper = new ObjectMapper();
+
+            BatchEditParameter[] listOfUpdates = mapper.readValue(params.getBatchEdits(), BatchEditParameter[].class);
+            if (listOfUpdates.length == 0) {
+                throw new IllegalArgumentException("At least one edit must be defined.");
+            }
+
+        }
         //
         // insert metadata
         //

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -340,13 +340,20 @@ public class Aligner extends BaseAligner<CswParams> {
                     AddElemValue propertyValue =
                         new AddElemValue(batchEditParameter.getValue());
 
-                    metadataChanged = editLib.addElementOrFragmentFromXpath(
-                        md,
-                        metadataSchema,
-                        batchEditParameter.getXpath(),
-                        propertyValue,
-                        createXpathNodeIfNotExists
-                    ) || metadataChanged;
+                    boolean applyEdit = true;
+                    if (StringUtils.isNotEmpty(batchEditParameter.getCondition())) {
+                        final Object node = Xml.selectSingle(md, batchEditParameter.getCondition(), metadataSchema.getNamespaces());
+                        applyEdit = (node != null) || (node instanceof Boolean && (Boolean)node != false);
+                    }
+                    if (applyEdit) {
+                        metadataChanged = editLib.addElementOrFragmentFromXpath(
+                            md,
+                            metadataSchema,
+                            batchEditParameter.getXpath(),
+                            propertyValue,
+                            createXpathNodeIfNotExists
+                        ) || metadataChanged;
+                    }
                 }
                 if (metadataChanged) {
                     log.debug("  - Record updated by batch edit configuration:" + ri.uuid);

--- a/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
@@ -37,7 +37,7 @@ import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.processing.report.IProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
-import org.fao.geonet.api.records.model.BatchEditParameter;
+import org.fao.geonet.kernel.BatchEditParameter;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.events.history.RecordUpdatedEvent;
 import org.fao.geonet.kernel.AccessManager;

--- a/services/src/test/java/org/fao/geonet/services/metadata/BatchEditsServiceTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/BatchEditsServiceTest.java
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.ArrayList;
 import java.util.List;
 
-import org.fao.geonet.api.records.model.BatchEditParameter;
+import org.fao.geonet.kernel.BatchEditParameter;
 import org.fao.geonet.csw.common.util.Xml;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -86,6 +86,11 @@
               }
               $scope.isLoadingOneHarvester = false;
 
+              if ($scope.harvesterSelected.content && $scope.harvesterSelected.content.batchEdits) {
+                if (angular.isObject($scope.harvesterSelected.content.batchEdits)) {
+                  $scope.harvesterSelected.content.batchEdits = angular.toJson($scope.harvesterSelected.content.batchEdits, true);
+                }
+              }
               if ($scope.harvesterSelected.searches) {
                 if ($scope.harvesterSelected.searches[0].from) {
                   $scope.harvesterSelected.searches[0].from =

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -16,6 +16,8 @@
     "advancedCssProps": "Advanced properties",
     "allowedCategories": "Allowed Categories",
     "allowedCategoriesDescriptionHelp": "Categories that can be applied to this group",
+    "harvesterBatchEdits": "Batch edits",
+    "harvesterBatchEditsHelp": "Batch edits allow to update harvested records. It can be use to add, replace or delete element.",
     "andNodeLogo": " and logo",
     "applyXSLToRecord": "XSL transformation to apply",
     "applyXSLToRecordHelp": "The referenced XSL transform will be applied to each metadata record before it is added to Geonetwork",

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -42,7 +42,7 @@
     "removeField": "Remove this field",
     "addXpath-help": "Updating records using XPath needs careful definition of the changes. A change is defined by:",
     "addXpathTitle": "an optional title",
-    "addXpathXpath": "a mandatory <a href='http://xmlfr.org/w3c/TR/xpath/'>XPath</a> to point to the element(s) to update. XPath can not contain a filter expression.",
+    "addXpathXpath": "a mandatory <a href='http://xmlfr.org/w3c/TR/xpath/'>XPath</a> to point to the element(s) to update. XPath may contain a filter expression.",
     "addXpathInsertMode": "a type of update",
     "xpath": "XPath",
     "xpathValue": "Text or XML value",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
@@ -113,6 +113,18 @@
       <div id="gn-harvest-settings-csw-advanced-validate-list" data-gn-harvester-validation="harvesterSelected.content.validate"/>
       <p class="help-block" data-translate="">harvesterValidateHelp</p>
     </div>
+
+    <div id="gn-harvest-settings-csw-advanced-batchEdits-row">
+      <label id="gn-harvest-settings-csw-advanced-batchEdits-label" class="control-label">
+        <span data-translate="">harvesterBatchEdits</span>
+      </label>
+      <div id="gn-harvest-settings-csw-advanced-validate-list"
+           style="height: 300px"
+           ui-ace="{useWrapMode:true, showGutter:true, mode:'json'}"
+           data-ng-model="harvesterSelected.content.batchEdits"/>
+      <p class="help-block" data-translate="">harvesterBatchEditsHelp</p>
+    </div>
+
     <div id="gn-harvest-settings-csw-advanced-xsl-row">
       <label id="gn-harvest-settings-csw-advanced-xsl-label" class="control-label" data-translate="">applyXSLToRecord</label>
       <div id="gn-harvest-settings-csw-advanced-xsl-list" data-gn-import-xsl="harvesterSelected.site.xslfilter"/>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
@@ -100,7 +100,7 @@ var gnHarvestercsw = {
       + '  </options>'
       + '  <content>'
       + '    <validate>' + h.content.validate + '</validate>'
-      + '    <batchEdits>' + h.content.batchEdits + '</batchEdits>'
+      + '    <batchEdits><![CDATA[' + h.content.batchEdits + ']]></batchEdits>'
       + '  </content>'
       + $scope.buildResponseGroup(h)
       + $scope.buildResponseCategory(h) + '</node>';

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
@@ -21,12 +21,13 @@ var gnHarvestercsw = {
         "xpathFilter" : "",
         "rejectDuplicateResource" : false,
         "xslfilter": [],
-        "outputSchema": "",
+        "outputSchema": "http://www.isotc211.org/2005/gmd",
         "queryScope": "local",
         "hopCount": 2
       },
       "content" : {
-        "validate" : "NOVALIDATION"
+        "validate" : "NOVALIDATION",
+        "batchEdits" : ""
       },
       "options" : {
         "every" : "0 0 0 ? * *",
@@ -99,6 +100,7 @@ var gnHarvestercsw = {
       + '  </options>'
       + '  <content>'
       + '    <validate>' + h.content.validate + '</validate>'
+      + '    <batchEdits>' + h.content.batchEdits + '</batchEdits>'
       + '  </content>'
       + $scope.buildResponseGroup(h)
       + $scope.buildResponseCategory(h) + '</node>';

--- a/web/src/main/webapp/xsl/xml/harvesting/common.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/common.xsl
@@ -63,6 +63,9 @@
         <importxslt>
           <xsl:value-of select="$con/importxslt/value"/>
         </importxslt>
+        <batchEdits>
+          <xsl:value-of select="$con/batchEdits/value"/>
+        </batchEdits>
       </content>
 
       <options>


### PR DESCRIPTION
Add the possibility to define a batch editing configuration for an harvester. Catalogue administrator needs to be able to update some information during harvesting eg.
* Add some classification based on keywords
* Remap organisation name to make it consistent with local record values

Some users have been activating the option to edit harvested record but it is not easy to synchronize records later on (except for the OGC WxS harvester which only focus on a small set of information from the capabilities).

Batch edits allows to add/replace/delete information during the harvesting process.

![image](https://user-images.githubusercontent.com/1701393/69146084-5d6aa680-0acf-11ea-97d9-5f626f7da206.png)


Example of configuration:

```json
[
  {
    "condition": "count(.//gmd:keyword[*/text() = 'watersheds']) > 0",
    "xpath": "/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords[1]",
    "value": "<gn_add><gmd:descriptiveKeywords xmlns:gmd=\"http://www.isotc211.org/2005/gmd\" xmlns:gco=\"http://www.isotc211.org/2005/gco\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>Waste water</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\"./resources/codeList.xml#MD_KeywordTypeCode\" codeListValue=\"theme\"/></gmd:type></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>"
  },
  {
    "condition": "count(.//gmd:fileIdentifier[*/text() = 'da165110-88fd-11da-a88f-000d939bc5d8']) > 0",
    "xpath": "/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:supplementalInformation",
    "value": "<gn_delete></gn_delete>"
  },
  {
    "condition": "count(.//gmd:fileIdentifier[*/text() != 'da165110-88fd-11da-a88f-000d939bc5d8']) > 0",
    "xpath": "/gmd:dataQualityInfo",
    "value": "<gn_replace><gmd:DQ_DataQuality xmlns:gmd=\"http://www.isotc211.org/2005/gmd\" xmlns:gco=\"http://www.isotc211.org/2005/gco\"><gmd:lineage><gmd:LI_Lineage><gmd:statement><gco:CharacterString>New lineage</gco:CharacterString></gmd:statement></gmd:LI_Lineage></gmd:lineage></gmd:DQ_DataQuality></gn_replace>"
  }
]
```

Also see documentation on batch editing https://github.com/geonetwork/doc/blob/e989cccff782b2e51bee6cb8800fcaf2493c8f58/source/user-guide/workflow/batchediting.rst#defining-edits

Harvester providing this option:
* CSW (for now).

