### PR TITLE
Formatter / XSL / Improvement when not using tabs

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -288,14 +288,21 @@
           </xsl:if>
           <xsl:value-of select="$title"/>
         </h1>
-        <xsl:choose>
-          <xsl:when test="normalize-space($content) = ''">
-            No information
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:copy-of select="$content"/><xsl:comment select="'icon'"/>
-          </xsl:otherwise>
-        </xsl:choose>
+        <xsl:if test="normalize-space($content) != ''">
+          <xsl:choose>
+            <!-- In tab mode, the top level container is not needed for styling
+            as it is contained by tab-pane. Also if the tab contains only one child
+            do not build a block. -->
+            <xsl:when test="$tabs = 'true' or count(*) = 1">
+              <xsl:copy-of select="$content"/>&#160;
+            </xsl:when>
+            <xsl:otherwise>
+              <div class="entry name">
+                <xsl:copy-of select="$content"/>&#160;
+              </div>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:if>
       </div>
     </xsl:if>
   </xsl:template>
@@ -323,15 +330,30 @@
                       select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
 
         <xsl:element name="h{1 + count(ancestor-or-self::*[name(.) = 'section'])}">
-          <xsl:attribute name="class" select="'view-header'"/>
           <xsl:value-of select="$title"/>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates mode="render-view"
-                           select="section|field"/>
-    <xsl:comment select="'icon'"/></div>
+                           select="section|field|xsl"/>&#160;
+    </div>
   </xsl:template>
 
+
+  <xsl:template mode="render-view"
+                match="xsl">
+    <div id="gn-section-{generate-id()}">
+      <xsl:if test="@name">
+        <xsl:variable name="title"
+                      select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
+
+        <xsl:element name="h{3 + count(ancestor-or-self::*[name(.) = 'section'])}">
+          <xsl:value-of select="$title"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates mode="render-view"
+                           select="@xpath"/>&#160;
+    </div>
+  </xsl:template>
 
   <!-- Render metadata elements defined by XPath -->
   <xsl:template mode="render-view"
@@ -364,56 +386,59 @@
                 match="field[template]"
                 priority="2">
     <xsl:param name="base" select="$metadata"/>
-    <xsl:if test="@name">
-      <xsl:variable name="title"
-                    select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
 
-      <xsl:element name="h{3 + 1 + count(ancestor-or-self::*[name(.) = 'section'])}">
-        <xsl:attribute name="class" select="'view-header'"/>
-        <xsl:value-of select="$title"/>
-      </xsl:element>
-    </xsl:if>
+    <div class="entry name">
+      <xsl:if test="@name">
+        <xsl:variable name="title"
+                      select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
 
-    <xsl:variable name="fieldXpath"
-                  select="@xpath"/>
-    <xsl:variable name="fields" select="template/values/key"/>
+        <xsl:element name="h{3 + 1 + count(ancestor-or-self::*[name(.) = 'section'])}">
+          <xsl:value-of select="$title"/>
+        </xsl:element>
+      </xsl:if>
 
-    <xsl:variable name="elements">
-      <saxon:call-template name="{concat('evaluate-', $schema)}">
-        <xsl:with-param name="base" select="$base"/>
-        <xsl:with-param name="in"
-                        select="concat('/../', $fieldXpath)"/>
-      </saxon:call-template>
-    </xsl:variable>
+      <xsl:variable name="fieldXpath"
+                    select="@xpath"/>
+      <xsl:variable name="fields" select="template/values/key"/>
 
-    <!-- Loop on each element matching current field -->
-    <xsl:for-each select="$elements/*">
-      <xsl:variable name="element" select="."/>
+      <xsl:variable name="elements">
+        <saxon:call-template name="{concat('evaluate-', $schema)}">
+          <xsl:with-param name="base" select="$base"/>
+          <xsl:with-param name="in"
+                          select="concat('/../', $fieldXpath)"/>
+        </saxon:call-template>
+      </xsl:variable>
 
-      <!-- Loop on each fields -->
-      <xsl:for-each select="$fields">
-        <xsl:variable name="nodes">
-          <saxon:call-template name="{concat('evaluate-', $schema)}">
-            <xsl:with-param name="base" select="$element"/>
-            <xsl:with-param name="in"
-                            select="concat('/./',
-                           replace(@xpath, '/gco:CharacterString', ''))"/>
-          </saxon:call-template>
-        </xsl:variable>
+      <!-- Loop on each element matching current field -->
+      <xsl:for-each select="$elements/*">
+        <xsl:variable name="element" select="."/>
+        <div class="target">
+          <!-- Loop on each fields -->
+          <xsl:for-each select="$fields">
+            <xsl:variable name="nodes">
+              <saxon:call-template name="{concat('evaluate-', $schema)}">
+                <xsl:with-param name="base" select="$element"/>
+                <xsl:with-param name="in"
+                                select="concat('/./',
+                               replace(@xpath, '/gco:CharacterString', ''))"/>
+              </saxon:call-template>
+            </xsl:variable>
 
-        <xsl:variable name="fieldName">
-          <xsl:if test="@label">
-            <xsl:value-of select="gn-fn-render:get-schema-strings($schemaStrings, @label)"/>
-          </xsl:if>
-        </xsl:variable>
+            <xsl:variable name="fieldName">
+              <xsl:if test="@label">
+                <xsl:value-of select="gn-fn-render:get-schema-strings($schemaStrings, @label)"/>
+              </xsl:if>
+            </xsl:variable>
 
-        <xsl:for-each select="$nodes">
-          <xsl:apply-templates mode="render-field">
-            <xsl:with-param name="fieldName" select="$fieldName"/>
-          </xsl:apply-templates>
-        </xsl:for-each>
+            <xsl:for-each select="$nodes">
+              <xsl:apply-templates mode="render-field">
+                <xsl:with-param name="fieldName" select="$fieldName"/>
+              </xsl:apply-templates>
+            </xsl:for-each>
+          </xsl:for-each>
+        </div>
       </xsl:for-each>
-    </xsl:for-each>
+    </div>
   </xsl:template>
 
   <!-- Render metadata elements defined by XPath -->


### PR DESCRIPTION
Make styling consistent depending on formatter config:
* when a tab contains only one section - remove unnecessary block

Before:

![image](https://user-images.githubusercontent.com/1701393/75319363-d31fa480-586c-11ea-903b-89bf0364a620.png)

After:

![image](https://user-images.githubusercontent.com/1701393/75319453-fba79e80-586c-11ea-87e9-a18ef9f6ce9b.png)


* when a view has one tab - make styling consistent

Before (border-bottom is not the standard layout):
![image](https://user-images.githubusercontent.com/1701393/75319352-cef38700-586c-11ea-9741-1ec82c865e14.png)

After:
![image](https://user-images.githubusercontent.com/1701393/75319396-e0d52a00-586c-11ea-8568-e6d1ad1a2e86.png)


* when a field is based on a template - create a block with its field


For testing configure the formatter to have advanced view in one tab and INSPIRE view (which use template field mode):
```json
"formatter": {
        "list": [
          {
            "label": "defaultView",
            "url": ""
          },
          {
            "label": "full",
            "url": "/formatters/xsl-view?root=div&view=advanced&tabs=false"
          },
          {
            "label": "inspire",
            "url": "/formatters/xsl-view?root=div&view=inspire&tabs=false"
          }
        ],
        "defaultUrl": ""
      },
```



* Also add XSL field mode rendering (not used in core GN)