### PR TITLE
Formatter improvements (ISO19110 mainly)

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -49,7 +49,9 @@
 
   <!-- Define the metadata to be loaded for this schema plugin-->
   <xsl:variable name="metadata"
-                select="/root/(gfc:FC_FeatureType|gfc:FC_FeatureCatalogue)"/>
+                select="if (/root/gfc:FC_FeatureCatalogue)
+                        then /root/gfc:FC_FeatureCatalogue
+                        else /root/gfc:FC_FeatureType"/>
 
 
   <!-- Specific schema rendering -->
@@ -69,11 +71,17 @@
   </xsl:template>
 
 
+  <!-- Ignore some fields displayed in header or in right column -->
+  <xsl:template mode="render-field"
+                match="gmx:name|gmx:scope|gfc:featureType[count(*) = 0]"
+                priority="2000"/>
+
+
   <!-- Most of the elements are ... -->
-  <xsl:template mode="render-field" match="*[gco:CharacterString|gco:Integer|gco:Decimal|
+  <xsl:template mode="render-field" match="*[(gco:CharacterString|gco:Integer|gco:Decimal|
        gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
        gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|
-       gco:LocalName|gmd:PT_FreeText|gml:beginPosition|gml:endPosition|gco:Date|gco:DateTime|*/@codeListValue]">
+       gco:LocalName|gmd:PT_FreeText|gml:beginPosition|gml:endPosition|gco:Date|gco:DateTime|*/@codeListValue) != '']">
     <xsl:param name="fieldName" select="''" as="xs:string"/>
 
     <dl>
@@ -89,45 +97,195 @@
   </xsl:template>
 
 
+  <xsl:template mode="render-field"
+                match="gfc:listedValue"
+                priority="2000">
+    <xsl:param name="fieldName" select="''" as="xs:string"/>
+
+    <xsl:if test="preceding-sibling::*[1][local-name() != 'listedValue']">
+      <strong>
+        <xsl:value-of select="if ($fieldName)
+                                then $fieldName
+                                else tr:nodeLabel(tr:create($schema), name(), null)"/>
+      </strong>
+      <table class="table table-bordered">
+        <tbody>
+          <tr>
+            <th>
+              <xsl:value-of select="tr:nodeLabel(tr:create($schema), 'gfc:code', null)"/>
+            </th>
+            <th>
+              <xsl:value-of select="tr:nodeLabel(tr:create($schema), 'gfc:label', null)"/>
+            </th>
+            <th>
+              <xsl:value-of select="tr:nodeLabel(tr:create($schema), 'gfc:definition', null)"/>
+            </th>
+          </tr>
+          <xsl:for-each select="../gfc:listedValue/*">
+            <tr>
+              <td>
+                <xsl:apply-templates mode="render-value" select="gfc:code"/>
+              </td>
+              <td>
+                <xsl:apply-templates mode="render-value" select="gfc:label"/>
+              </td>
+              <td>
+                <xsl:apply-templates mode="render-value" select="gfc:definition"/>
+              </td>
+            </tr>
+          </xsl:for-each>
+        </tbody>
+      </table>
+    </xsl:if>
+  </xsl:template>
+
   <!-- Some major sections are boxed -->
   <xsl:template mode="render-field"
                 match="*[name() = $configuration/editor/fieldsWithFieldset/name
