### PR TITLE
 Use system property to customise the parent directory of the log folder

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/log4j-dev.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j-dev.xml
@@ -18,7 +18,7 @@
   </appender>
   <appender name="fileAppender" class="org.apache.log4j.RollingFileAppender">
     <param name="Threshold" value="ALL"/>
-    <param name="File" value="logs/geonetwork.log"/>
+    <param name="File" value="${log_dir}logs/geonetwork.log"/>
     <layout class="org.apache.log4j.PatternLayout">
       <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c] - %m%n"/>
     </layout>

--- a/web/src/main/webapp/WEB-INF/classes/log4j-index.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j-index.xml
@@ -18,7 +18,7 @@
   </appender>
   <appender name="fileAppender" class="org.apache.log4j.RollingFileAppender">
     <param name="Threshold" value="ALL"/>
-    <param name="File" value="logs/geonetwork.log"/>
+    <param name="File" value="${log_dir}logs/geonetwork.log"/>
     <layout class="org.apache.log4j.PatternLayout">
       <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c] - %m%n"/>
     </layout>

--- a/web/src/main/webapp/WEB-INF/classes/log4j-search.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j-search.xml
@@ -18,7 +18,7 @@
   </appender>
   <appender name="fileAppender" class="org.apache.log4j.RollingFileAppender">
     <param name="Threshold" value="ALL"/>
-    <param name="File" value="logs/geonetwork.log"/>
+    <param name="File" value="${log_dir}logs/geonetwork.log"/>
     <layout class="org.apache.log4j.PatternLayout">
       <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c] - %m%n"/>
     </layout>

--- a/web/src/main/webapp/WEB-INF/classes/log4j.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j.xml
@@ -18,7 +18,7 @@
   </appender>
   <appender name="fileAppender" class="org.apache.log4j.RollingFileAppender">
     <param name="Threshold" value="ALL"/>
-    <param name="File" value="logs/geonetwork.log"/>
+    <param name="File" value="${log_dir}logs/geonetwork.log"/>
     <layout class="org.apache.log4j.PatternLayout">
       <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c] - %m%n"/>
     </layout>


### PR DESCRIPTION
Added support for a system property `log_dir`to customise the to customise the parent directory of the log folder:

- `-Dlog_dir=/var/tomcat/` (path should end with /) -> the log file is created in `/var/tomcat/logs/geonetwork.log`.

- if not defined, a relative path is used.