### PR TITLE
Increase the max width of the popover

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -30,6 +30,9 @@
   display: none;
 }
 
+.popover {
+  max-width: 350px;
+}
 .jumbotron {
   h1 {
     font-size: 36px;


### PR DESCRIPTION
In the map, in the layer settings dropdown, the texts can 'break' out off the popover window when they are too large. This PR increases the `max-width` of the popover a little, so texts fit.

<img width="565" alt="gn-popover-fix" src="https://user-images.githubusercontent.com/19608667/70135590-a4899780-168a-11ea-826b-f714b7e2a35f.png">
