### PR TITLE
Fix for sticking the feature identify table to the bottom

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -101,7 +101,6 @@
     }
   }
   gn-features-tables, .gn-viewer-info-pane {
-    bottom: calc(~"@{gn-bottombar-height} - 3px");
     .gn-features-table {
       box-shadow: none;
     }


### PR DESCRIPTION
The feature identify table was not displayed at the bottom of the map. This PR fixes this issue, it fixes the identify table to the bottom of the map.