### PR TITLE
Multi portal mode / User entity listener may be triggered outside a request scope

### DIFF
--- a/domain/src/main/java/org/fao/geonet/entitylistener/UserNodeIdSetter.java
+++ b/domain/src/main/java/org/fao/geonet/entitylistener/UserNodeIdSetter.java
@@ -25,6 +25,7 @@ package org.fao.geonet.entitylistener;
 
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.domain.User;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 
@@ -45,7 +46,12 @@ public class UserNodeIdSetter implements GeonetworkEntityListener<User> {
     @Override
     public void handleEvent(final PersistentEventType type, final User entity) {
         if (type == PersistentEventType.PostLoad || type == PersistentEventType.PostPersist || type == PersistentEventType.PrePersist) {
-            entity.getSecurity().setNodeId(context.getBean(NodeInfo.class).getId());
+            try {
+                entity.getSecurity().setNodeId(context.getBean(NodeInfo.class).getId());
+            } catch (BeanCreationException exception) {
+                // This event may not be triggered on a request (eg. while indexing in background)
+                // and user can't be attached to a node in such case as NodeInfo is on request scope only.
+            }
         }
     }
 }


### PR DESCRIPTION
Error was triggered when synchronizing index on startup and when an error occur 
Then the owner of the record was retrieved and the exception created.

Related to https://github.com/geonetwork/core-geonetwork/pull/4542