### PR TITLE
Fix: Do not use an empty string as `background-image`

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -19,12 +19,21 @@ html, body {
 }
 // background image and color
 [ng-app^="gn_search_"] body, [ng-app="gn_login"] body {
-  background-image: url(@gn-background-image); 
   background-color: @gn-background-color;
   background-position: center top;
   background-size: cover;
   background-repeat: no-repeat;
   background-attachment: fixed;
+}
+// check if the variable is a not an empty string, if not, then set the background image
+//
+// if the background image is an empty string it will be substitued with the name of the css file,
+// see: https://stackoverflow.com/questions/20727262/css-file-considered-as-being-an-image-resource
+[ng-app^="gn_search_"] body when not (@gn-background-image = "") {
+  background-image: url(@gn-background-image);
+}
+[ng-app^="gn_login"] body when not (@gn-background-image = "") {
+  background-image: url(@gn-background-image);
 }
 
 .row {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -10,8 +10,9 @@
 
 // body background (image & color)
 //
-// when there is an empty string, no background image is used.
-@gn-background-image: '';
+// change the variable to a string pointing towards an image, like 'www.dummy.net/image.png'. When no
+// background image is needed, leave as is (none).
+@gn-background-image: none;
 @gn-background-color: @body-bg;
 
 // overwrite color for accessibility


### PR DESCRIPTION
In GeoNetwork it is possible to change the `background-image` via the settings. However, if you do not change it, it defaults to an empty string.

This empty string has a nasty side-effect, it is substituted with the name of it's stylesheet and this causes the stylesheet to be loaded twice

Read more: https://stackoverflow.com/questions/20727262/css-file-considered-as-being-an-image-resource

This PR fixes this with setting the default to `none` (variable_default.less) and if there's an empty string it's not put directly in the `background-image` property (http://lesscss.org/features/#css-guards-feature).