### PR TITLE
jdom transitive dependency excludes (due to ill-advised jaxen pom)

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -58,6 +58,16 @@
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom</artifactId>
+      <exclusions>
+         <exclusion>
+           <groupId>maven-plugins</groupId>
+           <artifactId>maven-cobertura-plugin</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>maven-plugins</groupId>
+           <artifactId>maven-findbugs-plugin</artifactId>
+         </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>jdbm</groupId>

--- a/csw-server/pom.xml
+++ b/csw-server/pom.xml
@@ -63,7 +63,16 @@
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom</artifactId>
-      <version>1.1.2</version>
+      <exclusions>
+         <exclusion>
+           <groupId>maven-plugins</groupId>
+           <artifactId>maven-cobertura-plugin</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>maven-plugins</groupId>
+           <artifactId>maven-findbugs-plugin</artifactId>
+         </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/csw-server/pom.xml
+++ b/csw-server/pom.xml
@@ -69,7 +69,6 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
     </dependency>
   </dependencies>
 

--- a/schemas/schema-core/pom.xml
+++ b/schemas/schema-core/pom.xml
@@ -39,6 +39,17 @@
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom</artifactId>
+      <exclusions>
+         <!-- this is a workaround for a mistake in packaging -->
+         <exclusion>
+           <groupId>maven-plugins</groupId>
+           <artifactId>maven-cobertura-plugin</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>maven-plugins</groupId>
+           <artifactId>maven-findbugs-plugin</artifactId>
+         </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
This addressed https://github.com/geonetwork/core-geonetwork/issues/4684 by introducing excludes into each dependency on `jdom`.

This is a build change only, addressing a il-advised dependency introduced by jaxen. The project had incorrectly added a dependency on two maven plugins as compile time dependencies dragging them into our codebase. Our build does not have a maven plugin repository available during compile time prevent a complete build from a fresh local maven repository.