### PR TITLE
Harvester / CSW / Update / Apply xpath filter and batch edits

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -63,11 +63,13 @@ import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
+import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.jdom.xpath.XPath;
 
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;


### PR DESCRIPTION
If 2 harvesters are harvesting same records, the second one is on update mode and was not applying its configuration (xpath filter and batch were only applied on addMetadata).

Some users are configuring 2 harvesters on same records to add specific privileges on some of them only.

Also in update mode, if remote record was updated, the new version will not apply batch edits.