### PR TITLE
Related resource / Add possibility to hide a parent element in case no relation found.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -116,6 +116,7 @@
               title: '@',
               list: '@',
               filter: '@',
+              container: '@',
               user: '=',
               hasResults: '=?'
             },
@@ -171,9 +172,14 @@
                            scope.relations[idx] = value;
                          }
                        });
+                    
+                       if (angular.isDefined(scope.container) 
+                           && scope.relations == null) {
+                         $(scope.container).hide();
+                       }
                        if (controller) {
-                          controller.finishRequest(elem, scope.relationFound);
-                        }
+                         controller.finishRequest(elem, scope.relationFound);
+                       }
                      } , function() {
                       if (controller) {
                         controller.finishRequest(elem, false);


### PR DESCRIPTION
Example, when you have a custom layout and you need to hide a parent when no relation found. Below, we want to hide the row element containing the label and the directive:
![image](https://user-images.githubusercontent.com/1701393/69149821-9b6bc880-0ad7-11ea-8b58-72ec7cdb2766.png)

Use a CSS selector to point to a container element to hide.