### PR TITLE
PDF / Language parameter does not override Accept-Language header in all cases.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -283,14 +283,10 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             language = LanguageUtils.locale2gnCode(iso3lang);
         }
 
-        final ServiceContext context = createServiceContext(
-            language,
-            formatType,
-            request.getNativeRequest(HttpServletRequest.class));
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, servletRequest);
 
         if(approved) {
-        	metadata = context.getBean(MetadataRepository.class).findOneByUuid(metadataUuid);
+        	metadata = ApplicationContextHolder.get().getBean(MetadataRepository.class).findOneByUuid(metadataUuid);
         }
 
 
@@ -303,6 +299,12 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         ISODate changeDate = metadata.getDataInfo().getChangeDate();
 
         Validator validator;
+
+        final ServiceContext context = createServiceContext(
+            language,
+            formatType,
+            request.getNativeRequest(HttpServletRequest.class));
+
         if (changeDate != null) {
             final long changeDateAsTime = changeDate.toDate().getTime();
             long roundedChangeDate = changeDateAsTime / 1000 * 1000;

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
@@ -35,6 +35,7 @@ import com.vividsolutions.jts.util.Assert;
 
 import groovy.util.slurpersupport.GPathResult;
 
+import jeeves.server.context.ServiceContext;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.records.formatters.groovy.CurrentLanguageHolder;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
@@ -121,8 +122,13 @@ public class SchemaLocalizations {
         ServletRequestAttributes attributes = (ServletRequestAttributes) obj;
         HttpServletRequest request = attributes.getRequest();
 
+
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        final String lang3 =  appContext.getBean(LanguageUtils.class).getIso3langCode(request.getLocales());
+        final ServiceContext serviceContext = ServiceContext.get();
+
+        final String lang3 = serviceContext != null ?
+            serviceContext.getLanguage() :
+            appContext.getBean(LanguageUtils.class).getIso3langCode(request.getLocales());
         final String lang2 = appContext.getBean(IsoLanguagesMapper.class).iso639_2_to_iso639_1(lang3);
         CurrentLanguageHolder languageHolder = new CurrentLanguageHolder() {
             @Override


### PR DESCRIPTION
Testing: Load a formatter forcing language to `cat` with http://localhost:8080/geonetwork/srv/api/records/HOM_GEOL_NATURES_FOND_50.xml/formatters/xsl-view?output=pdf&language=cat&approved=true will usually return another language (for me french) depending on the browser Accept-Language header. The language parameter is supposed to force the language (it was working for multilingual metadata field value - but this issue applies mainly to field label). 

Reason was that 2 serviceContexts were created, the first with the language parameter
and the second with the header info. SchemaLocalization getting info from ServletRequestAttribute was wrong.

Fix: Create the correct ServiceContext before formatting.