### PR TITLE
Uniform view for related records in the Metadata view

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -167,12 +167,15 @@
               </div>
 
               <!-- Layers grid directive -->
-              <div data-gn-layers-grid
-                   id="gn-addonlinesrc-layers-row"
-                   data-ng-show="OGCProtocol != null"
-                   data-gn-selection-mode="isEditing ? 'single' : 'multiple'"
-                   data-layers="layers"
-                   data-selection="params.selectedLayers">
+              <div class="form-group">
+                <div data-gn-layers-grid
+                     id="gn-addonlinesrc-layers-row"
+                     class="col-sm-9 col-md-offset-2"
+                     data-ng-show="OGCProtocol != null"
+                     data-gn-selection-mode="isEditing ? 'single' : 'multiple'"
+                     data-layers="layers"
+                     data-selection="params.selectedLayers">
+                </div>
               </div>
 
             </div>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -21,24 +21,15 @@
         </strong>
         <strong data-ng-if="(mainType !== 'WMS') && (mainType !== 'WMSSERVICE') && (mainType !== 'WMTS') &&
                             (mainType !== 'WMTSSERVICE') && (mainType !== 'WFS') && (mainType !== 'WCS')">
-          <i class="fa"
+          <i class="fa fa-question-circle"
              data-ng-class="config.getClassIcon(mainType)"/>&nbsp;
-        </strong>
         </strong>
       </div>
       <div data-ng-class="mainType === 'MDFCATS' ? 'col-xs-11' : 'col-xs-8 col-sm-8'">
-        <!-- WMS & WFS contains layer name in title -->
-        <h3 data-ng-if="((mainType === 'WMS' || mainType === 'WMSSERVICE' ||
-                          mainType === 'WMTS' || mainType === 'WMTSSERVICE' ||
-                          mainType === 'WFS') &&
-                        !isLayerProtocol(r)) &&
-                      mainType !== 'WCS' &&
-                      mainType !== 'LINKDOWNLOAD' &&
-                      mainType !== 'LINK'">
-          {{::(r.title | gnLocalized: lang) || (r.url | gnLocalized: lang)}}
-        </h3>
+        <!-- Always display title if available -->
+        <h3 data-ng-if="::(r.title | gnLocalized: lang).length">{{::(r.title | gnLocalized: lang)}}</h3>
         <!-- Display description if available -->
-        <h4 data-ng-if="(mainType === 'WMS' || mainType === 'WMSSERVICE' ||
+        <p data-ng-if="(mainType === 'WMS' || mainType === 'WMSSERVICE' ||
                        mainType === 'WMTS' || mainType === 'WMTSSERVICE' ||
                        mainType === 'WCS' ||
                        mainType.indexOf('LINK') === 0 ||
@@ -46,7 +37,7 @@
                        r.protocol === 'OGC:WFS') &&
                        r.locDescription.length > 0">
           {{::r.locDescription | striptags | characters:150}}
-        </h4>
+        </p>
         <div data-ng-switch on="mainType">
           <div data-ng-switch-when="WMS">
             <p class="text-muted">
@@ -79,9 +70,9 @@
           <div data-ng-switch-when="WFS">
             <p class="text-muted"
                data-ng-if="isLayerProtocol(r)">
-            <span data-translate=""
-                  data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
-                  wfsLinkDetails</span>
+              <span data-translate=""
+                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                wfsLinkDetails</span>
             </p>
             <div data-ng-if="isLayerProtocol(r)"
                  data-gn-no-map-wfs-download=""
@@ -91,9 +82,9 @@
 
             <p class="text-muted"
                data-ng-if="!isLayerProtocol(r)">
-            <span data-translate=""
-                  data-translate-values="{url:'{{r.url | gnLocalized: lang}}'}">
-              wfsServiceLinkDetails</span>
+              <span data-translate=""
+                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}'}">
+                wfsServiceLinkDetails</span>
             </p>
             <div data-ng-if="!isLayerProtocol(r)"
                  data-gn-no-map-wfs-download=""
@@ -105,26 +96,26 @@
           <div data-ng-switch-when="TMS">
             <span data-translate=""
                   data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
-                  tmsLinkDetails</span>
+              tmsLinkDetails</span>
           </div>
 
           <div data-ng-switch-when="SOS">
             <span data-translate=""
                   data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
-                  sosLinkDetails</span>
+              sosLinkDetails</span>
           </div>
 
           <div data-ng-switch-when="ESRI:REST">
             <span data-translate=""
                   data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
-                  esriRestLinkDetails</span>
+              esriRestLinkDetails</span>
           </div>
 
           <div data-ng-switch-when="WCS">
             <p class="text-muted">
             <span data-translate=""
                   data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
