### PR TITLE
[BP] Stop infinite harvester loop if start > nextRecord

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -392,6 +392,13 @@ class Harvester implements IHarvester<HarvestResult> {
                 break;
             }
 
+            // Some misbehaving CSW return nextRecord = 1 when start is over numberOfRecordsMatched
+            // Break the loop if nextRecord is smaller than start.
+            if (nextRecord != null && nextRecord < start) {
+                log.warning(String.format("Forcing harvest end since nextRecord < start (nextRecord = %d, start = %d)", nextRecord, start));
+                break;
+            }
+
             // Start position of next record.
             // Note that some servers may return less records than requested (it's ok for CSW protocol)
             start += returnedCount;


### PR DESCRIPTION
Some server aren't compliant with CSW specification. In some cases they can  return a value
different of 0 for nextRecord when the harvester has reached the end of the available
results.
This commit stops the harvesting loop if the value of `nextResult` returned by the server
is smaller than the current `start` record.

Backport of #4443.