### PR TITLE
Home page / Add possibility to customize facets.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -110,23 +110,23 @@ goog.require('gn_alert');
           'showSocialBarInFooter': true,
           'fluidLayout': true,
           'facetConfig': {
-            'codelist_hierarchyLevel_text': {
-              'terms': {
-                'field': 'codelist_hierarchyLevel_text',
-                'size': 10
-              }
-            },
-            'topic': {
-              'terms': {
-                'field': 'topic_text',
-                'size': 20
-              }
-            },
             'inspireThemeUri': {
               'terms': {
                 'field': 'inspireThemeUri',
                 'size': 34
                 // "order" : { "_key" : "asc" }
+              }
+            },
+            'topic_text': {
+              'terms': {
+                'field': 'topic_text',
+                'size': 20
+              }
+            },
+            'codelist_hierarchyLevel_text': {
+              'terms': {
+                'field': 'codelist_hierarchyLevel_text',
+                'size': 10
               }
             }
           },
@@ -621,6 +621,7 @@ goog.require('gn_alert');
         var copy = angular.copy(defaultConfig);
         copy.mods.header.languages = {};
         copy.mods.search.grid.related = [];
+        copy.mods.home.facetConfig = {};
         copy.mods.search.facetConfig = {};
         copy.mods.search.scoreConfig = {};
         copy.mods.map["map-editor"].layers = [];
@@ -1047,7 +1048,19 @@ goog.require('gn_alert');
                     aggs: gnGlobalSettings.gnCfg.mods.home.facetConfig}).
               then(function(r) {
                 $scope.searchInfo = r.data;
-                $scope.browse = $scope.searchInfo.aggregations.inspireThemeUri ? 'inspire' : 'topics';
+                var keys = Object.keys(gnGlobalSettings.gnCfg.mods.home.facetConfig);
+                    selectedFacet = keys[0];
+                for (var i = 0; i < keys.length; i ++) {
+                  if ($scope.searchInfo.aggregations[keys[i]].buckets.length > 0) {
+                    selectedFacet = keys[i];
+                    break;
+                  }
+                }
+                $scope.homeFacet = {
+                  list: keys,
+                  key: selectedFacet,
+                  lastKey: keys[keys.length - 1]
+                };
               });
             }
           });

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -31,6 +31,8 @@
   "codelist_status_text": "Status",
   "resourceTemporalDateRange": "Resource temporal coverage",
   "facet-dateStamp": "Record update",
+  "facet-format": "Formats",
+  "facet-topic": "Topics",
   "facet-codelist_hierarchyLevel_text": "Type of resources",
   "facet-codelist_resourceScope_text": "Type of resources",
   "facet-codelist_spatialRepresentationType_text": "Spatial representation type",

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -33,6 +33,7 @@
   "facet-dateStamp": "Record update",
   "facet-format": "Formats",
   "facet-topic": "Topics",
+  "facet-inspireThemeUri": "INSPIRE themes",
   "facet-codelist_hierarchyLevel_text": "Type of resources",
   "facet-codelist_resourceScope_text": "Type of resources",
   "facet-codelist_spatialRepresentationType_text": "Spatial representation type",

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -81,13 +81,6 @@
         <h4>
           <span data-translate="">browseBy</span>
           <span>
-            <label data-ng-show="searchInfo.aggregations.inspireThemeUri
-                              && searchInfo.aggregations.inspireThemeUri.buckets.length > 0">
-              <input type="radio" name="homeFacet"
-                     data-ng-model="homeFacet.key"
-                     data-ng-value="k"/>
-              <span data-translate="">inspireThemes</span>&nbsp;
-            </label>
             <label data-ng-repeat="facetKey in homeFacet.list"
                    data-ng-init="agg = searchInfo.aggregations[facetKey]"
                    data-ng-show="agg.buckets.length > 0 && facetKey != homeFacet.lastKey">
@@ -99,7 +92,7 @@
           </span>
         </h4>
         <div class="row">
-          <span data-ng-show="homeFacet.key !== 'inspire'"
+          <span data-ng-show="homeFacet.key !== 'inspireThemeUri'"
                 data-ng-repeat="facet in searchInfo.aggregations[homeFacet.key].buckets"
                 class="col-xs-12 col-sm-6 col-md-4 chips-card">
             <div class="badge-result badge-result-topic clearfix">
@@ -123,7 +116,7 @@
           </span>
           <!-- TODOES Sort alpha -->
           <span data-ng-repeat="(key, facet) in searchInfo.aggregations.inspireThemeUri.buckets"
-                data-ng-show="homeFacet.key === 'inspire'"
+                data-ng-show="homeFacet.key === 'inspireThemeUri'"
                 data-ng-init="code = facet.key.slice(facet.key.lastIndexOf('/')+1)"
                 class="col-xs-12 col-sm-6 col-md-4 chips-card">
             <div class="badge-result badge-result-inspire clearfix">

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -74,35 +74,45 @@
   </div>
 
 
-
-  <div class="row gn-row-topics" data-ng-show="searchInfo.hits.total.value > 0 && searchInfo.aggregations">
+  <div class="row gn-row-topics"
+       data-ng-show="searchInfo.hits.total.value > 0 && searchInfo.aggregations">
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
-      <div class="col-sm-12 col-md-9" data-ng-show="browse !== ''">
+      <div class="col-sm-12 col-md-9" data-ng-show="homeFacet.list.length > 0">
         <h4>
           <span data-translate="">browseBy</span>
