### PR TITLE
Fixed header option for GeoNetwork

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/cssstyle/CssStyleSettingsService.java
+++ b/services/src/main/java/org/fao/geonet/api/cssstyle/CssStyleSettingsService.java
@@ -300,11 +300,17 @@ public class CssStyleSettingsService {
             final String key = iter.next();
             if (input.getString(key) != null) {
 
-                if(!key.equals("gnBackgroundImage") && !StringUtils.isEmpty(input.getString(key))) {
+                if(!key.equals("gnBackgroundImage") && !key.equals("gnHeaderHeight") && !StringUtils.isEmpty(input.getString(key))) {
                     Pattern pattern = Pattern.compile("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$");
                     Matcher matcher = pattern.matcher(input.getString(key));
                     if (!matcher.matches()) {
                         throw new JSONException("Invalid color value. It must be in the format #RRGGBB.");
+                    }
+                } else if(key.equals("gnHeaderHeight") && !StringUtils.isEmpty(input.getString(key))) {
+                    Pattern pattern = Pattern.compile("^([0-9])+(px)$");
+                    Matcher matcher = pattern.matcher(input.getString(key));
+                    if (!matcher.matches()) {
+                        throw new JSONException("Invalid pixel value. It must be in the format 100px.");
                     }
                 } else if(key.equals("gnBackgroundImage") && !StringUtils.isEmpty(input.getString(key))) {
                     Pattern pattern = Pattern.compile("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -705,6 +705,19 @@
            data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
            {{('ui-' + key + '-help') | translate}} </p>
       </div>
+
+      <div data-ng-switch-when="isHeaderFixed">
+        <input type="checkbox"
+               id="{{key}}-checkbox"
+               data-ng-model="mCfg[key]"/>&nbsp;
+        <label class="control-label"
+               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+           {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
       <div data-ng-switch-when="logoInHeaderPosition">
           <label class="control-label">{{('ui-' + key) | translate}}</label>
   

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -96,7 +96,8 @@ goog.require('gn_alert');
           'isLogoInHeader': false,
           'logoInHeaderPosition': 'left',
           'fluidHeaderLayout': true,
-          'showGNName': true
+          'showGNName': true,
+          'isHeaderFixed': false
         },
         'cookieWarning': {
           'enabled': true,
@@ -484,6 +485,8 @@ goog.require('gn_alert');
       $scope.fluidEditorLayout = gnGlobalSettings.gnCfg.mods.editor.fluidEditorLayout;
       $scope.fluidHeaderLayout = gnGlobalSettings.gnCfg.mods.header.fluidHeaderLayout;
       $scope.showGNName = gnGlobalSettings.gnCfg.mods.header.showGNName;
+      $scope.isHeaderFixed = gnGlobalSettings.gnCfg.mods.header.isHeaderFixed;
+      $scope.isLogoInHeader = gnGlobalSettings.gnCfg.mods.header.isLogoInHeader;
 
       // If gnLangs current already set by config, do not use URL
       $scope.langs = gnGlobalSettings.gnCfg.mods.header.languages;

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1360,6 +1360,8 @@
     "ui-isLogoInHeader-help": "Show the logo in the header, above the navigation bar. The logo in the navigation bar will be removed. Only for the public pages (not the editor or admin).",
     "ui-logoInHeaderPosition": "Position of logo",
     "ui-logoInHeaderPosition-help": "Position of the logo in the header",
+    "ui-isHeaderFixed": "Fix the header",
+    "ui-isHeaderFixed-help": "The header is fixed and stays at the top of the page. Attention: when the option [Show the logo in header] is also selected, the header needs a set height. This can be done under [CSS & Style] > [Header] > [Height]",
     "left": "Left",
     "center": "Center",
     "right": "Right",
@@ -1439,5 +1441,6 @@
     "ui-defaultSearchString":"Default search",
     "ui-defaultSearchString-help":"This configuration lets you define a default filter for the search. The syntax is the one used in the angular facet query array.",
     "ui-autoFitOnLayer":"Always zoom on data",
-    "ui-autoFitOnLayer-help":"If checked, the map will automatically zoom on data when adding a layer from a record. Otherwise, a message will be shown to let the user zoom on data manually."
+    "ui-autoFitOnLayer-help":"If checked, the map will automatically zoom on data when adding a layer from a record. Otherwise, a message will be shown to let the user zoom on data manually.",
+    "styleVariable-gnHeaderHeight":"Height"
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
@@ -62,6 +62,11 @@
                   <color-picker data-ng-model="gnCssStyle.gnHeaderBackground"
                     color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
                 </div>
+                <div class="col-md-3">
+                  <label for="gnCssStyle.gnHeaderHeight" data-translate="">styleVariable-gnHeaderHeight</label>
+                  <input class="form-control" type="text"
+                    data-ng-model="gnCssStyle.gnHeaderHeight" />
+                </div>
               </div>
             </div>
             <div class="row gn-margin-bottom">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -12,11 +12,11 @@
 html, body {
   height:100%;
 }
-
 // header
 .gn-header {
   background-color: @gn-header-background;
 }
+
 // background image and color
 [ng-app^="gn_search_"] body, [ng-app="gn_login"] body {
   background-color: @gn-background-color;
@@ -24,6 +24,20 @@ html, body {
   background-size: cover;
   background-repeat: no-repeat;
   background-attachment: fixed;
+  &.gn-header-fixed {
+    padding-top: @gn-menubar-height;
+    &.gn-logo-in-header {
+      padding-top: calc(~"@{gn-header-height} + @{gn-menubar-height}");
+      .gn-header {
+        position: fixed;
+        right: 0;
+        left: 0;
+        top: 0;
+        z-index: 1030;
+        height: @gn-header-height;
+      }
+    }
+  }
 }
 // check if the variable is a not an empty string, if not, then set the background image
 //

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -5,12 +5,29 @@
 .navbar {
   margin-bottom: 0;
 }
+[ng-app^="gn_search_"] body, [ng-app="gn_login"] body {
+  &.gn-header-fixed {
+    .gn-top-bar {
+      position: fixed;
+      right: 0;
+      left: 0;
+      top: 0;
+      z-index: 1030;
+    }
+    &.gn-logo-in-header {
+      .gn-top-bar {
+        top: @gn-header-height;
+      }
+    }
+  }
+}
 
 .navbar-default {
   background-color: @gn-menubar-background;
   border-color: @gn-menubar-border-color;
   border-width: 0 0 1px 0;
   z-index: 100;
+  border-radius: 0;
   .navbar-nav > li > a, .navbar-nav > .open > a, .navbar-nav > .active > a {
     height: @gn-menubar-height;
     color: @gn-menubar-color;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -28,6 +28,7 @@
 
 // header
 @gn-header-background: #fff;
+@gn-header-height: 50px;
 // menu bar
 @gn-menubar-height: 50px;
 @gn-menubar-background: @navbar-default-bg;

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -67,7 +67,7 @@
       loading site information, check user login state
       and a facet search to get main site information.
       -->
-      <body data-ng-controller="GnCatController">
+      <body data-ng-controller="GnCatController" data-ng-class="[isHeaderFixed ? 'gn-header-fixed' : 'gn-header-relative', isLogoInHeader ? 'gn-logo-in-header' : 'gn-logo-in-navbar']">
 
         <div data-gn-alert-manager=""></div>
 


### PR DESCRIPTION
This PR adds an option to get a fixed header for GeoNetwork. 

In the admin there is a new setting to fix the header ([Settings] > [User interface] > [Header]), and an extra option to set the height of the header ([Settings] > [CSS & Style] > [Header] > [Height]). This height is needed for when both options for `Fixed Header` and `Show the logo in header` are selected.

![bridge-fixed-header](https://user-images.githubusercontent.com/19608667/78553419-7d460100-7809-11ea-80c8-16ad5718a4ec.png)
