### PR TITLE
Improve code to handle error responses in thesaurus upload via file or url

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -315,7 +315,9 @@
         } else {
           $rootScope.$broadcast('StatusUpdated', {
             title: $translate.instant('thesaurusUploadError'),
-            error: r.responseJSON || r.data,
+            error: r.responseJSON ||
+              $(r.responseText).find('description').text() ||
+              $(r.data).find('description').text() || r.data,
             timeout: 0,
             type: 'danger'});
 


### PR DESCRIPTION
Before the update:

![error-no-info](https://user-images.githubusercontent.com/1695003/84668916-7b44a080-af24-11ea-9c18-e3180b662b1d.png)

After the update:

![error-detailed](https://user-images.githubusercontent.com/1695003/84668923-7d0e6400-af24-11ea-8603-ed91a56f6be2.png)
