### PR TITLE
Set encoding to UTF-8 in metadata notifier requests

### DIFF
--- a/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierClient.java
+++ b/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierClient.java
@@ -49,6 +49,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -78,11 +79,11 @@ public class MetadataNotifierClient {
 
             // Create a method instance.
             HttpPost method = new HttpPost(notifier.getUrl());
-            final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(data, Charset.forName("UTF-8"));
+            final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(data, StandardCharsets.UTF_8);
             final RequestConfig.Builder configBuilder = RequestConfig.custom();
             configBuilder.setMaxRedirects(3);
 
-            method.addHeader("accept-charset", "UTF-8");
+            method.addHeader(org.apache.http.HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8.name());
             method.setEntity(entity);
 
             final boolean authenticationEnabled = StringUtils.isNotBlank(notifier.getUsername()) && notifier.getPassword() != null &&

--- a/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierClient.java
+++ b/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierClient.java
@@ -82,6 +82,7 @@ public class MetadataNotifierClient {
             final RequestConfig.Builder configBuilder = RequestConfig.custom();
             configBuilder.setMaxRedirects(3);
 
+            method.addHeader("accept-charset", "UTF-8");
             method.setEntity(entity);
 
             final boolean authenticationEnabled = StringUtils.isNotBlank(notifier.getUsername()) && notifier.getPassword() != null &&

--- a/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierClient.java
+++ b/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierClient.java
@@ -48,6 +48,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -77,7 +78,7 @@ public class MetadataNotifierClient {
 
             // Create a method instance.
             HttpPost method = new HttpPost(notifier.getUrl());
-            final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(data);
+            final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(data, Charset.forName("UTF-8"));
             final RequestConfig.Builder configBuilder = RequestConfig.custom();
             configBuilder.setMaxRedirects(3);
 


### PR DESCRIPTION
Set encoding to UTF-8 in metadata notifier requests, otherwise the xml special chars like accents are not encoded properly.