### PR TITLE
Updated db connections so that it can be specified as env variables.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1334,7 +1334,7 @@
     <db.name>#{systemEnvironment['DB_NAME']?:'gn'}</db.name>
     <db.username>#{systemEnvironment['DB_USERNAME']?:'www-data'}</db.username>
     <db.password>#{systemEnvironment['DB_PASSWORD']?:'www-data'}</db.password>
-    <db.connectionProperties>#{systemEnvironment['DB_CONNECTION_PROPERTIES']?:'LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE'}</db.connectionProperties>
+    <db.connectionProperties>#{systemEnvironment['DB_CONNECTION_PROPERTIES']}</db.connectionProperties>
 
     <db.pool.maxActive>30</db.pool.maxActive>
     <db.pool.maxIdle>10</db.pool.maxIdle>

--- a/pom.xml
+++ b/pom.xml
@@ -1328,16 +1328,16 @@
     <!-- Configure database config file to use. Could be
      h2, postgres, sqlserver, mysql, oracle, db2, postgres-postgis, jndi
      -->
-    <db.type>#{systemEnvironment['DB_TYPE']?:'h2'}</db.type>
+    <db.type>#{systemEnvironment['GEONETWORK_DB_TYPE']?:'h2'}</db.type>
     <!-- Instead of using db_type a specific config file can be specified 
          Note: do not reference ${db_type} in this value or it will cause errors due to SpEL not being evaluated before import -->
     <db.config.file></db.config.file>
-    <db.host>#{systemEnvironment['DB_HOST']?:'localhost'}</db.host>
-    <db.port>#{systemEnvironment['DB_PORT']}</db.port>
-    <db.name>#{systemEnvironment['DB_NAME']?:'gn'}</db.name>
-    <db.username>#{systemEnvironment['DB_USERNAME']?:'www-data'}</db.username>
-    <db.password>#{systemEnvironment['DB_PASSWORD']?:'www-data'}</db.password>
-    <db.connectionProperties>#{systemEnvironment['DB_CONNECTION_PROPERTIES']}</db.connectionProperties>
+    <db.host>#{systemEnvironment['GEONETWORK_DB_HOST']?:'localhost'}</db.host>
+    <db.port>#{systemEnvironment['GEONETWORK_DB_PORT']}</db.port>
+    <db.name>#{systemEnvironment['GEONETWORK_DB_NAME']?:'gn'}</db.name>
+    <db.username>#{systemEnvironment['GEONETWORK_DB_USERNAME']?:'www-data'}</db.username>
+    <db.password>#{systemEnvironment['GEONETWORK_DB_PASSWORD']?:'www-data'}</db.password>
+    <db.connectionProperties>#{systemEnvironment['GEONETWORK_DB_CONNECTION_PROPERTIES']}</db.connectionProperties>
 
     <db.pool.maxActive>30</db.pool.maxActive>
     <db.pool.maxIdle>10</db.pool.maxIdle>

--- a/pom.xml
+++ b/pom.xml
@@ -1329,6 +1329,9 @@
      h2, postgres, sqlserver, mysql, oracle, db2, postgres-postgis, jndi
      -->
     <db.type>#{systemEnvironment['DB_TYPE']?:'h2'}</db.type>
+    <!-- Instead of using db_type a specific config file can be specified 
+         Note: do not reference ${db_type} in this value or it will cause errors due to SpEL not being evaluated before import -->
+    <db.config.file></db.config.file>
     <db.host>#{systemEnvironment['DB_HOST']?:'localhost'}</db.host>
     <db.port>#{systemEnvironment['DB_PORT']}</db.port>
     <db.name>#{systemEnvironment['DB_NAME']?:'gn'}</db.name>

--- a/pom.xml
+++ b/pom.xml
@@ -1328,14 +1328,14 @@
     <!-- Configure database config file to use. Could be
      h2, postgres, sqlserver, mysql, oracle, db2, postgres-postgis, jndi
      -->
-    <db.type>h2</db.type>
-    <db.config.file>../config-db/${db.type}.xml</db.config.file>
-    <db.host>localhost</db.host>
-    <db.port></db.port>
-    <db.name>gn</db.name>
-    <db.username>www-data</db.username>
-    <db.password>www-data</db.password>
-    <db.connectionProperties></db.connectionProperties>
+    <db.type>#{systemEnvironment['DB_TYPE']?:'h2'}</db.type>
+    <db.host>#{systemEnvironment['DB_HOST']?:'localhost'}</db.host>
+    <db.port>#{systemEnvironment['DB_PORT']}</db.port>
+    <db.name>#{systemEnvironment['DB_NAME']?:'gn'}</db.name>
+    <db.username>#{systemEnvironment['DB_USERNAME']?:'www-data'}</db.username>
+    <db.password>#{systemEnvironment['DB_PASSWORD']?:'www-data'}</db.password>
+    <db.connectionProperties>#{systemEnvironment['DB_CONNECTION_PROPERTIES']?:'LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE'}</db.connectionProperties>
+
     <db.pool.maxActive>30</db.pool.maxActive>
     <db.pool.maxIdle>10</db.pool.maxIdle>
     <db.pool.initialSize>10</db.pool.initialSize>

--- a/web/src/main/webResources/WEB-INF/config-node/srv.xml
+++ b/web/src/main/webResources/WEB-INF/config-node/srv.xml
@@ -33,7 +33,8 @@
 
 
   <!-- Uncomment the database configuration you need to use -->
-  <import resource="../config-db/${db.type:h2}.xml"/>
+  <!-- Default using the db.config.file if it exists and if not then derive the db file based on the db_type -->
+  <import resource="${db.config.file:../config-db/${db.type:h2}.xml}"/>
   <!--<import resource="../config-db/h2.xml"/> -->
   <!--<import resource="../config-db/jndi-postgres-postgis.xml"/> -->
   <!--<import resource="../config-db/oracle.xml"/>-->

--- a/web/src/main/webResources/WEB-INF/config-node/srv.xml
+++ b/web/src/main/webResources/WEB-INF/config-node/srv.xml
@@ -33,7 +33,8 @@
 
 
   <!-- Uncomment the database configuration you need to use -->
-  <import resource="${db.config.file}"/>
+  <import resource="../config-db/${db.type:h2}.xml"/>
+  <!--<import resource="../config-db/h2.xml"/> -->
   <!--<import resource="../config-db/jndi-postgres-postgis.xml"/> -->
   <!--<import resource="../config-db/oracle.xml"/>-->
   <!--<import resource="../config-db/mysql.xml"/> -->


### PR DESCRIPTION
This pull request is add the ability to use env variables to set database connection properties as described in #4643 

Note: This change eliminated the pom setting for <db.config.file>. The reason it has been removed is for 2 reasons.
- As SpEL is being used to supply the db type parameter which is used in the svr.xml. The import does not parse the SpEL commands before the import and so it attempts to load a file called "config-db/#{systemEnvironment['DB_TYPE']?:'h2'}.xml"

- If the database file is specify the db config file in the pom then we are limiting the built war file to only support a single database at runtime.

Here is a list of environment variables that can be set at runtime to connect to a postgres database using SSL mode.

```
DB_TYPE=postgres
DB_NAME=geonetwork
DB_HOST=postgres.example.com
DB_USERNAME=geonetwork_user
DB_PASSWORD=geonetwork_password
DB_CONNECTION_PROPERTIES=sslmode=require
```
