### PR TITLE
Fixed bug with history link to the metadata.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -66,6 +66,7 @@ import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
 import org.fao.geonet.kernel.datamanager.IMetadataStatus;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.metadata.StatusActions;
 import org.fao.geonet.kernel.metadata.StatusActionsFactory;
 import org.fao.geonet.kernel.search.LuceneSearcher;
@@ -136,6 +137,9 @@ public class MetadataWorkflowApi {
 
     @Autowired
     StatusActionsFactory statusActionFactory;
+
+    @Autowired
+    IMetadataUtils metadataUtils;
 
     @ApiOperation(value = "Get record status history", notes = "", nickname = "getRecordStatusHistory")
     @RequestMapping(value = "/{metadataUuid}/status", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
@@ -477,8 +481,8 @@ public class MetadataWorkflowApi {
             String uuid = uuids.get(s.getId().getMetadataId());
             if (uuid == null) {
                 try {
-                    // Collect metadata uuid. For now we use Lucene
-                    uuid = LuceneSearcher.getMetadataFromIndexById(language, s.getId().getMetadataId() + "", "_uuid");
+                    // Collect metadata uuid.
+                    uuid=metadataUtils.getMetadataUuid(Integer.toString(s.getId().getMetadataId()));
                     uuids.put(s.getId().getMetadataId(), uuid);
                 } catch (Exception e1) {
                 }

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -439,6 +439,7 @@ public class MetadataWorkflowApi {
         }
 
         Map<Integer, String> titles = new HashMap<>();
+        Map<Integer, String> uuids = new HashMap<>();
 
         // Add all user info and record title to response
         for (MetadataStatus s : listOfStatus) {
@@ -472,6 +473,17 @@ public class MetadataWorkflowApi {
                 }
             }
             status.setTitle(title);
+
+            String uuid = uuids.get(s.getId().getMetadataId());
+            if (uuid == null) {
+                try {
+                    // Collect metadata uuid. For now we use Lucene
+                    uuid = LuceneSearcher.getMetadataFromIndexById(language, s.getId().getMetadataId() + "", "_uuid");
+                    uuids.put(s.getId().getMetadataId(), uuid);
+                } catch (Exception e1) {
+                }
+            }
+            status.setUuid(uuid);
 
             response.add(status);
         }

--- a/services/src/main/java/org/fao/geonet/api/records/model/MetadataStatusResponse.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/MetadataStatusResponse.java
@@ -41,6 +41,7 @@ public class MetadataStatusResponse extends MetadataStatus {
     String ownerProfile;
 
     String title;
+    String uuid;
     String currentStatus;
     String previousStatus;
 
@@ -150,8 +151,17 @@ public class MetadataStatusResponse extends MetadataStatus {
         return title;
     }
 
+    public String getUuid() {
+        return uuid;
+    }
+
     public MetadataStatusResponse setTitle(String title) {
         this.title = title;
+        return this;
+    }
+
+    public MetadataStatusResponse setUuid(String uuid) {
+        this.uuid = uuid;
         return this;
     }
 

--- a/web-ui/src/main/resources/catalog/components/history/partials/historyStep.html
+++ b/web-ui/src/main/resources/catalog/components/history/partials/historyStep.html
@@ -19,7 +19,7 @@
          title="{{'removeHistoryStep' | translate}}">
         <i class="fa fa-times text-danger"/>
       </a>
-      <a data-ng-href="catalog.search#/metadata/{{h.id.metadataId}}"
+      <a data-ng-href="catalog.search#/metadata/{{h.uuid}}"
          data-ng-hide="noTitle"><i>{{h.title}}</i></a>
       <br data-ng-hide="noTitle"/>
       <strong>


### PR DESCRIPTION
Fixed bug with where the history link to the metadata was not working because it was linking using the id instead of the uuid

This fix also add metadata uuid to the status api results.

This is the link that was not working.
![image](https://user-images.githubusercontent.com/1868233/83815459-a1518180-a696-11ea-919f-069fd85416df.png)
