### PR TITLE
Enhance ESRI REST API support

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -111,8 +111,7 @@
               'OGC:WMS-1.1.1-http-get-map',
               'OGC:WMS-1.3.0-http-get-map',
               'OGC:WFS',
-              'ESRI:REST',
-              'ESRI REST: Map Server'
+              'ESRI:REST'
               ],
             services: [
               'OGC:WMS-1.3.0-http-get-capabilities',

--- a/web-ui/src/main/resources/catalog/views/default/config.js
+++ b/web-ui/src/main/resources/catalog/views/default/config.js
@@ -111,7 +111,8 @@
               'OGC:WMS-1.1.1-http-get-map',
               'OGC:WMS-1.3.0-http-get-map',
               'OGC:WFS',
-              'ESRI:REST'
+              'ESRI:REST',
+              'ESRI REST: Map Server'
               ],
             services: [
               'OGC:WMS-1.3.0-http-get-capabilities',

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -261,7 +261,7 @@
             uuid: md ? md.getUuid() : null,
             type:
               link.protocol.indexOf('WMTS') > -1 ? 'wmts' :
-                ((link.protocol == 'ESRI:REST') || (link.protocol == 'ESRI REST: Map Server') ? 'esrirest' : 'wms'),
+                ((link.protocol == 'ESRI:REST') || (link.protocol.startsWith('ESRI REST')) ? 'esrirest' : 'wms'),
             url: $filter('gnLocalized')(link.url) || link.url
           };
 

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -221,7 +221,7 @@
       $scope.toggleListType = function(type) {
         $scope.type = type;
       };
-      
+
       $scope.infoTabs = {
         lastRecords: {
           title: 'lastRecords',
@@ -261,7 +261,7 @@
             uuid: md ? md.getUuid() : null,
             type:
               link.protocol.indexOf('WMTS') > -1 ? 'wmts' :
-              (link.protocol == 'ESRI:REST' ? 'esrirest' : 'wms'),
+                ((link.protocol == 'ESRI:REST') || (link.protocol == 'ESRI REST: Map Server') ? 'esrirest' : 'wms'),
             url: $filter('gnLocalized')(link.url) || link.url
           };
 


### PR DESCRIPTION
This transaction is to enhance the GN ESRI REST API support to cover one of the commonly used subtype "Map Server" protocol.

Esri supports a various protocol types:
ESRI REST, 
ESRI REST: Feature Server, 
ESRI REST: Image Service,  
ESRI REST: Map Server, 
ESRI REST: Tiled Map Service, 
OGC WMS

More than half of the datasets (maybe close to 80%) from FGP (https://maps.canada.ca/en/index.html)  with the Esri mapping capabilities use the ESRI REST: Map Server protocol instead.

Geonetwork adds the ESRI Rest API support in 3.10, but it only supports one type ESRI REST.

There are a few reports for the issue from the community:

https://gis.stackexchange.com/questions/352239/geonetwork-3-10-esri-rest-map-view-issue

My DFO co-worker Ian @ianwallen also filed an issue against the hnap
https://github.com/metadata101/iso19139.ca.HNAP/issues/55

To reproduce the issue:
a. From a fresh geonetwork "master' install, login admin,
![esri_1_mainpage](https://user-images.githubusercontent.com/64438599/85170708-c966e600-b23b-11ea-8cef-a6b9793a0f29.png)

b. Choose one of the dataset record with ESRI service link and click add to the map:
![esri_2_addtomap](https://user-images.githubusercontent.com/64438599/85170744-d388e480-b23b-11ea-905c-f88a814da2c5.png)

c.1. Before the fix
![esri_3_maperror](https://user-images.githubusercontent.com/64438599/85170582-99b7de00-b23b-11ea-9e5e-fd7f145bdc68.png)

c.2. After the fix
![esri_4_fix_addtomap](https://user-images.githubusercontent.com/64438599/85170646-b3f1bc00-b23b-11ea-8364-2e1cb468c213.png)