-    or @gco:isoType = $configuration/editor/fieldsWithFieldset/name]|
-      gmd:report/*|
-      gmd:result/*|
-      gmd:extent[name(..)!='gmd:EX_TemporalExtent']|
-      *[$isFlatMode = false() and gmd:* and not(gco:CharacterString) and not(gmd:URL)]">
+                         or @gco:isoType = $configuration/editor/fieldsWithFieldset/name]|
+                       *[$isFlatMode = false()
+                         and gmd:*
+                         and not(gco:CharacterString)
+                         and not(gmd:URL)]">
     <div class="entry name">
       <h3>
         <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
       </h3>
       <div class="target">
-        <xsl:apply-templates mode="render-field" select="*"/>
+        <xsl:choose>
+          <xsl:when test="count(*) > 0">
+            <xsl:apply-templates mode="render-field" select="*"/>
+          </xsl:when>
+          <xsl:otherwise><xsl:comment select="'No information.'"/></xsl:otherwise>
+        </xsl:choose>
       </div>
     </div>
   </xsl:template>
 
   <!-- A contact is displayed with its role as header -->
   <xsl:template mode="render-field"
-                match="*[gmd:CI_ResponsibleParty]">
-    <dl class="gn-contact">
-      <dt>
+                match="*[gmd:CI_ResponsibleParty]"
+                priority="100">
+    <xsl:param name="layout"
+               required="no"/>
+
+
+    <xsl:variable name="email">
+      <xsl:for-each select="*/gmd:contactInfo/
+                                      */gmd:address/*/gmd:electronicMailAddress">
         <xsl:apply-templates mode="render-value"
-                             select="*/gmd:role/*/@codeListValue"/>
-      </dt>
-      <dd>
-        <div>
-          <xsl:apply-templates mode="render-field"
-                               select="*/(gmd:organisationName|gmd:individualName)"/>
+                             select="."/><xsl:if test="position() != last()">, </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="role" select="*/gmd:role/gmd:CI_RoleCode/@codeListValue" />
+
+    <!-- Display name is <org name> - <individual name> (<position name>) -->
+    <!-- with separator/parentheses as required -->
+    <xsl:variable name="displayName">
+      <xsl:if test="*/gmd:organisationName">
+        <xsl:apply-templates mode="render-value" select="*/gmd:organisationName"/>
+      </xsl:if>
+      <xsl:if test="*/gmd:organisationName and */gmd:individualName|*/gmd:positionName"> - </xsl:if>
+      <xsl:if test="*/gmd:individualName">
+        <xsl:apply-templates mode="render-value" select="*/gmd:individualName"/>
+      </xsl:if>
+      <xsl:if test="*/gmd:positionName">
+        <xsl:choose>
+          <xsl:when test="*/gmd:individualName">
+            (<xsl:apply-templates mode="render-value" select="*/gmd:positionName"/>)
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates mode="render-value" select="*/gmd:positionName"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:if>
+    </xsl:variable>
+
+    <xsl:choose>
+      <xsl:when test="$layout = 'short'">
+        <xsl:copy-of select="$displayName"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <div class="gn-contact">
+          <strong>
+            <xsl:comment select="'email'"/>
+            <xsl:apply-templates mode="render-value"
+                                 select="*/gmd:role/*/@codeListValue"/>
+          </strong>
+          <address>
+            <xsl:choose>
+              <xsl:when test="$email">
+                <i class="fa fa-fw fa-envelope">&#160;</i>
+                <a href="mailto:{normalize-space($email)}">
+                  <xsl:copy-of select="$displayName"/><xsl:comment select="'email'"/>
+                </a>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:copy-of select="$displayName"/><xsl:comment select="'name'"/>
+              </xsl:otherwise>
+            </xsl:choose>
+            <br/>
+            <xsl:for-each select="*/gmd:contactInfo/*">
+              <xsl:for-each select="gmd:address/*">
+                <div>
+                  <i class="fa fa-fw fa-map-marker"><xsl:comment select="'address'"/></i>
+                  <xsl:for-each select="gmd:deliveryPoint[normalize-space(.) != '']">
+                    <xsl:apply-templates mode="render-value" select="."/>,
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:city[normalize-space(.) != '']">
+                    <xsl:apply-templates mode="render-value" select="."/>,
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:administrativeArea[normalize-space(.) != '']">
+                    <xsl:apply-templates mode="render-value" select="."/>,
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:postalCode[normalize-space(.) != '']">
+                    <xsl:apply-templates mode="render-value" select="."/>,
+                  </xsl:for-each>
+                  <xsl:for-each select="gmd:country[normalize-space(.) != '']">
+                    <xsl:apply-templates mode="render-value" select="."/>
+                  </xsl:for-each>
+                </div>
+              </xsl:for-each>
+            </xsl:for-each>
+            <xsl:for-each select="*/gmd:contactInfo/*">
+              <xsl:for-each select="gmd:phone/*/gmd:voice[normalize-space(.) != '']">
+                <xsl:variable name="phoneNumber">
+                  <xsl:apply-templates mode="render-value" select="."/>
+                </xsl:variable>
+                <i class="fa fa-fw fa-phone"><xsl:comment select="'phone'"/></i>
+                <a href="tel:{translate($phoneNumber,' ','')}">
+                  <xsl:value-of select="$phoneNumber"/>
+                </a>
+                <br/>
+              </xsl:for-each>
+              <xsl:for-each select="gmd:phone/*/gmd:facsimile[normalize-space(.) != '']">
+                <xsl:variable name="phoneNumber">
+                  <xsl:apply-templates mode="render-value" select="."/>
+                </xsl:variable>
+                <i class="fa fa-fw fa-fax"><xsl:comment select="'fax'"/></i>
+                <a href="tel:{translate($phoneNumber,' ','')}">
+                  <xsl:value-of select="normalize-space($phoneNumber)"/>
+                </a>
+                <br/>
+              </xsl:for-each>
+              <xsl:for-each select="gmd:onlineResource/*/gmd:linkage/gmd:URL[normalize-space(.) != '']">
+                <xsl:variable name="web">
+                  <xsl:apply-templates mode="render-value" select="."/></xsl:variable>
+                <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
+                <a href="{normalize-space($web)}">
+                  <xsl:value-of select="normalize-space($web)"/>
+                </a>
+              </xsl:for-each>
+              <xsl:for-each select="gmd:hoursOfService[normalize-space(.) != '']">
+                <xsl:apply-templates mode="render-field"
+                                     select="."/>
+              </xsl:for-each>
+            </xsl:for-each>
+          </address>
         </div>
