### PR TITLE
 Extent API / Add color parameters

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -23,13 +23,11 @@
 
 package org.fao.geonet.api.records.extent;
 
-import org.locationtech.jts.awt.ShapeWriter;
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.api.regions.GeomFormat;
+import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.kernel.region.RegionNotFoundEx;
 import org.fao.geonet.kernel.region.RegionsDAO;
@@ -40,6 +38,10 @@ import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.JTSFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.locationtech.jts.awt.ShapeWriter;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.opengis.metadata.extent.Extent;
 import org.opengis.metadata.extent.GeographicBoundingBox;
 import org.opengis.metadata.extent.GeographicExtent;
@@ -121,7 +123,7 @@ public class MapRenderer {
     }
 
     public BufferedImage render(String id, String srs, Integer width, Integer height,
-                                String background, String geomParam, String geomType, String geomSrs) throws Exception {
+                                String background, String geomParam, String geomType, String geomSrs, String fillColor, String strokeColor) throws Exception {
         ApplicationContext appContext = context.getApplicationContext();
         Map<String, String> regionGetMapBackgroundLayers = appContext.getBean("regionGetMapBackgroundLayers", Map.class);
         SortedSet<ExpandFactor> regionGetMapExpandFactors = appContext.getBean("regionGetMapExpandFactors", SortedSet.class);
@@ -199,7 +201,10 @@ public class MapRenderer {
                 // Setup the proxy for the request if required
                 URLConnection conn = Lib.net.setupProxy(context, imageUrl);
                 in = conn.getInputStream();
-                image = ImageIO.read(in);
+                BufferedImage original = ImageIO.read(in);
+                image = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_ARGB);
+                Graphics2D g2d = image.createGraphics();
+                g2d.drawImage(original, 0, 0, null);
             } catch (IOException e) {
                 image = new BufferedImage(imageDimensions.width, imageDimensions.height, BufferedImage.TYPE_INT_ARGB);
                 error = e;
@@ -219,20 +224,47 @@ public class MapRenderer {
                 graphics.drawString(error.getMessage(), 0, imageDimensions.height / 2);
             }
             ShapeWriter shapeWriter = new ShapeWriter();
+            Color geomFillColor = getColor(fillColor, new Color(0, 0, 0, 50));
+            Color geomStrokeColor = getColor(strokeColor, new Color(0, 0, 0, 255));
             AffineTransform worldToScreenTransform = worldToScreenTransform(bboxOfImage, imageDimensions);
             for (int i = 0; i < geom.getNumGeometries(); i++) {
                 // draw each included geometry separately to ensure they are filled correctly
                 Shape shape = worldToScreenTransform.createTransformedShape(shapeWriter.toShape(geom.getGeometryN(i)));
-                graphics.setColor(Color.yellow);
-                graphics.draw(shape);
-
-                graphics.setColor(new Color(255, 255, 0, 100));
+                graphics.setColor(geomFillColor);
                 graphics.fill(shape);
+
+                graphics.setColor(geomStrokeColor);
+                graphics.setStroke(new BasicStroke(2));
+                graphics.draw(shape);
             }
         } finally {
             graphics.dispose();
         }
         return image;
