### PR TITLE
Uniform look for the Statistics pages in the Admin (replaces #4674)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/history/partials/history.html
+++ b/web-ui/src/main/resources/catalog/components/history/partials/history.html
@@ -1,9 +1,9 @@
-<section>
-  <h2><i class="fa fa-fw fa-history"/><span data-translate="">history</span></h2>
+<fieldset>
+  <legend data-translate="">history</legend>
 
   <div class="row">
-    <div class="col-xs-4">
-
+    <div class="col-xs-12 col-md-4">
+      <div class="form-group">
       <label class="form-control"
              data-ng-repeat="(k, v) in filter.types">
         <i class="fa fa-fw"
@@ -14,9 +14,10 @@
         <input type="checkbox" data-ng-model="filter.types[k]"/>
         <span>{{k + 'Type' | translate}}</span>
       </label>
+      </div>
     </div>
 
-    <div class="col-xs-4">
+    <div class="col-xs-12 col-md-4">
       <div class="form-group">
         <label data-translate="">filterStatusByAuthor</label>
         <input class="form-control"
@@ -30,7 +31,7 @@
                data-gn-user-picker="filter.ownerFilter"/>
       </div>
     </div>
-    <div class="col-xs-4">
+    <div class="col-xs-12 col-md-4">
 
       <div class="form-group">
         <label data-translate="">filterStatusByRecordId</label>
@@ -42,7 +43,6 @@
                data-typeahead-min-length="1"
                data-typeahead-focus-first="false"
                data-typeahead-wait-ms="300">
-
       </div>
 
       <div class="form-group">
@@ -51,7 +51,8 @@
                type="date"
                pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}"
                data-ng-model="filter.dateFromFilter"/>
-
+      </div>
+      <div class="form-group">
         <label data-translate="">filterStatusToDate</label>
         <input class="form-control"
                type="date"
@@ -72,4 +73,4 @@
       </a>
     </li>
   </ul>
-</section>
+</fieldset>

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/record-links.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/record-links.html
@@ -1,82 +1,85 @@
 <div data-ng-controller="GnDashboardRecordLinksController">
-  <div>
-    <div class="row">
-      <div class="col-md-12">
-        <h1 data-translate="">recordLinksDashboard</h1>
-        <p class="text-muted" data-translate="">
-          recordLinksDashboardSubtitle
-        </p>
+  <div class="panel panel-default">
+    <div class="panel-heading"
+          data-gn-slide-toggle="">
+      <strong data-translate="">recordLinksDashboard</strong>
+      <p data-translate="">
+        recordLinksDashboardSubtitle
+      </p>
+    </div>
+    <!-- /.panel-heading -->
+    <div class="panel-body">
+
+      <div class="clearfix">
+        <div class="pull-right btn-toolbar">
+          <button type="button" class="btn btn-primary"
+                  title="{{'analyzeLinks-help' | translate}}"
+                  data-ng-disabled="!user.isAdministrator()"
+                  data-gn-click-and-spin="analyzeLinks()">
+            <i class="fa fa-fw fa-cogs"/>&nbsp;
+            <span data-translate="">analyzeLinks</span>
+          </button>
+
+          <button type="button" class="btn btn-danger"
+                  data-ng-click="removeAll()"
+                  data-ng-disabled="!user.isAdministrator()"
+                  data-gn-confirm-click="{{'removeAllLinksAndStatusConfirm' | translate}}">
+            <i class="fa fa-fw fa-times"/>&nbsp;
+            <span data-translate="">removeAllLinksAndStatus</span>
+          </button>
+
+          <button type="button" class="btn btn-default"
+                  title="{{'downloadAsCsv-help' | translate}}"
+                  data-ng-click="downloadAsCsv()">
+            <i class="fa fa-fw fa-download"/>&nbsp;
+            <span data-translate="">downloadAsCsv</span>
+          </button>
+        </div>
       </div>
-    </div>
-  </div>
 
