### PR TITLE
Add label for the annotation text input

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/draw/partials/draw.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/draw/partials/draw.html
@@ -1,6 +1,6 @@
 <div gi-btn-group>
 
-  <div class="btn-group flux">
+  <div class="btn-group flux gn-margin-bottom">
     <div class="btn-group" role="group">
       <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"
               aria-haspopup="true" aria-expanded="false">
@@ -28,8 +28,12 @@
     </button>
   </div>
 
-  <input class="form-control" ng-show="drawText.active" ng-model="text"
-         title="{{'tipDrawText'|translate}}">
+  <label ng-show="drawText.active" >{{'textInput'|translate}}
+    <input class="form-control" ng-model="text"
+           placeholder="{{'textInput'|translate}}"
+           title="{{'tipDrawText'|translate}}">
+  </label>
+  
   <div gn-style-form="featureStyleCfg" gn-style-type="getActiveDrawType()"></div>
 
   <!--

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -316,6 +316,7 @@
   "textStrokeWidth": "Stroke width",
   "textWidth":"Size",
   "textFont":"Font",
+  "textInput":"Type your text",
   "drawFillColor":"Fill color",
   "drawStrokeColor":"Stroke color",
   "drawWidth":"Width",


### PR DESCRIPTION
Add a label for the text `<input>` for the annotation text on the map, so the user knows where the input is for

**Before**:
<img width="404" alt="gn_annotation_before" src="https://user-images.githubusercontent.com/19608667/70060785-77ce7500-15e3-11ea-867a-fa0ce95db190.png">

**After**:
<img width="403" alt="gn_annotation_after" src="https://user-images.githubusercontent.com/19608667/70060809-7ef58300-15e3-11ea-808b-84edbe9a6dbf.png">
