### PR TITLE
Portal page improvement

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/Group.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Group.java
@@ -201,7 +201,7 @@ public class Group extends Localized implements Serializable {
     @ElementCollection(fetch = FetchType.LAZY, targetClass = String.class)
     @CollectionTable(joinColumns = @JoinColumn(name = "idDes"), name = "GroupsDes")
     @MapKeyColumn(name = "langId", length = 5)
-    @Column(name = "label", nullable = false, length = 96)
+    @Column(name = "label", nullable = false, length = 255)
     public Map<String, String> getLabelTranslations() {
         return super.getLabelTranslations();
     }

--- a/domain/src/main/java/org/fao/geonet/domain/Localized.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Localized.java
@@ -48,7 +48,7 @@ import java.util.Map;
  * @ElementCollection(fetch = FetchType.LAZY, targetClass = String.class)
  * @CollectionTable(joinColumns = @JoinColumn(name = "iddes"), name = "groupsdes")
  * @MapKeyColumn(name = "langid", length = 5)
- * @Column(name = "label", nullable = false, length = 96)
+ * @Column(name = "label", nullable = false, length = 255)
  * public Map<String, String> getLabelTranslations() {
  * return super.getLabelTranslations();
  * }

--- a/domain/src/main/java/org/fao/geonet/domain/Schematron.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Schematron.java
@@ -135,7 +135,7 @@ public class Schematron extends Localized {
     @ElementCollection(fetch = FetchType.LAZY, targetClass = String.class)
     @CollectionTable(joinColumns = @JoinColumn(name = "idDes"), name = "SchematronDes")
     @MapKeyColumn(name = "langId", length = 5)
-    @Column(name = "label", nullable = false, length = 96)
+    @Column(name = "label", nullable = false, length = 255)
     public Map<String, String> getLabelTranslations() {
         return super.getLabelTranslations();
     }

--- a/domain/src/main/java/org/fao/geonet/domain/Source.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Source.java
@@ -147,7 +147,7 @@ public class Source extends Localized {
     @ElementCollection(fetch = FetchType.LAZY, targetClass = String.class)
     @CollectionTable(joinColumns = @JoinColumn(name = "idDes"), name = "SourcesDes")
     @MapKeyColumn(name = "langId", length = 5)
-    @Column(name = "label", nullable = false, length = 96)
+    @Column(name = "label", nullable = false, length = 255)
     public Map<String, String> getLabelTranslations() {
         return super.getLabelTranslations();
     }

--- a/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
@@ -29,8 +29,6 @@ import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.GeonetEntity;
 import org.fao.geonet.domain.Language;
 import org.fao.geonet.domain.Source;
@@ -40,7 +38,6 @@ import org.fao.geonet.repository.LanguageRepository;
 import org.fao.geonet.repository.SortUtils;
 import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.resources.Resources;
-import org.fao.geonet.utils.Log;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -50,7 +47,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -59,7 +55,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -136,7 +131,7 @@ public class SourcesApi {
         sources.stream().map(GeonetEntity::asXml).forEach(sourcesList::addContent);
         response.setContentType(MediaType.TEXT_HTML_VALUE);
         response.getWriter().write(
-            new XsltResponseWriter()
+            new XsltResponseWriter("portal")
                 .withJson("catalog/locales/en-core.json")
                 .withJson("catalog/locales/en-search.json")
                 .withXml(sourcesList)

--- a/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java
@@ -109,7 +109,7 @@ public class SearchApi {
             response.getWriter().write(Xml.getJSON(results));
         } else {
             response.getWriter().write(
-                new XsltResponseWriter()
+                new XsltResponseWriter("search")
                     .withJson("catalog/locales/en-core.json")
                     .withJson("catalog/locales/en-search.json")
                     .withXml(results)

--- a/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
@@ -46,7 +46,7 @@ import java.util.Map;
 public class XsltResponseWriter {
     public static final String TRANSLATIONS = "translations";
     Element xml;
-    public XsltResponseWriter() {
+    public XsltResponseWriter(String serviceName) {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
         String url = settingManager.getBaseURL();
         Element gui = new Element("gui");
@@ -63,7 +63,7 @@ public class XsltResponseWriter {
         Element settings = settingManager.getAllAsXML(true);
         settings.setName("systemConfig");
         gui.addContent(settings);
-        gui.addContent(new Element("reqService").setText("search"));
+        gui.addContent(new Element("reqService").setText(serviceName));
 
         Element translations = new Element(TRANSLATIONS);
 

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -38,7 +38,8 @@
            data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
           <span class="gn-name"
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
-                title="{{info['system/site/name']}}">{{info['node/name'] || info['system/site/name']}}</span>
+                title="{{info['node/name'] || info['system/site/name']}}">
+            {{info['node/name'].split('|')[0] || info['system/site/name']}}</span>
         </a>
       </li>
       <li class="gn-menuitem-xs" data-ng-if="gnCfg.mods.search.enabled">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -18,12 +18,12 @@ html, body {
 }
 
 // background image and color
-[ng-app^="gn_search_"] body, [ng-app="gn_login"] body {
+[ng-app^="gn_search_"] body, [ng-app="gn_login"] body, .gn-background {
   background-color: @gn-background-color;
   background-position: center top;
   background-size: cover;
   background-repeat: no-repeat;
-  background-attachment: fixed;
+  //background-attachment: fixed;
   &.gn-header-fixed {
     padding-top: @gn-menubar-height;
     &.gn-logo-in-header {
@@ -44,6 +44,9 @@ html, body {
 // if the background image is an empty string it will be substitued with the name of the css file,
 // see: https://stackoverflow.com/questions/20727262/css-file-considered-as-being-an-image-resource
 [ng-app^="gn_search_"] body when (isstring(@gn-background-image)) {
+  background-image: url(@gn-background-image);
+}
+.gn-background when (isstring(@gn-background-image)) {
   background-image: url(@gn-background-image);
 }
 [ng-app^="gn_login"] body when (isstring(@gn-background-image)) {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_portal_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_portal_default.less
@@ -1,0 +1,39 @@
+@import "../../../style/gn_search.less";
+@import "gn_layout_default.less";
+@import "gn_navbar_default.less";
+@import "gn_footer_default.less";
+@import "gn_infolist_default.less";
+@import "gn_variables_default.less"; // must be last
+
+
+div.gn-full > div.container {
+  width: 100%;
+  padding: 0px;
+  background-color: #9e9e9e;
+
+  .gn-background {
+    padding-top: 20px;
+    padding-bottom: 20px;
+    h1, h2 {
+      //color: white;
+    }
+    h1 {
+      font-weight: bold;
+    }
+  }
+  .title {
+    color: white;
+    h1 {
+      font-size: 20px;
+      font-weight: bold;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      margin-top: 0px;
+      margin-bottom: 0px;
+    }
+    p {
+      display: block;
+    }
+  }
+}

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
@@ -1,3 +1,8 @@
+
+ALTER TABLE groupsdes ALTER COLUMN label TYPE varchar(255);
+ALTER TABLE sourcesdes ALTER COLUMN label TYPE varchar(255);
+ALTER TABLE schematrondes ALTER COLUMN label TYPE varchar(255);
+
 UPDATE Settings SET value='3.11.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 
@@ -6,4 +11,3 @@ ALTER TABLE Validation ALTER COLUMN valType TYPE varchar(128);
 
 -- New setting for server timezone
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');
-

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -67,7 +67,7 @@
 
   <xsl:variable name="shibbolethOn"
                 select="util:existsBean('shibbolethConfiguration')"/>
-                
+
   <xsl:variable name="shibbolethHideLogin"
                 select="util:shibbolethHideLogin()"/>
 
@@ -87,6 +87,7 @@
       or $service = 'search'
       or $service = 'md.format.html') then 'gn_search'
     else if ($service = 'display') then 'gn_formatter_viewer'
+    else if ($service = 'portal') then 'gn_portal'
     else 'gn'"/>
 
   <xsl:variable name="customFilename" select="concat($angularApp, '_', $searchView)"></xsl:variable>

--- a/web/src/main/webapp/xslt/ui-search/portal-list.xsl
+++ b/web/src/main/webapp/xslt/ui-search/portal-list.xsl
@@ -23,13 +23,16 @@
   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0" xmlns:xls="http://www.w3.org/1999/XSL/Transform"
+                version="2.0"
                 exclude-result-prefixes="#all">
   <xsl:import href="../base-layout-nojs.xsl"/>
   <xsl:import href="../common/functions-core.xsl"/>
 
   <xsl:template mode="content" match="/">
-    <div class="row gn-portal"
+
+    <xsl:variable name="infoSeparator" select="'|'"/>
+
+    <div class="row gn-portal gn-row-main"
          id="{/root/gui/systemConfig/system/site/siteId}"
          itemscope="itemscope"
          itemtype="http://schema.org/DataCatalog">
@@ -40,7 +43,7 @@
       </span>
       <meta itemprop="url" content="{$nodeUrl}search"></meta>
 
-      <div class="col-md-6">
+      <div class="container-fluid gn-background">
         <div style="text-align:center;">
           <div class="gn-md-thumbnail">
             <a href="{$nodeUrl}">
@@ -59,40 +62,53 @@
           </a>
         </div>
       </div>
-      <div class="col-md-6">
-        <br/>
-        <!--<div class="well">
-          <br/>
-        </div>-->
-      </div>
     </div>
     <div class="gn-info-list-blocks">
-        <ul class="row gn-info-list">
-          <xsl:for-each select=".//sources/record[type = 'subportal']">
-            <xsl:sort select="label/*[name() = $lang]"/>
-            <li>
+      <ul class="row gn-info-list">
+        <xsl:for-each select=".//sources/record[type = 'subportal']">
+          <xsl:sort select="label/*[name() = $lang]"/>
+          <li>
+            <xsl:variable name="portalInfo"
+                          select="if (label/*[name() = $lang] != '')
+                                              then label/*[name() = $lang]
+                                              else name"/>
+            <xsl:variable name="portalTitle"
+                          select="if (contains($portalInfo, $infoSeparator))
+                                  then substring-before($portalInfo, $infoSeparator)
+                                  else $portalInfo"/>
+            <xsl:variable name="portalDescription"
+                          select="if (contains($portalInfo, $infoSeparator))
+                                  then substring-after($portalInfo, $infoSeparator)
+                                  else ''"/>
+            <a href="../../{uuid}"
+               title="{$portalInfo}">
               <section class="resultcard clearfix hasThumbnail hasThumbnail">
                 <div class="title">
-                  <a href="../../{uuid}">
-                    <h4><xsl:value-of select="if (label/*[name() = $lang] != '') then label/*[name() = $lang] else name"/></h4>
-                  </a>
+                  <h1>
+                    <xsl:value-of select="$portalTitle"/>
+                  </h1>
+                  <p>
+                    <xsl:value-of select="$portalDescription"/>
+                  </p>
                 </div>
                 <div class="gn-md-thumbnail">
                   <a href="../../{uuid}">
                     <div class="gn-img-thumbnail"
-                         style="background-image: url(../../images/harvesting/{if (logo != '') then logo else 'blank.png'})"><br/></div>
+                         style="background-image: url(../../images/harvesting/{if (logo != '') then logo else 'blank.png'})">
+                      <br/>
+                    </div>
                   </a>
                 </div>
                 <div class="content">
                   <div class="abstract">
                   </div>
-                  <div class="introduction"> </div>
                 </div>
               </section>
-            </li>
-          </xsl:for-each>
-        </ul>
-        <br/>
+            </a>
+          </li>
+        </xsl:for-each>
+      </ul>
+      <br/>
     </div>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
* Add specific style so it is easier to customize
* Use the background image if set in CSS style config

![image](https://user-images.githubusercontent.com/1701393/84491504-f39d2e80-aca4-11ea-8883-0817d4e580dd.png)


* Portal / Title / Add tooltip on long portal name
* Portal / Add optional description. One line to describe the portal in the portal page, document page title and top toolbar tooltip
* Portal name can be translated using "{title}|{description}"

![image](https://user-images.githubusercontent.com/1701393/84491594-10396680-aca5-11ea-9cc3-a9cf087a92ca.png)


* Fix tooltip on top tool bar
![image](https://user-images.githubusercontent.com/1701393/84491544-00218700-aca5-11ea-8a23-77df1a39db6f.png)

* Also increase the size of the label of groups, sources and schematron to 255 (like other localized tables)