### PR TITLE
Angular view / Related resources / Fix word wrap on long label button

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -356,6 +356,9 @@ header div.gn-abstract {
   p {
     word-wrap: break-word;
   }
+  .btn {
+    white-space: normal;
+  }
 }
 
 


### PR DESCRIPTION
Fix when long labels are used in button
![image](https://user-images.githubusercontent.com/1701393/79240945-ace0b300-7e72-11ea-8247-b139ed7ee129.png)

After the fix:
![image](https://user-images.githubusercontent.com/1701393/79240966-b36f2a80-7e72-11ea-9636-4bc0ee776aec.png)
