### PR TITLE
Search / Improve the search active filters display

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -35,6 +35,9 @@
           link: function(scope, element, attrs, ngSearchFormCtrl) {
             scope.currentFilters = [];
 
+            // key is the raw facet path, value is a valid filter object
+            scope.facetFilterCache = {};
+
             function getSearchParams() {
               if (scope.useLocationParameters) {
                 return $location.search();
@@ -59,6 +62,10 @@
 
             function createNewFiltersFromFacets(facetParam) {
               return facetParam.split('&').map(function (raw) {
+                if (scope.facetFilterCache[raw]) {
+                  return scope.facetFilterCache[raw];
+                }
+
                 var queryParts = raw.split('/');
                 var dimensionKey = queryParts[0];
 
@@ -68,10 +75,6 @@
                     dimension = d;
                   }
                 });
-
-                if (!dimension) {
-                  return
-                }
 
                 var categoryLabel, rootPath = decodeURIComponent(queryParts[1]);
                 function lookupCategory(categories, currentQueryPartIndex) {
@@ -91,12 +94,14 @@
                   lookupCategory(dimension.category, 1);
                 }
 
-                return {
+                var filter = {
                   key: dimension['@label'],
                   value: categoryLabel || rootPath,
                   isFacet: true,
                   facetKey: dimension['@name']
                 };
+                scope.facetFilterCache[raw] = filter;
+                return filter;
               });
             }
 

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -156,6 +156,17 @@
                   continue;
                 }
 
+                // special logic for categories: add cat- prefix to each category for translations
+                if (filterKey === '_cat') {
+                  scope.currentFilters.push({
+                    key: filterKey,
+                    value: value.split(' or ').map(function(val) {
+                      return 'cat-' + val;
+                    }).join(' or ')
+                  });
+                  continue;
+                }
+
                 // general case
                 scope.currentFilters.push({
                   key: filterKey,

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -151,7 +151,7 @@
                 if (filterKey === 'geometry') {
                   scope.currentFilters.push({
                     key: 'geometry',
-                    value: 'boundingBox'
+                    value: 'geometryFilter'
                   });
                   continue;
                 }

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -76,27 +76,28 @@
                   }
                 });
 
