### PR TITLE
remove jetty dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,10 +44,7 @@
       <groupId>org.tuckey</groupId>
       <artifactId>urlrewritefilter</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -44,7 +44,6 @@ import jeeves.server.sources.ServiceRequest.OutputMethod;
 import jeeves.server.sources.http.HttpServiceRequest;
 import jeeves.server.sources.http.JeevesServlet;
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jetty.io.EofException;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
 import org.fao.geonet.NodeInfo;
@@ -71,6 +70,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
@@ -844,7 +844,7 @@ public class ServiceManager {
                                 } finally {
                                     timerContext.stop();
                                 }
-                                
+
                                 if (outPage.getContentType() != null
                                     && outPage.getContentType().startsWith("text/plain")) {
                                     req.beginStream(outPage.getContentType(), -1, "attachment;", cache);
@@ -854,7 +854,7 @@ public class ServiceManager {
                                 req.getOutputStream().write(baos.toByteArray());
                                 req.endStream();
                             }
-                        } catch (EofException e) {
+                        } catch (EOFException e) {
                             // ignore this.
                             // it happens because the stream closes by client.
                         } catch (Exception e) {
@@ -922,7 +922,7 @@ public class ServiceManager {
                 req.beginStream(outPage.getContentType(), cache);
                 Xml.transform(rootElem, styleSheet, req.getOutputStream());
                 req.endStream();
-            } catch (EofException e) {
+            } catch (EOFException e) {
                 // ignore this.
                 // it happens because the stream closes by client.
             } catch (Exception e) {

--- a/core/src/main/java/org/fao/geonet/kernel/KeywordBean.java
+++ b/core/src/main/java/org/fao/geonet/kernel/KeywordBean.java
@@ -24,7 +24,7 @@ package org.fao.geonet.kernel;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.eclipse.jetty.util.URIUtil;
+import org.apache.commons.httpclient.URIException;
 import org.fao.geonet.constants.Geonet.Namespaces;
 import org.fao.geonet.exceptions.LabelNotFoundException;
 import org.fao.geonet.languages.IsoLanguagesMapper;
@@ -101,7 +101,7 @@ public class KeywordBean {
      * @return a complex iso19139 representation of the keyword
      */
     @JsonIgnore
-    public static Element getComplexIso19139Elt(List<KeywordBean> kbList) {
+    public static Element getComplexIso19139Elt(List<KeywordBean> kbList) throws URIException {
         Element root = new Element("MD_Keywords", Namespaces.GMD);
 
         Element cs = new Element("CharacterString", Namespaces.GCO);
@@ -116,7 +116,7 @@ public class KeywordBean {
             Element keyword = new Element("keyword", Namespaces.GMD);
             if (kb.getUriCode() != null && kb.getUriCode().length() != 0) {
                 an.setText(kb.getDefaultValue());
-                an.setAttribute("href", URIUtil.encodePath(kb.keywordUrl + kb.getUriCode()), Namespaces.XLINK);
+                an.setAttribute("href", org.apache.commons.httpclient.util.URIUtil.encodePath(kb.keywordUrl + kb.getUriCode()), Namespaces.XLINK);
                 keyword.addContent((Content) an.clone());
             } else {
                 cs.setText(kb.getDefaultValue());
@@ -527,14 +527,14 @@ public class KeywordBean {
      * @return an iso19139 representation of the keyword
      */
     @JsonIgnore
-    public Element getIso19139() {
+    public Element getIso19139() throws URIException {
         Element ele = new Element("MD_Keywords", Namespaces.GMD);
         Element el = new Element("keyword", Namespaces.GMD);
         Element an = new Element("Anchor", Namespaces.GMX);
         Element cs = new Element("CharacterString", Namespaces.GCO);
         if (getUriCode() != null && getUriCode().length() != 0) {
             an.setText(getDefaultValue());
-            an.setAttribute("href", URIUtil.encodePath(keywordUrl + getUriCode()), Namespaces.XLINK);
+            an.setAttribute("href", org.apache.commons.httpclient.util.URIUtil.encodePath(keywordUrl + getUriCode()), Namespaces.XLINK);
             el.addContent(an);
         } else {
             cs.setText(getDefaultValue());

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -27,7 +27,6 @@ import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
@@ -96,6 +95,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -168,7 +168,8 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
 
     Set<String> waitForIndexing = new HashSet<String>();
     Set<String> indexing = new HashSet<String>();
-    Set<IndexMetadataTask> batchIndex = new ConcurrentHashSet<IndexMetadataTask>();
+
+    Set<IndexMetadataTask> batchIndex = (new ConcurrentHashMap<>()).newKeySet(); //replaces ConcurrentHashSet
 
     @Override
     public void forceIndexChanges() throws IOException {
@@ -203,7 +204,7 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
                 metadataManager.deleteMetadata(ServiceContext.get(), String.valueOf(md.getId()));
             } catch (Exception e) {
                 Log.warning(Geonet.DATA_MANAGER, String.format(
-                    
+
                     "Error during removal of metadata %s part of batch delete operation. " +
                     "This error may create a ghost record (ie. not in the index " +
                     "but still present in the database). " +

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
@@ -25,7 +25,6 @@ package org.fao.geonet.kernel.datamanager.draft;
 
 import com.google.common.base.Optional;
 import jeeves.server.context.ServiceContext;
-import org.eclipse.jetty.io.RuntimeIOException;
 import org.fao.geonet.api.records.attachments.StoreUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
@@ -591,7 +590,7 @@ public class DraftMetadataUtils extends BaseMetadataUtils {
 
         } catch (Exception ex) {
             Log.error(Geonet.RESOURCES, "Failed copy of resources: " + ex.getMessage(), ex);
-            throw new RuntimeIOException(ex);
+            throw new RuntimeException(ex);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,7 @@
           <artifactId>maven-release-plugin</artifactId>
           <version>2.0</version>
         </plugin>
-        <plugin>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-maven-plugin</artifactId>
-          <version>${jetty.version}</version>
-        </plugin>
+
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
@@ -437,22 +433,7 @@
         <version>2.3</version>
       </dependency>
 
-      <!-- Jetty stuff -->
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-webapp</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
+
 
       <!-- Apache -->
       <dependency>

--- a/wro4j/src/test/java/org/fao/geonet/wro4j/GeonetWroModelFactoryTest.java
+++ b/wro4j/src/test/java/org/fao/geonet/wro4j/GeonetWroModelFactoryTest.java
@@ -33,8 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.http.client.utils.URIUtils;
-import org.eclipse.jetty.util.URIUtil;
 
 import static org.fao.geonet.wro4j.ClosureDependencyUriLocator.PATH_TO_WEBAPP_BASE_FROM_CLOSURE_BASE_JS_FILE;
 import static org.fao.geonet.wro4j.GeonetWroModelFactory.CLASSPATH_PREFIX;
@@ -134,7 +132,7 @@ public class GeonetWroModelFactoryTest {
             jsTestBaseDirAsPath = jsTestBaseDirAsPath.substring(1);
 
             // let's encode the filesystem path as it should be encoded by wro
-            jsTestBaseDirAsPath = URIUtil.encodePath(jsTestBaseDirAsPath);
+            jsTestBaseDirAsPath = org.apache.commons.httpclient.util.URIUtil.encodePath(jsTestBaseDirAsPath);
 
         }
 


### PR DESCRIPTION
I noticed that we had direct dependencies with jetty, and the PR removes them. 

a) there were two exception classes.  I replaced them with their parents.  I don't think they were being actively used "for real" anywhere
b) there was usage of jetty's ConcurrentHashSet (now deprecated) - I replaced that with the standard java 8 class
c) there was usage of jetty's URIUtil, which i replaced with apache common's version.  I don't think this was actually being used anywhere....

However, there are indirect reference to jetty via org.apache.camel:camel-websocket and (older jetty) via org.apache.hadoop.
 