### PR TITLE
Reorganize latest maps on the homepage and the map

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js
@@ -58,8 +58,9 @@
        */
       var overlayCanvas = document.createElement('canvas');
       overlayCanvas.style.position = 'absolute';
+      overlayCanvas.style.width = '100%';
+      overlayCanvas.style.height = '100%';
       var overlayLayer = new ol.layer.Layer({
-        className: 'abcd',
         render: function() {
           // print rectangle might not be ready if config is loading
           if (!printRectangle) {
@@ -67,11 +68,12 @@
           }
 
           var size = $scope.map.getSize();
-          overlayCanvas.width = size[0];
-          overlayCanvas.height = size[1];
-          var ctx = overlayCanvas.getContext('2d');
           var height = size[1] * ol.has.DEVICE_PIXEL_RATIO;
           var width = size[0] * ol.has.DEVICE_PIXEL_RATIO;
+          overlayCanvas.width = width;
+          overlayCanvas.height = height;
+          var ctx = overlayCanvas.getContext('2d');
+          
 
           var minx, miny, maxx, maxy;
           minx = printRectangle[0], miny = printRectangle[1],

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -45,8 +45,9 @@
      */
     var overlayCanvas = document.createElement('canvas');
     overlayCanvas.style.position = 'absolute';
+    overlayCanvas.style.width = '100%';
+    overlayCanvas.style.height = '100%';
     var overlayLayer = new ol.layer.Layer({
-      className: 'abcd',
       render: function() {
         // print rectangle might not be ready if config is loading
         if (!printRectangle) {
@@ -54,11 +55,12 @@
         }
 
         var size = $scope.map.getSize();
-        overlayCanvas.width = size[0];
-        overlayCanvas.height = size[1];
-        var ctx = overlayCanvas.getContext('2d');
         var height = size[1] * ol.has.DEVICE_PIXEL_RATIO;
         var width = size[0] * ol.has.DEVICE_PIXEL_RATIO;
+        overlayCanvas.width = width;
+        overlayCanvas.height = height;
+        var ctx = overlayCanvas.getContext('2d');
+        
 
         var minx, miny, maxx, maxy;
         minx = printRectangle[0], miny = printRectangle[1],

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
@@ -1,22 +1,30 @@
-<ul class="list-group gn-resultview gn-resultview-sumup">
-  <li class="list-group-item gn-grid gn-map-item flex-col flex-align-stretch"
-      data-ng-repeat="md in searchResults.records"
-      data-gn-fix-mdlinks=""
-      title="{{(md.abstract || md.defaultAbstract) | striptags}}"
-      ng-click="loadMap(maps[0], md)">
+<ul class="row gn-info-list">
+  <li data-ng-repeat="md in searchResults.records"
+      data-gn-fix-mdlinks="">
 
-    <div class="gn-md-thumbnail flex-grow"
-         ng-style="{ 'background-image': md.getThumbnails().list[0].url && 'url(' + md.getThumbnails().list[0].url + ')' }">
-    </div>
+    <section class="resultcard clearfix"
+             data-ng-class="md.getThumbnails().list[0].url ? 'hasThumbnail' : 'noThumbnail'">
 
-    <div class="gn-img-thumbnail-caption">
-      {{md.title || md.defaultTitle}}
-    </div>
-
-    <a class=""
-        ng-href="#/metadata/{{md.getUuid()}}"
-        title="{{'openRecord' | translate}}" translate>
-      openRecord
-    </a>
+      <div class="title">
+        <a ng-href="#/metadata/{{md.getUuid()}}">
+          <h4>{{md.title || md.defaultTitle}}&nbsp;</h4>
+        </a>
+      </div>
+      
+      <div class="gn-md-thumbnail">
+        <a href="">
+          <div class="gn-img-thumbnail"
+               ng-click="resultviewFns.loadMap(maps[0], md)"
+               ng-style="{ 'background-image': md.getThumbnails().list[0].url && 'url(' + md.getThumbnails().list[0].url + ')' }">
+          </div>
+        </a>
+      </div>
+      
+      <div class="content">
+        <div class="abstract">
+          {{md.abstract || defaultAbstract}}
+        </div>
+      </div>
+    </section>
   </li>
 </ul>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
@@ -14,7 +14,7 @@
       <div class="gn-md-thumbnail">
         <a href="">
           <div class="gn-img-thumbnail"
-               ng-click="resultviewFns.loadMap(maps[0], md)"
+               ng-click="resultviewFns && resultviewFns.loadMap ? resultviewFns.loadMap(maps[0], md) : loadMap(maps[0], md)"
                ng-style="{ 'background-image': md.getThumbnails().list[0].url && 'url(' + md.getThumbnails().list[0].url + ')' }">
           </div>
         </a>

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerModule.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerModule.js
@@ -146,9 +146,10 @@
           }
           overlay.setPosition(coordinate);
           $(overlay.getElement()).show();
-        }, this, function(layer) {
-          return layer.get('getinfo');
-        });
+        }.bind(this),  {
+          layerFilter: function(layer) {
+            return layer.get('getinfo');
+        }});
         if (!f) {
           hidetimer = $timeout(function() {
             $(div).hide();

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
@@ -65,10 +65,10 @@
                  if (layer && layer.get('featureTooltip')) {
                    return feature;
                  }
-               }, undefined, function(layer) {
-                return layer instanceof ol.layer.Vector;
-
-              });
+               }.bind(this), {
+                layerFilter: function(layer) {
+                  return layer instanceof ol.layer.Vector;
+              }});
               if (feature) {
                 var props = feature.getProperties();
                 var tooltipContent = '<ul>';

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -256,7 +256,7 @@
       </h3>
     </div>
     <div class="panel-body">
-      <div gn-ows-context="" map="map" user="user"></div>
+      <div gn-ows-context="" class="gn-info-list-blocks" map="map" user="user"></div>
     </div>
   </div>
 

--- a/web-ui/src/main/resources/catalog/style/gn_infolist.less
+++ b/web-ui/src/main/resources/catalog/style/gn_infolist.less
@@ -245,3 +245,17 @@
     }
   }
 }