-                var categoryLabel, rootPath = decodeURIComponent(queryParts[1]);
-                function lookupCategory(categories, currentQueryPartIndex) {
-                  categories.forEach(function (c) {
+                var categoryLabel;
+                function lookupCategory(subtree, currentQueryPartIndex) {
+                  if (!subtree.category) {
+                    return false;
+                  }
+                  subtree.category.forEach(function (c) {
                     if (c['@value'] === decodeURIComponent(queryParts[currentQueryPartIndex])) {
                       currentQueryPartIndex++;
                       if (currentQueryPartIndex === queryParts.length) {
                         categoryLabel = c['@label'];
                         return true;
-                      } else if(c.category) {
-                        lookupCategory(c.category, currentQueryPartIndex);
                       }
+                      lookupCategory(c, currentQueryPartIndex);
                     }
                   })
                 }
-                if (dimension.category) {
-                  lookupCategory(dimension.category, 1);
-                }
+
+                lookupCategory(dimension, 1);
 
                 var filter = {
                   key: dimension['@label'],
-                  value: categoryLabel || rootPath,
+                  value: categoryLabel || decodeURIComponent(queryParts[1]),
                   isFacet: true,
                   facetKey: dimension['@name']
                 };
@@ -109,10 +110,12 @@
               if (!facetQuery) {
                 return;
               }
-              var facets = facetQuery.split('&').filter(function (facet) {
-                return facet.split('/')[0] !== facetKey;
-              });
-              return facets.join('&');
+              return facetQuery
+                .split('&')
+                .filter(function (facet) {
+                  return facet.split('/')[0] !== facetKey;
+                })
+                .join('&');
             }
 
             function removeAllFilters() {
@@ -165,9 +168,12 @@
                 if (filterKey === '_cat') {
                   scope.currentFilters.push({
                     key: filterKey,
-                    value: value.split(' or ').map(function(val) {
-                      return 'cat-' + val;
-                    }).join(' or ')
+                    value: value
+                      .split(' or ')
+                      .map(function(val) {
+                        return 'cat-' + val;
+                      })
+                      .join(' or ')
                   });
                   continue;
                 }

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -3,463 +3,171 @@
 
   goog.require('gn_thesaurus_service');
 
-  var module = angular.module('search_filter_tags_directive',
-      ['gn_thesaurus_service', 'pascalprecht.translate']);
-  module.filter('decodeURIComponent', function() {
-    return window.decodeURIComponent;
-  });
+  var EXCLUDED_PARAMS = [
+    'bboxes',
+    'bucket',
+    'fast',
+    'from',
+    'ownRecords',
+    'resultType',
+    'sortBy',
+    'sortOrder',
+    'to',
+    '_content_type',
+    '_isTemplate',
+    '_owner'];
+
+  var module = angular.module('search_filter_tags_directive', ['pascalprecht.translate']);
 
   module.directive('searchFilterTags',
-      ['$location', 'gnThesaurusService', '$q', '$cacheFactory', '$browser', '$timeout',
-       function($location, gnThesaurusService, $q, $cacheFactory, $browser, $timeout) {
-         var cache = $cacheFactory('locationsSearchFilterTags');
-         var useLocationParameters = true;
-         var thesaurusKey = 'external.place.regions';
+    ['$location',
+      function($location) {
+        return {
+          restrict: 'EA',
+          require: '^ngSearchForm',
+          templateUrl: '../../catalog/components/search/searchfiltertag/'+
+            'partials/searchFilterTagsTemplate.html',
+          scope: {
+            dimensions: '=',
+            useLocationParameters: '='
+          },
+          link: function(scope, element, attrs, ngSearchFormCtrl) {
+            scope.currentFilters = [];
 
-
-         var searchInFilters = function(filters, filterKey, filterType) {
-           var found = false;
-           for (var i = 0; i < filters.length && !found; i++) {
-             var filter = filters[i];
-             found = filter.key === filterKey && filter.type === filterType;
-           }
-
-           return found;
-         };
-
-         var generateCurrentFilters =
-          function(filters, currentFilters, controller) {
-            // Remove old filters not present in filters keeping the old order
-            var deferred = $q.defer();
-
-            var newFilters = [];
-            var newFacets = getFacets(filters['facet.q']);
-            var newLocationsPromise = getLocationsPromise(filters['geometry']);
-            newLocationsPromise.then(function(locations) {
-
-              angular.forEach(currentFilters, function(oldF, index) {
-                if (newFacets.length > 0) {
-                  if (oldF.type == 'facet' &&
-                 searchInFacets(oldF, newFacets).length > 0 &&
-                 searchInFacets(oldF, newFacets)[0].value === oldF.value) {
-                    var label = getLabelForFacet(
-                   oldF.key, oldF.value, controller.getSearchResults());
-
-                    newFilters = newFilters.concat({
-                      type: 'facet',
-                      key: oldF.key,
-                      value: oldF.value,
-                      labelKey: label
-                    });
-                  } else if (oldF.type === 'geometry' &&
-                 searchInGeometries(oldF, locations) > 0) {
-                    newFilters = newFilters.concat({
-                      type: 'geometry',
-                      key: oldF.key,
-                      value: oldF.value
-                    });
-                  } else if (oldF.type === 'boolean' &&
-                 oldF.value === true && filters[oldF.key] !== undefined) {
-                    newFilters = newFilters.concat({
-                      type: 'boolean',
-                      key: oldF.key,
-                      value: true,
-                      labelKey: getLabelKey(oldF.key)
-                    });
-                  } else if (oldF.value === filters[oldF.key]) {
-                    newFilters = newFilters.concat(oldF);
-                  }
-                }
-              });
-
-
-              // Add new filters
-              for (var filterKey in filters) {
-                if (filterKeyIsTaggable(filterKey) &&
-               !(searchInFilters(newFilters, filterKey,
-               getTypeForKey(filterKey))) &&
-               !hasEmptyValue(filters[filterKey])) {
-                  var newFilter =
-                 createNewFilter(filterKey, filters[filterKey]);
-                  if (newFilter.length > 0) {
-                    newFilters = newFilters.concat(newFilter);
-                  }
-                }
-                if (filterKey === 'facet.q') {
-                  angular.forEach(newFacets, function(nf, index) {
-                    if (!searchInFilters(newFilters, nf.dimension, 'facet')) {
-                      newFilters = newFilters.concat(
-                     createNewFilterFromFacets(nf, controller));
-                    }
-                  });
-                }
-                if (filterKey === 'geometry') {
-                  angular.forEach(locations, function(newLocation) {
-                    if (!searchInFilters(newFilters,
-                        newLocation.key, 'geometry')) {
-                      newFilters = newFilters.concat(newLocation);
-                    }
-                  });
-                }
-              }
-              deferred.resolve(newFilters);
-            });
-
-            return deferred.promise;
-
-          };
-
-         var hasEmptyValue = function(value) {
-           if (!angular.isDefined(value) || value === null ||
-            (angular.isString(value) && value.trim() === '')) {
-             return true;
-           } else {
-             return false;
-           }
-         };
-
-         var getLabelForFacet = function(key, value, searchResults) {
-           if (!searchResults || !searchResults.dimension) {
-             return value;
-           }
-
-           var currentDimension =
-            $.grep(searchResults.dimension, function(elem, index) {
-              return elem['@name'] === key;
-            });
-           if (currentDimension.length > 0) {
-             var d = currentDimension[0];
-             // Find label in dimension categories
-             if (d.category) {
-               var category = $.grep(d.category, function(cat, index) {
-                 return cat['@value'] === decodeURIComponent(value);
-               });
-               if (category.length > 0) {
-                 return category[0]['@label'];
-               }
-             }
-           }
-
-           return value;
-
-         };
-
-         /**
-         *
-         * @param {string} key the key of the param
-         * @param {string} filterParam the value of the filter
-         * @return {array}
-         */
-         var createNewFilter = function(key, filterParam) {
-           var result = [];
-           if (getLabelKey(key)) {
-             var newFilter = {};
-             newFilter['type'] = 'boolean';
-             newFilter['value'] = filterParam;
-             newFilter['labelKey'] = getLabelKey(key);
-             newFilter['key'] = key;
-             result.push(newFilter);
-           } else if (key === 'geometry') {
-            /*var newFilter = {};
-             newFilter['type'] = 'geometry';
-             newFilter['value'] = filterParam;
-             newFilter['key'] = key;
-             newFilter['labelKey'] = 'Localisation';
-             result.push(newFilter);*/
-           } else {
-             var newFilter = {};
-             newFilter['key'] = key;
-             newFilter['type'] = 'standard';
-
-             var val = filterParam;
-             if (angular.isArray(val)) {
-               val = val[0];
-             } else if (angular.isObject(val) && val.label && val.label != '') {
-               val = val.label;
-             }
-             newFilter['value'] = angular.isString(val) ? val : '';
-             result.push(newFilter);
-           }
-
-           return result;
-         };
-
-         var getTypeForKey = function(key) {
-           var type = null;
-           if (getLabelKey(key)) {
-             type = 'boolean';
-           } else if (key === 'geometry') {
-             type = 'geometry';
-           } else {
-             type = 'standard';
-           }
-           return type;
-         };
-
-         var createNewFilterFromFacets = function(facet, controller) {
-
-           var newFilter = {};
-           var result = [];
-           var label = getLabelForFacet(
-            facet.dimension, facet.value, controller.getSearchResults());
-           newFilter['type'] = 'facet';
-           newFilter['value'] = facet.value;
-           newFilter['key'] = facet.dimension;
-           newFilter['labelKey'] = label;
-           result.push(newFilter);
-           return result;
-
-         };
-
-         var getLabelKey = function(labelKey) {
-           var availableLabels = {
-             dynamic: 'Visualisation',
-             download: 'DownloadData',
-             nodynamicdownload: 'DataOnRequest'
-           };
-
-           return availableLabels[labelKey];
-
-         };
-
-         var filterKeyIsTaggable = function(filterKey) {
-           var filtersNotTaggables = [
-             'bboxes', 'fast', 'facet.q', 'from', 'geometry',
-             'resultType', 'sortBy', 'sortOrder', '_owner', '_isTemplate',
-             'to', '_content_type', 'ownRecords', 'bucket'];
-           return $.inArray(filterKey, filtersNotTaggables) == -1;
-         };
-
-         var searchInFacets = function(filter, newFacets) {
-           var key = filter.key;
-           return $.grep(newFacets, function(elem, indexInArray) {
-             return elem && elem.dimension && elem.dimension == key;
-           }).length != 0;
-         };
-
-         var searchInGeometries = function(filter, newLocations) {
-           var key = filter.key;
-           return $.grep(newLocations, function(elem, indexInArray) {
-             return elem && elem.key && elem.key == key;
-           }).length != 0;
-         };
-
-
-         var getFacets = function(facetQParam) {
-           var categoryList = [];
-           if (!facetQParam) {
-             return categoryList;
-           }
-           var dimensionList =
-            facetQParam.split('&');
-           $.each(dimensionList, function(idx) {
-             // Dimension filter contains the dimension name first
-             // and then the drilldown path. User may uncheck
-             // an element in the middle of the path. In such case
-             // only activate the parent node.
-             var dimensionFilter = dimensionList[idx].split('/');
-
-             // Dimension but not in that category path. Add filter.
-             if (dimensionFilter.length == 2) {
-               categoryList.push({
-                 dimension: dimensionFilter[0],
-                 value: dimensionFilter[1]
-               });
-             }
-           });
-
-           return categoryList;
-         };
-
-         var getLocationsPromise = function(geometryParam) {
-           var prefix = 'region:';
-           var locations = [];
-           if (!geometryParam || geometryParam.indexOf(prefix) !== 0 ||
-            geometryParam === prefix) {
-             return $q.all();
-           }
-           var locationList =
-            geometryParam.substring(prefix.length).split(/\s*,\s*/);
-           var promises = [];
-           $.each(locationList, function(idx) {
-             promises.push(
-             getKeywordFromUri(locationList[idx]).then(function(kw) {
-               locations.push(
-                {
-                  value: kw.label,
-                  key: kw.props.uri,
-                  type: 'geometry'
-                }
-               );
-             }));
-           });
-           var deferred = $q.defer();
-           $q.all(promises).then(function() {
-             deferred.resolve(locations);
-           });
-           return deferred.promise;
-         };
-
-         var getKeywordFromUri = function(uri) {
-           var defer = $q.defer();
-           if (!cache.get(uri)) {
-             gnThesaurusService.lookupURI(
-              thesaurusKey, uri).then(
-             function(keyword) {
-               if (keyword) {
-                 var kw = {};
-                 kw['label'] =
-                 keyword.prefLabel[Object.keys(keyword.prefLabel)[0]];
-                 kw['props'] = {};
-                 kw['props']['uri'] = keyword.uri;
-                 cache.put(uri, kw);
-                 defer.resolve(kw);
-               } else {
-                 // defer.reject(keyword);
-               }
-
-             }, function(rejected) {
-               defer.reject(rejected);
-             });
-           } else {
-             $browser.defer(function() {
-               defer.resolve(cache.get(uri));
-             });
-           }
-           return defer.promise;
-         };
-
-         var buildQParam = function(facetsArray) {
-           // Build facet.q
-           var facetQParam = '';
-           $.each(facetsArray, function(idx, facet) {
-             if (facet.value) {
-               facetQParam = facetQParam +
-                facet.key +
-                '/' +
-                facet.value +
-                (idx < facetsArray.length - 1 ? '&' : '');
-             }
-           });
-           return facetQParam;
-         };
-
-         var buildGeometryParam = function(locationsArray) {
-           var geometryParam = 'region:';
-           var locations = [];
-           if (locationsArray && locationsArray.length > 0) {
-             $.each(locationsArray, function(idx, location) {
-               locations.push(location.key);
-             });
-           } else {
-             return null;
-           }
-           return geometryParam + locations.join(',');
-         };
-
-         var getSearchParameters =
-          function(useLocation, locationProvider, controller) {
-            if (useLocation) {
-              return locationProvider.search();
-            } else {
-              return controller.getFinalParams();
-            }
-          };
-
-         var setSearchParameter =
-          function(useLocation, locationProvider,
-                   controller, paramKey, paramValue) {
-            if (useLocation) {
-              locationProvider.search(paramKey, paramValue);
-            } else {
-              var params = controller.getSearchParams();
-              if (paramValue == null) {
-                delete params[paramKey];
+            function getSearchParams() {
+              if (scope.useLocationParameters) {
+                return $location.search();
               } else {
-                params[paramKey] = paramValue;
+                return ngSearchFormCtrl.getFinalParams();
               }
-
             }
-          };
 
-         return {
-           restrict: 'EA',
-           require: '^ngSearchForm',
-           templateUrl: '../../catalog/components/' +
-           'search/searchfiltertag/partials/' +
-           'searchFilterTagsTemplate.html',
-           scope: {
-             privateVar: '@',
-             useLocationParameters: '@',
-             thesaurusKey: '@'
-           },
-           link: function(scope, element, attrs, ngSearchFormCtrl) {
-             if (scope.useLocationParameters === 'false') {
-               useLocationParameters = false;
-             }
+            function setSearchParameter(paramKey, paramValue) {
+              if (scope.useLocationParameters) {
+                $location.search(paramKey, paramValue);
+              } else {
+                var params = ngSearchFormCtrl.getSearchParams();
+                if (!paramValue) {
+                  delete params[paramKey];
+                } else {
+                  params[paramKey] = paramValue;
+                }
+                ngSearchFormCtrl.triggerSearch();
+              }
+            }
 
-             if (scope.thesaurusKey && scope.thesaurusKey !== '') {
-               thesaurusKey = scope.thesaurusKey;
-             }
+            function createNewFiltersFromFacets(facetParam) {
+              return facetParam.split('&').map(function (raw) {
+                var queryParts = raw.split('/');
+                var dimensionKey = queryParts[0];
 
-             scope.currentFilters = [];
-             scope.$watch(function() {
-               return getSearchParameters(useLocationParameters,
-                $location, ngSearchFormCtrl);
-             }, function(newFilters, oldVal, currentScope) {
-               $timeout(function () {
-                 generateCurrentFilters(newFilters,
-                   currentScope.currentFilters, ngSearchFormCtrl)
-                   .then(function (calculatedFilters) {
-                     scope.currentFilters = calculatedFilters;
-                   });
-               }, 100);
-             }, true);
-
-             scope.removeFilter = function(filter) {
-               if (filter.type === 'facet') {
-                 var newFacets = $.grep(scope.currentFilters,
-                  function(element, index) {
-                    return element.type === 'facet' &&
-                   element.key !== filter.key;
-                  });
-                 var newFacetQParam = buildQParam(newFacets);
-                 if (newFacetQParam == '') {
-                   newFacetQParam = null;
-                 }
-                 setSearchParameter(useLocationParameters,
-                  $location, ngSearchFormCtrl, 'facet.q', newFacetQParam);
-                // $location.search('facet.q', newFacetQParam);
-
-               } else if (filter.type === 'geometry') {
-                 var newLocations = $.grep(scope.currentFilters,
-                  function(element, index) {
-                    return element.type === 'geometry' &&
-                   element.key !== filter.key;
+                var dimension;
+                scope.dimensions.forEach(function (d) {
+                  if (d['@name'] === dimensionKey) {
+                    dimension = d;
                   }
-                 );
-                 var newGeometryParam = buildGeometryParam(newLocations);
-                 setSearchParameter(useLocationParameters,
-                  $location, ngSearchFormCtrl, 'geometry', newGeometryParam);
-                // $location.search('geometry', newGeometryParam);
-               } else if (filter.type === 'boolean') {
-                 setSearchParameter(useLocationParameters,
-                  $location, ngSearchFormCtrl, filter.key, null);
-                // $location.search(filter.key, null);
-               } else {
-                 setSearchParameter(useLocationParameters,
-                  $location, ngSearchFormCtrl, filter.key, null);
-                 //$location.search(filter.key, null);
-               }
-               if (!useLocationParameters) {
-                 // Programmatically start the new search.
-                 ngSearchFormCtrl.triggerSearch();
-               }
+                });
 
-             };
-           }
-         };
-       }]);
+                if (!dimension) {
+                  return
+                }
+
+                var categoryLabel, rootPath = decodeURIComponent(queryParts[1]);
+                function lookupCategory(categories, currentQueryPartIndex) {
+                  categories.forEach(function (c) {
+                    if (c['@value'] === decodeURIComponent(queryParts[currentQueryPartIndex])) {
+                      currentQueryPartIndex++;
+                      if (currentQueryPartIndex === queryParts.length) {
+                        categoryLabel = c['@label'];
+                        return true;
+                      } else if(c.category) {
+                        lookupCategory(c.category, currentQueryPartIndex);
+                      }
+                    }
+                  })
+                }
+                if (dimension.category) {
+                  lookupCategory(dimension.category, 1);
+                }
+
+                return {
+                  key: dimension['@label'],
+                  value: categoryLabel || rootPath,
+                  isFacet: true,
+                  facetKey: dimension['@name']
+                };
+              });
+            }
+
+            function removeFacet(facetKey) {
+              var facetQuery = getSearchParams()['facet.q'];
+              if (!facetQuery) {
+                return;
+              }
+              var facets = facetQuery.split('&').filter(function (facet) {
+                return facet.split('/')[0] !== facetKey;
+              });
+              setSearchParameter('facet.q', facets.join('&'));
+            }
+
+            scope.$watch(function() {
+              return getSearchParams();
+            }, function(newFilters, oldVal) {
+              scope.currentFilters = [];
+
+              for (var filterKey in newFilters) {
+                // filter param is excluded from summary
+                if (EXCLUDED_PARAMS.indexOf(filterKey) > -1) {
+                  continue;
+                }
+
+                var value = newFilters[filterKey];
+
+                // value is empty/undefined
+                if (!value || typeof value !== 'string') {
+                  continue;
+                }
+
+                // special logic for facets (decoding facet.q value)
+                if (filterKey === 'facet.q') {
+                  var facetFilters = createNewFiltersFromFacets(value);
+                  Array.prototype.push.apply(scope.currentFilters, facetFilters);
+                  continue;
+                }
+
+                // special logic for geometry: we assume the filter is a bounding box
+                if (filterKey === 'geometry') {
+                  scope.currentFilters.push({
+                    key: 'geometry',
+                    value: 'boundingBox'
+                  });
+                  continue;
+                }
+
+                // general case
+                scope.currentFilters.push({
+                  key: filterKey,
+                  value: value
+                });
+              }
+            }, true);
+
+            scope.removeFilter = function(filter) {
+              if (filter.isFacet) {
+                removeFacet(filter.facetKey);
+              } else {
+                setSearchParameter(filter.key, null);
+              }
+            };
+
+            scope.removeAll = function() {
+              scope.$emit('resetSearch', null, false);
+            }
+          }
+        };
+
+      }]
+  );
 
   module.filter('translatearray', ['$translate', function($translate) {
 

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -14,7 +14,7 @@
       <span class="fa fa-times text-danger delete-icon"></span>
       <strong class="text-no-wrap text-uppercase" translate>{{filter.key}}</strong>
       <div class="flex-spacer"></div>
-      <span class="text-no-wrap text-ellipsis" translate>{{filter.value | translatearray}}</span>
+      <span translate>{{filter.value | translatearray}}</span>
     </a>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -1,13 +1,16 @@
-<div col-md-offset-3 col-md-6 relative ngr-margin-bottom>
-  <span class="btn btn-sm btn-primary searchterm" data-ng-repeat="filter in currentFilters">
-    <span data-ng-if="filter.type == 'facet'"
-          data-ng-attr-title="{{filter.labelKey | decodeURIComponent | translate}}">{{filter.labelKey | decodeURIComponent | translate}}</span>
-    <span data-ng-if="filter.type == 'standard'"
-          data-ng-attr-title="{{filter.value | decodeURIComponent | translatearray:' or '}}">{{filter.value | decodeURIComponent | translatearray:' or '}}</span>
-    <span data-ng-if="filter.type == 'boolean'"
-          data-ng-attr-title="{{filter.labelKey | translate}}">{{filter.labelKey | translate}}</span>
-    <span data-ng-if="filter.type == 'geometry'"
-          data-ng-attr-title="{{filter.value}}">{{filter.value}}</span>
-    <i class="fa fa-times" data-ng-click="removeFilter(filter)"></i>
-</span>
+<div class="search-filter-tags alert alert-success small" ng-if="currentFilters.length">
+  <a href class="alert-link filter-group flex-row flex-wrap"
+     title="{{'removeThisFilter' | translate}}"
+     ng-repeat="filter in currentFilters"
+     ng-click="removeFilter(filter)">
+    <span class="fa fa-times text-danger delete-icon"></span>
+    <strong class="text-no-wrap text-uppercase" translate>{{filter.key}}</strong>
+    <div class="flex-spacer"></div>
+    <span class="text-no-wrap text-ellipsis" translate>{{filter.value | translatearray}}</span>
+  </a>
+  <div ng-if="currentFilters.length > 0" class="text-right remove-all-link">
+    <a href ng-click="removeAll()"
+       class="text-danger"
+       translate>removeAllFilters</a>
+  </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -1,16 +1,20 @@
-<div class="search-filter-tags alert alert-success small" ng-if="currentFilters.length">
-  <a href class="alert-link filter-group flex-row flex-wrap"
-     title="{{'removeThisFilter' | translate}}"
-     ng-repeat="filter in currentFilters"
-     ng-click="removeFilter(filter)">
-    <span class="fa fa-times text-danger delete-icon"></span>
-    <strong class="text-no-wrap text-uppercase" translate>{{filter.key}}</strong>
-    <div class="flex-spacer"></div>
-    <span class="text-no-wrap text-ellipsis" translate>{{filter.value | translatearray}}</span>
-  </a>
-  <div ng-if="currentFilters.length > 0" class="text-right remove-all-link">
+<div class="search-filter-tags panel panel-success" ng-if="currentFilters.length">
+  <div class="panel-heading flex-row">
+    <span translate>activeFilters</span>
+    <div class="flex-spacer flex-grow"></div>
     <a href ng-click="removeAll()"
-       class="text-danger"
+       class="btn btn-default btn-xs remove-all"
        translate>removeAllFilters</a>
+  </div>
+  <div class="panel-body">
+    <a href class="filter-group flex-row flex-wrap"
+       title="{{'removeThisFilter' | translate}}"
+       ng-repeat="filter in currentFilters"
+       ng-click="removeFilter(filter)">
+      <span class="fa fa-times text-danger delete-icon"></span>
+      <strong class="text-no-wrap text-uppercase" translate>{{filter.key}}</strong>
+      <div class="flex-spacer"></div>
+      <span class="text-no-wrap text-ellipsis" translate>{{filter.value | translatearray}}</span>
+    </a>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -518,5 +518,6 @@
   "changeDateTo": "Resources changed before",
   "dateFrom": "Records updated before",
   "dateTo": "Records updated after",
-  "activeFilters": "Active filters"
+  "activeFilters": "Active filters",
+  "geometryFilter": "Bounding Box"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -517,5 +517,6 @@
   "changeDateFrom": "Resources changed after",
   "changeDateTo": "Resources changed before",
   "dateFrom": "Records updated before",
-  "dateTo": "Records updated after"
+  "dateTo": "Records updated after",
+  "activeFilters": "Active filters"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -509,5 +509,13 @@
   "moreFacet": "{{count}} more",
   "lessFacet": "{{count}} less",
   "allFacet": "all ({{count}})",
-  "initialFacet": "initial ({{count}})"
+  "initialFacet": "initial ({{count}})",
+  "removeThisFilter": "Remove this filter",
+  "removeAllFilters": "Remove all filters",
+  "creationDateFrom": "Resources created after",
+  "creationDateTo": "Resources created before",
+  "changeDateFrom": "Resources changed after",
+  "changeDateTo": "Resources changed before",
+  "dateFrom": "Records updated before",
+  "dateTo": "Records updated after"
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1169,6 +1169,9 @@ gn-indexing-task-status {
 .flex-align-end { align-items: flex-end; }
 .flex-align-start { align-items: flex-start; }
 .flex-align-stretch { align-items: stretch; }
+.flex-nowrap, .flex-no-wrap { flex-wrap: nowrap; }
+.flex-wrap { flex-wrap: wrap; }
+.flex-wrap-r { flex-wrap: wrap-reverse; }
 .text-wrap { white-space: normal; }
 .text-nowrap, .text-no-wrap { white-space: nowrap; }
 .text-ellipsis { white-space: nowrap; text-overflow: ellipsis; overflow: hidden; }

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -724,8 +724,12 @@ button.active [role=tooltip] {
 }
 
 .search-filter-tags {
-  padding: @alert-padding*0.75 @alert-padding;
-  a.alert-link, .remove-all-link > a {
+  .panel-body {
+    background-color: fade(@panel-success-heading-bg, 50%);
+    font-size: 0.9em;
+  }
+  a.filter-group, .remove-all-link > a {
+    color: @panel-success-text;
     font-weight: initial;
     &:hover, &:focus {
       text-decoration: underline;
@@ -742,7 +746,7 @@ button.active [role=tooltip] {
       position: absolute;
       right: calc(~"100% + 3px");
       top: 0;
-      line-height: 1.1em;
+      line-height: 1em;
       opacity: 0;
     }
     &:hover, &:focus {
@@ -751,7 +755,7 @@ button.active [role=tooltip] {
       }
     }
   }
-  .remove-all-link {
-    margin-bottom: -@alert-padding*0.5;
+  .remove-all {
+    color: @panel-danger-text;
   }
 }

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -722,3 +722,36 @@ button.active [role=tooltip] {
   background-color: white;
   padding-top: 15px;
 }
+
+.search-filter-tags {
+  padding: @alert-padding*0.75 @alert-padding;
+  a.alert-link, .remove-all-link > a {
+    font-weight: initial;
+    &:hover, &:focus {
+      text-decoration: underline;
+    }
+  }
+  .filter-group {
+    position: relative;
+    line-height: 1.1em;
+    margin-left: 1em;
+    &:not(:last-child) {
+      margin-bottom: 0.8em;
+    }
+    .delete-icon {
+      position: absolute;
+      right: calc(~"100% + 3px");
+      top: 0;
+      line-height: 1.1em;
+      opacity: 0;
+    }
+    &:hover, &:focus {
+      .delete-icon {
+        opacity: 1;
+      }
+    }
+  }
+  .remove-all-link {
+    margin-bottom: -@alert-padding*0.5;
+  }
+}

--- a/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
@@ -91,14 +91,6 @@
               </div>
             </form>
             <br/>
-            <div class="row" ng-if="isFilterTagsDisplayed">
-              <div class="gn-results-heading col-md-offset-3">
-                <div data-search-filter-tags
-                     data-dimensions="searchResults.dimension"
-                     data-use-location-parameters="false"
-                     ng-if="searchResults.dimension"></div>
-              </div>
-            </div>
             <div class="row"
                  data-ng-show="searchResults.records.length > 0">
               <div class="col-md-offset-3 col-md-4 relative">
@@ -120,6 +112,11 @@
 
             <div class="row">
               <div class="col-md-3 gn-search-facet">
+
+                <div data-search-filter-tags
+                     data-dimensions="searchResults.dimension"
+                     data-use-location-parameters="false"
+                     ng-if="isFilterTagsDisplayed && searchResults.dimension"></div>
 
                 <!-- Hierachical facet mode -->
                 <div data-ng-show="searchResults.records.length > 0"

--- a/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
@@ -91,10 +91,12 @@
               </div>
             </form>
             <br/>
-            <div class="row">
+            <div class="row" ng-if="isFilterTagsDisplayed">
               <div class="gn-results-heading col-md-offset-3">
-                <div data-search-filter-tags data-use-location-parameters="false"
-                     data-ng-show="isFilterTagsDisplayed"></div>
+                <div data-search-filter-tags
+                     data-dimensions="searchResults.dimension"
+                     data-use-location-parameters="false"
+                     ng-if="searchResults.dimension"></div>
               </div>
             </div>
             <div class="row"

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -72,10 +72,12 @@
           </form>
         </div>
 
-        <div class="row">
+        <div class="row" ng-if="isFilterTagsDisplayed">
           <div class="gn-results-heading col-md-offset-3">
-            <div data-search-filter-tags data-use-location-parameters="false"
-                data-ng-show="isFilterTagsDisplayed"></div>
+            <div data-search-filter-tags
+                 data-dimensions="searchResults.dimension"
+                 data-use-location-parameters="false"
+                 ng-if="searchResults.dimension"></div>
           </div>
         </div>
 

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -72,19 +72,14 @@
           </form>
         </div>
 
-        <div class="row" ng-if="isFilterTagsDisplayed">
-          <div class="gn-results-heading col-md-offset-3">
-            <div data-search-filter-tags
-                 data-dimensions="searchResults.dimension"
-                 data-use-location-parameters="false"
-                 ng-if="searchResults.dimension"></div>
-          </div>
-        </div>
-
-
 
         <div class="row">
           <div class="col-sm-3 col-md-3 gn-search-facet">
+
+            <div data-search-filter-tags
+                 data-dimensions="searchResults.dimension"
+                 data-use-location-parameters="false"
+                 ng-if="isFilterTagsDisplayed && searchResults.dimension"></div>
 
             <!-- Hierachical facet mode -->
             <div data-ng-show="searchResults.records.length > 0"

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -18,21 +18,6 @@
     }
   }
 }
-// search terms
-.searchterm {
-  margin: 0 5px 5px 0;
-  max-width: 100%;
-  span {
-    max-width: 15em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    float: left;
-  }
-  i {
-    margin-top: -15px;
-    margin-left: 5px;
-  }
-}
 
 ul.gn-resultview, [data-gn-user-searches-list] {
   .gn-source-logo {

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -6,16 +6,17 @@
   <div class="row gn-row-results">
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
       <div class="col-md-3 gn-search-facet">
-        <div data-search-filter-tags
-             data-dimensions="searchResults.dimension"
-             data-use-location-parameters="true"
-             ng-if="isFilterTagsDisplayedInSearch && searchResults.dimension">
-        </div>
 
         <div data-ng-show="searchResults.records.length > 0"
             data-gn-saved-selections-panel="user"></div>
 
         <div data-gn-user-searches-panel="user"></div>
+
+        <div data-search-filter-tags
+             data-dimensions="searchResults.dimension"
+             data-use-location-parameters="true"
+             ng-if="isFilterTagsDisplayedInSearch && searchResults.dimension">
+        </div>
 
         <!-- Hierachical facet mode -->
         <div class="panel panel-default"

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -6,6 +6,11 @@
   <div class="row gn-row-results">
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
       <div class="col-md-3 gn-search-facet">
+        <div data-search-filter-tags
+             data-dimensions="searchResults.dimension"
+             data-use-location-parameters="true"
+             ng-if="isFilterTagsDisplayedInSearch && searchResults.dimension">
+        </div>
 
         <div data-ng-show="searchResults.records.length > 0"
             data-gn-saved-selections-panel="user"></div>
@@ -31,15 +36,6 @@
       </div>
 
       <div class="col-md-9 container-fluid">
-      <div class="row" data-ng-show="isFilterTagsDisplayedInSearch">
-        <div class="col-xs-12">
-          <div data-search-filter-tags
-               data-dimensions="searchResults.dimension"
-               data-use-location-parameters="true"
-               ng-if="searchResults.dimension">
-          </div>
-        </div>
-      </div>
       <div class="row gn-row-tools">
         <div class="col-xs-12 col-md-9"
             data-gn-facet-dimension-list="searchResults.dimension"

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -33,8 +33,10 @@
       <div class="col-md-9 container-fluid">
       <div class="row" data-ng-show="isFilterTagsDisplayedInSearch">
         <div class="col-xs-12">
-          <div data-search-filter-tags="">
-
+          <div data-search-filter-tags
+               data-dimensions="searchResults.dimension"
+               data-use-location-parameters="true"
+               ng-if="searchResults.dimension">
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR is a follow-up of #4361.

The `SearchFilterTags` directive is reworked:
* simpler logic by removing the special cases for geometry and boolean filters which were not used (if I'm not mistaken)
* no more HTTP request to the thesaurus endpoint; the `dimension` object is used to read the keyword labels
* `privateVar` and `thesaurusKey` attributes are not used anymore
* support for nested keywords (e.g. GEMET)
* button for clearing all filters at once (same as resetting the search)
* filters are shown on the side above the facets panel, instead of above the search results

The active filters are not actually shown as "tags" anymore, but I kept the directive name to avoid breaking too many things in custom projects.

![image](https://user-images.githubusercontent.com/10629150/72796543-cab9c580-3c3f-11ea-8f95-389a18435dbe.png)


![image](https://user-images.githubusercontent.com/10629150/72796497-b249ab00-3c3f-11ea-936c-20a9e8be419d.png)
![image](https://user-images.githubusercontent.com/10629150/72796636-f9d03700-3c3f-11ea-9a87-f953a20a61e8.png)


Also it still works in editor board and batch edit.