### PR TITLE
Increase length of Validation.valType column

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/MetadataValidationId.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataValidationId.java
@@ -23,12 +23,11 @@
 
 package org.fao.geonet.domain;
 
-import java.io.Serializable;
-
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import java.io.Serializable;
 
 /**
  * Id object for the {@link MetadataValidation} entity.
@@ -82,7 +81,7 @@ public class MetadataValidationId implements Serializable {
      * @return a string representing the type of validation of this validation entity (example:
      * iso19139)
      */
-    @Column(name = "valType", length = 40)
+    @Column(name = "valType", length = 128)
     public String getValidationType() {
         return _validationType;
     }

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
@@ -1,2 +1,5 @@
 UPDATE Settings SET value='3.11.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
+
+-- Increase the length of Validation type (where the schematron file name is stored)
+ALTER TABLE Validation ALTER COLUMN valType TYPE varchar(128);


### PR DESCRIPTION
Sometimes the name of the schematron files are longer than 40 characters. This commit allow file names up to 128 characters long instead of 40.