### PR TITLE
Editing / History / Only save changes at the end of the editing session

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -261,23 +261,28 @@ public class MetadataEditingApi {
             boolean ufo = true;
             boolean index = true;
             dataMan.updateMetadata(context, id, md, withValidationErrors, ufo, index, context.getLanguage(), changeDate,
-                    updateDateStamp);
+                updateDateStamp);
 
-            XMLOutputter outp = new XMLOutputter();
-            String xmlBefore = outp.outputString(beforeMetadata);
-            String xmlAfter = outp.outputString(md);
-            new RecordUpdatedEvent(Long.parseLong(id), session.getUserIdAsInt(), xmlBefore, xmlAfter)
+            if (terminate) {
+                XMLOutputter outp = new XMLOutputter();
+                String xmlBefore = outp.outputString(beforeMetadata);
+                String xmlAfter = outp.outputString(md);
+                new RecordUpdatedEvent(Long.parseLong(id), session.getUserIdAsInt(), xmlBefore, xmlAfter)
                     .publish(applicationContext);
+            }
         } else {
             Log.trace(Geonet.DATA_MANAGER, " > Updating contents");
             ajaxEditUtils.updateContent(params, false, true);
 
             Element afterMetadata = dataMan.getMetadata(context, String.valueOf(metadata.getId()), false, false, false);
-            XMLOutputter outp = new XMLOutputter();
-            String xmlBefore = outp.outputString(beforeMetadata);
-            String xmlAfter = outp.outputString(afterMetadata);
-            new RecordUpdatedEvent(Long.parseLong(id), session.getUserIdAsInt(), xmlBefore, xmlAfter)
+
+            if (terminate) {
+                XMLOutputter outp = new XMLOutputter();
+                String xmlBefore = outp.outputString(beforeMetadata);
+                String xmlAfter = outp.outputString(afterMetadata);
+                new RecordUpdatedEvent(Long.parseLong(id), session.getUserIdAsInt(), xmlBefore, xmlAfter)
                     .publish(applicationContext);
+            }
         }
 
         // -----------------------------------------------------------------------


### PR DESCRIPTION
Currently every time editors change tab a copy is preserved. Only record history when editing session is closed.

Related to https://github.com/geonetwork/core-geonetwork/pull/3209