### PR TITLE
API / Attachments / Images / Add a size parameter.

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/ImageUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/ImageUtil.java
@@ -1,0 +1,72 @@
+/*
+ * =============================================================================
+ * ===	Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * ===	and United Nations Environment Programme (UNEP)
+ * ===
+ * ===	This program is free software; you can redistribute it and/or modify
+ * ===	it under the terms of the GNU General Public License as published by
+ * ===	the Free Software Foundation; either version 2 of the License, or (at
+ * ===	your option) any later version.
+ * ===
+ * ===	This program is distributed in the hope that it will be useful, but
+ * ===	WITHOUT ANY WARRANTY; without even the implied warranty of
+ * ===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * ===	General Public License for more details.
+ * ===
+ * ===	You should have received a copy of the GNU General Public License
+ * ===	along with this program; if not, write to the Free Software
+ * ===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ * ===
+ * ===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * ===	Rome - Italy. email: geonetwork@osgeo.org
+ * ==============================================================================
+ */
+
+package org.fao.geonet.util;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+public class ImageUtil {
+    public static Dimension getScaledDimension(Dimension imgSize, Dimension boundary) {
+        int original_width = imgSize.width;
+        int original_height = imgSize.height;
+        int bound_width = boundary.width;
+        int bound_height = boundary.height;
+        int new_width = original_width;
+        int new_height = original_height;
+
+        // first check if we need to scale width
+        if (original_width > bound_width) {
+            //scale width to fit
+            new_width = bound_width;
+            //scale height to maintain aspect ratio
+            new_height = (new_width * original_height) / original_width;
+        }
+
+        // then check if we need to scale even with the new height
+        if (new_height > bound_height) {
+            //scale height to fit instead
+            new_height = bound_height;
+            //scale width to maintain aspect ratio
+            new_width = (new_height * original_width) / original_height;
+        }
+
+        return new Dimension(new_width, new_height);
+    }
+
+    public static BufferedImage resize(BufferedImage img, int size) {
+        Dimension imgSize = new Dimension(img.getWidth(), img.getHeight());
+        Dimension boundary = new Dimension(size, size);
+        final Dimension scaledDimension = getScaledDimension(imgSize, boundary);
+        int width = (int) scaledDimension.getWidth();
+        int height = (int) scaledDimension.getHeight();
+        Image tmp = img.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+        BufferedImage resized = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = resized.createGraphics();
+        g2d.drawImage(tmp, 0, 0, null);
+        g2d.dispose();
+        return resized;
+    }
+}


### PR DESCRIPTION
This can be useful to reduce loading time on search results page.
When thumbnails is quite big (500ko) x number of results per page
can make the results slow to load when low bandwidth available.

![image](https://user-images.githubusercontent.com/1701393/78767405-da1cf500-798a-11ea-91fe-23391a0f4ea0.png)
