### PR TITLE
Metadata batch validation show validation summary instead of a message with '[Object object]' text

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -61,7 +61,7 @@
       var windowOption = '';
       var translations = null;
       $translate(['metadataPublished', 'metadataUnpublished',
-        'metadataPublishedError', 'metadataUnpublishedError']).then(function(t) {
+        'metadataPublishedError', 'metadataUnpublishedError', 'metadataValidated']).then(function(t) {
         translations = t;
       });
       var alertResult = function(msg) {
@@ -170,9 +170,19 @@
               'bucket=' + bucket, null, {
                     method: 'PUT'
                   }).then(function(data) {
-            alertResult(data.data);
-            $rootScope.$broadcast('operationOnSelectionStop');
-            $rootScope.$broadcast('search');
+            $rootScope.processReport = data.data;
+
+            // A report is returned
+            gnUtilityService.openModal({
+              title: translations.metadataValidated,
+              content: '<div gn-batch-report="processReport"></div>',
+              className: 'gn-validation-popup',
+              onCloseCallback: function () {
+                $rootScope.$broadcast('operationOnSelectionStop');
+                $rootScope.$broadcast('search');
+                $rootScope.processReport = null;
+              }
+            }, $rootScope, 'metadataValidationUpdated');
           });
         }
       };

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -508,5 +508,6 @@
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
     "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
-    "workingCopy": "Working copy"
+    "workingCopy": "Working copy",
+    "metadataValidated": "Metadata validated."
 }


### PR DESCRIPTION
Metadata batch validation from the Editor Dashboard displays the following message when the process finishes:

![validation-message](https://user-images.githubusercontent.com/1695003/78570154-e25b2000-7824-11ea-98aa-728b0d570bfa.png)

Update to display the validation summary report returned:

![validation-report](https://user-images.githubusercontent.com/1695003/78570172-e9822e00-7824-11ea-9143-b207492884cd.png)
