### PR TITLE
Stop infinite CSW harvester loop if start > nextRecord

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -221,9 +221,13 @@ class Harvester implements IHarvester<HarvestResult> {
     }
 
     /**
-     * Does CSW GetRecordsRequest.
+     * Does CSW GetRecordsRequest
+     * @param server
+     * @param s
+     * @param uuids
      * @param aligner
-     * @param errors2
+     * @param harvesterErrors
+     * @throws Exception
      */
     private void searchAndAlign(CswServer server, Search s, Set<String> uuids,
         Aligner aligner, List<HarvestError> harvesterErrors) throws Exception {
@@ -264,7 +268,7 @@ class Harvester implements IHarvester<HarvestResult> {
 
 
         while (true) {
-            if(this.cancelMonitor.get()) {
+            if (this.cancelMonitor.get()) {
               log.error("Harvester stopped in the middle of running!");
               //Returning whatever, we have to move on and finish!
               return;
@@ -375,14 +379,19 @@ class Harvester implements IHarvester<HarvestResult> {
                 break;
             }
 
+            // Some misbehaving CSW return nextRecord = 1 when start is over numberOfRecordsMatched
+            // Break the loop if nextRecord is smaller than start.
+            if (nextRecord != null && nextRecord < start) {
+                log.warning(String.format("Forcing harvest end since nextRecord < start (nextRecord = %d, start = %d)", nextRecord, start));
+                break;
+            }
+
             // Start position of next record.
             // Note that some servers may return less records than requested (it's ok for CSW protocol)
             start += returnedCount;
         }
 
         log.debug("Records added to result list : " + uuids.size());
-
-        return;
     }
 
     private void setUpRequest(GetRecordsRequest request, CswOperation oper, CswServer server, Search s, URL url,


### PR DESCRIPTION
Some server aren't compliant with CSW specification. In some cases they can  return a value
different of `0` for `nextRecord` when the harvester has reached the end of the available
results.
This commit stops the harvesting loop if the value of `nextResult` returned by the server
is smaller than the current `start` record.

Could be a complement to #3713.