### PR TITLE
Fix for #4005: Use `File Identifier` in metadata tab of the full metadata view

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -596,9 +596,6 @@
   <xsl:template mode="render-field"
                 match="gmd:fileIdentifier"
                 priority="100">
-    <xsl:variable name="fileIdentifier">
-      <xsl:apply-templates mode="render-value" select="*"/>
-    </xsl:variable>
     <dl>
       <dt>
         <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
@@ -606,7 +603,7 @@
       <dd>
         <xsl:apply-templates mode="render-value" select="*"/>
         <xsl:apply-templates mode="render-value" select="@*"/>
-        <a class="btn btn-default" href="{$nodeUrl}api/records/{$fileIdentifier}/formatters/xml">
+        <a class="btn btn-default" href="{$nodeUrl}api/records/{$metadataUuid}/formatters/xml">
           <i class="fa fa-file-code-o"><xsl:comment select="'file'"/></i>
           <span><xsl:value-of select="$schemaStrings/metadataInXML"/></span>
         </a>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -596,6 +596,9 @@
   <xsl:template mode="render-field"
                 match="gmd:fileIdentifier"
                 priority="100">
+    <xsl:variable name="fileIdentifier">
+      <xsl:apply-templates mode="render-value" select="*"/>
+    </xsl:variable>
     <dl>
       <dt>
         <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
@@ -603,7 +606,7 @@
       <dd>
         <xsl:apply-templates mode="render-value" select="*"/>
         <xsl:apply-templates mode="render-value" select="@*"/>
-        <a class="btn btn-default" href="{$nodeUrl}api/records/{$metadataId}/formatters/xml">
+        <a class="btn btn-default" href="{$nodeUrl}api/records/{$fileIdentifier}/formatters/xml">
           <i class="fa fa-file-code-o"><xsl:comment select="'file'"/></i>
           <span><xsl:value-of select="$schemaStrings/metadataInXML"/></span>
         </a>


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/4005

This PR changes the use of the 'internal id' to into the 'file identifier'

![gn-metadata-file-identifier](https://user-images.githubusercontent.com/19608667/73158625-af8a0280-40e4-11ea-9a32-bff6ad11144c.png)
