### PR TITLE
better error handling for language detection

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -128,16 +128,22 @@
                                               gnGlobalSettings.gnCfg.langDetector,
                                               gnGlobalSettings
                                             );
-                  var currentUILang2_3char = gnCurrentEdit.allLanguages.iso2code[currentUILang_3char].replace("#","");
                   var result = [currentUILang_3char];
-                  if (!_.contains(result,currentUILang2_3char))
+
+                  var currentUILang2_3char = gnCurrentEdit.allLanguages.iso2code[currentUILang_3char];
+                  if (currentUILang2_3char) {
+                    currentUILang2_3char = currentUILang2_3char.replace("#", "");
+                    if (!_.contains(result,currentUILang2_3char))
                       result.push(currentUILang2_3char);
+                  }
+
+
                   if (gnLangs.langs[currentUILang_3char]) {
-                      v = gnLangs.langs[currentUILang_3char];
+                       v = gnLangs.langs[currentUILang_3char];
                        if (!_.contains(result,v))
                          result.push(v);
                   }
-                  if (gnLangs.langs[currentUILang2_3char]) {
+                  if ( (currentUILang2_3char)  &&  (gnLangs.langs[currentUILang2_3char])) {
                       v = gnLangs.langs[currentUILang2_3char];
                        if (!_.contains(result,v))
                          result.push(v);


### PR DESCRIPTION
There was a minor issue with language detection when the UI language wasn't already apart of the record (i.e. english-only record, with french ui).

See @fxprunayre  comment in https://github.com/geonetwork/core-geonetwork/pull/4766#pullrequestreview-458965663

cf. https://github.com/geonetwork/core-geonetwork/pull/4766