### PR TITLE
Styling improvements to the full metadata view

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -508,85 +508,80 @@
       <xsl:otherwise>
         <div class="gn-contact">
           <strong>
-            <i class="fa fa-envelope"><xsl:comment select="'email'"/></i>
+            <xsl:comment select="'email'"/>
             <xsl:apply-templates mode="render-value"
                                  select="*/gmd:role/*/@codeListValue"/>
           </strong>
-          <div class="row">
-            <div class="col-md-6">
-              <address>
-                  <xsl:choose>
-                    <xsl:when test="$email">
-                      <a href="mailto:{normalize-space($email)}">
-                        <xsl:copy-of select="$displayName"/><xsl:comment select="'email'"/>
-                      </a>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:copy-of select="$displayName"/><xsl:comment select="'name'"/>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                <br/>
-                <xsl:for-each select="*/gmd:contactInfo/*">
-                  <xsl:for-each select="gmd:address/*">
-                    <div><xsl:comment select="'address'"/>
-                      <xsl:for-each select="gmd:deliveryPoint[normalize-space(.) != '']">
-                          <xsl:apply-templates mode="render-value" select="."/>
-                      </xsl:for-each>
-                      <xsl:for-each select="gmd:city[normalize-space(.) != '']">
-                          <xsl:apply-templates mode="render-value" select="."/>
-                      </xsl:for-each>
-                      <xsl:for-each select="gmd:administrativeArea[normalize-space(.) != '']">
-                          <xsl:apply-templates mode="render-value" select="."/>
-                      </xsl:for-each>
-                      <xsl:for-each select="gmd:postalCode[normalize-space(.) != '']">
-                          <xsl:apply-templates mode="render-value" select="."/>
-                      </xsl:for-each>
-                      <xsl:for-each select="gmd:country[normalize-space(.) != '']">
-                          <xsl:apply-templates mode="render-value" select="."/>
-                      </xsl:for-each>
-                    </div>
-                    <br/>
+          <address>
+              <xsl:choose>
+                <xsl:when test="$email">
+                  <i class="fa fa-fw fa-envelope"></i>
+                  <a href="mailto:{normalize-space($email)}">
+                    <xsl:copy-of select="$displayName"/><xsl:comment select="'email'"/>
+                  </a>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:copy-of select="$displayName"/><xsl:comment select="'name'"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            <br/>
+            <xsl:for-each select="*/gmd:contactInfo/*">
+              <xsl:for-each select="gmd:address/*">
+                <div>
+                <i class="fa fa-fw fa-map-marker"><xsl:comment select="'address'"/></i>
+                  <xsl:for-each select="gmd:deliveryPoint[normalize-space(.) != '']">
+                      <xsl:apply-templates mode="render-value" select="."/>&#183;
                   </xsl:for-each>
-                </xsl:for-each>
-              </address>
-            </div>
-            <div class="col-md-6">
-              <address>
-                <xsl:for-each select="*/gmd:contactInfo/*">
-                  <xsl:for-each select="gmd:phone/*/gmd:voice[normalize-space(.) != '']">
-                      <xsl:variable name="phoneNumber">
-                        <xsl:apply-templates mode="render-value" select="."/>
-                      </xsl:variable>
-                      <i class="fa fa-phone"><xsl:comment select="'phone'"/></i>
-                      <a href="{translate($phoneNumber,' ','')}">
-                        <xsl:value-of select="$phoneNumber"/>
-                      </a>
+                  <xsl:for-each select="gmd:city[normalize-space(.) != '']">
+                      <xsl:apply-templates mode="render-value" select="."/>&#183;
                   </xsl:for-each>
-                  <xsl:for-each select="gmd:phone/*/gmd:facsimile[normalize-space(.) != '']">
-                    <xsl:variable name="phoneNumber">
+                  <xsl:for-each select="gmd:administrativeArea[normalize-space(.) != '']">
+                      <xsl:apply-templates mode="render-value" select="."/>&#183;
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:postalCode[normalize-space(.) != '']">
+                      <xsl:apply-templates mode="render-value" select="."/>&#183;
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:country[normalize-space(.) != '']">
                       <xsl:apply-templates mode="render-value" select="."/>
-                    </xsl:variable>
-                    <i class="fa fa-fax"><xsl:comment select="'fax'"/></i>
-                    <a href="{translate($phoneNumber,' ','')}">
-                      <xsl:value-of select="normalize-space($phoneNumber)"/>
-                    </a>
                   </xsl:for-each>
