### PR TITLE
Display only the first help icon in a multilingual field in the Editor

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -364,6 +364,22 @@
         padding-right: 0;
       }
     }
+    // multilingual
+    .gn-multilingual-field {
+      .form-control {
+        margin-bottom: 5px;
+      }
+    }
+    // ----- only show first help icon
+    [data-gn-multilingual-field] + .gn-control {
+      // > .field-tooltip {
+      //   // display: none;
+      //   background-color: red;
+      // }
+      > .field-tooltip ~ .field-tooltip {
+        display: none;
+      }
+    }
   }
   // sidebar in the editor
   .gn-editor-tools-container {


### PR DESCRIPTION
When you choose to display the help in the `Editor` as icons, GeoNetwork displays all the help icons for all multilingual fields in the `Editor`. All these help icons and help texts are the same. This PR displays only the first of all these help icon.

**Before**
![gn-tooltips-before](https://user-images.githubusercontent.com/19608667/83139005-f5cf8c80-a0eb-11ea-82c0-987ede5e11f8.png)

**After**
![gn-tooltips-after](https://user-images.githubusercontent.com/19608667/83139019-fe27c780-a0eb-11ea-9576-0ce5809e083a.png)
