### PR TITLE
Better support to INSPIRE validation

### DIFF
--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -67,6 +67,7 @@
           <array>
             <value>Conformance class: INSPIRE Profile based on EN ISO 19115 and EN ISO 19119</value>
             <value>Conformance class: XML encoding of ISO 19115/19119 metadata</value>
+            <value>Conformance class: Conformance class: Metadata for interoperability</value>
           </array>
         </entry>
         <entry key="TG version 2.0 - Data sets and series">
@@ -76,14 +77,14 @@
             <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
           </array>
         </entry>
-        <entry key="TG version 2.0 - Spatial data service">
+        <entry key="TG version 2.0 - Network services">
           <array>
             <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
-            <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
-            <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
+            <!--<value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
+            <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>-->
             <value>Conformance Class 3: INSPIRE Spatial Data Service baseline metadata.</value>
-            <!--<value>Conformance Class 4: INSPIRE Network Services metadata.</value>
-            <value>Conformance Class 5: INSPIRE Invocable Spatial Data Services metadata.</value>
+            <value>Conformance Class 4: INSPIRE Network Services metadata.</value>
+            <!--<value>Conformance Class 5: INSPIRE Invocable Spatial Data Services metadata.</value>
             <value>Conformance Class 6: INSPIRE Interoperable Spatial Data Services metadata.</value>
             <value>Conformance Class 7: INSPIRE Harmonised Spatial Data Services metadata.</value>-->
           </array>


### PR DESCRIPTION
I would suggest the following changes:
1) to add also the conformance class "Conformance class: Metadata for interoperability" to the TG version 1.3 validation, that checks the presence of the additional metadata required for the already harmonised datasets (datasets conformant to the INSPIRE data models).
2) making available the validation for the "Network Services" (i.e. WMS, WFS, CSW) instead of "Spatial data service". The last ones are a particular type of services, like processing or something like this, not commonly used. For validation of network services, the conformance classes are: Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records, Conformance Class 3: INSPIRE Spatial Data Service baseline metadata and Conformance Class 4: INSPIRE Network Services metadata.