### PR TITLE
Date picker directive - use utc format to process the date. Fixes #4260

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/datepicker/DatePickerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/datepicker/DatePickerDirective.js
@@ -94,7 +94,7 @@
              } else {
                var isDateTime = scope.value.indexOf('T') !== -1;
                var tokens = scope.value.split('T');
-               scope.date = new Date(isDateTime ? tokens[0] : scope.value);
+               scope.date = new Date(moment(isDateTime ? tokens[0] : scope.value).utc().format());
                scope.time = isDateTime ?
                moment(tokens[1], 'HH:mm:ss').toDate() :
                undefined;


### PR DESCRIPTION
Check details in #4260.

Tested with GMT+1 (Europe) and GMT-5 (Canada) and looks working fine.