### PR TITLE
Reorganize mappanels

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
@@ -1,130 +1,157 @@
 <div class="context">
   <a href="" class="hidden download-element"></a>
+
+  <div class="btn-group" role="group">
+    <!-- upload -->
+    <div class="btn-group width-33" role="group">
+      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span data-translate="">load</span>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li>
+          <a class="import">
+            <i class="fa fa-upload"></i>&nbsp;
+            <span data-translate="">uploadContext</span>
+          </a>
+        </li>
+        <li>
+          <a data-ng-click="reset()">
+            <i class="fa fa-map-o"></i>&nbsp;
+            <span data-translate="">resetContext</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <!-- download -->
+    <div class="btn-group width-33" role="group">
+      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span data-translate="">download</span>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li>
+          <a data-ng-click="save($event)"
+              title="{{'downloadContext'|translate}}">
+            <i class="fa fa-file-code-o"></i>&nbsp;
+            <span data-translate="">saveMapAsContext</span>
+          </a>
+        </li>
+        <li data-ng-if="isExportMapAsImageEnabled">
+          <a data-ng-click="saveMapAsImage($event)">
+            <i class="fa fa-file-image-o"></i>&nbsp;
+            <span data-translate="">saveMapAsImage</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <!-- save -->
+    <button type="button"
+            class="btn btn-default width-33"
+            data-ng-if="isSaveMapInCatalogAllowed && user.isEditorOrMore()"
+            data-toggle="collapse"
+            data-target="#saveform"
+            aria-expanded="false" 
+            aria-controls="saveform">
+      <span data-translate="">Save</span>
+    </button>
+  </div>
+
+  <!-- save form -->
+  <form data-ng-if="isSaveMapInCatalogAllowed && user.isEditorOrMore()">
+
+    <div class="collapse" id="saveform">
+      <h4 data-translate="">saveMapInCatalog</h4>
+      <p data-ng-if="mapUuid != null"
+          data-translate=""
+          data-translate-values="{uuid: '{{mapUuid}}'}">mapSavedInCatalog</p>
+      <input type="hidden" name="_csrf" value="{{csrf}}"/>
+      <div class="form-group">
+        <label for="mapTitle"
+              data-translate="">mapTitle</label>
+        <input type="text"
+              class="form-control"
+              name="mapTitle"
+              data-ng-model="mapProps.title"
+              data-ng-required=""
+              id="mapTitle">
+      </div>
+      <div class="form-group">
+        <label for="mapAbstract"
+              data-translate="">mapAbstract</label>
+        <textarea class="form-control"
+                  name="mapAbstract"
+                  data-ng-model="mapProps.recordAbstract"
+                  id="mapAbstract"></textarea>
+      </div>
+      <div class="form-group"
+          data-ng-show="groups && groups.length > 1">
+        <label data-translate="">group</label>
+        <div data-groups-combo=""
+            data-optional="{{user.isAdministrator()}}"
+            data-owner-group="mapProps.group"
+            lang="lang"
+            data-groups="groups"
+            data-profile="Editor"
+            data-exclude-special-groups="true"/>
+      </div>
+      <input type="hidden"
+            name="publishedToAll"
+            data-ng-model="mapProps.publishToAll"/>
+      <div class="btn-group dropup">
+        <button type="button" class="btn btn-default width-75"
+                data-gn-click-and-spin="saveInCatalog($event)"
+                title="{{'saveInCatalog'|translate}}">
+          <i class="fa fa-save"/>
+          <span data-translate="">saveMapInCatalogAction</span>
+        </button>
+        <button type="button"
+                class="btn btn-default dropdown-toggle width-25"
+                data-toggle="dropdown">
+          <span class="caret"></span>&nbsp;
+        </button>
+        <ul class="dropdown-menu pull-right" role="menu">
+          <li><a
+            title="{{'saveInCatalogAndPublish-help' | translate}}"
+            data-gn-click-and-spin="saveInCatalog($event, true)"
+            href="">
+            <i class="fa fa-unlock"/>
+            <span data-translate="">saveMapInCatalogActionAndPublish</span>
+          </a></li>
+        </ul>
+      </div>
+    </div>
+    <!-- /.collapse -->
+  </form>
+  <!-- /saveform -->
+
+  <!-- search form -->
   <form class="form-horizontal clearfix"
         role="form"
         data-ng-controller="gnsMapSearchController"
         data-ng-search-form=""
         data-runSearch="true">
 
+    <input type="hidden" name="_csrf" value="{{csrf}}"/>
+
     <h4>
