### PR TITLE
Harvester / CSW / Misc fix.

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -210,7 +210,6 @@ public class Aligner extends BaseAligner<CswParams> {
                         case OVERRIDE:
                             updateMetadata(ri, Integer.toString(metadataUtils.findOneByUuid(ri.uuid).getId()), true);
                             log.debug("Overriding record with uuid " + ri.uuid);
-                            result.updatedMetadata++;
 
                             if (params.isIfRecordExistAppendPrivileges()) {
                                 addPrivileges(id, params.getPrivileges(), localGroups, context);
@@ -444,9 +443,6 @@ public class Aligner extends BaseAligner<CswParams> {
 
             metadataManager.save(metadata);
         }
-
-        OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
-        repository.deleteAllByMetadataId(Integer.parseInt(id));
 
         addPrivileges(id, params.getPrivileges(), localGroups, context);
 

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
@@ -102,7 +102,7 @@ var gnHarvestercsw = {
       + '  </options>'
       + '  <content>'
       + '    <validate>' + h.content.validate + '</validate>'
-      + '    <batchEdits><![CDATA[' + h.content.batchEdits + ']]></batchEdits>'
+      + '    <batchEdits><![CDATA[' + (h.content.batchEdits == '' ? '[]' : h.content.batchEdits) + ']]></batchEdits>'
       + '  </content>'
       + $scope.buildResponseGroup(h)
       + $scope.buildResponseCategory(h) + '</node>';


### PR DESCRIPTION
* If reset batch edit form field with empty content, set the value to no edits (ie. empty array)
* Do not count updates twice. result.updatedMetadata++ was done in case of OVERRIDE and in the update method.
* Do not delete privileges twice. Deletion is handled in BaseAligner.addPrivileges.