### PR TITLE
ISO19139 / Add missing translation

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
@@ -3166,4 +3166,8 @@
     <label>Field of application</label>
     <description>Field of application</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/labels.xml
@@ -3064,4 +3064,8 @@
   <element name="gmx:MX_ScopeCode">
     <label>Codi</label>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
@@ -3156,4 +3156,8 @@
     <label>Field of application</label>
     <description>Field of application</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/labels.xml
@@ -2933,4 +2933,8 @@
     <label>Toepassingsveld</label>
     <description>Field of application</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
@@ -3552,4 +3552,8 @@
     <label>Upper cardinality</label>
     <description>Upper cardinality</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/labels.xml
@@ -3392,4 +3392,8 @@
   <element name="gco:Scale">
     <label>Scale</label>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
@@ -6551,4 +6551,8 @@ http://www.sandre.eaufrance.fr/?urn=urn:sandre:ensembledonnees:BDCarthage:FXX:::
   <element name="gco:Boolean">
     <label>Booléen</label>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -3795,4 +3795,8 @@
     <label>Upper cardinality</label>
     <description>Upper cardinality</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/labels.xml
@@ -3180,4 +3180,8 @@
   <element name="gmd:Country">
     <label>Paese</label>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Tipo di link</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
@@ -3086,4 +3086,8 @@
     <label>Field of application</label>
     <description>Field of application</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/labels.xml
@@ -2589,4 +2589,8 @@
     <label>Field of application</label>
     <description>Field of application</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
@@ -3153,4 +3153,8 @@
     <label>Field of application</label>
     <description>Field of application</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
@@ -3237,4 +3237,8 @@
     <label>Field of application</label>
     <description>Field of application</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/slo/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/slo/labels.xml
@@ -2859,4 +2859,8 @@ presnosť / vertikálna -</option>
   <element name="gco:Scale">
     <label>Mierka</label>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/labels.xml
@@ -3160,4 +3160,8 @@
   <element name="gmx:MX_ScopeCode">
     <label>Código</label>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/labels.xml
@@ -2767,4 +2767,8 @@
     <label>Field of application</label>
     <description>Field of application</description>
   </element>
+  <element name="xlink:type">
+    <label>Link</label>
+    <description>Link type</description>
+  </element>
 </labels>


### PR DESCRIPTION
This adds a generic translation for xlink to avoid the error on the console:

`gn-fn-metadata:getLabel | missing translation in schema iso19139 for xlink:type.`