### PR TITLE
validation report UX

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -40,9 +40,10 @@
             templateUrl: '../../catalog/components/edit/validationreport/' +
                 'partials/validationreport.html',
             scope: {},
-            link: function(scope) {
-              scope.showErrors = false;
-              scope.showSuccess = false;
+            link: function(scope, element, attrs) {
+              scope.showErrors = attrs.initialShowErrors == 'true';
+              scope.showSuccess = attrs.initialShowSuccesses == 'true';
+              scope.initialSectionsClosed = (attrs.initialSectionStates == "closed") ? "true":"false";
               scope.alwaysOnTop = false;
               scope.gnCurrentEdit = gnCurrentEdit;
               scope.loading = false;

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -42,8 +42,17 @@
             scope: {},
             link: function(scope, element, attrs) {
               scope.showErrors = attrs.initialShowErrors == 'true';
+              if (attrs.initialShowErrors === undefined) {
+                  scope.showErrors = true; //default
+              }
               scope.showSuccess = attrs.initialShowSuccesses == 'true';
+              if (attrs.initialShowSuccesses === undefined) {
+                  scope.showSuccess = true; //default
+              }
               scope.initialSectionsClosed = (attrs.initialSectionStates == "closed") ? "true":"false";
+              if (attrs.initialSectionStates === undefined) {
+                  scope.initialSectionsClosed = "true"; //default
+              }
               scope.alwaysOnTop = false;
               scope.gnCurrentEdit = gnCurrentEdit;
               scope.loading = false;

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -35,7 +35,7 @@
       <div class="panel panel-default"
            data-ng-repeat="type in ruleTypes"
            data-ng-class="'schematron-result-list-' + labelImportanceClass(type)">
-        <div data-gn-slide-toggle="" class="panel-heading clearfix">
+        <div data-gn-slide-toggle="{{initialSectionsClosed}}" class="panel-heading clearfix">
           <div class="col-md-9">
             <h2 class="gn-schematron-title"><span data-ng-if="type.schematronVerificationError">
               <i class="fa fa-exclamation-triangle fa-fw text-danger"></i>&nbsp;</span>{{(type.label || type.id) | translate}}</h2>

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -751,8 +751,8 @@
    * the element to indicate the status
    * collapsed or expanded.
    */
-  module.directive('gnSlideToggle', [
-    function() {
+  module.directive('gnSlideToggle', ["$timeout",
+    function($timeout) {
       return {
         restrict: 'A',
         link: function(scope, element, attrs) {
@@ -779,7 +779,9 @@
             });
           });
           if (attrs['gnSlideToggle'] == 'true') {
-            element.click();
+            $timeout(function() {
+                 element.click();
+            },0); //this needs to be done after the DOM is updated
           }
         }
       };


### PR DESCRIPTION
I noticed UX problem with the validation report.  100% of people using thought it was completely broken.

In order to see the errors, the user must know to press the green/red thumbs-up/thumbs-down icons.

I've set this up so that three things are configurable in the directive;
a) the green thumb up "button" state at the beginning
b) the red thumbs down "button" state at the beginning
c) set the "sections" open/closed at the beginning.

I've set them all to false by default so it would function as-is now.

Previously;
a) green thumbs up ---> NO
b) red thumbs up ---> NO
c) sections open --> YES

Settings should be, for user understanding;
a) green thumbs up ---> YES
b) red thumbs up ---> YES
c) sections open --> NO

I've changed this so that if you don't specify the values, you will get the latter settings (error & sucesses & closed).

To change, do something like this;

        <directive data-gn-validation-report="" data-initial-show-errors="true" data-initial-show-successes="true" data-initial-section-states="closed"/>
