### PR TITLE
Fix: Map panel height should take into account the height of the bottom bar

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -44,6 +44,7 @@
   }
 
   .panel-tools {
+    max-height: ~"calc(100% - 2em - @{gn-bottombar-height} + 3px)";
     .panel-heading {
       background-color: transparent;
     }


### PR DESCRIPTION
The map panel can fall behind the bottom bar when it contains a lot of content. This PR calculates the height of the map panel and takes into account the height of the bottom bar.

**Before**:
<img width="426" alt="gn_mappanel_before" src="https://user-images.githubusercontent.com/19608667/69972519-0c709e80-1522-11ea-8472-8d2e8219c4ce.png">

**After**:
<img width="432" alt="gn_mappanel_after" src="https://user-images.githubusercontent.com/19608667/69972553-1b575100-1522-11ea-921f-3cce541bd530.png">
