### PR TITLE
Fixed bug with assigning resources to a metadata record.

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -80,7 +80,7 @@ public class ResourceLoggerStore extends AbstractStore {
             ResourceHolder holder = decoratedStore.getResource(context, metadataUuid, visibility, resourceId, approved);
             if (holder != null) {
                 // TODO: Add Requester details which may have been provided by a form ?
-                storeGetRequest(context, metadataUuid, resourceId, "", "", "", "", new ISODate().toString());
+                storeGetRequest(context, metadataUuid, holder.getMetadata().getId(), "", "", "", "", new ISODate().toString());
             }
             return holder;
         }


### PR DESCRIPTION
Fixed bug where it was supplying the resourceId which was the simple filename and it would use this to query the database and never found the result because the database contains more than just the base filename. Changed it to get the getId() function which returns the same format as the filename stored in the database.