### PR TITLE
Home page / Add tooltip on title and overview

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -10,6 +10,7 @@
 
       <div class="title">
         <a href=""
+           title="{{md.title || md.defaultTitle}}"
            gn-metadata-open="md"
            gn-records="searchResults.records"
            gn-formatter="formatter.defaultUrl">
@@ -19,6 +20,7 @@
 
       <div class="gn-md-thumbnail">
         <a href=""
+           title="{{(md.abstract || md.defaultAbstract) | striptags}}"
            gn-metadata-open="md"
            gn-records="searchResults.records"
            gn-formatter="formatter.defaultUrl">


### PR DESCRIPTION
Tooltip content

* Title has full title 
* Overview as abstract 

![image](https://user-images.githubusercontent.com/1701393/82348633-6e05c600-99f9-11ea-8193-27d853bb0d18.png)

It makes the user less blind to what is going to click on when records have long and similar titles