### PR TITLE
DB migration / resources.get converted to attachments API

### DIFF
--- a/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java
+++ b/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java
@@ -85,7 +85,7 @@ public class MetadataResourceDatabaseMigration extends DatabaseMigrationTask {
     private static final String URL_ATTACHED_RESOURCES = "api/records/%s/attachments/";
 
     private static final Pattern pattern = Pattern.compile(
-            "(.*)\\/([a-zA-Z0-9_\\-]+)\\/([a-z]{2,3})\\/{1,2}resources.get\\?.*fname=([\\p{L}\\w\\s\\.\\-]+)(&.*|$)");
+            "(.*)\\/([a-zA-Z0-9_\\-]+)\\/([a-z]{2,3})\\/{1,2}resources.get\\?.*fname=([\\p{L}\\w\\s_=\\(\\)\\.\\-%:]+)(&.*|$)");
 
     public static boolean updateMetadataResourcesLink(@Nonnull Element xml,
                                                       @Nullable String uuid,


### PR DESCRIPTION
Some extra characters can be used in thumbnail filename "_=()%:".

Even it the migration task is quite old it may still be used in some places.

Tested on Ifremer 20k records.