### PR TITLE
Fix for #4527: Replace mixin with plain CSS code

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -971,7 +971,9 @@ gn-md-type-widget, gn-md-type-inspire-validation-widget {
     .gn-user-name {
       max-width: 200px;
       display: inline-block;
-      .text-overflow();
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .gn-user-role {
       text-transform: uppercase;


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/pull/4527

The mixin causing the error is replaced with plain CSS code.