### PR TITLE
Remove invalid content length header in log file download. 

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/LoggingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/LoggingApi.java
@@ -170,7 +170,6 @@ public class LoggingApi {
 
             // set headers for the response
             response.setContentType("application/zip");
-            response.setContentLength((int) file.length());
             String headerKey = "Content-Disposition";
             String headerValue = String.format(
                 "attachment; filename=\"catalog-log-%s-%s.zip\"",


### PR DESCRIPTION
The value was set to the log file size, but the service returns a zip file with different size, causing download issues in some cases.

![error-download-activity](https://user-images.githubusercontent.com/1695003/74911121-42544f00-53bc-11ea-8508-9e81f6df3bb2.png)
