### PR TITLE
Fix serialization exclusion in MetadataCategory

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/MetadataCategory.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataCategory.java
@@ -47,7 +47,7 @@ import java.util.Set;
 @EntityListeners(MetadataCategoryEntityListenerManager.class)
 @SequenceGenerator(name = MetadataCategory.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MetadataCategory extends Localized implements Serializable {
-    private static final Set<String> EXCLUDE_FROM_XML = Sets.newHashSet("records");
+    private static final Set<String> EXCLUDE_FROM_XML = Sets.newHashSet("getRecords");
 
     static final String ID_SEQ_NAME = "metadata_category_id_seq";
     private int _id;


### PR DESCRIPTION
I've encountered an issue where metadata full view (iso19139, formatter, xsl-view) would take a long time to load on a large-ish database (10k+). It happened due to metadata to XML serialization propagating like [metadata -> category -> all metadata in that category] and generating thousands of hibernate queries for a single metadata view. Problem was traced to an incorrect exclusion in MetadataCategory with respect to the "getRecords" method. The exclusion was corrected and the fix was tested on a 3.10.2 instance.