### PR TITLE
Don't add '#' to thesaurus url. Related to #3918

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -357,11 +357,6 @@ public class Thesaurus {
         // Define namespace
         String namespaceSkos = "http://www.w3.org/2004/02/skos/core#";
         String namespaceGml = "http://www.opengis.net/gml#";
-        String namespace = keyword.getNameSpaceCode();
-
-        if (namespace.equals("#")) {
-            namespace = this.defaultNamespace;
-        }
 
         // Create subject
         URI mySubject = myFactory.createURI(keyword.getUriCode());
@@ -736,10 +731,6 @@ public class Thesaurus {
                 new java.net.URI(this.defaultNamespace);
             } catch (Exception e) {
                 this.defaultNamespace = DEFAULT_THESAURUS_NAMESPACE;
-            }
-
-            if (!this.defaultNamespace.endsWith("#")) {
-                this.defaultNamespace += "#";
             }
 
             Element dateEl = Xml.selectElement(thesaurusEl, "skos:ConceptScheme/dcterms:issued|skos:Collection/dc:date", theNSs);


### PR DESCRIPTION
Reverts a change introduced in https://github.com/geonetwork/core-geonetwork/commit/51a9bb99be19c00f8492bf9739109c0b30daec68 that causes validation issues in INSPIRE.

Tests with external and local vocabularies seem fine.