### PR TITLE
Region API / Move to /api

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/region/Region.java
+++ b/core/src/main/java/org/fao/geonet/kernel/region/Region.java
@@ -37,6 +37,7 @@ import org.opengis.referencing.operation.TransformException;
 import java.util.Collections;
 import java.util.Map;
 
+
 public class Region {
     public static final String REGION_EL = "region";
     public static final CoordinateReferenceSystem WGS84;

--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialIndexWriter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialIndexWriter.java
@@ -30,7 +30,6 @@ import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.index.SpatialIndex;
 import com.vividsolutions.jts.index.strtree.STRtree;
-
 import org.apache.jcs.access.exception.CacheException;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.utils.Log;
@@ -63,6 +62,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
 import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Path;
@@ -74,8 +74,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
-
-import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * This class is responsible for extracting geographic information from metadata and writing that
@@ -505,7 +503,7 @@ public class SpatialIndexWriter implements FeatureListener {
         } else if (geometry instanceof MultiPolygon) {
             return (MultiPolygon) geometry;
         }
-        String message = geometry.getClass() + " cannot be converted to a polygon. Check Metadata";
+        String message = geometry.getClass() + " cannot be converted to a polygon. Check metadata";
         Log.error(Geonet.INDEX_ENGINE, message);
         throw new IllegalArgumentException(message);
     }

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -183,7 +183,7 @@
   </xsl:template>
 
   <xsl:template mode="getExtent" match="gmd:MD_Metadata">
-    <section class="gn-md-side-overview">
+    <section class="gn-md-side-extent">
       <h2>
         <i class="fa fa-fw fa-map-marker"><xsl:comment select="'image'"/></i>
         <span><xsl:comment select="name()"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -315,6 +315,12 @@
 
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
+      <xsl:if test="*/gmd:EX_Extent/*/gmd:EX_BoundingPolygon">
+        <Field name="boundingPolygon" string="y" store="true" index="false"/>
+      </xsl:if>
+
+      <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
       <xsl:for-each select="//gmd:MD_Keywords">
         <!-- Index all keywords as text or anchor -->
         <xsl:variable name="listOfKeywords"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -3152,7 +3152,7 @@
         <section xpath="/gmd:MD_Metadata/gmd:distributionInfo"/>
         <section xpath="/gmd:MD_Metadata/gmd:dataQualityInfo"/>
         <section xpath="/gmd:MD_Metadata/gmd:contentInfo"/>
-        <section name="gmd:MD_Metadata">
+        <section>
           <field xpath="/gmd:MD_Metadata/gmd:fileIdentifier"/>
           <field xpath="/gmd:MD_Metadata/gmd:language" or="language" in="/gmd:MD_Metadata"/>
           <field xpath="/gmd:MD_Metadata/gmd:characterSet"/>

--- a/services/src/main/java/org/fao/geonet/api/records/extent/ExpandFactor.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/ExpandFactor.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.records.extent;
 
 import javax.annotation.Nonnull;
 

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -86,7 +86,7 @@ public class MapRenderer {
      * Check if a geometry is in the domain of validity of a projection and if not return the
      * intersection of the geometry with the coordinate system domain of validity.
      */
-    private static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
+    public static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
         final GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory(null);
         final Extent domainOfValidity = mapCRS.getDomainOfValidity();
         Geometry adjustedGeom = geom;
@@ -108,9 +108,8 @@ public class MapRenderer {
                         if (env.contains(geom.getEnvelopeInternal())) {
                             return geom;
                         } else {
-                            adjustedGeom = geometryFactory.toGeometry(
-                                env.intersection(geom.getEnvelopeInternal())
-                            );
+                            Geometry extentPolygon = JTS.toGeometry(env);
+                            adjustedGeom = geom.intersection(extentPolygon);
                         }
                     }
                 }

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -1,4 +1,27 @@
-package org.fao.geonet.services.region;
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.records.extent;
 
 import com.vividsolutions.jts.awt.ShapeWriter;
 import com.vividsolutions.jts.geom.Envelope;
