### PR TITLE
Update multiselect directive to support readonly mode. User management page uses this directive for group/profiles, but should not allow to change that information to non admin users.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/multiselect/MultiselectDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/multiselect/MultiselectDirective.js
@@ -43,13 +43,16 @@
         restrict: 'A',
         scope: {
           'selected': '=gnMultiselect',
-          'choices': '='
+          'choices': '=',
+          'readonlyMode': '='
         },
         templateUrl: '../../catalog/components/common/multiselect/partials/' +
             'multiselect.html',
         link: function(scope, element, attrs) {
 
           var sortOnSelection = true;
+
+          scope.readonlyMode = scope.readonlyMode || false;
 
           //
           scope.currentSelectionLeft = [];

--- a/web-ui/src/main/resources/catalog/components/common/multiselect/partials/multiselect.html
+++ b/web-ui/src/main/resources/catalog/components/common/multiselect/partials/multiselect.html
@@ -2,9 +2,11 @@
   <div class="col-md-5">
     <label data-translate="" class="text-capitalize">unselected</label>
     <input class="form-control"
+           data-ng-disabled="readonlyMode"
            data-ng-model="optionsSearch.$"
            placeholder="{{'filter' | translate}}"/>
     <select multiple=""
+            data-ng-disabled="readonlyMode"
             class="form-control"
             data-ng-model="currentSelectionLeft">
       <option data-ng-repeat="e in options | filter:optionsSearch | orderBy:'langlabel'"
@@ -16,17 +18,21 @@
   <div class="col-md-1">
     <br/>
     <div class="btn-group-vertical">
-      <button class="btn btn-default fa fa-angle-right" data-ng-click="select()"/>
-      <button class="btn btn-default fa fa-angle-left" data-ng-click="unselect()"/>
+      <button class="btn btn-default fa fa-angle-right" data-ng-click="select()"
+              data-ng-disabled="readonlyMode"/>
+      <button class="btn btn-default fa fa-angle-left" data-ng-click="unselect()"
+              data-ng-disabled="readonlyMode"/>
     </div>
   </div>
   <div class="col-md-5">
     <label data-translate="" class="text-capitalize">selected</label>
     <input class="form-control"
+           data-ng-disabled="readonlyMode"
            data-ng-model="selectedSearch.$"
            placeholder="{{'filter' | translate}}"/>
     <select multiple=""
             class="form-control"
+            data-ng-disabled="readonlyMode"
             data-ng-model="currentSelectionRight">
       <option data-ng-repeat="e in selected | filter:selectedSearch | orderBy:'langlabel'"
               value="{{e.id}}"

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -231,7 +231,32 @@
             </fieldset>
 
 
-            <fieldset>
+            <fieldset data-ng-if="!user.isUserAdminOrMore()">
+              <legend data-translate="profile"></legend>
+
+              <div data-ng-if="groupsByProfile['RegisteredUser'].length > 0">
+                <h4 data-translate="">RegisteredUser</h4>
+                <ul>
+                  <li data-ng-repeat="g in groupsByProfile['RegisteredUser']">{{g.langlabel}}</li>
+                </ul>
+              </div>
+
+              <div data-ng-if="groupsByProfile['Editor'].length > 0">
+                <h4 data-translate="">Editor</h4>
+                <ul>
+                  <li data-ng-repeat="g in groupsByProfile['Editor']">{{g.langlabel}}</li>
+                </ul>
+              </div>
+
+              <div data-ng-if="groupsByProfile['Reviewer'].length > 0">
+                <h4 data-translate="">Reviewer</h4>
+                <ul>
+                  <li data-ng-repeat="g in groupsByProfile['Reviewer']">{{g.langlabel}}</li>
+                </ul>
+              </div>
+            </fieldset>
+
+            <fieldset data-ng-if="user.isUserAdminOrMore()">
               <legend data-translate="">defineUserGroupsPerProfile</legend>
               <input type="hidden" name="profile" data-ng-model="userSelected.profile"
                      value="{{userSelected.profile}}"/>
@@ -247,21 +272,18 @@
               <div
                 data-ng-show="userSelected.profile != 'Administrator'">
                 <h3 data-translate="">RegisteredUser</h3>
-                <div
+
                 <div data-gn-multiselect="groupsByProfile['RegisteredUser']"
-                     data-readonly-mode="!user.isUserAdminOrMore()"
                      data-choices="groups"></div>
 
 
                 <h3 data-translate="">Editor</h3>
                 <div data-gn-multiselect="groupsByProfile['Editor']"
-                     data-readonly-mode="!user.isUserAdminOrMore()"
                      data-choices="groups"></div>
 
 
                 <h3 data-translate="">Reviewer</h3>
                 <div data-gn-multiselect="groupsByProfile['Reviewer']"
-                     data-readonly-mode="!user.isUserAdminOrMore()"
                      data-choices="groups"></div>
 
                 <p class="help-block"
@@ -270,7 +292,6 @@
 
                 <h3 data-translate="">UserAdmin</h3>
                 <div data-gn-multiselect="groupsByProfile['UserAdmin']"
-                     data-readonly-mode="!user.isUserAdminOrMore()"
                      data-choices="groups"></div>
 
                 <p class="help-block"

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -247,20 +247,21 @@
               <div
                 data-ng-show="userSelected.profile != 'Administrator'">
                 <h3 data-translate="">RegisteredUser</h3>
+                <div
                 <div data-gn-multiselect="groupsByProfile['RegisteredUser']"
-                     data-ng-disabled="!user.isUserAdminOrMore()"
+                     data-readonly-mode="!user.isUserAdminOrMore()"
                      data-choices="groups"></div>
 
 
                 <h3 data-translate="">Editor</h3>
                 <div data-gn-multiselect="groupsByProfile['Editor']"
-                     data-ng-disabled="!user.isUserAdminOrMore()"
+                     data-readonly-mode="!user.isUserAdminOrMore()"
                      data-choices="groups"></div>
 
 
                 <h3 data-translate="">Reviewer</h3>
                 <div data-gn-multiselect="groupsByProfile['Reviewer']"
-                     data-ng-disabled="!user.isUserAdminOrMore()"
+                     data-readonly-mode="!user.isUserAdminOrMore()"
                      data-choices="groups"></div>
 
                 <p class="help-block"
@@ -269,7 +270,7 @@
 
                 <h3 data-translate="">UserAdmin</h3>
                 <div data-gn-multiselect="groupsByProfile['UserAdmin']"
-                     data-ng-disabled="!user.isUserAdminOrMore()"
+                     data-readonly-mode="!user.isUserAdminOrMore()"
                      data-choices="groups"></div>
 
                 <p class="help-block"


### PR DESCRIPTION
Test:

- Login with a user with profile Editor and access to the user info page from the login menu.
- User group/profile settings should be disabled:

![user-group-profile-disabled](https://user-images.githubusercontent.com/1695003/84491719-44148c00-aca5-11ea-9602-46a1451ff424.png)

Previously `data-ng-disabled` was used, but that only works for form fields, allowing the user remove permissions for himself.

- Login with user admin or administrator profiles, and select a user, group/profile settings should be enabled.
