### PR TITLE
Fix for the `none` background image causing a 404 to a non existing page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -29,10 +29,10 @@ html, body {
 //
 // if the background image is an empty string it will be substitued with the name of the css file,
 // see: https://stackoverflow.com/questions/20727262/css-file-considered-as-being-an-image-resource
-[ng-app^="gn_search_"] body when not (@gn-background-image = "") {
+[ng-app^="gn_search_"] body when (isstring(@gn-background-image)) {
   background-image: url(@gn-background-image);
 }
-[ng-app^="gn_login"] body when not (@gn-background-image = "") {
+[ng-app^="gn_login"] body when (isstring(@gn-background-image)) {
   background-image: url(@gn-background-image);
 }
 


### PR DESCRIPTION
Using `none` for the background-image variable was causing a 404 in the browser to a non existing page called 'none'.

See the first line of the screenshot
![browser-error](https://user-images.githubusercontent.com/19608667/77907717-698b1f80-728a-11ea-9b64-49184d71f8c9.png)

This PR improves the check for the value of the background-image variable, so there is no non existing page anymore.