-      <span data-translate="">loadAMap</span>
-      <a class="btn btn-default btn-xs pull-right"
-         data-ng-click="triggerSearch(); $event.stopPropagation();">
-        <i class="fa fa-refresh"/>
-    </a>
+        <span data-translate="">loadAMap</span>
+        <a class="btn btn-default btn-xs pull-right"
+            data-ng-click="triggerSearch(); $event.stopPropagation();">
+          <i class="fa fa-refresh"/>
+      </a>
     </h4>
-
-    <input type="hidden" name="_csrf" value="{{csrf}}"/>
-
-    <div class="btn-group" role="group">
-      <a class="btn btn-default"
-          data-ng-click="reset()">
-        <i class="fa fa-map-o"></i>&nbsp;
-        <span data-translate="">resetContext</span>
-      </a>
-      <a class="btn btn-default import">
-        <i class="fa fa-upload"></i>&nbsp;
-        <span data-translate="">uploadContext</span>
-      </a>
-    </div>
+    <div data-ng-show="searchResults.records.length > 0"
+        data-gn-results-container=""
+        data-search-results="searchResults"
+        data-template-url="resultTemplate"></div>
 
     <div data-ng-show="searchResults.records.length > 0"
-         data-gn-results-container=""
-         data-search-results="searchResults"
-         data-template-url="resultTemplate"></div>
-
-    <div data-ng-show="searchResults.records.length > 0"
-         class="text-center"
-         data-gn-pagination="paginationInfo"
-         data-hits-values="searchObj.hitsperpageValues"></div>
+        class="text-center"
+        data-gn-pagination="paginationInfo"
+        data-hits-values="searchObj.hitsperpageValues"></div>
   </form>
-
-  <h4 data-translate="">downloadContext</h4>
-  <div class="btn-group" role="group">
-    <a class="btn btn-default"
-        data-ng-click="save($event)"
-        title="{{'downloadContext'|translate}}">
-      <i class="fa fa-file-code-o"></i>&nbsp;
-      <span data-translate="">saveMapAsContext</span>
-    </a>
-    <a class="btn btn-default"
-        data-ng-if="isExportMapAsImageEnabled"
-        data-ng-click="saveMapAsImage($event)">
-      <i class="fa fa-file-image-o"></i>&nbsp;
-      <span data-translate="">saveMapAsImage</span>
-    </a>
-  </div>
-
-  <form data-ng-if="isSaveMapInCatalogAllowed && user.isEditorOrMore()">
-    <h4 data-translate="">saveMapInCatalog</h4>
-
-    <input type="hidden" name="_csrf" value="{{csrf}}"/>
-    <div class="form-group">
-      <label for="mapTitle"
-             data-translate="">mapTitle</label>
-      <input type="text"
-             class="form-control"
-             name="mapTitle"
-             data-ng-model="mapProps.title"
-             data-ng-required=""
-             id="mapTitle">
-    </div>
-    <div class="form-group">
-      <label for="mapAbstract"
-             data-translate="">mapAbstract</label>
-      <textarea class="form-control"
-                name="mapAbstract"
-                data-ng-model="mapProps.recordAbstract"
-                id="mapAbstract"></textarea>
-    </div>
-
-    <div class="form-group"
-         data-ng-show="groups && groups.length > 1">
-      <label data-translate="">group</label>
-      <div data-groups-combo=""
-           data-optional="{{user.isAdministrator()}}"
-           data-owner-group="mapProps.group"
-           lang="lang"
-           data-groups="groups"
-           data-profile="Editor"
-           data-exclude-special-groups="true"/>
-    </div>
-
-    <input type="hidden"
-           name="publishedToAll"
-           data-ng-model="mapProps.publishToAll"/>
-
-    <div class="btn-group dropup">
-      <button type="button" class="btn btn-default"
-              data-gn-click-and-spin="saveInCatalog($event)"
-              title="{{'saveInCatalog'|translate}}">
-        <i class="fa fa-save"/>
-        <span data-translate="">saveMapInCatalogAction</span>
-      </button>
-      <button type="button"
-              class="btn btn-default dropdown-toggle"
-              data-toggle="dropdown">
-        <span class="caret"></span>&nbsp;
-      </button>
-      <ul class="dropdown-menu pull-right" role="menu">
-        <li><a
-          title="{{'saveInCatalogAndPublish-help' | translate}}"
-          data-gn-click-and-spin="saveInCatalog($event, true)"
-          href="">
-          <i class="fa fa-unlock"/>
-          <span data-translate="">saveMapInCatalogActionAndPublish</span>
-        </a></li>
-      </ul>
-    </div>
-
-
-
-
-    <p data-ng-if="mapUuid != null"
-        data-translate=""
-        data-translate-values="{uuid: '{{mapUuid}}'}">mapSavedInCatalog</p>
-  </form>
-
+  <!-- /search form -->
 </div>
 
 <input class="hidden" type="file"

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
@@ -3,7 +3,7 @@
 
   <div class="btn-group" role="group">
     <!-- upload -->
