### PR TITLE
Remove unused namespaces from OAI records

### DIFF
--- a/schemas/csw-record/src/main/plugin/csw-record/convert/oai_dc.xsl
+++ b/schemas/csw-record/src/main/plugin/csw-record/convert/oai_dc.xsl
@@ -24,7 +24,8 @@
   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
-                version="1.0">
+                version="1.0"
+                exclude-result-prefixes="csw">
 
   <!-- ============================================================================================ -->
 

--- a/schemas/iso19110/src/main/plugin/iso19110/convert/oai_dc.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/convert/oai_dc.xsl
@@ -23,9 +23,11 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:gco="http://www.isotc211.org/2005/gco"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gfc="http://www.isotc211.org/2005/gfc"
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                exclude-result-prefixes="gco gfc gmx"
                 version="1.0">
 
   <!-- ============================================================================================ -->

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/oai_dc.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/oai_dc.xsl
@@ -25,6 +25,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                exclude-result-prefixes="gmd gco"
                 version="1.0">
 
   <!-- ============================================================================================ -->


### PR DESCRIPTION
Remove unused namespaces like `gmc`, `gco`... from output of `oai_dc` transformations.