### PR TITLE
Allow to exclude elements from flatModeExceptions

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -490,6 +490,17 @@ relevant to have parent defined to have more control over the list.
       <xs:attribute ref="use"/>
       <xs:attribute ref="addDirective"/>
       <xs:attribute name="xpath" type="xs:string" use="optional"/>
+      <xs:attribute name="excludeFrom" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+        Used in for elements in flatModeException to exclude them from this mode if the parent of the element is listed in this attribute.
+
+        For example, apply flatModeExceptions to all gmd:contact, except for the ones in gmd:MD_MaintenanceInformation.
+        ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
 
@@ -691,7 +702,7 @@ A good default config with all directives is:
       </sidePanel>
 
 
-For the online source panel, the list of choices can be overridden with a "config-id" attribute 
+For the online source panel, the list of choices can be overridden with a "config-id" attribute
 pointing to a JSON configuration file in config/associated-panel. This file allows to customize
 the list of type of link user can set by defining for each type the list of fields to display and
 default values for fields (eg. protocol, function, application profile).
@@ -951,7 +962,7 @@ Adding a section to a tab
 A section is a group of fields. If a name attribute is provided,
 then it will create an HTML fieldset which is collapsible.
 If no name attribute is provided, then it just render the inner elements.
-For example, if you need a tab without a root fieldset, juste create 
+For example, if you need a tab without a root fieldset, juste create
 the mandatory section with no name and then the inner elements.
 
 
@@ -1789,20 +1800,20 @@ An autocompletion list based on a thesaurus.
             <xs:enumeration value="data-gn-directory-entry-selector">
               <xs:annotation>
                 <xs:documentation><![CDATA[
-This field facilitates users in selecting a `subtemplate` (also known as xml-snippet) from the catalogue. Subtemplates are mostly used to store contact details, 
-but can also be used to store snippets of xml having Quality reports, Access constraints, CRS definitions, etc. 
+This field facilitates users in selecting a `subtemplate` (also known as xml-snippet) from the catalogue. Subtemplates are mostly used to store contact details,
+but can also be used to store snippets of xml having Quality reports, Access constraints, CRS definitions, etc.
 
 .. code-block:: xml
 
-    <for name="gmd:report" 
-      addDirective="data-gn-directory-entry-selector" 
+    <for name="gmd:report"
+      addDirective="data-gn-directory-entry-selector"
       xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_DomainConsistency/gmd:result">
-      <directiveAttributes 
-        data-template-add-action="true" 
-        data-search-action="true" 
-        data-popup-action="false" 
-        data-filter='{"_root": "gmd:DQ_DomainConsistency"}' 
-        data-template-type="report" 
+      <directiveAttributes
+        data-template-add-action="true"
+        data-search-action="true"
+        data-popup-action="false"
+        data-filter='{"_root": "gmd:DQ_DomainConsistency"}'
+        data-template-type="report"
         data-insert-modes="text" />
     </for>
                 ]]></xs:documentation>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
@@ -173,7 +173,7 @@
       test="$isEditing and
             (
               not($isFlatMode) or
-              gn-fn-metadata:isFieldFlatModeException($viewConfig, $name)
+              gn-fn-metadata:isFieldFlatModeException($viewConfig, $name,  name(..))
             ) and
             $service != 'embedded' and
             count(following-sibling::node()[name() = $name]) = 0">

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
@@ -51,7 +51,7 @@
                   select="gn-fn-metadata:getFieldAddDirective($editorConfig, $name)"/>
 
     <xsl:variable name="flatModeException"
-                  select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name)"/>
+                  select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name,  name(..))"/>
 
     <xsl:if test="$isEditing and (not($isFlatMode) or $flatModeException)">
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -3141,7 +3141,7 @@
                    data-ng-if="gnCurrentEdit.geoPublisherConfig"
                    data-config="{{gnCurrentEdit.geoPublisherConfig}}"
                    data-lang="lang"/>
-        
+
         <directive data-gn-suggestion-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
@@ -3178,6 +3178,11 @@
       </tab>
 
       <!-- Elements that should not use the "flat" mode -->
+      <!-- Use excludeFrom attribute to don't apply flat mode exception if the element parent is in that list. For example:
+            <for name="gmd:contact" excludeFrom="gmd:MD_MaintenanceInformation"/>
+
+            Applies flat mode exceptions for all gmd:contact, except for the ones in gmd:MD_MaintenanceInformation.
+      -->
       <flatModeExceptions>
         <for name="gmd:descriptiveKeywords"/>
         <for name="gmd:keyword"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -69,7 +69,7 @@
 
     <xsl:variable name="name" select="concat(@prefix, ':', @name)"/>
     <xsl:variable name="flatModeException"
-                  select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name)"/>
+                  select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name,  name(..))"/>
 
 
     <xsl:if test="$name = 'gmd:descriptiveKeywords' and count(../gmd:descriptiveKeywords) = 0">

--- a/web/src/main/webapp/xslt/common/functions-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/functions-metadata.xsl
@@ -452,11 +452,12 @@
           for[@name = $name and @addDirective]/
           directiveAttributes/@*"/>
   </xsl:function>
-  
+
   <!-- Return if a flat mode exception has been defined in the current view for a field. -->
   <xsl:function name="gn-fn-metadata:isFieldFlatModeException" as="xs:boolean">
     <xsl:param name="configuration" as="node()?"/>
     <xsl:param name="name" as="xs:string"/>
+    <xsl:param name="parent" as="xs:string?" />
 
     <xsl:choose>
       <xsl:when test="not($configuration)">
@@ -464,7 +465,9 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:variable name="exception"
-                      select="count($configuration/flatModeExceptions/for[@name = $name])"/>
+                      select="if (string($parent))
+                  then count($configuration/flatModeExceptions/for[@name = $name and (not(@excludeFrom) or (@excludeFrom and not(contains(@excludeFrom, $parent))))])
+                  else count($configuration/flatModeExceptions/for[@name = $name])"/>
 
         <xsl:value-of select="if ($exception > 0)
                       then true()


### PR DESCRIPTION
For certain elements can be relevant to exclude them from flat mode exceptions, depending on the parent element. For example: don't apply flat mode to `gmd:contact` except if  it's defined in `gmd:MD_MaintenanceInformation`.

Currently if we define:

```
 <flatModeExceptions>
  ...
  <for name="gmd:contact"/>
  ...
</flatModeExceptions>
```

If `gmd:contact` is rendered in non-flat mode, and if not present in the metadata a button to add it is displayed in any element that can contain `gmd:contact` (`gmd:MD_Metadata` and `gmd:MD_MaintenanceInformation`)

![contact_1](https://user-images.githubusercontent.com/1695003/71898189-f5dce900-3158-11ea-8174-b03942fd76a8.png)

With the change we can only apply this for `gmd:MD_Metadata`, excluding it from `gmd:MD_MaintenanceInformation`:

```
 <flatModeExceptions>
  ...
  <for name="gmd:contact" excludeFrom="gmd:MD_MaintenanceInformation"/>
   ...
</flatModeExceptions>
```

![contact_2](https://user-images.githubusercontent.com/1695003/71898333-5704bc80-3159-11ea-8be0-3af59df0aff2.png)
