### PR TITLE
New LDAP test cases and infrastructure

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,6 +81,13 @@
       <artifactId>spring-context-support</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.directory.server</groupId>
+      <artifactId>apacheds-all</artifactId>
+      <version>2.0.0-M24</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-orm</artifactId>
     </dependency>
@@ -334,6 +341,7 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>domain</artifactId>

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/AbstractLDAPUserDetailsContextMapper.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/AbstractLDAPUserDetailsContextMapper.java
@@ -29,6 +29,7 @@ import org.fao.geonet.domain.Profile;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.kernel.security.WritableUserDetailsContextMapper;
 import org.fao.geonet.utils.Log;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -41,10 +42,7 @@ import org.springframework.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Map LDAP user information to GeoNetworkUser information.
@@ -71,6 +69,13 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
     private boolean ldapUsernameCaseInsensitive = true;
 
 
+    private LDAPUtils ldapUtils;
+
+    public void setLdapUtils(LDAPUtils utils){
+        this.ldapUtils = utils;
+    }
+
+
     public void mapUserToContext(UserDetails user, DirContextAdapter ctx) {
         ctx.setAttributeValues("objectclass", new String[]{"top", "person",
             "organizationalPerson", "inetOrgPerson"});
@@ -91,13 +96,15 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
                                           String username, Collection<? extends GrantedAuthority> authorities) {
 
         Profile defaultProfile;
-        if (mapping.get("profile")[1] != null) {
+        if ( (mapping.get("profile") != null) && (mapping.get("profile")[1] != null)) {
             defaultProfile = Profile.valueOf(mapping.get("profile")[1]);
         } else {
             defaultProfile = Profile.RegisteredUser;
         }
         String defaultGroup = mapping.get("privilege")[1];
-        LDAPUtils ldapUtils = ApplicationContextHolder.get().getBean(LDAPUtils.class);
+        //allow proper injection
+        LDAPUtils ldapUtils = this.ldapUtils != null? this.ldapUtils :
+            ApplicationContextHolder.get().getBean(LDAPUtils.class);
 
         Map<String, ArrayList<String>> userInfo = ldapUtils
             .convertAttributes(userCtx.getAttributes().getAll());
@@ -108,9 +115,10 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
 
         LDAPUser userDetails = new LDAPUser(username);
         User user = userDetails.getUser();
-        user.setName(getUserInfo(userInfo, "name"))
-            .setSurname(getUserInfo(userInfo, "surname"))
-            .setOrganisation(getUserInfo(userInfo, "organisation"));
+        user.setName(getUserInfo(userInfo, "name"));
+
+        user.setSurname(getUserInfo(userInfo, "surname"));
+        user.setOrganisation(getUserInfo(userInfo, "organisation"));
         user.getEmailAddresses().clear();
         user.getEmailAddresses().add(getUserInfo(userInfo, "mail"));
         user.getPrimaryAddress().setAddress(getUserInfo(userInfo, "address"))
@@ -185,7 +193,9 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
     @Override
     public synchronized void saveUser(LDAPUser userDetails) {
         try {
-            LDAPUtils ldapUtils = ApplicationContextHolder.get().getBean(LDAPUtils.class);
+            //allow proper injection
+            LDAPUtils ldapUtils = this.ldapUtils != null? this.ldapUtils :
+                ApplicationContextHolder.get().getBean(LDAPUtils.class);
 
             if (createNonExistingLdapUser
                 && !ldapManager.userExists(userDetails.getUsername())) {
@@ -226,6 +236,23 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
         return getUserInfo(userInfo, attributeName, "");
     }
 
+    //returns null if not available
+    private String getValue(Map<String, ArrayList<String>> userInfo,String ldapAttributeName) {
+        if ( (ldapAttributeName == null) || (userInfo == null)) //bad args
+            return null;
+        ArrayList<String> info = userInfo.get(ldapAttributeName);
+        if ( (info == null) || (info.size() ==0)) //no value supplied
+            return null;
+        if (info.size()==1) // only one value -- that's it
+            return info.get(0);
+        // we sometime get > 1 value here, especially for CN containing the full DN
+        if (info.get(1) == null) //no value there
+            return info.get(0);
+        if (info.get(0).length() < info.get(1).length()) //return shortest
+            return info.get(0);
+        return info.get(1);
+    }
+
     /**
      * Return the first element of userInfo corresponding to the attribute name. If attributeName
      * mapping is not defined, return empty string. If no value found in LDAP user info, return
@@ -240,10 +267,10 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
             String ldapAttributeName = attributeMapping[0];
             String configDefaultValue = attributeMapping[1];
 
-            if (ldapAttributeName != null
-                && userInfo.get(ldapAttributeName) != null
-                && userInfo.get(ldapAttributeName).get(0) != null) {
-                value = userInfo.get(ldapAttributeName).get(0);
+            String v = getValue(userInfo, ldapAttributeName);
+
+            if (v != null) {
+                value = v;
             } else if (configDefaultValue != null) {
                 value = configDefaultValue;
             } else {

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/AbstractLDAPUserDetailsContextMapper.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/AbstractLDAPUserDetailsContextMapper.java
@@ -29,7 +29,6 @@ import org.fao.geonet.domain.Profile;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.kernel.security.WritableUserDetailsContextMapper;
 import org.fao.geonet.utils.Log;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -42,7 +41,10 @@ import org.springframework.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Map LDAP user information to GeoNetworkUser information.
@@ -96,15 +98,14 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
                                           String username, Collection<? extends GrantedAuthority> authorities) {
 
         Profile defaultProfile;
-        if ( (mapping.get("profile") != null) && (mapping.get("profile")[1] != null)) {
+        if ((mapping.get("profile") != null) && (mapping.get("profile")[1] != null)) {
             defaultProfile = Profile.valueOf(mapping.get("profile")[1]);
         } else {
             defaultProfile = Profile.RegisteredUser;
         }
         String defaultGroup = mapping.get("privilege")[1];
         //allow proper injection
-        LDAPUtils ldapUtils = this.ldapUtils != null? this.ldapUtils :
-            ApplicationContextHolder.get().getBean(LDAPUtils.class);
+        LDAPUtils ldapUtils = ApplicationContextHolder.get().getBean(LDAPUtils.class);
 
         Map<String, ArrayList<String>> userInfo = ldapUtils
             .convertAttributes(userCtx.getAttributes().getAll());
@@ -238,12 +239,12 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
 
     //returns null if not available
     private String getValue(Map<String, ArrayList<String>> userInfo,String ldapAttributeName) {
-        if ( (ldapAttributeName == null) || (userInfo == null)) //bad args
+        if ((ldapAttributeName == null) || (userInfo == null)) //bad args
             return null;
         ArrayList<String> info = userInfo.get(ldapAttributeName);
-        if ( (info == null) || (info.size() ==0)) //no value supplied
+        if ((info == null) || (info.size() ==0)) //no value supplied
             return null;
-        if (info.size()==1) // only one value -- that's it
+        if (info.size() == 1) // only one value -- that's it
             return info.get(0);
         // we sometime get > 1 value here, especially for CN containing the full DN
         if (info.get(1) == null) //no value there

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRole.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRole.java
@@ -1,0 +1,77 @@
+//=============================================================================
+//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.security.ldap;
+
+import org.fao.geonet.domain.Profile;
+
+/**
+ * very simple class that just holds a user's group/profile information.
+ */
+public class LDAPRole {
+
+    String groupName;
+    Profile profile;
+
+
+    public LDAPRole(String groupName, Profile profile) {
+        this.groupName = groupName;
+        this.profile = profile;
+    }
+
+    public LDAPRole(String groupName, String profileName) {
+        this.groupName = groupName;
+        this.profile = Profile.findProfileIgnoreCase(profileName);
+    }
+
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public Profile getProfile() {
+        return profile;
+    }
+
+    public void setProfile(Profile profile) {
+        this.profile = profile;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof LDAPRole))
+            return false;
+
+        return this.getGroupName() == ((LDAPRole) obj).getGroupName() &&
+            this.getProfile().name() == ((LDAPRole) obj).getProfile().name();
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getGroupName().hashCode() ^ this.getProfile().name().hashCode() ;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRole.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRole.java
@@ -34,14 +34,18 @@ public class LDAPRole {
     Profile profile;
 
 
-    public LDAPRole(String groupName, Profile profile) {
+    public LDAPRole(String groupName, Profile profile) throws Exception {
+        if ((groupName == null) || (profile == null))
+            throw new Exception("groupName and profile must not be null");
         this.groupName = groupName;
         this.profile = profile;
     }
 
-    public LDAPRole(String groupName, String profileName) {
+    public LDAPRole(String groupName, String profileName) throws Exception {
         this.groupName = groupName;
         this.profile = Profile.findProfileIgnoreCase(profileName);
+        if ((groupName == null) || (profile == null))
+            throw new Exception("groupName and profile must not be null");
     }
 
 
@@ -49,7 +53,9 @@ public class LDAPRole {
         return groupName;
     }
 
-    public void setGroupName(String groupName) {
+    public void setGroupName(String groupName) throws Exception {
+        if (groupName == null)
+            throw new Exception("groupName must not be null");
         this.groupName = groupName;
     }
 
@@ -57,7 +63,9 @@ public class LDAPRole {
         return profile;
     }
 
-    public void setProfile(Profile profile) {
+    public void setProfile(Profile profile) throws Exception {
+        if (profile == null)
+            throw new Exception("profile must not be null");
         this.profile = profile;
     }
 
@@ -66,8 +74,11 @@ public class LDAPRole {
         if (!(obj instanceof LDAPRole))
             return false;
 
-        return this.getGroupName() == ((LDAPRole) obj).getGroupName() &&
-            this.getProfile().name() == ((LDAPRole) obj).getProfile().name();
+        boolean groupNameEqual =  this.getGroupName().equals(((LDAPRole) obj).getGroupName());
+        boolean profileNameEqual =  this.getProfile().name().equals(((LDAPRole) obj).getProfile().name());
+
+
+        return groupNameEqual && profileNameEqual;
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverter.java
@@ -1,0 +1,49 @@
+//=============================================================================
+//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.security.ldap;
+
+import org.fao.geonet.domain.LDAPUser;
+
+import javax.naming.directory.Attributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+//given information about a LDAP-Group/User, return the gn-groups/gn-profile associated with that person
+public interface LDAPRoleConverter {
+
+    /**
+     *
+     * @param userInfo      -- information about the user
+     * @param userDetails   -- information about the user
+     * @param ldapGroupName  -- name of the ldap group the user is a member of
+     * @param ldapGroupAttributes -- attributes of the group the user is a member of
+     * @return List of ldap roles (GN-group name and GN-Profile)
+     */
+    List<LDAPRole> convert(Map<String, ArrayList<String>> userInfo,
+                           LDAPUser userDetails,
+                           String ldapGroupName,
+                           Attributes ldapGroupAttributes);
+
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverter.java
@@ -34,16 +34,22 @@ import java.util.Map;
 public interface LDAPRoleConverter {
 
     /**
+     * Convert LDAP information (person info as well as info about a group they are a memember of) to a list of
+     * roles.
      *
-     * @param userInfo      -- information about the user
-     * @param userDetails   -- information about the user
-     * @param ldapGroupName  -- name of the ldap group the user is a member of
-     * @param ldapGroupAttributes -- attributes of the group the user is a member of
+     * In general, the person info (userInfo, userDetails) are not used - they're included for future special cases.
+     *     eg. an LDAP attribute inside the person that gives a role.
+     *
+     *
+     * @param userInfo       information about the user (all attributes from LDAP person object)
+     * @param userDetails    information about the user (constructed/paresed from LDAP person object by GN)
+     * @param ldapGroupName  name of the ldap group the user is a member of
+     * @param ldapGroupAttributes  attributes of the group the user is a member of
      * @return List of ldap roles (GN-group name and GN-Profile)
      */
     List<LDAPRole> convert(Map<String, ArrayList<String>> userInfo,
                            LDAPUser userDetails,
                            String ldapGroupName,
-                           Attributes ldapGroupAttributes);
+                           Attributes ldapGroupAttributes) throws Exception;
 
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterGroupNameConverter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterGroupNameConverter.java
@@ -1,0 +1,57 @@
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.security.ldap;
+
+import org.fao.geonet.domain.LDAPUser;
+
+import javax.naming.directory.Attributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This does a direct conversion from a LDAP group name to a list of LDAPRoles.
+ * See LDAPRoleConverterGroupNameParser for another example.
+ *
+ */
+public class LDAPRoleConverterGroupNameConverter implements LDAPRoleConverter {
+    //groupName (from LDAP) to a list of LDAPRoles (GN-Group and GN-Profile)
+    Map<String,List<LDAPRole>> convertMap;
+
+
+    //given an LDAP role name, find the list of LDAPRoles that are assigned to them.
+    @Override
+    public List<LDAPRole> convert(Map<String, ArrayList<String>> userInfo, LDAPUser userDetails, String ldapGroupName, Attributes ldapGroupAttributes) {
+        if ( (convertMap == null) || (!convertMap.containsKey(ldapGroupName)))
+            return new ArrayList<LDAPRole>();
+        return convertMap.get(ldapGroupName);
+    }
+
+
+    public void setConvertMap(Map<String, List<LDAPRole>> convertMap) {
+        this.convertMap = convertMap;
+    }
+
+    public Map<String, List<LDAPRole>> getConvertMap() {
+        return convertMap;
+    }
+
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterGroupNameConverter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterGroupNameConverter.java
@@ -1,3 +1,6 @@
+//=============================================================================
+//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
 //===	This program is free software; you can redistribute it and/or modify
@@ -34,14 +37,15 @@ import java.util.Map;
  */
 public class LDAPRoleConverterGroupNameConverter implements LDAPRoleConverter {
     //groupName (from LDAP) to a list of LDAPRoles (GN-Group and GN-Profile)
-    Map<String,List<LDAPRole>> convertMap;
+    Map<String, List<LDAPRole>> convertMap;
 
 
     //given an LDAP role name, find the list of LDAPRoles that are assigned to them.
     @Override
     public List<LDAPRole> convert(Map<String, ArrayList<String>> userInfo, LDAPUser userDetails, String ldapGroupName, Attributes ldapGroupAttributes) {
-        if ( (convertMap == null) || (!convertMap.containsKey(ldapGroupName)))
+        if ((convertMap == null) || (!convertMap.containsKey(ldapGroupName))) {
             return new ArrayList<LDAPRole>();
+        }
         return convertMap.get(ldapGroupName);
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterGroupNameParser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterGroupNameParser.java
@@ -1,0 +1,142 @@
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+// @author dblasby geocat
+
+package org.fao.geonet.kernel.security.ldap;
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.LDAPUser;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.utils.Log;
+
+import javax.naming.directory.Attributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+
+/**
+ * The found "LdapGroupName" will be parsed by `ldapMembershipQueryParser` (i.e. GCAT_(.*)_(.*))
+ * groupIndexInPattern, profileIndexInPattern are group numbers in the `ldapMembershipQueryParser`
+ * <p>
+ * For example,
+ * ldapMembershipQueryParser = GCAT_(.*)_(.*))
+ * groupIndexInPattern=1
+ * profileIndexInPattern=2
+ * <p>
+ * For a group called "GCAT_GENERAL_EDITOR", then;
+ * GN-Group = "GENERAL"
+ * GN-PROFILE = "EDITOR" (which is converted to "Editor" via the `profileMapping`
+ *
+ */
+public class LDAPRoleConverterGroupNameParser implements LDAPRoleConverter{
+
+    //How to parse the groups into GN-GROUP and GN-PROFILE
+    //i.e. GCAT_(.*)_(.*) to parse GCAT_GENERAL_EDITOR
+    private Pattern ldapMembershipQueryParser;
+
+    //these go with the ldapMembershipQueryParser
+    // they correspond to the groups returned by the parser
+    // i.e. GCAT_(.*)_(.*) to parse GCAT_GENERAL_EDITOR
+    //        1=> GENERAL
+    //        2=> EDITOR
+    private int groupIndexInPattern;
+    private int profileIndexInPattern;
+
+
+
+    //map a ldap group name profile to an actual profile
+    // i.e. admin --> Administrator
+    Map<String, Profile> profileMapping;
+
+    //This will take a role like "GCAT_general_admin" and convert it GN-Group=general and GN-Profile=admin
+    @Override
+    public List<LDAPRole> convert(Map<String, ArrayList<String>> userInfo, LDAPUser userDetails, String ldapGroupName, Attributes LdapGroupAttributes) {
+        if (ldapMembershipQueryParser == null)
+            return new ArrayList<LDAPRole>(); // nothing to do
+
+        Matcher matcher = ldapMembershipQueryParser.matcher(ldapGroupName); // does this match the parser?
+
+        if (!matcher.matches())  //LDAP group name not in correct format...
+            return new ArrayList<LDAPRole>(); // nothing to do;
+
+        String group = matcher.group(this.groupIndexInPattern);
+        String profile_str = matcher.group(this.getProfileIndexInPattern());
+
+        Profile profile = getProfile(profile_str); //convert to a GN `Profile` object (simple and with conversion)
+
+        if (profile == null)
+            return new ArrayList<LDAPRole>(); // nothing to do;
+
+        Log.debug(Geonet.LDAP, "for ldap user " + userDetails.getUsername() + " for LDAP group " + ldapGroupName +
+            " gives group= " + group + " with profile= " + profile.name());
+
+        List<LDAPRole> result = new ArrayList<>(1);
+        result.add(new LDAPRole(group,profile));
+
+        return result;
+    }
+
+    //given a profile name, find the Profile that it matches
+    //see `profileMapping` for transitions
+    public Profile getProfile(String pname) {
+        if ((this.profileMapping != null) && (this.profileMapping.containsKey(pname)))
+            return this.profileMapping.get(pname);
+
+        Profile p = Profile.findProfileIgnoreCase(pname);
+        return p;
+    }
+
+
+    public String getLdapMembershipQueryParser() {
+        return ldapMembershipQueryParser.toString();
+    }
+
+    public void setLdapMembershipQueryParser(String ldapMembershipQueryParser) {
+        this.ldapMembershipQueryParser = Pattern.compile(ldapMembershipQueryParser);
+    }
+
+    public int getGroupIndexInPattern() {
+        return groupIndexInPattern;
+    }
+
+    public void setGroupIndexInPattern(int groupIndexInPattern) {
+        this.groupIndexInPattern = groupIndexInPattern;
+    }
+
+    public int getProfileIndexInPattern() {
+        return profileIndexInPattern;
+    }
+
+    public void setProfileIndexInPattern(int profileIndexInPattern) {
+        this.profileIndexInPattern = profileIndexInPattern;
+    }
+
+    public Map<String, Profile> getProfileMapping() {
+        return profileMapping;
+    }
+
+    public void setProfileMapping(Map<String, Profile> profileMapping) {
+        this.profileMapping = profileMapping;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterGroupNameParser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterGroupNameParser.java
@@ -1,3 +1,6 @@
+//=============================================================================
+//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
 //===	This program is free software; you can redistribute it and/or modify
@@ -71,7 +74,8 @@ public class LDAPRoleConverterGroupNameParser implements LDAPRoleConverter{
 
     //This will take a role like "GCAT_general_admin" and convert it GN-Group=general and GN-Profile=admin
     @Override
-    public List<LDAPRole> convert(Map<String, ArrayList<String>> userInfo, LDAPUser userDetails, String ldapGroupName, Attributes LdapGroupAttributes) {
+    public List<LDAPRole> convert(Map<String, ArrayList<String>> userInfo, LDAPUser userDetails, String ldapGroupName, Attributes LdapGroupAttributes)
+        throws Exception {
         if (ldapMembershipQueryParser == null)
             return new ArrayList<LDAPRole>(); // nothing to do
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhanced.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhanced.java
@@ -1,0 +1,250 @@
+//=============================================================================
+//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+package org.fao.geonet.kernel.security.ldap;
+
+import jeeves.component.ProfileManager;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.LDAPUser;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.utils.Log;
+import org.springframework.util.StringUtils;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.*;
+import java.text.MessageFormat;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Get all user information from the LDAP user's attributes excluding profiles and groups which are
+ * searched in another LDAP location. For profiles and groups, define the search location and the
+ * extraction pattern.
+ * <p>
+ * This search (including subtrees) in the LDAP starting at 'membershipSearchStartObject'
+ * It will execute the query ldapMembershipQuery.
+ * for ldapMembershipQuery;
+ * {0} = username (i.e. what the user types in to login)
+ * {1} = cn for the ldap user object (short version)  i.e. "blasby, david"
+ * {2} = cn for the ldap user object (full version)   i.e. "blasby, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com"
+ * ** typically you'll be using {2}
+ * <p>
+ * The found ldap groups will be parsed by `ldapMembershipQueryParser` (i.e. GCAT_(.*)_(.*))
+ * groupIndexInPattern, profileIndexInPattern are group numbers in the `ldapMembershipQueryParser`
+ * <p>
+ * For example,
+ * ldapMembershipQueryParser = GCAT_(.*)_(.*))
+ * groupIndexInPattern=1
+ * profileIndexInPattern=2
+ * <p>
+ * For a group called "GCAT_GENERAL_EDITOR", then;
+ * GN-Group = "GENERAL"
+ * GN-PROFILE = "EDITOR" (which is converted to "Editor" via the `profileMapping`
+ *
+ * @author dblasby/francois
+ */
+public class LDAPUserDetailsContextMapperWithProfileSearchEnhanced extends AbstractLDAPUserDetailsContextMapper {
+
+    //Query used to find group membership
+    private String ldapMembershipQuery;
+
+    //How to parse the groups into GN-GROUP and GN-PROFILE
+    //i.e. GCAT_(.*)_(.*) to parse GCAT_GENERAL_EDITOR
+    private Pattern ldapMembershipQueryParser;
+
+    //these go with the ldapMembershipQueryParser
+    // they correspond to the groups returned by the parser
+    // i.e. GCAT_(.*)_(.*) to parse GCAT_GENERAL_EDITOR
+    //        1=> GENERAL
+    //        2=> EDITOR
+    private int groupIndexInPattern;
+    private int profileIndexInPattern;
+
+    //where to start searching in the LDAP
+    // typically this will be "" (search entire directory)
+    private String membershipSearchStartObject;
+
+
+    public void setMembershipSearchStartObject(String membershipSearchStartObject) {
+        this.membershipSearchStartObject = membershipSearchStartObject;
+    }
+
+    public void setLdapMembershipQuery(String ldapMembershipQuery) {
+        this.ldapMembershipQuery = ldapMembershipQuery;
+    }
+
+    public void setLdapMembershipQueryParser(String ldapMembershipQueryParser) {
+        this.ldapMembershipQueryParser = Pattern.compile(ldapMembershipQueryParser);
+    }
+
+    //This will find the shortest "cn" attribute given in the object
+    // typically, there are >1 of these.  I.e. "blasby, david" and "blasby, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com"
+    public String cn_short(Attributes atts) throws NamingException {
+        Attribute value = atts.get("cn");
+        List values = Collections.list(value.getAll());
+        Comparator<String> comparator = (str1, str2) -> str1.length() > str2.length() ? 1 : -1;
+        String shortest = (String) values.stream().sorted(comparator).findFirst().get();
+        return shortest;
+    }
+
+    //This will find the longest "cn" attribute given in the object
+    // typically, there are >1 of these.  I.e. "blasby, david" and "blasby, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com"
+    public String cn_short(Map<String, ArrayList<String>> userInfo) {
+        ArrayList<String> cn = userInfo.get("cn");
+        if ((cn == null) || (cn.size() == 0))  // bad user!
+            return null;
+        Comparator<String> comparator = (str1, str2) -> str1.length() > str2.length() ? 1 : -1;
+        String shortest = cn.stream().sorted(comparator).findFirst().get();
+        return shortest;
+    }
+
+    //This will find the longest "cn" value given in the map
+    // typically, there are >1 of these.  I.e. "blasby, david" and "blasby, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com"
+    public String cn_long(Map<String, ArrayList<String>> userInfo) {
+        ArrayList<String> cn = userInfo.get("cn");
+        if ((cn == null) || (cn.size() == 0))  // bad user!
+            return null;
+        Comparator<String> comparator = (str1, str2) -> str1.length() > str2.length() ? -1 : 1;
+        String longest = cn.stream().sorted(comparator).findFirst().get();
+        return longest;
+    }
+
+    //escape a string for the query
+    //"blasby\, david"  ==> "blasby\\, david"
+    //This is required for membership searches in AD
+    public String escape(String str) {
+        return str.replace("\\", "\\\\");
+    }
+
+    //given a profile name, find the Profile that it matches
+    //see `profileMapping` for transitions
+    public Profile getProfile(String pname) {
+        if ((this.profileMapping != null) && (this.profileMapping.containsKey(pname)))
+            return this.profileMapping.get(pname);
+
+        Profile p = Profile.findProfileIgnoreCase(pname);
+        return p;
+    }
+
+
+    //main method to find the user's ldap group memberships
+    // a) will populate the GN-Group and GN-Profile in userDetails
+    // b) will look for the "highest" Profile given and set that as the user's main profile  -userDetails.getUser().setProfile(highestUserProfile)
+    protected void setProfilesAndPrivileges(Profile defaultProfile,
+                                            String defaultGroup, Map<String, ArrayList<String>> userInfo,
+                                            LDAPUser userDetails) {
+
+        if (!StringUtils.isEmpty(ldapMembershipQuery)) {
+            if (Log.isDebugEnabled(Geonet.LDAP)) {
+                StringBuffer sb = new StringBuffer("Group and profile search:");
+                sb.append("\nLDAP Membership Query query: \t" + ldapMembershipQuery);
+                sb.append("\nldapMembershipQueryParser: \t" + ldapMembershipQueryParser.toString());
+                sb.append("\ngroupIndexInPattern: \t" + groupIndexInPattern);
+                sb.append("\nprofileIndexInPattern: \t" + profileIndexInPattern);
+                sb.append("\nmembershipSearchStartObject: \t" + membershipSearchStartObject);
+
+                Log.debug(Geonet.LDAP, sb.toString());
+            }
+            // TODO: add more control on values
+            NamingEnumeration<?> ldapInfoList;
+            try {
+                DirContext dc = contextSource.getReadOnlyContext();
+
+
+                String username = escape(userDetails.getUsername());
+                String cn_short = escape(cn_short(userInfo));
+                String cn_long = escape(cn_long(userInfo));
+
+                String groupsQuery = MessageFormat.format(this.ldapMembershipQuery,
+                    username, cn_short, cn_long);
+
+                SearchControls searchControls = new SearchControls();
+                searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE); //recursive
+
+                ldapInfoList = dc.search(membershipSearchStartObject, groupsQuery, searchControls);
+                while (ldapInfoList.hasMore()) {
+                    SearchResult sr = (SearchResult) ldapInfoList.next();
+                    String ldapGroupName = cn_short(sr.getAttributes());
+
+                    Matcher matcher = ldapMembershipQueryParser.matcher(ldapGroupName); // does this match the parser?
+
+                    if (!matcher.matches())  //LDAP group name not in correct format...
+                        continue;
+
+                    String group = matcher.group(this.groupIndexInPattern);
+                    String profile_str = matcher.group(this.getProfileIndexInPattern());
+
+                    Profile profile = getProfile(profile_str); //convert to a GN `Profile` object (simple and with conversion)
+
+                    if (profile == null)
+                        continue;
+
+                    Log.debug(Geonet.LDAP, "for ldap user " + username + " for LDAP group " + ldapGroupName +
+                        " gives group= " + group + " with profile= " + profile.name());
+
+                    userDetails.addPrivilege(group, profile); //add the profile info
+
+                }
+
+                //highest access is the "generic" access for the user
+                // TODO: what are the impacts of this?
+                Profile highestUserProfile = ProfileManager.getHighestProfile(userDetails.getPrivileges().values().toArray(new Profile[0]));
+                if (highestUserProfile != null) {
+                    if (Log.isDebugEnabled(Geonet.LDAP)) {
+                        Log.debug(Geonet.LDAP, "  Highest user profile is " + highestUserProfile);
+                    }
+                    userDetails.getUser().setProfile(highestUserProfile);
+                }
+
+                // If no profile defined, use default profile
+                if (userDetails.getUser().getProfile() == null) {
+                    if (Log.isDebugEnabled(Geonet.LDAP)) {
+                        Log.debug(Geonet.LDAP, "  No profile defined in LDAP, using default profile " + defaultProfile);
+                    }
+                    userDetails.getUser().setProfile(defaultProfile);
+                }
+
+            } catch (NamingException e) {
+                Log.error(Geonet.LDAP, "Failed to extract profiles and groups. Error is: " + e.getMessage(), e);
+            }
+        }
+    }
+
+
+    public int getGroupIndexInPattern() {
+        return groupIndexInPattern;
+    }
+
+    public void setGroupIndexInPattern(int groupIndexInPattern) {
+        this.groupIndexInPattern = groupIndexInPattern;
+    }
+
+    public int getProfileIndexInPattern() {
+        return profileIndexInPattern;
+    }
+
+    public void setProfileIndexInPattern(int profileIndexInPattern) {
+        this.profileIndexInPattern = profileIndexInPattern;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhanced.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhanced.java
@@ -174,7 +174,7 @@ public class LDAPUserDetailsContextMapperWithProfileSearchEnhanced extends Abstr
                     //NOTE: they will return an empty list if they don't know what the role means
                     //      allRoles is a set, you can add duplicates to it with no problem...
                     for(LDAPRoleConverter converter : this.ldapRoleConverters){
-                        List<LDAPRole> newRoles = converter.convert(userInfo,userDetails,ldapGroupName,sr.getAttributes());
+                        List<LDAPRole> newRoles = converter.convert(userInfo, userDetails, ldapGroupName, sr.getAttributes());
                         if (newRoles != null)
                             allRoles.addAll(newRoles);
                     }
@@ -202,8 +202,9 @@ public class LDAPUserDetailsContextMapperWithProfileSearchEnhanced extends Abstr
                     userDetails.getUser().setProfile(defaultProfile);
                 }
 
-            } catch (NamingException e) {
+            } catch (Exception e) {
                 Log.error(Geonet.LDAP, "Failed to extract profiles and groups. Error is: " + e.getMessage(), e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LdapUserDetailsManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LdapUserDetailsManager.java
@@ -71,7 +71,7 @@ import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.util.Assert;
 
 /**
- * Made this class because of the stupid implementation of {@link org.springframework.security.ldap.userdetails.LdapUserDetailsManager#setGroupMemberAttributeName(String)}
+ * Made this class because of the stupid implementation of {@link org.springframework.security.ldap.userdetails.LdapUserDetailsManager#setGroupMembeldaprAttributeName(String)}
  *
  * @author delawen
  */
@@ -245,6 +245,7 @@ public class LdapUserDetailsManager implements UserDetailsManager {
                 throws NamingException {
                 DistinguishedName fullDn = LdapUtils.getFullDn(dn, ctx);
                 SearchControls ctrls = new SearchControls();
+                ctrls.setSearchScope(SearchControls.SUBTREE_SCOPE); // search down the tree
                 ctrls.setReturningAttributes(new String[]{groupRoleAttributeName});
 
                 return ctx.search(groupSearchBase, groupSearchFilter,

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/README.md
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/README.md
@@ -1,0 +1,40 @@
+Using LDAPUserDetailsContextMapperWithProfileSearchEnhanced
+===========================================================
+
+I've modified `LDAPUserDetailsContextMapperWithProfileSearch` so it works in more situations, is much simpler, uses strategy objects, and has a good set of test cases.
+
+The original `LDAPUserDetailsContextMapperWithProfileSearch` was extremely difficult to understand.
+
+Please see the test cases (and the corresponding README.md).  This contains;
+
+1. Tests that show functionality
+2. The test cases run an LDAP server 
+3. There are easy instructions for setting up a configured LDAP server so you can run GeoNetwork against it.
+ 
+There two biggest differences with `LDAPUserDetailsContextMapperWithProfileSearch` are;
+
+1. Moved functionality to Strategy Object
+     * cf. `SearchingLdapUsernameToDnMapper`
+          * instead of apriori knowing where (in the dir hierarchy) a user is stored, this will search for it
+     * cf. `LDAPRoleConverterGroupNameParser`
+          * this parses an LDAP Group name to determine its GN-Group and GN-profile
+              * ie. GCAT_general_editor --> GN-group=general, GN-Profile=Editor
+     * cf. `LDAPRoleConverterGroupNameConverter`
+          * this is a simple conversion between an LDAP group name and a set of GN Roles
+2. I've removed assumptions about how the LDAP is structured
+     * it searches in the dir hierarchy for Users and Groups 
+         * old implementation assumed they were all in one directory
+
+
+I've left the main `AbstractLDAPUserDetailsContextMapper` unchanged, and the old LDAP infrastructure should still work.  
+
+However, if you are setting up a new LDAP configuration, I recommend you use the new infrastructure since its much easier to understand.
+Here's the recommended process - its a bit lengthy, but it gives you the best understanding of what's going on.
+
+1. Create an .ldif that sets up an LDAP server that matches your configuration
+     * c.f. `data.ldif` in test resource 
+2. Modify the `LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest-context.xml` so it matches your configuration
+3. The existing test cases use the configuration in `data.ldif`, but you can run these and modify them to ensure your configuration is working
+4. See the instructions (README.md in the test cases dir) to run the LDAP server (with your .ldif) and GeoNetwork
+
+

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/README.md
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/README.md
@@ -1,7 +1,7 @@
 Using LDAPUserDetailsContextMapperWithProfileSearchEnhanced
 ===========================================================
 
-I've modified `LDAPUserDetailsContextMapperWithProfileSearch` so it works in more situations, is much simpler, uses strategy objects, and has a good set of test cases.
+`LDAPUserDetailsContextMapperWithProfileSearch` was modified so it works in more situations, is much simpler, uses strategy objects, and has a good set of test cases.
 
 The original `LDAPUserDetailsContextMapperWithProfileSearch` was extremely difficult to understand.
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/SearchingLdapUsernameToDnMapper.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/SearchingLdapUsernameToDnMapper.java
@@ -1,0 +1,68 @@
+//=============================================================================
+//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.security.ldap;
+
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.core.DistinguishedName;
+import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.security.ldap.LdapUsernameToDnMapper;
+import org.springframework.security.ldap.search.LdapUserSearch;
+import org.springframework.util.Assert;
+
+
+//see org.springframework.security.ldap.DefaultLdapUsernameToDnMapper
+//
+// This   Searches for the user.  If they are found, then we use that DN
+// If not, we throw an exception.
+//  If not, either they made a typo in the name or they are attempting to create a new user.
+//    We should NOT allow users to be created (we have no idea where to put them, and its really dangerous).
+//
+public class SearchingLdapUsernameToDnMapper implements LdapUsernameToDnMapper {
+
+    private LdapContextSource ldapContextSource;
+    private LdapUserSearch ldapUserSearch;
+
+    public void setLdapContextSource(LdapContextSource source) {
+        this.ldapContextSource = source;
+    }
+
+    public void setLdapUserSearch(LdapUserSearch ldapUserSearch) {
+        this.ldapUserSearch = ldapUserSearch;
+    }
+
+    @Override
+    public DistinguishedName buildDn(String username) {
+
+        Assert.notNull(ldapContextSource, "ldapContextSource is not injected");
+        Assert.notNull(ldapUserSearch, "ldapUserSearch is not injected");
+        if (username.contains("*"))
+            throw new RuntimeException("Security violation - LDAP username contains *!");
+
+        username = username; // might need to escape characters here - like "blasby\, david", but not required by AD
+        DirContextOperations result = ldapUserSearch.searchForUser(username);
+
+        return (DistinguishedName) result.getDn();
+    }
+
+}

--- a/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterTest.java
@@ -1,0 +1,128 @@
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+// @author dblasby geocat
+
+package org.fao.geonet.kernel.security.ldap;
+
+import org.fao.geonet.domain.LDAPUser;
+import org.fao.geonet.domain.Profile;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class LDAPRoleConverterTest {
+
+    //simple test for parsing "GCAT_GENERAL_Administrator"
+    @Test
+    public void test_LDAPRoleConverter1() {
+        LDAPRoleConverterGroupNameParser out = new LDAPRoleConverterGroupNameParser();
+
+        LDAPUser userDetails = new LDAPUser("dblasby@example.com");
+
+        out.setLdapMembershipQueryParser("GCAT_(.*)_(.*)");
+        out.setGroupIndexInPattern(1);
+        out.setProfileIndexInPattern(2);
+        out.setProfileMapping(null);
+
+        List<LDAPRole> result = out.convert(null,userDetails,"GCAT_GENERAL_Administrator",null);
+        assertEquals(1,result.size());
+        assertEquals("GENERAL", result.get(0).getGroupName());
+        assertEquals(Profile.Administrator, result.get(0).getProfile());
+    }
+
+    //tests profile mapping (admin -> Administrator)
+    @Test
+    public void test_LDAPRoleConverter2() {
+        LDAPRoleConverterGroupNameParser out = new LDAPRoleConverterGroupNameParser();
+
+        LDAPUser userDetails = new LDAPUser("dblasby@example.com");
+
+        out.setLdapMembershipQueryParser("GCAT_(.*)_(.*)");
+        out.setGroupIndexInPattern(1);
+        out.setProfileIndexInPattern(2);
+
+        Map<String,Profile> profileMap = new HashMap<>();
+        profileMap.put("admin",Profile.Administrator);
+        profileMap.put("editor",Profile.Editor);
+
+        out.setProfileMapping(profileMap);
+
+        List<LDAPRole> result = out.convert(null,userDetails,"GCAT_GENERAL_admin",null);
+        assertEquals(1,result.size());
+        assertEquals("GENERAL", result.get(0).getGroupName());
+        assertEquals(Profile.Administrator, result.get(0).getProfile());
+    }
+
+    //testswhen the LDAP role doesn't match the pattern (shouldn't return anything)
+    @Test
+    public void test_LDAPRoleConverter3() {
+        LDAPRoleConverterGroupNameParser out = new LDAPRoleConverterGroupNameParser();
+
+        LDAPUser userDetails = new LDAPUser("dblasby@example.com");
+
+        out.setLdapMembershipQueryParser("GCAT_(.*)_(.*)");
+        out.setGroupIndexInPattern(1);
+        out.setProfileIndexInPattern(2);
+
+        Map<String,Profile> profileMap = new HashMap<>();
+        profileMap.put("admin",Profile.Administrator);
+        profileMap.put("editor",Profile.Editor);
+
+        out.setProfileMapping(profileMap);
+
+        List<LDAPRole> result = out.convert(null,userDetails,"BAD GROUP NAME",null);
+        assertEquals(0,result.size());
+    }
+
+    //sets up a direct link between an LDAP group and a list of GN-Roles (gn-group and gn-profile)
+    //also tests when the LDAP role doesn't match, LDAPRoleConverterGroupNameConverter doesn't return anything
+    @Test
+    public void test_LDAPRoleConverterGroupNameConverter1(){
+        LDAPRoleConverterGroupNameConverter out = new LDAPRoleConverterGroupNameConverter();
+
+        Map<String,List<LDAPRole>> map = new HashMap<>();
+        List<LDAPRole> roles = new ArrayList<LDAPRole>(
+                                        Arrays.asList( new LDAPRole("group1","Administrator"),
+                                                       new LDAPRole("group2","Editor")
+                                        ));
+        map.put("ldap_abc",roles);
+
+        out.setConvertMap(map);
+
+        LDAPUser userDetails = new LDAPUser("dblasby@example.com");
+
+        List<LDAPRole> result = out.convert(null,userDetails,"ldap_abc",null);
+        assertEquals(2,result.size());
+        assertEquals("group1", result.get(0).getGroupName());
+        assertEquals(Profile.Administrator, result.get(0).getProfile());
+
+        assertEquals("group2", result.get(1).getGroupName());
+        assertEquals(Profile.Editor, result.get(1).getProfile());
+
+
+        result = out.convert(null,userDetails,"BAD_GROUP_NAME",null);
+        assertEquals(0,result.size());
+    }
+
+
+
+}

--- a/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPRoleConverterTest.java
@@ -1,3 +1,6 @@
+//=============================================================================
+//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
 //===	This program is free software; you can redistribute it and/or modify
@@ -33,7 +36,7 @@ public class LDAPRoleConverterTest {
 
     //simple test for parsing "GCAT_GENERAL_Administrator"
     @Test
-    public void test_LDAPRoleConverter1() {
+    public void test_parse_GCAT_GENERAL_Administrator() throws Exception{
         LDAPRoleConverterGroupNameParser out = new LDAPRoleConverterGroupNameParser();
 
         LDAPUser userDetails = new LDAPUser("dblasby@example.com");
@@ -44,14 +47,14 @@ public class LDAPRoleConverterTest {
         out.setProfileMapping(null);
 
         List<LDAPRole> result = out.convert(null,userDetails,"GCAT_GENERAL_Administrator",null);
-        assertEquals(1,result.size());
+        assertEquals(1, result.size());
         assertEquals("GENERAL", result.get(0).getGroupName());
         assertEquals(Profile.Administrator, result.get(0).getProfile());
     }
 
     //tests profile mapping (admin -> Administrator)
     @Test
-    public void test_LDAPRoleConverter2() {
+    public void test_profile_mapping() throws Exception {
         LDAPRoleConverterGroupNameParser out = new LDAPRoleConverterGroupNameParser();
 
         LDAPUser userDetails = new LDAPUser("dblasby@example.com");
@@ -67,14 +70,14 @@ public class LDAPRoleConverterTest {
         out.setProfileMapping(profileMap);
 
         List<LDAPRole> result = out.convert(null,userDetails,"GCAT_GENERAL_admin",null);
-        assertEquals(1,result.size());
+        assertEquals(1, result.size());
         assertEquals("GENERAL", result.get(0).getGroupName());
         assertEquals(Profile.Administrator, result.get(0).getProfile());
     }
 
     //testswhen the LDAP role doesn't match the pattern (shouldn't return anything)
     @Test
-    public void test_LDAPRoleConverter3() {
+    public void test_no_matching_roles() throws Exception {
         LDAPRoleConverterGroupNameParser out = new LDAPRoleConverterGroupNameParser();
 
         LDAPUser userDetails = new LDAPUser("dblasby@example.com");
@@ -84,8 +87,8 @@ public class LDAPRoleConverterTest {
         out.setProfileIndexInPattern(2);
 
         Map<String,Profile> profileMap = new HashMap<>();
-        profileMap.put("admin",Profile.Administrator);
-        profileMap.put("editor",Profile.Editor);
+        profileMap.put("admin", Profile.Administrator);
+        profileMap.put("editor", Profile.Editor);
 
         out.setProfileMapping(profileMap);
 
@@ -96,7 +99,7 @@ public class LDAPRoleConverterTest {
     //sets up a direct link between an LDAP group and a list of GN-Roles (gn-group and gn-profile)
     //also tests when the LDAP role doesn't match, LDAPRoleConverterGroupNameConverter doesn't return anything
     @Test
-    public void test_LDAPRoleConverterGroupNameConverter1(){
+    public void test_LDAPRoleConverterGroupNameConverter_direct_match() throws Exception {
         LDAPRoleConverterGroupNameConverter out = new LDAPRoleConverterGroupNameConverter();
 
         Map<String,List<LDAPRole>> map = new HashMap<>();
@@ -111,7 +114,7 @@ public class LDAPRoleConverterTest {
         LDAPUser userDetails = new LDAPUser("dblasby@example.com");
 
         List<LDAPRole> result = out.convert(null,userDetails,"ldap_abc",null);
-        assertEquals(2,result.size());
+        assertEquals(2, result.size());
         assertEquals("group1", result.get(0).getGroupName());
         assertEquals(Profile.Administrator, result.get(0).getProfile());
 
@@ -120,7 +123,7 @@ public class LDAPRoleConverterTest {
 
 
         result = out.convert(null,userDetails,"BAD_GROUP_NAME",null);
-        assertEquals(0,result.size());
+        assertEquals(0, result.size());
     }
 
 

--- a/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.security.ldap;
+
+import org.apache.directory.api.util.FileUtils;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.annotations.CreatePartition;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.factory.DSAnnotationProcessor;
+import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
+import org.apache.directory.server.factory.ServerAnnotationProcessor;
+import org.apache.directory.server.ldap.LdapServer;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.domain.*;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.UserGroupRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.specification.UserGroupSpecs;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.ldap.core.*;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
+import org.springframework.security.ldap.LdapUsernameToDnMapper;
+import org.springframework.security.ldap.LdapUtils;
+import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
+import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.naming.Context;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+
+// ====================================================================================
+//  SEE THE DATA.LDIF FILE FOR THE LDAP LAYOUT
+//
+//   (it has comments at the top showing the tree)
+// ====================================================================================
+
+//Normally, you would use an org.apache.directory.server.core.integ.FrameworkRunner to run LDAP tests
+// however, that means you cannot use the SPRING runner, which makes life a bit more difficult.
+// So, we added setupServer/shutdown() server methods that will start/stop the LDAP server in the same manner.
+// This allows SPRING tests (with the spring runner) to run with an LDAP server!
+@CreateLdapServer(
+    transports = {@CreateTransport(port = 3333, protocol = "LDAP", address = "localhost")},
+    allowAnonymousAccess = false
+)
+@CreateDS(
+    name = "myDS",
+    partitions = {@CreatePartition(name = "test", suffix = LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.ldapSearchBase)}
+)
+@ApplyLdifFiles({"org/fao/geonet/kernel/security/ldap/data.ldif"})
+//run with spring
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+    "classpath:org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest-context.xml"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+public class LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest extends AbstractLdapTestUnit {
+
+    @Autowired
+    private ConfigurableApplicationContext _appContext;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserGroupRepository userGroupRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    DefaultSpringSecurityContextSource contextSource;
+
+    @Autowired
+    LdapUsernameToDnMapper usernameMapper;
+
+    @Autowired
+    LdapUserDetailsManager ldapUserDetailsService;
+
+    @Autowired
+    LDAPUserDetailsContextMapperWithProfileSearchEnhanced ldapUserContextMapper;
+
+    @Autowired
+    LdapAuthenticationProvider ldapAuthProvider;
+
+    @Autowired
+    FilterBasedLdapUserSearch ldapUserSearch;
+
+    //very simple test
+    // this will find the DN by searching by username
+    @Test
+    public void test_searchingLdapUsernameToDnMapper() {
+        DistinguishedName name = usernameMapper.buildDn("dblasby@example.com");
+        assertEquals("cn=blasby\\, david,ou=GIS Department,ou=Corporate Users", name.toString());
+
+
+        name = usernameMapper.buildDn("jgee@example.com");
+        assertEquals("cn=gee\\, jody,ou=Project Admin,ou=Corporate Users", name.toString());
+    }
+
+
+    //trivial test - make sure that the we can access the LDAP server and do a query via the contextSource bean
+    @Test
+    public void test_contextSource() throws NamingException {
+        DirContext ctx = contextSource.getReadOnlyContext();
+        List<SearchResult> results = queryLDAP("(objectClass=*)", ctx, null, null);
+        assertTrue(results.size() > 8);
+    }
+
+    //trivial test to make sure ldapUserSearch is working (finds users)
+    @Test
+    public void test_ldapUserSearch() {
+        DirContextOperations result = ldapUserSearch.searchForUser("dblasby@example.com");
+        assertNotNull(result);
+        assertEquals("cn=blasby\\, david,ou=GIS Department,ou=Corporate Users", result.getDn().toString());
+    }
+
+    //test the ldapUserDetailsService bean by looking for a user
+    //This bean also imports the LDAP user into geonetwork (i.e. inside UserRepo)
+    @Test
+    public void test_ldapUserDetailsService() throws NamingException {
+        boolean orig_importPrivilegesFromLdap = ldapUserContextMapper.isImportPrivilegesFromLdap();
+        try {
+            ldapUserContextMapper.setImportPrivilegesFromLdap(false); // we don't want to do this for this test case - this is just about the basics
+            UserDetails details = ldapUserDetailsService.loadUserByUsername("dblasby@example.com");
+            assertNotNull(details);
+
+            User user = userRepository.findOneByUsername("dblasby@example.com");
+            assertNotNull(user);
+            assertEquals("blasby", user.getSurname());
+        } finally {
+            ldapUserContextMapper.setImportPrivilegesFromLdap(orig_importPrivilegesFromLdap); //reset
+        }
+    }
+
+
+    //this is the main test - will set group/profiles for the user (dblasby)
+    @Test
+    @Transactional
+    public void test_ldapUserDetailsService_groups_and_profiles_dblasby() throws NamingException {
+
+        //make sure its already in the repository, or nothing will happen
+        Group group = new Group().setName("GENERAL");
+        group = groupRepository.save(group);
+
+
+        UserDetails details = ldapUserDetailsService.loadUserByUsername("dblasby@example.com");
+        assertNotNull(details);
+        assertEquals(3, details.getAuthorities().size());
+        assertEquals(Profile.Guest.name(), details.getAuthorities().toArray(new GrantedAuthority[0])[0].getAuthority());
+        assertEquals(Profile.Editor.name(), details.getAuthorities().toArray(new GrantedAuthority[0])[1].getAuthority());
+        assertEquals(Profile.RegisteredUser.name(), details.getAuthorities().toArray(new GrantedAuthority[0])[2].getAuthority());
+
+
+        LDAPUser user1 = (LDAPUser) details;
+        assertEquals(1, user1.getPrivileges().size());
+        assertTrue(user1.getPrivileges().containsKey("GENERAL"));
+        assertEquals(1, user1.getPrivileges().get("GENERAL").toArray().length);
+        assertEquals(Profile.Editor, user1.getPrivileges().get("GENERAL").toArray()[0]);
+
+
+        User user = userRepository.findOneByUsername("dblasby@example.com");
+        assertNotNull(user);
+        assertEquals("blasby", user.getSurname());
+        assertEquals(Profile.Editor, user.getProfile());
+
+        List<UserGroup> ug = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()));
+        assertNotNull(ug);
+        assertEquals(1, ug.size());
+        assertEquals("GENERAL", ug.get(0).getGroup().getName());
+    }
+
+    //this is the main test - will set group/profiles for the user (admin)
+    @Test
+    @Transactional
+    public void test_ldapUserDetailsService_groups_and_profiles_admin() throws NamingException {
+
+        //make sure its already in the repository, or nothing will happen
+        Group group = new Group().setName("GENERAL");
+        group = groupRepository.save(group);
+
+
+        UserDetails details = ldapUserDetailsService.loadUserByUsername("admin@example.com");
+        assertNotNull(details);
+
+        LDAPUser user1 = (LDAPUser) details;
+        assertEquals(1, user1.getPrivileges().size());
+        assertTrue(user1.getPrivileges().containsKey("GENERAL"));
+        assertEquals(1, user1.getPrivileges().get("GENERAL").toArray().length);
+        assertEquals(Profile.Administrator, user1.getPrivileges().get("GENERAL").toArray()[0]);
+
+
+        User user = userRepository.findOneByUsername("admin@example.com");
+        assertNotNull(user);
+        assertEquals("admin", user.getSurname());
+        assertEquals(Profile.Administrator, user.getProfile());
+
+        List<UserGroup> ug = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()));
+        assertNotNull(ug);
+        assertEquals(1, ug.size());
+        assertEquals("GENERAL", ug.get(0).getGroup().getName());
+    }
+
+    //this is the main test - will set group/profiles for the user (jody)
+    @Test
+    @Transactional
+    public void test_ldapUserDetailsService_groups_and_profiles_jody() throws NamingException {
+
+        //make sure its already in the repository, or nothing will happen
+        Group group = new Group().setName("GENERAL");
+        group = groupRepository.save(group);
+
+
+        UserDetails details = ldapUserDetailsService.loadUserByUsername("jgee@example.com");
+        assertNotNull(details);
+
+        LDAPUser user1 = (LDAPUser) details;
+        assertEquals(0, user1.getPrivileges().size());
+
+        User user = userRepository.findOneByUsername("jgee@example.com");
+        assertNotNull(user);
+        assertEquals("gee", user.getSurname());
+        assertEquals(Profile.RegisteredUser, user.getProfile());
+
+        List<UserGroup> ug = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()));
+        assertNotNull(ug);
+        assertEquals(0, ug.size());
+    }
+
+
+    @Test
+    @Transactional
+    public void test_ldapAuthProvider() {
+        UsernamePasswordAuthenticationToken userpass = new UsernamePasswordAuthenticationToken("dblasby@example.com", "blasby1", null);
+
+        Authentication result = ldapAuthProvider.authenticate(userpass);
+        assertNotNull(result);
+        assertTrue(result.isAuthenticated());
+    }
+
+    @Test(expected = BadCredentialsException.class)
+    public void test_ldapAuthProvider_badPass() {
+        UsernamePasswordAuthenticationToken userpass = new UsernamePasswordAuthenticationToken("dblasby@example.com", "BAD_PASSWORD", null);
+
+        //will throw because the password is wrong
+        Authentication result = ldapAuthProvider.authenticate(userpass);
+    }
+
+
+    //=========================================================================================
+
+    public final static String ldapSearchBase = "dc=example,dc=com";
+
+
+    DirectoryService LDAPservice = null;
+    LdapServer ldapServer = null;
+
+    public void setupLDAP() throws Exception {
+        CreateLdapServer classLdapServerBuilder = this.getClass().getAnnotation(CreateLdapServer.class);
+        CreateDS dsBuilder = this.getClass().getAnnotation(CreateDS.class);
+        LDAPservice = DSAnnotationProcessor.createDS(dsBuilder);
+        ApplyLdifFiles applyLdifFiles = this.getClass().getAnnotation(ApplyLdifFiles.class);
+        DSAnnotationProcessor.injectLdifFiles(applyLdifFiles.clazz(), LDAPservice, applyLdifFiles.value());
+
+        CreateLdapServer createLdapServer = getClass().getAnnotation(CreateLdapServer.class);
+        ldapServer = ServerAnnotationProcessor.instantiateLdapServer(createLdapServer, LDAPservice);
+        ldapServer.start();
+    }
+
+    public void shutdownLDAP() throws Exception {
+        ldapServer.stop();
+        LDAPservice.shutdown();
+        FileUtils.deleteDirectory(LDAPservice.getInstanceLayout().getInstanceDirectory());
+    }
+
+    @After
+    public void after() throws Exception {
+        shutdownLDAP();
+    }
+
+    //gets the spring context
+    @Before
+    public void before() throws Exception {
+        setupLDAP();
+        ApplicationContextHolder.set(this._appContext); // this is for code using antipattern - ApplicationContextHolder.get().getBean(...)
+
+        userRepository.deleteAll();
+        groupRepository.deleteAll();
+        userGroupRepository.deleteAll();
+    }
+
+
+    //very basic test - using LDAPTemplate
+    // this is testing the LDAP test-case server ... and explores the dataset
+    @Test
+    public void test_LdapTemplate() {
+        LdapTemplate template = new LdapTemplate(this.contextSource);
+        String username = "dblasby@example.com";
+
+        DistinguishedName dn = new DistinguishedName("cn=" + username);
+        SearchExecutor se = new SearchExecutor() {
+            public NamingEnumeration<SearchResult> executeSearch(DirContext ctx)
+                throws NamingException {
+                DistinguishedName fullDn = LdapUtils.getFullDn(dn, ctx);
+                SearchControls ctrls = new SearchControls();
+                //ctrls.setReturningAttributes(new String[]{"cn"});
+                ctrls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+
+                return ctx.search("", "(mail=dblasby@example.com)",
+                    new String[]{fullDn.toUrl(), username}, ctrls);
+
+            }
+        };
+
+        final boolean[] pass = {false};
+        NameClassPairCallbackHandler handler = new NameClassPairCallbackHandler() {
+            @Override
+            public void handleNameClassPair(NameClassPair nameClassPair) {
+                pass[0] = true;
+            }
+        };
+
+        template.search(se, handler);
+        assertEquals(pass[0], true);
+    }
+
+
+    //this is ensuring that the LDAP server is up-and-running, and can do two things;
+    // a) find user by name
+    // b) find groups a user is a member of
+    //These will be used in the main system, but best to check here
+    @Test
+    public void test_LDAPIsWorking() throws Exception {
+        Hashtable env = new Hashtable();
+        env.put(Context.INITIAL_CONTEXT_FACTORY,
+            "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldap://localhost:4444/");
+
+        // anonymous access
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.SECURITY_PRINCIPAL, "cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com");
+        env.put(Context.SECURITY_CREDENTIALS, "admin1");
+
+        // Create the initial context
+        DirContext ctx = new InitialDirContext(env);
+        SearchControls searchControls = new SearchControls();
+        searchControls.setCountLimit(1000);
+        searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+        String ldapSearchBase = "dc=example,dc=com";
+
+        //search for user
+        {
+            String searchFilter = "(mail=dblasby@example.com)";
+            NamingEnumeration<SearchResult> results = ctx.search(ldapSearchBase, searchFilter, searchControls);
+            List<SearchResult> list = Collections.list(results);
+            assertEquals(1, list.size());
+            assertTrue(list.get(0).getName().contains("blasby"));
+        }
+        //search for groups user belongs to
+        {
+            String searchFilter = "(&    (objectClass=*)    (member=cn=blasby\\\\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com))";
+            NamingEnumeration<SearchResult> results = ctx.search(ldapSearchBase, searchFilter, searchControls);
+            List<SearchResult> list = Collections.list(results);
+            assertEquals(3, list.size());
+            assertTrue(list.get(0).getName().contains("Geoserver Admin") || list.get(1).getName().contains("Geoserver Admin") || list.get(2).getName().contains("Geoserver Admin"));
+            assertTrue(list.get(0).getName().contains("Geonetwork Developer") || list.get(1).getName().contains("Geonetwork Developer") || list.get(2).getName().contains("Geonetwork Developer"));
+            assertTrue(list.get(0).getName().contains("GCAT_GENERAL_EDITOR") || list.get(1).getName().contains("GCAT_GENERAL_EDITOR") || list.get(2).getName().contains("GCAT_GENERAL_EDITOR"));
+
+            // assertTrue(list.get(0).getName().contains("blasby"));
+        }
+    }
+
+    public List<SearchResult> queryLDAP(String searchFilter, DirContext ctx, String ldapSearchBase, SearchControls controls) throws NamingException {
+        if (controls == null) {
+            controls = new SearchControls();
+            controls.setCountLimit(1000);
+            controls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        }
+        if (ldapSearchBase == null)
+            ldapSearchBase = "";
+        if (ctx == null)
+            ctx = contextSource.getReadOnlyContext();
+
+        NamingEnumeration<SearchResult> results = ctx.search(ldapSearchBase, searchFilter, controls);
+        List<SearchResult> list = Collections.list(results);
+        return list;
+    }
+}

--- a/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.java
@@ -381,7 +381,7 @@ public class LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest extends A
         Hashtable env = new Hashtable();
         env.put(Context.INITIAL_CONTEXT_FACTORY,
             "com.sun.jndi.ldap.LdapCtxFactory");
-        env.put(Context.PROVIDER_URL, "ldap://localhost:4444/");
+        env.put(Context.PROVIDER_URL, "ldap://localhost:3333/");
 
         // anonymous access
         env.put(Context.SECURITY_AUTHENTICATION, "simple");

--- a/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.java
@@ -132,6 +132,9 @@ public class LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest extends A
     @Autowired
     FilterBasedLdapUserSearch ldapUserSearch;
 
+    @Autowired
+    LDAPRoleConverterGroupNameParser ldapRoleConverterGroupNameParser;
+
     //very simple test
     // this will find the DN by searching by username
     @Test

--- a/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.java
@@ -22,6 +22,7 @@
  */
 package org.fao.geonet.kernel.security.ldap;
 
+import net.sf.ehcache.CacheManager;
 import org.apache.directory.api.util.FileUtils;
 import org.apache.directory.server.annotations.CreateLdapServer;
 import org.apache.directory.server.annotations.CreateTransport;
@@ -136,19 +137,23 @@ public class LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest extends A
 
     //=------------------------------------------------------------------
 
-    @AfterClass
-    public static void afterClass() throws Exception {
+    @After
+    public void after() throws Exception {
         shutdownLDAP();
     }
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        setupLDAP();
+    @AfterClass
+    public static void afterClass() {
+        CacheManager.getInstance().shutdown(); //we need to make sure this is gone or we'll conflict with hibernate
     }
+
+
 
     //gets the spring context
     @Before
     public void before() throws Exception {
+        setupLDAP();
+
         ApplicationContextHolder.set(this._appContext); // this is for code using antipattern - ApplicationContextHolder.get().getBean(...)
 
         userRepository.deleteAll();
@@ -322,10 +327,10 @@ public class LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest extends A
     public final static String ldapSearchBase = "dc=example,dc=com";
 
 
-    static DirectoryService LDAPservice = null;
-    static LdapServer ldapServer = null;
+    DirectoryService LDAPservice = null;
+    LdapServer ldapServer = null;
 
-    public static void setupLDAP() throws Exception {
+    public  void setupLDAP() throws Exception {
         CreateLdapServer classLdapServerBuilder = LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.class.getAnnotation(CreateLdapServer.class);
         CreateDS dsBuilder = LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest.class.getAnnotation(CreateDS.class);
         LDAPservice = DSAnnotationProcessor.createDS(dsBuilder);
@@ -337,7 +342,7 @@ public class LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest extends A
         ldapServer.start();
     }
 
-    public static void shutdownLDAP() throws Exception {
+    public   void shutdownLDAP() throws Exception {
         ldapServer.stop();
         LDAPservice.shutdown();
         FileUtils.deleteDirectory(LDAPservice.getInstanceLayout().getInstanceDirectory());

--- a/core/src/test/resources/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest-context.xml
+++ b/core/src/test/resources/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest-context.xml
@@ -14,6 +14,18 @@
 
 <!--  <ctx:property-placeholder location="classpath:org/fao/geonet/kernel/security/ldap/LDAP-test-properties.properties"/>-->
 
+  <bean id="ldapRoleConverterGroupNameParser"
+        class="org.fao.geonet.kernel.security.ldap.LDAPRoleConverterGroupNameParser">
+    <property name="ldapMembershipQueryParser" value="GCAT_(.*)_(.*)"/>
+    <property name="groupIndexInPattern" value="1"/>
+    <property name="profileIndexInPattern" value="2"/>
+    <property name="profileMapping">
+      <map>
+        <entry key="ADMIN" value="Administrator"/>
+        <entry key="EDITOR" value="Editor"/>
+      </map>
+    </property>
+  </bean>
 
   <!-- Add ldap authentication to authentication manager -->
   <bean id="ldapAuthenticationProviderPostProcessor"
@@ -90,10 +102,7 @@
       </map>
     </property>
     <property name="profileMapping">
-      <map>
-        <entry key="ADMIN" value="Administrator"/>
-        <entry key="EDITOR" value="Editor"/>
-      </map>
+      <map/>
     </property>
     <property name="ldapUtils" ref="ldapUtils"/>
     <property name="importPrivilegesFromLdap" value="true"/>
@@ -103,12 +112,14 @@
 
     <property name="ldapManager" ref="ldapUserDetailsService" />
 
-    <property name="ldapMembershipQuery" value="(&amp;(objectClass=*)(member=cn={2})(cn=GCAT_*))"/>
-    <property name="ldapMembershipQueryParser" value="GCAT_(.*)_(.*)"/>
-    <property name="groupIndexInPattern" value="1"/>
-    <property name="profileIndexInPattern" value="2"/>
-
     <property name="membershipSearchStartObject" value=""/>
+    <property name="ldapMembershipQuery" value="(&amp;(objectClass=*)(member=cn={2})(cn=GCAT_*))"/>
+
+   <property name="ldapRoleConverters">
+     <util:list>
+       <ref bean="ldapRoleConverterGroupNameParser"/>
+     </util:list>
+   </property>
 
 
     <property name="contextSource" ref="contextSource" />

--- a/core/src/test/resources/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest-context.xml
+++ b/core/src/test/resources/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearchEnhancedTest-context.xml
@@ -1,0 +1,204 @@
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns="http://www.springframework.org/schema/beans"
+       xmlns:jpa="http://www.springframework.org/schema/data/jpa"
+       xmlns:ctx="http://www.springframework.org/schema/context"
+
+       xsi:schemaLocation="
+         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+         http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa-1.3.xsd
+         http://www.springframework.org/schema/context  http://www.springframework.org/schema/context/spring-context-3.0.xsd
+		">
+
+
+<!--  <ctx:property-placeholder location="classpath:org/fao/geonet/kernel/security/ldap/LDAP-test-properties.properties"/>-->
+
+
+  <!-- Add ldap authentication to authentication manager -->
+  <bean id="ldapAuthenticationProviderPostProcessor"
+        class="jeeves.config.springutil.AddAuthenticationProviderPostProcessor">
+    <constructor-arg ref="ldapAuthProvider"/>
+  </bean>
+
+  <!-- LDAP configuration-->
+  <bean id="contextSource"
+        class="org.springframework.security.ldap.DefaultSpringSecurityContextSource">
+    <constructor-arg value="ldap://localhost:3333/dc=example,dc=com"/>
+    <!-- For non anonymous binding -->
+    <property name="userDn" value="cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com"/>
+    <property name="password" value="admin1"/>
+  </bean>
+
+  <bean id="ldapUserSearch" class="org.springframework.security.ldap.search.FilterBasedLdapUserSearch">
+    <constructor-arg name="searchBase" value=""/>
+    <constructor-arg name="searchFilter" value="(mail={0})"/>
+    <constructor-arg name="contextSource" ref="contextSource"/>
+
+    <property name="searchSubtree" value="true"/>
+  </bean>
+
+
+  <bean id="usernameMapper"
+        class="org.fao.geonet.kernel.security.ldap.SearchingLdapUsernameToDnMapper">
+    <property name="ldapContextSource" ref="contextSource"/>
+    <property name="ldapUserSearch" ref="ldapUserSearch"/>
+  </bean>
+
+  <bean id="ldapAuthProvider"
+        class="org.springframework.security.ldap.authentication.LdapAuthenticationProvider">
+    <constructor-arg>
+      <bean class="org.springframework.security.ldap.authentication.BindAuthenticator">
+        <constructor-arg ref="contextSource"/>
+        <property name="userSearch" ref="ldapUserSearch"/>
+      </bean>
+    </constructor-arg>
+    <property name="userDetailsContextMapper" ref="ldapUserContextMapper"/>
+  </bean>
+
+  <bean id="ldapUserDetailsService"
+        class="org.fao.geonet.kernel.security.ldap.LdapUserDetailsManager">
+    <constructor-arg ref="contextSource"/>
+    <constructor-arg name="groupMemberAttributeName"
+                     value="cn"/>
+    <constructor-arg name="query"
+                     value="mail={1}"/>
+    <property name="groupSearchBase"
+              value=""/>
+    <property name="usernameMapper" ref="usernameMapper"/>
+    <property name="userDetailsMapper" ref="ldapUserContextMapper"/>
+  </bean>
+
+  <bean id="ldapUtils" class="org.fao.geonet.kernel.security.ldap.LDAPUtils"/>
+
+
+  <bean id="ldapUserContextMapper" class="org.fao.geonet.kernel.security.ldap.LDAPUserDetailsContextMapperWithProfileSearchEnhanced">
+    <property name="mapping">
+      <map>
+        <entry key="name" value="cn,"/>
+        <entry key="surname" value="sn,"/>
+        <entry key="mail" value="mail,"/>
+        <entry key="organisation" value=","/>
+        <entry key="address" value=","/>
+        <entry key="zip" value=","/>
+        <entry key="state" value=","/>
+        <entry key="city" value=","/>
+        <entry key="country" value=","/>
+
+        <entry key="profile" value=",RegisteredUser"/>
+        <entry key="privilege" value=",none"/>
+      </map>
+    </property>
+    <property name="profileMapping">
+      <map>
+        <entry key="ADMIN" value="Administrator"/>
+        <entry key="EDITOR" value="Editor"/>
+      </map>
+    </property>
+    <property name="ldapUtils" ref="ldapUtils"/>
+    <property name="importPrivilegesFromLdap" value="true"/>
+    <!-- typically, don't want GN to modify the LDAP server! -->
+    <property name="createNonExistingLdapGroup" value="false" />
+    <property name="createNonExistingLdapUser" value="false" />
+
+    <property name="ldapManager" ref="ldapUserDetailsService" />
+
+    <property name="ldapMembershipQuery" value="(&amp;(objectClass=*)(member=cn={2})(cn=GCAT_*))"/>
+    <property name="ldapMembershipQueryParser" value="GCAT_(.*)_(.*)"/>
+    <property name="groupIndexInPattern" value="1"/>
+    <property name="profileIndexInPattern" value="2"/>
+
+    <property name="membershipSearchStartObject" value=""/>
+
+
+    <property name="contextSource" ref="contextSource" />
+  </bean>
+
+  <!-- ==================================================================================================== -->
+  <!-- ==================================================================================================== -->
+  <!-- ==================================================================================================== -->
+                                          <!-- stuff for JPA/repositories -->
+  <!-- ==================================================================================================== -->
+  <!-- ==================================================================================================== -->
+  <!-- ==================================================================================================== -->
+
+
+
+  <jpa:repositories base-package="org.fao.geonet.repository"
+                    factory-class="org.fao.geonet.repository.GeonetRepositoryFactoryBean"
+                    entity-manager-factory-ref="entityManagerFactory"
+                    transaction-manager-ref="transactionManager"/>
+
+  <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
+    <property name="entityManagerFactory" ref="entityManagerFactory"/>
+  </bean>
+
+  <bean id="entityManagerFactory"
+        class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
+    <property name="dataSource" ref="jdbcDataSource"/>
+    <property name="packagesToScan" value="org.fao.geonet.domain"/>
+    <property name="jpaVendorAdapter" ref="jpaVendorAdapter"/>
+    <property name="jpaPropertyMap" ref="jpaPropertyMap"/>
+  </bean>
+
+
+
+  <bean lazy-init="true" id="jpaVendorAdapter"
+        class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter">
+    <property name="generateDdl" ref="generateDdl"/>
+    <property name="showSql" value="false"/>
+    <property name="database" ref="jpaVendorAdapterDatabaseParam"/>
+  </bean>
+
+  <bean id="nodeInfo" class="org.fao.geonet.NodeInfo">
+    <property name="id" value="testNodeId"/>
+    <property name="defaultNode" value="true"/>
+  </bean>
+
+  <bean id="systemInfo" class="org.fao.geonet.SystemInfo" factory-method="createForTesting">
+    <constructor-arg value="development"/>
+  </bean>
+
+  <bean id="IS_DEFAULT_CONTEXT_BEAN" class="java.lang.Boolean">
+    <constructor-arg index="0" value="true"/>
+  </bean>
+
+  <!--<jdbc:embedded-database type="H2" id="jdbcDataSource" />-->
+  <bean id="jdbcDataSource"
+        class="org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactoryBean">
+    <property name="databaseType" value="H2"/>
+    <property name="databaseConfigurer">
+      <bean class="org.fao.geonet.GeonetworkH2TestEmbeddedDatabaseConfigurer">
+        <!--<property name="compatilityMode" value="MySQL"/>-->
+        <!--<property name="compatilityMode" value="Oracle"/>-->
+        <!--<property name="compatilityMode" value="DB2"/>-->
+        <!--<property name="compatilityMode" value="MSSQLServer"/>-->
+        <!--<property name="compatilityMode" value="PostgreSQL"/>-->
+      </bean>
+    </property>
+  </bean>
+  <bean id="jpaVendorAdapterDatabaseParam" class="java.lang.String">
+    <constructor-arg value="H2"/>
+  </bean>
+
+  <bean id="generateDdl" class="java.lang.String">
+    <constructor-arg value="true"/>
+  </bean>
+
+  <util:map id="jpaPropertyMap">
+    <entry key="shared-cache-mode" value="ENABLE_SELECTIVE"/>
+    <entry key="javax.persistence.lock.timeout" value="30000"/>
+    <entry key="org.hibernate.flushMode" value="AUTO"/>
+    <entry key="access" value="PROPERTY"/>
+    <entry key="hibernate.id.new_generator_mappings" value="true"/>
+    <entry key="hibernate.cache.use_second_level_cache" value="true"/>
+    <!--<entry key="hibernate.cache.region.factory_class" value="org.hibernate.cache.internal.NoCachingRegionFactory"/> -->
+    <entry key="hibernate.cache.region.factory_class"
+           value="org.hibernate.cache.ehcache.EhCacheRegionFactory"/>
+    <entry key="hibernate.jdbc.batch_size" value="3"/>
+    <entry key="hibernate.jdbc.batch_versioned_data" value="true"/>
+    <entry key="hibernate.enable_lazy_load_no_trans" value="true"/>
+  </util:map>
+
+
+</beans>

--- a/core/src/test/resources/org/fao/geonet/kernel/security/ldap/README.md
+++ b/core/src/test/resources/org/fao/geonet/kernel/security/ldap/README.md
@@ -1,0 +1,34 @@
+Running Fully Inside GeoNetwork
+===============================
+
+I've set this up so you can easily run a local LDAP server (complete with GN and LDAP configuration).
+
+Setup LDAP
+----------
+
+1. Download and install Apache Directory Studio
+2. Add a new Server (might have to open the "Server" View)
+3. Open a connection to the new Server
+4. right-click on the connection and import a "ldif" file
+5. choose "data_for_Apache_Directory_Studio.ldif" 
+    * This is the same a data.ldif but it doesn't define the dc=example,dc=com folder (its pre-created)
+6. Feel free to explore the LDAP tree in Apache Directory Studio    
+    
+
+Setup GeoNetwork
+---------------- 
+
+1. Remove the comment for `<import resource="config-security-ldap.xml"/>` in `web/src/main/webapp/WEB-INF/config-security/config-security.xml`
+2. Replace the contents of `web/src/main/webapp/WEB-INF/config-security/config-security-ldap.xml` with the contents from `apache-directory-studio-security-context.xml`
+3. Rebuild and run Geonework
+4. Login as admin/admin user
+5. in the admin menu, add a "GENERAL" group (all caps) 
+
+Using GeoNetwork
+----------------
+1. You can login with the standard admin/admin user
+2. You can also login with these users;
+   dblasby@example.com/blasby1 -- has "Editor" rights in GENERAL group
+   admin@example.com/admin1 -- has "Administrator" rights in GENERAL group
+   jgee@example.com/jody1 -- no groups -- "RegisteredUser"
+   

--- a/core/src/test/resources/org/fao/geonet/kernel/security/ldap/README.md
+++ b/core/src/test/resources/org/fao/geonet/kernel/security/ldap/README.md
@@ -13,7 +13,8 @@ Setup LDAP
 5. choose "data_for_Apache_Directory_Studio.ldif" 
     * This is the same a data.ldif but it doesn't define the dc=example,dc=com folder (its pre-created)
 6. Feel free to explore the LDAP tree in Apache Directory Studio    
-    
+  
+NOTE: use port 3333  
 
 Setup GeoNetwork
 ---------------- 

--- a/core/src/test/resources/org/fao/geonet/kernel/security/ldap/apache-directory-studio-security-context.xml
+++ b/core/src/test/resources/org/fao/geonet/kernel/security/ldap/apache-directory-studio-security-context.xml
@@ -1,0 +1,118 @@
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns="http://www.springframework.org/schema/beans"
+       xmlns:jpa="http://www.springframework.org/schema/data/jpa"
+       xmlns:ctx="http://www.springframework.org/schema/context"
+
+       xsi:schemaLocation="
+         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+         http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa-1.3.xsd
+         http://www.springframework.org/schema/context  http://www.springframework.org/schema/context/spring-context-3.0.xsd
+		">
+
+
+<!--  <ctx:property-placeholder location="classpath:org/fao/geonet/kernel/security/ldap/LDAP-test-properties.properties"/>-->
+
+
+  <!-- Add ldap authentication to authentication manager -->
+  <bean id="ldapAuthenticationProviderPostProcessor"
+        class="jeeves.config.springutil.AddAuthenticationProviderPostProcessor">
+    <constructor-arg ref="ldapAuthProvider"/>
+  </bean>
+
+  <!-- LDAP configuration-->
+  <bean id="contextSource"
+        class="org.springframework.security.ldap.DefaultSpringSecurityContextSource">
+    <constructor-arg value="ldap://localhost:3333/dc=example,dc=com"/>
+    <!-- For non anonymous binding -->
+    <property name="userDn" value="cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com"/>
+    <property name="password" value="admin1"/>
+  </bean>
+
+  <bean id="ldapUserSearch" class="org.springframework.security.ldap.search.FilterBasedLdapUserSearch">
+    <constructor-arg name="searchBase" value=""/>
+    <constructor-arg name="searchFilter" value="(mail={0})"/>
+    <constructor-arg name="contextSource" ref="contextSource"/>
+
+    <property name="searchSubtree" value="true"/>
+  </bean>
+
+
+  <bean id="usernameMapper"
+        class="org.fao.geonet.kernel.security.ldap.SearchingLdapUsernameToDnMapper">
+    <property name="ldapContextSource" ref="contextSource"/>
+    <property name="ldapUserSearch" ref="ldapUserSearch"/>
+  </bean>
+
+  <bean id="ldapAuthProvider"
+        class="org.springframework.security.ldap.authentication.LdapAuthenticationProvider">
+    <constructor-arg>
+      <bean class="org.springframework.security.ldap.authentication.BindAuthenticator">
+        <constructor-arg ref="contextSource"/>
+        <property name="userSearch" ref="ldapUserSearch"/>
+      </bean>
+    </constructor-arg>
+    <property name="userDetailsContextMapper" ref="ldapUserContextMapper"/>
+  </bean>
+
+  <bean id="ldapUserDetailsService"
+        class="org.fao.geonet.kernel.security.ldap.LdapUserDetailsManager">
+    <constructor-arg ref="contextSource"/>
+    <constructor-arg name="groupMemberAttributeName"
+                     value="cn"/>
+    <constructor-arg name="query"
+                     value="mail={1}"/>
+    <property name="groupSearchBase"
+              value=""/>
+    <property name="usernameMapper" ref="usernameMapper"/>
+    <property name="userDetailsMapper" ref="ldapUserContextMapper"/>
+  </bean>
+
+  <bean id="ldapUtils" class="org.fao.geonet.kernel.security.ldap.LDAPUtils"/>
+
+
+  <bean id="ldapUserContextMapper" class="org.fao.geonet.kernel.security.ldap.LDAPUserDetailsContextMapperWithProfileSearchEnhanced">
+    <property name="mapping">
+      <map>
+        <entry key="name" value="cn,"/>
+        <entry key="surname" value="sn,"/>
+        <entry key="mail" value="mail,"/>
+        <entry key="organisation" value=","/>
+        <entry key="address" value=","/>
+        <entry key="zip" value=","/>
+        <entry key="state" value=","/>
+        <entry key="city" value=","/>
+        <entry key="country" value=","/>
+
+        <entry key="profile" value=",RegisteredUser"/>
+        <entry key="privilege" value=",none"/>
+      </map>
+    </property>
+    <property name="profileMapping">
+      <map>
+        <entry key="ADMIN" value="Administrator"/>
+        <entry key="EDITOR" value="Editor"/>
+      </map>
+    </property>
+    <property name="ldapUtils" ref="ldapUtils"/>
+    <property name="importPrivilegesFromLdap" value="true"/>
+    <!-- typically, don't want GN to modify the LDAP server! -->
+    <property name="createNonExistingLdapGroup" value="false" />
+    <property name="createNonExistingLdapUser" value="false" />
+
+    <property name="ldapManager" ref="ldapUserDetailsService" />
+
+    <property name="ldapMembershipQuery" value="(&amp;(objectClass=*)(member=cn={2})(cn=GCAT_*))"/>
+    <property name="ldapMembershipQueryParser" value="GCAT_(.*)_(.*)"/>
+    <property name="groupIndexInPattern" value="1"/>
+    <property name="profileIndexInPattern" value="2"/>
+
+    <property name="membershipSearchStartObject" value=""/>
+
+
+    <property name="contextSource" ref="contextSource" />
+  </bean>
+
+
+</beans>

--- a/core/src/test/resources/org/fao/geonet/kernel/security/ldap/apache-directory-studio-security-context.xml
+++ b/core/src/test/resources/org/fao/geonet/kernel/security/ldap/apache-directory-studio-security-context.xml
@@ -14,6 +14,18 @@
 
 <!--  <ctx:property-placeholder location="classpath:org/fao/geonet/kernel/security/ldap/LDAP-test-properties.properties"/>-->
 
+  <bean id="ldapRoleConverterGroupNameParser"
+        class="org.fao.geonet.kernel.security.ldap.LDAPRoleConverterGroupNameParser">
+    <property name="ldapMembershipQueryParser" value="GCAT_(.*)_(.*)"/>
+    <property name="groupIndexInPattern" value="1"/>
+    <property name="profileIndexInPattern" value="2"/>
+    <property name="profileMapping">
+      <map>
+        <entry key="ADMIN" value="Administrator"/>
+        <entry key="EDITOR" value="Editor"/>
+      </map>
+    </property>
+  </bean>
 
   <!-- Add ldap authentication to authentication manager -->
   <bean id="ldapAuthenticationProviderPostProcessor"
@@ -90,10 +102,7 @@
       </map>
     </property>
     <property name="profileMapping">
-      <map>
-        <entry key="ADMIN" value="Administrator"/>
-        <entry key="EDITOR" value="Editor"/>
-      </map>
+      <map/>
     </property>
     <property name="ldapUtils" ref="ldapUtils"/>
     <property name="importPrivilegesFromLdap" value="true"/>
@@ -103,16 +112,17 @@
 
     <property name="ldapManager" ref="ldapUserDetailsService" />
 
-    <property name="ldapMembershipQuery" value="(&amp;(objectClass=*)(member=cn={2})(cn=GCAT_*))"/>
-    <property name="ldapMembershipQueryParser" value="GCAT_(.*)_(.*)"/>
-    <property name="groupIndexInPattern" value="1"/>
-    <property name="profileIndexInPattern" value="2"/>
-
     <property name="membershipSearchStartObject" value=""/>
+    <property name="ldapMembershipQuery" value="(&amp;(objectClass=*)(member=cn={2})(cn=GCAT_*))"/>
+
+    <property name="ldapRoleConverters">
+      <util:list>
+        <ref bean="ldapRoleConverterGroupNameParser"/>
+      </util:list>
+    </property>
 
 
     <property name="contextSource" ref="contextSource" />
   </bean>
-
 
 </beans>

--- a/core/src/test/resources/org/fao/geonet/kernel/security/ldap/data.ldif
+++ b/core/src/test/resources/org/fao/geonet/kernel/security/ldap/data.ldif
@@ -1,0 +1,121 @@
+# LDAP
+#  /com
+#     /example
+#         /Corporate Users
+#               /GIS Department
+#                   * david blasby (blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#                   * admin (admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#               /Project Admin
+#                   * jody gee (gee\, jody,ou=Project Admin,ou=Corporate Users,dc=example,dc=com)
+#
+#         /Org Groups
+#               /Geoserver Admin
+#                    * member: david blasby (blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#               /Geonetwork Developer
+#                    * member: david blasby (blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#                    * member: jody gee (gee\, jody,ou=Project Admin,ou=Corporate Users,dc=example,dc=com)
+#               /PostGIS Developer
+#                    * member: admin (admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#
+#               /GCAT_GENERAL_EDITOR
+#                    * member: david blasby (blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#               /GCAT_GENERAL_ADMIN
+#                    * member: admin (admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#
+#   david blasby -> EDITOR
+#   admin -> ADMIN
+#   jody gee -> RegisteredUser
+
+version: 1
+dn: dc=example,dc=com
+objectClass: domain
+objectClass: top
+dc: example
+
+
+dn: ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Corporate Users
+
+dn: ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: GIS Department
+
+dn: ou=Project Admin,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Project Admin
+
+
+dn: cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+givenName: admin
+sn: admin
+cn: admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+userPassword: admin1
+telephoneNumber: 1
+mail: admin@example.com
+
+dn: cn=blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+givenName: david
+sn: blasby
+cn: blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+userPassword: blasby1
+telephoneNumber: 2
+mail: dblasby@example.com
+
+
+dn: cn=gee\, jody,ou=Project Admin,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+givenName: jody
+sn: gee
+cn: jody gee,ou=Project Admin,ou=Corporate Users,dc=example,dc=com
+userPassword: jody1
+telephoneNumber: 3
+mail: jgee@example.com
+
+dn: ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Org Groups
+
+dn: cn=Geoserver Admin,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: Geoserver Admin
+member: cn=blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+
+
+dn: cn=Geonetwork Developer,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: Geonetwork Developer
+member: cn=blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+member: cn=gee\, jody,ou=Project Admin,ou=Corporate Users,dc=example,dc=com
+
+dn: cn=PostGIS Developer,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: PostGIS Developer
+member: cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+
+
+dn: cn=GCAT_GENERAL_ADMIN,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: GCAT_GENERAL_ADMIN
+member: cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+
+
+dn: cn=GCAT_GENERAL_EDITOR,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: GCAT_GENERAL_EDITOR
+member: cn=blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+

--- a/core/src/test/resources/org/fao/geonet/kernel/security/ldap/data_for_Apache_Directory_Studio.ldif
+++ b/core/src/test/resources/org/fao/geonet/kernel/security/ldap/data_for_Apache_Directory_Studio.ldif
@@ -1,0 +1,117 @@
+# LDAP
+#  /com
+#     /example
+#         /Corporate Users
+#               /GIS Department
+#                   * david blasby (blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#                   * admin (admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#               /Project Admin
+#                   * jody gee (gee\, jody,ou=Project Admin,ou=Corporate Users,dc=example,dc=com)
+#
+#         /Org Groups
+#               /Geoserver Admin
+#                    * member: david blasby (blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#               /Geonetwork Developer
+#                    * member: david blasby (blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#                    * member: jody gee (gee\, jody,ou=Project Admin,ou=Corporate Users,dc=example,dc=com)
+#               /PostGIS Developer
+#                    * member: admin (admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#
+#               /GCAT_GENERAL_EDITOR
+#                    * member: david blasby (blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#               /GCAT_GENERAL_ADMIN
+#                    * member: admin (admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com)
+#
+#   david blasby -> EDITOR
+#   admin -> ADMIN
+#   jody gee -> RegisteredUser
+
+version: 1
+
+
+dn: ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Corporate Users
+
+dn: ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: GIS Department
+
+dn: ou=Project Admin,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Project Admin
+
+
+dn: cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+givenName: admin
+sn: admin
+cn: admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+userPassword: admin1
+telephoneNumber: 1
+mail: admin@example.com
+
+dn: cn=blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+givenName: david
+sn: blasby
+cn: blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+userPassword: blasby1
+telephoneNumber: 2
+mail: dblasby@example.com
+
+
+dn: cn=gee\, jody,ou=Project Admin,ou=Corporate Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+givenName: jody
+sn: gee
+cn: jody gee,ou=Project Admin,ou=Corporate Users,dc=example,dc=com
+userPassword: jody1
+telephoneNumber: 3
+mail: jgee@example.com
+
+dn: ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Org Groups
+
+dn: cn=Geoserver Admin,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: Geoserver Admin
+member: cn=blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+
+
+dn: cn=Geonetwork Developer,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: Geonetwork Developer
+member: cn=blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+member: cn=gee\, jody,ou=Project Admin,ou=Corporate Users,dc=example,dc=com
+
+dn: cn=PostGIS Developer,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: PostGIS Developer
+member: cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+
+
+dn: cn=GCAT_GENERAL_ADMIN,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: GCAT_GENERAL_ADMIN
+member: cn=admin,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+
+
+dn: cn=GCAT_GENERAL_EDITOR,ou=Org Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: GCAT_GENERAL_EDITOR
+member: cn=blasby\, david,ou=GIS Department,ou=Corporate Users,dc=example,dc=com
+


### PR DESCRIPTION
I've added more infrastructure to the LDAP system.  I've only made very minor changes to the existing infrastructure, so I think this shouldn't affect anyone.

The new infrastructure;
a) It much easier to understand and modify using strategy objects and spring configuration
b) has a bunch of test case
     * test cases run a pre-configured LDAP server

The main difference between this infrastructure and the old infrastructure is that there are much few assumptions about how the LDAP directory is structures (i.e. it searches for users/group instead of assuming where there are in the directory).

I had a very hard time trying to figure out what the old infrastructure actually did - the documentation was missing, confusing, misleading, or wrong.  There were no test cases, and there was too much work pushed into one object (new infrastructure pushes details in to strategy objects).

This infrastructure improves this.

Please see the two README.md files and the test cases.