### PR TITLE
Angular view / Associated resource / Layer name may contain quote

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -43,14 +43,14 @@
           <div data-ng-switch-when="WMS">
             <p class="text-muted">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{(r.title | gnLocalized: lang).replace('\'', '\\\'')}}'}">
                 wmsLinkDetails</span>
             </p>
           </div>
           <div data-ng-switch-when="WMTS">
             <p class="text-muted">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{(r.title | gnLocalized: lang).replace('\'', '\\\'')}}'}">
                 wmtsLinkDetails</span>
             </p>
           </div>


### PR DESCRIPTION
Avoid JS error in this case and display the label properly.

Before:
![image](https://user-images.githubusercontent.com/1701393/79550445-9ddb4a00-8098-11ea-8475-ba819a19db63.png)

Error:
![image](https://user-images.githubusercontent.com/1701393/79550490-af245680-8098-11ea-8cf7-82f0918a73de.png)


After:
![image](https://user-images.githubusercontent.com/1701393/79550475-a92e7580-8098-11ea-8921-99bc758207f0.png)
