### PR TITLE
Editor / Polygon / Fix validation error on srsName and id attributes.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-subtemplate.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-subtemplate.xsl
@@ -175,7 +175,7 @@
     </xsl:choose>
   </xsl:template>
 
-
+  <xsl:template match="gml:LinearRing/@srsName"/>
 
   <xsl:template name="correct_ns_prefix">
     <xsl:param name="element"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -274,6 +274,8 @@
   <!-- Fix srsName attribute generate CRS:84 (EPSG:4326 with long/lat
          ordering) by default -->
 
+  <xsl:template match="gml:LinearRing/@srsName"/>
+
   <xsl:template match="@srsName">
     <xsl:choose>
       <xsl:when test="normalize-space(.)=''">
@@ -288,10 +290,10 @@
   </xsl:template>
 
   <!-- Add required gml attributes if missing -->
-  <xsl:template match="gml:Polygon[not(@gml:id) and not(@srsName)]|
-                       gml:MultiSurface[not(@gml:id) and not(@srsName)]|
-                       gml:LineString[not(@gml:id) and not(@srsName)]|
-                       gml320:Polygon[not(@gml320:id) and not(@srsName)]">
+  <xsl:template match="gml:Polygon[not(@gml:id) or not(@srsName)]|
+                       gml:MultiSurface[not(@gml:id) or not(@srsName)]|
+                       gml:LineString[not(@gml:id) or not(@srsName)]|
+                       gml320:Polygon[not(@gml320:id) or not(@srsName)]">
     <xsl:copy copy-namespaces="no">
       <xsl:choose>
         <xsl:when test="$isUsing2005Schema and not($isUsing2007Schema)">
@@ -479,10 +481,10 @@
 
       <xsl:if test="normalize-space(./text()) != '' and string(@codeListValue)">
         <xsl:value-of select="java:getIsoLanguageLabel(@codeListValue, $mainLanguage)" />
-        <!-- 
+        <!--
              If wanting to get strings from codelists then add gmd:LanguageCode codelist in loc/{lang}/codelists.xml
              and use getCodelistTranslation instead of getIsoLanguageLabel. This will allow for custom values such as "eng; USA"
-             i.e. 
+             i.e.
              <xsl:value-of select="java:getCodelistTranslation(name(), string(@codeListValue), string($mainLanguage))"/>
         -->
       </xsl:if>


### PR DESCRIPTION
When adding bounding polygon, issues are reported on validation.

![image](https://user-images.githubusercontent.com/1701393/85522811-6d6adb80-b606-11ea-8c02-726e4d61f55e.png)

Since OL6 update, an srsName is added to LinearRing in GML3.2.0.

![image](https://user-images.githubusercontent.com/1701393/85522835-722f8f80-b606-11ea-87c6-a8056e1ae5b9.png)

GML2 OL format was not. See
 https://github.com/openlayers/openlayers/blame/v6.3.1/src/ol/format/GML2.js#L228
.
GML3 does https://github.com/openlayers/openlayers/blob/v6.3.1/src/ol/format/GML3.js#L503

From the XSD, this attribute should probably not be added https://schemas.wmo.int/wmdr/1.0RC6/documentation/schemadoc/schemas/geometryBasic2d_xsd/elements/LinearRing.html.

Workaround that issue by updating `LinearRing` in `update-fixed-info.xsl`.


Also require https://github.com/metadata101/iso19115-3.2018/pull/70 for ISO19115-3