### PR TITLE
Improved styling for the portals

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_portal_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_portal_default.less
@@ -5,35 +5,67 @@
 @import "gn_infolist_default.less";
 @import "gn_variables_default.less"; // must be last
 
+.gn-portal {
+  div.gn-full > div.container {
+    width: 100%;
+    padding: 0px;
+    margin: 0;
+    background-color: #9e9e9e;
 
-div.gn-full > div.container {
-  width: 100%;
-  padding: 0px;
-  background-color: #9e9e9e;
+    // portal logo
+    .gn-portal-main-logo {
+      min-width: auto;
+      min-height: auto;
+    }
+    .gn-background {
+      padding: 2em 0 4em;
+      h1 {
+        font-weight: 400;
+        margin-top: 30px;
+      }
+      h1, h2 {
+        color: #fff;
+      }
 
-  .gn-background {
-    padding-top: 20px;
-    padding-bottom: 20px;
-    h1, h2 {
-      //color: white;
     }
-    h1 {
-      font-weight: bold;
+    // blocks
+    .gn-info-list {
+      li {
+        text-align: center;
+        .gn-md-thumbnail {
+          border: none;
+          .gn-img-thumbnail {
+            background-size: contain;
+            filter: none;
+          }
+        }
+        .title {
+          background: none;
+          border: none;
+          &:hover {
+            background: none;
+          }
+          h1 {
+            font-size: 24px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            margin: 10px 0;
+          }
+          p {
+            display: block;
+            line-height: 1.6em;
+            font-size: 16px;
+          }
+        }
+        .resultcard.hasThumbnail:hover {
+          .title {
+            background: none;
+          }
+        }
+      }
     }
-  }
-  .title {
-    color: white;
-    h1 {
-      font-size: 20px;
-      font-weight: bold;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      margin-top: 0px;
-      margin-bottom: 0px;
-    }
-    p {
-      display: block;
-    }
+
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_portal_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_portal_default.less
@@ -23,10 +23,6 @@
         font-weight: 400;
         margin-top: 30px;
       }
-      h1, h2 {
-        color: #fff;
-      }
-
     }
     // blocks
     .gn-info-list {

--- a/web/src/main/webapp/xslt/ui-search/portal-list.xsl
+++ b/web/src/main/webapp/xslt/ui-search/portal-list.xsl
@@ -32,7 +32,7 @@
 
     <xsl:variable name="infoSeparator" select="'|'"/>
 
-    <div class="row gn-portal gn-row-main"
+    <div class="row gn-portal"
          id="{/root/gui/systemConfig/system/site/siteId}"
          itemscope="itemscope"
          itemtype="http://schema.org/DataCatalog">
@@ -63,7 +63,7 @@
         </div>
       </div>
     </div>
-    <div class="gn-info-list-blocks">
+    <div class="container gn-info-list-blocks">
       <ul class="row gn-info-list">
         <xsl:for-each select=".//sources/record[type = 'subportal']">
           <xsl:sort select="label/*[name() = $lang]"/>
@@ -82,7 +82,12 @@
                                   else ''"/>
             <a href="../../{uuid}"
                title="{$portalInfo}">
-              <section class="resultcard clearfix hasThumbnail hasThumbnail">
+              <section class="resultcard clearfix hasThumbnail">
+                <div class="gn-md-thumbnail">
+                  <div class="gn-img-thumbnail"
+                        style="background-image: url(../../images/harvesting/{if (logo != '') then logo else 'blank.png'})">
+                  </div>
+                </div>
                 <div class="title">
                   <h1>
                     <xsl:value-of select="$portalTitle"/>
@@ -90,18 +95,6 @@
                   <p>
                     <xsl:value-of select="$portalDescription"/>
                   </p>
-                </div>
-                <div class="gn-md-thumbnail">
-                  <a href="../../{uuid}">
-                    <div class="gn-img-thumbnail"
-                         style="background-image: url(../../images/harvesting/{if (logo != '') then logo else 'blank.png'})">
-                      <br/>
-                    </div>
-                  </a>
-                </div>
-                <div class="content">
-                  <div class="abstract">
-                  </div>
                 </div>
               </section>
             </a>


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/4758

Some improvements where made to the portal page:
- display icon before title and description
- fixed width for the icon section
- removed borders and backgrounds from the icon block

**Before**: https://github.com/geonetwork/core-geonetwork/pull/4758

**After**:
![gn-portals](https://user-images.githubusercontent.com/19608667/84780470-e904d100-afe5-11ea-8f4e-a8e6baf62b69.png)
