### PR TITLE
Allow CRS:84 to be specified as projection on bounding polygon's

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -175,7 +175,7 @@
             ctrl.initValue = function() {
               if (ctrl.polygonXml) {
                 var srsName = ctrl.polygonXml.match(
-                    new RegExp('srsName=\"(EPSG:[0-9]*)\"'));
+                    new RegExp('srsName=\"([^"]*)\"'));
                 ctrl.dataProjection = srsName && srsName.length === 2 ?
                     srsName[1] : 'EPSG:4326';
 


### PR DESCRIPTION
Allows CRS:84 to be defined as a projection for use on bounding boxes/polygons in ui settings and not be changed to EPSG:4326 when editing it.

Refer https://github.com/geonetwork/core-geonetwork/issues/4255 and https://github.com/geonetwork/core-geonetwork/pull/4318