### PR TITLE
use more precise references for setting element values on server

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/MultiEntryCombiner.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/MultiEntryCombiner.js
@@ -45,9 +45,10 @@
  *   The configuration (see example, below) defines;
  *
  *    a) how the fields are joined together ("; " in this example) -- combiner
- *    b) root_id of the field in the metadata.  We'll set values like ("_lang_eng_14")
- *    c) values -- actual Metadata record values (one per language)
- *    d) configuration - this defines how the edit fields are shown to the user
+ *    b) root_id of the field in the metadata.
+ *    c) refs - this is the refs that should be sent back to the server to update fields
+ *    d) values -- actual Metadata record values (one per language)
+ *    e) configuration - this defines how the edit fields are shown to the user
  *        a) type - what type is this?  (fixedValue, thesaurus, freeText)
  *        b) heading - helper text to show ABOVE the field
  *        c) other configuration information
@@ -77,6 +78,11 @@
   * * {
      *   "combiner":"; ",
      *   "root_id":"14",
+     *   "refs":
+     *          {
+     *            "eng":"15" ,           # default document lang - this is ref to <CharacterString>
+     *            "fra":"lang_fra_14"    # missing lang - this will be created in record if set
+     *          }
      *   "defaultLang":"eng",
      *   "values":
      *       {
@@ -190,6 +196,7 @@
                           gnGlobalSettings
                         )].substring(1);
             scope.root_id = scope.config.root_id;
+            scope.refs = scope.config.refs;
             scope.element = element;
             //we need to do this because GN trims a trailing "; ", which causes problems
             scope.combinerSimple = scope.config.combiner.trim(); //"; " -> ";"

--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner.html
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner.html
@@ -1,6 +1,6 @@
 <div>
   <!--- These are the actual values returned to the server -->
-  <input type="hidden" ng-repeat="(lang,text) in config.values"  value="{{text}}" name="_lang_{{lang}}_{{root_id}}" lang="{{lang}}"/>
+  <input type="hidden" ng-repeat="(lang,text) in config.values"  value="{{text}}" name="_{{refs[lang]}}" lang="{{lang}}"/>
 
 
 <div style="padding-left: 15px; padding-right: 15px">


### PR DESCRIPTION
I've changed how values are sent back to the server - there is more control now.

It used to always send them back like '_lang_eng_14' (based on root_id).

However, you now send a refs dictionary in the json config.  It uses these values instead.
