### PR TITLE
change order of nav-pills in multilingual fields

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
@@ -37,6 +37,12 @@
    *
    * It also set direction attribute for RTL language.
    *
+   *  When using nav pills, you can control focusing of the underlying <input>
+   *  by adding a data-focus-to-input='true|false' attribute on the <input>.
+   *  Default is true (old behaviour).
+   *  For UX, type-ahead fields (i.e. keyword picker) should be be annotated with data-focus-to-input='false'
+   *  because they pop-up the selection when focused.
+   *
    */
   module.directive('gnMultilingualField', ['$timeout', '$translate',
     function($timeout, $translate) {
@@ -111,6 +117,14 @@
             );
             return langCode;
           }
+          //looks for the 'data-focus-to-input' attribute on the <input>
+          //default is true
+          // otherwise, its the value of 'data-focus-to-input' (should be true|false)
+          function shouldFocus(element) {
+            if ($(element).attr('data-focus-to-input') === undefined)
+              return true; // default
+            return ($(element).attr('data-focus-to-input') === 'true')
+          }
 
           //since scope.languages is a dictionary, we give it an explicit order
           // Order is based on the occurrence of the "<input>" inside element.
@@ -175,7 +189,9 @@
               if ($(this).attr('lang') === scope.currentLanguage ||
                   ($(this).attr('lang') === mainLanguage &&
                   scope.currentLanguage === '')) {
-                $(this).removeClass('hidden').focus();
+                  var el = $(this).removeClass('hidden');
+                  if (shouldFocus(el))
+                    el.focus();
               } else {
                 $(this).addClass('hidden');
               }
@@ -196,7 +212,7 @@
                 setLabel('oneLanguage');
                 $(this).prev('span').removeClass('hidden');
                 var el = $(this).removeClass('hidden');
-                if (focus) {
+                if (focus && shouldFocus(el)) {
                   el.focus();
                 }
               } else {
@@ -208,7 +224,7 @@
                 } else {
                   scope.currentLanguage = mainLanguage;
                   var el = $(this).removeClass('hidden');
-                  if (focus) {
+                  if (focus && shouldFocus(el)) {
                     el.focus();
                   }
                 }

--- a/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
@@ -112,6 +112,30 @@
             return langCode;
           }
 
+          //since scope.languages is a dictionary, we give it an explicit order
+          // Order is based on the occurrence of the "<input>" inside element.
+          // This is more aesthetically pleasing (the nav pills are in the same order as the inputs in the UI)
+          function computeLanguageOrdered(languages,element) {
+            //find the order of items (i.e textarea) underneath
+            var result = [];
+            $(element).find(formFieldsSelector).each(function() {
+              var key = _.invert(languages)["#"+this.lang];
+              if (!_.findWhere(result,{key: key})) // in lookups (i.e. country) there could be multiples of the same things
+                result.push({"key":key,"value":"#"+this.lang});
+            });
+
+            //there might be missing ones in the result list - add them now
+            for (var key in languages) {
+                //do we have this key already?
+                if (!_.findWhere(result,{key: key})) {
+                     result.push( {"key":key,"value":languages[key]});
+                }
+            }
+            return result;
+          };
+
+          scope.languagesOrdered = computeLanguageOrdered(scope.languages,element);
+
           $timeout(function() {
             scope.expanded = scope.expanded === 'true';
 

--- a/web-ui/src/main/resources/catalog/components/edit/multilingualfield/partials/multilingualfield.html
+++ b/web-ui/src/main/resources/catalog/components/edit/multilingualfield/partials/multilingualfield.html
@@ -5,11 +5,11 @@
            data-ng-click="displayAllLanguages(undefined, true)"
            data-translate=""
            title="{{languageSwitchHelp}}">{{languageSwitchLabel}}</a></li>
-    <li data-ng-repeat="(key, value) in languages"
+    <li data-ng-repeat="lang in languagesOrdered"
         data-ng-hide="expanded"
-        data-ng-class="{'active': value === '#' + currentLanguage, 'no-data': value !== '#' + currentLanguage && !hasData[value]}">
+        data-ng-class="{'active': lang['value'] === '#' + currentLanguage, 'no-data': lang['value'] !== '#' + currentLanguage && !hasData[lang['value']]}">
       <a href=""
-         data-ng-click="switchToLanguage(value)">{{key | translate}}</a>
+         data-ng-click="switchToLanguage(lang['value'])">{{lang['key'] | translate}}</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
This contains UX changes for the multilingual fields


1. ordering of nav-pills

Right now the nav-pills ("all french english") at the bottom of a multilingual fields aren't in the same order as the <input> appear in the UI.  This looks "funny."

This PR will put the order of the pills in the same order as in the UI.

It does this by looking at the lang=... attribute of the <input> contained in the element.

NOTE: the angular object goes from from a dictionary to a ["key": key, "value": value] list.

2. control focus when changing languages

Right now when you changes languages (using nav pills), focus() is called on one of the <input> fields.  It most cases this is ok.  However, for some <inputs> this will cause popups to happen.  For example, the Keyword Picker.  This isn't very nice for users. 

You can now annotate the <input data-focus-to-input='true|false'> to control this.
NOTE: it defaults to "true" (which is the current behaviour).