### PR TITLE
Externalize InspireValidatorUtils configuration

### DIFF
--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -32,7 +32,7 @@
 
   <context:property-placeholder location="${app.properties}"
                                 file-encoding="UTF-8"
-                                ignore-unresolvable="true" />
+                                ignore-unresolvable="true"/>
   <context:component-scan base-package="org.fao.geonet.api"/>
   <context:component-scan base-package="org.fao.geonet.guiapi"/>
   <context:component-scan base-package="org.fao.geonet.guiservices"/>
@@ -87,63 +87,6 @@
   <bean id="InspireValidatorUtils"
         class="org.fao.geonet.api.records.editing.InspireValidatorUtils"
         scope="singleton">
-    <property name="testsuites">
-      <map>
-        <entry key="TG version 1.3">
-          <array>
-            <value>Conformance class: INSPIRE Profile based on EN ISO 19115 and EN ISO 19119</value>
-            <value>Conformance class: XML encoding of ISO 19115/19119 metadata</value>
-            <value>Conformance class: Conformance class: Metadata for interoperability</value>
-          </array>
-        </entry>
-        <entry key="TG version 2.0 - Data sets and series">
-          <array>
-            <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
-            <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
-            <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
-          </array>
-        </entry>
-        <entry key="TG version 2.0 - Network services">
-          <array>
-            <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
-            <!--<value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
-            <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>-->
-            <value>Conformance Class 3: INSPIRE Spatial Data Service baseline metadata.</value>
-            <value>Conformance Class 4: INSPIRE Network Services metadata.</value>
-            <!--<value>Conformance Class 5: INSPIRE Invocable Spatial Data Services metadata.</value>
-            <value>Conformance Class 6: INSPIRE Interoperable Spatial Data Services metadata.</value>
-            <value>Conformance Class 7: INSPIRE Harmonised Spatial Data Services metadata.</value>-->
-          </array>
-        </entry>
-      </map>
-    </property>
-    <!--
-      key format:
-
-      SCHEMAID::TG_RULE_NAME
-
-      If a metadata schema doesn't match, the schema dependency hierarchy
-      is checked to verify if any parent schema matches any rules.
-    -->
-    <property name="testsuitesConditions">
-      <map>
-        <entry key="iso19139::TG version 2.0 - Data sets and series" value="gmd:hierarchyLevel[*/@codeListValue = 'dataset' or */@codeListValue = 'series']" />
-        <entry key="iso19139::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification" />
-        <entry key="iso19115-3.2018::TG version 2.0 - Data sets and series" value="mdb:metadataScope[*/mdb:resourceScope/*/@codeListValue = 'dataset' or */mdb:resourceScope/*/@codeListValue = 'series']" />
-        <entry key="iso19115-3.2018::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification" />
-      </map>
-    </property>
-    <property name="defaultTestSuite" value="TG version 1.3"/>
-    <!-- ETF validator provides a service to check if a validation task has finished.
-         The following parameters allow to configure:
-
-          - Max. number of checks to do before throwing an Exception, to avoid waiting forever
-            if any issue with the ETF validator returning the task as pending while any error happened.
-
-          - Interval to wait until do a new check, in milliseconds.
-    -->
-    <property name="maxNumberOfEtfChecks" value="20"/>
-    <property name="intervalBetweenEtfChecks" value="5000"/>
   </bean>
 
   <bean id="resourceUploadHandler"
@@ -204,8 +147,8 @@
         class="org.fao.geonet.api.processing.report.registry.ProcessingReportRegistry"/>
 
   <bean id="apiMessages" class="org.springframework.context.support.ResourceBundleMessageSource">
-    <property name="basename" value="org.fao.geonet.api.Messages" />
-    <property name="useCodeAsDefaultMessage" value="true" />
+    <property name="basename" value="org.fao.geonet.api.Messages"/>
+    <property name="useCodeAsDefaultMessage" value="true"/>
   </bean>
 
   <bean id="SpringLocalServiceInvoker" class="org.fao.geonet.kernel.SpringLocalServiceInvoker"
@@ -215,6 +158,6 @@
   <bean id="cssStyleSettingService" class="org.fao.geonet.api.cssstyle.service.CssStyleSettingDatabaseService">
   </bean>
 
