### PR TITLE
fix(wps) use processDescription for dropdown output options

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -139,7 +139,7 @@
                 &nbsp;<span translate>wpsExecute</span>
               </button>
 
-              <div class="output-selection dropup" ng-if="executeResponse.processOutputs.output.length > 0">
+              <div class="output-selection dropup" ng-if="processDescription.processOutputs.output.length > 0">
                 <button class="btn btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <span class="caret"></span>
                   &nbsp;<span translate>wpsSelectOutput</span>


### PR DESCRIPTION
@jahow 
Use processDescription to check possible outputs. 
This is used later to loop over the processOutputs.