### PR TITLE
Added $schemaDir variable for schematron.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/SchematronValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchematronValidator.java
@@ -172,6 +172,7 @@ public class SchematronValidator {
             params.put("lang", lang);
             params.put("rule", ruleId);
             params.put("thesaurusDir", thesaurusManager.getThesauriDirectory().toString());
+            params.put("schemaDir", schemaDir.toString());
 
             Path file = schemaDir.resolve(SCHEMATRON_DIR).resolve(schematron.getFile());
             Element xmlReport = Xml.transform(md, file, params);

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -338,6 +338,8 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
                     params.put("lang", lang);
                     params.put("rule", rule);
                     params.put("thesaurusDir", thesaurusManager.getThesauriDirectory());
+                    params.put("schemaDir", metadataSchema.getSchemaDir().toString());
+
                     Element xmlReport = Xml.transform(md, schemaTronXmlXslt, params);
                     if (xmlReport != null) {
                         report.addContent(xmlReport);

--- a/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
+++ b/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
@@ -209,6 +209,7 @@
     <axsl:param name="lang"/>
     <axsl:param name="thesaurusDir"/>
     <axsl:param name="rule"/>
+    <axsl:param name="schemaDir"/>
 
     <axsl:variable name="loc" select="document(concat('../loc/', $lang, '/', $rule, '.xml'))"/>
   </xsl:template>


### PR DESCRIPTION
This will allow schematron to retrieve a  codelist that can be used in the validation process.
Using something like the following.


`<sch:let name="codelist" value="document(concat('file:///', $schemaDir, '/loc/', $lang, '/codelists.xml'))"/>
`

Or the following if we want to be able to execute it from Windows...
`<sch:let name="codelist" value="document(concat('file:///', replace(concat($schemaDir, '/loc/', $lang, '/codelists.xml'), '\\', '/')))"/>
`

We could replace all `"\"` by `"/"` in the java code however if we do so then we should also update the $thesaurusDir as well to be consistent.  

We could also make the variable a URI which would be more portable however it could break existing functionality for $thesaurusDir usage