### PR TITLE
Shift to new maven repositories (OSGeo)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -356,7 +356,6 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>${print-lib.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-httpclient</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,40 @@
 
   <developers>
     <developer>
+      <name>Christophe Mangeat</name>
+      <id>cmangeat</id>
+      <organization>camptocamp</organization>
+      <organizationUrl>https://camptocamp.com</organizationUrl>
+      <email>christophe.mangeat@camptocamp.com</email>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+      <timezone>Europe/Paris</timezone>
+    </developer>
+    <developer>
+      <name>Florent Gravin</name>
+      <id>fgravin</id>
+      <organization>camptocamp</organization>
+      <organizationUrl>https://camptocamp.com</organizationUrl>
+      <email>florent.gravin@camptocamp.com</email>
+      <roles>
+        <role>Project Steering Committee</role>
+        <role>Java Developer</role>
+      </roles>
+      <timezone>Europe/Paris</timezone>
+    </developer>
+    <developer>
+      <name>Olivier Guyot</name>
+      <id>jahow</id>
+      <organization>camptocamp</organization>
+      <organizationUrl>https://camptocamp.com</organizationUrl>
+      <email>olivier.guyot@camptocamp.com</email>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+      <timezone>Europe/Paris</timezone>
+    </developer>
+    <developer>
       <name>Jody Garnett</name>
       <id>jodygarnett</id>
       <organization>GeoCat B.V.</organization>
@@ -104,7 +138,7 @@
       </roles>
       <timezone>America/Vancouver</timezone>
     </developer>
-    <!-- TODO developer part-->
+    <!-- TODO add developers, alphabetical by user name-->
   </developers>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,17 @@
   <artifactId>geonetwork</artifactId>
   <packaging>pom</packaging>
   <version>3.11.0-SNAPSHOT</version>
+
   <name>GeoNetwork opensource</name>
   <description>GeoNetwork opensource is a standards based, Free and
     Open Source catalog application to manage spatially referenced
     resources through the web.
   </description>
   <url>http://geonetwork-opensource.org</url>
+  <organization>
+    <name>Open Source Geospatial Foundation</name>
+    <url>https://www.osgeo.org/</url>
+  </organization>
   <scm>
     <connection>
       scm:git:https://github.com/geonetwork/core-geonetwork
@@ -86,19 +91,20 @@
     </mailingList>
   </mailingLists>
 
-  <!-- TODO developer part-->
   <developers>
     <developer>
-      <name/>
-      <id/>
-      <organization/>
-      <organizationUrl/>
-      <email/>
+      <name>Jody Garnett</name>
+      <id>jodygarnett</id>
+      <organization>GeoCat B.V.</organization>
+      <organizationUrl>https://www.geocat.net</organizationUrl>
+      <email>jody.garnett@gmail.com</email>
       <roles>
-        <role/>
+        <role>Java Developer</role>
+        <role>Maven Build</role>
       </roles>
-      <timezone/>
+      <timezone>America/Vancouver</timezone>
     </developer>
+    <!-- TODO developer part-->
   </developers>
 
   <licenses>
@@ -1349,12 +1355,27 @@
   </profiles>
 
   <distributionManagement>
+    <repository>
+      <id>osgeo</id>
+      <name>OSGeo GeoNetwork Release Repository</name>
+      <url>https://repo.osgeo.org/repository/geonetwork-releases/</url>
+    </repository>
+    <snapshotRepository>
+      <id> osgeo </id>
+      <name>OSGeo GeoNetwork Snapshot Repository</name>
+      <url>https://repo.osgeo.org/repository/geonetwork-snapshots/</url>
+     </snapshotRepository>
+  </distributionManagement>
+
+  <!--
+  <distributionManagement>
     <snapshotRepository>
       <id>scp-repository.geonetwork-opensource.org</id>
       <name>GeoNetwork opensource repositories</name>
       <url>scpexe://TO DEFINED</url>
     </snapshotRepository>
   </distributionManagement>
+  -->
 
   <properties>
     <db.properties>WEB-INF/config-db/jdbc.properties</db.properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1361,7 +1361,7 @@
       <url>https://repo.osgeo.org/repository/geonetwork-releases/</url>
     </repository>
     <snapshotRepository>
-      <id> osgeo </id>
+      <id>osgeo</id>
       <name>OSGeo GeoNetwork Snapshot Repository</name>
       <url>https://repo.osgeo.org/repository/geonetwork-snapshots/</url>
      </snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -869,7 +869,7 @@
       <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>${print-lib.version}</version>
+        <version>2.1.6</version>
       </dependency>
 
       <!-- Lib utils -->
@@ -1498,7 +1498,6 @@
     <node.version>v8.11.1</node.version>
     <npm.version>5.8.0</npm.version>
     <xmlunit.version>2.1.1</xmlunit.version>
-    <print-lib.version>2.1.6</print-lib.version>
     <jackson.version>2.10.3</jackson.version>
     <flying-saucer>9.0.7</flying-saucer>
     <camel.version>2.14.4</camel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1235,8 +1235,10 @@
       <url>http://maven.k-int.com/content/repositories/releases/</url>
     </repository-->
 
-    <!-- managed by repo.osgeo.org geonetwork-releass  -->
-    <!-- third party jar upload                        -->
+    <!-- managed by repo.osgeo.org geonetwork-cache     -->
+    <!-- third party jar upload                         -->
+    <!-- TODO: move this content to geonetwork-releases -->
+    <!--
     <repository>
       <snapshots>
         <enabled>false</enabled>
@@ -1248,7 +1250,7 @@
       <name>GeoNetwork remote repository</name>
       <url>https://raw.githubusercontent.com/geonetwork/core-maven-repo/master</url>
     </repository>
-
+    -->
     <!-- managed by repo.osgeo.org seasar-cache       -->
     <!-- /net.arnx.jsonic/jsonic/*                    -->
     <!-- seasar repo, has jsonic - used by langdetect -->
@@ -1259,7 +1261,7 @@
       <url>http://maven.seasar.org/maven2</url>
     </repository>
     -->
-    <!-- managed by repo.osgeo.org geonetwork-releass  -->
+    <!-- managed by repo.osgeo.org geonetwork-releases  -->
     <!-- third party jar upload                        -->
     <!-- org.mapfish.print:print-lib-2.1.6.jar         -->
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -91,56 +91,6 @@
     </mailingList>
   </mailingLists>
 
-  <developers>
-    <developer>
-      <name>Christophe Mangeat</name>
-      <id>cmangeat</id>
-      <organization>camptocamp</organization>
-      <organizationUrl>https://camptocamp.com</organizationUrl>
-      <email>christophe.mangeat@camptocamp.com</email>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-      <timezone>Europe/Paris</timezone>
-    </developer>
-    <developer>
-      <name>Florent Gravin</name>
-      <id>fgravin</id>
-      <organization>camptocamp</organization>
-      <organizationUrl>https://camptocamp.com</organizationUrl>
-      <email>florent.gravin@camptocamp.com</email>
-      <roles>
-        <role>Project Steering Committee</role>
-        <role>Java Developer</role>
-      </roles>
-      <timezone>Europe/Paris</timezone>
-    </developer>
-    <developer>
-      <name>Olivier Guyot</name>
-      <id>jahow</id>
-      <organization>camptocamp</organization>
-      <organizationUrl>https://camptocamp.com</organizationUrl>
-      <email>olivier.guyot@camptocamp.com</email>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-      <timezone>Europe/Paris</timezone>
-    </developer>
-    <developer>
-      <name>Jody Garnett</name>
-      <id>jodygarnett</id>
-      <organization>GeoCat B.V.</organization>
-      <organizationUrl>https://www.geocat.net</organizationUrl>
-      <email>jody.garnett@gmail.com</email>
-      <roles>
-        <role>Java Developer</role>
-        <role>Maven Build</role>
-      </roles>
-      <timezone>America/Vancouver</timezone>
-    </developer>
-    <!-- TODO add developers, alphabetical by user name-->
-  </developers>
-
   <licenses>
     <license>
       <name>General Public License (GPL)</name>

--- a/pom.xml
+++ b/pom.xml
@@ -645,13 +645,13 @@
         <version>1.3</version> <!-- TODO check version -->
       </dependency>
       <!-- May be required to register connection unwrappers with
-			     geotools
+           geotools
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>spring-jdbc</artifactId>
+      s  <artifactId>spring-jdbc</artifactId>
         <version>2.5.3</version>
       </dependency>
-			-->
+      -->
       <dependency>
         <groupId>org.eclipse.core</groupId>
         <artifactId>org.eclipse.core.runtime</artifactId>
@@ -680,7 +680,7 @@
         <version>1.0</version>
       </dependency>
 
-      <!-- Geotools and spatial search stuff -->
+      <!-- GeoTools and spatial search stuff -->
       <dependency>
         <groupId>org.geotools.xsd</groupId>
         <artifactId>gt-xsd-gml3</artifactId>
@@ -854,17 +854,16 @@
         <version>1.7.8</version>
       </dependency>
 
-      <!-- Databased stuff -->
-      <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>1.3.174</version>
-      </dependency>
       <!-- Other stuff -->
       <dependency>
         <groupId>dlib</groupId>  <!--FIXME Handled by local repository -->
         <artifactId>dlib</artifactId>
         <version>1.0</version> <!-- FIXME totally unknown -->
+      </dependency>
+      <dependency>
+        <groupId>org.mapfish.print</groupId>
+        <artifactId>print-lib</artifactId>
+        <version>${print-lib.version}</version>
       </dependency>
 
       <!-- Lib utils -->
@@ -895,6 +894,7 @@
         <artifactId>metrics-log4j</artifactId>
         <version>${metrics.version}</version>
       </dependency>
+
       <!-- Tests -->
       <dependency>
         <groupId>junit</groupId>
@@ -933,7 +933,12 @@
         <scope>test</scope>
       </dependency>
 
-      <!-- db -->
+      <!-- Databased stuff -->
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>1.3.174</version>
+      </dependency>
       <dependency>
         <groupId>org.postgis</groupId>
         <artifactId>postgis-jdbc</artifactId>
@@ -961,7 +966,14 @@
         <artifactId>ojdbc</artifactId>
         <version>14</version>
       </dependency>
-			-->
+      -->
+      <!-- Oracle changed policy, this is from maven central -->
+      <!-- Oracle Free Use Terms and Conditions (FUTC) -->
+      <dependency>
+         <groupId>com.oracle.database.jdbc</groupId>
+         <artifactId>ojdbc8</artifactId>
+         <version>19.6.0.0</version>
+       </dependency>
       <dependency>
         <groupId>org.codehaus.izpack</groupId>
         <artifactId>izpack-standalone-compiler</artifactId>
@@ -1146,11 +1158,13 @@
         <artifactId>elasticsearch</artifactId>
         <version>${es.version}</version>
       </dependency>-->
+
       <!--Require Lucene 5 <dependency>
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>transport</artifactId>
         <version>${es.version}</version>
       </dependency>-->
+
       <dependency>
         <groupId>io.searchbox</groupId>
         <artifactId>jest</artifactId>
@@ -1209,18 +1223,23 @@
       <url>https://repo.osgeo.org/repository/release/</url>
     </repository>
 
-    <repository>
+    <!-- managed by repo.osgeo.org k-int-cache -->
+    <!-- /marcxml/marcxml/*                    -->
+    <!-- /marc4j/marc4j/*                      -->
+    <!--repository>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
       <id>k-int</id>
       <name>Developer k-int repository</name>
       <url>http://maven.k-int.com/content/repositories/releases/</url>
-    </repository>
+    </repository-->
 
+    <!-- managed by repo.osgeo.org geonetwork-releass  -->
+    <!-- third party jar upload                        -->
     <repository>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </snapshots>
       <releases>
         <enabled>true</enabled>
@@ -1230,19 +1249,26 @@
       <url>https://raw.githubusercontent.com/geonetwork/core-maven-repo/master</url>
     </repository>
 
+    <!-- managed by repo.osgeo.org seasar-cache       -->
+    <!-- /net.arnx.jsonic/jsonic/*                    -->
     <!-- seasar repo, has jsonic - used by langdetect -->
+    <!--
     <repository>
       <id>maven.seasar.org</id>
       <name>The Seasar Foundation Maven2 Repository</name>
       <url>http://maven.seasar.org/maven2</url>
     </repository>
-
+    -->
+    <!-- managed by repo.osgeo.org geonetwork-releass  -->
+    <!-- third party jar upload                        -->
+    <!-- org.mapfish.print:print-lib-2.1.6.jar         -->
+    <!--
     <repository>
       <id>georchestra-mfprint</id>
       <name>build-releases</name>
       <url>https://packages.georchestra.org/artifactory/mapfish-print</url>
     </repository>
-
+    -->
   </repositories>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -654,7 +654,7 @@
            geotools
       <dependency>
         <groupId>org.springframework</groupId>
-      s  <artifactId>spring-jdbc</artifactId>
+        <artifactId>spring-jdbc</artifactId>
         <version>2.5.3</version>
       </dependency>
       -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -322,6 +322,7 @@
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
         </exclusion>
+        <!--
         <exclusion>
           <groupId>com.codahale.metrics</groupId>
           <artifactId>metrics-core</artifactId>
@@ -342,6 +343,7 @@
           <groupId>com.codahale.metrics</groupId>
           <artifactId>metrics-httpclient</artifactId>
         </exclusion>
+        -->
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -364,6 +364,7 @@
           <groupId>org.apache.xmlgraphics</groupId>
           <artifactId>batik-transcoder</artifactId>
         </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- ====================== -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -322,7 +322,6 @@
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
         </exclusion>
-        <!--
         <exclusion>
           <groupId>com.codahale.metrics</groupId>
           <artifactId>metrics-core</artifactId>
@@ -343,7 +342,6 @@
           <groupId>com.codahale.metrics</groupId>
           <artifactId>metrics-httpclient</artifactId>
         </exclusion>
-        -->
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -317,8 +317,6 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <!-- why no exclusions like in core/pom.xml? -->
-      <!--
       <exclusions>
         <exclusion>
           <groupId>commons-httpclient</groupId>
@@ -364,7 +362,6 @@
           <groupId>org.apache.xmlgraphics</groupId>
           <artifactId>batik-transcoder</artifactId>
         </exclusion>
-        -->
     </dependency>
 
     <!-- ====================== -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -317,7 +317,54 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>${print-lib.version}</version>
+      <!-- why no exclusions like in core/pom.xml? -->
+      <!--
+      <exclusions>
+        <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-servlets</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-web</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.xmlgraphics</groupId>
+          <artifactId>batik-transcoder</artifactId>
+        </exclusion>
+        -->
     </dependency>
 
     <!-- ====================== -->


### PR DESCRIPTION
See proposal [Host Geonetwork artifacts on repo.osgeo.org](https://github.com/geonetwork/core-geonetwork/wiki/Host-Geonetwork-artifacts-on-repo.osgeo.org-(Nexus-Artifactory-Repo)) for details.

Cache remote repositories:

* [x] define repo.osgeo.org seasar-cache
* [x] define repo.osgeo.org k-int-cache
* [x] define repo.osgeo.org geonetwork-cache as a proxy for core-maven-repo.

Note replacing [core-maven-repo](https://github.com/geonetwork/core-maven-repo) was not successful and is being cached above.
Build changes and dependency review:

* [x] pom.xml cleanup with organization, developer, ...
* [x] oracle driver (testing with Oracle-XE recommended)

Going to save change to maven-resources-plugin:copy-resources to maven-dependency-plugin:unpack for subsequent PR as it may be quite extensive.