### PR TITLE
Avoid duplicated thesaurus label in the metadata editor for iso19139 metadata multilingual metadata

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -31,6 +31,7 @@
                 xmlns:gn="http://www.fao.org/geonetwork"
                 xmlns:xslutil="java:org.fao.geonet.util.XslUtil"
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
+                xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
                 xmlns:java="java:org.fao.geonet.util.XslUtil"
                 version="2.0"
                 exclude-result-prefixes="#all">
@@ -159,8 +160,13 @@
     <xsl:variable name="thesaurusIdentifier"
                   select="normalize-space(gmd:thesaurusName/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/*/text())"/>
 
-    <xsl:variable name="thesaurusTitle"
-                  select="gmd:thesaurusName/gmd:CI_Citation/gmd:title/(gco:CharacterString|gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString|gmx:Anchor)"/>
+    <xsl:variable name="thesaurusTitle">
+      <xsl:for-each select="gmd:thesaurusName/gmd:CI_Citation/gmd:title">
+        <xsl:call-template name="localised">
+          <xsl:with-param name="langId" select="$langId"/>
+        </xsl:call-template>
+      </xsl:for-each>
+    </xsl:variable>
 
 
     <xsl:variable name="thesaurusConfig"


### PR DESCRIPTION
Fix to avoid duplicated thesaurus label in the metadata editor for iso19139 metadata multilingual metadata:

![image_2020_06_24T08_02_14_258Z](https://user-images.githubusercontent.com/1695003/85545344-2a1b6780-b61c-11ea-8640-b471e267678b.png)
