### PR TITLE
Use projection axis order when writing gml for bounding polygon's

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
@@ -2898,7 +2898,7 @@
     <description>Name of the Spatial Reference System. By default set to
       geographic (epsg:4326)
     </description>
-    <example>urn:x-ogc:def:crs:EPSG:6.6:4326</example>
+    <example>urn:ogc:def:crs:EPSG:6.6:4326</example>
   </element>
 
   <!-- ==================================================== -->

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
@@ -2888,7 +2888,7 @@
     <description>Name of the Spatial Reference System. By default set to
       geographic (epsg:4326)
     </description>
-    <example>urn:x-ogc:def:crs:EPSG:6.6:4326</example>
+    <example>urn:ogc:def:crs:EPSG:6.6:4326</example>
   </element>
 
   <!-- ==================================================== -->

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/labels.xml
@@ -2519,7 +2519,7 @@
     <description>Name of the Spatial Reference System. By default set to
       geographic (epsg:4326)
     </description>
-    <example>urn:x-ogc:def:crs:EPSG:6.6:4326</example>
+    <example>urn:ogc:def:crs:EPSG:6.6:4326</example>
   </element>
   <!-- ==================================================== -->
 

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
@@ -2981,7 +2981,7 @@
     <description>Name of the Spatial Reference System. By default set to
       geographic (epsg:4326)
     </description>
-    <example>urn:x-ogc:def:crs:EPSG:6.6:4326</example>
+    <example>urn:ogc:def:crs:EPSG:6.6:4326</example>
   </element>
 
   <element name="srv:SV_ServiceIdentification">

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
@@ -2859,7 +2859,7 @@
     <description>Nome do sistema de referência espacial. Por padrão
       definido (epsg:4326)
     </description>
-    <example>urn:x-ogc:def:crs:EPSG:6.6:4326</example>
+    <example>urn:ogc:def:crs:EPSG:6.6:4326</example>
   </element>
 
   <!-- ==================================================== -->

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
@@ -2968,7 +2968,7 @@
     <description>Name of the Spatial Reference System. By default set to
       geographic (epsg:4326)
     </description>
-    <example>urn:x-ogc:def:crs:EPSG:6.6:4326</example>
+    <example>urn:ogc:def:crs:EPSG:6.6:4326</example>
   </element>
 
   <!-- ==================================================== -->

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -302,7 +302,7 @@
         <xsl:value-of select="generate-id(.)"/>
       </xsl:attribute>
       <xsl:attribute name="srsName">
-        <xsl:text>urn:x-ogc:def:crs:EPSG:6.6:4326</xsl:text>
+        <xsl:text>urn:ogc:def:crs:EPSG:6.6:4326</xsl:text>
       </xsl:attribute>
       <xsl:copy-of select="@*"/>
       <xsl:apply-templates select="*"/>

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -207,7 +207,7 @@
               featureNS: options.gmlFeatureNS ||
                   'http://mapserver.gis.umn.edu/mapserver',
               featureType: options.gmlFeatureElement || 'features',
-              srsName: options.crs !== 'EPSG:4326' ? options.crs : undefined
+              srsName: options.crs
             });
 
             if (options.outputAsWFSFeaturesCollection) {
@@ -314,7 +314,7 @@
                 /http:\/\/www.opengis.net\/gml\/3.2/g,
                 'http://www.opengis.net/gml')
                 .replace(/urn:x-ogc:def:crs:EPSG:6.6:4326/g,
-                  'EPSG:4326'), {
+                  'urn:ogc:def:crs:EPSG:6.6:4326'), {
               dataProjection: options.crs,
               featureProjection: outputProjection
             })[0];

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -207,7 +207,7 @@ goog.require('gn_alert');
           },
           'projection': 'EPSG:3857',
           'projectionList': [{
-            'code': 'EPSG:4326',
+            'code': 'urn:ogc:def:crs:EPSG:6.6:4326',
             'label': 'WGS84 (EPSG:4326)'
           }, {
             'code': 'EPSG:3857',


### PR DESCRIPTION
Also change default WGS (EPSG:4326) code to be urn:ogc:def:EPSG:6.6:4326 instead of EPSG:4326 for 19139 as lat/lon ordering of coordinates is normally expected to be followed for this code.

Requires https://github.com/geonetwork/core-geonetwork/pull/4319 for srs not to be changed back to EPSG:4326 when editing an existing bounding polygon

Fixes https://github.com/geonetwork/core-geonetwork/issues/4255 in 3.8.x