### PR TITLE
Fix #4389: Font-awesome location and update all version numbers

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -7,7 +7,7 @@
 @import "gn_icons.less";
 @import "ellipsis.less";
 
-@fa-version: '4.3.0';
+@fa-version: '4.4.0';
 @fa-font-path: '../catalog/lib/style/font-awesome/fonts';
 
 

--- a/web-ui/src/main/resources/catalog/style/gn_fonts.less
+++ b/web-ui/src/main/resources/catalog/style/gn_fonts.less
@@ -1,1 +1,3 @@
 @import "../lib/style/font-awesome/less/font-awesome.less";
+
+@fa-font-path: '../catalog/lib/style/font-awesome/fonts';

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -6,9 +6,6 @@
 @import "gn.less";
 @import "gn_viewer.less";
 
-@fa-version: '4.1.0';
-@fa-font-path: '../catalog/lib/style/font-awesome/fonts';
-
 @panel-heading-height: 2.8em;
 
 


### PR DESCRIPTION
This PR fixes the issue in: https://github.com/geonetwork/core-geonetwork/issues/4389

All version numbers of Font-awesome are `4.4.0` and the location is fixed (no more 302 errors)