-                  <xsl:for-each select="gmd:onlineResource/*/gmd:linkage/gmd:URL[normalize-space(.) != '']">
-                    <xsl:variable name="web">
-                      <xsl:apply-templates mode="render-value" select="."/></xsl:variable>
-                    <i class="fa fa-link"><xsl:comment select="'link'"/></i>
-                    <a href="{normalize-space($web)}">
-                      <xsl:value-of select="normalize-space($web)"/>
-                    </a>
-                  </xsl:for-each>
-                  <xsl:for-each select="gmd:hoursOfService[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-field"
-                                           select="."/>
-                  </xsl:for-each>
-                </xsl:for-each>
-              </address>
-            </div>
-          </div>
+                </div>
+              </xsl:for-each>
+            </xsl:for-each>
+            <xsl:for-each select="*/gmd:contactInfo/*">
+              <xsl:for-each select="gmd:phone/*/gmd:voice[normalize-space(.) != '']">
+                  <xsl:variable name="phoneNumber">
+                    <xsl:apply-templates mode="render-value" select="."/>
+                  </xsl:variable>
+                  <i class="fa fa-fw fa-phone"><xsl:comment select="'phone'"/></i>
+                  <a href="tel:{translate($phoneNumber,' ','')}">
+                    <xsl:value-of select="$phoneNumber"/>
+                  </a>
+                  <br/>
+              </xsl:for-each>
+              <xsl:for-each select="gmd:phone/*/gmd:facsimile[normalize-space(.) != '']">
+                <xsl:variable name="phoneNumber">
+                  <xsl:apply-templates mode="render-value" select="."/>
+                </xsl:variable>
+                <i class="fa fa-fw fa-fax"><xsl:comment select="'fax'"/></i>
+                <a href="tel:{translate($phoneNumber,' ','')}">
+                  <xsl:value-of select="normalize-space($phoneNumber)"/>
+                </a>
+                <br/>
+              </xsl:for-each>
+              <xsl:for-each select="gmd:onlineResource/*/gmd:linkage/gmd:URL[normalize-space(.) != '']">
+                <xsl:variable name="web">
+                  <xsl:apply-templates mode="render-value" select="."/></xsl:variable>
+                <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
+                <a href="{normalize-space($web)}">
+                  <xsl:value-of select="normalize-space($web)"/>
+                </a>
+              </xsl:for-each>
+              <xsl:for-each select="gmd:hoursOfService[normalize-space(.) != '']">
+                  <xsl:apply-templates mode="render-field"
+                                        select="."/>
+              </xsl:for-each>
+            </xsl:for-each>
+          </address>
         </div>
       </xsl:otherwise>
     </xsl:choose>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -208,7 +208,7 @@
 
       <xsl:for-each select="gmd:identificationInfo/*/gmd:graphicOverview/*">
         <img data-gn-img-modal="md"
-             class="gn-img-thumbnail center-block"
+             class="gn-img-thumbnail"
              alt="{$schemaStrings/overview}"
              src="{gmd:fileName/*}"/>
 
@@ -530,16 +530,16 @@
                 <div>
                 <i class="fa fa-fw fa-map-marker"><xsl:comment select="'address'"/></i>
                   <xsl:for-each select="gmd:deliveryPoint[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>&#183;
+                      <xsl:apply-templates mode="render-value" select="."/>,
                   </xsl:for-each>
                   <xsl:for-each select="gmd:city[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>&#183;
+                      <xsl:apply-templates mode="render-value" select="."/>,
                   </xsl:for-each>
                   <xsl:for-each select="gmd:administrativeArea[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>&#183;
+                      <xsl:apply-templates mode="render-value" select="."/>,
                   </xsl:for-each>
                   <xsl:for-each select="gmd:postalCode[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>&#183;
+                      <xsl:apply-templates mode="render-value" select="."/>,
                   </xsl:for-each>
                   <xsl:for-each select="gmd:country[normalize-space(.) != '']">
                       <xsl:apply-templates mode="render-value" select="."/>

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -97,30 +97,26 @@
   <!-- Group by organisation/role -->
   <div class="gn-contact flex-row" data-ng-if="mode == 'org-role'"
        data-ng-repeat="(org, contactByOrgRole) in mdContactsByOrgRole">
-
-    <div class="flex-noshrink">
-      <i class="fa fa-envelope"></i>
-    </div>
-    <div class="flex-spacer"></div>
     <address>
-      <div>
-        <strong data-ng-if="::orgWebsite[org]">
-          <a data-ng-href="{{::orgWebsite[org]}}">{{org}}</a><br/>
-        </strong>
-        <strong data-ng-if="::!orgWebsite[org]">
-          {{org}}
-        </strong>
-      </div>
+      <strong data-ng-if="::orgWebsite[org]">
+        <i class="fa fa-fw fa-link"></i>
+        <a data-ng-href="{{::orgWebsite[org]}}">{{org}}</a><br/>
+      </strong>
+      <strong data-ng-if="::!orgWebsite[org]">
+        {{org}}
+      </strong>
 
       <div ng-repeat="(key, contactGroupByAddress) in contactByOrgRole | groupBy:'address'">
-        <span class="text-muted" data-ng-if="key != ''">
+        <span data-ng-if="key != ''">
+          <i class="fa fa-fw fa-map-marker"></i>
           {{key}}<br/>
         </span>
         <ul>
           <li ng-repeat="(roles, contactGroupByRole) in contactGroupByAddress | groupBy:'roles'">
