### PR TITLE
iso19139/Don't lose gmd:country for mainlanguage in gmd:locale

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -177,6 +177,8 @@
               <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"
                                        codeListValue="{$defaultEncoding}"/>
             </gmd:characterEncoding>
+            <!-- Apply country if it exists.  -->
+            <xsl:apply-templates select="gmd:locale/gmd:PT_Locale[gmd:languageCode/*/@codeListValue = $mainLanguage]/gmd:country"/>
           </gmd:PT_Locale>
         </gmd:locale>
       </xsl:if>


### PR DESCRIPTION
If the main language locale contain a gmd:country the update-fixed-info.xsl is not including the gmd:country during the  gmd:locale creation for the main language so the gmd:country value is dropped/lost.

This fix copies the gmd:country code if it exists so that it is not lost.