### PR TITLE
Include bounding polygons in pdf if have access to do so

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -96,6 +96,7 @@ import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.OperationAllowedSpecs;
+import org.fao.geonet.services.region.MapRenderer;
 import org.fao.geonet.util.XslUtil;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.IO;
@@ -568,8 +569,9 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             XslUtil.setNoScript();
             ITextRenderer renderer = new ITextRenderer();
             String siteUrl = context.getBean(SettingManager.class).getSiteURL(lang);
+            MapRenderer mapRenderer = new MapRenderer(context);
             renderer.getSharedContext().setReplacedElementFactory(new ImageReplacedElementFactory(siteUrl, renderer.getSharedContext()
-                .getReplacedElementFactory()));
+                .getReplacedElementFactory(), mapRenderer));
             renderer.getSharedContext().setDotsPerPixel(13);
             renderer.setDocumentFromString(htmlContent, siteUrl);
             renderer.layout();

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
@@ -31,6 +31,9 @@ import com.itextpdf.text.Image;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.services.region.GetMap;
+import org.fao.geonet.services.region.MapRenderer;
 import org.fao.geonet.utils.Log;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.ReplacedElement;
@@ -43,9 +46,14 @@ import org.xhtmlrenderer.pdf.ITextImageElement;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.imageio.ImageIO;
@@ -53,11 +61,19 @@ import javax.imageio.ImageIO;
 public class ImageReplacedElementFactory implements ReplacedElementFactory {
     private static Set<String> imgFormatExts = null;
     private final ReplacedElementFactory superFactory;
+    private final MapRenderer mapRenderer;
     private String baseURL;
 
     public ImageReplacedElementFactory(String baseURL, ReplacedElementFactory superFactory) {
         this.superFactory = superFactory;
         this.baseURL = baseURL;
+        this.mapRenderer = null;
+    }
+
+    public ImageReplacedElementFactory(String baseURL, ReplacedElementFactory superFactory, MapRenderer mapRenderer) {
+        this.superFactory = superFactory;
+        this.baseURL = baseURL;
+        this.mapRenderer = mapRenderer;
     }
 
     private static Set<String> getSupportedExts() {
@@ -85,7 +101,28 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
 
         String nodeName = element.getNodeName();
         String src = element.getAttribute("src");
-        if ("img".equals(nodeName) && src.contains("region.getmap.png")) {
+        if ("img".equals(nodeName) && src.startsWith(baseURL + "region.getmap.png") && mapRenderer != null) {
+            BufferedImage image = null;
+            try {
+                Map<String, String> parameters = getParams(src);
+
+                String id = parameters.get(Params.ID);
+                String srs = parameters.get(GetMap.MAP_SRS_PARAM) != null ? parameters.get(GetMap.MAP_SRS_PARAM) : "EPSG:4326";
+                Integer width = parameters.get(GetMap.WIDTH_PARAM) != null ? Integer.parseInt(parameters.get(GetMap.WIDTH_PARAM)) : null;
+                Integer height = parameters.get(GetMap.HEIGHT_PARAM) != null ? Integer.parseInt(parameters.get(GetMap.HEIGHT_PARAM)) : null;
+                String background = parameters.get(GetMap.BACKGROUND_PARAM);
+                String geomParam = parameters.get(GetMap.GEOM_PARAM);
+                String geomType = parameters.get(GetMap.GEOM_TYPE_PARAM) != null ? parameters.get(GetMap.GEOM_TYPE_PARAM) : "WKT";
+                String geomSrs = parameters.get(GetMap.GEOM_SRS_PARAM) != null ? parameters.get(GetMap.GEOM_SRS_PARAM) : "EPSG:4326";
+
+                image = mapRenderer.render(
+                    id, srs, width, height, background, geomParam, geomType, geomSrs);
+            } catch (Exception e) {
+                Log.warning(Geonet.GEONETWORK, "Error writing metadata to PDF", e);
+            }
+            float factor = layoutContext.getDotsPerPixel();
+            return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new BufferedImageLoader(image), factor);
+        } else if ("img".equals(nodeName) && src.contains("region.getmap.png")) {
             StringBuilder builder = new StringBuilder(baseURL);
             try {
                 if (StringUtils.startsWith(src, "http")) {
@@ -107,10 +144,10 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
                 Log.warning(Geonet.GEONETWORK, "Error writing metadata to PDF", e);
             }
             float factor = layoutContext.getDotsPerPixel();
-            return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, builder.toString(), factor);
+            return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new UrlImageLoader(builder.toString()), factor);
         } else if ("img".equals(nodeName) && isSupportedImageFormat(src)) {
             float factor = layoutContext.getDotsPerPixel();
-            return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, src, factor);
+            return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new UrlImageLoader(src), factor);
         }
 
         try {
@@ -120,20 +157,29 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
         }
     }
 
