### PR TITLE
[#4865] Add option setting for changing the background color of the search block

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1450,5 +1450,6 @@
     "ui-defaultSearchString-help":"This configuration lets you define a default filter for the search. The syntax is the one used in the angular facet query array.",
     "ui-autoFitOnLayer":"Always zoom on data",
     "ui-autoFitOnLayer-help":"If checked, the map will automatically zoom on data when adding a layer from a record. Otherwise, a message will be shown to let the user zoom on data manually.",
-    "styleVariable-gnHeaderHeight":"Height"
+    "styleVariable-gnHeaderHeight":"Height",
+    "styleVariable-gnSearchBackgroundColor": "Backgound color"
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/cssstyle.html
@@ -125,6 +125,11 @@
               </div>
               <div class="form-row">
                 <div class="col-md-3">
+                  <label for="gnCssStyle.gnSearchBackgroundColor" data-translate="">styleVariable-gnSearchBackgroundColor</label>
+                  <color-picker data-ng-model="gnCssStyle.gnSearchBackgroundColor"
+                    color-picker-format="'hex'" color-picker-alpha="true"></color-picker>
+                </div>
+                <div class="col-md-3">
                   <label for="gnCssStyle.gnSearchOutlineColor" data-translate="">styleVariable-gnSearchOutlineColor</label>
                   <color-picker data-ng-model="gnCssStyle.gnSearchOutlineColor"
                     color-picker-format="'hex'" color-picker-alpha="true"></color-picker>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -72,6 +72,7 @@
     .gn-top-search {
       padding-top: 0;
       padding-bottom: 0;
+      background-color: #fff;
     }
   }
   .gn-search-facet {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -58,7 +58,8 @@ html, body {
   margin-right: 0;
 }
 .gn-row-main {
-  margin: 2em 0 4em;
+  padding: 2em 0 4em;
+  background-color: @gn-search-background-color;
   .gn-form-any {
     .input-lg {
       &:focus {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -74,7 +74,7 @@
     position: relative;
     padding-top: 2em;
     padding-bottom: 2em;
-    background-color: #fff;
+    background-color: @gn-search-background-color;
     [typeahead] {
       vertical-align: middle;
       display: inline-block;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -49,6 +49,8 @@
 // home page
 //
 // ----- search input
+@gn-search-background-color: @body-bg;
+
 @gn-search-outline-color: @brand-primary;
 @gn-search-button-background-color: @brand-primary;
 @gn-search-button-color: @btn-primary-color;
@@ -64,7 +66,7 @@
 @gn-resultcard-background-color: @body-bg;
 @gn-resultcard-title-background-color: #505050;
 @gn-resultcard-title-background-color-hover: #333;
-@gn-resultcard-title-color: #fff; // @navbar-default-link-color;
+@gn-resultcard-title-color: #fff;
 @gn-resultcard-title-border: 0px solid @navbar-default-border;
 
 // search results page


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/issues/4865

This PR adds the option to change the background colour of the search blocks on the home and search results page. When no colour is chosen in the admin, the background colour defaults to the same colour as the `body`

**Setting in the admin**

![gn-search-bg-setting](https://user-images.githubusercontent.com/19608667/88173835-8b3a5900-cc23-11ea-8e87-7c7f4c68c49c.png)

**The coloured search on the homepage**

![gn-search-bg-home](https://user-images.githubusercontent.com/19608667/88173864-98574800-cc23-11ea-9ea3-0186a0c181a4.png)

**The search block on the results page**

![gn-search-bg-results](https://user-images.githubusercontent.com/19608667/88173885-a311dd00-cc23-11ea-9961-9224547a5e42.png)