### PR TITLE
in map geocoder, only pan to presumed coordinates if they start the input

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/localisation/LocalisationService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/localisation/LocalisationService.js
@@ -42,7 +42,7 @@
       DMSEast, 'g');
   var regexpDMSDegree = new RegExp(DMSDegree, 'g');
   var regexpCoordinate = new RegExp(
-      '(\-?[\\d\\.\']+)[\\s,]+(\-?[\\d\\.\']+)');
+      '^\\s*(\-?[\\d\\.\']+)[\\s,]+(\-?[\\d\\.\']+)');
 
 
   /**


### PR DESCRIPTION
currently, if you enter e.g. a gb postcode such as SE1 2AA into the map geocoder, it presumes the digits are coordinates, and pans to them (around equatorial guinea in this case); so, only convert and pan to numbers if input starts with numbers ([via gitter](https://gitter.im/geonetwork/core-geonetwork?at=5e3c3687ea9ba00b84b65d31))

_note_ location names can be odd, so it's quite conceivable someone might start entering two numbers for reasons other than entering a coordinate pair, they may get a little surprise when the map pans there (i know i did) although it's obviously really handy being able to quickly get to a lng lat pair.