@@ -6,6 +29,7 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.io.IOUtils;
+import org.fao.geonet.api.regions.GeomFormat;
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.kernel.region.RegionNotFoundEx;
 import org.fao.geonet.kernel.region.RegionsDAO;
@@ -147,7 +171,7 @@ public class MapRenderer {
             // * request param is 'settings' and db setting is a named bg layer
             // * request param is a named bg layer
             // * request param is a full url
-            if (background.equalsIgnoreCase(GetMap.SETTING_BACKGROUND)) {
+            if (background.equalsIgnoreCase(MetadataExtentApi.SETTING_BACKGROUND)) {
                 String bgSetting = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
                 if (bgSetting.startsWith("http://") || bgSetting.startsWith("https://")) {
                     background = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.records.extent;
+
+import com.google.common.base.Optional;
+import com.vividsolutions.jts.geom.Envelope;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import jeeves.server.context.ServiceContext;
+import jeeves.server.dispatchers.ServiceManager;
+import jeeves.services.ReadWriteController;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.api.API;
+import org.fao.geonet.api.ApiParams;
+import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.regions.MetadataRegionDAO;
+import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.region.Region;
+import org.fao.geonet.kernel.region.RegionsDAO;
+import org.fao.geonet.kernel.region.Request;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.NativeWebRequest;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.imageio.ImageIO;
+import javax.servlet.http.HttpServletRequest;
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static org.fao.geonet.api.ApiParams.*;
+
+@RequestMapping(value = {
+    "/{portal}/api/records",
+    "/{portal}/api/" + API.VERSION_0_1 +
+        "/records"
+})
+@Api(value = API_CLASS_RECORD_TAG,
+    tags = API_CLASS_RECORD_TAG,
+    description = API_CLASS_RECORD_OPS)
+@Controller("recordExtent")
+@ReadWriteController
+public class MetadataExtentApi {
+
+    public static final String MAP_SRS_PARAM = "mapsrs";
+    public static final String GEOM_SRS_PARAM = "geomsrs";
+    public static final String WIDTH_PARAM = "width";
+    public static final String GEOM_PARAM = "geom";
+    public static final String GEOM_TYPE_PARAM = "geomtype";
+    public static final String HEIGHT_PARAM = "height";
+    public static final String BACKGROUND_PARAM = "background";
+    public static final String SETTING_BACKGROUND = "settings";
+
+    @Autowired
+    IMetadataManager metadataManager;
+
+    @Autowired
+    private ServiceManager serviceManager;
+
+    public static AffineTransform worldToScreenTransform(Envelope mapExtent, Dimension screenSize) {
+        return MapRenderer.worldToScreenTransform(mapExtent, screenSize);
+    }
+
+    @ApiOperation(
+        value = "Get record extents as image",
+        notes = "A rendering of the geometry as a png. If no background is specified the image will be " +
+            "transparent. In getMap the envelope of the geometry is calculated then it is expanded by a " +
+            "factor.  That factor is the size of the map.  This allows the map to be slightly bigger than " +
+            "the geometry allowing some context to be shown. This parameter allows different factors to be " +
+            "chosen per scale level." +
+            "\n" +
+            "Proportion is the proportion of the world that the geometry covers (bounds of WGS84)/(bounds " +
+            "of geometry in WGS84)\n" +
+            "\n" +
+            "Named backgrounds allow the background parameter to be a simple key and the complete URL will " +
+            "be looked up from this list of named backgrounds\n",
+        nickname = "getRecordExtents")
+    @RequestMapping(
+        value = "/{metadataUuid}/extents.png",
+        produces = {
+            MediaType.IMAGE_PNG_VALUE
+        },
+        method = RequestMethod.GET)
+    public HttpEntity<byte[]> getRecordExtentAsImage(
+        @ApiParam(
+            value = API_PARAM_RECORD_UUID,
+            required = true)
+        @PathVariable(value = "metadataUuid")
+            String metadataUuid,
+        @RequestParam(value = MAP_SRS_PARAM, defaultValue = "EPSG:4326") String srs,
+        @ApiParam(value = "(optional) width of the image that is created. Only one of width and height are permitted")
+        @RequestParam(value = WIDTH_PARAM, required = false, defaultValue = "300") Integer width,
+        @ApiParam(value = "(optional) height of the image that is created. Only one of width and height are permitted")
+        @RequestParam(value = HEIGHT_PARAM, required = false) Integer height,
+        @ApiParam(value = "(optional) URL for loading a background image for regions or a key that references the namedBackgrounds (configured in config-spring-geonetwork.xml). A WMS Getmap request is the typical example. The URL must be parameterized with the following parameters: minx, maxx, miny, maxy, width, height")
+        @RequestParam(value = BACKGROUND_PARAM, required = false, defaultValue = "settings") String background,
+        @ApiIgnore
+            NativeWebRequest nativeWebRequest,
+        @ApiIgnore
+            HttpServletRequest request) throws Exception {
+        AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
+        ServiceContext context = ApiUtils.createServiceContext(request);
+
+        if (width != null && height != null) {
+            throw new BadParameterEx(
+                WIDTH_PARAM,
+                "Only one of "
+                    + WIDTH_PARAM
+                    + " and "
+                    + HEIGHT_PARAM
+                    + " can be defined currently.  Future versions may support this but it is not supported at the moment");
+        }
+
+        if (width == null && height == null) {
+            throw new BadParameterEx(WIDTH_PARAM, "One of " + WIDTH_PARAM + " or " + HEIGHT_PARAM
+                + " parameters must be included in the request");
+
+        }
+
+        String outputFileName = metadataUuid + "-extent.png";
+        String regionId = "metadata:@id" + metadata.getId();
+
+        MetadataRegionDAO dao = ApplicationContextHolder.get().getBean(MetadataRegionDAO.class);
+
+        final Request searchRequest = dao.createSearchRequest(context);
+        searchRequest.id(regionId);
+        Optional<Long> lastModifiedOption = searchRequest.getLastModified();
+        if (lastModifiedOption.isPresent()) {
+            final Long lastModified = lastModifiedOption.get();
+            if (lastModified != null && nativeWebRequest.checkNotModified(lastModified)) {
+                return null;
+            }
+        }
+        MapRenderer renderer = new MapRenderer(context);
+        BufferedImage image = renderer.render(regionId, srs, width, height, background, null, null, null);
+
+        if (image == null) return null;
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();) {
+            ImageIO.write(image, "png", out);
+            MultiValueMap<String, String> headers = new HttpHeaders();
+            headers.add("Content-Disposition", "inline; filename=\"" + outputFileName + "\"");
+            headers.add("Cache-Control", "no-cache");
+            headers.add("Content-Type", "image/png");
+            return new HttpEntity<>(out.toByteArray(), headers);
+        }
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -96,7 +96,7 @@ import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.OperationAllowedSpecs;
-import org.fao.geonet.services.region.MapRenderer;
+import org.fao.geonet.api.records.extent.MapRenderer;
 import org.fao.geonet.util.XslUtil;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.IO;

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/PDF.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/PDF.java
@@ -24,7 +24,7 @@
 package org.fao.geonet.api.records.formatters;
 
 import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.services.region.MapRenderer;
+import org.fao.geonet.api.records.extent.MapRenderer;
 import org.fao.geonet.util.XslUtil;
 import org.fao.geonet.utils.BinaryFile;
 import org.jdom.Element;

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/groovy/MapConfig.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/groovy/MapConfig.java
@@ -23,12 +23,12 @@
 
 package org.fao.geonet.api.records.formatters.groovy;
 
-import org.fao.geonet.services.region.GetMap;
+import org.fao.geonet.api.records.extent.MetadataExtentApi;
 
 /**
- * Encapsulates the map parameters used when making {@link org.fao.geonet.services.region.GetMap}
+ * Encapsulates the map parameters used when making {@link org.fao.geonet.services.region.MetadataExtentApi}
  * requests.
- *
+ * <p>
  * The parameters are read from the setting (background, width and mapproj) and are to be used when
  * displaying geometries and extents.
  *
@@ -47,10 +47,10 @@ public class MapConfig {
 
     /**
      * The value to pass as the <em>background</em> parameter when making a request to {@link
-     * org.fao.geonet.services.region.GetMap} when rendering extents and geometries.
+     * org.fao.geonet.services.region.MetadataExtentApi} when rendering extents and geometries.
      */
     public String getBackground() {
-        return background.toLowerCase().startsWith("http://") ? GetMap.SETTING_BACKGROUND : background;
+        return background.toLowerCase().startsWith("http://") ? MetadataExtentApi.SETTING_BACKGROUND : background;
     }
 
     public void setBackground(String background) {

--- a/services/src/main/java/org/fao/geonet/api/regions/GeomFormat.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/GeomFormat.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.regions;
 
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.WKTReader;

--- a/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
@@ -27,6 +27,7 @@ import com.vividsolutions.jts.geom.Geometry;
 
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.api.regions.metadata.MetadataRegionSearchRequest.Id;
+import org.fao.geonet.api.records.extent.MapRenderer;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
@@ -53,6 +54,7 @@ public class MetadataRegion extends Region {
         Integer desiredCode = CRS.lookupEpsgCode(projection, false);
         boolean differentCrsCode = sourceCode == null || desiredCode == null || desiredCode.intValue() != sourceCode.intValue();
         if (differentCrsCode && !CRS.equalsIgnoreMetadata(coordinateReferenceSystem, projection)) {
+            geometry = MapRenderer.computeGeomInDomainOfValidity(geometry, projection);
             MathTransform transform = CRS.findMathTransform(coordinateReferenceSystem, projection, true);
             return JTS.transform(geometry, transform);
         }

--- a/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.regions;
 
 import com.vividsolutions.jts.geom.Geometry;
 

--- a/services/src/main/java/org/fao/geonet/api/regions/MetadataRegionDAO.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/MetadataRegionDAO.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.regions;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
@@ -29,30 +29,40 @@ import io.swagger.annotations.*;
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
-import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.records.extent.MapRenderer;
 import org.fao.geonet.api.regions.model.Category;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
+import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.KeywordBean;
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.kernel.region.RegionsDAO;
 import org.fao.geonet.kernel.region.Request;
-import org.fao.geonet.services.region.ThesaurusBasedRegionsDAO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import springfox.documentation.annotations.ApiIgnore;
 
+import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
+import static org.fao.geonet.api.records.extent.MetadataExtentApi.*;
 
 /**
  *
@@ -202,5 +212,73 @@ public class RegionsApi {
             request.maxRecords(maxRecords);
         }
         return request;
+    }
+
+
+    @ApiOperation(
+        value = "Get geometry as image",
+        notes = "A rendering of the geometry as a png.",
+        nickname = "getGeomAsImage")
+    @RequestMapping(
+        value = "/geom.png",
+        produces = {
+            MediaType.IMAGE_PNG_VALUE
+        },
+        method = RequestMethod.GET)
+    public HttpEntity<byte[]> getGeomAsImage(
+        @RequestParam(value = MAP_SRS_PARAM, defaultValue = "EPSG:4326") String srs,
+        @ApiParam(value = "(optional) width of the image that is created. Only one of width and height are permitted")
+        @RequestParam(value = WIDTH_PARAM, required = false, defaultValue = "300") Integer width,
+        @ApiParam(value = "(optional) height of the image that is created. Only one of width and height are permitted")
+        @RequestParam(value = HEIGHT_PARAM, required = false) Integer height,
+        @ApiParam(value = "(optional) URL for loading a background image for regions or a key that references the namedBackgrounds (configured in config-spring-geonetwork.xml). A WMS Getmap request is the typical example. The URL must be parameterized with the following parameters: minx, maxx, miny, maxy, width, height")
+        @RequestParam(value = BACKGROUND_PARAM, required = false, defaultValue = "settings") String background,
+        @ApiParam(value = "(optional) a wkt or gml encoded geometry.")
+        @RequestParam(value = GEOM_PARAM, required = false) String geomParam,
+        @ApiParam(value = "(optional) defines if geom is wkt or gml. Allowed values are wkt and gml. if not specified the it is assumed the geometry is wkt")
+        @RequestParam(value = GEOM_TYPE_PARAM, defaultValue = "WKT") String geomType,
+        @ApiParam(value = "")
+        @RequestParam(value = GEOM_SRS_PARAM, defaultValue = "EPSG:4326") String geomSrs,
+        @ApiIgnore
+            NativeWebRequest nativeWebRequest,
+        @ApiIgnore
+            HttpServletRequest request) throws Exception {
+        final ServiceContext context = ApiUtils.createServiceContext(request);
+        if (width != null && height != null) {
+            throw new BadParameterEx(
+                WIDTH_PARAM,
+                "Only one of "
+                    + WIDTH_PARAM
+                    + " and "
+                    + HEIGHT_PARAM
+                    + " can be defined currently.  Future versions may support this but it is not supported at the moment");
+        }
+
+        if (width == null && height == null) {
+            throw new BadParameterEx(WIDTH_PARAM, "One of " + WIDTH_PARAM + " or " + HEIGHT_PARAM
+                + " parameters must be included in the request");
+
+        }
+
+        String outputFileName = "geom.png";
+        String regionId = null;
+
+        if (nativeWebRequest.checkNotModified(geomParam + srs + background)) {
+            return null;
+        }
+
+        MapRenderer renderer = new MapRenderer(context);
+        BufferedImage image = renderer.render(regionId, srs, width, height, background, geomParam, geomType, geomSrs);
+
+        if (image == null) return null;
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();) {
+            ImageIO.write(image, "png", out);
+            MultiValueMap<String, String> headers = new HttpHeaders();
+            headers.add("Content-Disposition", "inline; filename=\"" + outputFileName + "\"");
+            headers.add("Cache-Control", "public, max-age: " + TimeUnit.DAYS.toSeconds(5));
+            headers.add("Content-Type", "image/png");
+            return new HttpEntity<>(out.toByteArray(), headers);
+        }
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/regions/ThesaurusBasedRegionsDAO.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/ThesaurusBasedRegionsDAO.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.regions;
 
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;

--- a/services/src/main/java/org/fao/geonet/api/regions/ThesaurusRequest.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/ThesaurusRequest.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.regions;
 
 import com.google.common.base.Optional;
 

--- a/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java
@@ -45,7 +45,7 @@ import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.kernel.search.spatial.SpatialIndexWriter;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.services.Utils;
-import org.fao.geonet.services.region.MetadataRegion;
+import org.fao.geonet.api.regions.MetadataRegion;
 import org.fao.geonet.utils.Xml;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
@@ -63,6 +63,9 @@ import jeeves.server.context.ServiceContext;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
 
+/**
+ * TODO: A polygon may be exclusion and in such case should be substracted from the overall extent?
+ */
 public class MetadataRegionSearchRequest extends Request {
 
     public static final String PREFIX = "metadata:";
@@ -342,6 +345,7 @@ public class MetadataRegionSearchRequest extends Request {
         }
     }
 
+    @Deprecated
     public static class FileId extends Id {
 
         private static final String PREFIX = "@fileId";
@@ -386,6 +390,7 @@ public class MetadataRegionSearchRequest extends Request {
 
     }
 
+    @Deprecated
     public static class Uuid extends Id {
 
         private static final String PREFIX = "@uuid";

--- a/services/src/main/java/org/fao/geonet/services/region/Get.java
+++ b/services/src/main/java/org/fao/geonet/services/region/Get.java
@@ -41,7 +41,7 @@ import java.util.Collection;
 /**
  * Returns a specific region and coordinates given its id
  */
-
+@Deprecated
 public class Get implements Service {
     public void init(Path appPath, ServiceConfig params) throws Exception {
     }

--- a/services/src/main/java/org/fao/geonet/services/region/GetGeom.java
+++ b/services/src/main/java/org/fao/geonet/services/region/GetGeom.java
@@ -31,6 +31,7 @@ import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 
 import org.fao.geonet.Util;
+import org.fao.geonet.api.regions.GeomFormat;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.kernel.region.RegionNotFoundEx;
@@ -45,7 +46,7 @@ import java.util.Collection;
 /**
  * Returns a specific region and coordinates given its id
  */
-
+@Deprecated
 public class GetGeom implements Service {
     private static final String SIMPLIFIED_PARAM = "simplified";
 

--- a/services/src/main/java/org/fao/geonet/services/region/GetMap.java
+++ b/services/src/main/java/org/fao/geonet/services/region/GetMap.java
@@ -27,6 +27,7 @@ import com.google.common.base.Optional;
 import com.vividsolutions.jts.geom.Envelope;
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.ServiceManager;
+import org.fao.geonet.api.records.extent.MapRenderer;
 import org.fao.geonet.constants.Params;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.region.RegionsDAO;
@@ -75,6 +76,7 @@ import java.util.concurrent.TimeUnit;
  * following parameters: minx, maxx, miny, maxy, width, height and optionally srs
  */
 @Controller
+@Deprecated
 public class GetMap {
     public static final String MAP_SRS_PARAM = "mapsrs";
     public static final String GEOM_SRS_PARAM = "geomsrs";

--- a/services/src/main/java/org/fao/geonet/services/region/ListCategories.java
+++ b/services/src/main/java/org/fao/geonet/services/region/ListCategories.java
@@ -27,6 +27,7 @@ import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 
+import org.fao.geonet.api.regions.ThesaurusBasedRegionsDAO;
 import org.fao.geonet.kernel.KeywordBean;
 import org.fao.geonet.kernel.region.RegionsDAO;
 import org.jdom.Element;

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -74,13 +74,13 @@
     </entry>
   </util:map>
 
-  <bean id="RegionsDAO" class="org.fao.geonet.services.region.ThesaurusBasedRegionsDAO">
+  <bean id="RegionsDAO" class="org.fao.geonet.api.regions.ThesaurusBasedRegionsDAO">
     <constructor-arg ref="languages"/>
     <property name="cacheAllRegionsInMemory" value="true"/>
     <property name="thesaurusName" value="external.place.regions"/>
   </bean>
 
-  <bean id="MetadataRegionsDAO" class="org.fao.geonet.services.region.MetadataRegionDAO">
+  <bean id="MetadataRegionsDAO" class="org.fao.geonet.api.regions.MetadataRegionDAO">
     <property name="cacheAllRegionsInMemory" value="false"/>
   </bean>
 

--- a/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
@@ -10,8 +10,8 @@ import static org.junit.Assert.*;
 
 public class MapRendererTest {
 
-    private final transient WKTWriter wktWriter = new WKTWriter();
-    private final transient WKTReader wktReader = new WKTReader();
+    private final WKTWriter wktWriter = new WKTWriter();
+    private final WKTReader wktReader = new WKTReader();
 
     @Test
     public void domainContainsBoundingBox() throws Exception {

--- a/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
@@ -1,0 +1,51 @@
+package org.fao.geonet.api.records.extent;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+import org.fao.geonet.kernel.region.Region;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MapRendererTest {
+
+    private final transient WKTWriter wktWriter = new WKTWriter();
+    private final transient WKTReader wktReader = new WKTReader();
+
+    @Test
+    public void domainContainsBoundingBox() throws Exception {
+        String test = "POLYGON ((40 -63, 40 -20, 70 -20, 70 -63, 40 -63))";
+        Geometry bbox = wktReader.read(test);
+        bbox.setSRID(4326);
+        String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
+        assertEquals(test, result);
+    }
+
+    @Test
+    public void domainIntersectsBoundingBox() throws Exception {
+        String test = "POLYGON ((40 -86, 40 -20, 70 -20, 70 -86, 40 -86))";
+        Geometry bbox = wktReader.read(test);
+        bbox.setSRID(4326);
+        String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
+        assertEquals("POLYGON ((40 -85.06, 40 -20, 70 -20, 70 -85.06, 40 -85.06))", result);
+    }
+
+    @Test
+    public void domainContainsBoundingPolygon() throws Exception {
+        String test = "POLYGON ((165 -83, 135 -76, 161 -76, 153 -81, 165 -83))";
+        Geometry bbox = wktReader.read(test);
+        bbox.setSRID(4326);
+        String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
+        assertEquals("POLYGON ((165 -83, 135 -76, 161 -76, 153 -81, 165 -83))", result);
+    }
+
+    @Test
+    public void domainIntersectsBoundingPolygon() throws Exception {
+        String test = "POLYGON ((165 -87, 135 -76, 161 -76, 153 -81, 165 -87))";
+        Geometry bbox = wktReader.read(test);
+        bbox.setSRID(4326);
+        String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
+        assertEquals("POLYGON ((159.70909090909092 -85.06, 135 -76, 161 -76, 153 -81, 161.12 -85.06, 159.70909090909092 -85.06))", result);
+    }
+}

--- a/services/src/test/java/org/fao/geonet/api/regions/GeomFormatTest.java
+++ b/services/src/test/java/org/fao/geonet/api/regions/GeomFormatTest.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.regions;
 
 import com.vividsolutions.jts.geom.Geometry;
 

--- a/services/src/test/java/org/fao/geonet/api/regions/ListRegionsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/regions/ListRegionsTest.java
@@ -21,10 +21,11 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.regions;
 
 import org.fao.geonet.api.regions.ListRegionsResponse;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.fao.geonet.services.region.List;
 import org.fao.geonet.utils.Xml;
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/services/src/test/java/org/fao/geonet/api/regions/MetadataRegionDAOTest.java
+++ b/services/src/test/java/org/fao/geonet/api/regions/MetadataRegionDAOTest.java
@@ -21,7 +21,7 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
-package org.fao.geonet.services.region;
+package org.fao.geonet.api.regions;
 
 import com.google.common.collect.Lists;
 
@@ -31,6 +31,7 @@ import jeeves.server.context.ServiceContext;
 
 import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.Constants;
+import org.fao.geonet.api.regions.MetadataRegionDAO;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.domain.ReservedGroup;

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -140,7 +140,7 @@ header div.gn-abstract {
     margin: 2em 0 0 90px;
     border: 1px solid #ccc;
   }
-  .gn-md-side-overview > .extent {
+  .gn-md-side-extent > .extent {
     margin: 0 0 0 0;
     .coord {
       display: none;

--- a/web-ui/src/main/resources/catalog/style/gn_metadata_pdf.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata_pdf.less
@@ -57,6 +57,13 @@
       margin-bottom: 5px;
     }
   }
+  /*
+  Extent is already displayed in main view usually.
+  Social and associated resources require JS.
+  So hidden from side bar in PDF output. */
+  .gn-md-side-extent, .gn-md-side-social, .gn-md-side-associated {
+    display: none;
+  }
   dl {
     margin: 0;
     border-top: 1px solid #999999;

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -511,7 +511,7 @@
           </div>
           <div data-gn-md-feedback="mdView.current.record"></div>
 
-          <section class="gn-md-side-extent" data-ng-if="mdView.current.record.geoBox.length > 0">
+          <section class="gn-md-side-extent" data-ng-if="mdView.current.record.geoBox || mdView.current.record.boundingPolygon">
             <h2>
               <i class="fa fa-fw fa-map-marker"></i>
               <span data-translate="">extent</span>
@@ -522,7 +522,7 @@
             </ul>
             </p>
             <!-- TODO: use map config -->
-            <p data-ng-if="mdView.current.record.geoBox">
+            <p data-ng-if="mdView.current.record.geoBox || mdView.current.record.boundingPolygon">
               <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
                   alt="{{'extent' | translate}}"
                   aria-label="{{'extent' | translate}}"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -522,11 +522,11 @@
             </ul>
             </p>
             <!-- TODO: use map config -->
-            <p data-ng-repeat="bbox in mdView.current.record.geoBox">
+            <p data-ng-if="mdView.current.record.geoBox">
               <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
                   alt="{{'extent' | translate}}"
                   aria-label="{{'extent' | translate}}"
-                  data-ng-src="{{gnUrl}}{{lang}}/region.getmap.png?mapsrs=EPSG:3857&width=250&background=settings&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
+                  data-ng-src="../api/records/{{mdView.current.record.getUuid()}}/extents.png"/>
             </p>
 
           </section>

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -145,11 +145,11 @@
   </bean>
 
   <util:set id="regionGetMapExpandFactors" set-class="java.util.TreeSet">
-    <bean class="org.fao.geonet.services.region.ExpandFactor"
+    <bean class="org.fao.geonet.api.records.extent.ExpandFactor"
           p:proportion=".0005" p:factor="2"/>
-    <bean class="org.fao.geonet.services.region.ExpandFactor"
+    <bean class="org.fao.geonet.api.records.extent.ExpandFactor"
           p:proportion=".01" p:factor=".5"/>
-    <bean class="org.fao.geonet.services.region.ExpandFactor"
+    <bean class="org.fao.geonet.api.records.extent.ExpandFactor"
           p:proportion=".015" p:factor=".2"/>
   </util:set>
 

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -176,6 +176,7 @@
       <field name="tempExtentBegin" tagName="tempExtentBegin"/>
       <field name="tempExtentEnd" tagName="tempExtentEnd"/>
       <field name="geoBox" tagName="geoBox"/>
+      <field name="boundingPolygon" tagName="boundingPolygon"/>
       <field name="extentDesc" tagName="geoDesc"/>
       <field name="geoDescCode" tagName="geoDescCode"/>
       <field name="_indexingError" tagName="idxError"/>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -71,22 +71,9 @@
 
     <!-- TODO get system config -->
     <xsl:if test="$geometry">
-      <xsl:variable name="background"
-                    select="util:getSettingValue('region/getmap/background')"/>
-      <xsl:variable name="width"
-                    select="util:getSettingValue('region/getmap/width')"/>
-      <xsl:variable name="mapproj"
-                    select="util:getSettingValue('region/getmap/mapproj')"/>
-
       <img class="gn-img-extent"
            alt="{$schemaStrings/thumbnail}"
-           src="{$nodeUrl}eng/region.getmap.png?mapsrs={if ($mapproj != '')
-                                         then $mapproj
-                                         else 'EPSG:3857'}&amp;width={
-                                         if ($width != '')
-                                         then $width
-                                         else '600'
-                                         }&amp;background=settings&amp;geomsrs=EPSG:4326&amp;geom={$geometry}"/>
+           src="{$nodeUrl}api/regions/geom.png?geomsrs=EPSG:4326&amp;geom={$geometry}"/>
     </xsl:if>
 
   </xsl:function>
@@ -94,25 +81,10 @@
   <!-- Use region API to display metadata extent -->
   <xsl:function name="gn-fn-render:extent">
     <xsl:param name="uuid" as="xs:string"/>
-
-    <!-- TODO get system config -->
     <xsl:if test="$uuid">
-      <xsl:variable name="background"
-                    select="util:getSettingValue('region/getmap/background')"/>
-      <xsl:variable name="width"
-                    select="util:getSettingValue('region/getmap/width')"/>
-      <xsl:variable name="mapproj"
-                    select="util:getSettingValue('region/getmap/mapproj')"/>
-
       <img class="gn-img-extent"
            alt="{$schemaStrings/thumbnail}"
-           src="{$nodeUrl}eng/region.getmap.png?id=metadata:@uuid{$uuid}&amp;mapsrs={if ($mapproj != '')
-                                         then $mapproj
-                                         else 'EPSG:3857'}&amp;width={
-                                         if ($width != '')
-                                         then $width
-                                         else '600'
-                                         }&amp;background=settings"/>
+           src="{$nodeUrl}api/records/{$uuid}/extents.png"/>
     </xsl:if>
 
   </xsl:function>


### PR DESCRIPTION
Main goal here is to move part of the region API following Jeeves services pattern to the main /api. It also provides simple access to a record extents as image using `/api/records/{uuid}/extents.png` URL.

* Add GET /api/records/{uuid}/extents.png to render a record extents (replace region.getmap.png)
* Add GET /api/regions/geom.png to render a geometry (eg. a bbox)
* Record view / Angular / Use same extent rendering as advanced view
* PDF / Hide extent duplicated at the end of the PDF. Remove sections which requires JS to work ie. social, associated resources
* Indexing / Do not fails if a LineString has to be indexed or rendered in region API
* ISO19139 / Fix missing label for simple view, section gmd:MD_Metadata

