### PR TITLE
Display bounding polygons in 19139 full view

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -187,13 +187,20 @@
       <h2>
         <i class="fa fa-fw fa-map-marker"><xsl:comment select="'image'"/></i>
         <span><xsl:comment select="name()"/>
-          <xsl:value-of select="$schemaStrings/extent"/>
+          <xsl:value-of select="$schemaStrings/spatialExtent"/>
         </span>
       </h2>
 
-      <xsl:apply-templates mode="render-field"
-                           select=".//gmd:EX_GeographicBoundingBox">
-      </xsl:apply-templates>
+      <xsl:choose>
+        <xsl:when test=".//gmd:EX_BoundingPolygon">
+          <xsl:copy-of select="gn-fn-render:extent($metadataUuid)"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates mode="render-field"
+                               select=".//gmd:EX_GeographicBoundingBox">
+          </xsl:apply-templates>
+        </xsl:otherwise>
+      </xsl:choose>
     </section>
   </xsl:template>
 
@@ -460,6 +467,34 @@
     <br/>
   </xsl:template>
 
+
+  <!-- Display spatial extents containing bounding polygons on a map -->
+
+  <xsl:template mode="render-field"
+                match="gmd:EX_Extent[gmd:geographicElement/*/gmd:polygon]"
+                priority="100">
+    <div class="entry name">
+      <h2>
+        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:apply-templates mode="render-value"
+                             select="@*"/>
+      </h2>
+      <div class="target"><xsl:comment select="name()"/>
+
+        <xsl:apply-templates mode="render-field" select="gmd:description"/>
+
+        <xsl:copy-of select="gn-fn-render:extent($metadataUuid)"/>
+
+        <!-- Display any included geographic descriptions separately after displayed map -->
+
+        <xsl:apply-templates mode="render-field" select="gmd:geographicElement[gmd:EX_GeographicDescription]"/>
+
+        <xsl:apply-templates mode="render-field" select="gmd:temporalElement"/>
+        <xsl:apply-templates mode="render-field" select="gmd:verticalElement"/>
+
+      </div>
+    </div>
+  </xsl:template>
 
   <!-- A contact is displayed with its role as header -->
   <xsl:template mode="render-field"

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/strings.xml
@@ -137,6 +137,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Extensió espacial</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/strings.xml
@@ -117,6 +117,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Ruimtelijke dekking</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
@@ -139,6 +139,8 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Spatial extent</spatialExtent>
+
   <freeTextKeywords>Other keywords</freeTextKeywords>
   <resource_url>URL</resource_url>
   <resource_protocol>Protocol</resource_protocol>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/strings.xml
@@ -132,6 +132,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Alueellinen kattavuus</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
@@ -138,6 +138,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Étendue spatiale</extent>
+  <spatialExtent>Étendue spatiale</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/strings.xml
@@ -133,6 +133,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Räumliche Ausdehnung</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/strings.xml
@@ -134,6 +134,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Estensione spaziale</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/strings.xml
@@ -92,6 +92,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Spatial extent</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/strings.xml
@@ -93,6 +93,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Spatial extent</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/strings.xml
@@ -92,6 +92,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Extensão espacial</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/strings.xml
@@ -133,6 +133,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Пространственная протяженность</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/slo/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/slo/strings.xml
@@ -133,6 +133,7 @@ Zložte identifikátor zdroja pomocou adresy URL katalógu a identifikátora
   <otherconstraints>Ďalšie obmedzenia</otherconstraints>
   <operateson>Združený zdroj</operateson>
   <extent>Geografické ohraničenie </extent>
+  <spatialExtent>Priestorový rozsah</spatialExtent>
   <freetextkeywords>Ďalšie kľúčové slová </freetextkeywords>
   <resource_url>URL</resource_url>
   <resource_protocol>Protokol</resource_protocol>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/strings.xml
@@ -137,6 +137,7 @@
   <otherConstraints>Other constraints</otherConstraints>
   <operatesOn>Coupled resource</operatesOn>
   <extent>Geographic bounding box</extent>
+  <spatialExtent>Extensión espacial</spatialExtent>
   <freeTextKeywords>Other keywords</freeTextKeywords>
 
   <addCrs>Projection</addCrs>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/strings.xml
@@ -120,6 +120,7 @@
   <add-extent-from-geokeywords>Compute extent from keyword</add-extent-from-geokeywords>
   <add-extent-from-geokeywordsHelp>Analyze each keyword of type place and add matching extent.
   </add-extent-from-geokeywordsHelp>
+  <spatialExtent>Spatial extent</spatialExtent>
 
   <!-- String for INSPIRE SDS tab -->
 

--- a/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java
@@ -26,11 +26,15 @@ package org.fao.geonet.api.regions.metadata;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Polygon;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Geonet.Namespaces;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.kernel.DataManager;
@@ -43,6 +47,9 @@ import org.fao.geonet.lib.Lib;
 import org.fao.geonet.services.Utils;
 import org.fao.geonet.services.region.MetadataRegion;
 import org.fao.geonet.utils.Xml;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.xml.Parser;
 import org.jdom.Element;
 import org.jdom.filter.Filter;
