### PR TITLE
git allow keyword picker to be used inside another component

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -507,11 +507,13 @@
       return {
         restrict: 'A',
         scope: {
+             fauxMultilingual: '@fauxMultilingual' // we are doing our own multi-lingual support
         },
         link: function(scope, element, attrs) {
           scope.thesaurusKey = attrs.thesaurusKey || '';
           scope.orderById = attrs.orderById || 'false';
           scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
+          scope.fauxMultilingual = scope.fauxMultilingual==="true"; //default false
 
 
 
@@ -639,14 +641,16 @@
             }).bind('typeahead:selected',
               $.proxy(function(obj, keyword) {
                 var inputs = $(obj.currentTarget).parent().parent().find('input.tt-input');
-                if (isMultilingualMode && inputs.size() > 0) {
+                if ((isMultilingualMode||scope.fauxMultilingual) && inputs.size() > 0) {
                   for (var i = 0; i < inputs.size(); i ++) {
                     var input = inputs.get(i);
                     var lang = input.getAttribute('lang');
                     var value = keyword.props.values[gnCurrentEdit.allLanguages.code2iso['#' + lang]];
                     if (value) {
                       $(input).typeahead('val', value);
-                    }
+                      // this makes sure that angular knows the value has changed
+                      $(input).triggerHandler('input');
+                     }
                     // If no value for the language, value is not set.
                   }
                 } else {


### PR DESCRIPTION
This is a minor change the thesaurus keyword picker.

I am re-using this as a component in another component.

a) I've given the ability for it to be in multi-lingual mode without it being in a "proper" multilingual element.  Just add "faux-multilingual='true'".  This defaults to false, so this should NOT be noticed by anyone.

b) I noticed that angular was not being notified of changes to a value - I added a "kicker" so it gets notified.

-----------------------

NORMAL WAY (schmatic)
* note - adding data-gn-multilingual-field actually makes a lot of changes

\<div data-gn-multilingual-field="... config ...">
   <input lang="fre" ... />
   <input lang="eng" ... />
\</div>



WRONG WAY - if you do this, there are two issues;
a) the two type-ahead inputs are INDEPENDENT (i.e. they can have different values)
b) it doesn't do multi-languge (i.e. everything will be in english)

\<div>
   <input lang="fre" ... />
   <input lang="eng" ... />
\</div>



NEW WAY
This makes it work in the same way as the "normal way," but you don't need to 
attach the data-gn-multilingual-field directive.

\<div>
   <input lang="fre" data-faux-multilingual="true" ... />
   <input lang="eng" data-faux-multilingual="true" ... />
\</div>

See https://github.com/geonetwork/core-geonetwork/pull/4597 for a more concrete example.

NOTE: you only need to use this IF you are re-using the keyword picker inside another component.  Most people will not use this.