### PR TITLE
Remove unnecessary # in thesaurus URLs

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -22,6 +22,7 @@
 
 package org.fao.geonet.kernel;
 
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.exceptions.TermNotFoundException;
@@ -359,7 +360,7 @@ public class Thesaurus {
         String namespaceGml = "http://www.opengis.net/gml#";
         String namespace = keyword.getNameSpaceCode();
 
-        if (namespace.equals("#")) {
+        if (StringUtils.isBlank(namespace) || namespace.equals("#")) {
             namespace = this.defaultNamespace;
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -738,10 +738,6 @@ public class Thesaurus {
                 this.defaultNamespace = DEFAULT_THESAURUS_NAMESPACE;
             }
 
-            if (!this.defaultNamespace.endsWith("#")) {
-                this.defaultNamespace += "#";
-            }
-
             Element dateEl = Xml.selectElement(thesaurusEl, "skos:ConceptScheme/dcterms:issued|skos:Collection/dc:date", theNSs);
 
             Date thesaususDate = parseThesaurusDate(dateEl);


### PR DESCRIPTION
To automatically add # in thesaurus URLs seems not necessary and it creates problems in some dutch schemas Schematron. On NationalGeoregister we removed it without noticing any issue, so probably it's a good idea not add it anymore.