### PR TITLE
iso19139/gmd:LanguageCode text() lost

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -465,6 +465,16 @@
   <xsl:template match="gmd:LanguageCode[@codeListValue]" priority="10">
     <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/">
       <xsl:apply-templates select="@*[name(.)!='codeList']"/>
+
+      <xsl:if test="normalize-space(./text()) != '' and string(@codeListValue)">
+        <xsl:value-of select="java:getIsoLanguageLabel(@codeListValue, $mainLanguage)" />
+        <!-- 
+             If wanting to get strings from codelists then add gmd:LanguageCode codelist in loc/{lang}/codelists.xml
+             and use getCodelistTranslation instead of getIsoLanguageLabel. This will allow for custom values such as "eng; USA"
+             i.e. 
+             <xsl:value-of select="java:getCodelistTranslation(name(), string(@codeListValue), string($mainLanguage))"/>
+        -->
+      </xsl:if>
     </gmd:LanguageCode>
   </xsl:template>
 


### PR DESCRIPTION
If the following was used for the gmd:language

```
  <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng">
   eng  
   </gmd:LanguageCode>
```

The text portion will be removed and it will be saved as 

```
  <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
```

So the text portion is lost.

This pull request ensure that if a text() existed then it will update the value based on the code list value using getIsoLanguageLabel.

However if we want to create our own custom code list with values like "eng; USA" then a sample is provided
using the getCodelistTranslation function so that we can have something like the following

```
  <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng">
   eng; USA
   </gmd:LanguageCode>
```


This is cleaned up reSubmission of pull request #4215