### PR TITLE
do not want a default namespace to be inferred from srsName attribute…

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/extract-gml.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-gml.xsl
@@ -54,7 +54,7 @@
                             local-name() != 'MultiCurve' and
                             count(*) > 0 and
                             .//(gml:posList|gml320:posList) != '']">
-      <xsl:copy-of select="."/>
+      <xsl:copy-of copy-namespaces="no" select="."/>
     </xsl:for-each>
   </xsl:template>
 


### PR DESCRIPTION
… when default namespace is gml

Having metadata embedding such geom definition:

```
<gmd:geographicElement>
            <gmd:EX_BoundingPolygon>
              <gmd:polygon>
                <MultiSurface xmlns="http://www.opengis.net/gml/3.2" gml:id="d27273282e718">
                  <gml:surfaceMember>
                    <Polygon  gml:id="d27273282e720" srsName="urn:x-ogc:def:crs:EPSG:6.6:4326">
                      <exterior>
```

Experiencing  ```The namespace xmlns="" could not be added as a namespace to "Polygon": The namespace prefix "" collides with the element namespace prefix``` at both indexing or rendering (.../geonetwork/srv/api/records/2d4aa7b7-4c93-4507-acbe-3b51cd661545/extents.png?mapsrs=EPSG:21781) time.

Thought that default namespace did NOT apply to attributes, that is to say that srsName with no gml prefix should mean srsName from "root". I don't understand why saxon try somehow to infer a default namespace from attribute when transforming the jdom tree (maybe is the jdom tree malformed).

Rendering stack trace:
```
at net.sf.saxon.Controller.transformDocument(Controller.java:1807)
	at net.sf.saxon.Controller.transform(Controller.java:1621)
	at org.fao.geonet.utils.Xml.transform(Xml.java:518)
	at org.fao.geonet.utils.Xml.transform(Xml.java:371)
	at org.fao.geonet.kernel.search.spatial.SpatialIndexWriter.getSpatialExtent(SpatialIndexWriter.java:143)
	at org.fao.geonet.api.regions.metadata.MetadataRegionSearchRequest.loadSpatialExtent(MetadataRegionSearchRequest.java:173)
	at org.fao.geonet.api.regions.metadata.MetadataRegionSearchRequest.execute(MetadataRegionSearchRequest.java:117)
	at org.fao.geonet.kernel.region.Request.get(Request.java:89)
	at org.fao.geonet.api.regions.MetadataRegionDAO.getGeom(MetadataRegionDAO.java:70)
	at org.fao.geonet.kernel.region.RegionsDAO.getGeom(RegionsDAO.java:83)
	at org.fao.geonet.api.records.extent.MapRenderer.render(MapRenderer.java:135)
	at org.fao.geonet.api.records.extent.MetadataExtentApi.getRecordExtentAsImage(MetadataExtentApi.java:177)
```