+    }
+
+    private Color getColor(String color, Color defaultColor) {
+        if (StringUtils.isNotEmpty(color)) {
+            String[] colorsConfig = color.split(",");
+            if (colorsConfig.length == 4) {
+                try {
+                    return new Color(
+                        Integer.parseInt(colorsConfig[0]),
+                        Integer.parseInt(colorsConfig[1]),
+                        Integer.parseInt(colorsConfig[2]),
+                        Integer.parseInt(colorsConfig[3]));
+                } catch (Exception e) {
+                    throw new BadParameterEx(String.format(
+                        "Invalid color configuration '%s'. Error is '%s'. Format must be 'RED,GREEN,BLUE,ALPHA' with integer value from 0 to 255.",
+                        color, e.getMessage()));
+                }
+            } else {
+                throw new BadParameterEx(String.format(
+                    "Invalid color configuration '%s'. Format must be 'RED,GREEN,BLUE,ALPHA' with integer value from 0 to 255.",
+                    color));
+            }
+        }
+        return defaultColor;
     }
 
     private double calculateExpandFactor(SortedSet<ExpandFactor> regionGetMapExpandFactors, Envelope bboxOfImage,

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
@@ -67,6 +67,7 @@ import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
@@ -136,6 +137,12 @@ public class MetadataExtentApi {
         @RequestParam(value = HEIGHT_PARAM, required = false) Integer height,
         @ApiParam(value = "(optional) URL for loading a background image for regions or a key that references the namedBackgrounds (configured in config-spring-geonetwork.xml). A WMS Getmap request is the typical example. The URL must be parameterized with the following parameters: minx, maxx, miny, maxy, width, height")
         @RequestParam(value = BACKGROUND_PARAM, required = false, defaultValue = "settings") String background,
+        @ApiParam(value = "(optional) Fill color with format RED,GREEN,BLUE,ALPHA")
+        @RequestParam(value = "", required = false, defaultValue = "0,0,0,50")
+        String fillColor,
+        @ApiParam(value = "(optional) Stroke color with format RED,GREEN,BLUE,ALPHA")
+        @RequestParam(value = "", required = false, defaultValue = "0,0,0,255")
+        String strokeColor,
         @ApiIgnore
             NativeWebRequest nativeWebRequest,
         @ApiIgnore
@@ -174,7 +181,11 @@ public class MetadataExtentApi {
             }
         }
         MapRenderer renderer = new MapRenderer(context);
-        BufferedImage image = renderer.render(regionId, srs, width, height, background, null, null, null);
+        BufferedImage image = renderer.render(
+            regionId, srs, width, height, background,
+            null, null, null,
+            fillColor,
+            strokeColor);
 
         if (image == null) return null;
 

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
@@ -99,7 +99,7 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
         String nodeName = element.getNodeName();
         String src = element.getAttribute("src");
         if ("img".equals(nodeName)
-            && (src.startsWith(baseURL + "region.getmap.png") || src.endsWith("/extents.png") || src.endsWith("/geom.png"))
+            && (src.startsWith(baseURL + "region.getmap.png") || src.contains("/extents.png") || src.endsWith("/geom.png"))
             && mapRenderer != null) {
             BufferedImage image = null;
             try {
@@ -115,14 +115,14 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
                 String geomSrs = parameters.get(MetadataExtentApi.GEOM_SRS_PARAM) != null ? parameters.get(MetadataExtentApi.GEOM_SRS_PARAM) : "EPSG:4326";
 
                 image = mapRenderer.render(
-                    id, srs, width, height, background, geomParam, geomType, geomSrs);
+                    id, srs, width, height, background, geomParam, geomType, geomSrs, null, null);
             } catch (Exception e) {
                 Log.warning(Geonet.GEONETWORK, "Error writing metadata to PDF", e);
             }
             float factor = layoutContext.getDotsPerPixel();
             return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new BufferedImageLoader(image), factor);
         } else if ("img".equals(nodeName)
-            && (src.startsWith(baseURL + "region.getmap.png") || src.endsWith("/extents.png") || src.endsWith("/geom.png"))) {
+            && (src.startsWith(baseURL + "region.getmap.png") || src.contains("/extents.png") || src.endsWith("/geom.png"))) {
             StringBuilder builder = new StringBuilder(baseURL);
             try {
                 if (StringUtils.startsWith(src, "http")) {
@@ -172,7 +172,7 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
     }
 
     private boolean isSupportedImageFormat(String imgUrl) {
-        String ext = Files.getFileExtension(imgUrl);
+        String ext = Files.getFileExtension(imgUrl.replaceAll("\\?.*", ""));
         return ext.trim().isEmpty() || getSupportedExts().contains(ext);
     }
 

--- a/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
@@ -23,7 +23,6 @@
 
 package org.fao.geonet.api.regions;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import io.swagger.annotations.*;
 import jeeves.server.context.ServiceContext;
@@ -33,7 +32,6 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.records.extent.MapRenderer;
 import org.fao.geonet.api.regions.model.Category;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
-import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.KeywordBean;
 import org.fao.geonet.kernel.region.Region;
@@ -61,7 +59,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 import static org.fao.geonet.api.records.extent.MetadataExtentApi.*;
 
 /**
@@ -250,7 +247,7 @@ public class RegionsApi {
         }
 
         MapRenderer renderer = new MapRenderer(context);
-        BufferedImage image = renderer.render(regionId, srs, width, height, background, geomParam, geomType, geomSrs);
+        BufferedImage image = renderer.render(regionId, srs, width, height, background, geomParam, geomType, geomSrs, null, null);
 
         if (image == null) return null;
 

--- a/services/src/main/java/org/fao/geonet/services/region/GetMap.java
+++ b/services/src/main/java/org/fao/geonet/services/region/GetMap.java
@@ -201,7 +201,7 @@ public class GetMap {
         }
 
         MapRenderer renderer = new MapRenderer(context);
-        BufferedImage image = renderer.render(id, srs, width, height, background, geomParam, geomType, geomSrs);
+        BufferedImage image = renderer.render(id, srs, width, height, background, geomParam, geomType, geomSrs, null, null);
 
         if (image == null) return null;
 

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -28,11 +28,11 @@
 
     <xsl:variable name="boxGeometry"
                   select="concat('POLYGON((',
-                  $east, ' ', $south, ',',
-                  $east, ' ', $north, ',',
-                  $west, ' ', $north, ',',
-                  $west, ' ', $south, ',',
-                  $east, ' ', $south, '))')"/>
+                  $east, '%20', $south, ',',
+                  $east, '%20', $north, ',',
+                  $west, '%20', $north, ',',
+                  $west, '%20', $south, ',',
+                  $east, '%20', $south, '))')"/>
     <xsl:variable name="numberFormat" select="'0.00'"/>
 
     <div class="thumbnail extent">


### PR DESCRIPTION
* Add new parameter for
  * fill color: fillColor
  * stroke color: strokeColor
![image](https://user-images.githubusercontent.com/1701393/82643443-cadac980-9c0f-11ea-9612-15067e785f25.png)

* Draw fill before stroke - rendering of geometry border is better
* Change default colors to make mix of small/large extent more visible (see below)
* Fix buffered image type when the base image was loaded from a URL. Always create an ARGB image. Improves colors & transparency.
* PDF / Fix rendering of images when API /api/regions/geom.png is used - encode " "
* PDF / Fix rendering of an image with URL with parameters - extension not retrieved properly

 Eg.

* Before
![image](https://user-images.githubusercontent.com/1701393/82643364-a979dd80-9c0f-11ea-93b6-bf97a3ae9b04.png)

* Default

![image](https://user-images.githubusercontent.com/1701393/82643163-5d2e9d80-9c0f-11ea-889f-a206d7103d20.png)

* Custom with http://localhost:8080/geonetwork/srv/api/records/93eede6e-c196-40e3-9253-7f2237b49de1/extents.png?fillColor=0,255,0,44&strokeColor=255,255,0,255

![image](https://user-images.githubusercontent.com/1701393/82643174-615abb00-9c0f-11ea-97ba-cea67e36765e.png)