-  <div class="pull-right btn-toolbar">
-    <button type="button" class="btn btn-primary"
-            title="{{'analyzeLinks-help' | translate}}"
-            data-ng-disabled="!user.isAdministrator()"
-            data-gn-click-and-spin="analyzeLinks()">
-      <i class="fa fa-fw fa-cogs"/>&nbsp;
-      <span data-translate="">analyzeLinks</span>
-    </button>
-
-    <button type="button" class="btn btn-danger"
-            data-ng-click="removeAll()"
-            data-ng-disabled="!user.isAdministrator()"
-            data-gn-confirm-click="{{'removeAllLinksAndStatusConfirm' | translate}}">
-      <i class="fa fa-fw fa-times"/>&nbsp;
-      <span data-translate="">removeAllLinksAndStatus</span>
-    </button>
-
-    <button type="button" class="btn btn-default"
-            title="{{'downloadAsCsv-help' | translate}}"
-            data-ng-click="downloadAsCsv()">
-      <i class="fa fa-fw fa-download"/>&nbsp;
-      <span data-translate="">downloadAsCsv</span>
-    </button>
-  </div>
-
-  <br/>
-  <br/>
-
-  <div data-ng-if="error" class="row">
-    <div class="alert alert-danger" role="alert">
-      <i class="fa fa-exclamation-triangle fa-fw"/>
-      <span>{{error.description}}</span>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="form-group col-lg-3">
-      <label class="control-label"
-             for="gn-link-group-owner"
-             data-translate="">_groupOwner</label>
-      <div id="gn-link-group-owner"
-           data-groups-combo=""
-           data-set-default-value="false"
-           data-owner-group="groupOwnerIdFilter"
-           lang="lang"
-           groups="groups"
-           data-exclude-special-groups="true">&nbsp;
+      <div data-ng-if="error" class="row gn-margin-top">
+        <div class="alert alert-danger" role="alert">
+          <i class="fa fa-exclamation-triangle fa-fw"/>
+          <span>{{error.description}}</span>
+        </div>
       </div>
-    </div>
-    <div class="form-group col-lg-3">
-      <label class="control-label"
-             for="gn-link-group"
-             data-translate="">_groupPublished</label>
-      <div id="gn-link-group"
-           data-groups-combo=""
-           data-set-default-value="false"
-           data-owner-group="groupIdFilter"
-           lang="lang"
-           groups="groups"
-           data-exclude-special-groups="true">&nbsp;
+
+      <div class="row">
+        <div class="form-group col-lg-3 gn-nopadding-left">
+          <label class="control-label"
+                for="gn-link-group-owner"
+                data-translate="">_groupOwner</label>
+          <div id="gn-link-group-owner"
+              data-groups-combo=""
+              data-set-default-value="false"
+              data-owner-group="groupOwnerIdFilter"
+              lang="lang"
+              groups="groups"
+              data-exclude-special-groups="true">&nbsp;
+          </div>
+        </div>
+        <div class="form-group col-lg-3 gn-nopadding-left">
+          <label class="control-label"
+                for="gn-link-group"
+                data-translate="">_groupPublished</label>
+          <div id="gn-link-group"
+              data-groups-combo=""
+              data-set-default-value="false"
+              data-owner-group="groupIdFilter"
+              lang="lang"
+              groups="groups"
+              data-exclude-special-groups="true">&nbsp;
+          </div>
+        </div>
       </div>
+      <table id="bstable" bs-table-control="bsTableControl" ng-model="tc">
+      </table>
+
+      <br>
+
+      <gn-dashboard-record-links-processes-container/>
     </div>
+    <!-- /.panel-body -->
   </div>
-  <table id="bstable" bs-table-control="bsTableControl" ng-model="tc">
-  </table>
-
-  <br>
-
-  <gn-dashboard-record-links-processes-container/>
+  <!-- /.panel panel-default -->
 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/versioning.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/versioning.html
@@ -8,10 +8,10 @@
         <div data-gn-history=""></div>
 
         <!-- VCS history - old features not much supported now. -->
-        <section>
-          <h2><i class="fa fa-fw fa-chevron-left"/><span data-translate="">vcshistory</span></h2>
+        <fieldset>
+          <legend data-translate="">vcshistory</legend>
 
-          <div class="panel-body" data-ng-controller="GnVcsController">
+          <div data-ng-controller="GnVcsController">
             <div class="alert alert-info"
                  data-ng-show="logs.length === 0"
                  data-translate="">
@@ -25,7 +25,7 @@
               </li>
             </ul>
           </div>
-        </section>
+        </fieldset>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR replaces: https://github.com/geonetwork/core-geonetwork/pull/4674

The `Record links analysis` and `Versioning` pages had a different looking layout than all the other admin pages. This PR changes that and gives it a more uniform look across all pages in the admin.

**Record links analysis before**
![gn-admin-recordlinks-before](https://user-images.githubusercontent.com/19608667/81647118-c7d02400-942c-11ea-8985-3a9e169089b4.png)

**Record links analysis after**
![gn-admin-recordlinks-after](https://user-images.githubusercontent.com/19608667/82823248-84070100-9ea7-11ea-9573-9cdde09aada4.png)

**Versioning before**
![gn-admin-history-before](https://user-images.githubusercontent.com/19608667/81647159-d74f6d00-942c-11ea-8e6f-895b95f7c12a.png)

**Versioning after**
![gn-admin-history-after](https://user-images.githubusercontent.com/19608667/81647173-dcacb780-942c-11ea-8503-6bacca3f3218.png)

