### PR TITLE
Record view / Add download menu configuration.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -168,6 +168,20 @@ goog.require('gn_alert');
             }],
             defaultUrl: ''
           },
+          'downloadFormatter': [{
+            'label': 'exportMEF',
+            'url': '/formatters/zip?withRelated=false',
+            'class': 'fa-file-zip-o'
+          }, {
+            'label': 'exportPDF',
+            'url' : '/formatters/xsl-view?output=pdf&language=${lang}',
+            'class': 'fa-file-pdf-o'
+          }, {
+            'label': 'exportXML',
+            // 'url' : '/formatters/xml?attachment=false',
+            'url' : '/formatters/xml',
+            'class': 'fa-file-code-o'
+          }],
           'grid': {
             'related': ['parent', 'children', 'services', 'datasets']
           },

--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -86,8 +86,9 @@
     }
   ]);
 
-  module.directive('gnMdActionsMenu', ['gnMetadataActions', '$http', 'gnConfig', 'gnConfigService',
-    function(gnMetadataActions, $http, gnConfig, gnConfigService) {
+  module.directive('gnMdActionsMenu', ['gnMetadataActions',
+    '$http', 'gnConfig', 'gnConfigService', 'gnGlobalSettings',
+    function(gnMetadataActions, $http, gnConfig, gnConfigService, gnGlobalSettings) {
       return {
         restrict: 'A',
         replace: true,
@@ -96,6 +97,7 @@
         link: function linkFn(scope, element, attrs) {
           scope.mdService = gnMetadataActions;
           scope.md = scope.$eval(attrs.gnMdActionsMenu);
+          scope.formatterList = gnGlobalSettings.gnCfg.mods.search.downloadFormatter;
 
           scope.tasks = [];
           scope.hasVisibletasks = false;

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -56,7 +56,7 @@
       <!-- TODO: Some installation only allows status update
       based on current status. -->
 
-      <!-- 
+      <!--
         Workflow:
 
         Editor
@@ -206,26 +206,15 @@
           <span data-translate="">permalink</span>
         </a>
       </li>
-      <li role="menuitem">
-        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/zip?root=div&output=zip&approved={{mdView.current.record.draft != 'y'}}"
+      <li role="menuitem" data-ng-repeat="f in formatterList">
+        <a data-ng-href="../api/records/{{md.getUuid()}}{{f.url.replace('${lang}', lang)}}{{f.url.indexOf('?') !== -1 ? '&': '?'}}approved={{mdView.current.record.draft != 'y'}}"
            target="_blank">
-          <i class="fa fa-fw fa-file-zip-o"></i>&nbsp;
-          <span data-translate="">exportMEF</span>
+          <i class="fa fa-fw {{f.class}}"></i>&nbsp;
+          <span data-translate="">{{f.label | translate}}</span>
         </a>
       </li>
-      <li role="menuitem">
-        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xsl-view?output=pdf&language={{lang}}&approved={{mdView.current.record.draft != 'y'}}"
-           target="_blank">
-          <i class="fa fa-fw fa-file-pdf-o"></i>&nbsp;
-          <span data-translate="">exportPDF</span>
-        </a>
-      </li>
-      <li role="menuitem">
-        <a data-ng-href="../api/records/{{md.getUuid()}}/formatters/xml?attachment=true&approved={{mdView.current.record.draft != 'y'}}">
-          <i class="fa fa-fw fa-file-code-o"></i>&nbsp;
-          <span data-translate="">exportXML</span>
-        </a>
-      </li>
+
+      <!-- TODO: RDF export should be replaced by a formatter. -->
       <li role="menuitem">
         <a data-ng-href=""
            data-ng-click="mdService.metadataRDF(md.getUuid(), mdView.current.record.draft != 'y')">


### PR DESCRIPTION
This adds a configuration for 
![image](https://user-images.githubusercontent.com/1701393/73073699-2db59180-3eb8-11ea-8210-b99feef1b187.png)

It allows for example to easily :
* change the menu proposed for export formats
* add new formatters
* turn off export of related records in MEF (which is now the default as it was misleading to user to export one record and ending up with many in the ZIP)
* configure the XML to not be an attachment and to open directly in the browser which the preferred way for some users


RDF menu is not covered by this because it uses an old Jeeves service and some code for this was also duplicated in the schema for csw. A cleanup would be welcome to move DCAT conversion to a formatter.