### PR TITLE
Fix for toLowerCase bug for featureinfo on unknown format

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -147,16 +147,18 @@
       }
     }).then(function(response) {
 
-      if(infoFormat.toLowerCase().localeCompare('application/json') == 0 ||
-          infoFormat.toLowerCase().localeCompare('application/geojson') == 0 ) {
+      if(infoFormat &&
+        (infoFormat.toLowerCase().localeCompare('application/json') == 0 ||
+          infoFormat.toLowerCase().localeCompare('application/geojson') == 0 )) {
         var jsonf = new ol.format.GeoJSON();
         var features = [];
         response.data.features.forEach(function(f) {
           features.push(jsonf.readFeature(f));
         });
         this.features = features;
-      } else if(infoFormat.toLowerCase().localeCompare('text/xml') == 0
-        || infoFormat.toLowerCase().localeCompare('application/vnd.ogc.gml') == 0 ) {
+      } else if(infoFormat &&
+        (infoFormat.toLowerCase().localeCompare('text/xml') == 0
+        || infoFormat.toLowerCase().localeCompare('application/vnd.ogc.gml') == 0 )) {
         var format = new ol.format.WMSGetFeatureInfo();
         this.features = format.readFeatures(response.data, {
           featureProjection: map.getView().getProjection()


### PR DESCRIPTION
Feature info on a layer in the map with a layer with a not recognised feature format caused an error. This error also stopped the feature info of other layers in the map.

This PR catches the unknown format and lets the other feature info to pass through.