### PR TITLE
Fix the the attribution overlap on smaller (landscape) screens.

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -386,7 +386,6 @@
     }
   }
 }
-
 // map for Editor and Batch Editor
 .gn-drawmap-panel {
   .gn-editor-map {
@@ -395,22 +394,16 @@
     margin-top: 30px;
     [ol-map] {
       .ol-attribution {
-        bottom: 4px;
-        right: auto;
-        left: 4px;
-        height: auto;
-        padding: 5px;
-        border-radius: 0;
-        ul {
-          font-size: 1rem;
-          padding-left: 0;
-          padding-right: 10px;
-          li {
-            white-space: nowrap;
-          }
-        }
+        .gn-attribution();
       }
     }
+  }
+}
+// online resource panel
+.add-onlinesrc {
+  // attribution on the 'make thumbnail' map 
+  .ol-attribution {
+    .gn-attribution();
   }
 }
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -13,16 +13,6 @@
   width: 250px !important;
   height: 250px !important;
   margin: 5px;
-  .ol-attribution {
-    right: auto;
-    left: .5em;
-    button {
-      background-color: @brand-primary;
-    }
-  }
-  .ol-attribution button {
-    float: left;
-  }
 }
 
 // map viewer
@@ -33,26 +23,16 @@
   left: 0px;
   right: 0px;
   .ol-attribution {
+    .gn-attribution();
     bottom: 1em;
-    right: auto;
     left: 1em;
-    height: auto;
-    padding: 5px;
-    border-radius: 0;
-    ul {
-      font-size: 1rem;
-      padding-left: 0;
-      padding-right: 10px;
-      li {
-        white-space: nowrap;
-      }
-    }
     button {
       background-color: @brand-primary;
     }
-  }
-  .ol-attribution button {
-    float: left;
+    @media screen and (max-height: 768px) {
+      left: auto;
+      right: 1em;
+    }
   }
 
   .panel-tools {
@@ -126,20 +106,7 @@
   [ol-map] {
     background: @body-bg;
     .ol-attribution {
-      bottom: 4px;
-      right: auto;
-      left: 4px;
-      height: auto;
-      padding: 5px;
-      border-radius: 0;
-      ul {
-        font-size: 1rem;
-        padding-left: 0;
-        padding-right: 10px;
-        li {
-          white-space: nowrap;
-        }
-      }
+      .gn-attribution();
     }
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -71,3 +71,20 @@
   }
 }
 
+// attribution mixin
+.gn-attribution() {
+  bottom: 4px;
+  right: auto;
+  left: 4px;
+  height: auto;
+  padding: 5px;
+  border-radius: 0;
+  ul {
+    font-size: 1rem;
+    padding-left: 0;
+    padding-right: 10px;
+    li {
+      white-space: nowrap;
+    }
+  }
+}


### PR DESCRIPTION
When the screen (and map) is not so high, the attribution box overlapped with the `control tools` (the zoom tools). This PR aligns the attribution box to the right on smaller screens

Changes:
- Create attribution mixin
- Clean unused attribution styles
- Fix attribution for 'make thumbnail' map