### PR TITLE
avoid to set too long batchkey

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/LinkStatus.java
+++ b/domain/src/main/java/org/fao/geonet/domain/LinkStatus.java
@@ -197,7 +197,7 @@ public class LinkStatus extends GeonetEntity implements Comparable<LinkStatus> {
      */
     @Column(nullable = true)
     public String getBatchKey() {
-        return statusInfo;
+        return batchKey;
     }
 
     public void setBatchKey(String batchKey) {


### PR DESCRIPTION
@josegar74 please ?
@fxprunayre por favor ?

so to avoid 

java.sql.BatchUpdateException: Batch entry 0 insert into LinkStatus (batchKey, checkDate, failing, link, statusInfo, statusValue, id) values ('Host name ''www.upc.es'' does not match the certificate subject provided by the peer (CN=www.upc.edu, OU=UPCnet, O=Universitat Politècnica de Catalunya. BarcelonaTech., L=Barcelona, C=ES, SERIALNUMBER=Government Entity, OID.1.3.6.1.4.1.311.60.2.1.3=ES, OID.2.5.4.15=Government Entity)', '2019-12-10T13:49:32', 'y', 334555813, 'Host name ''www.upc.es'' does not match the certificate subject provided by the peer (CN=www.upc.edu, OU=UPCnet, O=Universitat Politècnica de Catalunya. BarcelonaTech., L=Barcelona, C=ES, SERIALNUMBER=Government Entity, OID.1.3.6.1.4.1.311.60.2.1.3=ES, OID.2.5.4.15=Government Entity)', '4XX', 334574309) was aborted: ERROR: value too long for type character varying(255)

for example.