### PR TITLE
JNDI support improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1326,7 +1326,7 @@
     <!--<app.properties>file:/${geonetwork.dir}/config.properties</app.properties>-->
 
     <!-- Configure database config file to use. Could be
-     h2, postgres, sqlserver, mysql, oracle, db2, postgres-postgis, jndi-postgres-postgis
+     h2, postgres, sqlserver, mysql, oracle, db2, postgres-postgis, jndi
      -->
     <db.type>h2</db.type>
     <db.config.file>../config-db/${db.type}.xml</db.config.file>

--- a/web/src/main/webResources/WEB-INF/config-db/jndi.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndi.xml
@@ -52,7 +52,6 @@
         <entry key="Data Source" value-ref="jdbcDataSource"/>
         <entry key="Loose bbox" value="true"/>
         <entry key="Estimated extends" value="true"/>
-        <entry key="schema" value="public" />
         <entry key="encode functions" value="true"/>
         <entry key="validate connections" value="true"/>
         <entry key="fetch size" value="1000"/>

--- a/web/src/main/webResources/WEB-INF/config-db/jndi.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndi.xml
@@ -29,29 +29,19 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 	">
 
-  <bean id="datastoreFactory" class="org.geotools.data.postgis.PostgisNGDataStoreFactory"/>
-  <bean id="datastore"
-        factory-bean="datastoreFactory"
-        factory-method="createDataStore">
-    <constructor-arg>
-      <map>
-        <description>
-          The datastore factory parameters see Geotools documentation for details.
-
-          http://docs.geotools.org/latest/userguide/library/data/datastore.html
-        </description>
-        <entry key="dbtype" value="postgis"/>
-        <entry key="Loose bbox" value="true"/>
-        <entry key="Estimated extends" value="true"/>
-        <entry key="encode functions" value="true"/>
-        <entry key="Expose primary keys" value="true"/>
-        <entry key="Data Source" value-ref="jdbcDataSource"/>
-      </map>
-    </constructor-arg>
+  <bean id="jdbcDataSource" class="org.springframework.jndi.JndiObjectFactoryBean">
+    <!-- comp/env/jdbc/geonetwork works with WEB-INF/jetty-env.xml supplied with GN -->
+    <property name="jndiName" value="java:comp/env/jdbc/geonetwork"/>
+    <property name="cache" value="true"/>
+    <property name="exposeAccessContext" value="false"/>
   </bean>
 
-  <!-- Note: in case of JNDI access, use this bean instead of the previous ones:
-  <bean id="datastoreFactory" class="org.geotools.data.postgis.PostgisNGJNDIDataStoreFactory"/>
+  <bean id="jpaVendorAdapterDatabaseParam" class="java.lang.String">
+    <constructor-arg value="#{environment.gnDatabaseDialect}"/>
+  </bean>
+
+  <!-- Enable for PostGis configuration with JNDI -->
+  <!--<bean id="datastoreFactory" class="org.geotools.data.postgis.PostgisNGJNDIDataStoreFactory"/>
   <bean id="datastore" factory-bean="datastoreFactory" factory-method="createDataStore">
     <constructor-arg>
       <map>
@@ -62,14 +52,12 @@
         <entry key="Data Source" value-ref="jdbcDataSource"/>
         <entry key="Loose bbox" value="true"/>
         <entry key="Estimated extends" value="true"/>
-        <entry key="schema" value="${database.schema}" />
+        <entry key="schema" value="public" />
         <entry key="encode functions" value="true"/>
         <entry key="validate connections" value="true"/>
         <entry key="fetch size" value="1000"/>
         <entry key="Expose primary keys" value="true"/>
       </map>
     </constructor-arg>
-  </bean>
-  -->
-
+  </bean>-->
 </beans>

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/README.md
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/README.md
@@ -1,0 +1,6 @@
+##Useful files if you use tomcat:
+
+* pick the jndi configuration for the database you want to use
+* rename the file to geonetwork.xml (or to appName.xml if you use another name)
+* put the file inside tomcat/conf/Catalina/localhost
+* be sure that the jar for the driver you want to use is in tomcat/lib

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/README.md
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/README.md
@@ -1,6 +1,77 @@
-##Useful files if you use tomcat:
+# JNDI example files for Tomcat
 