-  <bean id="userFeedbackService" class="org.fao.geonet.api.userfeedback.service.UserFeedbackDatabaseService" />
+  <bean id="userFeedbackService" class="org.fao.geonet.api.userfeedback.service.UserFeedbackDatabaseService"/>
 
 </beans>

--- a/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/editing/InspireValidatorUtilsTest.java
@@ -1,9 +1,6 @@
 package org.fao.geonet.api.records.editing;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-
+import jeeves.server.context.ServiceContext;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.domain.MetadataValidationStatus;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
@@ -11,10 +8,15 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
 
-import jeeves.server.context.ServiceContext;
+import java.io.IOException;
 
-public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
+import static org.junit.Assert.assertEquals;
+
+@ContextConfiguration(inheritLocations = true, locations = "classpath:inspire-validator-test-context.xml")
+public class InspireValidatorUtilsTest
+    extends AbstractServiceIntegrationTest {
 
     private static String URL = "http://inspire-sandbox.jrc.ec.europa.eu/etf-webapp";
 
@@ -86,39 +88,31 @@ public class InspireValidatorUtilsTest extends AbstractServiceIntegrationTest {
 
     }
 
-    @Test
-    public void testCalculateValidationStatus() {
-        MetadataValidationStatus metadataValidationStatus =
-            inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_INTERNAL_ERROR);
+    @Test public void testCalculateValidationStatus() {
+        MetadataValidationStatus metadataValidationStatus = inspireValidatorUtils
+            .calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_INTERNAL_ERROR);
 
         assertEquals(MetadataValidationStatus.NEVER_CALCULATED, metadataValidationStatus);
 
-        metadataValidationStatus =
-            inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_UNDEFINED);
+        metadataValidationStatus = inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_UNDEFINED);
 
         assertEquals(MetadataValidationStatus.NEVER_CALCULATED, metadataValidationStatus);
 
-        metadataValidationStatus =
-            inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_NOT_APPLICABLE);
+        metadataValidationStatus = inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_NOT_APPLICABLE);
 
         assertEquals(MetadataValidationStatus.DOES_NOT_APPLY, metadataValidationStatus);
 
-        metadataValidationStatus =
-            inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_PASSED);
+        metadataValidationStatus = inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_PASSED);
 
         assertEquals(MetadataValidationStatus.VALID, metadataValidationStatus);
 
-        metadataValidationStatus =
-            inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_PASSED_MANUAL);
+        metadataValidationStatus = inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_PASSED_MANUAL);
 
         assertEquals(MetadataValidationStatus.VALID, metadataValidationStatus);
 
-        metadataValidationStatus =
-            inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_FAILED);
+        metadataValidationStatus = inspireValidatorUtils.calculateValidationStatus(inspireValidatorUtils.TEST_STATUS_FAILED);
 
         assertEquals(MetadataValidationStatus.INVALID, metadataValidationStatus);
     }
-
-
 }
 

--- a/services/src/test/resources/inspire-validator-test-context.xml
+++ b/services/src/test/resources/inspire-validator-test-context.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2020 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+
+  <util:map id="inspireEtfValidatorTestsuites">
+    <entry key="TG version 1.3">
+      <array>
+        <value>Conformance class: INSPIRE Profile based on EN ISO 19115 and EN ISO 19119</value>
+        <value>Conformance class: XML encoding of ISO 19115/19119 metadata</value>
+        <value>Conformance class: Conformance class: Metadata for interoperability</value>
+      </array>
+    </entry>
+    <entry key="TG version 2.0 - Data sets and series">
+      <array>
+        <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
+        <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
+        <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
+      </array>
+    </entry>
+    <entry key="TG version 2.0 - Network services">
+      <array>
+        <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
+        <!--<value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
+        <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>-->
+        <value>Conformance Class 3: INSPIRE Spatial Data Service baseline metadata.</value>
+        <value>Conformance Class 4: INSPIRE Network Services metadata.</value>
+        <!--<value>Conformance Class 5: INSPIRE Invocable Spatial Data Services metadata.</value>
+        <value>Conformance Class 6: INSPIRE Interoperable Spatial Data Services metadata.</value>
+        <value>Conformance Class 7: INSPIRE Harmonised Spatial Data Services metadata.</value>-->
+      </array>
+    </entry>
+  </util:map>
+
+
+  <util:map id="inspireEtfValidatorTestsuitesConditions">
+    <!--
+       key format:
+
+       SCHEMAID::TG_RULE_NAME
+
+       If a metadata schema doesn't match, the schema dependency hierarchy
+       is checked to verify if any parent schema matches any rules.
+      -->
+    <entry key="iso19139::TG version 2.0 - Data sets and series"
+           value="gmd:hierarchyLevel[*/@codeListValue = 'dataset' or */@codeListValue = 'series']"/>
+    <entry key="iso19139::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
+    <entry key="iso19115-3.2018::TG version 2.0 - Data sets and series"
+           value="mdb:metadataScope[*/mdb:resourceScope/*/@codeListValue = 'dataset' or */mdb:resourceScope/*/@codeListValue = 'series']"/>
+    <entry key="iso19115-3.2018::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
+  </util:map>
+
+
+  <!-- ETF validator provides a service to check if a validation task has finished.
+       The following parameters allow to configure:
+
+        - Default test suite to execute if none is specified.
+
+        - Max. number of checks to do before throwing an Exception, to avoid waiting forever
+          if any issue with the ETF validator returning the task as pending while any error happened.
+
+        - Interval to wait until do a new check, in milliseconds.
+  -->
+  <util:map id="validatorAdditionalConfig">
+    <entry key="defaultTestSuite" value="TG version 1.3"/>
+    <entry key="maxNumberOfEtfChecks" value="20"/>
+    <entry key="intervalBetweenEtfChecks" value="5000"/>
+  </util:map>
+
+
+</beans>

