### PR TITLE
Search / Allow searches on `_groupOwner`

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -1828,8 +1828,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
 
         // List of lucene fields which MUST not be control by user, to be removed from the CSW service specific constraint
         List<String> SECURITY_FIELDS = Arrays.asList(
-            LuceneIndexField.OWNER,
-            LuceneIndexField.GROUP_OWNER);
+            LuceneIndexField.OWNER);
 
         BooleanQuery bq;
         if (q instanceof BooleanQuery) {


### PR DESCRIPTION
User may want to set a portal filter to ` _groupPublished:templates _groupOwner:2234` but currently the `_groupOwner` field is removed. 

It is not a security field has user groups will always be added to the query so there is no reason to exclude it from here.