### PR TITLE
Make links and dropdowns keyword accessible

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/savedselections/partials/action.html
+++ b/web-ui/src/main/resources/catalog/components/common/savedselections/partials/action.html
@@ -18,7 +18,7 @@
     <li data-ng-repeat="s in selections.list"
         data-ng-show="canBeAdded(s)"
         role="menuitem">
-      <a data-ng-click="add(s)">
+      <a href="" data-ng-click="add(s)">
         {{s.label[lang] || (s.name | translate)}}
       </a>
     </li>
@@ -29,7 +29,7 @@
     <li data-ng-repeat="s in selections.list"
         data-ng-show="canBeRemoved(s)"
         role="menuitem">
-      <a data-ng-click="remove(s)">
+      <a href="" data-ng-click="remove(s)">
         {{s.label[lang] || (s.name | translate)}}
       </a>
     </li>

--- a/web-ui/src/main/resources/catalog/components/search/formfields/partials/sortByCombo.html
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/partials/sortByCombo.html
@@ -13,7 +13,7 @@
       <li data-ng-repeat="v in ::values"
           role="menuitem"
           data-ng-class="v.sortBy === params.sortBy ? 'disabled' : ''">
-        <a data-ng-click="sortBy(v)">{{v.sortBy | translate}}</a></li>
+        <a href="" data-ng-click="sortBy(v)">{{v.sortBy | translate}}</a></li>
     </ul>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
+++ b/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
@@ -37,7 +37,7 @@
         <li data-ng-repeat="nb in values"
             role="menuitem"
             data-ng-class="nb === config.hitsPerPage ? 'disabled' : ''">
-          <a data-ng-click="updateSearch(nb)">{{nb}}</a>
+          <a href="" data-ng-click="updateSearch(nb)">{{nb}}</a>
         </li>
       </ul>
     </li>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/templateswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/templateswitcher.html
@@ -13,7 +13,8 @@
   <ul class="dropdown-menu">
     <li data-ng-repeat="t in listOfResultTemplate"
         data-ng-hide="t.tplUrl == resultTemplate">
-      <a data-ng-click="setResultTemplate(t);"
+      <a href=""
+         data-ng-click="setResultTemplate(t);"
          title="{{t.tooltip | translate}}">
         <i class="fa {{t.icon}}"/>&nbsp;
         {{t.tooltip | translate}}

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
@@ -13,9 +13,9 @@
           {{selection.length}} <span data-translate="">selected</span><span class="caret"/>
         </button>
         <ul class="dropdown-menu">
-          <li><a data-ng-click="selectAll(true)" data-translate="">selectAll</a>
+          <li><a href="" data-ng-click="selectAll(true)" data-translate="">selectAll</a>
           </li>
-          <li><a data-ng-click="selectAll(false)" data-translate="">selectNone</a>
+          <li><a href="" data-ng-click="selectAll(false)" data-translate="">selectNone</a>
           </li>
         </ul>
       </div>

--- a/web-ui/src/main/resources/catalog/lib/angular.ext/tabs.js
+++ b/web-ui/src/main/resources/catalog/lib/angular.ext/tabs.js
@@ -180,7 +180,7 @@ angular.module('ui.bootstrap.tabs', [])
         restrict: 'EA',
         replace: true,
         template: '<li ng-class="{active: active, disabled: disabled}">' +
-            '<a ng-click="select()" tab-heading-transclude>{{heading}}</a>' +
+            '<a href="" ng-click="select()" tab-heading-transclude>{{heading}}</a>' +
         '</li>',
         transclude: true,
         scope: {

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -14,16 +14,16 @@
     </button>
     <ul class="dropdown-menu" role="menu">
       <li role="menuitem">
-        <a data-ng-href=""
-             data-ng-if="user.canEditRecord(md) && user.isEditorOrMore() && md.draft != 'y'"
-             data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())">
+        <a href=""
+           data-ng-if="user.canEditRecord(md) && user.isEditorOrMore() && md.draft != 'y'"
+           data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())">
           <i class="fa fa-fw fa-key"></i>&nbsp;
           <span data-translate="">privileges</span>
         </a>
       </li>
       <li role="menuitem"
           data-ng-if="md.isOwned() && user.isUserAdminOrMore()">
