### PR TITLE
Fix for too wide logo in result list

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -213,6 +213,9 @@ ul.gn-resultview {
     }
     .gn-md-logo {
       margin-top: 5px;
+      img {
+        max-width: 100%;
+      }
     }
     .gn-md-thumbnail {
       border-radius: 0;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -65,7 +65,7 @@
   }
 }
 .gn-source-logo {
-  max-width: 60px;
+  max-width: 100%;
   max-height: 60px;
 }
 


### PR DESCRIPTION
When you change the catalog logo and choose a very wide one, the view in the search result list is broken. This PR adds a `max-width` to the logo so it's displayed properly.

**Before**
![gn-logo-before](https://user-images.githubusercontent.com/19608667/72730717-30e80f00-3b92-11ea-817f-a25f982253b7.png)

**After**
![gn-logo-after](https://user-images.githubusercontent.com/19608667/72730728-38a7b380-3b92-11ea-9c26-d1b4e8cf65a7.png)
