### PR TITLE
Active filter & facet filter / Improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsClient.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsClient.js
@@ -79,8 +79,10 @@
       );
     };
 
-    this.loadMoreTerms = function(query, facetPath, newSize, facetConfig) {
-      var params = gnESService.getMoreTermsParams(query, facetPath, newSize, facetConfig);
+    this.getTermsParamsWithNewSizeOrFilter = function(
+      query, facetPath, newSize, include, exclude, facetConfig) {
+      var params = gnESService.getTermsParamsWithNewSizeOrFilter(
+        query, facetPath, newSize, include, exclude, facetConfig);
       return callApi('_search', params).then(
         function(response) {
           var model = gnESFacet.getUIModel(response, params);

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -202,6 +202,8 @@
             facetModel.type = 'terms';
             facetModel.size = reqAgg.terms.size;
             facetModel.more = respAgg.sum_other_doc_count > 0;
+            facetModel.includeFilter = reqAgg.terms.include !== undefined;
+            facetModel.excludeFilter = reqAgg.terms.exclude !== undefined;
             var esFacet = this;
             respAgg.buckets.forEach(function (bucket) {
               if (bucket.key) {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -88,6 +88,13 @@
     });
   }
 
+  FacetsController.prototype.filterTerms = function (facet) {
+    this.searchCtrl.filterTerms(facet).then(function (terms) {
+      angular.merge(facet, terms);
+      facet.items = terms.items;
+    });
+  }
+
   FacetsController.prototype.onUpdateDateRange = function (facet, from, to) {
     var query_string =  '+' + facet.key + ':[' + moment(from, 'DD-MM-YYYY').toISOString() + ' TO ' +
       moment(to, 'DD-MM-YYYY').toISOString() + ']';
@@ -169,6 +176,7 @@
   FacetController.prototype.filter = function (facet, item) {
     var value = !item.inverted;
     if (facet.type === 'terms') {
+      facet.include = '';
       if (!item.isNested) {
         this.facetsCtrl.lastUpdatedFacet = facet;
       }

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -29,6 +29,18 @@
     </a>
     <div class="gn-facet-root-container"
          ng-class="{'collapse': ctrl.fLvlCollapse[facet.key]}">
+
+      <div>
+        <input title="{{'facetIncludeFilter' | translate}}"
+               ng-if="facet.type === 'terms' && facet.includeFilter"
+               ng-model="facet.include"
+               ng-model-options="{debounce: 200}"
+               ng-change="ctrl.filterTerms(facet)"
+               class="form-control input-sm"
+               type="text"
+               />
+      </div>
+
       <div class="gn-facet-container"
            es-facet="::facet"
            es-facet-item="::item"

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -208,19 +208,27 @@
               }
             }, true);
 
+            scope.isNegative = function(value) {
+              return value === false
+                     || (value && value.match && value.match(/^-\(.*\)$/) != null);
+            };
+
             scope.removeFilter = function(filter) {
-              removeFacetElement=[]
-              removeFacetElement.push(filter.key)
-              if (Object.keys(filter.value)[0] != 0)
-                removeFacetElement.push(Object.keys(filter.value)[0])
-              else
+              removeFacetElement=[];
+              removeFacetElement.push(filter.key);
+              var keys = Object.keys(filter.value);
+              if (keys[0] != 0) {
+                removeFacetElement.push(keys[0])
+                ngSearchFormCtrl.updateState(removeFacetElement, filter.value[keys[0]]);
+              } else {
                 removeFacetElement.push(filter.value)
-              ngSearchFormCtrl.updateState(removeFacetElement, true);
+                ngSearchFormCtrl.updateState(removeFacetElement, true);
+              }
             };
 
             scope.removeAll = function() {
               removeAllFilters();
-            }
+            };
           }
         };
 
@@ -235,11 +243,11 @@
         result = input.split(/\[(.*?)\]/)[1]
       }
       else if (angular.isString(input)){
-        result=input;
+        result = input;
       }
       else {
         angular.forEach(input, function(value, key) {
-          result=key
+          result = key
         })
       }
       return result;

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -18,9 +18,14 @@
         <span ng-if="filter.key === 'any'">{{filter.key}}</span>
       </strong>
       <div class="flex-spacer"></div>
-      <span ng-repeat="(key, value) in filter.value"
+      <span ng-if="filter.key === 'any'">
+        {{filter.value}}
+      </span>
+      <span ng-if="filter.key !== 'any'"
+            ng-repeat="(key, value) in filter.value"
             ng-class="{'gn-filter-negative': isNegative(value)}"
             translate>{{key | facetTranslator: filter.key | capitalize}}</span>
