### PR TITLE
Improved way of declaring the `isUserFeedbackEnabled` variable

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -112,8 +112,8 @@
     }]);
 
   module.directive('gnMetadataRate', [
-    '$http', 'gnConfig',
-    function($http, gnConfig) {
+    '$http', 'gnConfig', 'gnConfigService',
+    function($http, gnConfig, gnConfigService) {
       return {
         templateUrl: '../../catalog/components/search/mdview/partials/' +
             'rate.html',
@@ -125,15 +125,17 @@
 
         link: function(scope, element, attrs, controller) {
           scope.isRatingEnabled = false;
-
-          var statusSystemRating =
-            gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
-          if (statusSystemRating == 'advanced') {
-            scope.isUserFeedbackEnabled = true;
-          }
-          if (statusSystemRating == 'basic') {
-            scope.isRatingEnabled = true;
-          }
+          
+          gnConfigService.load().then(function(c) {
+            var statusSystemRating =
+              gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
+            if (statusSystemRating == 'advanced') {
+              scope.isUserFeedbackEnabled = true;
+            }
+            if (statusSystemRating == 'basic') {
+              scope.isRatingEnabled = true;
+            }
+          });
 
           scope.$watch('md', function() {
             scope.rate = scope.md ? scope.md.rating : null;

--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnmdFeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnmdFeedbackDirective.js
@@ -32,8 +32,8 @@
   module
       .directive(
           'gnMdFeedback', [
-            '$http', 'gnConfig', 'vcRecaptchaService', '$translate',
-          function($http, gnConfig, vcRecaptchaService, $translate) {
+            '$http', 'gnConfig', 'vcRecaptchaService', '$translate', 'gnConfigService',
+          function($http, gnConfig, vcRecaptchaService, $translate, gnConfigService) {
             return {
               restrict: 'A',
               replace: true,
@@ -46,10 +46,15 @@
 
                 scope.showLabel = attrs.showLabel;
 
-                var statusSystemRating = gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
-                if (statusSystemRating == 'advanced') {
-                  scope.isUserFeedbackEnabled = true;
-                }
+                scope.isUserFeedbackEnabled = false;
+
+                gnConfigService.load().then(function(c) {
+                  var statusSystemRating =
+                    gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
+                  if (statusSystemRating == 'advanced') {
+                    scope.isUserFeedbackEnabled = true;
+                  }
+                });
 
                 scope.recaptchaEnabled =
                   gnConfig['system.userSelfRegistration.recaptcha.enable'];

--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -54,8 +54,9 @@
     'gnGlobalSettings',
     'gnConfig',
     'orderByFilter',
+    'gnConfigService',
     function($scope, $q, $http, suggestService, gnAlertService,
-             gnSearchSettings, gnGlobalSettings, gnConfig, orderByFilter) {
+             gnSearchSettings, gnGlobalSettings, gnConfig, orderByFilter, gnConfigService) {
 
       /** Object to be shared through directives and controllers */
       $scope.searchObj = {
@@ -68,10 +69,13 @@
 
       $scope.isUserFeedbackEnabled = false;
 
-      var statusSystemRating = gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
-      if (statusSystemRating == 'advanced') {
-        $scope.isUserFeedbackEnabled = true;
-      }
+      gnConfigService.load().then(function(c) {
+        var statusSystemRating =
+          gnConfig[gnConfig.key.isRatingUserFeedbackEnabled];
+        if (statusSystemRating == 'advanced') {
+          $scope.isUserFeedbackEnabled = true;
+        }
+      });
 
       $scope.isUserSearchesEnabled = gnGlobalSettings.gnCfg.mods.search.usersearches.enabled;
       $scope.displayFeaturedSearchesPanel =


### PR DESCRIPTION
The `isUserFeedbackEnabled` variable is used to trigger the showing of comments (for instance on the homepage). The variable stayed `undefined` and therefore the 'Comments' were not shown and clickable on the homepage.

It seemed the response wasn't received in time, this PR uses `gnConfigService` to solve this.

**The `comments` section on the homepage**
![gn-comments](https://user-images.githubusercontent.com/19608667/84392014-0dce0280-abfa-11ea-8751-d0c47c1d7e3f.png)