-* pick the jndi configuration for the database you want to use
-* rename the file to geonetwork.xml (or to appName.xml if you use another name)
-* put the file inside tomcat/conf/Catalina/localhost
-* be sure that the jar for the driver you want to use is in tomcat/lib
+This folder contains JNDI example files for Tomcat for H2, Oracle and Postgres.
+
+* Pick the jndi configuration for the database you want to use and fill the relevant parameters for your database
+* Rename the file to geonetwork.xml (or to appName.xml if you use another name)
+* Put the file inside `TOMCAT_DIR/conf/Catalina/localhost` 
+* Be sure that the jar for the driver you want to use is in `TOMCAT_DIR/lib`
+
+**Note:** replace `TOMCAT_DIR` with Tomcat path.
+
+Check the following links for additional documentation about JNDI configuration in Tomcat:
+
+- https://tomcat.apache.org/tomcat-8.5-doc/jndi-resources-howto.html#JDBC_Data_Sources
+- https://tomcat.apache.org/tomcat-8.5-doc/jndi-datasource-examples-howto.html
+
+## Postgres database example
+
+For a Postgres database use the file `postgres_JNDI_Example.xml`, configuring the following parameters:
+
+- `url`: JDBC connection string for Postgresql database, typically fill the hostname/port/database name. See additional parameters in https://jdbc.postgresql.org/documentation/head/connect.html
+- `username`: database username with read/write permissions in the database
+- `password`: database user password.
+- For other parameters check additional documentation in https://tomcat.apache.org/tomcat-8.5-doc/jndi-resources-howto.html#JDBC_Data_Sources
+
+```
+<Context>
+  <Environment name="gnDatabaseDialect" value="POSTGRESQL" type="java.lang.String" override="false"/>
+  <Resource name="jdbc/geonetwork" auth="Container"
+            factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+            type="javax.sql.DataSource" driverClassName="org.postgresql.Driver"
+            url="jdbc:postgresql://localhost:5432/postgres"
+            username="postgres" password="postgres" 
+            maxActive="20" maxIdle="10" defaultAutoCommit="false" maxWait="-1"/>
+</Context>
+```
+
+Once configured, assuming GeoNetwork is deployed as `geonetwork` (otherwise use the proper application name), 
+rename the file to `geonetwork.xml` and copy it to `TOMCAT_DIR/conf/Catalina/localhost`.
+
+Copy the Postgresql JDBC driver to `TOMCAT_DIR/lib`.
+
+**Note:** replace `TOMCAT_DIR` with Tomcat path.
+
+### Postgis support
+
+Additionally if you want to enable the spatial index to be stored in Postgis, you should add the Postgis extension to your database:
+
+```
+CREATE EXTENSION postgis;
+```
+
+See additional details in https://postgis.net/install/
+
+And uncomment the following Spring beans in the file `TOMCAT_DIR/webapps/geonetwork/WEB-INF/config-db/jndi.xml`:
+
+```
+  <!-- Enable for PostGis configuration with JNDI -->
+  <bean id="datastoreFactory" class="org.geotools.data.postgis.PostgisNGJNDIDataStoreFactory"/>
+  <bean id="datastore" factory-bean="datastoreFactory" factory-method="createDataStore">
+    <constructor-arg>
+      <map>
+        <description>The datastore factory parameters see Geotools documentation for details.
+          http://docs.geotools.org/latest/userguide/library/data/datastore.html
+        </description>
+        <entry key="dbtype" value="postgis"/>
+        <entry key="Data Source" value-ref="jdbcDataSource"/>
+        <entry key="Loose bbox" value="true"/>
+        <entry key="Estimated extends" value="true"/>
+        <entry key="encode functions" value="true"/>
+        <entry key="validate connections" value="true"/>
+        <entry key="fetch size" value="1000"/>
+        <entry key="Expose primary keys" value="true"/>
+      </map>
+    </constructor-arg>
+  </bean>
+```

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/h2_JNDI_Example.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/h2_JNDI_Example.xml
@@ -21,22 +21,12 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
-
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       default-lazy-init="true"
-       xmlns="http://www.springframework.org/schema/beans"
-       xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	">
-
-  <bean id="jdbcDataSource" class="org.springframework.jndi.JndiObjectFactoryBean">
-    <!-- comp/env/jdbc/geonetwork works with WEB-INF/jetty-env.xml supplied with GN -->
-    <property name="jndiName" value="java:comp/env/jdbc/geonetwork"/>
-    <property name="cache" value="true"/>
-    <property name="exposeAccessContext" value="false"/>
-  </bean>
-
-  <bean id="jpaVendorAdapterDatabaseParam" class="java.lang.String">
-    <constructor-arg value="POSTGRESQL"/>
-  </bean>
-</beans>
+<Context>
+<Environment name="gnDatabaseDialect" value="H2" type="java.lang.String" override="false"/>
+<Resource name="jdbc/geonetwork" auth="Container"
+          factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+          type="javax.sql.DataSource" driverClassName="org.h2.Driver"
+          url="jdbc:h2:gn;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE"
+          username="www-data" password="www-data" maxActive="20" maxIdle="10" defaultAutoCommit="false"
+maxWait="-1"/>
+</Context>

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/h2_JNDI_Example.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/h2_JNDI_Example.xml
@@ -21,12 +21,15 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
+
+<!-- See the README.md file for instructions to configure/use this file -->
 <Context>
