### PR TITLE
INSPIRE / CSW / Validator trigger error if ResponseLanguage is empty

### DIFF
--- a/web/src/main/webapp/xml/csw/record-to-csw-capabilities.xsl
+++ b/web/src/main/webapp/xml/csw/record-to-csw-capabilities.xsl
@@ -449,7 +449,7 @@
             </inspire_com:SupportedLanguages>
             <inspire_com:ResponseLanguage>
               <inspire_com:Language>
-                <xsl:value-of select="if ($outputLanguage != '') then $outputLanguage else $mainLanguage"/>
+                <xsl:value-of select="if ($language != '') then $outputLanguage else $mainLanguage"/>
               </inspire_com:Language>
             </inspire_com:ResponseLanguage>
           </inspire_ds:ExtendedCapabilities>

--- a/web/src/main/webapp/xml/csw/record-to-csw-capabilities.xsl
+++ b/web/src/main/webapp/xml/csw/record-to-csw-capabilities.xsl
@@ -449,7 +449,7 @@
             </inspire_com:SupportedLanguages>
             <inspire_com:ResponseLanguage>
               <inspire_com:Language>
-                <xsl:value-of select="$outputLanguage"/>
+                <xsl:value-of select="if ($outputLanguage != '') then $outputLanguage else $mainLanguage"/>
               </inspire_com:Language>
             </inspire_com:ResponseLanguage>
           </inspire_ds:ExtendedCapabilities>


### PR DESCRIPTION
If no language parameter provided in URL

Then 
```
Schema not valid: [org.xml.sax.SAXException: Fatal error: org.xml.sax.SAXParseException; lineNumber: 452; columnNumber: 36; cvc-enumeration-valid: Value '' is not facet-valid with respect to enumeration '[bul, cze, dan, dut, eng, est, fin, fre, ger, gre, hun, gle, ita, lav, lit, mlt, pol, por, rum, slo, slv, spa, swe]'. It must be a value from the enumeration. Response did not validate against schema 'http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd http://inspire.ec.europa.eu/schemas/inspire_ds/1.0 http://inspire.ec.europa.eu/schemas/inspire_ds/1.0/inspire_ds.xsd'.]
```

Technical guidance
```
If an unsupported language was requested or if no specific language was
requested <inspire_common:ResponseLanguage>/<inspire_common:Language> shall
correspond to the service default language.
```

Tested with success with http://inspire.ec.europa.eu/validator/v2/TestRuns/EID04f8ad19-8bb3-48cd-9c03-4333149c4b06.html