### PR TITLE
Language may be encoded using a prefix before language code

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -455,6 +455,7 @@
       return {
         restrict: 'A',
         link: function(scope, element, attrs) {
+          scope.prefix = attrs['prefix'] || '';
           element.attr('placeholder', '...');
           element.on('focus', function() {
             $http.get('../api/isolanguages', {}, {
@@ -465,6 +466,7 @@
               angular.forEach(data, function(lang) {
                 var defaultName = lang.label['eng'];
                 lang.name = lang.label[scope.lang] || defaultName;
+                lang.code = scope.prefix + lang.code;
                 lang.tokens = [lang.name, lang.code, defaultName];
               });
               var source = new Bloodhound({


### PR DESCRIPTION
eg. 

```xml

      <dcat:landingPage/>
      <dct:language rdf:resource="http://id.loc.gov/vocabulary/iso639-2/fre"/>
      <dct:language rdf:resource="http://id.loc.gov/vocabulary/iso639-2/eng"/>
      <dcat:distribution>
```