--- a/services/src/test/resources/inspire-validator-test-context.xml
+++ b/services/src/test/resources/inspire-validator-test-context.xml
@@ -27,24 +27,26 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+  <!-- This file contains the configuration used by the InspireValidatorUtils bean in services module -->
 
-  <util:map id="inspireEtfValidatorTestsuites">
+
+  <util:map id="inspireEtfValidatorTestsuites" key-type="java.lang.String" value-type="java.lang.String[]">
     <entry key="TG version 1.3">
-      <array>
+      <array value-type="java.lang.String">
         <value>Conformance class: INSPIRE Profile based on EN ISO 19115 and EN ISO 19119</value>
         <value>Conformance class: XML encoding of ISO 19115/19119 metadata</value>
         <value>Conformance class: Conformance class: Metadata for interoperability</value>
       </array>
     </entry>
     <entry key="TG version 2.0 - Data sets and series">
-      <array>
+      <array value-type="java.lang.String">
         <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
         <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
         <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
       </array>
     </entry>
     <entry key="TG version 2.0 - Network services">
-      <array>
+      <array value-type="java.lang.String">
         <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
         <!--<value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
         <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>-->

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -35,7 +35,7 @@
   <context:property-placeholder location="${app.properties}"
                                 order="1"
                                 file-encoding="UTF-8"
-                                ignore-unresolvable="true" />
+                                ignore-unresolvable="true"/>
 
   <import resource="config-spring-env.xml"/>
   <import resource="config-security/config-security.xml"/>
@@ -44,6 +44,7 @@
 
   <import resource="config-db/initial_data.xml"/>
   <import resource="config-print/config-spring-print.xml"/>
+  <import resource="config-etf-validator.xml"/>
 
   <!-- For database configuration look in the config-node configuration files (config-node/srv.xml) -->
 
@@ -192,11 +193,11 @@
   -->
 
 
-    <!-- Comment the following beans to get non-draft metadata and uncomment the beans below -->
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataIndexer"/>
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataManager"/>
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataUtils"/>
-    <!--<bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataIndexer"/>
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>-->
+  <!-- Comment the following beans to get non-draft metadata and uncomment the beans below -->
+  <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataIndexer"/>
+  <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataManager"/>
+  <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataUtils"/>
+  <!--<bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataIndexer"/>
+  <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>
+  <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>-->
 </beans>

