### PR TITLE
Fixed two classes in database migration with wrong package names

### DIFF
--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -123,7 +123,7 @@
     </entry>
     <entry key="3.0.0">
       <list>
-        <value>java:SetSequenceValueToMaxOfMetadataAndStats</value>
+        <value>java:v300.SetSequenceValueToMaxOfMetadataAndStats</value>
         <value>WEB-INF/classes/setup/sql/migrate/v300/migrate-</value>
         <value>WEB-INF/classes/setup/sql/migrate/v300/migrate-cswservice-</value>
       </list>
@@ -167,7 +167,7 @@
     </entry>
     <entry key="3.1.0">
       <list>
-        <value>java:org.fao.geonet.api.records.attachments.MetadataResourceDatabaseMigration</value>
+        <value>java:org.fao.geonet.MetadataResourceDatabaseMigration</value>
         <value>WEB-INF/classes/setup/sql/migrate/v310/migrate-</value>
       </list>
     </entry>


### PR DESCRIPTION
In database_migration.xml, fixed steps "3.0.0" and "3.1.0" which referenced classes with wrong package names, causing ClassNotFoundException during migration.