### PR TITLE
Indexing / More robust for date type & lucene expression support

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -66,7 +66,13 @@
         if(p.any || luceneQueryString) {
           var queryStringParams = [];
           if (p.any) {
-            queryStringParams.push(escapeSpecialCharacters(p.any));
+            var queryExpression = p.any.match(/^q\((.*)\)$/);
+            if (queryExpression == null) {
+              queryStringParams.push(escapeSpecialCharacters(p.any));
+            } else {
+              queryStringParams.push(queryExpression[1]);
+            }
+
           }
           if (luceneQueryString) {
             queryStringParams.push(luceneQueryString);

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -47,6 +47,34 @@
   <xsl:variable name="maxFieldLength" select="32000" as="xs:integer"/>
 
 
+  <!-- A date, dateTime, Year or Year and Month
+  Valid with regards to index date supported types:
+  date_optional_time||yyyy-MM-dd||yyyy-MM||yyyy||epoch_millis
+  -->
+  <xsl:function name="gn-fn-index:is-isoDate" as="xs:boolean">
+    <xsl:param name="value" as="xs:string?"/>
+    <xsl:value-of select="if ($value castable as xs:date
+                          or $value castable as xs:dateTime
+                          or matches($value, '[0-9]{4}(-[0-9]{2})?'))
+                          then true() else false()"/>
+  </xsl:function>
+
+  <!-- 2020-12-12 -->
+  <xsl:function name="gn-fn-index:is-date" as="xs:boolean">
+    <xsl:param name="value" as="xs:string?"/>
+    <xsl:value-of select="if ($value castable as xs:date)
+                          then true() else false()"/>
+  </xsl:function>
+
+
+  <!-- 2020-12-12T12:00:00 -->
+  <xsl:function name="gn-fn-index:is-dateTime" as="xs:boolean">
+    <xsl:param name="value" as="xs:string?"/>
+    <xsl:value-of select="if ($value castable as xs:dateTime)
+                          then true() else false()"/>
+  </xsl:function>
+
+
   <xsl:function name="gn-fn-index:add-field" as="node()*">
     <xsl:param name="fieldName" as="xs:string"/>
     <xsl:param name="fieldValue" as="xs:string?"/>


### PR DESCRIPTION
Avoid indexing error on:
* null date
* invalid date
* upper range bound greater than lower

eg.
```

  Caused by: java.lang.IllegalArgumentException: min value (696902400000)
 is greater than max value (20191028)

  org.elasticsearch.index.mapper.MapperParsingException: failed to parse field 
[resourceTemporalDateRange] of type [date_range] in document with id
 '3e501c87-9146-4d9b-9237-8165c8f7cd51'. Preview of field's value: 'now'

  Caused by: org.elasticsearch.ElasticsearchParseException: 
failed to parse date field [* date de début de période AAAA[-MM-JJ] *] with 
format [date_optional_time||yyyy-MM-dd||yyyy-MM||yyyy||epoch_millis]: 
[failed to parse date field [* date de début de période AAAA[-MM-JJ] *] 
with format [date_optional_time||yyyy-MM-dd||yyyy-MM||yyyy||epoch_millis]]

org.elasticsearch.index.mapper.MapperParsingException: 
failed to parse field [resourceTemporalDateRange] of type [date_range] 
in document with id '6d5020a8-aaae-41c7-b9e2-d3648594ec11'. 
Preview of field's value: 'null'

```


User can now search with `q()` to use a lucene expression eg.
`q(+uuid:12345)`.