-                  wcsLinkDetails</span>
+              wcsLinkDetails</span>
             </p>
           </div>
 
@@ -145,15 +136,15 @@
             <p class="text-muted">
             <span data-translate=""
                   data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
-          databaseLayerDetails</span>
+              databaseLayerDetails</span>
             </p>
           </div>
 
           <div data-ng-switch-when="FILE">
             <p class="text-muted">
-            <span data-translate=""
-                  data-translate-values="{url:'{{r.url | gnLocalized: lang}}', name:'{{r.title | gnLocalized: lang}}'}">
-          fileLayerDetails</span>
+              <span data-translate=""
+                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', name:'{{r.title | gnLocalized: lang}}'}">
+                fileLayerDetails</span>
               <input class="form-control"
                      type="text"
                      onClick="this.setSelectionRange(0, this.value.length)"
@@ -162,8 +153,7 @@
           </div>
 
           <div data-ng-switch-when="MDFCATS">
-            <h3>{{(r.title | gnLocalized: lang) }}</h3>
-            <h4 data-translate="">technicalInformation</h4>
+            <p data-translate="">technicalInformation</p>
             <div data-gn-attribute-table-renderer="r.featureType.attributeTable.element">
             </div>
           </div>
@@ -171,11 +161,6 @@
           <div data-ng-switch-default>
             <p class="text-muted"
                data-ng-if="mainType.indexOf('MD') == 0 && r.id">
-              <span class="gn-related-title">
-                <a href="#/metadata/{{r.id}}">
-                  {{(r.title | gnLocalized: lang) }}
-                </a> ({{(config.getLabel(mainType, type)) | translate}})
-              </span>
               <span class="gn-related-description">
                 {{ (r.description | gnLocalized: lang | striptags | words:35)}} <a href="#/metadata/{{r.id}}">{{'more' |
                 translate}}...</a>
@@ -184,7 +169,6 @@
 
             <p class="text-muted"
                data-ng-if="mainType.indexOf('MD') == -1">
-              <b>{{r.locTitle}}</b>
               <span ng-bind-html="r.url | gnLocalized: lang | linky:'_blank'"></span>
             </p>
           </div>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedObserverTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedObserverTemplate.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<div data-ng-hide="$parent.gnRelatedLoadFinished">
+<div data-ng-hide="$parent.gnRelatedLoadFinished" class="gn-margin-top gn-margin-bottom">
   <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
   <span class="sr-only">Loading...</span>
 </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
@@ -76,7 +76,7 @@
     <div class="clearfix gn-margin-top gn-margin-bottom text-warning" data-ng-show="typename != ''">
       <div class="fa fa-warning fa-2x fa-fw pull-left"></div>
       <div data-translate=""
-            class="pull-left"
+            class="pull-left width-75"
             data-translate-values="{typename:'{{typename}}'}">wfsTypenameNotAvailable</div>
     </div>
     <div class="row">

--- a/web-ui/src/main/resources/catalog/components/viewer/wmts/partials/wmtsDownload.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmts/partials/wmtsDownload.html
@@ -30,7 +30,7 @@
   <div data-ng-if="isWmtsAvailable && !isLayerInCapabilities" class="clearfix gn-margin-top gn-margin-bottom">
     <div class="fa fa-warning fa-2x fa-fw pull-left"></div>
     <div data-translate=""
-          class="pull-left"
+          class="pull-left width-75"
           data-translate-values="{layerName:'{{layerName}}'}">wmtsLayerNotAvailable</div>
   </div>
   <div class="row" data-ng-if="isWmtsAvailable && !isLayerInCapabilities && isMapViewerEnabled">


### PR DESCRIPTION
In the metadata view the different types of related records weren't always displayed in the same way.
This PR improves this where possible. Titles are now always shown first (as a `<h3>` for a11y), then the description (as a `<p>`). 

Some small changes are made:
- unknown types now have an icon
- warning message (WFS) displayed on the same line
- added margin for the loader icon

The way link details are shown depend on translation strings and are not covered in this PR.

**Screenshot after the changes:**
![gn-related](https://user-images.githubusercontent.com/19608667/71971281-92ab8f00-320a-11ea-96dc-9844df279815.png)
(titles in the screenshot are just for testing, the texts 'Unknown' and 'WFS' are just dummy names)

A small change was made to the online resource add/edit dialog: the layer grid is positioned like the rest of the elements

**Before:**
![gn-related-online-before](https://user-images.githubusercontent.com/19608667/71971362-bf5fa680-320a-11ea-962d-556d7bfa9b8b.png)

**After:**
![gn-related-online-after](https://user-images.githubusercontent.com/19608667/71971377-c5558780-320a-11ea-9053-a5ba513f549b.png)