-      </dd>
-      <dd>
-        <div>
-          <xsl:apply-templates mode="render-field"
-                               select="*/gmd:contactInfo"/>
-        </div>
-      </dd>
-    </dl>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
 
@@ -181,15 +339,24 @@
   </xsl:template>
 
   <!-- ... Codelists -->
-  <xsl:template mode="render-value" match="@codeListValue">
+  <xsl:template mode="render-value"
+                match="@codeListValue|@indeterminatePosition">
     <xsl:variable name="id" select="."/>
-    <!--<xsl:value-of select="tr:nodeLabel(tr:create($schema), .)"/>-->
     <xsl:variable name="codelistTranslation"
-                  select="$schemaCodelists//entry[code = $id]/label"/>
-
+                  select="tr:codelist-value-label(
+                            tr:create($schema),
+                            parent::node()/local-name(),
+                            $id)"/>
     <xsl:choose>
       <xsl:when test="$codelistTranslation != ''">
-        <xsl:value-of select="$codelistTranslation"/>
+
+        <xsl:variable name="codelistDesc"
+                      select="tr:codelist-value-desc(
+                            tr:create($schema),
+                            parent::node()/local-name(), $id)"/>
+        <span title="{$codelistDesc}">
+          <xsl:value-of select="$codelistTranslation"/>
+        </span>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$id"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/default.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/default.xsl
@@ -131,7 +131,7 @@
             "attributeTable" : [
             <xsl:for-each select="$attributes">
               {"name": "<xsl:value-of select="*/gfc:memberName/*/text()"/>",
-              "definition": "<xsl:value-of select="*/gfc:definition/*/text()"/>",
+              "definition": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:definition/*/text())"/>",
               "code": "<xsl:value-of select="*/gfc:code/*/text()"/>",
               "link": "<xsl:value-of select="*/gfc:code/*/@xlink:href"/>",
               "type": "<xsl:value-of select="*/gfc:valueType/gco:TypeName/gco:aName/*/text()"/>"
@@ -140,7 +140,7 @@
                 <xsl:for-each select="*/gfc:listedValue">{
                   "label": "<xsl:value-of select="*/gfc:label/*/text()"/>",
                   "code": "<xsl:value-of select="*/gfc:code/*/text()"/>",
-                  "definition": "<xsl:value-of select="*/gfc:definition/*/text()"/>"}
+                  "definition": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:definition/*/text())"/>"}
                   <xsl:if test="position() != last()">,</xsl:if>
                 </xsl:for-each>
                 ]

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/config-editor.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/config-editor.xml
@@ -72,7 +72,7 @@
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="default" default="true" mode="flat">
-        <section name="gfc:FC_FeatureCatalogue">
+        <section>
           <!-- Preserve gmx:* in editor for backward compatibility. -->
           <field xpath="/gfc:FC_FeatureCatalogue/gmx:name" or="name" in="/gfc:FC_FeatureCatalogue"/>
           <field xpath="/gfc:FC_FeatureCatalogue/gfc:name"/>
@@ -108,7 +108,6 @@
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="advanced">
-        <section xpath="/gfc:FC_FeatureType"/>
         <section xpath="/gfc:FC_FeatureCatalogue"/>
       </tab>
     </view>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
@@ -53,8 +53,7 @@
     <xsl:variable name="flatModeException"
                   select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name,  name(..))"/>
 
-    <xsl:if test="$isEditing and (not($isFlatMode) or $flatModeException)">
-
+    <xsl:if test="(not($isFlatMode) or $flatModeException)">
       <xsl:variable name="label"
                     select="gn-fn-metadata:getLabel($schema, $name, $labels)"/>
       <xsl:call-template name="render-element-to-add">

