### PR TITLE
Map / Background layer / Add support for WMS group layer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -99,7 +99,7 @@
             var parser = new ol.format.WMSCapabilities();
             cachedGetCapabilitiesUrls[getCapabilitiesUrl] = parser.read(data);
           }
-          var result = cachedGetCapabilitiesUrls[getCapabilitiesUrl];
+          var result = angular.copy(cachedGetCapabilitiesUrls[getCapabilitiesUrl], {});
           var layers = [];
           var url = result.Capability.Request.GetMap.
               DCPType[0].HTTP.Get.OnlineResource;
@@ -511,6 +511,8 @@
               // Multiple layers from the same service
               if (layerName.indexOf(',') !== -1) {
                 // Parameters 'styles' and 'layers' should have the same number of values.
+                needles[0].Name = layerName;
+                needles[0].Title = needles.map(function(l) {return l.Title}).join(', ');
                 needles[0].Style = new Array(layerList.length).join(',');
               }
               return needles[0];

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -255,7 +255,7 @@
                       if (!layer) {
                         return;
                       }
-                      bgLayers[idx - 1] = layer;
+                      bgLayers[idx] = layer;
 
                       layer.displayInLayerManager = false;
                       layer.background = true;
@@ -438,7 +438,7 @@
             }];
           } else if (source instanceof ol.source.ImageWMS ||
               source instanceof ol.source.TileWMS) {
-            name = '{type=wms,name=' + layer.get('name') + '}';
+            name = layer.get('name');
             params.server = [{
               onlineResource: [{
                 href: layer.get('url')
@@ -666,10 +666,9 @@
                   olL.set('tree_index', index);
                   olL.setOpacity(layer.opacity);
                   olL.setVisible(!layer.hidden);
-                  if (layer.title) {
-                    olL.set('title', layer.title);
-                    olL.set('label', layer.title);
-                  }
+                  var title =  layer.title ? layer.title : olL.get('label');
+                  olL.set('title', title || '');
+                  olL.set('label', title || '');
                   $rootScope.$broadcast('layerAddedFromContext', olL);
                   return olL;
                 }

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -292,6 +292,7 @@
       display: flex;
       .btn {
         flex: 1;
+        white-space: normal;
       }
       .dropdown-menu > li > a {
         padding: 8px 20px;


### PR DESCRIPTION
A group layer is a list of layers combined into one eg.

```xml
    <ows-context:Layer name="1,3,0,2,5,4" group="Background layers" hidden="false" opacity="1">
      <ows-context:Server service="urn:ogc:serviceType:WMS" version="1.3.0">
        <ows-context:OnlineResource
          xlink:href="https://bio.discomap.eea.europa.eu/arcgis/services/Internal/Basemap_EU_27_WM_Cached/MapServer/WmsServer"/>
      </ows-context:Server>
    </ows-context:Layer>
```

This fix
* the getCapabilities parsing which was altered once cached (by making a copy from the cache each time it is requested).
Write group layer in context properly (only first layer of the group was taken into account).
* Fix loading layer when a background is a WMS (spinner was never hidden).
* Set layer name and title properly for background layers.
* Fix display of long layer name in background layer button.

![image](https://user-images.githubusercontent.com/1701393/77674015-3e06ed00-6f8b-11ea-8cf6-b6c3de326f18.png)
