### PR TITLE
Add method to support HttpClientContext for HttpUriRequest requests in GeonetHttpRequestFactory

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java
+++ b/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java
@@ -188,16 +188,12 @@ public class GeonetHttpRequestFactory {
 
     public ClientHttpResponse execute(HttpUriRequest request,
                                       Function<HttpClientBuilder, Void> configurator,
-                                      HttpClientContext r) throws IOException {
+                                      HttpClientContext context) throws IOException {
         final HttpClientBuilder clientBuilder = getDefaultHttpClientBuilder();
         configurator.apply(clientBuilder);
         CloseableHttpClient httpClient = clientBuilder.build();
 
-        if (r != null) {
-            return new AdaptingResponse(httpClient, httpClient.execute(request, r));
-        } else {
-            return new AdaptingResponse(httpClient, httpClient.execute(request));
-        }
+        return new AdaptingResponse(httpClient, httpClient.execute(request, context));
     }
 
     public HttpClientBuilder getDefaultHttpClientBuilder() {

--- a/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java
+++ b/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java
@@ -33,6 +33,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.ConnectionRequest;
 import org.apache.http.conn.HttpClientConnectionManager;
@@ -183,6 +184,20 @@ public class GeonetHttpRequestFactory {
             return new AdaptingResponse(httpClient, httpClient.execute(request));
         }
 
+    }
+
+    public ClientHttpResponse execute(HttpUriRequest request,
+                                      Function<HttpClientBuilder, Void> configurator,
+                                      HttpClientContext r) throws IOException {
+        final HttpClientBuilder clientBuilder = getDefaultHttpClientBuilder();
+        configurator.apply(clientBuilder);
+        CloseableHttpClient httpClient = clientBuilder.build();
+
+        if (r != null) {
+            return new AdaptingResponse(httpClient, httpClient.execute(request, r));
+        } else {
+            return new AdaptingResponse(httpClient, httpClient.execute(request));
+        }
     }
 
     public HttpClientBuilder getDefaultHttpClientBuilder() {


### PR DESCRIPTION
`GeonetHttpRequestFactory` supports Preemptive Basic Auth for `XmlRequest` using ` HttpClientContext`:

https://github.com/geonetwork/core-geonetwork/blob/a3fbd28483f34d4b76b4a60801b26cf232930da6/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java#L173-L186

But this only works with `XmlRequest`, this pull request add support to use `HttpClientContext` in `HttpUriRequest`, so Preemptive Basic Auth can be supported in services that requires it.

Some usages are for metadata notifier (another PR will improve it) or other external services like DOI that can be configured and potentially requires it.

