### PR TITLE
Formatter / PDF / Restore the header with logo

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_metadata_pdf.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata_pdf.less
@@ -1,7 +1,27 @@
 .gn-top-bar, .gn-bottom-bar {
-  display: none;
+  display: block;
+  font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
+  li {
+    display: block;
+    list-style: none;
+    text-align: center;
+    font-size: 24px;
+  }
+  a {
+    text-decoration: none;
+    color: #000000;
+  }
+  button {
+    display: none;
+  }
 }
 .gn-metadata-view {
+  /*Mailto links are not created by flying saucer */
+  a[href^="mailto:"] {
+    text-decoration: none;
+    color: #000000;
+  }
+
   font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
   font-size: 13px;
   h1, h2, h3, h4, h5 {


### PR DESCRIPTION
PDF has no header now. It use to have something like
![image](https://user-images.githubusercontent.com/1701393/72902757-51e46780-3d2c-11ea-8e79-6c78db746ac0.png)

Make it simple
![image](https://user-images.githubusercontent.com/1701393/72902783-5e68c000-3d2c-11ea-8e3c-f4cd15f2fd1d.png)
