### PR TITLE
Map editor - use map promise to add the bbox layer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
@@ -247,7 +247,14 @@
 
              var map = gnMapsManager.createMap(gnMapsManager.EDITOR_MAP);
              scope.map = map;
-             map.addLayer(bboxLayer);
+
+             // Add the bboxLayer when the map is fully created. Otherwise
+             // if using a context file for the map, the layer is added
+             // too soon and removed when loaded the context file.
+             map.get('creationPromise').then(function() {
+               map.addLayer(bboxLayer);
+             });
+
              element.data('map', map);
 
              // initialize extent & bbox on map load


### PR DESCRIPTION
The map editor bbox layer is lost when using a context file to initialise the map. 

The code to create the map, uses a promise:

https://github.com/geonetwork/core-geonetwork/blob/64380c15ad68a5381c8efca35011496664427eae/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js#L243-L285

But the bbox layer is added without using the promise:

https://github.com/geonetwork/core-geonetwork/blob/64380c15ad68a5381c8efca35011496664427eae/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js#L248-L250

When using `osm` (default) is ok as the layer is added to the map, without removing other layers, but when **using a context file**, the map layers are removed, so if the bbox layer was added already, it is removed and the bbox selected by the user is not displayed.