### PR TITLE
Fix dependency issue #4661.  Dependency conflict causing issues on Windows build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -752,6 +752,12 @@
         <groupId>org.geotools</groupId>
         <artifactId>gt-wfs-ng</artifactId>
         <version>${geotools.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.xml</groupId>
+            <artifactId>xml-commons-resolver</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.geotools</groupId>


### PR DESCRIPTION
xml-commons-resolver (1.2) conflicts with xml-resolver-patched (1.2.1) - same jar different version.

Fixes issue #4661 