### PR TITLE
Support mandatory flag in editor sections. Initially supported for BoundingBox

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -225,12 +225,13 @@
       </xsl:choose>
     </xsl:variable>
 
+    <xsl:variable name="requiredClass" select="if ($labelConfig/condition = 'mandatory') then 'gn-required' else ''" />
 
     <xsl:call-template name="render-boxed-element">
       <xsl:with-param name="label"
                       select="$labelVal"/>
       <xsl:with-param name="editInfo" select="../gn:element"/>
-      <xsl:with-param name="cls" select="local-name()"/>
+      <xsl:with-param name="cls" select="concat(local-name(), ' ', $requiredClass)"/>
       <xsl:with-param name="subTreeSnippet">
 
         <xsl:variable name="identifier"

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -431,7 +431,7 @@ form.gn-editor {
       padding-right: 0px;
   }
 
-  .gn-required > div.th-inner:after,
+  .gn-required > div.th-inner:after, legend.gn-required:after,
   label.gn-required:after, .gn-required > label:after,
   label.gn-mandatory:after, .gn-mandatory > label:after {
       content: "*";
@@ -446,7 +446,10 @@ form.gn-editor {
     font-size: 2em;
     margin: -7px 0 0 7px;
   }
-
+  legend.gn-required:after {
+    font-size: 24px;
+    margin: 0px;
+  }
 
   .form-horizontal .form-group {
       margin-left: 0px;


### PR DESCRIPTION
Updating `labels.xml` with `condition` element:

```
  <element name="gmd:EX_GeographicBoundingBox" id="343.0">
    <label>Geographic bounding box</label>
    <description>Geographic position of the dataset</description>
    <condition>mandatory</condition>
  </element>
```

Allows to display a mandatory flag for the Bounding Box element:

![mandatory-bbox](https://user-images.githubusercontent.com/1695003/79346247-6d799b80-7f32-11ea-91a0-89db2ca54b7b.png)

Added CSS styling can be extended for other section elements if required.