### PR TITLE
Elements targeted by operation filters can be removed on processing.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -396,7 +396,7 @@ public class DataManager {
     @Deprecated
     public Element getMetadata(ServiceContext srvContext, String id, boolean forEditing, boolean withEditorValidationErrors,
             boolean keepXlinkAttributes) throws Exception {
-        return metadataManager.getMetadata(srvContext, id, forEditing, withEditorValidationErrors, keepXlinkAttributes);
+        return metadataManager.getMetadata(srvContext, id, forEditing, !forEditing, withEditorValidationErrors, keepXlinkAttributes);
     }
 
     @Deprecated

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
@@ -175,7 +175,6 @@ public abstract class XmlSerializer {
 
         String id = String.valueOf(metadata.getId());
         Element metadataXml = metadata.getXmlData(false);
-System.out.println(String.format("isIndexing: %s, applyFilter: %s", isIndexingTask, applyOperationsFilters));
         if (!isIndexingTask && applyOperationsFilters) {
             ServiceContext context = ServiceContext.get();
             MetadataSchema mds = _dataManager.getSchema(metadata.getDataInfo().getSchemaId());
@@ -196,10 +195,7 @@ System.out.println(String.format("isIndexing: %s, applyFilter: %s", isIndexingTa
                 Pair<String, Element> downloadXpathFilter = mds.getOperationFilter(ReservedOperation.download);
                 if (downloadXpathFilter != null) {
                     boolean canDownload = accessManager.canDownload(context, id);
-                    System.out.println(String.format("Can download %s", canDownload));
                     if (!canDownload) {
-
-                        System.out.println(String.format("Download filter"));
                         removeFilteredElement(metadataXml, downloadXpathFilter, namespaces);
                     }
                 }

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
@@ -156,7 +156,7 @@ public abstract class XmlSerializer {
      * and the string read is converted into xml.
      *
      * @param isIndexingTask If true, then withheld elements are not removed.
-     * @param applyOperationsFilters If true, then withheld elements are not removed.
+     * @param applyOperationsFilters If true, then withheld elements are filtered according to user privileges.
      */
     protected Element internalSelect(String id, boolean isIndexingTask, boolean applyOperationsFilters) throws Exception {
         IMetadataUtils _metadataUtils = ApplicationContextHolder.get().getBean(IMetadataUtils.class);

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializerDb.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializerDb.java
@@ -42,7 +42,7 @@ public class XmlSerializerDb extends XmlSerializer {
      * and the string read is converted into xml, XLinks are resolved when config'd on.
      */
     public Element select(ServiceContext context, String id) throws Exception {
-        Element rec = internalSelect(id, false, false);
+        Element rec = internalSelect(id, false, true);
         if (resolveXLinks()) Processor.detachXLink(rec, context);
         return rec;
     }
@@ -52,8 +52,8 @@ public class XmlSerializerDb extends XmlSerializer {
      * and the string read is converted into xml, XLinks are NOT resolved even if they are config'd
      * on - this is used when you want to do XLink processing yourself.
      */
-    public Element selectNoXLinkResolver(String id, boolean isIndexingTask, boolean forEditing) throws Exception {
-        return internalSelect(id, isIndexingTask, forEditing);
+    public Element selectNoXLinkResolver(String id, boolean isIndexingTask, boolean applyOperationsFilters) throws Exception {
+        return internalSelect(id, isIndexingTask, applyOperationsFilters);
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializerSvn.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializerSvn.java
@@ -44,8 +44,8 @@ public class XmlSerializerSvn extends XmlSerializer {
      * Retrieves the xml element whose id matches the given one. The element is read from the
      * database as subversion may be busy with commit changes.
      */
-    protected Element internalSelect(String id, boolean isIndexingTask, boolean forEditing) throws Exception {
-        Element rec = super.internalSelect(id, isIndexingTask, forEditing);
+    protected Element internalSelect(String id, boolean isIndexingTask, boolean applyOperationsFilters) throws Exception {
+        Element rec = super.internalSelect(id, isIndexingTask, applyOperationsFilters);
         if (rec != null) return (Element) rec.detach();
         else return null;
     }
@@ -66,8 +66,8 @@ public class XmlSerializerSvn extends XmlSerializer {
      * subversion and the string read is converted into xml, XLinks are NOT resolved even if they
      * are config'd on - this is used when you want to do XLink processing yourself.
      */
-    public Element selectNoXLinkResolver(String id, boolean isIndexingTask, boolean forEditing) throws Exception {
-        return internalSelect(id, isIndexingTask, forEditing);
+    public Element selectNoXLinkResolver(String id, boolean isIndexingTask, boolean applyOperationsFilters) throws Exception {
+        return internalSelect(id, isIndexingTask, applyOperationsFilters);
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
@@ -45,7 +45,7 @@ import jeeves.server.context.ServiceContext;
 
 /**
  * Utility interface to handle record insertions, removals and updates
- * 
+ *
  * @author delawen
  *
  */
@@ -53,7 +53,7 @@ public interface IMetadataManager {
 
     /**
      * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
-     * 
+     *
      * @param context
      * @param force
      * @throws Exception
@@ -62,7 +62,7 @@ public interface IMetadataManager {
 
     /**
      * Removes the record with the id metadataId
-     * 
+     *
      * @param context
      * @param metadataId
      * @throws Exception
@@ -71,9 +71,9 @@ public interface IMetadataManager {
 
     /**
      * Removes a record without notifying.
-     * 
+     *
      * FIXME explain better why this and not {@link #deleteMetadata(ServiceContext, String)}
-     * 
+     *
      * @param context
      * @param metadataId
      * @throws Exception
@@ -151,10 +151,15 @@ public interface IMetadataManager {
      * Retrieves a metadata (in xml) given its id; adds editing information if requested and validation errors if requested.
      *
      * @param forEditing Add extra element to build metadocument {@link EditLib#expandElements(String, Element)}
+     * @param applyOperationsFilters Filter elements based on operation filters
+     *                               eg. Remove WMS if not dynamic. For example, when processing
+     *                               a record, the complete records need to be processed and saved (not a filtered version), set it to false.
+     *                               If editing, set it to false.
      * @param keepXlinkAttributes When XLinks are resolved in non edit mode, do not remove XLink attributes.
      */
-    Element getMetadata(ServiceContext srvContext, String id, boolean forEditing, boolean withEditorValidationErrors,
-            boolean keepXlinkAttributes) throws Exception;
+    Element getMetadata(ServiceContext srvContext, String id,
+                        boolean forEditing, boolean applyOperationsFilters,
+                        boolean withEditorValidationErrors, boolean keepXlinkAttributes) throws Exception;
 
     /**
      * Update of owner info.
@@ -210,7 +215,7 @@ public interface IMetadataManager {
 
     /**
      * Returns a helpful EditLib for other utility classes
-     * 
+     *
      * @return
      */
     EditLib getEditLib();
@@ -218,7 +223,7 @@ public interface IMetadataManager {
     /**
      * Saves an AbstractMetadata into the database. Useful to avoid using the MetadataRepository classes directly, who may not know how to handle
      * AbstractMetadata types
-     * 
+     *
      * @param info
      */
     public AbstractMetadata save(AbstractMetadata info);
@@ -238,14 +243,14 @@ public interface IMetadataManager {
 
     /**
      * Delete all records that matches the specification
-     * 
+     *
      * @param specification
      */
     public void deleteAll(Specification<? extends AbstractMetadata> specification);
 
     /**
      * Remove the record with the identifier id
-     * 
+     *
      * @param id
      */
     public void delete(Integer id);
@@ -262,7 +267,7 @@ public interface IMetadataManager {
      */
     public void createBatchUpdateQuery(PathSpec<? extends AbstractMetadata, String> servicesPath, String newUuid,
             Specification<? extends AbstractMetadata> harvested);
-    
+
 
 	public Map<Integer, MetadataSourceInfo> findAllSourceInfo(Specification<? extends AbstractMetadata> specs);
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -412,7 +412,7 @@ public class BaseMetadataManager implements IMetadataManager {
     }
 
     /**
-     * @param context    
+     * @param context
      * @param metadataId
      * @throws Exception
      */
@@ -642,14 +642,19 @@ public class BaseMetadataManager implements IMetadataManager {
      *
      * @param forEditing          Add extra element to build metadocument
      *                            {@link EditLib#expandElements(String, Element)}
+     * @param applyOperationsFilters Filter elements based on operation filters
+     *                              eg. Remove WMS if not dynamic. For example, when processing
+     *                              a record, the complete records need to be processed and saved (not a filtered version). If editing, set it to false.
+     *                            {@link EditLib#expandElements(String, Element)}
      * @param keepXlinkAttributes When XLinks are resolved in non edit mode, do not remove XLink
      *                            attributes.
      */
     @Override
-    public Element getMetadata(ServiceContext srvContext, String id, boolean forEditing,
+    public Element getMetadata(ServiceContext srvContext, String id,
+                               boolean forEditing, boolean applyOperationsFilters,
                                boolean withEditorValidationErrors, boolean keepXlinkAttributes) throws Exception {
         boolean doXLinks = getXmlSerializer().resolveXLinks();
-        Element metadataXml = getXmlSerializer().selectNoXLinkResolver(id, false, forEditing);
+        Element metadataXml = getXmlSerializer().selectNoXLinkResolver(id, false, applyOperationsFilters);
         if (metadataXml == null)
             return null;
 
@@ -713,7 +718,7 @@ public class BaseMetadataManager implements IMetadataManager {
      */
     @Override
     public Element getMetadata(String id) throws Exception {
-        Element md = getXmlSerializer().selectNoXLinkResolver(id, false, false);
+        Element md = getXmlSerializer().selectNoXLinkResolver(id, false, true);
         if (md == null)
             return null;
         md.detach();
@@ -1043,7 +1048,7 @@ public class BaseMetadataManager implements IMetadataManager {
 
         // --- get parent metadata in read/only mode
         boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = false;
-        Element parent = getMetadata(srvContext, parentId, forEditing, withValidationErrors, keepXlinkAttributes);
+        Element parent = getMetadata(srvContext, parentId, forEditing, false, withValidationErrors, keepXlinkAttributes);
 
         Element env = new Element("update");
         env.addContent(new Element("parentUuid").setText(parentUuid));
@@ -1063,7 +1068,7 @@ public class BaseMetadataManager implements IMetadataManager {
                 continue;
             }
 
-            Element child = getMetadata(srvContext, childId, forEditing, withValidationErrors, keepXlinkAttributes);
+            Element child = getMetadata(srvContext, childId, forEditing, false, withValidationErrors, keepXlinkAttributes);
 
             String childSchema = child.getChild(Edit.RootChild.INFO, Edit.NAMESPACE)
                 .getChildText(Edit.Info.Elem.SCHEMA);

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -198,7 +198,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
         boolean keepXlinkAttributes = true;
         boolean forEditing = false;
         boolean withValidationErrors = false;
-        Element metadataBeforeAnyChanges = metadataManager.getMetadata(context, id, forEditing,
+        Element metadataBeforeAnyChanges = metadataManager.getMetadata(context, id, forEditing, false,
             withValidationErrors, keepXlinkAttributes);
         context.getUserSession().setProperty(Geonet.Session.METADATA_BEFORE_ANY_CHANGES + id, metadataBeforeAnyChanges);
         return Integer.valueOf(id);
@@ -548,7 +548,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @SuppressWarnings("unchecked")
     @Override
     public Element getMetadataNoInfo(ServiceContext srvContext, String id) throws Exception {
-        Element md = metadataManager.getMetadata(srvContext, id, false, false, false);
+        Element md = metadataManager.getMetadata(srvContext, id, false, true, false, false);
         md.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);
 
         // Drop Geonet namespace declaration. It may be contained
@@ -684,7 +684,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
     private void manageThumbnail(ServiceContext context, String id, boolean small, Element env, String styleSheet,
                                  boolean indexAfterChange) throws Exception {
         boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = true;
-        Element md = context.getBean(IMetadataManager.class).getMetadata(context, id, forEditing, withValidationErrors,
+        Element md = context.getBean(IMetadataManager.class).getMetadata(context, id, forEditing, false, withValidationErrors,
             keepXlinkAttributes);
 
         if (md == null)

--- a/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
@@ -178,7 +178,7 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
     @Test
     public void testInternalCompleteHidingHiddenElement() throws Exception {
         try (Closeable ignored = configureXmlSerializerAndServiceContext(false, false, false)) {
-            Element loadedMetadata = _xmlSerializer.internalSelect("1", false, false);
+            Element loadedMetadata = _xmlSerializer.internalSelect("1", false, true);
             List<?> withheld = Xml.selectNodes(loadedMetadata, "*//*[@gco:nilReason = 'withheld']", Arrays.asList(Geonet.Namespaces.GCO));
 
             assertEquals(0, withheld.size());
@@ -244,7 +244,7 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
             numberAttributes = 2;
         }
 
-        Element loadedMetadata = _xmlSerializer.internalSelect("" + _mdId, false, false);
+        Element loadedMetadata = _xmlSerializer.internalSelect("" + _mdId, false, true);
         List<?> resolutionElem = Xml.selectNodes(loadedMetadata,
             "*//gmd:MD_Resolution",
             XML_SELECT_NAMESPACE);
@@ -272,7 +272,7 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
 
     private void assertDownloadElements(boolean isEnabled) throws Exception {
         final int numberDownload = isEnabled ? 1 : 0;
-        Element loadedMetadata = _xmlSerializer.internalSelect("" + _mdId, false, false);
+        Element loadedMetadata = _xmlSerializer.internalSelect("" + _mdId, false, true);
         @SuppressWarnings("unchecked")
         List<Element> withheld = (List<Element>) Xml.selectNodes(loadedMetadata,
             XPATH_DOWNLOAD,
@@ -282,7 +282,7 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
 
     private void assertDynamicElements(boolean isEnabled) throws Exception {
         final int numberDownload = isEnabled ? 1 : 0;
-        Element loadedMetadata = _xmlSerializer.internalSelect("" + _mdId, false, false);
+        Element loadedMetadata = _xmlSerializer.internalSelect("" + _mdId, false, true);
         @SuppressWarnings("unchecked")
         List<Element> withheld = (List<Element>) Xml.selectNodes(loadedMetadata,
             XPATH_DYNAMIC,

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
@@ -121,7 +121,7 @@ public class XslProcessUtils {
             Element processedMetadata = null;
             try {
                 boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = true;
-                Element md = dataMan.getMetadata(context, id, forEditing, withValidationErrors, keepXlinkAttributes);
+                Element md = metadataManager.getMetadata(context, id, forEditing, false, withValidationErrors, keepXlinkAttributes);
 
                 Map<String, Object> xslParameter = new HashMap<>();
 

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -673,7 +673,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         boolean doXLinks = serializer.resolveXLinks();
 
 
-        Element metadata = serializer.removeHiddenElements(false, md, false);
+        Element metadata = serializer.removeHiddenElements(false, md, true);
         if (doXLinks) Processor.processXLink(metadata, context);
 
         boolean withholdWithheldElements = hide_withheld != null && hide_withheld;


### PR DESCRIPTION
This is a really old bug (5 years!) we observed in Sextant which was happenning from time to time and never managed to track down until now.
The record history helped on solving this (Thanks @PascalLike).

The issue happens under the following circunstances:
* Create a record, add attachments with protocol WWW:DOWNLOAD-1.0-http--download
* Update record privileges and allow Edit and disable Download for group A
* Sign in with a user of group A and edit the record
* Save is working fine.
* Add a thumbnail (ie. processing), the element filtered by the download operation are removed.

Schema-ident.xml is taking care of filtering:
```
<filter
      xpath="*//gmd:onLine[*/gmd:protocol/gco:CharacterString = 'WWW:DOWNLOAD-1.0-http--download']"
      ifNotOperation="download"/>
```
Usually when editing, the elements were not filtered, but when processing they were (with the history, we noticed that it was happening when linking a thumbnail).

Adding a specific parameter to applyOperationsFilters or not. In most
case the rule is: if you are doing something related to editing, do not
apply. In other situation, set it to true.