### PR TITLE
fix memory leak due to incorrect ref count handling (#4481)

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/IndexAndTaxonomy.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/IndexAndTaxonomy.java
@@ -44,5 +44,7 @@ public class IndexAndTaxonomy implements Closeable {
     @Override
     public void close() throws IOException {
         indexReader.releaseToNRTManager();
+        //TODO: this has a taxonomyReader in it, and it should be "closed" (decrement a ref)
+        // However, since it's public, not sure if we can do that or not since someone else might be using it...
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/LuceneIndexLanguageTracker.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/LuceneIndexLanguageTracker.java
@@ -226,7 +226,7 @@ public class LuceneIndexLanguageTracker {
 
             }
             return new IndexAndTaxonomy(finalVersion, new GeonetworkMultiReader(_openReaderCounter, readers, searchers),
-                taxonomyIndexTracker.acquire());
+                taxonomyIndexTracker.acquire()); //this is likely leaking a refCount to the TaxonomyReader
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
See #4481 

I've modified `TaxonomyIndexTracker` so that it does a better job of releasing TaxonomyReaders.

During harvesting, `maybeRefresh()` would be called (often).  The "`openIfChanged()`" call would create a new `DirectoryTaxonomyReader`.  However, the old one would not be released.

When you create a `TaxonomyReader`, it will have a ref count of 1.  There wasn't any code that would decrement it so it would always go in the `expiredReader` list.

I've modified this so it would be better at handling the ref counts.  The reference that `TaxonomyIndexTracker` keeps (for `this.taxonomyReader`) is one reference count (the one that is automatically created when you create a `TaxonomyReader`).  If someone calls `aquire()`, then it gets a 2nd reference count.

If `maybeRefresh()` creates another `TaxonomyReader`, it is throwing away its old one.  So, when `TaxonomyIndexTracker` no longer needs the old `Reader`, it decrements the ref count and it will be likely be released.

This means that code that calls `aquire()` should release (close or decrement the reference) when it's finished with it.  I noticed that this isn't happened (I put some comments in the code to indicate where) - however, this doesn't seem to be a major leak problem.  This PR doesn't fix this (existing) problem (which doesn't seem to be causing any issues).

Since the ref count is pretty complex, I've put quite a few comments in the code -- hopefully this will make sense to others in the future.
