### PR TITLE
add multilingual titles to thesauri

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -705,8 +705,6 @@ public class Thesaurus {
     //  {
     //      "en": "English Version (en)",
     //      "fr": "French Version (fr)"
-    //      "eng": "English Version (en)",
-    //      "fre": "French Version (fr)"
     //  }
     private void retrieveMultiLingualTitles(Element thesaurusEl) {
         List<Namespace> theNSs = new ArrayList<Namespace>();
@@ -724,12 +722,8 @@ public class Thesaurus {
             for (Element el: multiLingualTitles) {
                     //use both forms of the lang name
                      String lang = isoLanguageMapper.iso639_2_to_iso639_1(el.getAttribute("lang", xmlNS).getValue());
-                     String lang2 = isoLanguageMapper.iso639_1_to_iso639_2(el.getAttribute("lang", xmlNS).getValue());
                      String title = el.getTextTrim();
                      multilingualTitles.put(lang,title);
-                     if (!multilingualTitles.containsKey(lang2)) { // don't overwrite if its already explicitly given
-                         multilingualTitles.put(lang2, title);
-                     }
             }
         } catch (Exception e) {
             Log.warning(Geonet.THESAURUS,"error extracting multilingual titles from thesaurus",e);

--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -727,7 +727,9 @@ public class Thesaurus {
                      String lang2 = isoLanguageMapper.iso639_1_to_iso639_2(el.getAttribute("lang", xmlNS).getValue());
                      String title = el.getTextTrim();
                      multilingualTitles.put(lang,title);
-                     multilingualTitles.put(lang2,title);
+                     if (!multilingualTitles.containsKey(lang2)) { // don't overwrite if its already explicitly given
+                         multilingualTitles.put(lang2, title);
+                     }
             }
         } catch (Exception e) {
             Log.warning(Geonet.THESAURUS,"error extracting multilingual titles from thesaurus",e);

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -431,9 +431,7 @@ public class ThesaurusManager implements ThesaurusFinder {
             //add multilingual titles in to response
             //      "multilingualTitles":     [
             //            { "lang": "fr","title": "ECCC Data Usage Scope FR"},
-            //            {"lang": "en","title": "ECCC Data Usage Scope EN"},
-            //            {"lang": "fre","title": "ECCC Data Usage Scope FR"},
-            //            {"lang": "eng","title": "ECCC Data Usage Scope EN"}
+            //            {"lang": "en","title": "ECCC Data Usage Scope EN"}
             //      ],
             Element elMultilingualTitles = new Element("multilingualTitles");
             for (Map.Entry<String, String> entry : currentTh.getMultilingualTitles().entrySet()) {

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -428,6 +428,26 @@ public class ThesaurusManager implements ThesaurusFinder {
             }
             elTitle.addContent(title);
 
+            //add multilingual titles in to response
+            //      "multilingualTitles":     [
+            //            { "lang": "fr","title": "ECCC Data Usage Scope FR"},
+            //            {"lang": "en","title": "ECCC Data Usage Scope EN"},
+            //            {"lang": "fre","title": "ECCC Data Usage Scope FR"},
+            //            {"lang": "eng","title": "ECCC Data Usage Scope EN"}
+            //      ],
+            Element elMultilingualTitles = new Element("multilingualTitles");
+            for (Map.Entry<String, String> entry : currentTh.getMultilingualTitles().entrySet()) {
+                Element elMultilingualTitle = new Element("multilingualTitle");
+                Element elMultilingualTitl_lang = new Element("lang");
+                elMultilingualTitl_lang.setText(entry.getKey());
+                Element elMultilingualTitle_title = new Element("title");
+                elMultilingualTitle_title.setText(entry.getValue());
+                elMultilingualTitle.addContent(elMultilingualTitl_lang);
+                elMultilingualTitle.addContent(elMultilingualTitle_title);
+
+                elMultilingualTitles.addContent(elMultilingualTitle);
+            }
+
             Element elType = new Element("type");
             String type = currentTh.getType();
             elType.addContent(type);
@@ -460,6 +480,7 @@ public class ThesaurusManager implements ThesaurusFinder {
             elLoop.addContent(elDname);
             elLoop.addContent(elFname);
             elLoop.addContent(elTitle);
+            elLoop.addContent(elMultilingualTitles);
             elLoop.addContent(elDate);
             elLoop.addContent(elUrl);
             elLoop.addContent(elDefaultURI);

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -28,8 +28,10 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -131,6 +133,26 @@ public class ApiUtils {
                 uuidOrInternalId));
         }
         return id;
+    }
+
+    //fixes the uri fragment portion (that the part after the "#")
+    // so it is properly encoded
+    //http://www.thesaurus.gc.ca/concept/#Offshore area        -->   http://www.thesaurus.gc.ca/concept/#Offshore%20area
+    //http://www.thesaurus.gc.ca/concept/#AIDS (disease)       -->   http://www.thesaurus.gc.ca/concept/#AIDS%20%28disease%29
+    //http://www.thesaurus.gc.ca/concept/#Alzheimer's disease  -->   http://www.thesaurus.gc.ca/concept/#Alzheimer%27s%20disease
+    //
+    //Includes some special case handling for spaces and ":"
+    //
+    //TODO: there could be other special handling for special cases in the future
+    public static String fixURIFragment(String uri) throws UnsupportedEncodingException {
+        String[] parts = uri.split("#");
+        if (parts.length >1) {
+            parts[parts.length - 1] = parts[parts.length - 1].replace("+", " ");
+            parts[parts.length - 1] = URLEncoder.encode(parts[parts.length - 1], "UTF-8");
+            parts[parts.length - 1] = parts[parts.length - 1].replace("+", "%20");
+            parts[parts.length - 1] = parts[parts.length - 1].replace("%3A", ":");
+        }
+        return String.join("#",parts);
     }
 
 

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -407,19 +407,24 @@ public class KeywordsApi {
 
             KeywordBean kb;
             String[] url;
-            if (!uri.contains(SEPARATOR))
-                url = new String[] {uri};
-            else
+            if (!uri.contains(SEPARATOR)) {
+                url = new String[]{uri};
+            }
+            else {
                 url = uri.split(SEPARATOR);
+            }
             List<KeywordBean> kbList = new ArrayList<>();
             for (String currentUri : url) {
                 kb = searcher.searchById(currentUri, sThesaurusName, iso3langCodes);
-                if (kb == null)
+                if (kb == null) {
                     kb = searcher.searchById(currentUri, sThesaurusName, langs);
-                if (kb == null)
-                    kb = searcher.searchById(fixUri(currentUri), sThesaurusName, iso3langCodes);
-                if (kb == null)
-                    kb = searcher.searchById(fixUri(currentUri), sThesaurusName, langs);
+                }
+                if (kb == null) {
+                    kb = searcher.searchById(ApiUtils.fixURIFragment(currentUri), sThesaurusName, iso3langCodes);
+                }
+                if (kb == null) {
+                    kb = searcher.searchById(ApiUtils.fixURIFragment(currentUri), sThesaurusName, langs);
+                }
                 if (kb != null) {
                     kbList.add(kb);
                 }
@@ -462,16 +467,6 @@ public class KeywordsApi {
         return transform;
     }
 
-    // fixes common problems in uri
-    private String fixUri(String uri) throws   UnsupportedEncodingException {
-        String[] parts = uri.split("#");
-        if (parts.length >1) {
-            parts[parts.length - 1] = URLEncoder.encode(parts[parts.length - 1], "UTF-8");
-            parts[parts.length - 1] = parts[parts.length - 1].replace("+", "%20");
-            parts[parts.length - 1] = parts[parts.length - 1].replace("%3A", ":");
-        }
-        return String.join("#",parts);
-    }
 
     /**
      * Gets the thesaurus.

--- a/services/src/test/java/org/fao/geonet/api/ApiUtilsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/ApiUtilsTest.java
@@ -1,0 +1,31 @@
+package org.fao.geonet.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ApiUtilsTest {
+
+    @Test
+    public void testFixURIFragment() throws Exception {
+        String result;
+
+        //http://www.thesaurus.gc.ca/concept/#Offshore area        -->   http://www.thesaurus.gc.ca/concept/#Offshore%20area
+        result = ApiUtils.fixURIFragment("http://www.thesaurus.gc.ca/concept/#Offshore area");
+        Assert.assertEquals("http://www.thesaurus.gc.ca/concept/#Offshore%20area",result);
+
+        //http://www.thesaurus.gc.ca/concept/#AIDS (disease)       -->   http://www.thesaurus.gc.ca/concept/#AIDS%20%28disease%29
+        result = ApiUtils.fixURIFragment("http://www.thesaurus.gc.ca/concept/#AIDS (disease)");
+        Assert.assertEquals("http://www.thesaurus.gc.ca/concept/#AIDS%20%28disease%29",result);
+
+        //http://www.thesaurus.gc.ca/concept/#Alzheimer's disease  -->   http://www.thesaurus.gc.ca/concept/#Alzheimer%27s%20disease
+        result = ApiUtils.fixURIFragment("http://www.thesaurus.gc.ca/concept/#Alzheimer's disease");
+        Assert.assertEquals("http://www.thesaurus.gc.ca/concept/#Alzheimer%27s%20disease",result);
+
+        result = ApiUtils.fixURIFragment("http://www.thesaurus.gc.ca/concept/#simple");
+        Assert.assertEquals("http://www.thesaurus.gc.ca/concept/#simple",result);
+
+        //special case for "+"
+        result = ApiUtils.fixURIFragment("http://www.thesaurus.gc.ca/concept/#simple+space");
+        Assert.assertEquals("http://www.thesaurus.gc.ca/concept/#simple%20space",result);
+    }
+}

--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/MultiEntryCombiner.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/MultiEntryCombiner.js
@@ -194,7 +194,7 @@
             scope.currentUILang = gnCurrentEdit.allLanguages.iso2code[gnLangs.detectLang(
                           gnGlobalSettings.gnCfg.langDetector,
                           gnGlobalSettings
-                        )].substring(1);
+                        )].replace("#","");
             scope.root_id = scope.config.root_id;
             scope.refs = scope.config.refs;
             scope.element = element;

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -272,10 +272,6 @@
              //iso19139:{"eng":"#EN","fre":"#FR","ger":"#DE","chi":"#ZH","ara":"#AR","spa":"#ES","rus":"#RU"}
              scope.langConversion=JSON.parse(scope.lang); //dictionary, as above
 
-             // ["eng","fra"]   OR ["EN","FR","DE","ZH","AR","ES", "RU"]
-             scope.langAchors = _.map(scope.langConversion,function(l){
-                   return l.replace("#","");
-             });
              // ["eng","fre"]   OR ["eng","fre","ger","chi","ara","spa", "rus"]
              scope.baseLangs = _.keys(scope.langConversion);
 

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -266,11 +266,21 @@
              scope.transformations.split(',') : [scope.transformations];
              scope.maxTagsLabel = scope.maxTags || '∞';
 
-             //Get langs of metadata
-             var langs = [];
-             _.each(JSON.parse(scope.lang),function(l){
-                  langs.push(l.replace("#",""));
+
+             //examples;
+             //hnap:{"eng":"#eng","fre":"#fra"}
+             //iso19139:{"eng":"#EN","fre":"#FR","ger":"#DE","chi":"#ZH","ara":"#AR","spa":"#ES","rus":"#RU"}
+             scope.langConversion=JSON.parse(scope.lang); //dictionary, as above
+
+             // ["eng","fra"]   OR ["EN","FR","DE","ZH","AR","ES", "RU"]
+             scope.langAchors = _.map(scope.langConversion,function(l){
+                   return l.replace("#","");
              });
+             // ["eng","fre"]   OR ["eng","fre","ger","chi","ara","spa", "rus"]
+             scope.baseLangs = _.keys(scope.langConversion);
+
+             //Get langs of metadata
+             var langs = scope.baseLangs;  // ["eng","fre"]   OR ["eng","fre","ger","chi","ara","spa", "rus"]
 
              scope.mainLang = langs[0];
              scope.langs = langs.join(',');
@@ -528,7 +538,7 @@
                gnThesaurusService
                 .getXML(scope.thesaurusKey,
                getKeywordIds(), scope.currentTransformation, scope.langs,
-                   scope.textgroupOnly).then(
+                   scope.textgroupOnly,scope.langConversion).then(
                function(data) {
                  scope.snippet = data;
                });

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -146,9 +146,12 @@
                  thesaurusIdentifier;
                } else {
                  gnCurrentEdit.working = true;
+                 var langs = _.map(Object.keys(gnCurrentEdit.allLanguages.code2iso),function(k){
+                          return k.replace("#","");
+                      }).join(',');
                  return gnThesaurusService
                   .getXML(thesaurusIdentifier, null,
-                 attrs.transformation).then(
+                 attrs.transformation,langs).then(
                  function(data) {
                    // Add the fragment to the form
                    scope.snippet = data;
@@ -265,9 +268,10 @@
 
              //Get langs of metadata
              var langs = [];
-             for (var p in JSON.parse(scope.lang)) {
-               langs.push(p);
-             }
+             _.each(JSON.parse(scope.lang),function(l){
+                  langs.push(l.replace("#",""));
+             });
+
              scope.mainLang = langs[0];
              scope.langs = langs.join(',');
 

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -280,7 +280,7 @@
                * eg. to-iso19139-keyword for default form.
                */
               getXML: function(thesaurus,
-                  keywordUris, transformation, lang, textgroupOnly) {
+                  keywordUris, transformation, lang, textgroupOnly,langConversion) {
                 // http://localhost:8080/geonetwork/srv/eng/
                 // xml.keyword.get?thesaurus=external.place.regions&id=&
                 // multiple=false&transformation=to-iso19139-keyword&
@@ -291,6 +291,9 @@
                       keywordUris.join(',') : keywordUris || '',
                   transformation: transformation || 'to-iso19139-keyword'
                 };
+                if (langConversion) {
+                  params.langMap = JSON.stringify(langConversion);
+                }
                 if (lang) {
                   params.lang = lang;
                 }


### PR DESCRIPTION
This adds multilingual titles capabilities for thesauri.

Add language-specific titles to the ConceptSchema at the top of your thesaurus;

```xml
<rdf:RDF ...>
  <skos:ConceptScheme rdf:about="http://www.thesaurus.gc.ca/#CoreSubjectThesaurus">
         <dc:title>Government of Canada Core Subject Thesaurus</dc:title>
         **<dc:title xml:lang="en">Government of Canada Core Subject Thesaurus</dc:title>
         <dc:title xml:lang="fr">Thésaurus des sujets de base du gouvernement du Canada</dc:title>**
   </skos:ConceptScheme>
```

You will see this added to the Thesaurus object;

```json
"multilingualTitles":     [
            {
        "lang": "fr",
        "title": "Thésaurus des sujets de base du gouvernement du Canada"
      },
            {
        "lang": "en",
        "title": "Government of Canada Core Subject Thesaurus"
      },
            {
        "lang": "fre",
        "title": "Thésaurus des sujets de base du gouvernement du Canada"
      },
            {
        "lang": "eng",
        "title": "Government of Canada Core Subject Thesaurus"
      }
    ]
```

See HNAP in metadata101 for more details/examples for use.

Also added an optional langMap parameter to the keywords api.
This is optional.
For iso139139, you don't have to do anything -- the thesaurus-tranformation.xsl will automatically convert `"eng"` to `"#EN"`.

For HNAP, there needs to be conversion.  input is `"fre"`, output should be `"#fra"`.  You can specify this in with this dictionary.
```json
{"eng":"#eng","fre":"#fra"}
```
