### PR TITLE
Proxy / Limit to URL host registered in records.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1382,6 +1382,13 @@
      when watchlist notifier is triggered (Default 4AM) -->
     <savedselection.watchlist.frequency>0 0 4 * * ?</savedselection.watchlist.frequency>
 
+    <!-- Proxy security configuration:
+    * NONE: allow all.
+    * DB_LINK_CHECK:
+       * allow all for authenticated user
+       * allow only host registered in metadata link table
+    -->
+    <proxy.securityMode>DB_LINK_CHECK</proxy.securityMode>
 
     <!-- Jetty plugin port configuration -->
     <jetty.port>8080</jetty.port>

--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -1,11 +1,25 @@
 package org.fao.geonet.proxy;
 
+import jeeves.server.UserSession;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.exception.NotAllowedException;
+import org.fao.geonet.repository.LinkRepository;
+import org.fao.geonet.repository.MetadataLinkRepository;
+import org.fao.geonet.repository.specification.LinkSpecs;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * This is a class extending the real proxy to make sure we can tweak specifics like removing the CSRF token on requests
@@ -15,9 +29,30 @@ import javax.servlet.ServletConfig;
 public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemplateProxyServlet {
 
     private static final long serialVersionUID = 4847856943273604410L;
+    private static final String P_SECURITY_MODE = "securityMode";
+    private enum SECURITY_MODE {
+        NONE,
+        /**
+         * Check if the host of the requested URL is registered in
+         * at least one analyzed link in a metadata record.
+         */
+        DB_LINK_CHECK;
+
+        public static SECURITY_MODE parse(String value) {
+            if ("DB_LINK_CHECK".equals(value)) {
+                return DB_LINK_CHECK;
+            }
+            return NONE;
+        }
+    }
+    protected SECURITY_MODE securityMode;
+
+    @Autowired
+    MetadataLinkRepository metadataLinkRepository;
 
     /**
-     * These are the "hop-by-hop" headers that should not be copied. http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html Overriding
+     * These are the "hop-by-hop" headers that should not be copied.
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html Overriding
      * parent
      */
     static {
@@ -33,8 +68,14 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
         }
     }
 
+    protected void initTarget() throws ServletException {
+        securityMode = SECURITY_MODE.parse(getConfigParam(P_SECURITY_MODE));
+        super.initTarget();
+    }
+
     /**
-     * Creates the HttpClient used to make the proxied requests. It configures the client to use system properties like
+     * Creates the HttpClient used to make the proxied requests.
+     * It configures the client to use system properties like
      * <code>http.proxyHost</code> and <code>http.httpPort</code>.
      *
      * Called from {@link #init(ServletConfig)}.
@@ -47,5 +88,62 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
             .setDefaultRequestConfig(requestConfig)
             .useSystemProperties()
             .build();
+    }
+
+    protected void service(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
+        throws ServletException, IOException {
+        switch (securityMode) {
+            case NONE:
+                super.service(servletRequest, servletResponse);
+                break;
+            case DB_LINK_CHECK:
+                boolean proxyCallAllowed = false;
+
+                // Check if user is authenticated
+                UserSession userSession = ApiUtils.getUserSession(servletRequest.getSession());
+                if (userSession.isAuthenticated()) {
+                    proxyCallAllowed = true;
+                }
+
+                // Check if the link requested is in database link list
+                if (proxyCallAllowed == false
+                    && securityMode == SECURITY_MODE.DB_LINK_CHECK) {
+                    try {
+                        URI uri = new URI(servletRequest.getParameter("url"));
+                        String host = uri.getHost();
+                        LinkRepository linkRepository =
+                            ApplicationContextHolder.get().getBean(LinkRepository.class);
+                        long linksFound = linkRepository.count(
+                            LinkSpecs.filter(host, null, null,
+                                null, null, null));
+                        if (linksFound == 0) {
+                            String message = String.format(
+                                "The proxy does not allow to access '%s' " +
+                                    "because the URL host was not registered in any metadata records.",
+                                uri
+                            );
+                            if (linkRepository.count() == 0) {
+                                throw new NotAllowedException(
+                                    "The proxy is configured with DB_LINK_CHECK mode " +
+                                        "but the MetadataLink table is empty. " +
+                                        "Administrator may need to analyze record links from the admin console " +
+                                        "in order to register URL allowed by the proxy. " + message);
+                            }
+                            throw new NotAllowedException(message);
+                        }
+                        proxyCallAllowed = linksFound > 0;
+                    } catch (URISyntaxException e) {
+                        throw new IllegalArgumentException(String.format(
+                            "'%s' is invalid. Error is: '%s'",
+                            e.getMessage()
+                        ));
+                    }
+                }
+
+                if(proxyCallAllowed) {
+                    super.service(servletRequest, servletResponse);
+                }
+                break;
+        }
     }
 }

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -374,6 +374,10 @@
       <param-name>http.protocol.handle-redirects</param-name>
       <param-value>true</param-value>
     </init-param>
+    <init-param>
+      <param-name>securityMode</param-name>
+      <param-value>${proxy.securityMode}</param-value>
+    </init-param>
   </servlet>
   <servlet-mapping>
     <servlet-name>HttpProxy</servlet-name>


### PR DESCRIPTION
Currently the GeoNetwork proxy is quite permissive. It is used mainly in
the following cases:

* Map viewer / GetCapabilities document retrieval
* Map viewer / Load a WFS layer
* Map viewer / WMS GetFeatureInfo
* Record view / List atom feed resources
* Editor / Warning if a link return http errors
* Admin / Harvesting / GetCapabilities for CSW to retrieve queryable fields
* Admin / Thesaurus / Add from INSPIRE registry
* ...

Add a configuration to limit its usage to some URL host only.

2 modes are available:

* `NONE`: allow all like before.
* `DB_LINK_CHECK` (default):
   * allow all for authenticated user
   * allow only host registered in metadata link table

For anonymous user, if the host of the URL requested is not used in any
metadata record links, then a `NotAllowedException` is returned.

![image](https://user-images.githubusercontent.com/1701393/82905150-caba3100-9f63-11ea-8dc6-fe6d60fe84ce.png)

If a WMS URL is registered, all GetCapabilities, GetFeatureInfo will be
accepted. That's why only a host check is done.

Also if a request is made directly to the proxy, a `SecurityException` is
returned because no session exist. This limit its usage to user with a
catalog session.

![image](https://user-images.githubusercontent.com/1701393/82905141-c68e1380-9f63-11ea-91ec-1a61c214b819.png)


This change means that catalog reviewers have to use the metadata link analysis
tools to register links allowed for the proxy. In the future we may
trigger that as a background task to have an up to date list of links.
For now, if the table is empty the exception highlight the fact that the
link analysis tools should be used to populate the list.

![image](https://user-images.githubusercontent.com/1701393/82905128-c2fa8c80-9f63-11ea-864d-62578379e7a2.png)


Documentation https://github.com/geonetwork/doc/pull/144