### PR TITLE
Fix for the width of the localisation dropdown (for all screen sizes)

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -475,12 +475,32 @@
 
   [gn-localisation-input] {
     .dropdown-menu {
+      top: calc(~"100% - 2px");
+      width: auto;
+      max-width: 85vw;
       padding-bottom: 0;
       border-radius: 0;
       .list-group-item {
         border-radius: 0;
         border-left: 0;
         border-right: 0;
+        a {
+          display: block;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          max-width: 85vw;
+          min-width: auto;
+          @media (max-width: @screen-xs-max) {
+            em {
+              display: block;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              max-width: 85vw;
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
When using the localisation popup in the map, longer search results 'break' out of the dropdown. This PR fixes this by truncating the search result text, and on smaller screens the text will be displayed on 2 lines.

**Before**:
<img width="378" alt="gn-localisation-before" src="https://user-images.githubusercontent.com/19608667/70132307-3d68e480-1684-11ea-81f2-e0fca60ee0cb.png">

**After**:
![gn-localisation-after](https://user-images.githubusercontent.com/19608667/70132318-41950200-1684-11ea-82d1-ab5e2fe724d8.png)

![localhost_8080_geonetwork_srv_eng_catalog search](https://user-images.githubusercontent.com/19608667/70132556-c4b65800-1684-11ea-8d4b-3a5a7b8951a0.png)

