### PR TITLE
Fixed checking in XslFormatter to retrieve schema locations to make a case-insensitive comparison (the value of the schema was converted to lowercase, but not the values in the schema list)

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
@@ -154,7 +154,7 @@ public class XsltFormatter implements FormatterImpl {
         List<Element> elementList = new ArrayList<>(3);
         for (SchemaLocalization schemaLocalization : localization) {
             String currentSchema = schemaLocalization.schema.trim();
-            if ("all".equalsIgnoreCase(schema) || schemasToLoadList.contains(currentSchema.toLowerCase())) {
+            if ("all".equalsIgnoreCase(schema) || schemasToLoadList.stream().anyMatch(currentSchema::equalsIgnoreCase)) {
                 Element schemaEl = new Element(currentSchema);
 
                 Element labels = schemaLocalization.getLabels(language);


### PR DESCRIPTION
… 