+      <!-- TODO: Nested aggs support -->
     </a>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -7,17 +7,20 @@
        translate>removeAllFilters</a>
   </div>
   <div class="panel-body">
-    <a href class="filter-group flex-row flex-wrap"
+    <a href
+       class="filter-group flex-row flex-wrap"
        title="{{'removeThisFilter' | translate}}"
        ng-repeat="filter in currentFilters"
        ng-click="removeFilter(filter)">
       <span class="fa fa-times text-danger delete-icon"></span>
       <strong class="text-no-wrap text-uppercase">
-        <span ng-if="filter.key!='any'" translate>{{('facet-' + filter.key)}}</span>
-        <span ng-if="filter.key==='any'">{{filter.key}}</span>
+        <span ng-if="filter.key != 'any'" translate>{{('facet-' + filter.key)}}</span>
+        <span ng-if="filter.key === 'any'">{{filter.key}}</span>
       </strong>
       <div class="flex-spacer"></div>
-      <span translate>{{filter.value | translatearray}}</span>
+      <span ng-repeat="(key, value) in filter.value"
+            ng-class="{'gn-filter-negative': isNegative(value)}"
+            translate>{{key | facetTranslator: filter.key | capitalize}}</span>
     </a>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -497,12 +497,32 @@
         var key = facet.path[i];
         facetConfigs[key] = $scope.facetConfig[key];
       }
-      return gnESClient.loadMoreTerms(
-        $scope.searchObj.params.query,
+      var request = gnESService.generateEsRequest($scope.finalParams, $scope.searchObj.state, $scope.searchObj.configId);
+      return gnESClient.getTermsParamsWithNewSizeOrFilter(
+        request.query,
         facet.path,
         facet.items.length + (moreItemsNumber || 20),
+        undefined, undefined,
         facetConfigs
         );
+    }
+
+    this.filterTerms = function(facet) {
+      var facetConfigs = {};
+      for (var i = 0; i < facet.path.length; i++) {
+        if ((i + 1) % 2 === 0) continue;
+        var key = facet.path[i];
+        facetConfigs[key] = $scope.facetConfig[key];
+      }
+      var request = gnESService.generateEsRequest($scope.finalParams, $scope.searchObj.state, $scope.searchObj.configId)
+      return gnESClient.getTermsParamsWithNewSizeOrFilter(
+        request.query,
+        facet.path,
+        undefined,
+        facet.include,
+        facet.exclude,
+        facetConfigs
+      );
     }
   };
 

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -381,7 +381,7 @@ goog.require('gn_alert');
             'layers': ['OGC', 'ESRI:REST'],
             'maps': ['ows']
           },
-          'isFilterTagsDisplayedInSearch': false,
+          'isFilterTagsDisplayedInSearch': true,
           'usersearches': {
             'enabled': false,
             'displayFeaturedSearchesPanel': false

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -257,6 +257,7 @@ goog.require('gn_alert');
             'tag': {
               'terms': {
                 'field': 'tag',
+                'include': '.*',
                 'size': 10
               }
             },

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -1,4 +1,5 @@
 {
+  "facetIncludeFilter": "Filter values. Regular expression can be used using '/Land.*/'",
   "allValuesExcept": "All values except",
   "filterWithValue": "Filter with this value",
   "indexNotAvailable": "No search service available currently!",

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -731,6 +731,10 @@ button.active [role=tooltip] {
     background-color: fade(@panel-success-heading-bg, 50%);
     font-size: 0.9em;
   }
+  .gn-filter-negative {
+    color: @brand-danger;
+    text-decoration: line-through;
+  }
   a.filter-group, .remove-all-link > a {
     color: @panel-success-text;
     font-weight: initial;


### PR DESCRIPTION
## Active filter / Improvements


* Add support for negative filter
* Use same translation as facets
* Enable it by default.


![image](https://user-images.githubusercontent.com/1701393/88286361-e9813d80-ccf0-11ea-96c9-7d552e76da63.png)

## Facet filter


If a terms aggregation config declare an include element, an input is displayed to filter facet values.
This is enabled by default on tag which can contain lot of values.


![image](https://user-images.githubusercontent.com/1701393/88388961-d6847100-cdb5-11ea-8920-287061840621.png)


Also fix query was not preserved when clicking more
