### PR TITLE
Fixed bug with the administrator text not being translation correctly

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/AbstractMetadata.java
+++ b/domain/src/main/java/org/fao/geonet/domain/AbstractMetadata.java
@@ -43,6 +43,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Transient;
 
 import org.apache.lucene.document.Document;
+import org.fao.geonet.domain.userfeedback.Rating;
 import org.fao.geonet.utils.Xml;
 import org.hibernate.annotations.Type;
 import org.jdom.Element;
@@ -82,7 +83,7 @@ public abstract class AbstractMetadata extends GeonetEntity {
      * @return the id of the metadata
      */
     @Id
-    @SequenceGenerator(name=AbstractMetadata.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+    @SequenceGenerator(name=AbstractMetadata.ID_SEQ_NAME, sequenceName = AbstractMetadata.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
     @Column(nullable = false)
     public int getId() {

--- a/domain/src/main/java/org/fao/geonet/domain/Address.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Address.java
@@ -38,7 +38,7 @@ import java.io.Serializable;
 @Entity
 @Access(AccessType.PROPERTY)
 @EntityListeners(AddressEntityListenerManager.class)
-@SequenceGenerator(name = Address.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = Address.ID_SEQ_NAME, sequenceName = Address.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class Address extends GeonetEntity implements Serializable {
     static final String ID_SEQ_NAME = "address_id_seq";
 

--- a/domain/src/main/java/org/fao/geonet/domain/CswCapabilitiesInfoField.java
+++ b/domain/src/main/java/org/fao/geonet/domain/CswCapabilitiesInfoField.java
@@ -42,7 +42,7 @@ import javax.persistence.*;
 @Access(AccessType.PROPERTY)
 @Table(name = "CswServerCapabilitiesInfo")
 @EntityListeners(CswCapabilitiesInfoFieldEntityListenerManager.class)
-@SequenceGenerator(name = CswCapabilitiesInfoField.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = CswCapabilitiesInfoField.ID_SEQ_NAME, sequenceName = CswCapabilitiesInfoField.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class CswCapabilitiesInfoField extends GeonetEntity implements Serializable {
 
     static final String ID_SEQ_NAME = "csw_server_capabilities_info_id_seq";

--- a/domain/src/main/java/org/fao/geonet/domain/Group.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Group.java
@@ -70,7 +70,7 @@ import org.fao.geonet.entitylistener.GroupEntityListenerManager;
 @Cacheable
 @Access(AccessType.PROPERTY)
 @EntityListeners(GroupEntityListenerManager.class)
-@SequenceGenerator(name = Group.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = Group.ID_SEQ_NAME, sequenceName = Group.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class Group extends Localized implements Serializable {
     static final String ID_SEQ_NAME = "group_id_seq";
 

--- a/domain/src/main/java/org/fao/geonet/domain/HarvestHistory.java
+++ b/domain/src/main/java/org/fao/geonet/domain/HarvestHistory.java
@@ -62,7 +62,7 @@ import java.util.List;
 @Access(AccessType.PROPERTY)
 @Table(name = "HarvestHistory")
 @EntityListeners(HarvestHistoryEntityListenerManager.class)
-@SequenceGenerator(name = HarvestHistory.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = HarvestHistory.ID_SEQ_NAME, sequenceName = HarvestHistory.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class HarvestHistory extends GeonetEntity {
     static final String ID_SEQ_NAME = "harvest_history_id_seq";
     private int _id;

--- a/domain/src/main/java/org/fao/geonet/domain/HarvesterSetting.java
+++ b/domain/src/main/java/org/fao/geonet/domain/HarvesterSetting.java
@@ -73,7 +73,7 @@ import com.google.common.collect.Sets;
 @Table(name = "HarvesterSettings")
 @Access(AccessType.PROPERTY)
 @EntityListeners(HarvesterSettingEntityListenerManager.class)
-@SequenceGenerator(name = HarvesterSetting.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = HarvesterSetting.ID_SEQ_NAME, sequenceName = HarvesterSetting.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class HarvesterSetting extends GeonetEntity {
     static final String ID_SEQ_NAME = "harvester_setting_id_seq";
     private static final HashSet<String> EXCLUDE_FROM_XML = Sets.newHashSet("valueAsBool", "valueAsInt");

--- a/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
+++ b/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
@@ -42,7 +42,7 @@ import java.util.List;
 @Access(AccessType.PROPERTY)
 @Table(name = "InspireAtomFeed",
     indexes = { @Index(name = "idx_inspireatomfeed_metadataid", columnList = "metadataid") })
-@SequenceGenerator(name = InspireAtomFeed.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = InspireAtomFeed.ID_SEQ_NAME, sequenceName = InspireAtomFeed.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class InspireAtomFeed extends GeonetEntity implements Serializable {
     static final String ID_SEQ_NAME = "inspire_atom_feed_id_seq";
     private int _id;

--- a/domain/src/main/java/org/fao/geonet/domain/IsoLanguage.java
+++ b/domain/src/main/java/org/fao/geonet/domain/IsoLanguage.java
@@ -57,7 +57,7 @@ import javax.persistence.Table;
 @Table(name = "IsoLanguages")
 @EntityListeners(IsoLanguageEntityListenerManager.class)
 @Cacheable
-@SequenceGenerator(name = IsoLanguage.ID_SEQ_NAME, initialValue = 10000, allocationSize = 1)
+@SequenceGenerator(name = IsoLanguage.ID_SEQ_NAME, sequenceName = IsoLanguage.ID_SEQ_NAME, initialValue = 10000, allocationSize = 1)
 public class IsoLanguage extends Localized {
     static final String ID_SEQ_NAME = "iso_language_id_seq";
     private int id;

--- a/domain/src/main/java/org/fao/geonet/domain/Link.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Link.java
@@ -59,7 +59,7 @@ import java.util.TreeSet;
 @Cacheable
 @Access(AccessType.PROPERTY)
 @EntityListeners(LinkEntityListenerManager.class)
-@SequenceGenerator(name = Link.ID_SEQ_NAME, initialValue = 1, allocationSize = 1)
+@SequenceGenerator(name = Link.ID_SEQ_NAME, sequenceName = Link.ID_SEQ_NAME, initialValue = 1, allocationSize = 1)
 public class Link implements Serializable {
     static final String ID_SEQ_NAME = "link_id_seq";
 

--- a/domain/src/main/java/org/fao/geonet/domain/LinkStatus.java
+++ b/domain/src/main/java/org/fao/geonet/domain/LinkStatus.java
@@ -56,7 +56,7 @@ import javax.persistence.Table;
 @Table(name = "LinkStatus",
     indexes = {@Index(name = "idx_linkstatus_isFailing", columnList = "failing")})
 @EntityListeners(LinkStatusEntityListenerManager.class)
-@SequenceGenerator(name = LinkStatus.ID_SEQ_NAME, initialValue = 1, allocationSize = 1)
+@SequenceGenerator(name = LinkStatus.ID_SEQ_NAME, sequenceName = LinkStatus.ID_SEQ_NAME, initialValue = 1, allocationSize = 1)
 public class LinkStatus extends GeonetEntity implements Comparable<LinkStatus> {
     static final String ID_SEQ_NAME = "linkstatus_id_seq";
     private int id;

--- a/domain/src/main/java/org/fao/geonet/domain/MapServer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MapServer.java
@@ -43,7 +43,7 @@ import java.util.Map;
 @Cacheable
 @Access(AccessType.PROPERTY)
 @EntityListeners(MapServerEntityListenerManager.class)
-@SequenceGenerator(name = MapServer.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = MapServer.ID_SEQ_NAME, sequenceName = MapServer.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MapServer extends GeonetEntity {
     static final String ID_SEQ_NAME = "mapserver_id_seq";
 

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataCategory.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataCategory.java
@@ -45,7 +45,7 @@ import java.util.Set;
 @Cacheable
 @Table(name = "Categories")
 @EntityListeners(MetadataCategoryEntityListenerManager.class)
-@SequenceGenerator(name = MetadataCategory.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = MetadataCategory.ID_SEQ_NAME, sequenceName = MetadataCategory.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MetadataCategory extends Localized implements Serializable {
     private static final Set<String> EXCLUDE_FROM_XML = Sets.newHashSet("getRecords");
 

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataFileDownload.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataFileDownload.java
@@ -37,7 +37,7 @@ import javax.persistence.*;
 @Access(AccessType.PROPERTY)
 @Table(name = "MetadataFileDownloads",
     indexes = { @Index(name = "idx_metadatafiledownloads_metadataid", columnList = "metadataid") })
-@SequenceGenerator(name = MetadataFileDownload.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = MetadataFileDownload.ID_SEQ_NAME, sequenceName = MetadataFileDownload.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MetadataFileDownload {
     static final String ID_SEQ_NAME = "metadata_filedownload_id_seq";
     private int _id;

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataFileUpload.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataFileUpload.java
@@ -37,7 +37,7 @@ import javax.persistence.*;
 @Access(AccessType.PROPERTY)
 @Table(name = "MetadataFileUploads",
     indexes = { @Index(name = "idx_metadatafileuploads_metadataid", columnList = "metadataid") })
-@SequenceGenerator(name = MetadataFileUpload.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = MetadataFileUpload.ID_SEQ_NAME, sequenceName = MetadataFileUpload.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MetadataFileUpload extends GeonetEntity {
     static final String ID_SEQ_NAME = "metadata_fileupload_id_seq";
     private int _id;

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataIdentifierTemplate.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataIdentifierTemplate.java
@@ -38,7 +38,7 @@ import javax.persistence.*;
 @Cacheable
 @Access(AccessType.PROPERTY)
 @EntityListeners(MetadataIdentifierTemplateListenerManager.class)
-@SequenceGenerator(name = MetadataIdentifierTemplate.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = MetadataIdentifierTemplate.ID_SEQ_NAME, sequenceName = MetadataIdentifierTemplate.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MetadataIdentifierTemplate extends GeonetEntity {
     static final String ID_SEQ_NAME = "metadata_identifier_template_id_seq";
 

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataNotifier.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataNotifier.java
@@ -40,7 +40,7 @@ import java.util.List;
 @Access(AccessType.PROPERTY)
 @Table(name = "MetadataNotifiers")
 @EntityListeners(MetadataNotifierEntityListenerManager.class)
-@SequenceGenerator(name = MetadataNotifier.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = MetadataNotifier.ID_SEQ_NAME, sequenceName = MetadataNotifier.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MetadataNotifier extends GeonetEntity {
     static final String ID_SEQ_NAME = "metadata_notifier_id_seq";
 

--- a/domain/src/main/java/org/fao/geonet/domain/Operation.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Operation.java
@@ -41,7 +41,7 @@ import java.util.Map;
 @Cacheable
 @Access(AccessType.PROPERTY)
 @EntityListeners(OperationEntityListenerManager.class)
-@SequenceGenerator(name = Operation.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = Operation.ID_SEQ_NAME, sequenceName = Operation.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class Operation extends Localized {
     static final String ID_SEQ_NAME = "operation_id_seq";
     private int _id;

--- a/domain/src/main/java/org/fao/geonet/domain/Schematron.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Schematron.java
@@ -56,7 +56,7 @@ import javax.persistence.UniqueConstraint;
     uniqueConstraints = @UniqueConstraint(columnNames = {"schemaName", "filename"}))
 @Cacheable
 @Access(AccessType.PROPERTY)
-@SequenceGenerator(name = Schematron.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = Schematron.ID_SEQ_NAME, sequenceName = Schematron.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class Schematron extends Localized {
     public static final Comparator<? super Schematron> DISPLAY_PRIORITY_COMPARATOR = new Comparator<Schematron>() {
         @Override

--- a/domain/src/main/java/org/fao/geonet/domain/SchematronCriteria.java
+++ b/domain/src/main/java/org/fao/geonet/domain/SchematronCriteria.java
@@ -42,7 +42,7 @@ import java.util.List;
 @Table(name = "SchematronCriteria")
 @Cacheable
 @Access(AccessType.PROPERTY)
-@SequenceGenerator(name = SchematronCriteria.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = SchematronCriteria.ID_SEQ_NAME, sequenceName = SchematronCriteria.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class SchematronCriteria extends GeonetEntity {
     static final String ID_SEQ_NAME = "schematron_criteria_id_seq";
     static final String EL_UI_TYPE = "uitype";

--- a/domain/src/main/java/org/fao/geonet/domain/Selection.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Selection.java
@@ -56,7 +56,7 @@ import java.util.Map;
 @Cacheable
 @Table(name = "Selections")
 @EntityListeners(SelectionEntityListenerManager.class)
-@SequenceGenerator(name = Selection.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = Selection.ID_SEQ_NAME, sequenceName = Selection.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class Selection extends Localized implements Serializable {
     static final String ID_SEQ_NAME = "selection_id_seq";
     private int _id;

--- a/domain/src/main/java/org/fao/geonet/domain/Service.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Service.java
@@ -58,7 +58,7 @@ import javax.persistence.Table;
 @Access(AccessType.PROPERTY)
 @Table(name = "Services")
 @EntityListeners(ServiceEntityListenerManager.class)
-@SequenceGenerator(name = Service.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = Service.ID_SEQ_NAME, sequenceName = Service.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class Service extends GeonetEntity {
     static final String ID_SEQ_NAME = "service_id_seq";
     private int _id;

--- a/domain/src/main/java/org/fao/geonet/domain/ServiceParam.java
+++ b/domain/src/main/java/org/fao/geonet/domain/ServiceParam.java
@@ -49,7 +49,7 @@ import javax.persistence.Table;
 @Entity
 @Access(AccessType.PROPERTY)
 @Table(name = "ServiceParameters")
-@SequenceGenerator(name = ServiceParam.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = ServiceParam.ID_SEQ_NAME, sequenceName = ServiceParam.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class ServiceParam extends GeonetEntity {
     static final String ID_SEQ_NAME = "serviceparameters_id_seq";
     private static final List<Character> LEGALVALUES = Lists.newArrayList('+', '-', ' ', null);

--- a/domain/src/main/java/org/fao/geonet/domain/StatusValue.java
+++ b/domain/src/main/java/org/fao/geonet/domain/StatusValue.java
@@ -52,7 +52,7 @@ import java.util.Map;
 @Table(name = "StatusValues")
 @Cacheable
 @EntityListeners(StatusValueEntityListenerManager.class)
-@SequenceGenerator(name = StatusValue.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = StatusValue.ID_SEQ_NAME, sequenceName = StatusValue.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class StatusValue extends Localized {
     static final String ID_SEQ_NAME = "status_value_id_seq";
     private int _id;

--- a/domain/src/main/java/org/fao/geonet/domain/TextFile.java
+++ b/domain/src/main/java/org/fao/geonet/domain/TextFile.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 
 @Entity
 @Table(name = "files")
-@SequenceGenerator(name= TextFile.ID_SEQ_NAME, initialValue=1, allocationSize=1)
+@SequenceGenerator(name= TextFile.ID_SEQ_NAME, sequenceName = TextFile.ID_SEQ_NAME, initialValue=1, allocationSize=1)
 public class TextFile extends GeonetEntity {
 
     static final String ID_SEQ_NAME = "files_id_seq";
@@ -19,7 +19,7 @@ public class TextFile extends GeonetEntity {
     private String _mimeType;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = TextFile.ID_SEQ_NAME)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
     @Column(nullable = false)
     public int getId() {
         return this._id;

--- a/domain/src/main/java/org/fao/geonet/domain/User.java
+++ b/domain/src/main/java/org/fao/geonet/domain/User.java
@@ -51,7 +51,7 @@ import java.util.*;
 @Table(name = "Users")
 @Cacheable
 @EntityListeners(value = {UserEntityListenerManager.class})
-@SequenceGenerator(name = User.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = User.ID_SEQ_NAME, sequenceName = User.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class User extends GeonetEntity implements UserDetails {
     public static final String NODE_APPLICATION_CONTEXT_KEY = "jeevesNodeApplicationContext_";
     static final String ID_SEQ_NAME = "user_id_seq";

--- a/domain/src/main/java/org/fao/geonet/domain/UserSearch.java
+++ b/domain/src/main/java/org/fao/geonet/domain/UserSearch.java
@@ -37,7 +37,7 @@ import java.util.*;
 @Table(name = "UserSearch")
 @Access(AccessType.PROPERTY)
 @EntityListeners(UserSearchEntityListenerManager.class)
-@SequenceGenerator(name = UserSearch.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = UserSearch.ID_SEQ_NAME, sequenceName = UserSearch.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class UserSearch extends Localized implements Serializable {
     static final String ID_SEQ_NAME = "user_search_id_seq";
 

--- a/domain/src/main/java/org/fao/geonet/domain/userfeedback/Keyword.java
+++ b/domain/src/main/java/org/fao/geonet/domain/userfeedback/Keyword.java
@@ -34,6 +34,7 @@ import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+import org.fao.geonet.domain.CswCapabilitiesInfoField;
 import org.fao.geonet.domain.GeonetEntity;
 
 /**
@@ -41,7 +42,7 @@ import org.fao.geonet.domain.GeonetEntity;
  */
 @Entity(name = "GUF_Keywords")
 @Table(name = "GUF_Keywords")
-@SequenceGenerator(name = Keyword.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = Keyword.ID_SEQ_NAME, sequenceName = Keyword.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class Keyword extends GeonetEntity implements Serializable {
 
     /** The sequence name */
@@ -56,7 +57,7 @@ public class Keyword extends GeonetEntity implements Serializable {
 
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = Keyword.ID_SEQ_NAME)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
     public long getId() {
         return id;
     }

--- a/domain/src/main/java/org/fao/geonet/domain/userfeedback/Rating.java
+++ b/domain/src/main/java/org/fao/geonet/domain/userfeedback/Rating.java
@@ -40,7 +40,7 @@ import javax.persistence.Table;
  */
 @Entity(name = "GUF_Rating")
 @Table(name = "GUF_Rating")
-@SequenceGenerator(name = Rating.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = Rating.ID_SEQ_NAME, sequenceName = Rating.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class Rating implements Serializable {
 
     /** Sequence name */
@@ -56,7 +56,7 @@ public class Rating implements Serializable {
 
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = Rating.ID_SEQ_NAME)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
     public long getId() {
         return id;
     }

--- a/domain/src/main/java/org/fao/geonet/domain/userfeedback/RatingCriteria.java
+++ b/domain/src/main/java/org/fao/geonet/domain/userfeedback/RatingCriteria.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.domain.userfeedback;
 
+import org.fao.geonet.domain.CswCapabilitiesInfoField;
 import org.fao.geonet.domain.Localized;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.converter.BooleanToYNConverter;
@@ -57,7 +58,7 @@ import java.util.Map;
 @Cacheable
 @Access(AccessType.PROPERTY)
 @EntityListeners(RatingCriteriaEntityListenerManager.class)
-@SequenceGenerator(name = RatingCriteria.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
+@SequenceGenerator(name = RatingCriteria.ID_SEQ_NAME, sequenceName = RatingCriteria.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class RatingCriteria extends Localized implements Serializable {
     static final String ID_SEQ_NAME = "rating_criteria_id_seq";
 

--- a/web-ui/src/main/resources/catalog/locales/ca-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Administrador",
     "NEW": "Nou",
     "abstract": "Resum",
     "accessConstraints": "Restriccions d'Accés",

--- a/web-ui/src/main/resources/catalog/locales/ca-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-core.json
@@ -1,4 +1,5 @@
-{
+
+    "Administrator": "Administrador",    
     "all": "tots",
     "allInPage": "tots en una pàgina",
     "addToSelection": "Afegir a...",

--- a/web-ui/src/main/resources/catalog/locales/cs-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/cs-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Administrátor",
     "NEW": "Nový",
     "abstract": "Shrnutí",
     "accessConstraints": "Omezení přístupu",

--- a/web-ui/src/main/resources/catalog/locales/cs-core.json
+++ b/web-ui/src/main/resources/catalog/locales/cs-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Administrátor",
     "all": "všechny",
     "allInPage": "Všechny na stránce",
     "addToSelection": "Přidat do ...",

--- a/web-ui/src/main/resources/catalog/locales/de-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/de-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Administrator",
     "NEW": "Neu",
     "abstract": "Zusammenfassung",
     "accessConstraints": "Zugriffsbeschränkungen",

--- a/web-ui/src/main/resources/catalog/locales/de-core.json
+++ b/web-ui/src/main/resources/catalog/locales/de-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Administrator",
     "all": "Alles selektieren",
     "allInPage": "in der Seite alles selektieren",
     "addToSelection": "Hinzufügen zu...",

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Administrator",
     "NEW": "New",
     "abstract": "Abstract",
     "accessConstraints": "Access constraints",

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Administrator",
     "all": "all",
     "allInPage": "all in page",
     "addToSelection": "Add to ...",

--- a/web-ui/src/main/resources/catalog/locales/es-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/es-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Administrador",
     "NEW": "Nuevo",
     "abstract": "Resumen",
     "accessConstraints": "Restricciones de Acceso",

--- a/web-ui/src/main/resources/catalog/locales/es-core.json
+++ b/web-ui/src/main/resources/catalog/locales/es-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Administrador",
     "all": "todos",
     "allInPage": "todo en una página",
     "addToSelection": "Añadir a...",

--- a/web-ui/src/main/resources/catalog/locales/fi-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Ylläpitäjä",
     "NEW": "Uusi",
     "abstract": "Tiivistelmä",
     "accessConstraints": "Pääsyrajoitteet",

--- a/web-ui/src/main/resources/catalog/locales/fi-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Ylläpitäjä",
     "all": "kaikki",
     "allInPage": "kaikki sivulla",
     "addToSelection": "Lisää...",

--- a/web-ui/src/main/resources/catalog/locales/fr-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Administrateur",
     "NEW": "Nouveau",
     "abstract": "Résumé",
     "accessConstraints": "Contraintes d'accès",

--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Administrateur",
     "all": "Tout sélectionner",
     "allInPage": "Tout sélectionner dans la page",
     "addToSelection": "Ajouter à ...",

--- a/web-ui/src/main/resources/catalog/locales/is-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/is-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Stjórnandi",
     "NEW": "Nýtt",
     "abstract": "Útdráttur",
     "accessConstraints": "Aðgangshömlur",

--- a/web-ui/src/main/resources/catalog/locales/is-core.json
+++ b/web-ui/src/main/resources/catalog/locales/is-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Stjórnandi",
     "all": "Allt",
     "allInPage": "allt á einni síðu",
     "addToSelection": "Bæta við ...",

--- a/web-ui/src/main/resources/catalog/locales/it-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/it-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Amministratore",
     "NEW": "Nuovo",
     "abstract": "Descrizione",
     "accessConstraints": "Vincoli di accesso",

--- a/web-ui/src/main/resources/catalog/locales/it-core.json
+++ b/web-ui/src/main/resources/catalog/locales/it-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Amministratore",
     "all": "Seleziona tutto",
     "allInPage": "Seleziona tutto nella pagina",
     "addToSelection": "Aggiungi a ...",

--- a/web-ui/src/main/resources/catalog/locales/ko-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "관리자",
     "NEW": "새로운",
     "abstract": "요약",
     "accessConstraints": "접근 제한",

--- a/web-ui/src/main/resources/catalog/locales/ko-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "관리자",
     "all": "모두",
     "allInPage": "페이지의 모두",
     "addToSelection": "추가하기 ...",

--- a/web-ui/src/main/resources/catalog/locales/nl-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Beheerder",
     "NEW": "Nieuw",
     "abstract": "Korte beschrijving",
     "accessConstraints": "Toegangsrestrictie",

--- a/web-ui/src/main/resources/catalog/locales/nl-core.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Beheerder",
     "all": "selecteer alle records",
     "allInPage": "selecteer alle records op deze pagina",
     "addToSelection": "Toevoegen aan selectie",

--- a/web-ui/src/main/resources/catalog/locales/pt-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Administrador",
     "NEW": "Novo",
     "abstract": "Resumo",
     "accessConstraints": "Restrições de acesso",

--- a/web-ui/src/main/resources/catalog/locales/pt-core.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Administrador",
     "all": "todos",
     "allInPage": "todos na página",
     "addToSelection": "Adicionar à ...",

--- a/web-ui/src/main/resources/catalog/locales/ru-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Администратор",
     "NEW": "Новый",
     "abstract": "Реферат",
     "accessConstraints": "Ограничения доступа",

--- a/web-ui/src/main/resources/catalog/locales/ru-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Администратор",
     "all": "всё",
     "allInPage": "всё на странице",
     "addToSelection": "Добавить к...",

--- a/web-ui/src/main/resources/catalog/locales/sk-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "Administrátor",
     "NEW": "Nový",
     "abstract": "Zhrnutie",
     "accessConstraints": "Obmedzenie prístupu",

--- a/web-ui/src/main/resources/catalog/locales/sk-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "Administrátor",
     "all": "všetko",
     "allInPage": "všetko na stránke",
     "addToSelection": "Pridať do ...",

--- a/web-ui/src/main/resources/catalog/locales/zh-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-admin.json
@@ -1,5 +1,4 @@
 {
-    "Administrator": "管理员",
     "NEW": "新建",
     "abstract": "摘要",
     "accessConstraints": "访问受限项",

--- a/web-ui/src/main/resources/catalog/locales/zh-core.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-core.json
@@ -1,4 +1,5 @@
 {
+    "Administrator": "管理员",
     "all": "全部",
     "allInPage": "所有页面",
     "addToSelection": "添加 ...",

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -163,7 +163,7 @@
             data-ng-src="//gravatar.com/avatar/{{user.email | md5}}?s=18"/>
           <div class="gn-user-info hidden-sm hidden-md">
             <span class="gn-user-name">{{user.name}} {{user.surname}}</span><br>
-            <span class="gn-user-role">{{user.profile | lowercase | translate}}</span>
+            <span class="gn-user-role">{{user.profile | translate}}</span>
           </div>
           <span class="alert alert-danger ng-hide"
                 data-ng-show="session.remainingTime > 0 &&
@@ -186,7 +186,7 @@
           </li>
           <li class="dropdown-header hidden-xs" role="menuitem" translate>profile</li>
           <li class="hidden-xs" role="menuitem">
-            <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}">{{user.profile | lowercase | translate}}</a>
+            <a style="text-transform: lowercase" data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}">{{user.profile | translate}}</a>
           </li>
           <li role="separator" class="divider hidden-xs"></li>
           <li role="menuitem">


### PR DESCRIPTION
Administrator text was not being translated correct. Seems like it was broken several years ago...

![image](https://user-images.githubusercontent.com/1868233/84803750-c7511d00-afd8-11ea-9582-9096e8f21404.png)

Issue
The "Administrator" needed to be moved from the admin keys to the core keys as the text if display when not in administration area.
Also translation was being done on the text after it was lowercased so it never found the keys (this included the other keys such as editor/reviewer....).  So moved the lower case option into a style.