--- a/schemas/iso19110/src/main/plugin/iso19110/loc/eng/codelists.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/loc/eng/codelists.xml
@@ -21,7 +21,72 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
-
-<codelists/>
+<codelists>
+  <codelist name="gmd:CI_RoleCode" alias="roleCode">
+    <entry>
+      <code>resourceProvider</code>
+      <label>Resource provider</label>
+      <description>Party that supplies the resource</description>
+    </entry>
+    <entry>
+      <code>custodian</code>
+      <label>Custodian</label>
+      <description>Party that accepts accountability and responsability for the data and ensures
+        appropriate care and maintenance of the resource
+      </description>
+    </entry>
+    <entry>
+      <code>owner</code>
+      <label>Owner</label>
+      <description>Party that owns the resource</description>
+    </entry>
+    <entry>
+      <code>user</code>
+      <label>User</label>
+      <description>Party who uses the resource</description>
+    </entry>
+    <entry>
+      <code>distributor</code>
+      <label>Distributor</label>
+      <description>Party who distributes the resource</description>
+    </entry>
+    <entry>
+      <code>originator</code>
+      <label>Originator</label>
+      <description>Party who created the resource</description>
+    </entry>
+    <entry>
+      <code>pointOfContact</code>
+      <label>Point of contact</label>
+      <description>Party who can be contacted for acquiring knowledge about or acquisition of the
+        resource
+      </description>
+    </entry>
+    <entry>
+      <code>principalInvestigator</code>
+      <label>Principal investigator</label>
+      <description>Key party responsible for gathering information and conducting
+        research
+      </description>
+    </entry>
+    <entry>
+      <code>processor</code>
+      <label>Processor</label>
+      <description>Party wha has processed the data in a manner such that the resource has been
+        modified
+      </description>
+    </entry>
+    <entry>
+      <code>publisher</code>
+      <label>Publisher</label>
+      <description>Party who published the resource</description>
+    </entry>
+    <entry>
+      <code>author</code>
+      <label>Author</label>
+      <description>Party who authored the resource</description>
+    </entry>
+  </codelist>
+</codelists>
 
 

--- a/schemas/iso19110/src/main/plugin/iso19110/loc/fre/codelists.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/loc/fre/codelists.xml
@@ -21,5 +21,81 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
-
-<codelists/>
+<codelists>
+  <codelist name="gmd:CI_RoleCode" alias="roleCode">
+    <entry>
+      <code>resourceProvider</code>
+      <label>Fournisseur</label>
+      <description>Organisme qui fournit la ressource. Acteur qui délivre physiquement la ressource,
+        soit de manière directe au destinataire, soit par l’intermédiaire d’un diffuseur
+      </description>
+    </entry>
+    <entry>
+      <code>custodian</code>
+      <label>Gestionnaire</label>
+      <description>Acteur responsable de la gestion et de la mise à jour de la ressource
+      </description>
+    </entry>
+    <entry>
+      <code>owner</code>
+      <label>Propriétaire</label>
+      <description>Organisme qui est propriétaire de la ressource / Acteur qui détient les droits
+        patrimoniaux de la ressource
+      </description>
+    </entry>
+    <entry>
+      <code>user</code>
+      <label>Utilisateur</label>
+      <description>Organisme qui utilise ou a utilisé la ressource</description>
+    </entry>
+    <entry>
+      <code>distributor</code>
+      <label>Distributeur</label>
+      <description>Organisme qui distribue la ressource. Diffuseur de second niveau de la
+        ressource
+      </description>
+    </entry>
+    <entry>
+      <code>originator</code>
+      <label>A l’origine de</label>
+      <description>Organisme qui a commandé la ressource. Acteur qui a été habilité à créer la
+        ressource et qui a mis en place les moyens pour la constituer
+      </description>
+    </entry>
+    <entry>
+      <code>pointOfContact</code>
+      <label>Point de contact</label>
+      <description>Organisme que l’on peut contacter pour avoir des renseignements détaillés sur la
+        ressource. Acteur à contacter en premier lieu pour obtenir des informations relatives à la
+        ressource
+      </description>
+    </entry>
+    <entry>
+      <code>principalInvestigator</code>
+      <label>Point de recherche</label>
+      <description>Personne clé pour obtenir des informations sur la ressource et les recherches
+        conduites autour de la ressource&#xA;Acteur qui a assuré la réalisation de la
+        ressource,éventuellement en faisant appel à des co-traitants ou des sous traitants
+      </description>
+    </entry>
+    <entry>
+      <code>processor</code>
+      <label>Exécutant</label>
+      <description>Organisme qui a réalisé des traitements sur la ressource. Acteur qui est
+        intervenu lors de la réalisation de la ressource
+      </description>
+    </entry>
+    <entry>
+      <code>publisher</code>
+      <label>Editeur (publication)</label>
+      <description>Organisme qui assure la publication de la ressource.</description>
+    </entry>
+    <entry>
+      <code>author</code>
+      <label>Auteur</label>
+      <description>Organisme ou personne qui est auteur. Acteur qui dispose des droits moraux
+        relatifs à la ressource
+      </description>
+    </entry>
+  </codelist>
+</codelists>