-    <div class="btn-group width-33" role="group">
+    <div class="btn-group" role="group" data-ng-class="isSaveMapInCatalogAllowed && user.isEditorOrMore() ? 'width-33' : 'width-50'">
       <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span data-translate="">load</span>
         <span class="caret"></span>
@@ -24,7 +24,7 @@
       </ul>
     </div>
     <!-- download -->
-    <div class="btn-group width-33" role="group">
+    <div class="btn-group" role="group" data-ng-class="isSaveMapInCatalogAllowed && user.isEditorOrMore() ? 'width-33' : 'width-50'">
       <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span data-translate="">download</span>
         <span class="caret"></span>

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/partials/owscontext.html
@@ -141,6 +141,9 @@
           <i class="fa fa-refresh"/>
       </a>
     </h4>
+    <div data-ng-show="searchResults.records.length == 0">
+      <span data-translate="">noMaps</span>
+    </div>
     <div data-ng-show="searchResults.records.length > 0"
         data-gn-results-container=""
         data-search-results="searchResults"

--- a/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
@@ -34,42 +34,26 @@
          data-translate="">
         {{('noRecordFoundWithResourceRegistered' + mode) | translate}}
     </div>
-    <div data-ng-show="searchResults.records.length > 0">
-      <div class="pull-right"
-           data-gn-pagination="paginationInfo"
-           data-hits-values="searchObj.hitsperpageValues"></div>
-    </div>
-    <br/>
-    <br/>
 
-
-    <ul class="list-group">
-      <li class="list-group-item gn-searchlayer"
+    <ul class="gn-searchlayer-list">
+      <li class="gn-searchlayer"
           data-ng-repeat="m in searchResults.records"
           data-ng-init="md = getMetadata(m)">
-
-        <table>
-          <tr>
-            <th colspan="2">
-              {{md.title || md.defaultTitle}}
-              <a class="btn btn-cog"
-                 data-ng-href="#/metadata/{{md.getUuid()}}"
-                 title="{{'openRecord' | translate}}">
-                <i class="fa fa-fw fa-info-circle"/>
-              </a>
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <div class="gn-md-thumbnail">
-                <img class="gn-img-thumbnail"
-                     alt="{{md.title || md.defaultTitle}}"
-                     data-ng-src="{{md.getThumbnails().list[0].url}}"
-                     data-ng-if="md.getThumbnails().list[0].url"/>
-              </div>
-            </td>
-            <td>
-              <ul>
+        <h3>
+          <a data-ng-href="#/metadata/{{md.getUuid()}}"
+            title="{{'openRecord' | translate}}">
+          {{md.title || md.defaultTitle}}
+          </a>
+        </h3>
+        <div class="clearfix">
+          <div class="gn-md-thumbnail pull-left">
+            <img class="gn-img-thumbnail"
+                  alt="{{md.title || md.defaultTitle}}"
+                  data-ng-src="{{md.getThumbnails().list[0].url}}"
+                  data-ng-if="md.getThumbnails().list[0].url"/>
+          </div>
+          <div class="pull-left">
+            <ul>
                 <li data-ng-repeat="link in md.relevantLinks">
                   <a data-ng-click="addToMap(link)">
                     {{link.desc || link.name}}&nbsp;
@@ -81,10 +65,14 @@
                   </a>
                 </li>
               </ul>
-            </td>
-          </tr>
-        </table>
+          </div>
+        </div>
       </li>
     </ul>
+    <div data-ng-show="searchResults.records.length > 0">
+      <div class="pull-right"
+            data-gn-pagination="paginationInfo"
+            data-hits-values="searchObj.hitsperpageValues"></div>
+    </div>
   </form>
 </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -412,8 +412,9 @@
         scope: {
           collection: '='
         },
