### PR TITLE
Privileges / When user can't download disable download action

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
@@ -104,6 +104,7 @@
             role="button"
             class="btn btn-default dropdown-toggle"
             data-toggle="dropdown"
+            data-ng-disabled="md['geonet:info'].download == 'false'"
             title="{{'downloads' | translate}}"
             aria-label="{{'downloads' | translate}}">
       <span class="fa fa-download"></span>


### PR DESCRIPTION
Download links are not rendered in record view.
In result view, the button is active and should not.

Before:
![image](https://user-images.githubusercontent.com/1701393/75320197-7e7d2900-586e-11ea-9a92-ac0be61ff9fc.png)


After:

![image](https://user-images.githubusercontent.com/1701393/75320237-9359bc80-586e-11ea-80cf-cdc94ac5c4f2.png)
