### PR TITLE
Fix typo in closing XML tag

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/strings.xml
@@ -205,7 +205,7 @@
   <sds-accesspoint>URL do Ponto de Acesso</sds-accesspoint>
   <sds-add-accesspoint>Adicionar Ponto de Acesso</sds-add-accesspoint>
 
-  <sds-endpoint>Endpoint URL</sds-ponto final>
+  <sds-endpoint>Endpoint URL</sds-endpoint>
   <sds-add-endpoint>Adicionar ponto final</sds-add-endpoint>
 
   <sds-addNoConstraints>Sem Limitação</sds-addNoConstraints>


### PR DESCRIPTION
An XML closing tag was mistakenly translated.