### PR TITLE
allow multiple freekeyword sections

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -92,6 +92,11 @@
                }
              }
 
+             //if true, pressing the "add new keywords" button will always
+             //create a new section.  Otherwise, its will do the standard behaviour;
+             // a) if there isn't a freekeyword section, create it
+             // b) if there is a freekeyword section, just add another keyword to it
+             scope.alwaysCreateNewFreekeywordSection = (attrs.alwaysCreateNewFreekeywordSection == 'true');
 
              scope.allowFreeTextKeywords =
              (attrs.allowFreeTextKeywords === undefined) ||
@@ -115,12 +120,24 @@
              });
 
              scope.add = function() {
-               return gnEditor.add(gnCurrentEdit.id,
-                   scope.freekeywordElementRef || scope.elementRef,
-                 scope.freekeywordElementName || scope.elementName,
-                        scope.domId, 'before').then(function() {
-                 gnEditor.save(gnCurrentEdit.id, true);
-               });
+                 var metadataId =gnCurrentEdit.id;
+
+                 //if there is a freekeywordElementRef, then we're just adding a keyword (otherwise, whole section)
+                 var ref = scope.freekeywordElementRef || scope.elementRef;
+                 var name = scope.freekeywordElementName || scope.elementName;
+
+                 //override to always create a new freekeyword section
+                 if (scope.alwaysCreateNewFreekeywordSection) {
+                    ref = scope.elementRef;
+                    name = scope.elementName;
+                 }
+
+                 var insertRef = scope.domId;
+                 var position = 'before';
+                 return gnEditor.add(metadataId,ref,name,insertRef,position)
+                      .then(function() {
+                          gnEditor.save(gnCurrentEdit.id, true);
+                       });
              };
 
              scope.addThesaurus = function(thesaurusIdentifier) {


### PR DESCRIPTION
This allows multiple free keyword sections.  This is necessary if you want to have keywords of different types (currently not possible).

![image](https://user-images.githubusercontent.com/48937730/83790051-72aeb900-a64c-11ea-9551-7c8bc7613236.png)

You can see I've added a keyword ("a") with "Place" type.

However, if I press the "+ Add new keywords" button, it just adds a new "Place" keyword.  I cannot add other types of freetext keywords (i.e. Temporal, etc...).
This seems to be by design.

This PR allow you to add a 
data-always-create-new-freekeyword-section="true"
tag to the element.  Then, when you press the "+ Add new keywords", it will always create a new sections.

Pressing the button (no text, tooltip "keyword", immediately under the keyword) will add a slot to type in another keyword.
 

End result;
![image](https://user-images.githubusercontent.com/48937730/83790460-16986480-a64d-11ea-8dd5-58c49ae04a08.png)

