### PR TITLE
arcsde harvesting - 2 fixes

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/AbstractAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/AbstractAligner.java
@@ -30,6 +30,10 @@ public abstract class AbstractAligner<P extends AbstractParams> {
 
     protected P params;
 
+    public void setParams(P params) {
+      this.params = params;
+    }
+
     public int getOwner() {
         return Integer.parseInt(
                 (StringUtils.isNumeric(params.getOwnerIdUser()) && params.getOwnerIdUser().length() > 0) ? params.getOwnerIdUser() : params.getOwnerId());

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/arcsde/ArcSDEHarvester.java
@@ -305,6 +305,7 @@ public class ArcSDEHarvester extends AbstractHarvester<HarvestResult> {
 
                         BaseAligner aligner = new BaseAligner(cancelMonitor) {
                         };
+                        aligner.setParams(params);
                         //
                         // add / update the metadata from this harvesting result
                         //

--- a/harvesters/src/main/resources/config-spring-geonetwork.xml
+++ b/harvesters/src/main/resources/config-spring-geonetwork.xml
@@ -58,5 +58,8 @@
         class="org.fao.geonet.kernel.harvest.harvester.wfsfeatures.WfsFeaturesHarvester"
         scope="prototype"/>
 
+  <!-- ArcSDE also requires a ArcSDEConnectionFactory beans -->
+  <bean id="arcSDEConnectionFactory"
+    class="org.fao.geonet.kernel.harvest.harvester.arcsde.ArcSDEConnectionFactory" />
 
 </beans>


### PR DESCRIPTION
* First is adding a missing bean for db harvesting. It is a similar issue as the one described here: https://github.com/geonetwork/core-geonetwork/pull/4025 ; using a bean definition in one of the xml file was a quick fix to me because it was not convenient in the customer's environment to rebuild Java code, but there might be a better way:
  * no need of a bean for the `ArcSDEDatabaseFactory`, maybe a class with a static method would be a better approach ?
  * Shall we rescan for the other packages for missing Spring `@component`s (see PR above) ?
* second fix is to avoid a NPE when harvesting, especially when trying to set rights on the currently harvested MD (passing params from the harvester to the aligner).

Other question: currently targetting 3.8.x because this was the version deployed by the customer. Shall I need to rebase onto master ?

Tests: Applied and live-tested on the client infra.
