### PR TITLE
Fix: right size for asterisk in IE11

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -338,6 +338,9 @@
     .gn-field {
       label {
         font-size: 12px;
+        &:after {
+          font-size: 24px;
+        }
       }
       .gn-field {
         padding-top: 0;


### PR DESCRIPTION
In Internet Explorer 11 the asterisk indicating a required field has different sizes that are too large. This small PR fixes the issue.

**The error in IE11**
![gn-ie11-bug](https://user-images.githubusercontent.com/19608667/69709152-34fd3080-10fd-11ea-92c1-54d92de2db87.jpg)

**After the fix**
![gn-ie11-fix](https://user-images.githubusercontent.com/19608667/69709271-637b0b80-10fd-11ea-9979-555869f32c69.png)