-            {{roles }} :
+            {{roles }}:<br/>
             <span data-ng-repeat="c in contactGroupByRole track by $index">
               <span data-ng-if="c.email != ''">
+                <i class="fa fa-fw fa-envelope"></i>
                 <a href="mailto:{{c.email}}">
                   <span data-ng-hide="c.name">{{c.email}}</span>
                   <span data-ng-show="c.name">{{c.name}}</span>
@@ -131,9 +127,10 @@
                 <span data-ng-show="c.position">({{c.position}})</span>
               </span>
               <br>
+              <i class="fa fa-fw fa-phone" data-ng-if="c.phone != ''"></i>
               <a href="tel:{{c.phone}}"
-                data-ng-if="c.phone != ''">
-                {{c.phone}}
+                 data-ng-if="c.phone != ''">
+               {{c.phone}}
               </a>
               <span data-ng-if="!$last">,</span>
             </span>

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -495,6 +495,8 @@ ul.container-list {
 
 [data-gn-metadata-contacts], [gn-metadata-contacts] {
   .gn-contact {
-    margin-left: -1.7em;
+    address {
+      line-height: 1.7em;
+    }
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -67,6 +67,9 @@
     }
     h3 {
       margin-top: 0;
+      color: #333;
+      padding-left: 0;
+      margin-bottom: 10px;
     }
     .table-striped td {
       padding-left: 8px;
@@ -92,11 +95,76 @@
     border-bottom: 2px solid #e5e5e5;
   }
   .entry {
-    margin-left: 1em;
-    border-left: 2px solid #eeeeee;
-    padding-left: 5px;
+    margin-left: 8px;
+    border-left: 2px solid #ddd;
+    padding-left: 8px;
+    h2 {
+      margin-left: -16px;
+      margin-top: 10px;
+      margin-bottom: 0px;
+      background-color: #fff;
+      padding: 5px 0;
+    }
     dl {
       padding-bottom: 5px;
+      dt {
+        margin-left: -5px;
+        display: table;
+        white-space: nowrap;
+        &:before {
+          border-top: 2px solid #ddd;
+          content: '';
+          display: table-cell;
+          position: relative;
+          top: 0.5em;
+          width: 15px;
+        }
+        &:before { right: 5px; }
+      }
+      dd {
+        margin-left: 10px;
+        ul {
+          padding-left: 1.5em;
+          margin: 0;
+        }
+      }
+    }
+    address {
+      margin-bottom: 0;
+    }
+    .entry {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      h2 {
+        margin-left: -5px;
+        display: table;
+        white-space: nowrap;
+        margin-bottom: 5px;
+        &:before {
+          border-top: 2px solid #ddd;
+          content: '';
+          display: table-cell;
+          position: relative;
+          top: 0.5em;
+          width: 15px;
+        }
+        &:before { right: 5px; }
+      }
+      .target {
+        margin-left: 12px;
+        margin-bottom: 5px;
+        dl {
+          margin-left: 10px;
+        }
+      }
+    }
+    .gn-contact {
+      margin-left: 10px;
+      address {
+        padding: 5px 0 10px 0;
+        line-height: 1.7em;
+      }
     }
   }
   input[readonly] {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -82,7 +82,11 @@
   .gn-md-side {
     .gn-img-thumbnail,
     .gn-img-extent {
-      width: 100%;
+      max-width: 100%;
+    }
+    .gn-img-thumbnail {
+      border: 1px solid #ccc;
+      padding: 4px;
     }
     section {
       margin-bottom: 20px;
@@ -116,7 +120,7 @@
           content: '';
           display: table-cell;
           position: relative;
-          top: 0.5em;
+          top: 0.6em;
           width: 15px;
         }
         &:before { right: 5px; }
@@ -156,6 +160,14 @@
         margin-bottom: 5px;
         dl {
           margin-left: 10px;
+        }
+        .entry {
+          h2 {
+            margin-left: 5px;
+          }
+          dl {
+            margin-left: 20px;
+          }
         }
       }
     }

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -487,7 +487,6 @@
               </div>
             </div>
           </section>
-          </br>
 
           <div data-gn-userfeedback='mdView.current.record'
               data-gn-user={{user.username}}


### PR DESCRIPTION
This PR adds some styling/UI changes to the full view of the metadata page. The purpose is to achieve a more balanced view: better alignment to the left, even spaces between list items and a more indented tree structure.

Changes:
- adding more (even) whitespace
- no padding for related title
- change related title colour
- clearer tree structure
- 1 address element (not 2 in 2 columns)
- added icons
- telephone number has now `tel:` in front of the number (makes it clickable)

**Before**:
![gn-metadata-full-before](https://user-images.githubusercontent.com/19608667/73367191-78b41800-42af-11ea-9963-ceae98f950f9.png)

**After**:
![gn-metadata-full-after](https://user-images.githubusercontent.com/19608667/73367213-823d8000-42af-11ea-8857-cdb3eb434d1f.png)
