### PR TITLE
Fix null pointer exception in thesaurus API

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -290,9 +290,13 @@ public class KeywordsApi {
 
         String thesauriDomainName = null;
 
+        List<String> thesauri=null;
+        if (thesaurus!=null)
+            thesauri=Arrays.asList(thesaurus);
+
         KeywordSearchParamsBuilder builder = parseBuilder(
             lang, q, rows, start,
-            targetLangs, Arrays.asList(thesaurus),
+            targetLangs, thesauri,
             thesauriDomainName, type, uri, languagesMapper);
 
 //            if (checkModified(webRequest, thesaurusMan, builder)) {


### PR DESCRIPTION
Fix null pointer exception in thesaurus API when no thesaurus was supplied.

Arrays.asList(thesaurus) throwing null pointer error when thesaurus was null.