--- a/schemas/iso19110/src/main/plugin/iso19110/loc/fre/labels.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/loc/fre/labels.xml
@@ -77,7 +77,7 @@
     <description>Nom de la propriété, c’est-à-dire de la table</description>
   </element>
   <element name="gfc:carrierOfCharacteristics">
-    <label>Caractéristiques des attributs</label>
+    <label>Attribut</label>
     <description>Caractéristiques des attributs</description>
   </element>
   <element name="gfc:definition">
@@ -184,6 +184,12 @@
   <element name="gfc:valueType">
     <label>Type</label>
     <description></description>
+  </element>
+  <element name="gco:aName">
+    <label>Type</label>
+    <description/>
+    <help/>
+    <condition/>
   </element>
   <element name="gfc:memberName">
     <label>Nom</label>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -885,8 +885,9 @@
           <ul>
             <xsl:for-each select="parent::node()/*[name() = $nodeName]">
               <li>
-                <a href="{$nodeUrl}api/records/{@uuidref}">
-                  <i class="fa fa-link"><xsl:comment select="'link'"/></i>
+                <a data-gn-api-link=""
+                   href="{$nodeUrl}api/records/{@uuidref}">
+                  <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
                   <span><xsl:comment select="'dataset'"/>
                     <xsl:value-of select="gn-fn-render:getMetadataTitle(@uuidref, $langId)"/>
                   </span>

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -558,7 +558,7 @@
         'status', 'status_text', 'crs', 'identifier', 'responsibleParty',
         'mdLanguage', 'datasetLang', 'type', 'link', 'crsDetails',
         'creationDate', 'publicationDate', 'revisionDate', 'spatialRepresentationType_text'];
-      var listOfJsonFields = ['keywordGroup', 'crsDetails'];
+      var listOfJsonFields = ['keywordGroup', 'crsDetails', 'featureTypes'];
       // See below; probably not necessary
       var record = this;
       this.linksCache = [];

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1600,6 +1600,36 @@
     }
   ]);
 
+
+  /**
+   * @ngdoc gnApiLink
+   * @name gn_utility.directive:gnApiLink
+   *
+   * @description
+   * Convert the element href attribute
+   * from /srv/api/records/... to a link
+   * for the JS apps. This is usefull if
+   * a formatter is loaded into the JS app
+   * in order to have links to record to
+   * open in current app.
+   */
+  module.directive('gnApiLink', ['$compile',
+    function($compile) {
+      return {
+        restrict: 'A',
+        link: function(scope, element, attrs) {
+          var href = $(element).attr('href'),
+              apiPath = '/srv/api/records/';
+          if (href.indexOf(apiPath) != -1) {
+            $(element).attr('href',
+              href.replace(/.*\/srv\/api\/records\//, '#/metadata/'));
+          }
+        }
+      };
+    }
+  ]);
+
+
   /**
    * @ngdoc directive
    * @name gn_utility.directive:gnStringToNumber

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -395,6 +395,7 @@
     "link-hassources": "Is source dataset of",
     "link-sources": "Source datasets",
     "link-siblings": "Siblings",
+    "link-fcats": "Feature catalog",
     "indexAccessError": "Error during index access.",
     "applyFilter": "Apply Filter",
     "confirm": "OK",

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -1,4 +1,5 @@
 {
+    "featureCatReplace": "Replace existing feature catalog?",
     "add-extent-from-geokeywords": "Compute extent from keywords",
     "add-extent-from-geokeywords-help": "Search all keywords from thesaurus of type 'place' and add matching extents.",
     "addCRS-help": "Add new CRS",


### PR DESCRIPTION
* Index / Fix invalid feature type when reserved JSON characters are used
* ISO19110 / Full view / Do not display title & feature type description twice
* ISO19110 / Full view / Do not render empty values
* ISO19110 / Full view / Render list of values as table (like Angular view)
* ISO19110 / Full view / Fix right column layout when empty section
* ISO19110 / Full view / Same contact layout as 19139
* ISO19110 / Full view / Translate codelist
* Formatter in Angular app / Add utility directive to convert a landing page link to an Angular app link (to load the target record in the app instead of opening another tab)