### PR TITLE
Harvester / CSW / Fix batch edit condition

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -341,7 +341,9 @@ public class Aligner extends BaseAligner<CswParams> {
                     boolean applyEdit = true;
                     if (StringUtils.isNotEmpty(batchEditParameter.getCondition())) {
                         final Object node = Xml.selectSingle(md, batchEditParameter.getCondition(), metadataSchema.getNamespaces());
-                        applyEdit = (node != null) || (node instanceof Boolean && (Boolean)node != false);
+                        if (node != null && node instanceof Boolean && (Boolean)node != true) {
+                            applyEdit = false;
+                        }
                     }
                     if (applyEdit) {
                         metadataChanged = editLib.addElementOrFragmentFromXpath(

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -340,9 +340,10 @@ public class Aligner extends BaseAligner<CswParams> {
 
                     boolean applyEdit = true;
                     if (StringUtils.isNotEmpty(batchEditParameter.getCondition())) {
+                        applyEdit = false;
                         final Object node = Xml.selectSingle(md, batchEditParameter.getCondition(), metadataSchema.getNamespaces());
-                        if (node != null && node instanceof Boolean && (Boolean)node != true) {
-                            applyEdit = false;
+                        if (node != null && node instanceof Boolean && (Boolean)node == true) {
+                            applyEdit = true;
                         }
                     }
                     if (applyEdit) {

--- a/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
@@ -203,9 +203,10 @@ public class BatchEditsApi implements ApplicationContextAware {
 
                         boolean applyEdit = true;
                         if (StringUtils.isNotEmpty(batchEditParameter.getCondition())) {
+                            applyEdit = false;
                             final Object node = Xml.selectSingle(metadata, batchEditParameter.getCondition(), metadataSchema.getNamespaces());
-                            if (node != null && node instanceof Boolean && (Boolean)node != true) {
-                                applyEdit = false;
+                            if (node != null && node instanceof Boolean && (Boolean)node == true) {
+                                applyEdit = true;
                             }
                         }
                         if (applyEdit) {

--- a/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
@@ -204,7 +204,9 @@ public class BatchEditsApi implements ApplicationContextAware {
                         boolean applyEdit = true;
                         if (StringUtils.isNotEmpty(batchEditParameter.getCondition())) {
                             final Object node = Xml.selectSingle(metadata, batchEditParameter.getCondition(), metadataSchema.getNamespaces());
-                            applyEdit = (node != null) || (node instanceof Boolean && (Boolean)node != false);
+                            if (node != null && node instanceof Boolean && (Boolean)node != true) {
+                                applyEdit = false;
+                            }
                         }
                         if (applyEdit) {
                             metadataChanged = editLib.addElementOrFragmentFromXpath(


### PR DESCRIPTION
The condition in batch edit must return a boolean.

eg.
```xml
[
  {
    "condition": "count(.//gmd:fileIdentifier[*/text() = 'da165110-88fd-11da-a88f-000d939bc5d8']) > 0",
    "xpath": "/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords[1]",
    "value": "<gn_add><gmd:descriptiveKeywords xmlns:gmd=\"http://www.isotc211.org/2005/gmd\" xmlns:gco=\"http://www.isotc211.org/2005/gco\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>101</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\"./resources/codeList.xml#MD_KeywordTypeCode\" codeListValue=\"theme\"/></gmd:type></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>"

  },{
    "condition": "count(.//gmd:fileIdentifier[*/text() = '78f93047-74f8-4419-ac3d-fc62e4b0477b']) > 0",
    "xpath": "/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords[1]",
    "value": "<gn_add><gmd:descriptiveKeywords xmlns:gmd=\"http://www.isotc211.org/2005/gmd\" xmlns:gco=\"http://www.isotc211.org/2005/gco\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>202</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\"./resources/codeList.xml#MD_KeywordTypeCode\" codeListValue=\"theme\"/></gmd:type></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>"

  }
]
```

Fix update when expression was also matching an existing node.

Relates to https://github.com/geonetwork/core-geonetwork/pull/4172