### PR TITLE
Sharing / Add definition of publish.

### DIFF
--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -56,7 +56,7 @@
             key-type="java.lang.String"
             value-type="java.lang.String[]">
     <!-- INTERNET GROUP -->
-    <entry key="0">
+    <entry key="1">
       <array>
         <!-- View, download, dynamic -->
         <value>view</value>
@@ -65,7 +65,7 @@
       </array>
     </entry>
     <!-- INTRANET GROUP -->
-    <entry key="1">
+    <entry key="0">
       <array>
         <value>view</value>
         <value>download</value>

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -22,14 +22,13 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<beans xmlns:context="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        default-lazy-init="true"
-       xmlns="http://www.springframework.org/schema/beans" xsi:schemaLocation="
-		http://www.springframework.org/schema/beans
+       xmlns="http://www.springframework.org/schema/beans" xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.2.xsd
-    ">
+        http://www.springframework.org/schema/context/spring-context-3.2.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
   <context:property-placeholder location="${app.properties}"
                                 file-encoding="UTF-8"
@@ -47,6 +46,33 @@
     <constructor-arg index="0" ref="languages"/>
     <constructor-arg index="1" ref="defaultLanguage"/>
   </bean>
+
+  <!--
+   Configure here what the publish/unpublish action does.
+   By default, it set view, download and dynamic operation
+   to Internet and Intranet group.
+   -->
+  <util:map id="publicationConfig"
+            key-type="java.lang.String"
+            value-type="java.lang.String[]">
+    <!-- INTERNET GROUP -->
+    <entry key="0">
+      <array>
+        <!-- View, download, dynamic -->
+        <value>view</value>
+        <value>download</value>
+        <value>dynamic</value>
+      </array>
+    </entry>
+    <!-- INTRANET GROUP -->
+    <entry key="1">
+      <array>
+        <value>view</value>
+        <value>download</value>
+        <value>dynamic</value>
+      </array>
+    </entry>
+  </util:map>
 
   <bean id="RegionsDAO" class="org.fao.geonet.services.region.ThesaurusBasedRegionsDAO">
     <constructor-arg ref="languages"/>


### PR DESCRIPTION
In manage record, publish/unpublish operations currently act on Internet group privileges

![image](https://user-images.githubusercontent.com/1701393/73237893-54fdae80-4197-11ea-803f-f9349235c081.png)

In some installation, the list of operations may be different (eg. removing dynamic, add a new one) or it may be needed to add more privileges to Intranet group compared to the Internet one (eg. can download).

This adds a configuration of what publish action really do.