### PR TITLE
[WIP] Search / Show a summary of active filters in the filter panel

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/facets/FacetDimensionDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/facets/FacetDimensionDirective.js
@@ -360,12 +360,15 @@
             'partials/dimension-facet-recap.html';
         },
         scope: {
-          query: '=gnFacetDimensionRecap',
-          dimensions: '='
+          params: '=',
+          dimensions: '=',
+          facetConfig: '=',
+          removeFilterCallback: '&'
         },
         link: function(scope, element, attrs) {
-          scope.$watch('query', function() {
-            scope.items = scope.query.split('&').map(function (raw) {
+          scope.$watch('params[\'facet.q\']', function() {
+            var query = scope.params['facet.q'] || '';
+            scope.items = query.split('&').map(function (raw) {
               var parts = decodeURIComponent(raw).split('/');
               var dimensionKey = parts[0];
               var categoryValue = parts[1];
@@ -383,11 +386,17 @@
               })
 
               return {
-                dimension: dimension['@label'],
-                category: category['@label']
+                dimensionLabel: dimension['@label'],
+                categoryLabel: category['@label'],
+                category: category
               };
             });
           });
+
+          scope.removeItem = function(item) {
+            scope.categoryKey = item.dimensionLabel;
+            gnFacetConfigService.filter(scope, item.category, false);
+          };
         }
       };
     }]);

--- a/web-ui/src/main/resources/catalog/components/search/facets/FacetDimensionDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/facets/FacetDimensionDirective.js
@@ -349,4 +349,46 @@
         }
       };
     }]);
+
+  module.directive('gnFacetDimensionRecap', [
+    'gnFacetConfigService',
+    function(gnFacetConfigService) {
+      return {
+        restrict: 'A',
+        templateUrl: function(elem, attrs) {
+          return attrs.template || '../../catalog/components/search/facets/' +
+            'partials/dimension-facet-recap.html';
+        },
+        scope: {
+          query: '=gnFacetDimensionRecap',
+          dimensions: '='
+        },
+        link: function(scope, element, attrs) {
+          scope.$watch('query', function() {
+            scope.items = scope.query.split('&').map(function (raw) {
+              var parts = decodeURIComponent(raw).split('/');
+              var dimensionKey = parts[0];
+              var categoryValue = parts[1];
+
+              var dimension, category;
+              scope.dimensions.forEach(function (d) {
+                if (d['@name'] === dimensionKey) {
+                  dimension = d;
+                }
+              });
+              dimension.category.forEach(function (c) {
+                if (c['@value'] === categoryValue) {
+                  category = c;
+                }
+              })
+
+              return {
+                dimension: dimension['@label'],
+                category: category['@label']
+              };
+            });
+          });
+        }
+      };
+    }]);
 })();

--- a/web-ui/src/main/resources/catalog/components/search/facets/FacetDimensionDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/facets/FacetDimensionDirective.js
@@ -416,6 +416,11 @@
             scope.categoryKey = item.dimensionLabel;
             gnFacetConfigService.filter(scope, item.category, false);
           };
+
+          scope.removeAll = function() {
+            scope.params['facet.q'] = undefined;
+            scope.$emit('resetSearch', scope.params, true);
+          }
         }
       };
     }]);

--- a/web-ui/src/main/resources/catalog/components/search/facets/FacetDimensionDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/facets/FacetDimensionDirective.js
@@ -45,7 +45,8 @@
           facetList: '=',
           params: '=',
           tabField: '=',
