### PR TITLE
Add support for custom sql file for data initialization

### DIFF
--- a/web/src/main/webResources/WEB-INF/config-db/initial_data.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/initial_data.xml
@@ -107,6 +107,10 @@
       <constructor-arg value="WEB-INF/classes/setup/sql/data"/>
       <constructor-arg value="loc-slo-"/>
     </bean>
+    <bean class="org.fao.geonet.domain.Pair" factory-method="read">
+      <constructor-arg value="WEB-INF/classes/setup/sql/data"/>
+      <constructor-arg value="custom-data-db-"/>
+    </bean>
   </util:list>
 
 </beans>

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/custom-data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/custom-data-db-default.sql
@@ -1,0 +1,1 @@
+-- File to add custom project sql, it's loaded after the default data files


### PR DESCRIPTION
Added empty file for custom sql data initialization, applied after the default data initialization files from GeoNetwork. 

This can be useful in custom projects to add custom sql instructions in that file for custom data or update for example the settings to customise values, without having to update the default data files, facilitating the upgrade of custom projects to new versions of GeoNetwork. 

For example, if a project has a custom view named `minimal`, instead of updating the `data-db-default.sql`, it can be configured in the file `custom-data-db-default.sql`

```
-- File to add custom project sql, it's loaded after the default data files
UPDATE Settings SET value = 'minimal' WHERE name = 'system/ui/defaultView';
```