+    private Map<String, String> getParams(String src) throws MalformedURLException {
+        URL url = new URL(src);
+        String query = url.getQuery();
+        String[] keyValuePairs = query.split("&");
+        Map<String, String> parameters = new HashMap<>();
+        for (String keyValuePair: keyValuePairs) {
+            String[] pair = keyValuePair.split("=");
+            String key = pair[0];
+            String value = pair.length > 1 ? pair[1] : null;
+            parameters.put(key, value);
+        }
+        return parameters;
+    }
+
     private boolean isSupportedImageFormat(String imgUrl) {
         String ext = Files.getFileExtension(imgUrl);
         return ext.trim().isEmpty() || getSupportedExts().contains(ext);
     }
 
     private ReplacedElement loadImage(LayoutContext layoutContext, BlockBox box, UserAgentCallback userAgentCallback,
-                                      int cssWidth, int cssHeight, String url, float scaleFactor) {
-        InputStream input = null;
+                                      int cssWidth, int cssHeight, ImageLoader imageLoader, float scaleFactor) {
         try {
-            Log.error(Geonet.GEONETWORK, "URL -> " + url.toString());
-
-            input = new URL(url).openStream();
-            byte[] bytes = IOUtils.toByteArray(input);
-            Image image = Image.getInstance(bytes);
+            Image image = imageLoader.loadImage();
 
             image.scaleAbsolute(image.getPlainWidth() * scaleFactor, image.getPlainHeight() * scaleFactor);
             FSImage fsImage = new ITextFSImage(image);
@@ -156,10 +202,6 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
             } catch (Throwable e2) {
                 return new EmptyReplacedElement(cssWidth, cssHeight);
             }
-        } finally {
-            if (input != null) {
-                IOUtils.closeQuietly(input);
-            }
         }
     }
 
@@ -176,6 +218,49 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
     @Override
     public void setFormSubmissionListener(FormSubmissionListener listener) {
         superFactory.setFormSubmissionListener(listener);
+    }
+
+    /* Define API for loading an itext pdf image from a source */
+
+    private interface ImageLoader {
+        Image loadImage() throws Exception;
+    }
+
+    /* Define a url image loader  */
+
+    private class UrlImageLoader implements ImageLoader {
+        private final String url;
+
+        public UrlImageLoader(String url) {
+            this.url = url;
+        }
+
+        @Override
+        public Image loadImage() throws Exception {
+            Log.error(Geonet.GEONETWORK, "URL -> " + url);
+
+            try (InputStream input = new URL(url).openStream()) {
+                byte[] bytes = IOUtils.toByteArray(input);
+                return Image.getInstance(bytes);
+            }
+        }
+    }
+
+    /* Define an AWT BufferedImage image loader */
+
+    private class BufferedImageLoader implements ImageLoader {
+        private final BufferedImage bufferedImage;
+
+        public BufferedImageLoader(BufferedImage bufferedImage) {
+            this.bufferedImage = bufferedImage;
+        }
+
+        @Override
+        public Image loadImage() throws Exception {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(bufferedImage, "png", baos);
+            return Image.getInstance(baos.toByteArray());
+        }
     }
 
 }

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/PDF.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/PDF.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.api.records.formatters;
 
 import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.services.region.MapRenderer;
 import org.fao.geonet.util.XslUtil;
 import org.fao.geonet.utils.BinaryFile;
 import org.jdom.Element;
