### PR TITLE
Viewer / add setting to allow autofit on layer added from record

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -630,6 +630,18 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <div data-ng-switch-when="autoFitOnLayer">
+        <input type="checkbox"
+               id="{{key}}-checkbox"
+               data-ng-model="mCfg[key]"/>&nbsp;
+        <label class="control-label"
+               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
       <div data-ng-switch-when="grid">
         <h3>{{('ui-' + key) | translate}}</h3>
         <label class="control-label" translate>gridConfigRelatedTypes</label>

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -193,8 +193,15 @@
                       gnMap.feedLayerWithRelated(layer, config.group);
 
                       var extent = layer.get('cextent') || layer.get('extent');
+                      var autofit = gnViewerSettings.mapConfig.autoFitOnLayer;
+                      var message = extent && !autofit ? 'layerAdded' : 'layerAddedNoExtent';
+
+                      if (autofit) {
+                        scope.map.getView().fit(extent);
+                      }
+
                       gnAlertService.addAlert({
-                        msg: $translate.instant('layerAdded', {
+                        msg: $translate.instant(message, {
                           layer: layer.get('label'),
                           extent: extent ? extent.join(',') : ''
                         }),

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -246,7 +246,8 @@ goog.require('gn_alert');
             'context': '',
             'extent': [0, 0, 0, 0],
             'layers': [{'type': 'osm'}]
-          }
+          },
+          'autoFitOnLayer': false
         },
         'geocoder': {
             'enabled': true,

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1433,5 +1433,7 @@
     "removeAllLinksAndStatusConfirm": "Are you sure to remove all links and status history?",
     "moreLinks": "More links ...",
     "ui-defaultSearchString":"Default search",
-    "ui-defaultSearchString-help":"This configuration lets you define a default filter for the search. The syntax is the one used in the angular facet query array."
+    "ui-defaultSearchString-help":"This configuration lets you define a default filter for the search. The syntax is the one used in the angular facet query array.",
+    "ui-autoFitOnLayer":"Always zoom on data",
+    "ui-autoFitOnLayer-help":"If checked, the map will automatically zoom on data when adding a layer from a record. Otherwise, a message will be shown to let the user zoom on data manually."
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -127,6 +127,7 @@
   "nolayer": "No layer",
   "layers": "layers",
   "layerAdded": "Layer '{{layer}}' added to the map. Click <a href=\"#map?extent={{extent}}\">here to zoom to it</a>.",
+  "layerAddedNoExtent": "Layer '{{layer}}' added to the map.",
   "localLayerFile": "{{layer}} (local file)",
   "mostPopular": "Most popular",
   "mapImportFailure": "Failed to import layer",


### PR DESCRIPTION
This PR adds a new behaviour, disabled by default, where the map viewer automatically zoom in when adding a layer from a record. The standard behaviour shows this message:

![image](https://user-images.githubusercontent.com/10629150/71728016-447a4280-2e3c-11ea-8647-29af16673e86.png)

The added behaviour is the same as if the user was immediately clicking on the link in the message, and shows the following message:

![image](https://user-images.githubusercontent.com/10629150/71728132-8dca9200-2e3c-11ea-9c7a-978151220ebc.png)

This is controlled by the new UI setting `map/autoFitOnLayer`.

Note: I personally think this should be the default behaviour since most users don't even see this message, so if other people agree I can change it in the PR.