### PR TITLE
Fixed null pointer error on the jeevesAppContext while destroying object

### DIFF
--- a/core/src/main/java/jeeves/config/springutil/JeevesContextLoaderListener.java
+++ b/core/src/main/java/jeeves/config/springutil/JeevesContextLoaderListener.java
@@ -105,7 +105,9 @@ public class JeevesContextLoaderListener implements ServletContextListener {
          */
         JeevesApplicationContext jeevesAppContext =
             (JeevesApplicationContext) servletContext.getAttribute(User.NODE_APPLICATION_CONTEXT_KEY);
-        jeevesAppContext.destroy();
+        if (jeevesAppContext != null) {
+            jeevesAppContext.destroy();
+        }
 
         Log.info(Log.ENGINE, "Destroying the parent appContext");
         parentAppContext.destroy();


### PR DESCRIPTION
It would occur when GN failed to startup correctly - in which case jeevesAppContext was null when it tried to destroy the object.  So there should be a check before attempting to destroy.