### PR TITLE
Add post processing xslt for CSW results

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -50,9 +50,13 @@ import org.geotools.gml2.GMLConfiguration;
 import org.jdom.*;
 import org.springframework.context.ApplicationContext;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -133,10 +137,16 @@ public class SearchController {
             // Because for this application profile it is not possible that a query includes more than one
             // typename, any value(s) of the typeNames attribute of the elementSetName element are ignored.
             res = org.fao.geonet.csw.common.util.Xml.applyElementSetName(context, scm, schema, res, outSchema, setName, resultType, id, displayLanguage);
-            //
-            // apply elementnames
-            //
+
             res = applyElementNames(context, elemNames, typeName, scm, schema, res, resultType, info, strategy);
+
+            if(Log.isDebugEnabled(Geonet.CSW_SEARCH))
+                Log.debug(Geonet.CSW_SEARCH, "SearchController:retrieveMetadata: before applying postprocessing on metadata Element for id " + id);
+
+            res = applyPostProcessing(context, scm, schema, res, outSchema, setName, resultType, id, displayLanguage);
+
+            if(Log.isDebugEnabled(Geonet.CSW_SEARCH))
+                Log.debug(Geonet.CSW_SEARCH, "SearchController:retrieveMetadata: All processing is complete on metadata Element for id " + id);
 
             if (res != null) {
                 if (Log.isDebugEnabled(Geonet.CSW_SEARCH))
@@ -520,5 +530,55 @@ public class SearchController {
             counter++;
         }
         return counter;
+    }
+
+    /**
+     * Applies postprocessing stylesheet if available.
+     *
+     * Postprocessing files should be in the present/csw folder of the schema and have this naming:
+     *
+     * For default CSW service
+     *
+     * 1) gmd-csw-postprocessing.xsl : Postprocessing xsl applied for CSW service when requesting iso (gmd) output
+     * 2) csw-csw-postprocessing.xsl : Postprocessing xsl applied for CSW service when requesting ogc (csw) output
+     *
+     * For a custom CSW service named csw-inspire
+     *
+     * 1) gmd-csw-inspire-postprocessing.xsl : Postprocessing xsl applied for custom CSW csw-inspire service when requesting iso output
+     * 2) csw-csw-inspire-postprocessing.xsl : Postprocessing xsl applied for custom CSW csw-inspire service when requesting ogc (csw) output
+     *
+     * @param context Service context
+     * @param schemaManager schemamanager
+     * @param schema schema
+     * @param result result
+     * @param outputSchema requested OutputSchema
+     * @param elementSetName requested ElementSetName
+     * @param resultType requested ResultTYpe
+     * @param id metadata id
+     * @param displayLanguage language to use in response
+     * @return metadata
+     * @throws InvalidParameterValueEx hmm
+     */
+    private static Element applyPostProcessing(ServiceContext context, SchemaManager schemaManager, String schema,
+                                               Element result, String outputSchema, ElementSetName elementSetName,
+                                               ResultType resultType, String id, String displayLanguage) throws InvalidParameterValueEx {
+        Path schemaDir  = schemaManager.getSchemaCSWPresentDir(schema);
+        Path styleSheet = schemaDir.resolve(outputSchema + "-"+ context.getService() + "-postprocessing.xsl");
+
+        if (Files.exists(styleSheet)) {
+            Map<String, Object> params = new HashMap<String, Object>();
+            params.put("lang", displayLanguage);
+            params.put("displayInfo", resultType == ResultType.RESULTS_WITH_SUMMARY ? "true" : "false");
+
+            try {
+                result = Xml.transform(result, styleSheet, params);
+            } catch (Exception e) {
+                context.error("Error while transforming metadata with id : " + id + " using " + styleSheet);
+                context.error("  (C) StackTrace:\n" + Util.getStackTrace(e));
+                return null;
+            }
+        }
+
+        return result;
     }
 }

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -27,7 +27,9 @@ import jeeves.server.context.ServiceContext;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.search.Sort;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.NodeInfo;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
@@ -563,7 +565,12 @@ public class SearchController {
                                                Element result, String outputSchema, ElementSetName elementSetName,
                                                ResultType resultType, String id, String displayLanguage) throws InvalidParameterValueEx {
         Path schemaDir  = schemaManager.getSchemaCSWPresentDir(schema);
-        Path styleSheet = schemaDir.resolve(outputSchema + "-"+ context.getService() + "-postprocessing.xsl");
+        final NodeInfo nodeInfo = ApplicationContextHolder.get().getBean(NodeInfo.class);
+
+
+        Path styleSheet = schemaDir.resolve(outputSchema + "-"
+            + (context.getService().equals("csw") ? nodeInfo.getId() : context.getService())
+            + "-postprocessing.xsl");
 
         if (Files.exists(styleSheet)) {
             Map<String, Object> params = new HashMap<String, Object>();


### PR DESCRIPTION
Update of https://github.com/geonetwork/core-geonetwork/pull/1871 for master.

* Adding post process to `srv/eng/csw` by creating for each output schema a file eg. for gmd, `gmd-csw-postprocessing.xsl`
* Adding post process to a virtual CSW service `srv/eng/csw-inspire` by creating for each output schema a file eg. for gmd, `gmd-csw-inspirepostprocessing.xsl`
* Adding post process to a portal `inspire/eng/csw` by creating for each output schema a file eg. for gmd, `gmd-inspire-postprocessing.xsl`
