### PR TITLE
Improve error message when uploading a mef zip file 

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -397,10 +397,14 @@ public class Importer {
                 }
 
 
-                importRecord(uuid, uuidAction, md, schema, index,
-                    source, sourceName, sourceTranslations,
-                    context, metadataIdMap, createDate,
-                    changeDate, groupId, isTemplate);
+                try {
+                    importRecord(uuid, uuidAction, md, schema, index,
+                       source, sourceName, sourceTranslations,
+                       context, metadataIdMap, createDate,
+                       changeDate, groupId, isTemplate);
+                } catch (Exception e) {
+                        throw new Exception("Failed to import metadata with uuid '" + uuid + "'. " + e.getLocalizedMessage(), e);
+                }
 
                 if (fc.size() != 0 && fc.get(index) != null) {
                     // UUID is set as @uuid in root element


### PR DESCRIPTION
When loading MEF file containing lots of records. The system could generate an error similar to the following.

```
Failed to import MEF file 'export-full-1593552282553.zip'. Check error for details.
iso19139 is not permitted in the database as a non-harvested metadata. Apply a import stylesheet to convert file to allowed schemas
```

This is difficult to identify the file containing the error within the mef zip file.

This change will modify the error so that we get an error similar to the following.

```
Failed to import MEF file 'export-full-1593552282553.zip'. Check error for details.
Failed to import metadata with uuid '6522e8b8-efbc-4030-add5-4838238bb34d'. iso19139 is not permitted in the database as a non-harvested metadata. Apply a import stylesheet to convert file to allowed schemas
```

Note: It identifies the UUID from the MEF parsing and not the UUID that it attempted to insert into the database.  So if the option to generate new UUID is used during the import we are not presented with random UUID's.