### PR TITLE
Don't create PT_FreeText on main language if the CharacterString is null

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -421,11 +421,11 @@
 
               <!-- Populate PT_FreeText for default language if not existing and it is not null. -->
               <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
-              <xsl:if test="normalize-space(gco:CharacterString) != ''">
+              <xsl:if test="normalize-space(gco:CharacterString|gmx:Anchor) != ''">
                 <gmd:PT_FreeText>
                   <gmd:textGroup>
                     <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">
-                      <xsl:value-of select="gco:CharacterString"/>
+                      <xsl:value-of select="gco:CharacterString|gmx:Anchor"/>
                     </gmd:LocalisedCharacterString>
                   </gmd:textGroup>
                   <xsl:call-template name="populate-free-text"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -419,16 +419,18 @@
             </xsl:when>
             <xsl:otherwise>
 
-              <!-- Populate PT_FreeText for default language if not existing. -->
+              <!-- Populate PT_FreeText for default language if not existing and it is not null. -->
               <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
-              <gmd:PT_FreeText>
-                <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">
-                    <xsl:value-of select="gco:CharacterString"/>
-                  </gmd:LocalisedCharacterString>
-                </gmd:textGroup>
-                <xsl:call-template name="populate-free-text"/>
-              </gmd:PT_FreeText>
+              <xsl:if test="normalize-space(gco:CharacterString) != ''">
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">
+                      <xsl:value-of select="gco:CharacterString"/>
+                    </gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <xsl:call-template name="populate-free-text"/>
+                </gmd:PT_FreeText>
+              </xsl:if>
             </xsl:otherwise>
           </xsl:choose>
         </xsl:otherwise>


### PR DESCRIPTION
update-fixed-info.xsl creating empty PT_FreeText when gco:CharacterString is null.

This is not necessary so check for empty gco:CharacterString before adding PT_FreeText