### PR TITLE
ISO19139 / Multilingual / Add Anchor and fallback to non empty value

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -935,19 +935,34 @@
      </span>
   </xsl:template>
 
-
   <xsl:template mode="render-value"
                 match="*[gmx:Anchor]">
+    <xsl:apply-templates mode="render-value"
+                         select="gmx:Anchor"/>
+  </xsl:template>
+
+  <xsl:template mode="render-value"
+                match="gmx:Anchor">
+    <xsl:variable name="link"
+                  select="@xlink:href"/>
     <xsl:variable name="txt">
-      <xsl:apply-templates mode="localised" select=".">
+      <xsl:apply-templates mode="localised" select="..">
         <xsl:with-param name="langId" select="$langId"/>
       </xsl:apply-templates>
     </xsl:variable>
 
-    <a href="{gmx:Anchor/@xlink:href}">
-      <xsl:value-of select="$txt"/>
-    </a>
+    <xsl:choose>
+      <xsl:when test="$link != ''">
+        <a href="{$link}">
+          <xsl:value-of select="$txt"/>
+        </a>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$txt"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
+
 
 
   <xsl:template mode="render-value"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
@@ -24,6 +24,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:gn="http://www.fao.org/geonetwork"
                 xmlns:xslutil="java:org.fao.geonet.util.XslUtil"
                 version="2.0"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
@@ -110,32 +110,27 @@
   </xsl:template>
 
 
-  <!-- Template used to return a gco:CharacterString element
-        in default metadata language or in a specific locale
-        if exist.
-        FIXME : gmd:PT_FreeText should not be in the match clause as gco:CharacterString
-        is mandatory and PT_FreeText optional. Added for testing GM03 import.
+  <!-- Template used to return a translation if one found, 
+       or the text in default metadata language 
+       or the first non empty text element.
     -->
-  <xsl:template name="localised" mode="localised" match="*[gco:CharacterString or gmd:PT_FreeText]">
+  <xsl:template name="localised" mode="localised" match="*[gco:CharacterString or gmx:Anchor or gmd:PT_FreeText]">
     <xsl:param name="langId"/>
 
-    <xsl:choose>
-      <xsl:when
-        test="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId] and
-        gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId] != ''">
-        <xsl:value-of
-          select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId]"/>
-      </xsl:when>
-      <xsl:when test="not(gco:CharacterString)">
-        <!-- If no CharacterString, try to use the first textGroup available -->
-        <xsl:value-of
-          select="gmd:PT_FreeText/gmd:textGroup[position()=1]/gmd:LocalisedCharacterString"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="gco:CharacterString"/>
-      </xsl:otherwise>
-    </xsl:choose>
+    <xsl:variable name="translation"
+                  select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId]"/>
 
+    <xsl:variable name="mainValue"
+                  select="(gco:CharacterString|gmx:Anchor)[1]"/>
+
+    <xsl:variable name="firstNonEmptyValue"
+                  select="((gco:CharacterString|gmx:Anchor|gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString)[. != ''])[1]"/>
+
+    <xsl:value-of select="if($translation != '')
+                          then $translation
+                          else (if($mainValue != '')
+                                then $mainValue
+                                else $firstNonEmptyValue)"/>
   </xsl:template>
 
 


### PR DESCRIPTION
Some records may use multilingual Anchor. Add support for this.
Some multilingual record may have translations and no value defined for the main language. In such case, fallback to a non empty value if any.