### PR TITLE
iso19139 / incorrect gco:nilReason assignment

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -334,9 +334,9 @@
                                             @locale = concat('#', $mainLanguageId)])"/>
 
       <!-- Add nileason if text is empty -->
-      <xsl:variable name="isEmpty"
+      <xsl:variable name="isMainLanguageEmpty"
                     select="if ($isMultilingual and not($excluded))
-                            then $valueInPtFreeTextForMainLanguage = ''
+                            then ($valueInPtFreeTextForMainLanguage = '' and normalize-space(gco:CharacterString|gmx:Anchor) = '')
                             else if ($valueInPtFreeTextForMainLanguage != '')
                             then $valueInPtFreeTextForMainLanguage = ''
                             else normalize-space(gco:CharacterString|gmx:Anchor) = ''"/>
@@ -347,7 +347,7 @@
 
 
       <xsl:choose>
-        <xsl:when test="$isEmpty">
+        <xsl:when test="$isMainLanguageEmpty">
           <xsl:attribute name="gco:nilReason">
             <xsl:choose>
               <xsl:when test="@gco:nilReason">
@@ -357,7 +357,7 @@
             </xsl:choose>
           </xsl:attribute>
         </xsl:when>
-        <xsl:when test="@gco:nilReason != 'missing' and not($isEmpty)">
+        <xsl:when test="@gco:nilReason != 'missing' and not($isMainLanguageEmpty)">
           <xsl:copy-of select="@gco:nilReason"/>
         </xsl:when>
       </xsl:choose>


### PR DESCRIPTION
Bug fix -  wrong gco:nilReason update-fixed-info.xsl  was only checking the PT_FreeText and not CharacterString which was creating a gco:nilReason attribute when gco:CharacterString was not empty but PT_FreeText was.

This was happening during after importing data which did not contain the main language in the PT_FreeText yet. Running the update-fixed-info.xsl the first time was setting the gco:nilReason and the PT_FreeText. Running the update-fixed-info.xsl the second time would remove the gco:nilReason as the PT_FreeText existed. 

Also renamed isEmpty to isMainLanguageEmpty because it is only checking the main language for empty - not all languages.