@@ -62,7 +63,9 @@ public class PDF implements Service {
         try (OutputStream os = Files.newOutputStream(tempFile)) {
             ITextRenderer renderer = new ITextRenderer();
             String siteUrl = context.getBean(SettingManager.class).getSiteURL(context);
-            renderer.getSharedContext().setReplacedElementFactory(new ImageReplacedElementFactory(siteUrl, renderer.getSharedContext().getReplacedElementFactory()));
+            MapRenderer mapRenderer = new MapRenderer(context);
+            renderer.getSharedContext().setReplacedElementFactory(new ImageReplacedElementFactory(siteUrl,
+                renderer.getSharedContext().getReplacedElementFactory(), mapRenderer));
             renderer.setDocumentFromString(htmlContent, siteUrl);
             renderer.layout();
             renderer.createPDF(os);

--- a/services/src/main/java/org/fao/geonet/services/region/GetMap.java
+++ b/services/src/main/java/org/fao/geonet/services/region/GetMap.java
@@ -24,33 +24,14 @@
 package org.fao.geonet.services.region;
 
 import com.google.common.base.Optional;
-
-import com.vividsolutions.jts.awt.ShapeWriter;
 import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-
-import org.apache.commons.io.IOUtils;
+import jeeves.server.context.ServiceContext;
+import jeeves.server.dispatchers.ServiceManager;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.exceptions.BadParameterEx;
-import org.fao.geonet.kernel.region.Region;
-import org.fao.geonet.kernel.region.RegionNotFoundEx;
 import org.fao.geonet.kernel.region.RegionsDAO;
 import org.fao.geonet.kernel.region.Request;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.lib.Lib;
-import org.geotools.geometry.jts.JTS;
-import org.geotools.geometry.jts.JTSFactoryFinder;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.CRS;
-import org.opengis.metadata.extent.Extent;
-import org.opengis.metadata.extent.GeographicBoundingBox;
-import org.opengis.metadata.extent.GeographicExtent;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.referencing.operation.MathTransform;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
@@ -60,28 +41,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.NativeWebRequest;
 
+import javax.annotation.PostConstruct;
+import javax.imageio.ImageIO;
+import javax.servlet.http.HttpServletRequest;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.Collection;
-import java.util.Map;
-import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
-
-import javax.annotation.PostConstruct;
-import javax.imageio.ImageIO;
-import javax.servlet.http.HttpServletRequest;
-
-import jeeves.server.context.ServiceContext;
-import jeeves.server.dispatchers.ServiceManager;
-
-import static java.lang.Math.pow;
-import static java.lang.Math.sqrt;
 
 //=============================================================================
 
@@ -117,71 +85,17 @@ public class GetMap {
     public static final String BACKGROUND_PARAM = "background";
     public static final String OUTPUT_FILE_NAME = "outputFileName";
     public static final String SETTING_BACKGROUND = "settings";
-    private static final double WGS_DIAG = sqrt(pow(360, 2) + pow(180, 2));
 
     @Autowired
     private ServiceManager serviceManager;
-    @Autowired
-    private SettingManager settingManager;
-    @Autowired
-    private ApplicationContext context;
-    private Map<String, String> regionGetMapBackgroundLayers;
-    private SortedSet<ExpandFactor> regionGetMapExpandFactors;
-
-    /**
-     * Check if a geometry is in the domain of validity of a projection and if not return the
-     * intersection of the geometry with the coordinate system domain of validity.
-     */
-    private static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
-        final GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory(null);
-        final Extent domainOfValidity = mapCRS.getDomainOfValidity();
-        Geometry adjustedGeom = geom;
-        if (domainOfValidity != null) {
-            for (final GeographicExtent extent :
-                domainOfValidity.getGeographicElements()) {
-                if (Boolean.FALSE.equals(extent.getInclusion())) {
-                    continue;
-                }
-                if (extent instanceof GeographicBoundingBox) {
-                    if (extent != null) {
-                        GeographicBoundingBox box = (GeographicBoundingBox) extent;
-
-                        Envelope env = new Envelope(
-                            box.getWestBoundLongitude(),
-                            box.getEastBoundLongitude(),
-                            box.getSouthBoundLatitude(),
-                            box.getNorthBoundLatitude());
-                        if (env.contains(geom.getEnvelopeInternal())) {
-                            return geom;
-                        } else {
-                            adjustedGeom = geometryFactory.toGeometry(
-                                env.intersection(geom.getEnvelopeInternal())
-                            );
-                        }
-                    }
-                }
-            }
-            return adjustedGeom;
-        } else {
-            return geom;
-        }
-    }
 
     public static AffineTransform worldToScreenTransform(Envelope mapExtent, Dimension screenSize) {
-        double scaleX = screenSize.getWidth() / mapExtent.getWidth();
-        double scaleY = screenSize.getHeight() / mapExtent.getHeight();
-
-        double tx = -mapExtent.getMinX() * scaleX;
-        double ty = (mapExtent.getMinY() * scaleY) + screenSize.getHeight();
-
-        return new AffineTransform(scaleX, 0.0d, 0.0d, -scaleY, tx, ty);
+        return MapRenderer.worldToScreenTransform(mapExtent, screenSize);
     }
 
     @SuppressWarnings("unchecked")
     @PostConstruct
     public void init() {
-        this.regionGetMapBackgroundLayers = context.getBean("regionGetMapBackgroundLayers", Map.class);
-        this.regionGetMapExpandFactors = context.getBean("regionGetMapExpandFactors", SortedSet.class);
     }
 
     /**
@@ -242,15 +156,31 @@ public class GetMap {
             throw new BadParameterEx(Params.ID, "Only one of " + GEOM_PARAM + " or " + Params.ID + " is permitted");
         }
 
+        if (width != null && height != null) {
+            throw new BadParameterEx(
+                WIDTH_PARAM,
+                "Only one of "
+                    + WIDTH_PARAM
+                    + " and "
+                    + HEIGHT_PARAM
+                    + " can be defined currently.  Future versions may support this but it is not supported at the moment");
+        }
+
+        if (width == null && height == null) {
+            throw new BadParameterEx(WIDTH_PARAM, "One of " + WIDTH_PARAM + " or " + HEIGHT_PARAM
+                + " parameters must be included in the request");
+
+        }
+
         if (outputFileName == null) {
             outputFileName = "region.getmap." + imageFormat;
         }
 
-        // see calculateImageSize for more parameter checks
+        // resource modified?
 
-        Geometry geom = null;
         if (id != null) {
             Collection<RegionsDAO> daos = context.getApplicationContext().getBeansOfType(RegionsDAO.class).values();
+
             for (RegionsDAO regionsDAO : daos) {
                 final Request searchRequest = regionsDAO.createSearchRequest(context);
                 searchRequest.id(id);
@@ -261,112 +191,17 @@ public class GetMap {
                         return null;
                     }
                 }
-
-                geom = regionsDAO.getGeom(context, id, false, srs);
-                if (geom != null) {
-                    break;
-                }
-            }
-            if (geom == null) {
-                throw new RegionNotFoundEx(id);
             }
         } else {
             if (request.checkNotModified(geomParam + srs + background)) {
                 return null;
             }
-            GeomFormat format = GeomFormat.find(geomType);
-            geom = format.parse(geomParam);
-            if (!geomSrs.equals(srs)) {
-                CoordinateReferenceSystem mapCRS = Region.decodeCRS(srs);
-                CoordinateReferenceSystem geomCRS = Region.decodeCRS(geomSrs);
-
-                // Check if coordinates provided
-                // are in projection scope to avoid.
-                // eg. java.lang.RuntimeException:
-                // org.geotools.referencing.operation.projection.ProjectionException:
-                // Latitude 90°00.0'S is too close to a pole.
-                geom = computeGeomInDomainOfValidity(geom, mapCRS);
-                MathTransform transform = CRS.findMathTransform(geomCRS, mapCRS, true);
-                geom = JTS.transform(geom, transform);
-            }
-        }
-        BufferedImage image;
-        Envelope bboxOfImage = new Envelope(geom.getEnvelopeInternal());
-        double expandFactor = calculateExpandFactor(bboxOfImage, srs);
-        bboxOfImage.expandBy(bboxOfImage.getWidth() * expandFactor, bboxOfImage.getHeight() * expandFactor);
-        Dimension imageDimensions = calculateImageSize(bboxOfImage, width, height);
-
-
-        Exception error = null;
-        if (background != null) {
-            // 4 cases:
-            // * request param is 'settings' and db setting is a full url
-            // * request param is 'settings' and db setting is a named bg layer
-            // * request param is a named bg layer
-            // * request param is a full url
-            if (background.equalsIgnoreCase(SETTING_BACKGROUND)) {
-                String bgSetting = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
-                if (bgSetting.startsWith("http://") || bgSetting.startsWith("https://")) {
-                    background = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
-                } else if (this.regionGetMapBackgroundLayers.containsKey(bgSetting)) {
-                    background = this.regionGetMapBackgroundLayers.get(bgSetting);
-                }
-            } else if (this.regionGetMapBackgroundLayers.containsKey(background)) {
-                background = this.regionGetMapBackgroundLayers.get(background);
-            }
-
-            String minx = Double.toString(bboxOfImage.getMinX());
-            String maxx = Double.toString(bboxOfImage.getMaxX());
-            String miny = Double.toString(bboxOfImage.getMinY());
-            String maxy = Double.toString(bboxOfImage.getMaxY());
-            background = background.replace("{minx}", minx).replace("{maxx}", maxx).replace("{miny}", miny)
-                .replace("{maxy}", maxy).replace("{srs}", srs)
-                .replace("{width}", Integer.toString(imageDimensions.width))
-                .replace("{height}", Integer.toString(imageDimensions.height)).replace("{MINX}", minx)
-                .replace("{MAXX}", maxx).replace("{MINY}", miny).replace("{MAXY}", maxy).replace("{SRS}", srs)
-                .replace("{WIDTH}", Integer.toString(imageDimensions.width))
-                .replace("{HEIGHT}", Integer.toString(imageDimensions.height));
-
-            InputStream in = null;
-            try {
-                URL imageUrl = new URL(background);
-                // Setup the proxy for the request if required
-                URLConnection conn = Lib.net.setupProxy(context, imageUrl);
-                in = conn.getInputStream();
-                image = ImageIO.read(in);
-            } catch (IOException e) {
-                image = new BufferedImage(imageDimensions.width, imageDimensions.height, BufferedImage.TYPE_INT_ARGB);
-                error = e;
-            } finally {
-                if (in != null) {
-                    IOUtils.closeQuietly(in);
-                }
-
-            }
-        } else {
-            image = new BufferedImage(imageDimensions.width, imageDimensions.height, BufferedImage.TYPE_INT_ARGB);
         }
 
-        Graphics2D graphics = image.createGraphics();
-        try {
-            if (error != null) {
-                graphics.drawString(error.getMessage(), 0, imageDimensions.height / 2);
-            }
-            ShapeWriter shapeWriter = new ShapeWriter();
-            AffineTransform worldToScreenTransform = worldToScreenTransform(bboxOfImage, imageDimensions);
-            for (int i=0; i<geom.getNumGeometries(); i++) {
-                // draw each included geometry separately to ensure they are filled correctly
-                Shape shape = worldToScreenTransform.createTransformedShape(shapeWriter.toShape(geom.getGeometryN(i)));
-                graphics.setColor(Color.yellow);
-                graphics.draw(shape);
+        MapRenderer renderer = new MapRenderer(context);
+        BufferedImage image = renderer.render(id, srs, width, height, background, geomParam, geomType, geomSrs);
 
-                graphics.setColor(new Color(255, 255, 0, 100));
-                graphics.fill(shape);
-            }
-        } finally {
-            graphics.dispose();
-        }
-
+        if (image == null) return null;
 
         try (ByteArrayOutputStream out = new ByteArrayOutputStream();) {
             ImageIO.write(image, imageFormat, out);
@@ -383,48 +218,8 @@ public class GetMap {
         }
     }
 
-    private double calculateExpandFactor(Envelope bboxOfImage, String srs) throws Exception {
-        CoordinateReferenceSystem crs = Region.decodeCRS(srs);
-        ReferencedEnvelope env = new ReferencedEnvelope(bboxOfImage, crs);
-        env = env.transform(Region.WGS84, true);
-
-        double diag = sqrt(pow(env.getWidth(), 2) + pow(env.getHeight(), 2));
-
-        double scale = diag / WGS_DIAG;
-
-        for (ExpandFactor factor : regionGetMapExpandFactors) {
-            if (scale < factor.proportion) {
-                return factor.factor;
-            }
-        }
-        return regionGetMapExpandFactors.last().factor;
-    }
-
-    private Dimension calculateImageSize(Envelope bboxOfImage, Integer width, Integer height) {
-
-        if (width != null && height != null) {
-            throw new BadParameterEx(
-                WIDTH_PARAM,
-                "Only one of "
-                    + WIDTH_PARAM
-                    + " and "
-                    + HEIGHT_PARAM
-                    + " can be defined currently.  Future versions may support this but it is not supported at the moment");
-        }
-        if (width == null && height == null) {
-            throw new BadParameterEx(WIDTH_PARAM, "One of " + WIDTH_PARAM + " or " + HEIGHT_PARAM
-                + " parameters must be included in the request");
-
-        }
-
-        if (width != null) {
-            return new Dimension(width, (int) Math.round(bboxOfImage.getHeight() / bboxOfImage.getWidth() * width));
-        } else {
-            return new Dimension((int) Math.round(bboxOfImage.getWidth() / bboxOfImage.getHeight() * height), height);
-        }
-    }
-
 }
+
 
 // =============================================================================
 

--- a/services/src/main/java/org/fao/geonet/services/region/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/services/region/MapRenderer.java
@@ -1,0 +1,241 @@
+package org.fao.geonet.services.region;
+
+import com.vividsolutions.jts.awt.ShapeWriter;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import jeeves.server.context.ServiceContext;
+import org.apache.commons.io.IOUtils;
+import org.fao.geonet.kernel.region.Region;
+import org.fao.geonet.kernel.region.RegionNotFoundEx;
+import org.fao.geonet.kernel.region.RegionsDAO;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.lib.Lib;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.opengis.metadata.extent.Extent;
+import org.opengis.metadata.extent.GeographicBoundingBox;
+import org.opengis.metadata.extent.GeographicExtent;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.springframework.context.ApplicationContext;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collection;
+import java.util.Map;
+import java.util.SortedSet;
+
+import static java.lang.Math.pow;
+import static java.lang.Math.sqrt;
+
+public class MapRenderer {
+
+    private final ServiceContext context;
+
+    private static final double WGS_DIAG = sqrt(pow(360, 2) + pow(180, 2));
+
+    public MapRenderer(ServiceContext context) {
+        this.context = context;
+    }
+
+    public static AffineTransform worldToScreenTransform(Envelope mapExtent, Dimension screenSize) {
+        double scaleX = screenSize.getWidth() / mapExtent.getWidth();
+        double scaleY = screenSize.getHeight() / mapExtent.getHeight();
+
+        double tx = -mapExtent.getMinX() * scaleX;
+        double ty = (mapExtent.getMinY() * scaleY) + screenSize.getHeight();
+
+        return new AffineTransform(scaleX, 0.0d, 0.0d, -scaleY, tx, ty);
+    }
+
+    /**
+     * Check if a geometry is in the domain of validity of a projection and if not return the
+     * intersection of the geometry with the coordinate system domain of validity.
+     */
+    private static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
+        final GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory(null);
+        final Extent domainOfValidity = mapCRS.getDomainOfValidity();
+        Geometry adjustedGeom = geom;
+        if (domainOfValidity != null) {
+            for (final GeographicExtent extent :
+                domainOfValidity.getGeographicElements()) {
+                if (Boolean.FALSE.equals(extent.getInclusion())) {
+                    continue;
+                }
+                if (extent instanceof GeographicBoundingBox) {
+                    if (extent != null) {
+                        GeographicBoundingBox box = (GeographicBoundingBox) extent;
+
+                        Envelope env = new Envelope(
+                            box.getWestBoundLongitude(),
+                            box.getEastBoundLongitude(),
+                            box.getSouthBoundLatitude(),
+                            box.getNorthBoundLatitude());
+                        if (env.contains(geom.getEnvelopeInternal())) {
+                            return geom;
+                        } else {
+                            adjustedGeom = geometryFactory.toGeometry(
+                                env.intersection(geom.getEnvelopeInternal())
+                            );
+                        }
+                    }
+                }
+            }
+            return adjustedGeom;
+        } else {
+            return geom;
+        }
+    }
+
+    public BufferedImage render(String id, String srs, Integer width, Integer height,
+                                String background, String geomParam, String geomType, String geomSrs) throws Exception {
+        ApplicationContext appContext = context.getApplicationContext();
+        Map<String, String> regionGetMapBackgroundLayers = appContext.getBean("regionGetMapBackgroundLayers", Map.class);
+        SortedSet<ExpandFactor> regionGetMapExpandFactors = appContext.getBean("regionGetMapExpandFactors", SortedSet.class);
+        SettingManager settingManager = appContext.getBean(SettingManager.class);
+
+        Geometry geom = null;
+        if (id != null) {
+            Collection<RegionsDAO> daos = context.getApplicationContext().getBeansOfType(RegionsDAO.class).values();
+            for (RegionsDAO regionsDAO : daos) {
+
+                geom = regionsDAO.getGeom(context, id, false, srs);
+                if (geom != null) {
+                    break;
+                }
+            }
+            if (geom == null) {
+                throw new RegionNotFoundEx(id);
+            }
+        } else {
+            GeomFormat format = GeomFormat.find(geomType);
+            geom = format.parse(geomParam);
+            if (!geomSrs.equals(srs)) {
+                CoordinateReferenceSystem mapCRS = Region.decodeCRS(srs);
+                CoordinateReferenceSystem geomCRS = Region.decodeCRS(geomSrs);
+
+                // Check if coordinates provided
+                // are in projection scope to avoid.
+                // eg. java.lang.RuntimeException:
+                // org.geotools.referencing.operation.projection.ProjectionException:
+                // Latitude 90°00.0'S is too close to a pole.
+                geom = computeGeomInDomainOfValidity(geom, mapCRS);
+                MathTransform transform = CRS.findMathTransform(geomCRS, mapCRS, true);
+                geom = JTS.transform(geom, transform);
+            }
+        }
+        BufferedImage image;
+        Envelope bboxOfImage = new Envelope(geom.getEnvelopeInternal());
+        double expandFactor = calculateExpandFactor(regionGetMapExpandFactors, bboxOfImage, srs);
+        bboxOfImage.expandBy(bboxOfImage.getWidth() * expandFactor, bboxOfImage.getHeight() * expandFactor);
+        Dimension imageDimensions = calculateImageSize(bboxOfImage, width, height);
+
+        Exception error = null;
+        if (background != null) {
+            // 4 cases:
+            // * request param is 'settings' and db setting is a full url
+            // * request param is 'settings' and db setting is a named bg layer
+            // * request param is a named bg layer
+            // * request param is a full url
+            if (background.equalsIgnoreCase(GetMap.SETTING_BACKGROUND)) {
+                String bgSetting = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
+                if (bgSetting.startsWith("http://") || bgSetting.startsWith("https://")) {
+                    background = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
+                } else if (regionGetMapBackgroundLayers.containsKey(bgSetting)) {
+                    background = regionGetMapBackgroundLayers.get(bgSetting);
+                }
+            } else if (regionGetMapBackgroundLayers.containsKey(background)) {
+                background = regionGetMapBackgroundLayers.get(background);
+            }
+
+            String minx = Double.toString(bboxOfImage.getMinX());
+            String maxx = Double.toString(bboxOfImage.getMaxX());
+            String miny = Double.toString(bboxOfImage.getMinY());
+            String maxy = Double.toString(bboxOfImage.getMaxY());
+            background = background.replace("{minx}", minx).replace("{maxx}", maxx).replace("{miny}", miny)
+                .replace("{maxy}", maxy).replace("{srs}", srs)
+                .replace("{width}", Integer.toString(imageDimensions.width))
+                .replace("{height}", Integer.toString(imageDimensions.height)).replace("{MINX}", minx)
+                .replace("{MAXX}", maxx).replace("{MINY}", miny).replace("{MAXY}", maxy).replace("{SRS}", srs)
+                .replace("{WIDTH}", Integer.toString(imageDimensions.width))
+                .replace("{HEIGHT}", Integer.toString(imageDimensions.height));
+
+            InputStream in = null;
+            try {
+                URL imageUrl = new URL(background);
+                // Setup the proxy for the request if required
+                URLConnection conn = Lib.net.setupProxy(context, imageUrl);
+                in = conn.getInputStream();
+                image = ImageIO.read(in);
+            } catch (IOException e) {
+                image = new BufferedImage(imageDimensions.width, imageDimensions.height, BufferedImage.TYPE_INT_ARGB);
+                error = e;
+            } finally {
+                if (in != null) {
+                    IOUtils.closeQuietly(in);
+                }
+
+            }
+        } else {
+            image = new BufferedImage(imageDimensions.width, imageDimensions.height, BufferedImage.TYPE_INT_ARGB);
+        }
+
+        Graphics2D graphics = image.createGraphics();
+        try {
+            if (error != null) {
+                graphics.drawString(error.getMessage(), 0, imageDimensions.height / 2);
+            }
+            ShapeWriter shapeWriter = new ShapeWriter();
+            AffineTransform worldToScreenTransform = worldToScreenTransform(bboxOfImage, imageDimensions);
+            for (int i = 0; i < geom.getNumGeometries(); i++) {
+                // draw each included geometry separately to ensure they are filled correctly
+                Shape shape = worldToScreenTransform.createTransformedShape(shapeWriter.toShape(geom.getGeometryN(i)));
+                graphics.setColor(Color.yellow);
+                graphics.draw(shape);
+
+                graphics.setColor(new Color(255, 255, 0, 100));
+                graphics.fill(shape);
+            }
+        } finally {
+            graphics.dispose();
+        }
+        return image;
+    }
+
+    private double calculateExpandFactor(SortedSet<ExpandFactor> regionGetMapExpandFactors, Envelope bboxOfImage,
+                                         String srs) throws Exception {
+        CoordinateReferenceSystem crs = Region.decodeCRS(srs);
+        ReferencedEnvelope env = new ReferencedEnvelope(bboxOfImage, crs);
+        env = env.transform(Region.WGS84, true);
+
+        double diag = sqrt(pow(env.getWidth(), 2) + pow(env.getHeight(), 2));
+
+        double scale = diag / WGS_DIAG;
+
+        for (ExpandFactor factor : regionGetMapExpandFactors) {
+            if (scale < factor.proportion) {
+                return factor.factor;
+            }
+        }
+        return regionGetMapExpandFactors.last().factor;
+    }
+
+    private Dimension calculateImageSize(Envelope bboxOfImage, Integer width, Integer height) {
+        if (width != null) {
+            return new Dimension(width, (int) Math.round(bboxOfImage.getHeight() / bboxOfImage.getWidth() * width));
+        } else {
+            return new Dimension((int) Math.round(bboxOfImage.getWidth() / bboxOfImage.getHeight() * height), height);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/geonetwork/core-geonetwork/issues/4451

Seems silly to be using http to fetch the image (can tie up a request thread) and authenticate with oneself so I've opted for refactoring the GetMap service to extract map rendering to a separate class that can be used directly by the ImageReplacedElementFactory.  

ideally this would be a service, but had trouble doing that cleanly with the existing non spring based code.

Bounding polygon:

![image](https://user-images.githubusercontent.com/1860215/74704964-51c18400-5266-11ea-82c3-036ffbc01665.png)

Bounding box (still works):

![image](https://user-images.githubusercontent.com/1860215/74705026-8cc3b780-5266-11ea-80b3-f75b5cef46d4.png)

