### PR TITLE
remove take the first style as default style 

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -930,24 +930,8 @@
               if (getCapLayer.version) {
                 layerParam.VERSION = getCapLayer.version;
               }
-              if (requestedStyle) {
-                layerParam.STYLES = requestedStyle.Name;
-              } else {
-                // The first style element is the default style
-                var defaultStyle;
-                if (this.containsStyles(getCapLayer)) {
-                  defaultStyle = getCapLayer.Style[0];
-                }
-                if(defaultStyle) {
-                  // Set a casual style if available
-                  // to avoid issues on ESRI services
-                  layerParam.STYLES = defaultStyle.Name;
-                } else {
-                  // This is a problem for ESRI services
-                  // where STYLES is a mandatory field
-                  layerParam.STYLES = '';
-                }
-              }
+
+              layerParam.STYLES = requestedStyle?requestedStyle.Name:'';
 
               var projCode = map.getView().getProjection().getCode();
               if (getCapLayer.CRS) {


### PR DESCRIPTION
this was a workaround for esri services which is solved in this version of openlayers

esri wms service can't manage: ...&style&request=getmap
it requires: ...&style=&request=getmap
which is managed properly by this version of openlayers

verify with this service:
http://atlas.brabant.nl/arcgis/services/pgr_m01_milieu/MapServer/WMSServer