### PR TITLE
Uniform look for search inputs on Home and Search page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/periodchooser.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/periodchooser.html
@@ -13,7 +13,7 @@
   </div>
   <br/>
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-6 gn-nopadding-left">
       <div class="input-group date" data-date=""
            data-date-format="yyyy-mm-dd"
            data-gn-bootstrap-datepicker="dateFrom">
@@ -25,7 +25,7 @@
         class="fa fa-calendar"></i></span>
       </div>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6 gn-nopadding-right">
       <div class="input-group date" data-date=""
            data-date-format="yyyy-mm-dd"
            data-gn-bootstrap-datepicker="dateTo">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -145,7 +145,6 @@
 
 // advanced search
 .gn-search-filter {
-  padding: 5px;
   .nav-pills li {
     display: block;
   }
@@ -172,9 +171,6 @@
     .tagsinput-trigger {
       top: 34px;
       right: 25px;
-      @media (max-width: @screen-sm-max) {
-        top: 38px;
-      }
     }
     .tagsinput-clear {
       right: 20px;

--- a/web-ui/src/main/resources/catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html
@@ -1,6 +1,6 @@
-<div class="gn-search-filter col-lg-12 advancedSearchForm">
+<div class="gn-search-filter advancedSearchForm">
   <div class="row">
-    <div class="col-md-5 col-md-offset-1">
+    <div class="col-md-5 col-md-offset-1 col-lg-4 col-lg-offset-2">
       <h3 data-translate="">what</h3>
       <div class="form-group">
         <div class="col-sm-12">
@@ -39,7 +39,7 @@
         </div>
       </div>
     </div>
-    <div class="col-md-5 gn-search-filter-datepickers">
+    <div class="col-md-5 col-lg-4 gn-search-filter-datepickers">
       <h3 data-translate="">when</h3>
       <div data-gn-period-chooser="resourcesCreatedTheLast"
            data-date-from="searchObj.params.creationDateFrom"
@@ -53,5 +53,7 @@
            class="gn-search-filter-datepicker">
       </div>
     </div>
+    <!-- /.gn-search-filter-datepickers -->
   </div>
 </div>
+<!-- /.gn-search-filter -->

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -1,7 +1,7 @@
-<div>
+<!-- <div> -->
   <div class="row gn-row-main">
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
-      <div class="col-sm-8 col-sm-offset-2">
+      <div class="col-md-offset-1 col-md-10 col-lg-8 col-lg-offset-2">
 
         <div class="input-group gn-form-any">
           <input type="text"
@@ -239,4 +239,4 @@
     </div>
   </div>
   <!-- /.gn-row-info -->
-</div>
+<!-- </div> -->

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -4,68 +4,61 @@
   <!--ANY full text search input-->
   <div class="row gn-top-search">
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
-      <div class="col-md-12">
-        <div class="row">
-          <div class="col-md-offset-3 col-md-6 relative">
-            <div class="input-group gn-form-any">
-              <button data-gn-user-searches-list=""
-                      data-ng-cloak=""
-                      data-mode="button"/>
+      <div class="col-md-offset-1 col-md-10 col-lg-8 col-lg-offset-2 relative">
+        <div class="input-group gn-form-any">
+          <button data-gn-user-searches-list=""
+                  data-ng-cloak=""
+                  data-mode="button"/>
 
-              <input type="text"
-                    class="form-control input-lg"
-                    id="gn-any-field"
-                    data-ng-model="searchObj.params.any"
-                    placeholder="{{'anyPlaceHolder' | translate}}"
-                    aria-label="{{'anyPlaceHolder' | translate}}"
-                    data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
-                    data-typeahead="address for address in getAnySuggestions($viewValue)"
-                    data-typeahead-loading="anyLoading" class="form-control"
-                    data-typeahead-min-length="1"
-                    data-typeahead-focus-first="false"
-                    data-typeahead-wait-ms="300">
+          <input type="text"
+                class="form-control input-lg"
+                id="gn-any-field"
+                data-ng-model="searchObj.params.any"
+                placeholder="{{'anyPlaceHolder' | translate}}"
+                aria-label="{{'anyPlaceHolder' | translate}}"
+                data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
+                data-typeahead="address for address in getAnySuggestions($viewValue)"
+                data-typeahead-loading="anyLoading" class="form-control"
+                data-typeahead-min-length="1"
+                data-typeahead-focus-first="false"
+                data-typeahead-wait-ms="300">
 
-              <div class="input-group-btn">
-                <button type="button"
-                        class="btn btn-default btn-lg"
-                        title="{{'advanced' | translate}}"
-                        data-ng-model="searchObj.advancedMode"
-                        btn-checkbox=""
-                        btn-checkbox-true="1"
-                        btn-checkbox-false="0">
-                  <i class="fa fa-ellipsis-v"></i>
-                  <span class="sr-only" data-translate="">advanced</span>
-                </button>
+          <div class="input-group-btn">
 
-                <button type="button"
-                        data-ng-click="triggerSearch()"
-                        title="{{'search' | translate}}"
-                        class="btn btn-primary btn-lg">
-                  &nbsp;&nbsp;
-                  <i class="fa fa-search"></i>
-                  <span class="sr-only" data-translate="">search</span>
-                  &nbsp;&nbsp;
-                </button>
+            <button type="button"
+                    data-ng-click="triggerSearch()"
+                    title="{{'search' | translate}}"
+                    class="btn btn-primary btn-lg">
+              <i class="fa fa-fw fa-search"></i>
+              <span class="sr-only" data-translate="">search</span>
+            </button>
 
-                <button type="button"
-                        data-ng-click="resetSearch(searchObj.defaultParams);"
-                        title="{{'ClearTitle' | translate}}"
-                        class="btn btn-default btn-lg">
-                  <i class="fa fa-times text-danger"></i>
-                  <span class="sr-only" data-translate="">ClearTitle</span>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div class="col-lg-3">
+            <button type="button"
+                    data-ng-click="resetSearch(searchObj.defaultParams);"
+                    title="{{'ClearTitle' | translate}}"
+                    class="btn btn-default btn-lg">
+              <i class="fa fa-times text-danger"></i>
+              <span class="sr-only" data-translate="">ClearTitle</span>
+            </button>
+
+            <button type="button"
+                    class="btn btn-default btn-lg"
+                    title="{{'advanced' | translate}}"
+                    data-ng-model="searchObj.advancedMode"
+                    btn-checkbox=""
+                    btn-checkbox-true="1"
+                    btn-checkbox-false="0">
+              <i class="fa fa-ellipsis-v"></i>
+              <span class="sr-only" data-translate="">advanced</span>
+            </button>
           </div>
         </div>
-        <div class="row" data-ng-show="searchObj.advancedMode">
-          <!--Advanced search form-->
-          <div data-ng-include="advancedSearchTemplate"></div>
-
-        </div>
+      </div>
+      <div data-ng-show="searchObj.advancedMode">
+        <!--Advanced search form-->
+        <div data-ng-include="advancedSearchTemplate"></div>
       </div>
     </div>
   </div>
+  <!-- /.gn-top-search -->
 </form>


### PR DESCRIPTION
GeoNetwork has 2 search boxes on 2 pages: `Home` and `Search`, but they differ in width, and the advanced panel on the `Search` page also has a different width.

This PR changes the width, so all inputs and panels have the same width.

Restructured search boxes, all changes:
- same width on `Home` and `Search` page
- changed order of buttons (advanced is last)
- same width for advanced panel
- improved responsiveness
- removed/cleanup CSS

**Advanced search before**
![gn-search-before](https://user-images.githubusercontent.com/19608667/81652242-b8080e00-9433-11ea-8bcf-578d0bed3875.png)

**Advanced search after**
![gn-search-after](https://user-images.githubusercontent.com/19608667/81652271-c5bd9380-9433-11ea-9298-77e22eab0cd9.png)