+// list in the panel in the map
+.panel-tools {
+  .gn-info-list-blocks {
+    .gn-info-list {
+      li {
+        width: 50%;
+        height: 185px;
+        .gn-md-thumbnail {
+          height: 125px;
+        }
+      }
+    }
+  }
+}

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -443,35 +443,6 @@ span.gn-facet-label:first-letter {
   }
 }
 
-
-.gn-top-records {
-  .well();
-
-  /* Make a wide div with an horizontal scroll */
-  [data-gn-results-container] {
-    overflow-x: scroll;
-    overflow-y: hidden;
-
-    .gn-resultview {
-      display: flex;
-    }
-
-    /* to loop over results */
-    li.gn-grid {
-      width: 200px;
-      min-width: 200px;
-      height: 200px;
-      text-align: center;
-
-      .gn-md-thumbnail {
-        display: inline-block;
-        float: none;
-        margin-right: 0px;
-      }
-    }
-  }
-}
-
 .gn-img-thumbnail-caption {
   text-align: center;
   font-style: italic;

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -831,3 +831,21 @@ gn-geometry-tool .btn-group {
   color: white;
   pointer-events: none;
 }
+
+// attribution mixin
+.gn-attribution() {
+  bottom: 4px;
+  right: auto;
+  left: 4px;
+  height: auto;
+  padding: 5px;
+  border-radius: 0;
+  ul {
+    font-size: 1rem;
+    padding-left: 0;
+    padding-right: 10px;
+    li {
+      white-space: nowrap;
+    }
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -101,7 +101,6 @@
     }
   }
   gn-features-tables, .gn-viewer-info-pane {
-    bottom: calc(~"@{gn-bottombar-height} - 3px");
     .gn-features-table {
       box-shadow: none;
     }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -316,26 +316,6 @@ li.list-group-item.gn-map-item {
     }
   }
 
-  .gn-top-records [data-gn-results-container]  & {
-    padding: 14px;
-    height: 205px;
-
-    .gn-img-thumbnail-caption {
-      margin: 5px 0px;
-    }
-
-    &:hover {
-      cursor: pointer;
-
-      // note, this may not be correct if a theme is applied,
-      // as the actual result hover color is transparent black
-      @result-hover-color: rgb(234, 234, 234);
-      .gn-img-thumbnail-caption::after {
-        background: linear-gradient(to bottom, fade(@result-hover-color, 0%) 0%, @result-hover-color 100%);
-      }
-    }
-  }
-
   [gn-ows-context] ul.gn-resultview & {
     padding: 5px;
     height: 205px;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -70,21 +70,3 @@
     max-width: 150px;
   }
 }
