### PR TITLE
ISO19139: Fix bug with defaultTitle and defaultAbstract 

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/convert/functions.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/functions.xsl
@@ -191,8 +191,21 @@
   <xsl:template name="defaultTitle">
     <xsl:param name="isoDocLangId"/>
 
-    <xsl:variable name="poundLangId"
-                  select="concat('#',upper-case(java:twoCharLangCode($isoDocLangId)))"/>
+    <xsl:variable name="poundLangId">
+      <xsl:variable name="langIdFromlocale"
+                    select="/*[name(.)='gmd:MD_Metadata' or
+              name() = 'gmi:MI_Metadata' or
+              @gco:isoType='gmd:MD_Metadata' or
+              @gco:isoType='gmd:MI_Metadata']/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue=$isoDocLangId]/@id"/>
+        <xsl:choose>
+          <xsl:when test="string-length($langIdFromlocale) != 0">
+            <xsl:value-of select="concat('#',$langIdFromlocale)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat('#',upper-case(java:twoCharLangCode($isoDocLangId)))"/>
+          </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
 
     <xsl:variable name="identification" select="/*[name(.)='gmd:MD_Metadata' or
             name() = 'gmi:MI_Metadata' or
@@ -221,8 +234,21 @@
   <xsl:template name="defaultAbstract">
     <xsl:param name="isoDocLangId"/>
 
-    <xsl:variable name="poundLangId"
-                  select="concat('#',upper-case(java:twoCharLangCode($isoDocLangId)))" />
+    <xsl:variable name="poundLangId">
+      <xsl:variable name="langIdFromlocale"
+                    select="/*[name(.)='gmd:MD_Metadata' or
+              name() = 'gmi:MI_Metadata' or
+              @gco:isoType='gmd:MD_Metadata' or
+              @gco:isoType='gmd:MI_Metadata']/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue=$isoDocLangId]/@id"/>
+        <xsl:choose>
+          <xsl:when test="string-length($langIdFromlocale) != 0">
+            <xsl:value-of select="concat('#',$langIdFromlocale)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat('#',upper-case(java:twoCharLangCode($isoDocLangId)))"/>
+          </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
 
     <xsl:variable name="identification"
                   select="/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:identificationInfo/*[name(.)='gmd:MD_DataIdentification' or @gco:isoType='gmd:MD_DataIdentification' or name(.)='srv:SV_ServiceIdentification' or @gco:isoType='srv:SV_ServiceIdentification']"></xsl:variable>


### PR DESCRIPTION
Fix bug with defaultTitle and defaultAbstract where #lang was being selected based on 2 char lang code when it should be using the gmd:locale

Metadata using #fra with gmd:locale id as fra was failing to translate and defaultTitle and defaultAbstract was always the main language.

Kept old 2 char lang conversion for cases where the gmd:locale is not found.  But not sure if we really need to keep this? I cannot think of any cases where it would be needed. 