### PR TITLE
Record view / Associated resources / Avoid duplicates

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -171,6 +171,19 @@
                          } else {
                            scope.relations[idx] = value;
                          }
+                         
+                         if (scope.relations.siblings && scope.relations.associated) {
+                           for (var i = 0; i < scope.relations.associated.length; i++) {
+                             if (scope.relations.siblings.filter(function (e) {
+                               return e.id === scope.relations.associated[i].id;
+                             }).length > 0) {
+                               /* siblings object contains associated element */
+                             } else {
+                               scope.relations.siblings.push(scope.relations.associated[i])
+                             }
+                           }
+                           scope.relations.associated = {};
+                         }
                        });
                     
                        if (angular.isDefined(scope.container) 


### PR DESCRIPTION
When linking records with aggregates (19139) or associated resources (19115-3), if user connect the 2 records in both direction then the link is displayed twice. Combined siblings and associated records in one list to avoid this.