### PR TITLE
Updated connection settings to support port and connectionProperties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1331,10 +1331,11 @@
     <db.type>h2</db.type>
     <db.config.file>../config-db/${db.type}.xml</db.config.file>
     <db.host>localhost</db.host>
-    <db.port>5432</db.port>
+    <db.port></db.port>
     <db.name>gn</db.name>
     <db.username>www-data</db.username>
     <db.password>www-data</db.password>
+    <db.connectionProperties></db.connectionProperties>
     <db.pool.maxActive>30</db.pool.maxActive>
     <db.pool.maxIdle>10</db.pool.maxIdle>
     <db.pool.initialSize>10</db.pool.initialSize>

--- a/web/src/main/webResources/WEB-INF/config-db/h2.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/h2.xml
@@ -40,7 +40,7 @@
 
   <bean id="jdbcURL" class="java.lang.String">
     <constructor-arg
-      value="jdbc:h2:${jdbc.database};LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE"/>
+      value="jdbc:h2:${jdbc.database};${jdbc.connectionProperties:LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE}"/>
   </bean>
 
 </beans>

--- a/web/src/main/webResources/WEB-INF/config-db/jdbc.properties
+++ b/web/src/main/webResources/WEB-INF/config-db/jdbc.properties
@@ -26,6 +26,7 @@ jdbc.password=${db.password}
 jdbc.database=${db.name}
 jdbc.host=${db.host}
 jdbc.port=${db.port}
+jdbc.connectionProperties=${db.connectionProperties}
 jdbc.basic.removeAbandoned=true
 jdbc.basic.removeAbandonedTimeout=300
 jdbc.basic.logAbandoned=true

--- a/web/src/main/webResources/WEB-INF/config-db/mysql.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/mysql.xml
@@ -39,7 +39,7 @@
   </bean>
 
   <bean id="jdbcURL" class="java.lang.String">
-    <constructor-arg value="jdbc:mysql://${jdbc.host}:3306/${jdbc.database}"/>
+    <constructor-arg value="jdbc:mysql://${jdbc.host}:${jdbc.port:3306}/${jdbc.database}"/>
   </bean>
 
 </beans>

--- a/web/src/main/webResources/WEB-INF/config-db/oracle.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/oracle.xml
@@ -51,7 +51,7 @@
   </bean>
 
   <bean id="jdbcURL" class="java.lang.String">
-    <constructor-arg value="jdbc:oracle:thin:@${jdbc.host}:1521:${jdbc.database}"/>
+    <constructor-arg value="jdbc:oracle:thin:@${jdbc.host}:${jdbc.port:1521}:${jdbc.database}"/>
   </bean>
 
 </beans>

--- a/web/src/main/webResources/WEB-INF/config-db/postgres-postgis.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/postgres-postgis.xml
@@ -43,6 +43,6 @@
   </bean>
 
   <bean id="jdbcURL" class="java.lang.String">
-    <constructor-arg value="jdbc:postgresql_postGIS://${jdbc.host}:${jdbc.port}/${jdbc.database}"/>
+    <constructor-arg value="jdbc:postgresql_postGIS://${jdbc.host}:${jdbc.port:5432}/${jdbc.database}?${jdbc.connectionProperties}"/>
   </bean>
 </beans>

--- a/web/src/main/webResources/WEB-INF/config-db/postgres.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/postgres.xml
@@ -39,7 +39,7 @@
   </bean>
 
   <bean id="jdbcURL" class="java.lang.String">
-    <constructor-arg value="jdbc:postgresql://${jdbc.host}:${jdbc.port}/${jdbc.database}"/>
+    <constructor-arg value="jdbc:postgresql://${jdbc.host}:${jdbc.port:5432}/${jdbc.database}?${jdbc.connectionProperties}"/>
   </bean>
 
 </beans>


### PR DESCRIPTION
Updated connection settings so that it supports supplying the port and connectionProperties parameter.

Also fixed hard coded configuration port which defaulted to 5432 (postgresql) even though default config db is h2?

Related to issue #4624 

Note: only applied the new connectionProperties to h2 and postgresql database connection.  If other databases require the usage of this new connectionProperties then they will need to be added by someone else as I don't have access to test with some of the other databases at this time.  

