### PR TITLE
add dublin core section to thesaurus

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -430,8 +430,8 @@ public class ThesaurusManager implements ThesaurusFinder {
 
             //add multilingual titles in to response
             //      "multilingualTitles":     [
-            //            { "lang": "fr","title": "ECCC Data Usage Scope FR"},
-            //            {"lang": "en","title": "ECCC Data Usage Scope EN"}
+            //            { "lang": "fr","title": "Data Usage Scope FR"},
+            //            {"lang": "en","title": "Data Usage Scope EN"}
             //      ],
             Element elMultilingualTitles = new Element("multilingualTitles");
             for (Map.Entry<String, String> entry : currentTh.getMultilingualTitles().entrySet()) {
@@ -448,8 +448,8 @@ public class ThesaurusManager implements ThesaurusFinder {
 
             //add dublin core items to the response
             // "dublinCoreMultilingual": [
-            //    { "lang": "fr","tag":"title","value": "ECCC Data Usage Scope FR"},
-            //    {"lang": "en","tag":"title","value": "ECCC Data Usage Scope EN"}
+            //    { "lang": "fr","tag":"title","value": "Data Usage Scope FR"},
+            //    {"lang": "en","tag":"title","value": "Data Usage Scope EN"}
             //]
             Element elDublinCoreMultilingual = new Element("dublinCoreMultilinguals");
             for (Map.Entry<String, Map<String,String>> entryLang : currentTh.getDublinCoreMultilingual().entrySet()) {

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -446,6 +446,32 @@ public class ThesaurusManager implements ThesaurusFinder {
                 elMultilingualTitles.addContent(elMultilingualTitle);
             }
 
+            //add dublin core items to the response
+            // "dublinCoreMultilingual": [
+            //    { "lang": "fr","tag":"title","value": "ECCC Data Usage Scope FR"},
+            //    {"lang": "en","tag":"title","value": "ECCC Data Usage Scope EN"}
+            //]
+            Element elDublinCoreMultilingual = new Element("dublinCoreMultilinguals");
+            for (Map.Entry<String, Map<String,String>> entryLang : currentTh.getDublinCoreMultilingual().entrySet()) {
+                String lang = entryLang.getKey();
+                for (Map.Entry<String, String> entryItem : entryLang.getValue().entrySet()) {
+                    Element elItem = new Element("dublinCoreMultilingual");
+                    Element elLang = new Element("lang");
+                    elLang.setText(lang);
+                    Element elTag = new Element("tag");
+                    elTag.setText(entryItem.getKey());
+                    Element elValue = new Element("value");
+                    elValue.setText(entryItem.getValue());
+
+                    elItem.addContent(elLang);
+                    elItem.addContent(elTag);
+                    elItem.addContent(elValue);
+
+
+                    elDublinCoreMultilingual.addContent(elItem);
+                }
+            }
+
             Element elType = new Element("type");
             String type = currentTh.getType();
             elType.addContent(type);
@@ -479,6 +505,7 @@ public class ThesaurusManager implements ThesaurusFinder {
             elLoop.addContent(elFname);
             elLoop.addContent(elTitle);
             elLoop.addContent(elMultilingualTitles);
+            elLoop.addContent(elDublinCoreMultilingual);
             elLoop.addContent(elDate);
             elLoop.addContent(elUrl);
             elLoop.addContent(elDefaultURI);

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
@@ -94,6 +94,31 @@
     </xsl:apply-templates>
   </xsl:template>
 
+  <!-- given a thesarus and language, find the most appropriate responsible party name.
+       This will be in the dublin core section as "publisher"-->
+  <xsl:function name="geonet:getThesaurusResponsiblePartyIso19139">
+    <xsl:param name="thesarus" />
+    <xsl:param name="lang1" />
+    <xsl:variable name="lang" select="lower-case($lang1)" />
+    <xsl:variable name="lang_2letter" select="lower-case(util:twoCharLangCode($lang))" />
+
+    <xsl:variable name="thesaurusPublisherMultilingualNode" select="$thesarus/dublinCoreMultilinguals/dublinCoreMultilingual[lower-case(./lang) = $lang and ./tag='publisher']/value" />
+    <xsl:variable name="thesaurusPublisherMultilingualNode_2letter" select="$thesarus/dublinCoreMultilinguals/dublinCoreMultilingual[lower-case(./lang) = $lang_2letter and ./tag='publisher']/value" />
+
+    <xsl:choose>
+      <xsl:when test="$thesaurusPublisherMultilingualNode">
+        <xsl:value-of select="$thesaurusPublisherMultilingualNode"/>
+      </xsl:when>
+      <xsl:when test="$thesaurusPublisherMultilingualNode_2letter">
+        <xsl:value-of select="$thesaurusPublisherMultilingualNode_2letter"/>
+      </xsl:when>
+      <xsl:otherwise>
+        Unknown
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
+
   <xsl:template mode="to-iso19139-keyword" match="*[not(/root/request/skipdescriptivekeywords)]">
     <xsl:param name="textgroupOnly"/>
     <xsl:param name="listOfLanguage"/>
@@ -321,6 +346,30 @@
               </gmd:CI_Date>
             </gmd:date>
           </xsl:if>
+
+          <!--
+              You can pull in the publisher from the Thesaurus XML.  See Metadata101/iso19139.ca.HNAP
+              NOTE: HNAP only has 2 languages, so this should be modified so it loops through the non-default lanaguages
+                    instead of just using ${altLang}
+              NOTE: This also hard-codes the <gmd:role>, but you can also add this to the RDF and put it in here.
+              NOTE:      <xsl:variable name="currentThesaurusFull" select="$thesauri/thesaurus[key = $currentThesaurus]" />
+
+           <gmd:citedResponsibleParty>
+            <gmd:CI_ResponsibleParty>
+              <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString><xsl:value-of select="geonet:getThesaurusResponsibleParty($currentThesaurusFull,$mdlang)"/></gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#{$altLang}"><xsl:value-of select="geonet:getThesaurusResponsiblePartyIso19139($currentThesaurusFull,$altLang)"/></gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:organisationName>
+              <gmd:role>
+                <gmd:CI_RoleCode codeListValue="RI_409" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:citedResponsibleParty>
+          -->
 
           <xsl:if test="$withThesaurusAnchor">
             <gmd:identifier>


### PR DESCRIPTION
This adds more multilingual dublin core items to the Thesaurus.  This is to make the final metatadata record have more info in the keywords section.

For example, in the RDF;

<skos:ConceptScheme rdf:about="http://geonetwork-opensource.org/thesaurus/naturalearth-and-seavox">
    <dc:title>Content Scope</dc:title>
       <dc:title xml:lang="en">Content Scope EN</dc:title>
       <dc:title xml:lang="fr">Content Scope FR</dc:title>
    <dc:publisher xml:lang="en">publisher en</dc:publisher>
    <dc:publisher xml:lang="fr">publisher en</dc:publisher>
    <dc:description></dc:description>
  </skos:ConceptScheme>

In the final json output of thesaurus;

...
"dublinCoreMultilingual": [
            { "lang": "fr","tag":"publisher","value": "publisher fr"},
            {"lang": "en","tag":"publisher","value": "publisher en"}
 ]
...