-        <a data-ng-href=""
+        <a href=""
            data-ng-click="mdService.openTransferOwnership(md, null, getCatScope())">
           <i class="fa fa-fw fa-user"></i>&nbsp;
           <span data-translate="">transferOwnership</span>
@@ -37,7 +37,7 @@
           title="{{(!md.isPublished() ? (md.isValid() ? 'mdvalid' :
             (!md.hasValidation() ? 'mdnovalidation':
             (allowPublishInvalidMd() === false ? 'mdinvalidcantpublish' : 'mdinvalid'))) : '') | translate }}">
-        <a data-ng-click="mdService.publish(md, undefined, undefined, getCatScope())">
+        <a href="" data-ng-click="mdService.publish(md, undefined, undefined, getCatScope())">
           <i class="fa fa-fw"
              data-ng-class="md.isPublished() ? 'fa-lock' : 'fa-unlock'"></i>&nbsp;
           <span data-ng-if="md.isPublished()"
@@ -80,7 +80,7 @@
       <li role="menuitem"
           data-ng-if="user.canEditRecord(md) && (user.isAdmin() ||
           user.isEditorForGroup(md.groupOwner)) && md.mdStatus == 1 && isMdWorkflowEnable && md.isWorkflowEnabled()">
-        <a data-ng-href=""
+        <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 4, 14)">
           <i class="fa fa-fw fa-file-o"></i>&nbsp;
           <span data-translate="">mdStatusTitle-14</span>
@@ -89,7 +89,7 @@
       <li role="menuitem"
           data-ng-if="user.canEditRecord(md) && (user.isAdmin() ||
           user.isEditorForGroup(md.groupOwner)) && md.mdStatus == 3 && isMdWorkflowEnable && md.isWorkflowEnabled()">
-        <a data-ng-href=""
+        <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 1, 31)">
           <i class="fa fa-fw fa-file-o"></i>&nbsp;
           <span data-translate="">mdStatusTitle-31</span>
@@ -99,7 +99,7 @@
       <li role="menuitem"
           data-ng-if="user.canEditRecord(md) && !user.isReviewerForGroup(md.groupOwner) &&
           user.isEditorForGroup(md.groupOwner) && md.mdStatus == 4  && isMdWorkflowEnable && md.isWorkflowEnabled()">
-        <a data-ng-href=""
+        <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 1, 41)">
           <i class="fa fa-fw fa-undo"></i>&nbsp;
           <span data-translate="">mdStatusTitle-41</span>
@@ -109,8 +109,8 @@
       <li role="menuitem"
           data-ng-if="user.canEditRecord(md) && (user.isAdmin() || user.isReviewerForGroup(md.groupOwner)) &&
           md.mdStatus == 4  && isMdWorkflowEnable && md.isWorkflowEnabled()">
-        <a data-ng-href=""
-            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 2, 42)">
+        <a href=""
+           data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 2, 42)">
           <i class="fa fa-fw fa-thumbs-o-up"></i>&nbsp;
           <span data-translate="">mdStatusTitle-42</span>
         </a>
@@ -118,8 +118,8 @@
       <li role="menuitem"
           data-ng-if="user.canEditRecord(md) && (user.isAdmin() || user.isReviewerForGroup(md.groupOwner)) &&
           md.mdStatus == 1  && isMdWorkflowEnable && md.isWorkflowEnabled()">
-        <a data-ng-href=""
-            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 2, 12)">
+        <a href=""
+           data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 2, 12)">
           <i class="fa fa-fw fa-thumbs-o-up"></i>&nbsp;
           <span data-translate="">mdStatusTitle-12</span>
         </a>
