### PR TITLE
Add images folder to war to fix startup error

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -748,6 +748,11 @@
                   <filtering>true</filtering>
                   <targetPath>${build.webapp.resources}</targetPath>
                 </resource>
+                <resource>
+                  <directory>${geonetwork.webapp.dir}/WEB-INF/data/data/resources/images</directory>
+                  <filtering>true</filtering>
+                  <targetPath>${project.build.directory}/geonetwork/images</targetPath>
+                </resource>
               </resources>
               <filters>
                 <filter>${basedir}/src/main/filters/${env}.properties</filter>


### PR DESCRIPTION
The startup sequence uses the `<deploy-dir>/images` folder to create the logo for the current catalog. As this folder doesn't exist in the WAR, startup of geonetwork fails with the error

```
2020-07-20 14:52:54,141 ERROR [geonetwork] - /var/lib/geonetwork_data/data/resources/images/logos/14c848d1-3779-469c-8c1e-c62417672c83.png
java.nio.file.NoSuchFileException: /var/lib/geonetwork_data/data/resources/images/logos/14c848d1-3779-469c-8c1e-c62417672c83.png
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:244)
        at sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:103)
        at java.nio.file.Files.delete(Files.java:1126)
        at org.fao.geonet.utils.IO.deleteFile(IO.java:98)
        at org.fao.geonet.utils.IO.deleteFile(IO.java:93)
        at org.fao.geonet.resources.FileResources$FileResourceHolder.abort(FileResources.java:215)
        at org.fao.geonet.resources.Resources.copyLogo(Resources.java:292)
        at org.fao.geonet.Geonetwork.createSiteLogo(Geonetwork.java:488)
        at org.fao.geonet.Geonetwork.start(Geonetwork.java:290)
        at jeeves.server.JeevesEngine.initAppHandler(JeevesEngine.java:425)
        at jeeves.server.JeevesEngine.init(JeevesEngine.java:170)
        at jeeves.server.sources.http.JeevesServlet.init(JeevesServlet.java:80)
        at javax.servlet.GenericServlet.init(GenericServlet.java:158)
        at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:1144)
```

See https://github.com/geonetwork/core-geonetwork/issues/4660#issuecomment-661791334

This change copies the images already in `core-geonetwork/web/WEB-INF/data/data/resources/images` to `target/geonetwork/images` so tha the `<deploy-dir>/images` folder is available on geonetwork startup.

see #4660