### PR TITLE
Fix issued with using jdbc.port value when set.  #4833

### DIFF
--- a/web/src/main/webResources/WEB-INF/config-db/defaultJdbcDataSource.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/defaultJdbcDataSource.xml
@@ -31,7 +31,7 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 	">
   <context:property-placeholder location="${db.properties}" file-encoding="UTF-8"
-                                ignore-unresolvable="true" order="1"/>
+                                ignore-unresolvable="true" order="-1"/>
 
 
   <bean id="jdbcDataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">


### PR DESCRIPTION
Fix for issue #4833

Issue related to
https://stackoverflow.com/questions/28369582/spring-boot-spring-always-assigns-default-value-to-property-despite-of-it-bein