### PR TITLE
adds a lucene field named after the originating thesaurus

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -62,6 +62,12 @@
                 select="if ($inspire!='false') then document(concat('file:///', replace($thesauriDir, '\\', '/'), '/external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf')) else ''"/>
   <xsl:variable name="inspire-theme"
                 select="if ($inspire!='false') then $inspire-thesaurus//skos:Concept else ''"/>
+  <!--
+    This list contains substrings from keyword-uri's. if a keyword-uri contains the substring, the uri will be added to a field named as the substring
+    Typically used in keywords from thesauri from the INSPIRE registry, to be used as facet, keyword should be added using gmx:Anchor
+  -->
+  <xsl:variable name="inspire-thesauri-as-filter" select="'PriorityDataset,SpatialScope,featureconcept,SpatialDataServiceCategory'"/>
+
 
   <!-- If identification creation, publication and revision date
     should be indexed as a temporal extent information (eg. in INSPIRE
@@ -330,53 +336,62 @@
 
         <xsl:for-each select="$listOfKeywords">
           <xsl:variable name="keyword" select="string(.)"/>
-
+          <xsl:variable name="keyURI" select="./@xlink:href"/>
           <Field name="keyword" string="{$keyword}" store="true" index="true"/>
 
           <!-- If INSPIRE is enabled, check if the keyword is one of the 34 themes
                and index annex, theme and theme in english. -->
-          <xsl:if test="$inspire='true' and normalize-space(lower-case($thesaurusName)) = 'gemet - inspire themes, version 1.0'">
+          <xsl:if test="$inspire='true'">
+            <xsl:if test="$keyURI">
+              <xsl:for-each select="tokenize($inspire-thesauri-as-filter,',')">
+                <xsl:if test="contains($keyURI,concat('/',.,'/'))">
+                  <Field name="{.}" string="{$keyURI}" store="true" index="true"/>
+                </xsl:if> 
+              </xsl:for-each>
+            </xsl:if>
+            <xsl:if test="normalize-space(lower-case($thesaurusName)) = 'gemet - inspire themes, version 1.0'">
 
-            <xsl:if test="string-length(.) &gt; 0">
+              <xsl:if test="string-length(.) &gt; 0">
 
-              <xsl:variable name="inspireannex">
-                <xsl:call-template name="determineInspireAnnex">
-                  <xsl:with-param name="keyword" select="$keyword"/>
-                  <xsl:with-param name="inspireThemes" select="$inspire-theme"/>
-                </xsl:call-template>
-              </xsl:variable>
-
-              <xsl:variable name="inspireThemeAcronym">
-                <xsl:call-template name="getInspireThemeAcronym">
-                  <xsl:with-param name="keyword" select="$keyword"/>
-                </xsl:call-template>
-              </xsl:variable>
-
-              <!-- Add the inspire field if it's one of the 34 themes -->
-              <xsl:if test="normalize-space($inspireannex)!=''">
-                <Field name="inspiretheme" string="{$keyword}" store="true" index="true"/>
-                <Field name="inspirethemewithac"
-                       string="{concat($inspireThemeAcronym, '|', $keyword)}"
-                       store="true" index="true"/>
-
-                <!--<Field name="inspirethemeacronym" string="{$inspireThemeAcronym}" store="true" index="true"/>-->
-                <xsl:variable name="inspireThemeURI"
-                              select="$inspire-theme[skos:prefLabel = $keyword]/@rdf:about"/>
-                <Field name="inspirethemeuri" string="{$inspireThemeURI}" store="true"
-                       index="true"/>
-
-                <xsl:variable name="englishInspireTheme">
-                  <xsl:call-template name="translateInspireThemeToEnglish">
+                <xsl:variable name="inspireannex">
+                  <xsl:call-template name="determineInspireAnnex">
                     <xsl:with-param name="keyword" select="$keyword"/>
                     <xsl:with-param name="inspireThemes" select="$inspire-theme"/>
                   </xsl:call-template>
                 </xsl:variable>
 
-                <Field name="inspiretheme_en" string="{$englishInspireTheme}" store="true"
-                       index="true"/>
-                <Field name="inspireannex" string="{$inspireannex}" store="true" index="true"/>
-                <!-- FIXME : inspirecat field will be set multiple time if one record has many themes -->
-                <Field name="inspirecat" string="true" store="false" index="true"/>
+                <xsl:variable name="inspireThemeAcronym">
+                  <xsl:call-template name="getInspireThemeAcronym">
+                    <xsl:with-param name="keyword" select="$keyword"/>
+                  </xsl:call-template>
+                </xsl:variable>
+
+                <!-- Add the inspire field if it's one of the 34 themes -->
+                <xsl:if test="normalize-space($inspireannex)!=''">
+                  <Field name="inspiretheme" string="{$keyword}" store="true" index="true"/>
+                  <Field name="inspirethemewithac"
+                        string="{concat($inspireThemeAcronym, '|', $keyword)}"
+                        store="true" index="true"/>
+
+                  <!--<Field name="inspirethemeacronym" string="{$inspireThemeAcronym}" store="true" index="true"/>-->
+                  <xsl:variable name="inspireThemeURI"
+                                select="$inspire-theme[skos:prefLabel = $keyword]/@rdf:about"/>
+                  <Field name="inspirethemeuri" string="{$inspireThemeURI}" store="true"
+                        index="true"/>
+
+                  <xsl:variable name="englishInspireTheme">
+                    <xsl:call-template name="translateInspireThemeToEnglish">
+                      <xsl:with-param name="keyword" select="$keyword"/>
+                      <xsl:with-param name="inspireThemes" select="$inspire-theme"/>
+                    </xsl:call-template>
+                  </xsl:variable>
+
+                  <Field name="inspiretheme_en" string="{$englishInspireTheme}" store="true"
+                        index="true"/>
+                  <Field name="inspireannex" string="{$inspireannex}" store="true" index="true"/>
+                  <!-- FIXME : inspirecat field will be set multiple time if one record has many themes -->
+                  <Field name="inspirecat" string="true" store="false" index="true"/>
+                </xsl:if>
               </xsl:if>
             </xsl:if>
           </xsl:if>

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -437,6 +437,8 @@
   "hideLegend": "Hide legend",
   "selectStyle": "Select a style",
   "setOpacity": "Set the opacity",
+  "PriorityDataset":"Priority dataset",
+  "SpatialScope":"Spatial scope",
   "mdActions": "Available actions",
   "mdActions-view": "Viewable",
   "mdActions-download": "Downloadable",

--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -114,7 +114,10 @@
     <facet name="recordOwner" indexKey="recordOwner" label="recordOwner"/>
     <facet name="groupOwner" indexKey="_groupOwner" label="groupOwners"/>
     <facet name="publishedForGroup" indexKey="_groupPublished" label="publishedForGroup"/>
-	  <facet name="isPublishedToAll" indexKey="_isPublishedToAll" label="isPublishedToAll" />
+    <facet name="isPublishedToAll" indexKey="_isPublishedToAll" label="isPublishedToAll" />
+    <!-- INSPIRE; facet based on keyword-URI -->
+    <facet name="PriorityDataset" indexKey="PriorityDataset" label="PriorityDataset"/>
+    <facet name="SpatialScope" indexKey="SpatialScope" label="SpatialScope"/>
     <!--
     Example configuration for hierarchical facet based on
     the GeoNetwork region thesaurus or GEMET.
@@ -142,6 +145,10 @@
       <item facet="topicCat" translator="codelist:gmd:MD_TopicCategoryCode" max="20"/>
       <item facet="inspireThemeURI" sortBy="value" sortOrder="asc" max="35"
             translator="term:http://inspire.ec.europa.eu/theme"/>
+      <item facet="SpatialScope" sortBy="value" sortOrder="asc" max="6"
+            translator="term:http://inspire.ec.europa.eu/metadata-codelist/SpatialScope"/>
+      <item facet="PriorityDataset" sortBy="value" sortOrder="asc" max="15"
+            translator="term:http://inspire.ec.europa.eu/metadata-codelist/PriorityDataset"/>
       <!--<item facet="inspireTheme" sortBy="value" sortOrder="asc" max="35"/>-->
       <!--<item facet="inspireThemeWithAc" sortBy="value" sortOrder="asc" max="35"/>-->
       <item facet="keyword" max="15"/>
@@ -197,6 +204,10 @@
       <item facet="inspireThemeWithAc" sortBy="value" sortOrder="asc" max="35"/>
       <item facet="inspireThemeURI" sortBy="value" sortOrder="asc" max="35"
             translator="term:http://inspire.ec.europa.eu/theme"/>
+      <item facet="SpatialScope" sortBy="value" sortOrder="asc" max="6"
+            translator="term:http://inspire.ec.europa.eu/metadata-codelist/SpatialScope"/>
+      <item facet="PriorityDataset" sortBy="value" sortOrder="asc" max="15"
+            translator="term:http://inspire.ec.europa.eu/metadata-codelist/PriorityDataset"/>
       <item facet="keyword" max="15"/>
       <item facet="orgName" max="25"/>
       <item facet="createDateYear" sortBy="value" sortOrder="desc" max="40"/>


### PR DESCRIPTION
optimizes #4645

try again after #4650 failed

Uses substring from keyword-uri to identify which thesaurus it originates from (uses that as facet name), goal is to easily add new thesauri filters later
requires use of gmx:Anchor in keywords

I'm uncertain if should add the configuration to config-summary, we can also add it as documentation