### PR TITLE
Handle AccessDeniedException to return http status code 403 instead of 400

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
+++ b/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
@@ -35,6 +35,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.UnsatisfiedServletRequestParameterException;
@@ -84,7 +85,8 @@ public class GlobalExceptionController {
     @ResponseBody
     @ResponseStatus(HttpStatus.FORBIDDEN)
     @ExceptionHandler({
-        SecurityException.class
+        SecurityException.class,
+        AccessDeniedException.class
     })
     public Object securityHandler(final Exception exception) {
         return new ApiError("forbidden", exception.getClass().getSimpleName(), exception.getMessage());


### PR DESCRIPTION
For example, an anonimous user or with `RegisteredUser` profile trying to use metadata import API method, was returning http code 400 instead of 403 as expected.

See https://github.com/geonetwork/core-geonetwork/blob/97766465724233b20249204bdc0c44f0e2b8fee1/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java#L524