### PR TITLE
Formatter / Display a section only if there is something in

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -324,18 +324,25 @@
 
   <xsl:template mode="render-view"
                 match="section[not(@xpath)]">
-    <div id="gn-section-{generate-id()}" class="gn-tab-content">
-      <xsl:if test="@name">
-        <xsl:variable name="title"
-                      select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
 
-        <xsl:element name="h{1 + count(ancestor-or-self::*[name(.) = 'section'])}">
-          <xsl:value-of select="$title"/>
-        </xsl:element>
-      </xsl:if>
+    <xsl:variable name="content">
       <xsl:apply-templates mode="render-view"
                            select="section|field|xsl"/>&#160;
-    </div>
+    </xsl:variable>
+
+    <xsl:if test="count($content/*) > 0">
+      <div id="gn-section-{generate-id()}" class="gn-tab-content">
+        <xsl:if test="@name">
+          <xsl:variable name="title"
+                        select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
+
+          <xsl:element name="h{1 + count(ancestor-or-self::*[name(.) = 'section'])}">
+            <xsl:value-of select="$title"/>
+          </xsl:element>
+        </xsl:if>
+        <xsl:copy-of select="$content"/>
+      </div>
+    </xsl:if>
   </xsl:template>
 
 


### PR DESCRIPTION
eg. with this kind of editor config:

```xml

        <section name="emodnetQualityTitle">
          <section name="emodnetHorAccuracyTitle">
            <field xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/*/gmd:report/
                          gmd:DQ_GriddedDataPositionalAccuracy/gmd:measureDescription"/>
            <field xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/*/gmd:report/
                          gmd:DQ_GriddedDataPositionalAccuracy/gmd:result/*/gmd:value"/>
            <field xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/*/gmd:report/
                          gmd:DQ_GriddedDataPositionalAccuracy/gmd:evaluationMethodDescription"/>
          </section>

          <section name="emodnetVertAccuracyTitle">
            <field xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/*/gmd:report/
                            gmd:DQ_QuantitativeAttributeAccuracy/gmd:measureDescription"/>
            <field xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/*/gmd:report/
                            gmd:DQ_QuantitativeAttributeAccuracy/gmd:evaluationMethodDescription"/>
          </section>

          <section name="emodnetShoalBias">
            <field name="emodnetShoalBias"
                   xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/*/gmd:report/
                          gmd:DQ_NonQuantitativeAttributeAccuracy/gmd:result/
                           *[gmd:specification/*/gmd:title = 'Shoal bias']/
                              gmd:pass"/>
            <field name="emodnetShoalBiasDetails"
                   xpath="/gmd:MD_Metadata/gmd:dataQualityInfo/*/gmd:report/
                            gmd:DQ_NonQuantitativeAttributeAccuracy/gmd:result/
                           *[gmd:specification/*/gmd:title = 'Shoal bias']/
                                gmd:explanation"/>
          </section>

          <section name="emodnetSuitabilty">
            <field name="emodnetSuitabilityTitle"
                   xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/
                          gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation"/>
          </section>

```

Some element may not be filled. Do not display them in the corresponding view mode.

Before:

![image](https://user-images.githubusercontent.com/1701393/77762176-651bf800-7039-11ea-9ead-4f2654090fad.png)

After:

![image](https://user-images.githubusercontent.com/1701393/77762179-677e5200-7039-11ea-84fb-04278f371ec7.png)