@@ -128,8 +128,8 @@
       <li role="menuitem"
           data-ng-if="user.canEditRecord(md) && (user.isAdmin() || user.isReviewerForGroup(md.groupOwner)) &&
           md.mdStatus == 4  && isMdWorkflowEnable && md.isWorkflowEnabled()">
-        <a data-ng-href=""
-            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 1, 411)">
+        <a href=""
+           data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 1, 411)">
           <i class="fa fa-fw fa-thumbs-o-down"></i>&nbsp;
           <span data-translate="">mdStatusTitle-411</span>
         </a>
@@ -138,15 +138,15 @@
       <li role="menuitem"
           data-ng-if="user.canEditRecord(md) && (user.isAdmin() || user.isReviewerForGroup(md.groupOwner)) &&
           md.mdStatus == 4  && isMdWorkflowEnable && md.isWorkflowEnabled()">
-        <a data-ng-href=""
-            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 3, 33)">
+        <a href=""
+           data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 3, 33)">
           <i class="fa fa-fw fa-archive"></i>&nbsp;
           <span data-translate="">mdStatusTitle-33</span>
         </a>
       </li>
       <li data-ng-if="isMdWorkflowEnable && user.canEditRecord(md) && !md.isWorkflowEnabled()">
         <a role="menuitem"
-           data-ng-href=""
+           href=""
            data-ng-click="mdService.startWorkflow(md, getCatScope())">
           <i class="fa fa-fw fa-code-fork"></i>&nbsp;
           <span data-translate="">enableWorkflow</span>
@@ -160,7 +160,7 @@
       <li data-ng-repeat="t in tasks"
           data-ng-show="taskConfiguration[t.name] && taskConfiguration[t.name].isVisible && taskConfiguration[t.name].isVisible(md)"
           data-ng-class="::{'disabled': !taskConfiguration[t.name].isApplicable(md)}">
-        <a data-ng-click="mdService.openUpdateStatusPanel(getScope(md), 'task', t)">
+        <a href="" data-ng-click="mdService.openUpdateStatusPanel(getScope(md), 'task', t)">
           <i class="fa fa-fw"></i>&nbsp;
           <span>{{t.label | gnLocalized}}</span>
         </a>
@@ -170,7 +170,7 @@
 
 
       <li role="menuitem">
-        <a data-ng-href=""
+        <a href=""
            data-ng-if="user.isEditorOrMore() && md.draft != 'y'"
            data-ng-click="mdService.duplicate(md)">
           <i class="fa fa-fw fa-copy"></i>&nbsp;
@@ -178,7 +178,7 @@
         </a>
       </li>
       <li role="menuitem">
-        <a data-ng-href=""
+        <a href=""
            data-ng-if="user.isEditorOrMore() && md.draft != 'y'"
            data-ng-click="mdService.createChild(md)">
           <i class="fa fa-fw fa-sitemap"></i>&nbsp;
@@ -200,7 +200,7 @@
     </button>
     <ul class="dropdown-menu" role="menu">
       <li data-ng-class="{'disabled': md.draft === 'y'}">
-        <a data-ng-href=""
+        <a href=""
            data-ng-click="mdService.getPermalink(md)">
           <i class="fa fa-fw fa-link"></i>&nbsp;
           <span data-translate="">permalink</span>
@@ -216,7 +216,7 @@
 
       <!-- TODO: RDF export should be replaced by a formatter. -->
       <li role="menuitem">
-        <a data-ng-href=""
+        <a href=""
            data-ng-click="mdService.metadataRDF(md.getUuid(), mdView.current.record.draft != 'y')">
           <i class="fa fa-fw fa-share-alt"></i>&nbsp;
           <span data-translate="">exportRDF</span>


### PR DESCRIPTION
This PR adds `href=""` to links and dropdowns to make the elements accessible for keyboards. When you want to access elements on a page with `tab` or `arrow` keys a `<a>` needs to have the `href` attribute.