### PR TITLE
Fixes for metadata rating

### DIFF
--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnmdFeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnmdFeedbackDirective.js
@@ -46,7 +46,11 @@
 
                 scope.showLabel = attrs.showLabel;
 
-                scope.isFeedbackEnabled = gnConfig[gnConfig.key.isFeedbackEnabled];
+                var statusSystemRating = gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
+                if (statusSystemRating == 'advanced') {
+                  $scope.isUserFeedbackEnabled = true;
+                }
+
                 scope.recaptchaEnabled =
                   gnConfig['system.userSelfRegistration.recaptcha.enable'];
                 scope.recaptchaKey =

--- a/web-ui/src/main/resources/catalog/components/userfeedback/partials/mdFeedback.html
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/partials/mdFeedback.html
@@ -1,5 +1,5 @@
 <div class="md-feedback"
-     data-ng-show="isFeedbackEnabled">
+     data-ng-show="isUserFeedbackEnabled">
   <a href data-ng-click="toggle()"
      title="{{'fbFeedback' | translate}}"
      class="gn-md-feedback-btn">

--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -68,7 +68,7 @@
 
       $scope.isUserFeedbackEnabled = false;
 
-      statusSystemRating = gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
+      var statusSystemRating = gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
       if (statusSystemRating == 'advanced') {
         $scope.isUserFeedbackEnabled = true;
       }


### PR DESCRIPTION
- Use metadata rating setting to enable  the metadata rating panel in the metadata detail page instead of the user feedback setting (contact us feature).

- Add var declaration to javascript variable.