### PR TITLE
Fix for displaying icons for Online Resources

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -334,7 +334,7 @@
               action: openLink
             },
             'DEFAULT' : {
-              iconClass: 'fa-fw',
+              iconClass: 'fa-question-circle',
               label: 'openPage',
               action: openLink
             }

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -21,7 +21,7 @@
         </strong>
         <strong data-ng-if="(mainType !== 'WMS') && (mainType !== 'WMSSERVICE') && (mainType !== 'WMTS') &&
                             (mainType !== 'WMTSSERVICE') && (mainType !== 'WFS') && (mainType !== 'WCS')">
-          <i class="fa fa-question-circle"
+          <i class="fa"
              data-ng-class="config.getClassIcon(mainType)"/>&nbsp;
         </strong>
       </div>


### PR DESCRIPTION
The online resources in the metadata window have a fallback that shows a question mark for unknown types. However this icon was shown too often and overriding other icons when the type was known (e.g. downloads). This PR changes the way the fallback is used a little and prevents the override of known types.

**Before**
![gn-icon-before](https://user-images.githubusercontent.com/19608667/83751173-b8787b00-a666-11ea-95fe-cb8aa0cdc8ee.png)

**After**
![gn-icon-after](https://user-images.githubusercontent.com/19608667/83751190-bd3d2f00-a666-11ea-8c86-80d9ec525561.png)
