### PR TITLE
Transfer owner / NPE when history is ON and group owner is null (which is allowed in the DB)

### DIFF
--- a/events/src/main/java/org/fao/geonet/events/history/RecordGroupOwnerChangeEvent.java
+++ b/events/src/main/java/org/fao/geonet/events/history/RecordGroupOwnerChangeEvent.java
@@ -49,12 +49,12 @@ public class RecordGroupOwnerChangeEvent extends AbstractHistoryEvent {
 
     @Override
     public String getCurrentState() {
-        return newOwnerObjectJSON.toString();
+        return newOwnerObjectJSON != null ? newOwnerObjectJSON.toString(): null;
     }
 
     @Override
     public String getPreviousState() {
-        return oldOwnerObjectJSON.toString();
+        return oldOwnerObjectJSON != null ? oldOwnerObjectJSON.toString() : null;
     }
 
     @Override


### PR DESCRIPTION


```
java.lang.NullPointerException
	at org.fao.geonet.events.history.RecordGroupOwnerChangeEvent.getPreviousState(RecordGroupOwnerChangeEvent.java:57)
	at org.fao.geonet.listener.history.GenericMetadataEventListener.storeContentHistoryEvent(GenericMetadataEventListener.java:88)
	at org.fao.geonet.listener.history.GenericMetadataEventListener.handleEvent(GenericMetadataEventListener.java:60)
	at org.fao.geonet.listener.history.RecordGroupOwnerChangeListener.onApplicationEvent(RecordGroupOwnerChangeListener.java:49)
	at org.fao.geonet.listener.history.RecordGroupOwnerChangeListener.onApplicationEvent(RecordGroupOwnerChangeListener.java:30)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:166)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:138)
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:382)
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:336)
	at org.fao.geonet.events.history.RecordGroupOwnerChangeEvent.publish(RecordGroupOwnerChangeEvent.java:62)
	at org.fao.geonet.api.records.MetadataSharingApi.updateOwnership(MetadataSharingApi.java:913)
	at org.fao.geonet.api.records.MetadataSharingApi.setGroupAndOwner(MetadataSharingApi.java:764)
```