### PR TITLE
pdf - normalize URL before openStream()

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
@@ -49,7 +49,9 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.HashMap;
@@ -221,6 +223,7 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
     private ReplacedElement loadImage(LayoutContext layoutContext, BlockBox box, UserAgentCallback userAgentCallback,
                                       int cssWidth, int cssHeight, ImageLoader imageLoader, float scaleFactor) {
         try {
+
             Image image = imageLoader.loadImage();
 
             image.scaleAbsolute(image.getPlainWidth() * scaleFactor, image.getPlainHeight() * scaleFactor);
@@ -279,9 +282,11 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
 
         @Override
         public Image loadImage() throws Exception {
-            Log.error(Geonet.GEONETWORK, "URL -> " + url);
+            URI normalizedUrl = new URI(url).normalize();
+            Log.debug(Geonet.GEONETWORK, String.format("URL -> %s, normalized URL -> %s",
+                url, normalizedUrl.toString()));
 
-            try (InputStream input = new URL(url).openStream()) {
+            try (InputStream input = normalizedUrl.toURL().openStream()) {
                 byte[] bytes = IOUtils.toByteArray(input);
                 return Image.getInstance(bytes);
             }


### PR DESCRIPTION
We encountered the issue on geOrchestra, following an update of spring-security in our proxy placed in front of geonetwork.

Since spring-security 4.2.4, a stricter filter than the default one is defined by default, see the following class:

https://docs.spring.io/spring-security/site/docs/4.2.15.RELEASE/apidocs/org/springframework/security/web/firewall/StrictHttpFirewall.html


> Rejects URLs that are not normalized to avoid bypassing security constraints. There is no way to disable this as it is considered extremely risky to disable this constraint. A few options to allow this behavior is to normalize the request prior to the firewall or using DefaultHttpFirewall instead. Please keep in mind that normalizing the request is fragile and why requests are rejected rather than normalized.


When asking for a PDF export of a MD, some of the URLs pointing to e.g. images resources are passed to the PDF formatter which then tries to fetch them using URL.openStream(). These urls are not necessarily "normalized" (e.g. path is not recalculated to remove the "../" & "./").

This PR suggests to normalize the URLs before trying to fetch the remote resource.

**Please note that this is probably not necessary for now, given the spring-security version in use in GeoNetwork (3.2.0 in the parent pom), but could become an issue in the future in case of upgrade.**

Also changing the log level on the logger call to debug (this does not seem to be an error, since the message is more for information purposes).