### PR TITLE
fix online resources

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -554,6 +554,31 @@
                     var typeConfig = linkToEdit ?
                       getTypeConfig(linkToEdit) :
                       getType(linkType);
+
+                    if (gnCurrentEdit.mdOtherLanguages) {
+                       scope.mdOtherLanguages = gnCurrentEdit.mdOtherLanguages;
+                       scope.mdLangs = JSON.parse(scope.mdOtherLanguages);
+
+                       // not multilingual {"fre":"#"}
+                       if (Object.keys(scope.mdLangs).length > 1) {
+                         scope.isMdMultilingual = true;
+                         scope.mdLang = gnCurrentEdit.mdLanguage;
+
+                         for (var p in scope.mdLangs) {
+                           var v = scope.mdLangs[p];
+                           if (v.indexOf('#') === 0) {
+                             var l = v.substr(1);
+                             if (!l) {
+                               l = scope.mdLang;
+                             }
+                             scope.mdLangs[p] = l;
+                           }
+                         }
+                       } else {
+                         scope.isMdMultilingual = false;
+                       }
+                    }
+
                     scope.config.multilingualFields = [];
                     angular.forEach(typeConfig.fields, function(f, k) {
                     if (scope.isMdMultilingual &&
@@ -562,29 +587,7 @@
                       }
                     });
 
-                    if (gnCurrentEdit.mdOtherLanguages) {
-                      scope.mdOtherLanguages = gnCurrentEdit.mdOtherLanguages;
-                      scope.mdLangs = JSON.parse(scope.mdOtherLanguages);
 
-                      // not multilingual {"fre":"#"}
-                      if (Object.keys(scope.mdLangs).length > 1) {
-                        scope.isMdMultilingual = true;
-                        scope.mdLang = gnCurrentEdit.mdLanguage;
-
-                        for (var p in scope.mdLangs) {
-                          var v = scope.mdLangs[p];
-                          if (v.indexOf('#') === 0) {
-                            var l = v.substr(1);
-                            if (!l) {
-                              l = scope.mdLang;
-                            }
-                            scope.mdLangs[p] = l;
-                          }
-                        }
-                      } else {
-                        scope.isMdMultilingual = false;
-                      }
-                    }
 
                     initThumbnailMaker();
                     resetForm();
@@ -634,9 +637,13 @@
                         if (scope.isFieldMultilingual(field)) {
                           var e = {};
                           $.each(scope.mdLangs, function(key, v) {
-                            e[v] =
-                              (linkToEdit[fields[field]] &&
-                                linkToEdit[fields[field]][key]) || '';
+                          e[v] = ''; // default
+                          // if key is in the values dictionary
+                          if (linkToEdit[fields[field]] && linkToEdit[fields[field]][key])
+                              e[v] = linkToEdit[fields[field]][key];
+                          // otherwise if v is in values dictionary
+                          else if (linkToEdit[fields[field]] && linkToEdit[fields[field]][v])
+                               e[v] = linkToEdit[fields[field]][v];
                           });
                           fields[field] = e;
                         }


### PR DESCRIPTION
This is fixes two problems;

a) when you first open the online resources edit, the values for title/description are NOT shown on the UI (when open it a second time, they are there).
    * cause: scope.isMdMultilingual  was being used before set -- i just changed the order of the code

b) when you edit multilingual online resources, the UI doesn't show existing alternatives.
    * cause: linkToEdit[fields[field]][key] -- this should have been v
    * for example, this would be ger: DE (key = 'ger', v='DE').  The field has values using "DE" and "EN", etc... (not ger/eng).  I made it so it would handle both.