### PR TITLE
don't clear the multilingual fields when changing protocol

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -342,6 +342,7 @@
                 scope.ctrl = {};
               },
               post: function(scope, element, attrs) {
+                scope.clearFormOnProtocolChange = !(attrs.clearFormOnProtocolChange == "false"); //default to true (old behavior)
                 scope.popupid = attrs['gnPopupid'];
 
                 scope.config = null;
@@ -723,7 +724,7 @@
                 var resetProtocol = function() {
                   scope.layers = [];
                   scope.OGCProtocol = false;
-                  if (scope.params && !scope.isEditing) {
+                  if (scope.params && !scope.isEditing && scope.clearFormOnProtocolChange) {
                     scope.params.name = '';
                     scope.params.desc = '';
                     initMultilingualFields();
@@ -947,7 +948,7 @@
                   if (!angular.isUndefined(scope.params.protocol) && o !== n) {
                     resetProtocol();
                     scope.OGCProtocol = checkIsOgc(scope.params.protocol);
-                    if (scope.OGCProtocol != null && !scope.isEditing) {
+                    if (scope.OGCProtocol != null && !scope.isEditing && scope.clearFormOnProtocolChange) {
                       // Reset parameter in case of multilingual metadata
                       // Those parameters are object.
                       scope.params.name = '';

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -724,19 +724,28 @@
                 var resetProtocol = function() {
                   scope.layers = [];
                   scope.OGCProtocol = false;
-                  if (scope.params && !scope.isEditing && scope.clearFormOnProtocolChange) {
-                    scope.params.name = '';
-                    scope.params.desc = '';
-                    initMultilingualFields();
+                  if (scope.params && !scope.isEditing) {
+                    if (scope.clearFormOnProtocolChange) {
+                      scope.params.name = '';
+                      scope.params.desc = '';
+                      initMultilingualFields();
+                    }
+                    else {
+                      initMultilingualFields(['name','desc']);
+                    }
                     scope.params.selectedLayers = [];
                     scope.params.layers = [];
                   }
                 };
 
-                var initMultilingualFields = function() {
+                //doNotmodifyFields - list of field names
+                //   this will NOT update fields in this list.
+                var initMultilingualFields = function(doNotModifyFields) {
                   scope.config.multilingualFields.forEach(function(f) {
-                    scope.params[f] = {};
-                    setParameterValue(f, '');
+                    if ( (!doNotModifyFields) || (!_.contains(doNotModifyFields,f)) ) {
+                      scope.params[f] = {};
+                      setParameterValue(f, '');
+                    }
                   });
                 };
 

--- a/web-ui/src/main/resources/catalog/templates/editor/editor.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editor.html
@@ -32,7 +32,8 @@
      data-gn-popup-options="{title:'addOnlinesrcTitle'}"
      id="addonlinesrc-popup">
   <div data-gn-add-onlinesrc="" class="add-onlinesrc"
-       data-gn-popupid="#addonlinesrc-popup"></div>
+       data-gn-popupid="#addonlinesrc-popup"
+       data-clear-form-on-protocol-change="false"></div>
 </div>
 
 <div data-gn-modal="" class="onlinesrc-popup"


### PR DESCRIPTION
Both the description and resource name (both multilingual) in the online resource editor get cleared when you change the protocol. 

This ONLY happens in ADD mode (in Edit mode, they don't clear).  This is causing users confusion - they don't like those fields to be reset after they've typed them in.

This PR changes that behavior for ADD mode.  I've created another  configuration for the directive so you can control this.

data-clear-form-on-protocol-change="false"

FALSE (default) -> don't clear
TRUE --> clear (old behavior).

NOTE: This changes the default behavior to "don't clear"