### PR TITLE
Allow CRS:84 to be specified as projection on bounding polygon's

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -175,7 +175,7 @@
             ctrl.initValue = function() {
               if (ctrl.polygonXml) {
                 var srsName = ctrl.polygonXml.match(
-                    new RegExp('srsName=\"(EPSG:[0-9]*)\"'));
+                    new RegExp('srsName=\"([^"]*)\"'));
                 ctrl.dataProjection = srsName && srsName.length === 2 ?
                     srsName[1] : 'EPSG:4326';
 


### PR DESCRIPTION
This allows projections not of the form EPSG:[0-9]* to be used when creating bounding polygons.

The projection still needs to be supported by openlayers.

Refer https://github.com/geonetwork/core-geonetwork/issues/4255 for more information.