### PR TITLE
pom - switch to https for repo.maven.apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1241,7 +1241,7 @@
     <repository>
       <id>maven2</id>
       <name>Repository maven2</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
 
     <!-- seasar repo, has jsonic - used by langdetect -->


### PR DESCRIPTION
Getting this kind of errors with maven today:

```
[WARNING] Error resolving sources artifact. Artifact id: org.geonetwork-opensource:csw-server:java-source:sources:3.8.2 (Message: Could not transfer artifact org.geonetwork-opensource:csw-server:jar:sources:3.8.2 from/to maven2 (http://repo.maven.apache.org/maven2): Failed to transfer file: http://repo.maven.apache.org/maven2/org/geonetwork-opensource/csw-server/3.8.2/csw-server-3.8.2-sources.jar. Return code is: 501 , ReasonPhrase:HTTPS Required.
```

coherent with the following announcement: https://twitter.com/ASFMavenProject/status/1217495225905577984

Tests: maven OK