### PR TITLE
Remove the 'geonet' namespace from the metadata

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -1011,6 +1011,9 @@ public class BaseMetadataManager implements IMetadataManager {
 
             // add original metadata to result
             Element result = new Element("root");
+            // Remove the 'geonet' namespace to avoid adding it to the
+            // processed elements in updated-fixed-info
+            md.removeNamespaceDeclaration(Geonet.Namespaces.GEONET);
             result.addContent(md);
             // add 'environment' to result
             env.addContent(new Element("siteURL").setText(settingManager.getSiteURL(context)));


### PR DESCRIPTION
This namespace is added to the metadata to handle the metadata editing logic, and if not removed it's added to the metadata elements processed in update-fixed-info, unless `copy-namespaces="no"` is used, but some code uses `xsl:element` instead if `xsl:copy` and can't be use `copy-namespaces`. 

Adding this to the Java code avoids having to apply the change in the different metadata schemas.

Original result:

```
<gmd:characterSet xmlns:geonet="http://www.fao.org/geonetwork">
  <gmd:MD_CharacterSetCode codeListValue="utf8" 
    codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"/>
</gmd:characterSet>
```

With the change:

```
<gmd:characterSet>
  <gmd:MD_CharacterSetCode codeListValue="utf8" 
    codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"/>
</gmd:characterSet>
```