### PR TITLE
Add a localized time format in harvester logs

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -27,7 +27,7 @@ import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.DailyRollingFileAppender;
-import org.apache.log4j.PatternLayout;
+import org.apache.log4j.EnhancedPatternLayout;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.csw.common.exceptions.InvalidParameterValueEx;
@@ -209,7 +209,13 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
             + dateFormat.format(new Date(System.currentTimeMillis()))
             + ".log";
         fa.setFile(logfile);
-        fa.setLayout(new PatternLayout("%d{ISO8601} %-5p [%c] - %m%n"));
+
+        String timeZoneSetting = settingManager.getValue(Settings.SYSTEM_SERVER_TIMEZONE);
+        if (StringUtils.isBlank(timeZoneSetting)) {
+            timeZoneSetting = TimeZone.getDefault().getID();
+        }
+        fa.setLayout(new EnhancedPatternLayout("%d{yyyy-MM-dd'T'HH:mm:ss,SSSZ}{" + timeZoneSetting +"} %-5p [%c] - %m%n"));
+
         fa.setThreshold(log.getThreshold());
         fa.setAppend(true);
         fa.activateOptions();


### PR DESCRIPTION
In the harvesters log files print the date and time in the timezone set in GeoNetwork settings.
If no timezone is defined use the server default timezone.
The format for the date is ISO 8601 with offset: yyyy-MM-dd'T'HH:mm:ss,SSS±hhmm.
New format:
```
2020-07-31T10:55:13,712+0200 INFO  [test1] - Starting harvesting of test1
2020-07-31T10:55:13,817+0200 INFO  [test1] - Started harvesting from node : test1 (LocalFilesystemHarvester)
2020-07-31T10:55:13,927+0200 INFO  [test1] - Ended harvesting from node : test1 (LocalFilesystemHarvester)
```

Old format:
```
2020-07-31 10:55:13,712 INFO  [test1] - Starting harvesting of test1
2020-07-31 10:55:13,817 INFO  [test1] - Started harvesting from node : test1 (LocalFilesystemHarvester)
2020-07-31 10:55:13,927 INFO  [test1] - Ended harvesting from node : test1 (LocalFilesystemHarvester)
```

Related to #4053 and #1970. 