### PR TITLE
OWS Service / give higher priority to layer name than metadata/id when looking up layer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -468,22 +468,25 @@
                 }
 
                 //either names match or non namespaced names
+                // note: these matches are put at the beginning of the needles array
                 if (name == capName || nameNoNamespace == capNameNoNamespace) {
                   layers[i].nameToUse = capName;
                   if (capObj.version) {
                     layers[i].version = capObj.version;
                   }
-                  needles.push(layers[i]);
+                  needles.unshift(layers[i]);
                   break capabilityLayers;
                 }
 
                 //check dataset identifer match
+                // note: these matches are put at the end of the needles array
+                // because they are lower priority than the layername matches
+                // and the loop is not stopping after them
                 if (uuid != null) {
                   if (angular.isArray(layers[i].Identifier)) {
                     for (var c = 0; c < layers[i].Identifier.length; c++) {
                       if (layers[i].Identifier[c] == uuid) {
                         needles.push(layers[i]);
-                        break capabilityLayers;
                       }
                     }
                   }
@@ -493,7 +496,6 @@
                       if (mdu && mdu.OnlineResource &&
                         mdu.OnlineResource.indexOf(uuid) > 0) {
                         needles.push(layers[i]);
-                        break capabilityLayers;
                       }
                     }
                   }


### PR DESCRIPTION
Sometimes in a GetCapabilities response several Layer objects can be pointed to the same metadata record, such breaking right after the first metadata UUID and/or identifier match would mean we might be at the wrong Layer object.

This can be tested with the following record:
https://sextant.ifremer.fr/geonetwork/srv/api/records/f8ed7346-94ae-4a86-b38e-3b07f7e5bf6a/formatters/xml

Without this PR, the second WMS layer of this record ("Chenaux de la baie de Saint Brieuc") cannot be added to the map because the layer lookup always finds the first layer ("Habitats benthiques...").

The behaviour should not be changed other than that.

@fxprunayre apparently you're the last one to have modified this logic, please let me know if you think that fix is acceptable! thanks