### PR TITLE
Fix the menu for smaller screens

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -67,6 +67,8 @@
   }
   // more small screen oriented menu options
   @media (max-width: @screen-xs-max) {
+    padding-left: 0;
+    padding-right: 0;
     .navbar-header {
       .btn-link {
         padding: 13px;
@@ -77,14 +79,14 @@
     }
     .navbar-collapse {
       background-color: #fff;
-      padding-right: 15px;
-      padding-top: 10px;
-      padding-bottom: 10px;
-      margin: 0 -20px;
+      padding: 15px;
       box-shadow: 0 2px 0.5px rgba(0, 0, 0, 0.1) !important;
     }
     .navbar-nav > li > a, .navbar-nav > .open > a, .navbar-nav > .active > a {
       background: none;
+    }
+    .navbar-nav .open .dropdown-menu > li > a {
+      min-width: 0;
     }
     .gn-clear-xs {
       clear: both;
@@ -94,7 +96,7 @@
       padding: 15px 0;
       height: auto;
       font-size: 16px;
-      font-weight: 300;
+      font-weight: 400;
       clear: both;
       i {
         display: none;
@@ -113,7 +115,7 @@
         display: none;
       }
       .gn-menuitem-xs {
-        width: 33%;
+        width: calc(~"33% + 2px");
         height: 64px;
         text-align: center;
         border: 1px solid @navbar-default-border;
@@ -171,6 +173,7 @@
         display: block !important;
         padding: 0;
         margin: 0;
+        border: 0;
         .clearfix();
         // username & password input
         .form-group-sm {
@@ -191,8 +194,10 @@
       }
     }
     .language-switcher {
-      padding-left: 0;
-      padding-right: 0;
+      padding: 10px 15px;
+      .form-control {
+        width: calc(~"100% - 3px");
+      }
     }
     @media (min-width: @screen-sm-min) {
       li.dropdown-hover {


### PR DESCRIPTION
The menu on smaller screens has some small visual errors (padding and labels). This PR fixes these errors (see screenshots).

**Before the changes** 
![geonetwork-menu-before](https://user-images.githubusercontent.com/19608667/78761364-ca011780-7982-11ea-96dd-c522d5cfc0c5.png)

**After the changes**
![geonetwork-menu-after](https://user-images.githubusercontent.com/19608667/78761393-d1282580-7982-11ea-9ea9-53949b25c51f.png)

