### PR TITLE
Fix bug where gmd:LanguageCode text is lost. 

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -468,45 +468,14 @@
     <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/">
       <xsl:apply-templates select="@*[name(.)!='codeList']"/>
 
-      <!-- Update the language code text value if it exists
-           It will attempt to detect the existing format and update it.
-           Formats include
-              - 2 character lang code
-              - 3 character lang code
-              - character language code + country code (i.e. eng; USA)
-           if format can not be determined then it will keep the same value -->
-      <xsl:if test="normalize-space(./text()) != ''">
-        <xsl:choose>
-          <!-- If the length is 3 characters then assume the text is equal to the code list value -->
-          <xsl:when test="string-length(normalize-space(./text())) = 3 and @codeListValue != ''">
-            <xsl:value-of  select="normalize-space(@codeListValue)"/>
-          </xsl:when>
-          <!-- If the length is 2 characters then assume the text is equal to the code list value as a 2 char code-->
-          <xsl:when test="string-length(normalize-space(./text())) = 2 and @codeListValue != ''">
-            <xsl:value-of  select="normalize-space(upper-case(java:twoCharLangCode(@codeListValue, '')))"/>
-          </xsl:when>
-          <!-- If contains a ";" then assume language is in the format of "eng; USA" if there is a semicolon so we will update the language -->
-          <xsl:when test="contains(./text(),';') and @codeListValue != ''">
-            <xsl:value-of  select="normalize-space(@codeListValue)"/>
-            <xsl:text>; </xsl:text>
-            <xsl:variable name="langCode" select="@codeListValue"/>
-            <xsl:variable name="countryCode">
-              <xsl:value-of  select="normalize-space(/root/*/gmd:locale/gmd:PT_Locale[gmd:languageCode/*/@codeListValue = $langCode]/gmd:country/gmd:Country/@codeListValue)"/>
-            </xsl:variable>
-            <xsl:choose>
-              <xsl:when test="$countryCode != ''">
-                <xsl:value-of  select="$countryCode"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of  select="substring-after(./text(),';')"/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:when>
-          <!-- unknown format just keep it as is?? -->
-          <xsl:otherwise>
-            <xsl:value-of select="./text()"/>
-          </xsl:otherwise>
-        </xsl:choose>
+      <xsl:if test="normalize-space(./text()) != '' and string(@codeListValue)">
+        <xsl:value-of select="java:getIsoLanguageLabel(@codeListValue, $mainLanguage)" />
+        <!-- 
+             If wanting to get strings from codelists then add gmd:LanguageCode codelist in loc/{lang}/codelists.xml
+             and use getCodelistTranslation instead of getIsoLanguageLabel. This will allow for custom values such as "eng; USA"
+             i.e. 
+             <xsl:value-of select="java:getCodelistTranslation(name(), string(@codeListValue), string($mainLanguage))"/>
+        -->
       </xsl:if>
     </gmd:LanguageCode>
   </xsl:template>
@@ -519,6 +488,9 @@
         <xsl:value-of
           select="concat('http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#',local-name(.))"/>
       </xsl:attribute>
+      <xsl:if test="normalize-space(./text()) != '' and string(@codeListValue)">
+          <xsl:value-of select="java:getCodelistTranslation(name(), string(@codeListValue), string($mainLanguage))"/>
+      </xsl:if>
     </xsl:copy>
   </xsl:template>
 


### PR DESCRIPTION
If the following was used for the gmd:language

```
  <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng">
   eng; USA   
   </gmd:LanguageCode>
```

it will save it as 

```
  <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
```
So the text portion is lost.

This pull request fixed code so that the text node is not lost.
And it also added logic to attempt to update the text values if it exists based on the current main language.

As it is free form, it is difficult to guess all the possible formats so the ones that were added for now are 
              - 2 character lang code
              - 3 character lang code
              - character language code + country code (i.e. eng; USA)

This pull request also fixes a bug where the country code for the main language was being lost on update.