### PR TITLE
Editor / Overview / Add JPEG format in file filter.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
+++ b/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
@@ -38,7 +38,7 @@
         "thumbnailMaker": true
       },
       "icon": "fa gn-icon-thumbnail",
-      "fileStoreFilter": "*.{jpg,JPG,png,PNG,gif,GIF}",
+      "fileStoreFilter": "*.{jpg,JPG,jpeg,JPEG,png,PNG,gif,GIF}",
       "process": "thumbnail-add",
       "fields": {
         "url": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1701393/80611470-edc3f480-8a3a-11ea-9f32-c98ebb0888e1.png)

Only `jpg` format was supported so upload `jpeg` images were not listed while adding overviews