### PR TITLE
fix multilingual save issue (iso 19139)

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -423,16 +423,19 @@
 
               <!-- Populate PT_FreeText for default language if not existing and it is not null. -->
               <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
-              <xsl:if test="normalize-space(gco:CharacterString|gmx:Anchor) != ''">
-                <gmd:PT_FreeText>
-                  <gmd:textGroup>
-                    <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">
-                      <xsl:value-of select="gco:CharacterString|gmx:Anchor"/>
-                    </gmd:LocalisedCharacterString>
-                  </gmd:textGroup>
-                  <xsl:call-template name="populate-free-text"/>
-                </gmd:PT_FreeText>
-              </xsl:if>
+                <!-- only put this in if there's stuff to put in, otherwise we get a <gmd:PT_FreeText/> in output -->
+                <xsl:if test="(normalize-space(gco:CharacterString|gmx:Anchor) != '') or gmd:PT_FreeText">
+                  <gmd:PT_FreeText>
+                    <xsl:if test="normalize-space(gco:CharacterString|gmx:Anchor) != ''"> <!-- default lang-->
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">
+                          <xsl:value-of select="gco:CharacterString|gmx:Anchor"/>
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </xsl:if>
+                    <xsl:call-template name="populate-free-text"/> <!-- other langs -->
+                  </gmd:PT_FreeText>
+                </xsl:if>
             </xsl:otherwise>
           </xsl:choose>
         </xsl:otherwise>


### PR DESCRIPTION
Issue - when have a multilingual field with only the non-default languages, save doesn't save.


To reproduce, you need a multi-lingual document;

1. Run fresh 3.10.x & login
2. add iso 19139 templates and examples
3. create a new record, based on the "Template for Vector data in ISO19139 (multilingual)" template
4. edit the record in XML
5. go to the "abstract" part and delete all the information;
<gmd:abstract gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
    <gco:CharacterString/>
</gmd:abstract>
6. Save and edit in Simple mode
7. Change the GERMAN ("Deutsch") abstract  
8. Save

You will notice, that the change is "undone" and you will end up with nothing in the abstract.


This is a port of the HNAP change that fixes this;
https://github.com/metadata101/iso19139.ca.HNAP/pull/24

This was occurring because of how update-fixed-info.xsl was dealing with multi-lingual fields.