--- a/web/src/main/webapp/WEB-INF/config-etf-validator.xml
+++ b/web/src/main/webapp/WEB-INF/config-etf-validator.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2020 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+  <!-- This file contains the configuration used by the InspireValidatorUtils bean in services module -->
+
+
+  <util:map id="inspireEtfValidatorTestsuites">
+    <entry key="TG version 1.3">
+      <array>
+        <value>Conformance class: INSPIRE Profile based on EN ISO 19115 and EN ISO 19119</value>
+        <value>Conformance class: XML encoding of ISO 19115/19119 metadata</value>
+        <value>Conformance class: Conformance class: Metadata for interoperability</value>
+      </array>
+    </entry>
+    <entry key="TG version 2.0 - Data sets and series">
+      <array>
+        <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
+        <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
+        <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
+      </array>
+    </entry>
+    <entry key="TG version 2.0 - Network services">
+      <array>
+        <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
+        <!--<value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
+        <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>-->
+        <value>Conformance Class 3: INSPIRE Spatial Data Service baseline metadata.</value>
+        <value>Conformance Class 4: INSPIRE Network Services metadata.</value>
+        <!--<value>Conformance Class 5: INSPIRE Invocable Spatial Data Services metadata.</value>
+        <value>Conformance Class 6: INSPIRE Interoperable Spatial Data Services metadata.</value>
+        <value>Conformance Class 7: INSPIRE Harmonised Spatial Data Services metadata.</value>-->
+      </array>
+    </entry>
+  </util:map>
+
+
+  <util:map id="inspireEtfValidatorTestsuitesConditions">
+    <!--
+       key format:
+
+       SCHEMAID::TG_RULE_NAME
+
+       If a metadata schema doesn't match, the schema dependency hierarchy
+       is checked to verify if any parent schema matches any rules.
+      -->
+    <entry key="iso19139::TG version 2.0 - Data sets and series"
+           value="gmd:hierarchyLevel[*/@codeListValue = 'dataset' or */@codeListValue = 'series']"/>
+    <entry key="iso19139::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
+    <entry key="iso19115-3.2018::TG version 2.0 - Data sets and series"
+           value="mdb:metadataScope[*/mdb:resourceScope/*/@codeListValue = 'dataset' or */mdb:resourceScope/*/@codeListValue = 'series']"/>
+    <entry key="iso19115-3.2018::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
+  </util:map>
+
+
+  <!-- ETF validator provides a service to check if a validation task has finished.
+       The following parameters allow to configure:
+
+        - Default test suite to execute if none is specified.
+
+        - Max. number of checks to do before throwing an Exception, to avoid waiting forever
+          if any issue with the ETF validator returning the task as pending while any error happened.
+
+        - Interval to wait until do a new check, in milliseconds.
+  -->
+  <util:map id="validatorAdditionalConfig">
+    <entry key="defaultTestSuite" value="TG version 1.3"/>
+    <entry key="maxNumberOfEtfChecks" value="20"/>
+    <entry key="intervalBetweenEtfChecks" value="5000"/>
+  </util:map>
+
+
+</beans>

--- a/web/src/main/webapp/WEB-INF/config-etf-validator.xml
+++ b/web/src/main/webapp/WEB-INF/config-etf-validator.xml
@@ -30,23 +30,23 @@
   <!-- This file contains the configuration used by the InspireValidatorUtils bean in services module -->
 
 
-  <util:map id="inspireEtfValidatorTestsuites">
+  <util:map id="inspireEtfValidatorTestsuites" key-type="java.lang.String" value-type="java.lang.String[]">
     <entry key="TG version 1.3">
-      <array>
+      <array value-type="java.lang.String">
         <value>Conformance class: INSPIRE Profile based on EN ISO 19115 and EN ISO 19119</value>
         <value>Conformance class: XML encoding of ISO 19115/19119 metadata</value>
         <value>Conformance class: Conformance class: Metadata for interoperability</value>
       </array>
     </entry>
     <entry key="TG version 2.0 - Data sets and series">
-      <array>
+      <array value-type="java.lang.String">
         <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
         <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
         <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
       </array>
     </entry>
     <entry key="TG version 2.0 - Network services">
-      <array>
+      <array value-type="java.lang.String">
         <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
         <!--<value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
         <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>-->


### PR DESCRIPTION
`InspireValidatorUtils` was configured with some properties in the `config-spring-geonetwork.xml` in services JAR. That meant that for any change in the test suites set or conditions it was needed to uncompress the JAR file,
modify `config-spring-geonetwork.xml` and compress the JAR again.

With this commit a new `WEB-INF/config-etf-validator.xml` file is created in `web` project. This is where the `InspireValidatorUtils` are defined now, avoiding the work of changing the services JAR in case the administrator
would need to change this configuration.

Related to #4568.