### PR TITLE
MEF / Move back attachment folders in the record folder

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/MEF2Exporter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/MEF2Exporter.java
@@ -308,13 +308,13 @@ class MEF2Exporter {
         // --- save thumbnails and maps
 
         if (format == Format.PARTIAL || format == Format.FULL) {
-            StoreUtils.extract(context, metadata.getUuid(), publicResources, zipFs.getPath("public"), true);
+            StoreUtils.extract(context, metadata.getUuid(), publicResources, metadataRootDir.resolve("public"), true);
         }
 
         if (format == Format.FULL) {
             try {
                 Lib.resource.checkPrivilege(context, id, ReservedOperation.download);
-                StoreUtils.extract(context, metadata.getUuid(), privateResources, zipFs.getPath("private"), true);
+                StoreUtils.extract(context, metadata.getUuid(), privateResources, metadataRootDir.resolve("private"), true);
             } catch (Exception e) {
                 // Current user could not download private data
             }


### PR DESCRIPTION
Introduced in https://github.com/geonetwork/core-geonetwork/pull/4248/files#r370629987

This was making ZIP export and harvesting unusable.