### PR TITLE
Formatter / Template field / Add bottom margin to make distinction of each matching elements.

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -251,6 +251,11 @@ header div.gn-abstract {
 
   .gn-field-template div.target {
     margin-bottom: 2em;
+    dl:not(:first-child) {
+      dt:before {
+        border: none;
+      }
+    }
   }
 
   .img-thumbnail {

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -249,6 +249,10 @@ header div.gn-abstract {
     margin-left: 1em;
   }
 
+  .gn-field-template div.target {
+    margin-bottom: 2em;
+  }
+
   .img-thumbnail {
     margin-bottom: 1em;
   }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -394,7 +394,7 @@
                 priority="2">
     <xsl:param name="base" select="$metadata"/>
 
-    <div class="entry name">
+    <div class="entry name gn-field-template">
       <xsl:if test="@name">
         <xsl:variable name="title"
                       select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>


### PR DESCRIPTION
Does not apply to simple and advanced view making no usage of template field but in custom view if a template field match many elements, all fields are displayed one after the other with no way to make distinction between matching elements.

eg.

```xml
     <tab id="sdn-contact" mode="flat">
        <section>

          <field name="sdn-ResourceProviderTitle"
                 templateModeOnly="true"
                 notDisplayedIfMissing="true"
                 xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/
                          gmd:pointOfContact[*/gmd:role/*/@codeListValue = 'author']"
                 del=".">
            <template>
              <values readonlyIf="count(@xlink:href) > 0">
                <key label="organisationName"
                     xpath="gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString"/>
                <key label="country"
                     xpath="gmd:CI_ResponsibleParty/gmd:contactInfo/
                            gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country/gco:CharacterString"/>
                <key label="electronicMailAddress"
                     xpath="gmd:CI_ResponsibleParty/gmd:contactInfo/
                  gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString"
                     use="email"/>
                <key label="edmoId"
                     xpath="*[1]/@uuid"/>
              </values>
              <snippet>
```

Add some margin after each group of fields for an entry:

![image](https://user-images.githubusercontent.com/1701393/78978273-c5bb3280-7b19-11ea-82a7-829a1c341c9f.png)

