### PR TITLE
Add schema dependency to service module so that unit tests will not fail

### DIFF
--- a/add-schema.sh
+++ b/add-schema.sh
@@ -103,3 +103,27 @@ then
 \                </resource>
 SED_SCRIPT
 fi
+
+# Add schema resources in service/pom.xml with test scope for unit tests
+line=$(grep -n "<artifactId>schema-${schema}</artifactId>" services/pom.xml | cut -d: -f1)
+
+if [ ! $line ]
+then
+  line=$(grep -n '</dependencies>' services/pom.xml | cut -d: -f1)
+  finalLine=$(($line - 1))
+
+  projectGroupId='${project.groupId}'
+  gnSchemasVersion='${gn.schemas.version}'
+
+  echo "Adding schema ${schema} resources to service/pom.xml"
+
+  sed $sedopt -f /dev/stdin services/pom.xml << SED_SCRIPT
+  ${finalLine} a\\
+\    <dependency>\\
+\      <groupId>${projectGroupId}</groupId>\\
+\      <artifactId>schema-${schema}</artifactId>\\
+\      <version>${gnSchemasVersion}</version>\\
+\      <scope>test</scope>\\
+\    </dependency>
+SED_SCRIPT
+fi


### PR DESCRIPTION
When adding schema's to the code using the add-schema.sh, it can cause some unit test to fail.
See discussion on HNAP schema at the following location.
https://github.com/metadata101/iso19139.ca.HNAP/pull/56#discussion_r450872749

There are 2 options for fixing this issue.

**Option 1** 
Updated GeonetTestFixture.deploySchema so that it only deploys the geonetwork core schemas

**Option 2**
Add schema dependencies


Adding the schema dependencies(Option 2) has the benefit that unit test are being executed on the newly added schema. 
The implementation for option 2 is also easier to implement.

This PR is for option 2.