-        template: "<ul class='list-group'><li data-ng-show='collection.length > 10' >" +
-            "<input class='form-control input-sm' data-ng-model-options='{debounce: 200}' data-ng-model='layerSearchText'/>" +
+        template: "<ul class='gn-layer-tree'><li data-ng-show='collection.length > 10' >" +
+            "<div class='input-group input-group-sm'><span class='input-group-addon'><i class='fa fa-filter'></i></span>" + 
+            "<input class='form-control' data-ng-model-options='{debounce: 200}' data-ng-model='layerSearchText'/></div>" +
             "</li>" +
             '<gn-cap-tree-elt ng-repeat="member in collection | filter:layerSearchText | orderBy: \'Title\'" member="member">' +
             '</gn-cap-tree-elt></ul>'
@@ -447,8 +448,8 @@
           var el = element;
 
           scope.toggleNode = function(evt) {
-            el.find('.fa').first().toggleClass('fa-folder-o')
-                .toggleClass('fa-folder-open-o');
+            el.find('.fa').first().toggleClass('fa-folder-open-o')
+                .toggleClass('fa-folder-o');
             el.children('ul').toggle();
             evt.stopPropagation();
           };
@@ -461,7 +462,7 @@
 
           // Add all subchildren
           if (angular.isArray(scope.member.Layer)) {
-            element.append("<gn-cap-tree-col class='list-group' " +
+            element.append("<gn-cap-tree-col " +
                 "collection='member.Layer'></gn-cap-tree-col>");
             $compile(element.find('gn-cap-tree-col'))(scope);
           }

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/layer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/layer.html
@@ -1,6 +1,4 @@
-<li class="list-group-item"
-    data-ng-class='::!isParentNode ? "leaf" : ""'>
-
+<li data-ng-class='::!isParentNode ? "leaf" : ""'>
   <div class="flex-col">
     <div class="flex-row width-100 flex-align-stretch">
       <div class="flex-col flex-grow">
@@ -9,22 +7,23 @@
            data-ng-click="isParentNode ? toggleNode($event) : addLayer(null, $event)"
            title="{{member.Title || member.title}}">
           <i class='fa fa-fw'
-             data-ng-class='::isParentNode ? "fa-folder-o" : ""'></i>
+             data-ng-class='::isParentNode ? "fa-folder-open-o" : "fa-map-o"'></i>
           {{member.Title || member.title}}
           <span data-ng-if="member.Style.length === 1">
             &nbsp;({{member.Style[0].Title}})
           </span>
         </a>
       </div>
-      <div class="flex-spacer"></div>
-      <div class="flex-col">
+      <div class="gn-layer-toolbar btn-group btn-group-xs">
         <div class="gn-layer-actions"
-             data-ng-if="!isParentNode && member.Style.length > 1">
+            data-ng-if="!isParentNode && member.Style.length > 1">
           <div gn-popover
                gn-popover-placement="bottom">
             <a gn-popover-anchor role="button"
                tabindex="0"
-               class="fa fa-paint-brush">
+               class="btn btn-link btn-xs"
+              >
+              <i class="fa fa-paint-brush"></i>
               <i class="fa fa-fw fa-caret-down"></i>
             </a>
 
@@ -34,14 +33,14 @@
             </div>
           </div>
         </div>
+        <a href=""
+          class="btn btn-link btn-xs"
+          data-ng-click="isParentNode ? toggleNode($event) : addLayer(null, $event)"
+          data-ng-if="!isParentNode" class="btn btn-default btn-xs"
+          title="{{(isParentNode ? 'showGroupLayers' : 'addToMap') | translate}}">
+          <i class="fa fa-fw fa-plus"></i>
+        </a>
       </div>
-      <div class="flex-spacer" data-ng-if="member.Style.length > 1"></div>
-      <a href=""
-         class="fa fa-fw fa-plus"
-         data-ng-click="isParentNode ? toggleNode($event) : addLayer(null, $event)"
-         data-ng-if="!isParentNode" class="btn btn-default btn-xs"
-         title="{{(isParentNode ? 'showGroupLayers' : 'addToMap') | translate}}">
-      </a>
     </div>
   </div>
 </li>

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/styles.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/styles.html
@@ -1,6 +1,6 @@
 <div data-ng-show="styles.length > 1">
   <div data-ng-hide="layout === 'select'">
-    <h5>{{styles.length + '&nbsp;' + ('layerStylesAvailable' | translate)}}</h5>
+    <label>{{styles.length + '&nbsp;' + ('layerStylesAvailable' | translate)}}</label>
     <ul>
       <li data-ng-repeat="s in styles | orderBy:'Title'"
           class="flex-row width-100">

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/style/layertree.less
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/style/layertree.less
@@ -1,22 +1,32 @@
 .layerTree {
-  li {
-    padding: 2px;
-  }
-  ul ul {
-    margin: 2px 0 0 0;
-    padding-left: 5px;
-    .list-group-item {
-      border-width: 1px 0 0 0;
-      border-radius: 0;
+  .gn-layer-tree {
+    padding: 0;
+    list-style: none;
+    ul {
+      margin-left: 20px;
+      li {
+        padding: 0px;
+        list-style: none;
+      }
+    } 
+    a {
+      line-height: 22px;
+      padding: 3px 0;
+      &:active, &:focus {
+        text-decoration: none;
+      }
     }
-    display: none;
-  }
-  a {
-    line-height: 22px;
-    &:hover, &:active {
-      text-decoration: none;
+    .gn-layer-actions {
+      white-space: nowrap;
+    }
+    .gn-layer-toolbar {
+      float: right;
+      .btn-link {
+        color: #000;
+      }
     }
   }
+
   label {
     color: #444;
     font-weight: normal;
@@ -46,23 +56,14 @@
       }
     }
   }
-  .form-group {
-    margin-bottom: 0;
-  }
-  .list-group {
-    background-color: #fff;
-    margin-bottom: 10px;
-  }
-  .list-group-item {
-    padding-left: 2px;
-  }
   .dropdown-menu {
     width: 100%;
     font-size: 12px;
-    a {
-      padding: 3px 0 3px .5em;
-      margin-right: .5em;
-      overflow-x: hidden;
+    li {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 95%;
     }
   }
   .truncate {
@@ -72,30 +73,10 @@
     white-space: nowrap;
   }
   .popover {
-    max-width: 0;
+    max-width: 250px;
+    width: 250px;
     li {
       padding: 2px 0px;
     }
-  }
-}
-.layers, .layerTree {
-  max-height: 50em;
-  transition: max-height .25s ease;
-}
-[gn-wms-import="wms"], [gn-wms-import="wfs"] {
-  .list-group {
-    .list-group {
-      max-height: 250px;
-      overflow: auto;
-    }
-  }
-}
-[gn-wms-import="wmts"] {
-  .list-group {
-    max-height: 250px;
-    overflow: auto;
-  }
-  .truncate {
-    width: 15em;
   }
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -43,6 +43,7 @@
   "mapSavedInCatalog": "<a href='#/metadata/{{uuid}}'>View map metadata record</a>.",
   "mapAbstract": "Map abstract",
   "loadAMap": "Load a map",
+  "noMaps": "No maps found",
   "topMaps": "Latest maps",
   "uploadContext": "From file",
   "resetContext": "Default map",

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -248,6 +248,9 @@
       .btn {
         flex: 1;
       }
+      .dropdown-menu > li > a {
+        padding: 8px 20px;
+      }
     }
     .flux, .context {
       margin: .2em;
@@ -293,6 +296,9 @@
         clear: both;
         margin-top: 1.3em;
       }
+    }
+    h4 {
+      margin: 1em 0 0.5em 0;
     }
     h5 {
       margin: .2em 0;

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -219,12 +219,37 @@
     .gn-layer-outofrange > label {
       color: #999;
     }
-    .gn-searchlayer {
-      label {
-        font-size: 90%;
-        max-width: 68%;
+    .gn-searchlayer-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      .clearfix();
+      .gn-searchlayer {
+        h3 {
+          font-size: 16px;
+          margin: 10px 0;
+          color: #333;
+        }
+        label {
+          font-size: 90%;
+          max-width: 68%;
+        }
+        ul {
+          padding: 0 0 0 20px;
+          list-style: none;
+          li {
+            margin-bottom: 3px;
+            a {
+              cursor: pointer;
+              &:hover {
+                text-decoration: none;
+              }
+            }
+          }
+        }
       }
     }
+
     .list-group-item {
       transition: max-height @transition-params;
       &:hover {


### PR DESCRIPTION
UI improvements for some panels on the map: `Add layer from` and `Maps`. 

The layer tree on `Add layer from` is simplified (and the filter input now has an icon) and buttons and panels on the `Maps` panel have been reordered and are only shown when needed or logged in.

**Screenshots of the new layout**
![gn-mappanel-maps](https://user-images.githubusercontent.com/19608667/71672063-31e90600-2d75-11ea-9450-125781b49403.png)

![gn-mappanel-tree](https://user-images.githubusercontent.com/19608667/71672082-3f05f500-2d75-11ea-8265-7a421c66b838.png)
