### PR TITLE
version check more explicit (else won't work on esri)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -170,20 +170,8 @@
 
           try {
 
-            //check the version (some wfs responds in other version then requested)
-            if (data.indexOf('version="2.0.0"')>-1){
-              version = "2.0";
-            } else if (data.indexOf('version="1.1.0"')>-1) {
-              version = "1.1.0";
-            } else if (data.indexOf('version="1.0.0"')>-1) {
-              version = "1.0.0";
-            } else {
-              console.warn('no version detected');
-              defer.reject({msg: 'wfsGetCapabilitiesFailed',
-                owsExceptionReport: 'No WFS version detected on response'});
-            }
-
             var xml = $.parseXML(data);
+            var version = $(xml).find(":first-child").attr("version");
 
             //First cleanup not supported INSPIRE extensions:
             if (xml.getElementsByTagName('ExtendedCapabilities').length > 0) {
@@ -205,7 +193,7 @@
               xfsCap = unmarshaller110.unmarshalDocument(xml).value;
             } else if (version === '1.0.0') {
               xfsCap = unmarshaller100.unmarshalDocument(xml).value;
-            } else if (version === '2.0') {
+            } else if (version === '2.0.0') {
               xfsCap = unmarshaller20.unmarshalDocument(xml).value;
             } else {
               console.warn('WFS version '+version+' not supported.');


### PR DESCRIPTION
i noticed adding wfs to map has some challenges for esri-wfs
i solved one aspect in this PR, in case your working on this consider to merge this change, else let me work on the PR later to optimize some aspects
- for WFS 2.0.0 a js object is displayed in stead of title for selecting featuretype to add
- plain wfs url doesn't work, you need to explicitely add ?version=2.0.0&service=wfs&request=getcapabilities
- features are not loaded/added to map, no clear warnings

sample wfs:
http://atlas.brabant.nl/arcgis/services/pgr_r01_ruimtelijke_ontwikkeling/MapServer/WFSServer.