### PR TITLE
Fix an error when GN is deployed as ROOT context ("/")

### DIFF
--- a/web/src/main/webResources/WEB-INF/spring-servlet.xml
+++ b/web/src/main/webResources/WEB-INF/spring-servlet.xml
@@ -64,7 +64,7 @@
     <property name="paramName" value="\${language.default}"/>
   </bean>
   <bean id="urlLocaleChangeInterceptor" class="org.fao.geonet.i18n.UrlLocaleChangeInterceptor">
-    <property name="urlPosition" value="0"/>
+    <property name="urlPosition" value="2"/>
   </bean>
 
   <bean id="readWriteMvcInterceptor" class="jeeves.config.springutil.ReadOnlyMvcInterceptor"/>


### PR DESCRIPTION
Fixes #4309. Fixes an `ArrayIndexOutOfBoundsException` that happened when
GeoNetwork is deployed with ROOT ("/") as context name.

It also fix a bug related to the wrong part of the URL being selected as
the locale used in the request.