### PR TITLE
Validation report / Link check / Display status.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/schematron-rules-url-check.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/schematron-rules-url-check.xml
@@ -1,6 +1,6 @@
 <strings>
   <schematron.title>URL Validation</schematron.title>
   <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
-  <alert.invalidURL><div>Url is invalid, a 404 or some other error: </div></alert.invalidURL>
+  <alert.invalidURL><div>Url is not responding. Current status is </div></alert.invalidURL>
   <alert.validURL><div>Url is valid</div></alert.validURL>
 </strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-url-check.sch
+++ b/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-url-check.sch
@@ -14,14 +14,16 @@
         <!-- Check specification names and status -->
         <sch:rule context="//gmd:linkage//gmd:URL[starts-with(text(), 'http')]">
 
+            <sch:let name="status" value="xslutil:getURLStatusAsString(text())" />
             <sch:let name="isValidUrl" value="xslutil:validateURL(text())" />
             <sch:assert test="$isValidUrl = true()">
                 <sch:value-of select="$loc/strings/alert.invalidURL/div" />
-                '<sch:value-of select="string(.)" />'
+                <sch:value-of select="$status"/> -
+                <sch:value-of select="string(.)"/>
             </sch:assert>
             <sch:report test="$isValidUrl = true()">
                 <sch:value-of select="$loc/strings/alert.validURL/div" />
-                '<sch:value-of select="string(.)" />'
+                '<sch:value-of select="string(.)"/>'
             </sch:report>
         </sch:rule>
     </sch:pattern>

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -77,7 +77,8 @@
                 data-ng-show="(showErrors && rule.type === 'error') || (showSuccess && rule.type === 'success')"
                 data-ng-class="rule.type !== 'error' ? '' : (type.requirement === 'REQUIRED' ? 'text-danger' : 'text-info')">
               <p data-ng-class="rule.msg ? 'text-bold' : ''">{{pattern.title}}</p>
-              <p data-ng-show="rule.msg">{{rule.msg}}</p>
+              <p data-ng-show="rule.msg"
+                 ng-bind-html="rule.msg | linky"></p>
             </li>
           </ul>
         </div>

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -565,6 +565,7 @@ form.gn-tab-inspire {
         margin-top: 10px;
         overflow: auto;
         padding-bottom: 2px;
+        word-break: break-word;
       }
       &.text-danger {
         border-left: 4px solid @brand-danger;


### PR DESCRIPTION
Instead of only marking URL as invalid, 

![image](https://user-images.githubusercontent.com/1701393/88681813-42d2dd80-d0f2-11ea-90c5-3e08cc782830.png)

... report the HTTP status to the
user. Display URL as hyperlink so user can easily check the status.
Break long URL to avoid horizontal scroll.

![image](https://user-images.githubusercontent.com/1701393/88681732-2d5db380-d0f2-11ea-912c-b1a5bd0bb361.png)