-          pageSize: '='
+          pageSize: '=',
+          showRecap: '='
         },
         link: function(scope, element, attrs) {
           scope.facetQuery = scope.params['facet.q'];
@@ -368,6 +369,10 @@
         link: function(scope, element, attrs) {
           scope.$watch('params[\'facet.q\']', function() {
             var query = scope.params['facet.q'] || '';
+            if (!query) {
+              scope.items = [];
+              return;
+            }
             scope.items = query.split('&').map(function (raw) {
               var queryParts = raw.split('/');
               var dimensionKey = queryParts[0];

--- a/web-ui/src/main/resources/catalog/components/search/facets/FacetsConfigService.js
+++ b/web-ui/src/main/resources/catalog/components/search/facets/FacetsConfigService.js
@@ -145,8 +145,6 @@
         return category.label;
       };
 
-
-
       /**
        * Check that current category is already used
        * in current filter.
@@ -196,7 +194,12 @@
           }
         }
         return false;
-      };
+      }
+
+      function hasFilter(scope) {
+        var currentFilter = scope.params['facet.q'];
+        return currentFilter !== undefined && currentFilter !== '';
+      }
 
       return {
         loadConfig: loadConfig,
@@ -204,7 +207,8 @@
         buildPath: buildPath,
         buildLabel: buildLabel,
         isInFilter: isInFilter,
-        isOnDrillDownPath: isOnDrillDownPath
+        isOnDrillDownPath: isOnDrillDownPath,
+        hasFilter: hasFilter
       };
     }
   ]);

--- a/web-ui/src/main/resources/catalog/components/search/facets/FacetsConfigService.js
+++ b/web-ui/src/main/resources/catalog/components/search/facets/FacetsConfigService.js
@@ -196,19 +196,13 @@
         return false;
       }
 
-      function hasFilter(scope) {
-        var currentFilter = scope.params['facet.q'];
-        return currentFilter !== undefined && currentFilter !== '';
-      }
-
       return {
         loadConfig: loadConfig,
         filter: filter,
         buildPath: buildPath,
         buildLabel: buildLabel,
         isInFilter: isInFilter,
-        isOnDrillDownPath: isOnDrillDownPath,
-        hasFilter: hasFilter
+        isOnDrillDownPath: isOnDrillDownPath
       };
     }
   ]);

--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-list.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-list.html
@@ -1,5 +1,10 @@
 <div class="gn-facet-list">
 
+  <div gn-facet-dimension-recap="params['facet.q']"
+       data-dimensions="dimension"
+       ng-if="!isTabMode && dimension && hasFilter()">
+  </div>
+
   <!--Collapse all button for first panel-->
   <div class="btn-group width-100 flex-row flex-left" ng-hide="isTabMode">
     <button type="button" class="btn btn-default btn-sm gn-facet-toggle-btn"

--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-list.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-list.html
@@ -4,7 +4,7 @@
        data-params="params"
        data-dimensions="dimension"
        data-facet-config="facetConfig"
-       ng-if="!isTabMode && dimension && hasFilter()">
+       ng-if="showRecap && !isTabMode && dimension">
   </div>
 
   <!--Collapse all button for first panel-->

--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-list.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-list.html
@@ -1,7 +1,9 @@
 <div class="gn-facet-list">
 
-  <div gn-facet-dimension-recap="params['facet.q']"
+  <div gn-facet-dimension-recap
+       data-params="params"
        data-dimensions="dimension"
+       data-facet-config="facetConfig"
        ng-if="!isTabMode && dimension && hasFilter()">
   </div>
 

--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-recap.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-recap.html
@@ -1,7 +1,11 @@
 <div class="gn-dimension-facet-recap alert alert-success small">
-  <div ng-repeat="item in items" class="dimension-category flex-row flex-wrap">
-    <strong class="text-no-wrap text-uppercase" translate>{{item.dimension}}</strong>
+  <a href class="alert-link dimension-category flex-row flex-wrap"
+     title="{{'removeThisFacet' | translate}}"
+     ng-repeat="item in items"
+     ng-click="removeItem(item)">
+    <span class="fa fa-times text-danger delete-icon"></span>
+    <strong class="text-no-wrap text-uppercase" translate>{{item.dimensionLabel}}</strong>
     <div class="flex-spacer"></div>
-    <span class="text-no-wrap text-ellipsis" translate>{{item.category}}</span>
-  </div>
+    <span class="text-no-wrap text-ellipsis" translate>{{item.categoryLabel}}</span>
+  </a>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-recap.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-recap.html
@@ -8,4 +8,9 @@
     <div class="flex-spacer"></div>
     <span class="text-no-wrap text-ellipsis" translate>{{item.categoryLabel}}</span>
   </a>
+  <div ng-if="items.length > 0" class="text-right remove-all-link">
+    <a href ng-click="removeAll()"
+       class="text-danger"
+       translate>removeAllFacets</a>
+  </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-recap.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-recap.html
@@ -1,4 +1,4 @@
-<div class="gn-dimension-facet-recap alert alert-success small">
+<div class="gn-dimension-facet-recap alert alert-success small" ng-if="items.length">
   <a href class="alert-link dimension-category flex-row flex-wrap"
      title="{{'removeThisFacet' | translate}}"
      ng-repeat="item in items"

--- a/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-recap.html
+++ b/web-ui/src/main/resources/catalog/components/search/facets/partials/dimension-facet-recap.html
@@ -1,0 +1,7 @@
+<div class="gn-dimension-facet-recap alert alert-success small">
+  <div ng-repeat="item in items" class="dimension-category flex-row flex-wrap">
+    <strong class="text-no-wrap text-uppercase" translate>{{item.dimension}}</strong>
+    <div class="flex-spacer"></div>
+    <span class="text-no-wrap text-ellipsis" translate>{{item.category}}</span>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -509,5 +509,6 @@
   "moreFacet": "{{count}} more",
   "lessFacet": "{{count}} less",
   "allFacet": "all ({{count}})",
-  "initialFacet": "initial ({{count}})"
+  "initialFacet": "initial ({{count}})",
+  "removeThisFacet": "Remove this filter"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -510,5 +510,6 @@
   "lessFacet": "{{count}} less",
   "allFacet": "all ({{count}})",
   "initialFacet": "initial ({{count}})",
-  "removeThisFacet": "Remove this filter"
+  "removeThisFacet": "Remove this filter",
+  "removeAllFacets": "Remove all filters"
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1169,6 +1169,9 @@ gn-indexing-task-status {
 .flex-align-end { align-items: flex-end; }
 .flex-align-start { align-items: flex-start; }
 .flex-align-stretch { align-items: stretch; }
+.flex-nowrap, .flex-no-wrap { flex-wrap: nowrap; }
+.flex-wrap { flex-wrap: wrap; }
+.flex-wrap-r { flex-wrap: wrap-reverse; }
 .text-wrap { white-space: normal; }
 .text-nowrap, .text-no-wrap { white-space: nowrap; }
 .text-ellipsis { white-space: nowrap; text-overflow: ellipsis; overflow: hidden; }

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -725,10 +725,30 @@ button.active [role=tooltip] {
 
 .gn-dimension-facet-recap {
   padding: @alert-padding*0.75 @alert-padding;
+  a.alert-link {
+    font-weight: initial;
+    &:hover, &:focus {
+      text-decoration: underline;
+    }
+  }
   .dimension-category {
-    line-height: 1em;
+    position: relative;
+    line-height: 1.1em;
+    margin-left: 1em;
     &:not(:last-child) {
       margin-bottom: 0.8em;
+    }
+    .delete-icon {
+      position: absolute;
+      right: calc(~"100% + 3px");
+      top: 0;
+      line-height: 1.1em;
+      opacity: 0;
+    }
+    &:hover, &:focus {
+      .delete-icon {
+        opacity: 1;
+      }
     }
   }
 }

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -722,3 +722,23 @@ button.active [role=tooltip] {
   background-color: white;
   padding-top: 15px;
 }
+
+.gn-dimension-facet-recap {
+  padding: @alert-padding*0.75 @alert-padding;
+  .dimension-category {
+    line-height: 1em;
+    &:not(:last-child) {
+      margin-bottom: 0.8em;
+    }
+  }
+}
+
+.gn-search-facet {
+  // in the facet filter panel, integrate the recap without border
+  .gn-dimension-facet-recap {
+    border-width: 0;
+    border-bottom-width: 1px;
+    border-radius: 0;
+    margin: -@panel-body-padding -@panel-body-padding @line-height-computed -@panel-body-padding;
+  }
+}

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -725,7 +725,7 @@ button.active [role=tooltip] {
 
 .gn-dimension-facet-recap {
   padding: @alert-padding*0.75 @alert-padding;
-  a.alert-link {
+  a.alert-link, .remove-all-link > a {
     font-weight: initial;
     &:hover, &:focus {
       text-decoration: underline;
@@ -750,6 +750,9 @@ button.active [role=tooltip] {
         opacity: 1;
       }
     }
+  }
+  .remove-all-link {
+    margin-bottom: -@alert-padding*0.5;
   }
 }
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -24,7 +24,8 @@
                 data-params="searchObj.params"
                 data-facet-type="facetsSummaryType"
                 data-facet-list="facetConfig"
-                data-current-facets="currentFacets">
+                data-current-facets="currentFacets"
+                data-show-recap="true">
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR adds a directive called `GnFacetDimensionRecap` which shows a compact summary of all active filters in the filter panel:
![image](https://user-images.githubusercontent.com/10629150/72345891-1535c200-36d5-11ea-9625-97cda8437d01.png)

Users can click on single filters in the summary to remove them, or clear all filters.

The summary works for special path-like keywords such as the GEMET thesaurus.

This is only active in the main search (not in the editor board or others) and currently cannot be deactivated. Please let me know if you think a UI option should be given to hide this. Thanks!