### PR TITLE
Fixed bug uninitialized baseURL

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -200,7 +200,6 @@ public class BaseMetadataManager implements IMetadataManager {
     private UserSavedSelectionRepository userSavedSelectionRepository;
 
     private static final int METADATA_BATCH_PAGE_SIZE = 50000;
-    private String baseURL;
 
     @Autowired
     private ApplicationContext _applicationContext;
@@ -941,7 +940,7 @@ public class BaseMetadataManager implements IMetadataManager {
         } else {
             port = ":" + port;
         }
-        addElement(info, Edit.Info.Elem.BASEURL, protocol + "://" + host + port + baseURL);
+        addElement(info, Edit.Info.Elem.BASEURL, protocol + "://" + host + port + context.getBaseUrl());
         addElement(info, Edit.Info.Elem.LOCSERV, "/srv/en");
         return info;
     }


### PR DESCRIPTION
Fix bug with geonet baseurl not being correct.
It currently generated a baseurl in geonet:info that looks like the following.

`<baseUrl>http://localhost:8080null</baseUrl>`

The baseURL is never initialized.

This update will change it so that the baseurl looks like the following.

`<baseUrl>http://localhost:8080/geonetwork</baseUrl>`