### PR TITLE
Validation / Index in current thread to avoid lock

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
@@ -208,7 +208,7 @@ public class ValidateApi {
 
             // index records
             BatchOpsMetadataReindexer r = new BatchOpsMetadataReindexer(dataMan, report.getMetadata());
-            r.process();
+            r.process(true);
         } catch (Exception e) {
             throw e;
         } finally {


### PR DESCRIPTION
Fixes https://github.com/geonetwork/core-geonetwork/issues/4487

But globally there is more testing to do on all calls to process when multithread.