### PR TITLE
Restrict template creation based on METADATA_IMPORT_RESTRICT

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -611,7 +611,6 @@ public class BaseMetadataManager implements IMetadataManager {
         String mdImportSetting = settingManager.getValue(Settings.METADATA_IMPORT_RESTRICT);
         if (mdImportSetting != null && !mdImportSetting.equals("")) {
             if (!newMetadata.getHarvestInfo().isHarvested()
-                && newMetadata.getDataInfo().getType() == MetadataType.METADATA
                 && !Arrays.asList(mdImportSetting.split(",")).contains(schema)) {
                 throw new IllegalArgumentException(
                     schema + " is not permitted in the database as a non-harvested metadata.  "


### PR DESCRIPTION
Fix for #4782. This fix will apply the restriction for metadata template.  Metadata was already restricted.