-          <span
-            data-ng-show="isInspireEnabled && searchInfo.aggregations.inspireThemeUri">
-            <label data-ng-show="searchInfo.aggregations.inspireThemeUri">
-              <input type="radio" name="browse" value="inspire" data-ng-model="browse"/>
-              <span data-translate="">inspireThemes</span>
+          <span>
+            <label data-ng-show="searchInfo.aggregations.inspireThemeUri
+                              && searchInfo.aggregations.inspireThemeUri.buckets.length > 0">
+              <input type="radio" name="homeFacet"
+                     data-ng-model="homeFacet.key"
+                     data-ng-value="k"/>
+              <span data-translate="">inspireThemes</span>&nbsp;
             </label>
-            <label data-ng-show="searchInfo.aggregations.topic">
-              <input type="radio" name="browse" value="topics" data-ng-model="browse"/>
-              <span data-translate="">topicCats</span>
+            <label data-ng-repeat="facetKey in homeFacet.list"
+                   data-ng-init="agg = searchInfo.aggregations[facetKey]"
+                   data-ng-show="agg.buckets.length > 0 && facetKey != homeFacet.lastKey">
+              <input type="radio" name="homeFacet"
+                     data-ng-model="homeFacet.key"
+                     data-ng-value="facetKey"/>
+              <span data-translate="">{{::('facet-' + facetKey) | translate}}</span>&nbsp;
             </label>
           </span>
         </h4>
         <div class="row">
-          <span data-ng-show="browse === 'topics'"
-                data-ng-repeat="(key, facet) in searchInfo.aggregations.topic.buckets"
+          <span data-ng-show="homeFacet.key !== 'inspire'"
+                data-ng-repeat="facet in searchInfo.aggregations[homeFacet.key].buckets"
                 class="col-xs-12 col-sm-6 col-md-4 chips-card">
             <div class="badge-result badge-result-topic clearfix">
               <a class="pull-left clearfix"
                 title="{{facet.key}}"
                 role="link"
-                data-ng-href='#/search?query_string={"topic": {"{{facet.key}}": true} }'>
+                data-ng-href='#/search?query_string={"{{homeFacet.key}}": {"{{facet.key}}": true} }'>
+
+                <!-- TODOES Link label to icons? -->
                 <span class="badge-icon badge-result-topic pull-left">
-                  <i class="fa fa-3x fa-table gn-icon gn-icon-{{facet.key}}"></i>
+                  <i class="fa fa-3x gn-icon gn-icon-{{facet.key.toLowerCase().replace('/', '').replace(' ', '')}}"
+                     data-ng-show="homeFacet.key === 'topic_text' || homeFacet.key === 'codelist_hierarchyLevel_text'">
+                  </i>
                 </span>
                 <span class="badge-text pull-left">
                   <span class="gn-icon-label">{{facet.key}}</span>
@@ -113,7 +123,7 @@
           </span>
           <!-- TODOES Sort alpha -->
           <span data-ng-repeat="(key, facet) in searchInfo.aggregations.inspireThemeUri.buckets"
-                data-ng-show="browse === 'inspire'"
+                data-ng-show="homeFacet.key === 'inspire'"
                 data-ng-init="code = facet.key.slice(facet.key.lastIndexOf('/')+1)"
                 class="col-xs-12 col-sm-6 col-md-4 chips-card">
             <div class="badge-result badge-result-inspire clearfix">
@@ -131,20 +141,23 @@
           </span>
         </div>
       </div>
-      <div class="col-sm-12 col-md-3" data-ng-show="searchInfo.aggregations.codelist_hierarchyLevel_text.buckets.length > 0">
+      <div class="col-sm-12 col-md-3"
+           data-ng-show="searchInfo.aggregations[homeFacet.lastKey].buckets.length > 0">
         <h4>
-          <span data-translate="">browseTypes</span>
+          <span data-translate="">{{('facet-' + homeFacet.lastKey) | translate}}</span>
         </h4>
         <div class="row">
-            <span data-ng-repeat="(key, facet) in searchInfo.aggregations.codelist_hierarchyLevel_text.buckets"
+            <span data-ng-repeat="(key, facet) in searchInfo.aggregations[homeFacet.lastKey].buckets"
                   data-ng-show="facet.key"
                   class="col-xs-12 col-sm-6 col-md-12 chips-card">
               <div class="badge-result badge-result-type pull-left">
                 <a title="{{facet.key}}"
                   class="pull-left clearfix"
-                  data-ng-href='#/search?query_string={"codelist_hierarchyLevel_text": {"{{facet.key}}": true} }'>
+                  data-ng-href='#/search?query_string={"{{homeFacet.lastKey}}": {"{{facet.key}}": true} }'>
                   <span class="badge-icon pull-left">
-                    <i class="fa fa-3x fa-table gn-icon gn-icon-{{facet.key}}"></i>
+                    <i class="fa fa-3x gn-icon gn-icon-{{facet.key.toLowerCase().replace('/', '').replace(' ', '')}}"
+                       data-ng-show="homeFacet.lastKey === 'topic_text' || homeFacet.lastKey === 'codelist_hierarchyLevel_text'">
+                    </i>
                   </span>
                   <span class="badge-text pull-left">
                     <span class="gn-icon-label">{{facet.key}}</span>


### PR DESCRIPTION
Home page facet were limited to inspire theme, topic on the left side, resource type on the right side.

With this PR:
* The right side is composed with the last facet declared in the config
* The left side can be a list of one or more facets

![image](https://user-images.githubusercontent.com/1701393/84756408-0e341800-afc3-11ea-93d7-f9df002c3d04.png)
