### PR TITLE
Fix for add-schema services snippet #4914

### DIFF
--- a/add-schema.sh
+++ b/add-schema.sh
@@ -146,7 +146,7 @@ then
   finalLine=$(($line - 1))
 
   projectGroupId='${project.groupId}'
-  gnSchemasVersion='${gn.schemas.version}'
+  gnSchemasVersion='${project.version}'
 
   echo "Adding schema ${schema} resources to service/pom.xml"
 


### PR DESCRIPTION
Schema plugins now use `project.version` as per https://github.com/geonetwork/core-geonetwork/issues/4914