### PR TITLE
Update map editor styling to use 16:9 aspect ratio

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
@@ -119,12 +119,12 @@
       </span>
       <table>
         <tr>
-          <td>
+          <td class="olmap-map-wrapper">
             <div ng-if="map" ol-map="map"></div>
           </td>
         </tr>
       </table>
     </div>
-    
+
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -578,3 +578,22 @@ form.gn-editor.gn-indent-bluescale {
 
   }
 }
+
+// Editor map
+.gn-editor-map {
+  [ol-map] {
+    //width: 66%;
+    //height: 400px;
+    //display: inline-block;
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+  }
+  .olmap-map-wrapper {
+    text-align: center;
+    height: 0;
+    padding-bottom: 56.25%; /* 16:9 Aspect ratio*/
+    //padding-bottom: 75%; /* 4:3 */
+    position: relative;
+  }
+}


### PR DESCRIPTION
The current editor map viewer doesn't allow to zoom out of the extent in the map area, although the user can scroll to the non visible areas.

This makes a bit difficult to select big areas using the `Draw extent` tool.

![map-viewer-editor](https://user-images.githubusercontent.com/1695003/78558929-c4d18a80-7813-11ea-93d5-f39bbd9d4777.png)

Change to use a 16:9 aspect ratio for this map. Doesn't show the full world (for this is required to type the coordinates instead of using the `Draw extent` tool), but improves a bit the area displayed to allow to select bigger areas:

![map-viewer-editor-updated](https://user-images.githubusercontent.com/1695003/78558934-c7cc7b00-7813-11ea-90fe-3255ab245a82.png)