-<Environment name="gnDatabaseDialect" value="H2" type="java.lang.String" override="false"/>
-<Resource name="jdbc/geonetwork" auth="Container"
-          factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
-          type="javax.sql.DataSource" driverClassName="org.h2.Driver"
-          url="jdbc:h2:gn;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE"
-          username="www-data" password="www-data" maxActive="20" maxIdle="10" defaultAutoCommit="false"
-maxWait="-1"/>
+  <Environment name="gnDatabaseDialect" value="H2" type="java.lang.String" override="false"/>
+  <Resource name="jdbc/geonetwork" auth="Container"
+            factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+            type="javax.sql.DataSource" driverClassName="org.h2.Driver"
+            url="jdbc:h2:gn;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE"
+            username="www-data" password="www-data"
+            maxActive="20" maxIdle="10"
+            defaultAutoCommit="false" maxWait="-1"/>
 </Context>

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/oracle_JNDI_Example.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/oracle_JNDI_Example.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<Context>
+<Environment name="gnDatabaseDialect" value="ORACLE" type="java.lang.String" override="false"/>
+<Resource name="jdbc/geonetwork" auth="Container"
+          factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+          type="javax.sql.DataSource" driverClassName="oracle.jdbc.OracleDriver"
+          url="jdbc:oracle:thin:@//localhost:49161/xe"
+          username="system" password="oracle" maxActive="20" maxIdle="10" defaultAutoCommit="false"
+maxWait="-1"/>
+</Context>

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/oracle_JNDI_Example.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/oracle_JNDI_Example.xml
@@ -21,12 +21,15 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
+
+<!-- See the README.md file for instructions to configure/use this file -->
 <Context>
-<Environment name="gnDatabaseDialect" value="ORACLE" type="java.lang.String" override="false"/>
-<Resource name="jdbc/geonetwork" auth="Container"
-          factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
-          type="javax.sql.DataSource" driverClassName="oracle.jdbc.OracleDriver"
-          url="jdbc:oracle:thin:@//localhost:49161/xe"
-          username="system" password="oracle" maxActive="20" maxIdle="10" defaultAutoCommit="false"
-maxWait="-1"/>
+  <Environment name="gnDatabaseDialect" value="ORACLE" type="java.lang.String" override="false"/>
+  <Resource name="jdbc/geonetwork" auth="Container"
+            factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+            type="javax.sql.DataSource" driverClassName="oracle.jdbc.OracleDriver"
+            url="jdbc:oracle:thin:@//localhost:49161/xe"
+            username="system" password="oracle"
+            maxActive="20" maxIdle="10"
+            defaultAutoCommit="false" maxWait="-1"/>
 </Context>

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/postgres_JNDI_Example.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/postgres_JNDI_Example.xml
@@ -21,12 +21,14 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
+
+<!-- See the README.md file for instructions to configure/use this file -->
 <Context>
-<Environment name="gnDatabaseDialect" value="POSTGRESQL" type="java.lang.String" override="false"/>
-<Resource name="jdbc/geonetwork" auth="Container"
-          factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
-          type="javax.sql.DataSource" driverClassName="org.postgresql.Driver"
-          url="jdbc:postgresql://localhost:5432/postgres"
-          username="postgres" password="postgres" maxActive="20" maxIdle="10" defaultAutoCommit="false"
-maxWait="-1"/>
+  <Environment name="gnDatabaseDialect" value="POSTGRESQL" type="java.lang.String" override="false"/>
+  <Resource name="jdbc/geonetwork" auth="Container"
+            factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+            type="javax.sql.DataSource" driverClassName="org.postgresql.Driver"
+            url="jdbc:postgresql://localhost:5432/postgres"
+            username="postgres" password="postgres"
+            maxActive="20" maxIdle="10" defaultAutoCommit="false" maxWait="-1"/>
 </Context>

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/postgres_JNDI_Example.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/postgres_JNDI_Example.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<Context>
+<Environment name="gnDatabaseDialect" value="POSTGRESQL" type="java.lang.String" override="false"/>
+<Resource name="jdbc/geonetwork" auth="Container"
+          factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+          type="javax.sql.DataSource" driverClassName="org.postgresql.Driver"
+          url="jdbc:postgresql://localhost:5432/postgres"
+          username="postgres" password="postgres" maxActive="20" maxIdle="10" defaultAutoCommit="false"
+maxWait="-1"/>
+</Context>

--- a/web/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/web/src/main/webapp/WEB-INF/jetty-env.xml
@@ -18,10 +18,12 @@
     <Arg>jdbc/geonetwork</Arg>
     <Arg>
       <New class="org.apache.commons.dbcp.BasicDataSource">
