### PR TITLE
Index gmd:otherConstraints with gmx:Anchor

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -558,6 +558,16 @@
                  string="{string(.)}" store="true" index="true"/>
         </xsl:for-each>
 
+        <xsl:for-each select="gmd:otherConstraints/gmx:Anchor[not(string(@xlink:href))]">
+          <Field name="{$fieldPrefix}OtherConstraints"
+                 string="{string(.)}" store="true" index="true"/>
+        </xsl:for-each>
+
+        <xsl:for-each select="gmd:otherConstraints/gmx:Anchor[string(@xlink:href)]">
+          <Field name="{$fieldPrefix}UseLimitation"
+                 string="{concat('link|',string(@xlink:href), '|', string(.))}" store="true" index="true"/>
+        </xsl:for-each>
+
         <xsl:for-each select="gmd:useLimitation/gco:CharacterString">
             <Field name="{$fieldPrefix}UseLimitation"
                    string="{string(.)}" store="true" index="true"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -564,7 +564,7 @@
         </xsl:for-each>
 
         <xsl:for-each select="gmd:otherConstraints/gmx:Anchor[string(@xlink:href)]">
-          <Field name="{$fieldPrefix}UseLimitation"
+          <Field name="{$fieldPrefix}OtherConstraints"
                  string="{concat('link|',string(@xlink:href), '|', string(.))}" store="true" index="true"/>
         </xsl:for-each>
 


### PR DESCRIPTION
INSPIRE Technical Guidelines 2.0.1 require to use `gmx:Anchor` for `gmd:otherContraints`, updated the indexing to index these elements properly so are displayed in the metadata detail page:

![other-constraints-anchor](https://user-images.githubusercontent.com/1695003/74533069-01c68280-4f31-11ea-86f1-8a36dc0cadbb.png)
