### PR TITLE
Fix: Prevent the last layer of moving down.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -71,7 +71,13 @@
          * @param {ol.layer} layer
          * @param {float} delta
          */
-          this.moveLayer = function(layer, delta) {
+          this.moveLayer = function(layer, delta, last) {
+
+            // do not move the last layer down (last parameter only there when moving down)
+            if (last) {
+              return false;
+            }
+
             var index = $scope.layers.indexOf(layer);
             var layersCollection = $scope.map.getLayers();
             layersCollection.removeAt(index);

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
@@ -114,7 +114,7 @@
              title="{{'layerMoveUp'|translate}}"></a>
           <a href="" class="btn btn-default btn-sm fa fa-arrow-down"
              ng-disabled="$last"
-             ng-click="moveLayer(layer, -1)"
+             ng-click="moveLayer(layer, -1, $last)"
              title="{{'layerMoveDown'|translate}}"></a>
            <a href=""
               class="btn btn-default btn-sm fa fa-times"


### PR DESCRIPTION
In the layer manager of the map, the last of the foreground layers has a disabled 'move down' button, it's greyed out and has a 'disabled' cursor image. However, when you click the button, the layer is still moved down and therefore placed underneath a baselayer.

This PR adds a little JS code to prevent this from happening.