### PR TITLE
URL `/` redirect / Jsessionid appended to URL

### DIFF
--- a/core/src/main/java/org/fao/geonet/web/LocaleRedirects.java
+++ b/core/src/main/java/org/fao/geonet/web/LocaleRedirects.java
@@ -45,6 +45,7 @@ import org.springframework.web.servlet.view.RedirectView;
 import java.util.*;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 
 /**
@@ -111,6 +112,9 @@ public class LocaleRedirects {
                                       @RequestParam(value = NODE_PARAMETER, required = false) String portal
                              ) throws ResourceNotFoundException {
         String lang = lang(langParam, langCookie, langHeader);
+
+        HttpSession session = request.getSession();
+        if (session != null) session.invalidate();
 
         if (checkPortalExist(portal, !accept.startsWith(ACCEPT_VALUE))) {
             return redirectURL(createServiceUrl(request, _homeRedirectUrl, lang, portal));


### PR DESCRIPTION
See
https://stackoverflow.com/questions/2291236/how-can-i-prevent-spring-security-from-appending-jsessionid-xxx-to-login-redire
https://docs.spring.io/autorepo/docs/spring-security/4.2.x/apidocs/index.html?org/springframework/security/web/firewall/StrictHttpFirewall.html

Invalidate session for the root redirect so there is no need to carry session info using JSESSION id to the next location.

This change is probably related to Spring Security update. Does not affect 3.x.