### PR TITLE
Map Service / show error when parsing WMTS options failed

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1716,11 +1716,22 @@
                 if (!angular.isArray(l.Style)){ l.Style=[{Identifier:l.Style,isDefault:true}] };
               });
 
-              var options = ol.source.WMTS.optionsFromCapabilities(cap, {
-                layer: getCapLayer.Identifier,
-                matrixSet: map.getView().getProjection().getCode(),
-                projection: map.getView().getProjection().getCode()
-              });
+              var options;
+
+              try {
+                options = ol.source.WMTS.optionsFromCapabilities(cap, {
+                  layer: getCapLayer.Identifier,
+                  matrixSet: map.getView().getProjection().getCode(),
+                  projection: map.getView().getProjection().getCode()
+                });
+              } catch (e) {
+                gnAlertService.addAlert({
+                  msg: $translate.instant('wmtsLayerNoUsableMatrixSet'),
+                  delay: 5000,
+                  type: 'danger'
+                });
+                return;
+              }
 
               //Configuring url for service
               var url = capabilities.operationsMetadata.GetCapabilities.DCP.HTTP.Get[0].href;

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -409,7 +409,7 @@
                 });
 
             if (bboxProp) {
-              extent = ol.extent.containsExtent(proj.getWorldExtent(),
+              extent = proj.getWorldExtent() && ol.extent.containsExtent(proj.getWorldExtent(),
                       bboxProp) ?
                       ol.proj.transformExtent(bboxProp, 'EPSG:4326', proj) :
                       proj.getExtent();

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -145,7 +145,6 @@
 
         if (map.getView().getProjection().getCode() != projection) {
           var view = new ol.View({
-            extent: extent,
             projection: projection
           });
           map.setView(view);

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
@@ -113,7 +113,7 @@
                           }
 
                           var mapsConfig = {
-                            projection : newProj,
+                            projection : newProj
                           };
 
                           if (projectionConfig.resolutions

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
@@ -114,7 +114,6 @@
 
                           var mapsConfig = {
                             projection : newProj,
-                            extent : newExtent
                           };
 
                           if (projectionConfig.resolutions

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -513,5 +513,6 @@
     "cancelWorkingCopy": "Cancel working copy",
     "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
     "workingCopy": "Working copy",
-    "metadataValidated": "Metadata validated."
+    "metadataValidated": "Metadata validated.",
+    "wmtsLayerNoUsableMatrixSet": "The WMTS layer could not be added. This may be because none of the matrix sets match the known projections."
 }

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -514,5 +514,5 @@
     "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
     "workingCopy": "Working copy",
     "metadataValidated": "Metadata validated.",
-    "wmtsLayerNoUsableMatrixSet": "The WMTS layer could not be added. This may be because none of the matrix sets match the known projections."
+    "wmtsLayerNoUsableMatrixSet": "The WMTS layer could not be added. This may be because none of the projections advertised in the service matches any of the known projections of the application."
 }


### PR DESCRIPTION
Fixes #4800 and #4801 (not a fix per se, but I don't see any other option).

This may happen because none of the matrix sets given in the WMTS capabilities are in a projection defined in the settings.

An error message points the user towards this:
![image](https://user-images.githubusercontent.com/10629150/86096882-283a2400-bab4-11ea-9023-52a4d71fb9fd.png)

This PR also removes the `extent` restrictions that were sometimes put on map views, and which would prevent the user from panning/zooming out. This does not work well on polar projections and impedes user experience instead of improving it.

Finally a fix for #4802 was introduced as well.

@pvgenuchten could you maybe do a quick review? thanks!