### PR TITLE
[#4864] Fix for thumbnails on the homepage containing a space in the URL

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -25,7 +25,7 @@
            gn-records="searchResults.records"
            gn-formatter="formatter.defaultUrl">
           <div class="gn-img-thumbnail"
-               style="background-image: url({{md.getThumbnails().list[0].url}})">
+               style="background-image: url('{{md.getThumbnails().list[0].url}}')">
           </div>
         </a>
       </div>


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/issues/4864

Small fix for thumbnails on the homepage containing a space in the URL. Fixed by adding `'`s around the `background-image` styling in the thumbnail.