### PR TITLE
Fix indexing errors with multiple titles in Dublin Core

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/default.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/default.xsl
@@ -54,7 +54,9 @@
       <Field name="_docLocale" string="{$langCode}" store="true" index="true"/>
 
       <!-- For multilingual docs it is good to have a title in the default locale.  In this type of metadata we don't have one but in the general case we do so we need to add it to all -->
-      <Field name="_defaultTitle" string="{string(/simpledc/dc:title)}" store="true" index="true"/>
+      <xsl:if test="count(/simpledc/dc:title) > 0">
+        <Field name="_defaultTitle" string="{/simpledc/dc:title[string(.)][1]}" store="true" index="true"/>
+      </xsl:if>
 
       <xsl:for-each select="/simpledc/dc:language">
         <Field name="mdLanguage" string="{string(.)}" store="true" index="true"/>


### PR DESCRIPTION
Fix error in dublin core indexing when a metadata document has more than
one `dc:title`.

```xml
Error on line 57 of default.xsl:
  XPTY0004: A sequence of more than one item is not allowed as the first argument of
  string() (<dc:title/>, <dc:title/>)
```