### PR TITLE
avoid rss search to send link with two slashes

### DIFF
--- a/web/src/main/webapp/xslt/services/rss/rss-utils.xsl
+++ b/web/src/main/webapp/xslt/services/rss/rss-utils.xsl
@@ -42,7 +42,7 @@
 
       <xsl:variable name="metadata" select="exslt:node-set($md)/*[1]"/>
       <xsl:variable name="mdURL"
-                    select="normalize-space(concat($baseURL, '/', /root/gui/nodeId, '/metadata/', gn:info/uuid))"/>
+                    select="normalize-space(concat($baseURL, /root/gui/nodeId, '/metadata/', gn:info/uuid))"/>
       <xsl:variable name="thumbnailLink" select="$metadata/image[starts-with(., 'http')]"/>
       <xsl:variable name="bDynamic" select="gn:info/dynamic"/>
       <xsl:variable name="bDownload" select="gn:info/download"/>


### PR DESCRIPTION
It should avoid bot requests to load plenty of stack traces in logs.