-        <Set name="driverClassName">org.postgis.DriverWrapper</Set>
-        <Set name="url">jdbc:postgresql_postGIS://localhost:5432/gndb</Set>
-        <Set name="username">your_username</Set>
-        <Set name="password">your_password</Set>
+        <!--<Set name="driverClassName">org.postgis.DriverWrapper</Set>
+        <Set name="url">jdbc:postgresql_postGIS://localhost:5432/gndb</Set>-->
+        <Set name="driverClassName">org.h2.Driver</Set>
+        <Set name="url">jdbc:h2:gn;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE</Set>
+        <Set name="username">www-data</Set>
+        <Set name="password">www-data</Set>
         <Set name="validationQuery">SELECT 1</Set>
         <Set name="maxActive">10</Set>
         <Set name="maxIdle">10</Set>
@@ -37,5 +39,12 @@
     <Call name="bindToENC">
       <Arg>jdbc/geonetwork</Arg>
     </Call>
+  </New>
+
+  <!-- Change the value for the database to use -->
+  <New id="gnparameters" class="org.eclipse.jetty.plus.jndi.Resource">
+    <Arg></Arg>
+    <Arg>gnDatabaseDialect</Arg>
+    <Arg>H2</Arg>
   </New>
 </Configure>


### PR DESCRIPTION
JNDI support improvements:

- Add examples for Tomcat configuration.
- Change Jetty JNDI to use H2 by default.
- Support different databases (current support was focus on Postgres).


# JNDI example files for Tomcat

This folder contains JNDI example files for Tomcat for H2, Oracle and Postgres.

* Pick the jndi configuration for the database you want to use and fill the relevant parameters for your database
* Rename the file to geonetwork.xml (or to appName.xml if you use another name)
* Put the file inside `TOMCAT_DIR/conf/Catalina/localhost` 
* Be sure that the jar for the driver you want to use is in `TOMCAT_DIR/lib`

**Note:** replace `TOMCAT_DIR` with Tomcat path.

Check the following links for additional documentation about JNDI configuration in Tomcat:

- https://tomcat.apache.org/tomcat-8.5-doc/jndi-resources-howto.html#JDBC_Data_Sources
- https://tomcat.apache.org/tomcat-8.5-doc/jndi-datasource-examples-howto.html

## Postgres database example

For a Postgres database use the file `postgres_JNDI_Example.xml`, configuring the following parameters:

- `url`: JDBC connection string for Postgresql database, typically fill the hostname/port/database name. See additional parameters in https://jdbc.postgresql.org/documentation/head/connect.html
- `username`: database username with read/write permissions in the database
- `password`: database user password.
- For other parameters check additional documentation in https://tomcat.apache.org/tomcat-8.5-doc/jndi-resources-howto.html#JDBC_Data_Sources

```xml
<Context>
  <Environment name="gnDatabaseDialect" value="POSTGRESQL" type="java.lang.String" override="false"/>
  <Resource name="jdbc/geonetwork" auth="Container"
            factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
            type="javax.sql.DataSource" driverClassName="org.postgresql.Driver"
            url="jdbc:postgresql://localhost:5432/postgres"
            username="postgres" password="postgres" 
            maxActive="20" maxIdle="10" defaultAutoCommit="false" maxWait="-1"/>
</Context>
```

Once configured, assuming GeoNetwork is deployed as `geonetwork` (otherwise use the proper application name), 
rename the file to `geonetwork.xml` and copy it to `TOMCAT_DIR/conf/Catalina/localhost`.

Copy the Postgresql JDBC driver to `TOMCAT_DIR/lib`.

**Note:** replace `TOMCAT_DIR` with Tomcat path.

### Postgis support

Additionally if you want to enable the spatial index to be stored in Postgis, you should add the Postgis extension to your database:

```sql
CREATE EXTENSION postgis;
```

See additional details in https://postgis.net/install/

And uncomment the following Spring beans in the file `TOMCAT_DIR/webapps/geonetwork/WEB-INF/config-db/jndi.xml`:

```xml
  <!-- Enable for PostGis configuration with JNDI -->
  <bean id="datastoreFactory" class="org.geotools.data.postgis.PostgisNGJNDIDataStoreFactory"/>
  <bean id="datastore" factory-bean="datastoreFactory" factory-method="createDataStore">
    <constructor-arg>
      <map>
        <description>The datastore factory parameters see Geotools documentation for details.
          http://docs.geotools.org/latest/userguide/library/data/datastore.html
        </description>
        <entry key="dbtype" value="postgis"/>
        <entry key="Data Source" value-ref="jdbcDataSource"/>
        <entry key="Loose bbox" value="true"/>
        <entry key="Estimated extends" value="true"/>
        <entry key="encode functions" value="true"/>
        <entry key="validate connections" value="true"/>
        <entry key="fetch size" value="1000"/>
        <entry key="Expose primary keys" value="true"/>
      </map>
    </constructor-arg>
  </bean>
```
