### PR TITLE
Fix: Feature info table should display above bottombar

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -107,6 +107,12 @@
       }
     }
   }
+  gn-features-tables, .gn-viewer-info-pane {
+    bottom: calc(~"@{gn-bottombar-height} - 3px");
+    .gn-features-table {
+      box-shadow: none;
+    }
+  }
 }
 
 // minimap on search results


### PR DESCRIPTION
The Feature info table on the map is displayed behind the fixed bottombar. This PR displays the table above the bottombar by taking into account the height of the bottombar.

**Before the change:**
<img width="1237" alt="gn_gfi_before" src="https://user-images.githubusercontent.com/19608667/69971108-b26ed980-151f-11ea-9a42-410aa6094787.png">


**After the fix:**
<img width="1236" alt="gn_gfi_after" src="https://user-images.githubusercontent.com/19608667/69971134-bc90d800-151f-11ea-85ef-3098284048ac.png">