-
-// attribution mixin
-.gn-attribution() {
-  bottom: 4px;
-  right: auto;
-  left: 4px;
-  height: auto;
-  padding: 5px;
-  border-radius: 0;
-  ul {
-    font-size: 1rem;
-    padding-left: 0;
-    padding-right: 10px;
-    li {
-      white-space: nowrap;
-    }
-  }
-}

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -309,6 +309,7 @@
         },
         loadMap: function (map, md) {
           gnOwsContextService.loadContextFromUrl(map.url, viewerMap);
+          gnSearchLocation.setMap();
         }
       };
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -33,27 +33,6 @@
   </div>
   <!-- /.gn-row-main -->
 
-  <form class="form-horizontal"
-        role="form"
-        data-ng-controller="gnsSearchTopEntriesController"
-        data-ng-search-form=""
-        data-runSearch="true"
-        data-ng-show="searchResults.records.length > 0">
-    <div class="row gn-top-records" role="row">
-      <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
-        <h4 data-translate="">topMaps</h4>
-
-        <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
-        <div data-ng-show="searchResults.records.length > 0"
-             data-gn-results-container=""
-             data-search-results="searchResults"
-             data-template-url="resultTemplate"></div>
-      </div>
-    </div>
-    <!-- /.gn-top-records -->
-  </form>
-
   <div class="row" data-ng-show="searchInfo.count == 0">
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
       <div data-ng-show="searchInfo.count == 0"
@@ -215,6 +194,25 @@
                 data-ng-show="searchResults.records.length > 0">
               <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div data-gn-info-list=""></div>
+          </form>
+        </tab>
+        <tab heading="{{'topMaps' | translate}}"
+             role="tab"
+             active="infoTabs.topMaps.active">
+          <form class="form-horizontal"
+                role="form"
+                data-ng-controller="gnsSearchTopEntriesController"
+                data-ng-search-form=""
+                data-runSearch="true"
+                data-ng-show="searchResults.records.length > 0">
+            <div class="row gn-top-records" role="row">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+              <div data-ng-show="searchResults.records.length > 0"
+                  data-gn-results-container=""
+                  data-search-results="searchResults"
+                  data-template-url="resultTemplate"></div>
+            </div>
+            <!-- /.gn-top-records -->
           </form>
         </tab>
         <tab heading="{{'featuredUserSearches' | translate}}"


### PR DESCRIPTION
GeoNetwork has the option to save your own maps, these can be displayed on the homepage and in a maps panel in the sidebar on the map.

The maps on the homepage had their own block. This PR adds the latest maps on the same 'level' as the 'latest news' and 'most popular'. The different list types also apply to the latest maps. Furthermore it fixes the go to map link from the homepage (click on the thumbnail).

<img width="1202" alt="gn-latestmaps-home" src="https://user-images.githubusercontent.com/19608667/70237937-7da19300-1768-11ea-9d9f-de3ea196c43e.png">

This PR also gives the latest maps in the map panel the same styling as on the homepage.

<img width="631" alt="gn-latestmaps-map" src="https://user-images.githubusercontent.com/19608667/70238003-a4f86000-1768-11ea-8a01-c129ce0548cc.png">
