### PR TITLE
improve operateson link remove+resource constraint subtemplate option

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
@@ -209,13 +209,22 @@
 
     <xsl:template mode="index" match="gmd:MD_Format[count(ancestor::node()) =  1]">
         <Field name="_title"
-               string="{if ($title != '') then $title else gmd:name/gco:CharacterString}"
+               string="{if ($title != '') then $title else gmd:name/*/text()}"
                store="true" index="true"/>
 
         <xsl:call-template name="subtemplate-common-fields"/>
     </xsl:template>
 
+	<xsl:template mode="index" match="gmd:resourceConstraints[count(ancestor::node()) =  1]">
+        <Field name="_title"
+            string="{if ($title != '') then $title
+                     else concat(  
+                        string-join(gmd:MD_LegalConstraints/*/gmd:MD_RestrictionCode/@codeListValue[@codeListValue!='otherConstraints'], ', '), 
+                        ' ', string-join(gmd:MD_LegalConstraints/gmd:otherConstraints/*/text(), ', '))}"
+            store="true" index="true"/>
 
+        <xsl:call-template name="subtemplate-common-fields"/>
+    </xsl:template>
 
     <xsl:template name="subtemplate-common-fields">
         <Field name="any" string="{normalize-space(string(.))}" store="false" index="true"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/datasets-remove.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/datasets-remove.xsl
@@ -28,7 +28,8 @@ Stylesheet used to remove a reference to a online resource.
 <xsl:stylesheet xmlns:geonet="http://www.fao.org/geonetwork" xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                version="2.0" exclude-result-prefixes="#all">
 
   <xsl:param name="uuidref"/>
 
@@ -42,7 +43,8 @@ Stylesheet used to remove a reference to a online resource.
   <xsl:template
     match="geonet:*|
            srv:coupledResource[normalize-space(srv:SV_CoupledResource/srv:identifier/gco:CharacterString) = $uuidref]|
-           srv:operatesOn[@uuidref = $uuidref]"
+           srv:operatesOn[@uuidref = $uuidref]|
+           srv:operatesOn[contains(@xlink.href,$uuidref)]"
     priority="2"/>
 
 </xsl:stylesheet>


### PR DESCRIPTION
- optimizes remove-dataset by operateson element. operateson contains link to dataset-record in xlink:href (if no @uuidref), as used in [TG Req 3.6; inspire metadata; p65](https://inspire.ec.europa.eu/sites/default/files/documents/metadata/inspire-tg-metadata-iso19139-2.0.1.pdf)
- index subtemplates also for resource constraints