### PR TITLE
Update repositories used by build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1219,12 +1219,6 @@
       <url>https://raw.githubusercontent.com/geonetwork/core-maven-repo/master</url>
     </repository>
 
-    <repository>
-      <id>mvnrepository.com</id>
-      <name>Repository that has juniversalchardet</name>
-      <url>http://mvnrepository.com/artifact</url>
-    </repository>
-
     <!-- seasar repo, has jsonic - used by langdetect -->
     <repository>
       <id>maven.seasar.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1225,12 +1225,6 @@
       <url>http://mvnrepository.com/artifact</url>
     </repository>
 
-    <repository>
-      <id>maven2</id>
-      <name>Repository maven2</name>
-      <url>https://repo.maven.apache.org/maven2</url>
-    </repository>
-
     <!-- seasar repo, has jsonic - used by langdetect -->
     <repository>
       <id>maven.seasar.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1193,18 +1193,11 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>geotools</id>
-      <name>Geotools repository</name>
-      <url>http://download.osgeo.org/webdav/geotools/</url>
+      <id>osgeo</id>
+      <name>OSGeo repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
     </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>boundless</id>
-      <name>Boundless repository</name>
-      <url>http://repo.boundlessgeo.com/main/</url>
-    </repository>
+
     <repository>
       <snapshots>
         <enabled>false</enabled>
@@ -1213,7 +1206,6 @@
       <name>Developer k-int repository</name>
       <url>http://maven.k-int.com/content/repositories/releases/</url>
     </repository>
-
 
     <repository>
       <snapshots>
@@ -1231,11 +1223,6 @@
       <id>mvnrepository.com</id>
       <name>Repository that has juniversalchardet</name>
       <url>http://mvnrepository.com/artifact</url>
-    </repository>
-    <repository>
-      <id>maven.geo-solutions.it</id>
-      <name>geo-solutions</name>
-      <url>http://maven.geo-solutions.it</url>
     </repository>
 
     <repository>


### PR DESCRIPTION
Reducing the number of repositories in the build is an easy way to reduce build times:

* GeoTools repository moved to repo.osgeo.org
* GeoSolutions repository cached by repo.osgeo.org
* Boundless repository no longer available, contents moved to repo.osgeo.org
* Maven Central repository is assumed
* juniversalchardet is in maven central now

Please note that repo.osgeo.org is available to the geonetwork project if we wish to manage our own releases, docker images, or cache third-party dependencies.