@@ -50,10 +57,11 @@ import org.jdom.filter.Filter;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 
 import jeeves.server.context.ServiceContext;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
 
 public class MetadataRegionSearchRequest extends Request {
 
@@ -148,13 +156,30 @@ public class MetadataRegionSearchRequest extends Request {
         if (metadata != null) {
             Iterator<?> extents = null;
             extents = descentOrSelf(metadata);
+            HashSet<Polygon> polygons = new HashSet<>();
             while (extents.hasNext()) {
                 Object object = extents.next();
                 if (object instanceof Element) {
-                    regions.add(parseRegion(id, (Element) object));
+                    MultiPolygon boundingPolygon = parseElement((Element) object);
+                    polygons.addAll(getPolygons(boundingPolygon));
                 }
             }
+            MetadataRegion region = new MetadataRegion(id, null, getMultiPolygon(polygons));
+            regions.add(region);
         }
+    }
+
+    private ArrayList<Polygon> getPolygons(MultiPolygon boundingPolygon) {
+        ArrayList<Polygon> containedPolygons = new ArrayList<>();
+        for (int i = 0; i < boundingPolygon.getNumGeometries(); i++) {
+            containedPolygons.add((Polygon) boundingPolygon.getGeometryN(i));
+        }
+        return containedPolygons;
+    }
+
+    private MultiPolygon getMultiPolygon(HashSet<Polygon> polygons) {
+        Polygon[] array = new Polygon[polygons.size()];
+        return factory.createMultiPolygon(polygons.toArray(array));
     }
 
     Iterator<?> descentOrSelf(Element metadata) {
@@ -168,25 +193,9 @@ public class MetadataRegionSearchRequest extends Request {
     }
 
     Region parseRegion(Id mdId, Element extentObj) throws Exception {
-        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
-        gc.getBean(DataManager.class).getEditLib().removeEditingInfo(extentObj);
+        MultiPolygon geometry = parseElement(extentObj);
 
         String id = null;
-        Geometry geometry = null;
-        if ("polygon".equals(extentObj.getName())) {
-            String gml = Xml.getString(extentObj);
-            geometry = SpatialIndexWriter.parseGml(parsers[0], gml);
-        } else if ("EX_BoundingPolygon".equals(extentObj.getName())) {
-            String gml = Xml.getString(extentObj.getChild("polygon", Geonet.Namespaces.GMD));
-            geometry = SpatialIndexWriter.parseGml(parsers[0], gml);
-        } else if ("EX_GeographicBoundingBox".equals(extentObj.getName())) {
-            double minx = Double.parseDouble(extentObj.getChild("westBoundLongitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
-            double maxx = Double.parseDouble(extentObj.getChild("eastBoundLongitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
-            double miny = Double.parseDouble(extentObj.getChild("southBoundLatitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
-            double maxy = Double.parseDouble(extentObj.getChild("northBoundLatitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
-            geometry = factory.toGeometry(new Envelope(minx, maxx, miny, maxy));
-        }
-
         if (geometry != null) {
             Element element = extentObj.getChild("element", Geonet.Namespaces.GEONET);
             if (element != null) {
@@ -195,6 +204,64 @@ public class MetadataRegionSearchRequest extends Request {
             return new MetadataRegion(mdId, id, geometry);
         } else {
             return null;
+        }
+    }
+
+    private MultiPolygon parseElement(Element extentObj) throws Exception {
+        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+        gc.getBean(DataManager.class).getEditLib().removeEditingInfo(extentObj);
+
+        MultiPolygon geometry = null;
+        if ("polygon".equals(extentObj.getName())) {
+            geometry = parsePolygon(extentObj);
+        } else if ("EX_BoundingPolygon".equals(extentObj.getName())) {
+            Element polygon = extentObj.getChild("polygon", Namespaces.GMD);
+            geometry = parsePolygon(polygon);
+        } else if ("EX_GeographicBoundingBox".equals(extentObj.getName())) {
+            double minx = Double.parseDouble(extentObj.getChild("westBoundLongitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
+            double maxx = Double.parseDouble(extentObj.getChild("eastBoundLongitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
+            double miny = Double.parseDouble(extentObj.getChild("southBoundLatitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
+            double maxy = Double.parseDouble(extentObj.getChild("northBoundLatitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
+            Polygon[] polygons = {(Polygon)factory.toGeometry(new Envelope(minx, maxx, miny, maxy))};
+            geometry = factory.createMultiPolygon(polygons);
+        }
+        return geometry;
+    }
+
+    private MultiPolygon parsePolygon(Element extentObj) throws Exception {
+        // get gml node (only child)
+        List children = extentObj.getChildren();
+        if (children.size()==0) return null;
+        Element gmlNode = (Element) children.get(0);
+
+        // get geometry
+        String gml = Xml.getString(gmlNode);
+        Parser parser = getParser(gmlNode);
+        MultiPolygon geometry = SpatialIndexWriter.parseGml(parser, gml);
+
+        // if we have an srs and its not WGS84 then transform to WGS84
+        String srs = gmlNode.getAttributeValue("srsName");
+
+        CoordinateReferenceSystem sourceCRS;
+        if (srs != null && !(srs.equals(""))) {
+            sourceCRS = CRS.decode(srs);
+        } else {
+            sourceCRS = DefaultGeographicCRS.WGS84;
+        }
+
+        if (!CRS.equalsIgnoreMetadata(sourceCRS, DefaultGeographicCRS.WGS84)) {
+            MathTransform tform = CRS.findMathTransform(sourceCRS, DefaultGeographicCRS.WGS84);
+            geometry = (MultiPolygon) JTS.transform(geometry, tform);
+        }
+
+        return geometry;
+    }
+
+    private Parser getParser(Element gmlNode) {
+        if (gmlNode.getNamespace().equals(Namespaces.GML32)) {
+            return parsers[1]; // geotools gml3.2 parser
+        } else {
+            return parsers[0];
         }
     }
 

--- a/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java
@@ -215,13 +215,13 @@ public class MetadataRegionSearchRequest extends Request {
         if ("polygon".equals(extentObj.getName())) {
             geometry = parsePolygon(extentObj);
         } else if ("EX_BoundingPolygon".equals(extentObj.getName())) {
-            Element polygon = extentObj.getChild("polygon", Namespaces.GMD);
+            Element polygon = Xml.selectElement(extentObj, "*[local-name()='polygon']");
             geometry = parsePolygon(polygon);
         } else if ("EX_GeographicBoundingBox".equals(extentObj.getName())) {
-            double minx = Double.parseDouble(extentObj.getChild("westBoundLongitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
-            double maxx = Double.parseDouble(extentObj.getChild("eastBoundLongitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
-            double miny = Double.parseDouble(extentObj.getChild("southBoundLatitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
-            double maxy = Double.parseDouble(extentObj.getChild("northBoundLatitude", Geonet.Namespaces.GMD).getChildText("Decimal", Geonet.Namespaces.GCO));
+            double minx = Double.parseDouble(Xml.selectString(extentObj, "*[local-name()='westBoundLongitude']/*"));
+            double maxx = Double.parseDouble(Xml.selectString(extentObj, "*[local-name()='eastBoundLongitude']/*"));
+            double miny = Double.parseDouble(Xml.selectString(extentObj, "*[local-name()='southBoundLatitude']/*"));
+            double maxy = Double.parseDouble(Xml.selectString(extentObj, "*[local-name()='northBoundLatitude']/*"));
             Polygon[] polygons = {(Polygon)factory.toGeometry(new Envelope(minx, maxx, miny, maxy))};
             geometry = factory.createMultiPolygon(polygons);
         }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -91,6 +91,32 @@
 
   </xsl:function>
 
+  <!-- Use region API to display metadata extent -->
+  <xsl:function name="gn-fn-render:extent">
+    <xsl:param name="uuid" as="xs:string"/>
+
+    <!-- TODO get system config -->
+    <xsl:if test="$uuid">
+      <xsl:variable name="background"
+                    select="util:getSettingValue('region/getmap/background')"/>
+      <xsl:variable name="width"
+                    select="util:getSettingValue('region/getmap/width')"/>
+      <xsl:variable name="mapproj"
+                    select="util:getSettingValue('region/getmap/mapproj')"/>
+
+      <img class="gn-img-extent"
+           alt="{$schemaStrings/thumbnail}"
+           src="{$nodeUrl}eng/region.getmap.png?id=metadata:@uuid{$uuid}&amp;mapsrs={if ($mapproj != '')
+                                         then $mapproj
+                                         else 'EPSG:3857'}&amp;width={
+                                         if ($width != '')
+                                         then $width
+                                         else '600'
+                                         }&amp;background=settings"/>
+    </xsl:if>
+
+  </xsl:function>
+
   <!-- Template to get metadata title using its uuid.
          Title is loaded from current language index if available.
          If not, default title is returned.


### PR DESCRIPTION
Fixes https://github.com/geonetwork/core-geonetwork/issues/4258 for 19139.

Use region.getmap service to display the spatial extent of a metadata record containing bounding polygons that can also be rendered to a pdf.

Also modified the region.getmap service to:

- handle non WGS84 bounding polygons
- to use a gml 3.2 parser for gml 3.2 bounding polygons
- return all selected bounding polygons as a multi polygon

![image](https://user-images.githubusercontent.com/1860215/73737955-a4e00500-4797-11ea-83d9-304aab1f6005.png)

![image](https://user-images.githubusercontent.com/1860215/73738026-cd67ff00-4797-11ea-8316-f20cb06a49d9.png)

![image](https://user-images.githubusercontent.com/1860215/73718694-5e77af80-4771-11ea-8cdb-f1d46720c0c1.png)
