### PR TITLE
Landing page / Improve multilingual support

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
@@ -37,6 +37,7 @@
 
   <!-- Some utility -->
   <xsl:include href="../../layout/evaluate.xsl"/>
+  <xsl:include href="../../layout/utility-tpl.xsl"/>
 
   <!-- The core formatter XSL layout based on the editor configuration -->
   <xsl:include href="sharedFormatterDir/xslt/render-layout.xsl"/>
@@ -132,14 +133,18 @@
     </a>
   </xsl:template>
 
-  <!-- ... Dates -->
-  <xsl:template mode="render-value" match="*[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]">
-    <xsl:value-of select="format-date(., $dateFormats/date/for[@lang = $language]/text())"/>
+  <!-- ... Dates  -->
+  <xsl:template mode="render-value" match="*[matches(., '^[0-9]{4}-[0-9]{2}-[0-9]{2}$')]">
+    <span data-gn-humanize-time="{.}" data-format="DD MMM YYYY">
+      <xsl:value-of select="."/>
+    </span>
   </xsl:template>
 
   <xsl:template mode="render-value"
-                match="*[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}')]">
-    <xsl:value-of select="format-dateTime(., $dateFormats/dateTime/for[@lang = $language]/text())"/>
+                match="*[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$')]">
+    <span data-gn-humanize-time="{.}">
+      <xsl:value-of select="."/>
+    </span>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
@@ -29,6 +29,7 @@
                 exclude-result-prefixes="#all">
 
   <xsl:include href="utility-fn.xsl"/>
+  <xsl:include href="utility-tpl.xsl"/>
 
   <!-- Get the main metadata languages -->
   <xsl:template name="get-dublin-core-language">
@@ -38,16 +39,6 @@
   <xsl:template name="get-dublin-core-title">
     <xsl:value-of select="$metadata//dc:title"/>
   </xsl:template>
-
-  <!-- No multilingual support in Dublin core -->
-  <xsl:template name="get-dublin-core-other-languages-as-json"/>
-
-  <!-- Get the list of other languages -->
-  <xsl:template name="get-dublin-core-other-languages"/>
-
-  <xsl:template name="get-dublin-core-online-source-config"/>
-
-  <xsl:template name="get-dublin-core-extents-as-json">[]</xsl:template>
 
   <!-- Visit all tree -->
   <xsl:template mode="mode-dublin-core" match="dc:*|dct:*">

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/utility-tpl.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/utility-tpl.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="2.0"
+                exclude-result-prefixes="#all">
+  <!-- No multilingual support in Dublin core -->
+  <xsl:template name="get-dublin-core-other-languages-as-json"/>
+  <!-- Get the list of other languages -->
+  <xsl:template name="get-dublin-core-other-languages"/>
+  <xsl:template name="get-dublin-core-online-source-config"/>
+  <xsl:template name="get-dublin-core-extents-as-json">[]</xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -42,6 +42,7 @@
 
   <!-- Some utility -->
   <xsl:include href="../../layout/evaluate.xsl"/>
+  <xsl:include href="../../layout/utility-tpl.xsl"/>
 
   <!-- The core formatter XSL layout based on the editor configuration -->
   <xsl:include href="sharedFormatterDir/xslt/render-layout.xsl"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -319,19 +319,17 @@
 
   <!-- ... Dates -->
   <xsl:template mode="render-value" match="gco:Date[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]">
-    <xsl:variable name="df" select="if (string($dateFormats/dateTime/for[@lang = $language]/text()))
-                                    then $dateFormats/dateTime/for[@lang = $language]/text()
-                                    else $dateFormats/dateTime/for[@default = 'true']/text()" />
-    <xsl:value-of select="format-dateTime(., $df)"/>
+    <span data-gn-humanize-time="{.}" data-format="DD MMM YYYY">
+      <xsl:value-of select="."/>
+    </span>
   </xsl:template>
 
   <!-- if (tns:Employee/tns:EmpId = 4) then 'new' else 'old'-->
   <xsl:template mode="render-value"
                 match="gco:DateTime[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}')]">
-    <xsl:variable name="df" select="if (string($dateFormats/dateTime/for[@lang = $language]/text()))
-                                    then $dateFormats/dateTime/for[@lang = $language]/text()
-                                    else $dateFormats/dateTime/for[@default = 'true']/text()" />
-    <xsl:value-of select="format-dateTime(., $df)"/>
+    <span data-gn-humanize-time="{.}">
+      <xsl:value-of select="."/>
+    </span>
   </xsl:template>
 
   <xsl:template mode="render-value" match="gco:Date|gco:DateTime">

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
@@ -34,6 +34,7 @@
                 exclude-result-prefixes="#all">
 
   <xsl:include href="utility-fn.xsl"/>
+  <xsl:include href="utility-tpl.xsl"/>
   <xsl:include href="layout-custom-fields.xsl"/>
 
   <!-- Ignore all gn element -->
@@ -298,23 +299,10 @@
 
   </xsl:template>
 
-
-  <!-- Get the main metadata languages - none for ISO19110 -->
-  <xsl:template name="get-iso19110-language"/>
-
-  <!-- Get the list of other languages -->
-  <xsl:template name="get-iso19110-other-languages"/>
-
-  <xsl:template name="get-iso19110-other-languages-as-json"/>
-
-  <xsl:template name="get-iso19110-online-source-config"/>
-
   <xsl:template name="get-iso19110-title">
     <xsl:value-of select="$metadata/gfc:FC_FeatureCatalogue/gmx:name/gco:CharacterString|
                           $metadata/gfc:FC_FeatureCatalogue/gfc:name/gco:CharacterString|
                           $metadata/gfc:FC_FeatureType/gfc:typeName/gco:LocalName"/>
   </xsl:template>
-
-  <xsl:template name="get-iso19110-extents-as-json">[]</xsl:template>
 
 </xsl:stylesheet>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/utility-tpl.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/utility-tpl.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="2.0"
+                exclude-result-prefixes="#all">
+  <!-- Get the main metadata languages - none for ISO19110 -->
+  <xsl:template name="get-iso19110-language"/>
+  <!-- Get the list of other languages -->
+  <xsl:template name="get-iso19110-other-languages"/>
+  <xsl:template name="get-iso19110-other-languages-as-json"/>
+  <xsl:template name="get-iso19110-online-source-config"/>
+  <xsl:template name="get-iso19110-extents-as-json">[]</xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -359,7 +359,7 @@
       <name>srv:serviceTypeVersion</name>
     </exclude>
   </multilingualFields>
-  
+
   <tableFields>
     <!-- This is an example for organisation table layout.
     19115-3 being more flexible with link between orgs and individual,
@@ -409,7 +409,7 @@
         <section xpath="/mdb:MD_Metadata/mdb:metadataConstraints"/>
         <section xpath="/mdb:MD_Metadata/mdb:metadataMaintenance"/>
         <section xpath="/mdb:MD_Metadata/mdb:applicationSchemaInfo"/>
-        <section name="mdb:MD_Metadata">
+        <section name="metadata">
           <field xpath="/mdb:MD_Metadata/mdb:metadataIdentifier"/>
           <field xpath="/mdb:MD_Metadata/mdb:defaultLocale" or="defaultLocale"
                  in="/mdb:MD_Metadata"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl-multilingual.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl-multilingual.xsl
@@ -53,47 +53,67 @@
     <xsl:variable name="mainLanguage">
       <xsl:call-template name="get-iso19115-3.2018-language"/>
     </xsl:variable>
-    
+
     <xsl:choose>
       <xsl:when test="$metadata/gn:info[position() = last()]/isTemplate = 's'">
         <xsl:for-each select="distinct-values($metadata//lan:LocalisedCharacterString/@locale)">
           <xsl:variable name="locale" select="string(.)" />
-          <xsl:variable name="langId" select="xslutil:threeCharLangCode(substring($locale,2,2))" />
+          <xsl:variable name="langId" select="xslutil:threeCharLangCode(substring($locale, 2, 2))" />
           <lang id="{.}" code="{$langId}"/>
         </xsl:for-each>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:for-each select="$metadata/mdb:otherLocale/lan:PT_Locale[
-                                  lan:language/lan:LanguageCode/@codeListValue != $mainLanguage]">
+        <xsl:for-each select="$metadata/mdb:otherLocale/lan:PT_Locale">
           <lang id="{@id}" code="{lan:language/lan:LanguageCode/@codeListValue}"/>
         </xsl:for-each>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
-  <!-- Template used to return a translation if one found, 
-       or the text in default metadata language 
+  <!-- Template used to return a translation if one found,
+       or the text in default metadata language
        or the first non empty text element.
+       If language id used is "#ALL", then all translations
+       are reported with an xml:lang attribute indicating
+       the language of the text.
     -->
   <xsl:template name="get-iso19115-3.2018-localised"
                 mode="localised"
                 match="*[lan:PT_FreeText or gco:CharacterString or gcx:Anchor]">
     <xsl:param name="langId"/>
 
-    <xsl:variable name="translation"
-                  select="lan:PT_FreeText/lan:textGroup/lan:LocalisedCharacterString[@locale=$langId]"/>
-
     <xsl:variable name="mainValue"
                   select="(gco:CharacterString|gcx:Anchor)[1]"/>
 
-    <xsl:variable name="firstNonEmptyValue"
-                  select="((gco:CharacterString|gcx:Anchor|lan:PT_FreeText/lan:textGroup/lan:LocalisedCharacterString)[. != ''])[1]"/>
+    <xsl:choose>
+      <xsl:when test="$langId = '#ALL' and lan:PT_FreeText">
+        <xsl:choose>
+          <xsl:when test="lan:PT_FreeText">
+            <xsl:for-each select="lan:PT_FreeText/lan:textGroup/lan:LocalisedCharacterString[. != '']">
+              <xsl:variable name="id"
+                            select="replace(@locale, '#', '')"/>
+              <div xml:lang="{$metadata//lan:PT_Locale[@id = $id]/lan:language/*/@codeListValue}"><xsl:value-of select="."/></div>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise>
+            <div xml:lang="{$metadata//mdb:defaultLocale/*/lan:language/*/@codeListValue}"><xsl:value-of select="$mainValue"/></div>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="translation"
+                      select="lan:PT_FreeText/lan:textGroup/lan:LocalisedCharacterString[@locale= $langId]"/>
 
-    <xsl:value-of select="if($translation != '')
+        <xsl:variable name="firstNonEmptyValue"
+                      select="((gco:CharacterString|gcx:Anchor|lan:PT_FreeText/lan:textGroup/lan:LocalisedCharacterString)[. != ''])[1]"/>
+
+        <xsl:value-of select="if($translation != '')
                           then $translation
                           else (if($mainValue != '')
                                 then $mainValue
                                 else $firstNonEmptyValue)"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template mode="localised" match="*">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl-multilingual.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl-multilingual.xsl
@@ -66,6 +66,9 @@
         <xsl:for-each select="$metadata/mdb:otherLocale/lan:PT_Locale">
           <lang id="{@id}" code="{lan:language/lan:LanguageCode/@codeListValue}"/>
         </xsl:for-each>
+        <xsl:for-each select="$metadata/mdb:defaultLocale/*">
+          <lang id="{@id}" code="{lan:language/lan:LanguageCode/@codeListValue}" default=""/>
+        </xsl:for-each>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -359,8 +359,6 @@
           <xsl:variable name="isInPTFreeText"
                         select="count(lan:PT_FreeText/*/lan:LocalisedCharacterString[
                                             @locale = concat('#', $mainLanguageId)]) = 1"/>
-
-
           <xsl:choose>
             <xsl:when test="$isInPTFreeText">
               <!-- Update gco:CharacterString to contains
@@ -381,7 +379,7 @@
             <xsl:otherwise>
               <!-- Populate PT_FreeText for default language if not existing and it is not null. -->
               <xsl:apply-templates select="gco:CharacterString|gcx:Anchor"/>
-              <xsl:if test="normalize-space(gco:CharacterString|gcx:Anchor) != ''">
+              <xsl:if test="normalize-space(gco:CharacterString|gcx:Anchor) != '' or lan:PT_FreeText">
                 <lan:PT_FreeText>
                   <lan:textGroup>
                     <lan:LocalisedCharacterString locale="#{$mainLanguageId}">

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -39,9 +39,9 @@
                 version="2.0"
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
+
   <!-- This formatter render an ISO19139 record based on the
   editor configuration file.
-
 
   The layout is made in 2 modes:
   * render-field taking care of elements (eg. sections, label)
@@ -76,6 +76,10 @@
                 select="/root/gmd:MD_Metadata"/>
 
   <xsl:variable name="langId" select="gn-fn-iso19139:getLangId($metadata, $language)"/>
+
+  <xsl:variable name="allLanguages">
+    <xsl:call-template name="get-iso19139-other-languages"/>
+  </xsl:variable>
 
 
   <!-- Ignore some fields displayed in header or in right column -->
@@ -153,7 +157,7 @@
             <xsl:for-each select="current-group()">
               <xsl:sort select="."/>
               <a href="#/search?keyword={.}">
-                <span class="badge"><xsl:value-of select="."/></span>
+                <span class="badge"><xsl:copy-of select="."/></span>
               </a>
             </xsl:for-each>
             <xsl:if test="position() != last()">
@@ -165,7 +169,7 @@
           <xsl:for-each select="$tags/tag">
             <xsl:sort select="."/>
             <a href="#/search?keyword={.}">
-              <span class="badge"><xsl:value-of select="."/></span>
+              <span class="badge"><xsl:copy-of select="."/></span>
             </a>
           </xsl:for-each>
         </xsl:otherwise>
@@ -239,8 +243,8 @@
             <xsl:with-param name="langId" select="$langId"/>
           </xsl:call-template>
         </xsl:variable>
-        <xsl:call-template name="addLineBreaksAndHyperlinks">
-          <xsl:with-param name="txt" select="$txt"/>
+         <xsl:call-template name="addLineBreaksAndHyperlinks">
+            <xsl:with-param name="txt" select="$txt"/>
         </xsl:call-template>
       </xsl:for-each>
     </div>
@@ -363,9 +367,10 @@
     <xsl:if test="normalize-space(string-join(*|*/@codeListValue, '')) != ''">
       <dl>
         <dt>
-          <xsl:value-of select="if ($fieldName)
-                                  then $fieldName
-                                  else tr:nodeLabel(tr:create($schema), name(), null)"/>
+          <xsl:call-template name="render-field-label">
+            <xsl:with-param name="fieldName" select="$fieldName"/>
+            <xsl:with-param name="languages" select="$allLanguages"/>
+          </xsl:call-template>
         </dt>
         <dd><xsl:comment select="name()"/>
           <xsl:apply-templates mode="render-value" select="*|*/@codeListValue"/>
@@ -400,9 +405,9 @@
 
     <dl>
       <dt>
-        <xsl:value-of select="if ($fieldName)
-                                then $fieldName
-                                else tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="fieldName" select="$fieldName"/>
+        </xsl:call-template>
       </dt>
       <dd>
         <xsl:comment select="name()"/>
@@ -411,6 +416,61 @@
       </dd>
     </dl>
   </xsl:template>
+
+
+  <xsl:template name="render-field-label">
+    <xsl:param name="fieldName" select="''" as="xs:string" required="no"/>
+    <xsl:param name="languages" as="node()*" required="no"/>
+    <xsl:param name="contextLabel" as="attribute()?" required="no"/>
+
+    <xsl:variable name="name"
+                  select="name()"/>
+    <xsl:choose>
+      <!-- eg. for codelist, display label in all record languages -->
+      <xsl:when test="$fieldName = '' and $language = 'all' and count($languages/lang) > 0">
+        <xsl:for-each select="$languages/lang">
+          <div xml:lang="{@code}">
+            <xsl:value-of select="tr:nodeLabel(tr:create($schema, @code), $name, null)"/>
+            <xsl:if test="$contextLabel">
+              <xsl:variable name="extraLabel">
+                <xsl:apply-templates mode="render-value"
+                                     select="$contextLabel">
+                  <xsl:with-param name="forcedLanguage" select="@code"/>
+                </xsl:apply-templates>
+              </xsl:variable>
+              <xsl:value-of select="concat(' (', $extraLabel, ')')"/>
+            </xsl:if>
+          </div>
+        </xsl:for-each>
+      </xsl:when>
+      <!-- eg. for multilingual element, display label in all translations -->
+      <xsl:when test="$fieldName = '' and $language = 'all' and gmd:PT_FreeText">
+        <xsl:for-each select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[. != '']">
+          <xsl:variable name="id"
+                        select="replace(@locale, '#', '')"/>
+          <xsl:variable name="lang3"
+                        select="$metadata//gmd:locale/*[@id = $id]/gmd:languageCode/*/@codeListValue"/>
+          <div xml:lang="{$lang3}">
+            <xsl:value-of select="tr:nodeLabel(tr:create($schema, $lang3), $name, null)"/>
+          </div>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- Overriden label or element name in current UI language. -->
+        <xsl:value-of select="if ($fieldName)
+                                then $fieldName
+                                else tr:nodeLabel(tr:create($schema), $name, null)"/>
+        <xsl:if test="$contextLabel">
+          <xsl:variable name="extraLabel">
+            <xsl:apply-templates mode="render-value"
+                                 select="$contextLabel"/>
+          </xsl:variable>
+          <xsl:value-of select="concat(' (', $extraLabel, ')')"/>
+        </xsl:if>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
 
   <!-- Some elements are only containers so bypass them -->
   <xsl:template mode="render-field"
@@ -437,7 +497,9 @@
 
     <div class="entry name">
       <h2>
-        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="languages" select="$allLanguages"/>
+        </xsl:call-template>
         <xsl:apply-templates mode="render-value"
                              select="@*"/>
       </h2>
@@ -473,13 +535,14 @@
 
 
   <!-- Display spatial extents containing bounding polygons on a map -->
-
   <xsl:template mode="render-field"
                 match="gmd:EX_Extent[gmd:geographicElement/*/gmd:polygon]"
                 priority="100">
     <div class="entry name">
       <h2>
-        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="languages" select="$allLanguages"/>
+        </xsl:call-template>
         <xsl:apply-templates mode="render-value"
                              select="@*"/>
       </h2>
@@ -632,7 +695,9 @@
                 priority="100">
     <dl>
       <dt>
-        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="languages" select="$allLanguages"/>
+        </xsl:call-template>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value" select="*"/>
@@ -651,7 +716,9 @@
                 priority="100">
     <dl class="gn-link">
       <dt>
-        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="languages" select="$allLanguages"/>
+        </xsl:call-template>
       </dt>
       <dd>
         <xsl:variable name="linkUrl"
@@ -698,7 +765,9 @@
                 priority="100">
     <dl class="gn-code">
       <dt>
-        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="languages" select="$allLanguages"/>
+        </xsl:call-template>
       </dt>
       <dd>
 
@@ -735,13 +804,8 @@
                 priority="100">
     <dl class="gn-keyword">
       <dt>
-        <xsl:apply-templates mode="render-value"
-                             select="*/gmd:thesaurusName/gmd:CI_Citation/gmd:title/*"/>
-
-        <xsl:if test="*/gmd:type/*[@codeListValue != '']">
-          (<xsl:apply-templates mode="render-value"
-                                select="*/gmd:type/*/@codeListValue"/>)
-        </xsl:if>
+          <xsl:apply-templates mode="render-value"
+                               select="*/gmd:thesaurusName/gmd:CI_Citation/gmd:title"/>
       </dt>
       <dd>
         <div>
@@ -764,11 +828,19 @@
                 priority="100">
     <dl class="gn-keyword">
       <dt>
-        <xsl:value-of select="$schemaStrings/noThesaurusName"/>
-        <xsl:if test="*/gmd:type/*[@codeListValue != '']">
-          (<xsl:apply-templates mode="render-value"
-                                select="*/gmd:type/*/@codeListValue"/>)
-        </xsl:if>
+        <xsl:variable name="thesaurusType">
+          <xsl:apply-templates mode="render-value"
+                               select="*/gmd:type/*/@codeListValue[. != '']"/>
+        </xsl:variable>
+
+        <xsl:choose>
+          <xsl:when test="$thesaurusType != ''">
+            <xsl:copy-of select="$thesaurusType"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$schemaStrings/noThesaurusName"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </dt>
       <dd>
         <div>
@@ -790,7 +862,9 @@
                 priority="100">
     <dl class="gn-format">
       <dt>
-        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="languages" select="$allLanguages"/>
+        </xsl:call-template>
       </dt>
       <dd>
         <ul>
@@ -825,11 +899,10 @@
                 priority="100">
     <dl class="gn-date">
       <dt>
-        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
-        <xsl:if test="*/gmd:dateType/*[@codeListValue != '']">
-          (<xsl:apply-templates mode="render-value"
-                                select="*/gmd:dateType/*/@codeListValue"/>)
-        </xsl:if>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="languages" select="$allLanguages"/>
+          <xsl:with-param name="contextLabel" select="*/gmd:dateType/*/@codeListValue[. != '']"/>
+        </xsl:call-template>
       </dt>
       <dd>
         <xsl:apply-templates mode="render-value"
@@ -845,7 +918,9 @@
                 priority="100">
     <dl class="gn-date">
       <dt>
-        <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+        <xsl:call-template name="render-field-label">
+          <xsl:with-param name="languages" select="$allLanguages"/>
+        </xsl:call-template>
       </dt>
       <dd>
         <ul>
@@ -873,13 +948,15 @@
     <xsl:variable name="nodeName" select="name()"/>
 
     <!-- Only render the first element of this kind and render a list of
-    following siblings. -->
+    following siblings.   -->
     <xsl:variable name="isFirstOfItsKind"
                   select="count(preceding-sibling::node()[name() = $nodeName]) = 0"/>
     <xsl:if test="$isFirstOfItsKind">
       <dl class="gn-md-associated-resources">
         <dt>
-          <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
+          <xsl:call-template name="render-field-label">
+            <xsl:with-param name="languages" select="$allLanguages"/>
+          </xsl:call-template>
         </dt>
         <dd>
           <ul>
@@ -922,7 +999,7 @@
      </xsl:variable>
      <span>
       <xsl:choose>
-        <xsl:when test="name()='gmd:parentIdentifier'">
+        <xsl:when test="name() = 'gmd:parentIdentifier'">
           <a href="{$nodeUrl}api/records/{./gco:CharacterString}">
             <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
             <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
@@ -955,11 +1032,11 @@
     <xsl:choose>
       <xsl:when test="$link != ''">
         <a href="{$link}">
-          <xsl:value-of select="$txt"/>
+          <xsl:copy-of select="$txt"/>
         </a>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="$txt"/>
+        <xsl:copy-of select="$txt"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -1076,61 +1153,57 @@
   </xsl:template>
 
   <xsl:template mode="render-value"
-                match="gmd:language/gmd:LanguageCode/@codeListValue">
-      <xsl:value-of select="xslUtils:twoCharLangCode(.)"/>
+                match="gmd:language/gmd:LanguageCode/@codeListValue
+                       |gmd:language/gco:CharacterString">
+      <xsl:variable name="label"
+                    select="xslUtils:getIsoLanguageLabel(., .)"/>
+      <xsl:value-of select="if ($label != '') then $label else ."/>
   </xsl:template>
 
+  <!-- ... Codelists and enumeration -->
   <xsl:template mode="render-value"
-                match="gmd:language/gco:CharacterString">
-    <span data-translate=""><xsl:comment select="name()"/>
-      <xsl:value-of select="."/>
-    </span>
-  </xsl:template>
+                match="@codeListValue|
+                       @indeterminatePosition|
+                       gmd:MD_TopicCategoryCode|
+                       gmd:MD_ObligationCode|
+                       gmd:MD_PixelOrientationCode">
+    <xsl:param name="forcedLanguage" select="''" required="no"/>
 
-  <!-- ... Codelists -->
-  <xsl:template mode="render-value"
-                match="@codeListValue|@indeterminatePosition">
     <xsl:variable name="id" select="."/>
+    <xsl:variable name="name" select="name()"/>
+    <xsl:variable name="parentName"
+                  select="if (. instance of attribute())
+                          then parent::node()/local-name()
+                          else local-name()"/>
+
     <xsl:variable name="codelistTranslation"
                   select="tr:codelist-value-label(
-                            tr:create($schema),
-                            if (name() = 'indeterminatePosition') then 'indeterminatePosition' else parent::node()/local-name(),
+                            if ($forcedLanguage = '') then tr:create($schema) else tr:create($schema, $forcedLanguage),
+                            if ($name = 'indeterminatePosition') then 'indeterminatePosition' else $parentName,
                             $id)"/>
     <xsl:choose>
-      <xsl:when test="$codelistTranslation != ''">
+      <!-- eg. for codelist, display label in all record languages -->
+      <xsl:when test="$forcedLanguage = '' and $language = 'all' and count($allLanguages/lang) > 0">
+        <xsl:for-each select="$allLanguages/lang">
+          <xsl:variable name="codelistTranslation"
+                        select="tr:codelist-value-label(
+                            tr:create($schema, @code),
+                            if ($name = 'indeterminatePosition') then 'indeterminatePosition' else $parentName,
+                            $id)"/>
 
-        <xsl:variable name="codelistDesc"
-                      select="tr:codelist-value-desc(
+          <div xml:lang="{@code}"
+               title="{if ($codelistTranslation != '') then tr:codelist-value-desc(
                             tr:create($schema),
-                            parent::node()/local-name(), $id)"/>
-        <span title="{$codelistDesc}">
-          <xsl:value-of select="$codelistTranslation"/>
-        </span>
+                            $parentName, $id) else ''}">
+            <xsl:value-of select="if ($codelistTranslation != '') then $codelistTranslation else $id"/>
+          </div>
+        </xsl:for-each>
       </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="$id"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
-
-  <!-- Enumeration -->
-  <xsl:template mode="render-value"
-                match="gmd:MD_TopicCategoryCode|
-                        gmd:MD_ObligationCode|
-                        gmd:MD_PixelOrientationCode">
-    <xsl:variable name="id" select="."/>
-    <xsl:variable name="codelistTranslation"
-                  select="tr:codelist-value-label(
-                            tr:create($schema),
-                            local-name(), $id)"/>
-    <xsl:choose>
       <xsl:when test="$codelistTranslation != ''">
-
         <xsl:variable name="codelistDesc"
                       select="tr:codelist-value-desc(
-                            tr:create($schema),
-                            local-name(), $id)"/>
+                            if ($forcedLanguage = '') then tr:create($schema) else tr:create($schema, $forcedLanguage),
+                            $parentName, $id)"/>
         <span title="{$codelistDesc}">
           <xsl:value-of select="$codelistTranslation"/>
         </span>
@@ -1146,6 +1219,7 @@
                 priority="100">
     <i class="fa fa-lock text-warning" title="{{{{'withheld' | translate}}}}"><xsl:comment select="'warning'"/></i>
   </xsl:template>
+
   <xsl:template mode="render-value"
                 match="@*"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-fn.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-fn.xsl
@@ -30,10 +30,8 @@
                 exclude-result-prefixes="#all">
 
 
-  <!-- Get lang #id in metadata PT_Locale section,  deprecated: if not return the 2 first letters
-        of the lang iso3code in uper case.
-
-         if not return the lang iso3code in uper case.
+  <!-- Get lang #id in metadata PT_Locale section.
+       if not found, return the lang iso3code in upper case.
         -->
   <xsl:function name="gn-fn-iso19139:getLangId" as="xs:string">
     <xsl:param name="md"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
@@ -111,14 +111,21 @@
         </xsl:for-each>
       </xsl:when>
       <xsl:otherwise>
-
+        <xsl:variable name="mainLanguage">
+          <xsl:call-template name="get-iso19139-language"/>
+        </xsl:variable>
         <xsl:for-each select="$metadata/gmd:locale/gmd:PT_Locale">
-          <lang id="{@id}" code="{gmd:languageCode/gmd:LanguageCode/@codeListValue}"/>
+          <xsl:variable name="langCode"
+                        select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/>
+          <lang id="{@id}" code="{$langCode}">
+            <xsl:if test="$langCode = $mainLanguage">
+              <xsl:attribute name="default" select="''"/>
+            </xsl:if>
+          </lang>
         </xsl:for-each>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
-
 
   <!-- Template used to return a translation if one found,
        or the text in default metadata language

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl
@@ -120,27 +120,49 @@
   </xsl:template>
 
 
-  <!-- Template used to return a translation if one found, 
-       or the text in default metadata language 
+  <!-- Template used to return a translation if one found,
+       or the text in default metadata language
        or the first non empty text element.
+
+       If language id used is "#ALL", then all translations
+       are reported with an xml:lang attribute indicating
+       the language of the text.
     -->
   <xsl:template name="localised" mode="localised" match="*[gco:CharacterString or gmx:Anchor or gmd:PT_FreeText]">
     <xsl:param name="langId"/>
 
-    <xsl:variable name="translation"
-                  select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId]"/>
 
     <xsl:variable name="mainValue"
                   select="(gco:CharacterString|gmx:Anchor)[1]"/>
+    <xsl:choose>
+      <xsl:when test="$langId = '#ALL' and gmd:PT_FreeText">
+        <xsl:choose>
+          <xsl:when test="gmd:PT_FreeText">
+            <xsl:for-each select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[. != '']">
+              <xsl:variable name="id"
+                            select="replace(@locale, '#', '')"/>
+              <div xml:lang="{$metadata//gmd:locale/*[@id = $id]/gmd:languageCode/*/@codeListValue}"><xsl:value-of select="."/></div>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise>
+            <div xml:lang="{$metadata//gmd:MD_Metadata/gmd:language/*/@codeListValue}"><xsl:value-of select="$mainValue"/></div>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="translation"
+                      select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId]"/>
 
-    <xsl:variable name="firstNonEmptyValue"
-                  select="((gco:CharacterString|gmx:Anchor|gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString)[. != ''])[1]"/>
+        <xsl:variable name="firstNonEmptyValue"
+                      select="((gco:CharacterString|gmx:Anchor|gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString)[. != ''])[1]"/>
 
-    <xsl:value-of select="if($translation != '')
+        <xsl:value-of select="if($translation != '')
                           then $translation
                           else (if($mainValue != '')
                                 then $mainValue
                                 else $firstNonEmptyValue)"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
 

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
@@ -122,13 +122,16 @@ public class SchemaLocalizations {
         ServletRequestAttributes attributes = (ServletRequestAttributes) obj;
         HttpServletRequest request = attributes.getRequest();
 
-
         final ApplicationContext appContext = ApplicationContextHolder.get();
         final ServiceContext serviceContext = ServiceContext.get();
-
         final String lang3 = serviceContext != null ?
             serviceContext.getLanguage() :
             appContext.getBean(LanguageUtils.class).getIso3langCode(request.getLocales());
+        return create(schema, lang3);
+    }
+
+    public static SchemaLocalizations create(String schema, String lang3) throws IOException, JDOMException {
+        final ApplicationContext appContext = ApplicationContextHolder.get();
         final String lang2 = appContext.getBean(IsoLanguagesMapper.class).iso639_2_to_iso639_1(lang3);
         CurrentLanguageHolder languageHolder = new CurrentLanguageHolder() {
             @Override

--- a/web-ui/src/main/resources/catalog/js/GnLandingPageLib.js
+++ b/web-ui/src/main/resources/catalog/js/GnLandingPageLib.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+(function () {
+  gnLandingPage = {};
+  gnLandingPage.displayLanguage = function (lang, target) {
+    target.parentElement.parentElement.querySelectorAll('li').forEach(
+      function (li) {
+        li.classList.remove('active');
+      });
+    target.parentElement.classList.add('active');
+
+    var displayAll = lang === '';
+    document.querySelectorAll('div[xml\\:lang]').forEach(
+      function (div) {
+        if (displayAll) {
+          div.classList.remove('hidden');
+        } else {
+          var isFirst = false;
+          if (div.previousElementSibling == null) {
+            isFirst = true;
+          } else {
+            if (div.previousElementSibling.getAttribute('xml:lang') === null) {
+              isFirst = true;
+            }
+          }
+
+          if (isFirst) {
+            var translationAvailable = false;
+            div.parentElement.querySelectorAll('div[xml\\:lang]').forEach(
+              function (child) {
+                // Last element is default lang.
+                var isLast = true;
+                if (child.nextElementSibling != null && child.nextElementSibling.getAttribute('xml:lang') !== null) {
+                  isLast = false;
+                }
+
+                if (child.getAttribute('xml:lang') === lang) {
+                  child.classList.remove('hidden');
+                  translationAvailable = true;
+                } else if (isLast) {
+                  child.classList.add('hidden');
+                  if (!translationAvailable) {
+                    div.classList.remove('hidden')
+                  }
+                } else {
+                  child.classList.add('hidden');
+                }
+              });
+          }
+        }
+      });
+  };
+})();

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -129,7 +129,6 @@
 
   <xsl:template name="render-record">
     <div class="container-fluid gn-metadata-view gn-schema-{$schema}">
-
       <xsl:variable name="type">
         <xsl:apply-templates mode="getMetadataHierarchyLevel" select="$metadata"/>
       </xsl:variable>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:gn-fn-render="http://geonetwork-opensource.org/xsl/functions/render"
                 xmlns:gn-fn-core="http://geonetwork-opensource.org/xsl/functions/core"
+                xmlns:utils="java:org.fao.geonet.util.XslUtil"
                 xmlns:saxon="http://saxon.sf.net/"
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all"
@@ -45,7 +46,10 @@
             <xsl:call-template name="render-record"/>
           </xsl:with-param>
           <xsl:with-param name="title">
-            <xsl:apply-templates mode="getMetadataTitle" select="$metadata"/>
+            <xsl:variable name="title">
+              <xsl:apply-templates mode="getMetadataTitle" select="$metadata"/>
+            </xsl:variable>
+            <xsl:copy-of select="if ($title/div) then $title/div[1] else $title"/>
           </xsl:with-param>
           <xsl:with-param name="description">
             <xsl:apply-templates mode="getMetadataAbstract" select="$metadata"/>
@@ -56,10 +60,72 @@
           <xsl:with-param name="thumbnail">
             <xsl:apply-templates mode="getMetadataThumbnail" select="$metadata"/>
           </xsl:with-param>
+          <xsl:with-param name="meta">
+            <xsl:call-template name="render-language-meta"/>
+          </xsl:with-param>
         </xsl:call-template>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
+  <!--
+  https://support.google.com/webmasters/answer/189077
+  -->
+  <xsl:template name="render-language-meta">
+    <xsl:variable name="metadataOtherLanguages">
+      <saxon:call-template name="{concat('get-', $schema, '-other-languages')}"/>
+    </xsl:variable>
+
+    <xsl:variable name="defaultLanguage"
+                  select="$metadataOtherLanguages/*[position() = last()]/@code"/>
+
+    <xsl:for-each select="$metadataOtherLanguages/*">
+      <link rel="alternate"
+            hreflang="{utils:twoCharLangCode(@code)}"
+            href="{$nodeUrl}api/records/{$metadataUuid}?language={@code}" />
+    </xsl:for-each>
+    <xsl:if test="count($metadataOtherLanguages/*) > 1">
+      <link rel="alternate"
+            hreflang="x-default"
+            href="{$nodeUrl}api/records/{$metadataUuid}?language=all" />
+    </xsl:if>
+  </xsl:template>
+
+
+  <xsl:template name="render-language-switcher">
+    <xsl:if test="$language = 'all'">
+      <div class="gn-multilingual-field">
+        <ul class="nav nav-pills">
+          <script src="{$nodeUrl}../catalog/js/GnLandingPageLib.js?v={$buildNumber}">&amp;nbsp;</script>
+
+          <xsl:variable name="metadataOtherLanguages">
+            <saxon:call-template name="{concat('get-', $schema, '-other-languages')}"/>
+          </xsl:variable>
+
+          <xsl:variable name="defaultLanguage"
+                        select="$metadataOtherLanguages/*[position() = last()]/@code"/>
+
+          <xsl:for-each select="$metadataOtherLanguages/*">
+            <li class="">
+              <a onclick="gnLandingPage.displayLanguage('{@code}', this);">
+                <xsl:variable name="label"
+                              select="utils:getIsoLanguageLabel(@code, @code)"/>
+                <xsl:value-of select="if ($label != '') then $label else @code"/><xsl:text> </xsl:text>
+              </a>
+            </li>
+          </xsl:for-each>
+          <xsl:if test="count($metadataOtherLanguages/*) > 1">
+            <li class="active">
+              <a onclick="gnLandingPage.displayLanguage('', this);">
+                <xsl:value-of select="'All'"/>
+              </a>
+            </li>
+          </xsl:if>
+        </ul>
+      </div>
+    </xsl:if>
+  </xsl:template>
+
 
   <xsl:template name="render-record">
     <div class="container-fluid gn-metadata-view gn-schema-{$schema}">
@@ -81,8 +147,10 @@
             <header>
               <h1>
                 <i class="fa gn-icon-{$type}"><xsl:comment select="'icon'"/></i>
-                <xsl:value-of select="$title"/>
+                <xsl:copy-of select="$title"/>
               </h1>
+
+              <xsl:call-template name="render-language-switcher"/>
 
               <xsl:apply-templates mode="getMetadataHeader" select="$metadata"/>
 

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -97,6 +97,11 @@
       <div class="gn-multilingual-field">
         <ul class="nav nav-pills">
           <script src="{$nodeUrl}../catalog/js/GnLandingPageLib.js?v={$buildNumber}">&amp;nbsp;</script>
+          <script type="text/javascript">
+            window.onload = function() {
+              document.getElementById('gn-default-lang-link').click();
+            };
+          </script>
 
           <xsl:variable name="metadataOtherLanguages">
             <saxon:call-template name="{concat('get-', $schema, '-other-languages')}"/>
@@ -105,9 +110,10 @@
           <xsl:variable name="defaultLanguage"
                         select="$metadataOtherLanguages/*[position() = last()]/@code"/>
 
-          <xsl:for-each select="$metadataOtherLanguages/*">
+          <xsl:for-each select="($metadataOtherLanguages/*[@default], $metadataOtherLanguages/*[not(@default)])">
             <li class="">
-              <a onclick="gnLandingPage.displayLanguage('{@code}', this);">
+              <a id="{if (@default) then 'gn-default-lang-link' else ''}"
+                 onclick="gnLandingPage.displayLanguage('{@code}', this);">
                 <xsl:variable name="label"
                               select="utils:getIsoLanguageLabel(@code, @code)"/>
                 <xsl:value-of select="if ($label != '') then $label else @code"/><xsl:text> </xsl:text>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -403,7 +403,6 @@
         <xsl:if test="@name">
           <xsl:variable name="title"
                         select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
-
           <xsl:element name="h{1 + count(ancestor-or-self::*[name(.) = 'section'])}">
             <xsl:value-of select="$title"/>
           </xsl:element>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
@@ -74,19 +74,6 @@
   <xsl:variable name="nodeUrl"
                 select="/root/gui/nodeUrl"/>
 
-  <!-- Date formating -->
-  <xsl:variable name="dateFormats">
-    <dateTime>
-      <for lang="eng" default="true">[H1]:[m01]:[s01] on [D1] [MNn] [Y]</for>
-      <for lang="fre">[H1]:[m01]:[s01] le [D1] [MNn] [Y]</for>
-    </dateTime>
-    <date>
-      <for lang="eng" default="true">[D1] [MNn] [Y]</for>
-      <for lang="fre">[D1] [MNn] [Y]</for>
-    </date>
-  </xsl:variable>
-
-
   <xsl:variable name="schemaStrings"
                 select="/root/schemas/*[name() = $schema]/strings"/>
 

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -46,12 +46,16 @@
                select="concat(/root/gui/url,'/images/logos/favicon.png')"/>
     <xsl:param name="type"
                select="'dataset'"/>
+    <xsl:param name="meta" required="no" as="node()*"/>
 
 
     <html ng-app="{$angularModule}" lang="{$lang2chars}" id="ng-app">
       <head>
         <title><xsl:value-of select="$title"/></title>
         <meta charset="utf-8"/>
+
+        <xsl:copy-of select="$meta"/>
+
         <meta name="viewport" content="initial-scale=1.0"/>
         <meta name="apple-mobile-web-app-capable" content="yes"/>
 

--- a/web/src/main/webapp/xslt/common/utility-tpl.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl.xsl
@@ -223,134 +223,149 @@
     <xsl:param name="txt"/>
 
     <xsl:choose>
-      <xsl:when test="util:getSettingValue('system/clickablehyperlinks/enable') = 'true'">
-        <xsl:choose>
-          <xsl:when test="contains($txt,'&#13;&#10;')">
-            <p>
-              <xsl:choose>
-                <xsl:when test="contains($txt,'&#13;&#10;')">
-                  <xsl:call-template name="addLineBreaksAndHyperlinks">
-                    <xsl:with-param name="txt" select="substring-before($txt,'&#13;&#10;')"/>
-                  </xsl:call-template>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:call-template name="addHyperlinksAndLineBreaks">
-                    <xsl:with-param name="txt" select="substring-before($txt,'&#13;&#10;')"/>
-                  </xsl:call-template>
-                </xsl:otherwise>
-              </xsl:choose>
-            </p>
-            <p>
-              <xsl:choose>
-                <xsl:when test="contains($txt,'&#13;&#10;')">
-                  <xsl:call-template name="addLineBreaksAndHyperlinks">
-                    <xsl:with-param name="txt" select="substring-after($txt,'&#13;&#10;')"/>
-                  </xsl:call-template>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:call-template name="addHyperlinksAndLineBreaks">
-                    <xsl:with-param name="txt" select="substring-after($txt,'&#13;&#10;')"/>
-                  </xsl:call-template>
-                </xsl:otherwise>
-              </xsl:choose>
-            </p>
-          </xsl:when>
-          <xsl:when test="contains($txt,'&#13;')">
-            <p>
-              <xsl:choose>
-                <xsl:when test="contains($txt,'&#13;')">
-                  <xsl:call-template name="addLineBreaksAndHyperlinks">
-                    <xsl:with-param name="txt" select="substring-before($txt,'&#13;')"/>
-                  </xsl:call-template>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:call-template name="addHyperlinksAndLineBreaks">
-                    <xsl:with-param name="txt" select="substring-before($txt,'&#13;')"/>
-                  </xsl:call-template>
-                </xsl:otherwise>
-              </xsl:choose>
-            </p>
-            <p>
-              <xsl:choose>
-                <xsl:when test="contains($txt,'&#13;')">
-                  <xsl:call-template name="addLineBreaksAndHyperlinks">
-                    <xsl:with-param name="txt" select="substring-after($txt,'&#13;')"/>
-                  </xsl:call-template>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:call-template name="addHyperlinksAndLineBreaks">
-                    <xsl:with-param name="txt" select="substring-after($txt,'&#13;')"/>
-                  </xsl:call-template>
-                </xsl:otherwise>
-              </xsl:choose>
-            </p>
-          </xsl:when>
-          <xsl:when test="contains($txt,'&#10;')">
-            <p>
-              <xsl:choose>
-                <xsl:when test="contains($txt,'&#10;')">
-                  <xsl:call-template name="addLineBreaksAndHyperlinks">
-                    <xsl:with-param name="txt" select="substring-before($txt,'&#10;')"/>
-                  </xsl:call-template>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:call-template name="addHyperlinksAndLineBreaks">
-                    <xsl:with-param name="txt" select="substring-before($txt,'&#10;')"/>
-                  </xsl:call-template>
-                </xsl:otherwise>
-              </xsl:choose>
-            </p>
-            <p>
-              <xsl:choose>
-                <xsl:when test="contains($txt,'&#10;')">
-                  <xsl:call-template name="addLineBreaksAndHyperlinks">
-                    <xsl:with-param name="txt" select="substring-after($txt,'&#10;')"/>
-                  </xsl:call-template>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:call-template name="addHyperlinksAndLineBreaks">
-                    <xsl:with-param name="txt" select="substring-after($txt,'&#10;')"/>
-                  </xsl:call-template>
-                </xsl:otherwise>
-              </xsl:choose>
-            </p>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:call-template name="addHyperlinksAndLineBreaks">
-              <xsl:with-param name="txt"  select="$txt"/>
+      <xsl:when test="$txt instance of node() and $txt/div">
+        <xsl:for-each select="$txt/div">
+          <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:call-template name="addLineBreaksAndHyperlinks">
+              <xsl:with-param name="txt" select="."/>
             </xsl:call-template>
-          </xsl:otherwise>
-        </xsl:choose>
+          </xsl:copy>
+        </xsl:for-each>
       </xsl:when>
       <xsl:otherwise>
+
         <xsl:choose>
-          <xsl:when test="contains($txt,'&#13;&#10;')">
-            <p>
-              <xsl:value-of select="substring-before($txt,'&#13;&#10;')"/>
-            </p><p>
-            <xsl:call-template name="addLineBreaksAndHyperlinks">
-              <xsl:with-param name="txt"  select="substring-after($txt,'&#13;&#10;')"/>
-            </xsl:call-template>
-          </p>
-          </xsl:when>
-          <xsl:when test="contains($txt,'&#13;')">
-            <p><xsl:value-of select="substring-before($txt,'&#13;')"/>
-            </p><p>
-            <xsl:call-template name="addLineBreaksAndHyperlinks">
-              <xsl:with-param name="txt"  select="substring-after($txt,'&#13;')"/>
-            </xsl:call-template>
-          </p>
-          </xsl:when>
-          <xsl:when test="contains($txt,'&#10;')">
-            <p><xsl:value-of select="substring-before($txt,'&#10;')"/>
-            </p><p>
-            <xsl:call-template name="addLineBreaksAndHyperlinks">
-              <xsl:with-param name="txt"  select="substring-after($txt,'&#10;')"/>
-            </xsl:call-template>
-          </p>
+          <xsl:when test="util:getSettingValue('system/clickablehyperlinks/enable') = 'true'">
+            <xsl:choose>
+              <xsl:when test="contains($txt,'&#13;&#10;')">
+                <p>
+                  <xsl:choose>
+                    <xsl:when test="contains($txt,'&#13;&#10;')">
+                      <xsl:call-template name="addLineBreaksAndHyperlinks">
+                        <xsl:with-param name="txt" select="substring-before($txt,'&#13;&#10;')"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:call-template name="addHyperlinksAndLineBreaks">
+                        <xsl:with-param name="txt" select="substring-before($txt,'&#13;&#10;')"/>
+                      </xsl:call-template>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </p>
+                <p>
+                  <xsl:choose>
+                    <xsl:when test="contains($txt,'&#13;&#10;')">
+                      <xsl:call-template name="addLineBreaksAndHyperlinks">
+                        <xsl:with-param name="txt" select="substring-after($txt,'&#13;&#10;')"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:call-template name="addHyperlinksAndLineBreaks">
+                        <xsl:with-param name="txt" select="substring-after($txt,'&#13;&#10;')"/>
+                      </xsl:call-template>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </p>
+              </xsl:when>
+              <xsl:when test="contains($txt,'&#13;')">
+                <p>
+                  <xsl:choose>
+                    <xsl:when test="contains($txt,'&#13;')">
+                      <xsl:call-template name="addLineBreaksAndHyperlinks">
+                        <xsl:with-param name="txt" select="substring-before($txt,'&#13;')"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:call-template name="addHyperlinksAndLineBreaks">
+                        <xsl:with-param name="txt" select="substring-before($txt,'&#13;')"/>
+                      </xsl:call-template>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </p>
+                <p>
+                  <xsl:choose>
+                    <xsl:when test="contains($txt,'&#13;')">
+                      <xsl:call-template name="addLineBreaksAndHyperlinks">
+                        <xsl:with-param name="txt" select="substring-after($txt,'&#13;')"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:call-template name="addHyperlinksAndLineBreaks">
+                        <xsl:with-param name="txt" select="substring-after($txt,'&#13;')"/>
+                      </xsl:call-template>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </p>
+              </xsl:when>
+              <xsl:when test="contains($txt,'&#10;')">
+                <p>
+                  <xsl:choose>
+                    <xsl:when test="contains($txt,'&#10;')">
+                      <xsl:call-template name="addLineBreaksAndHyperlinks">
+                        <xsl:with-param name="txt" select="substring-before($txt,'&#10;')"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:call-template name="addHyperlinksAndLineBreaks">
+                        <xsl:with-param name="txt" select="substring-before($txt,'&#10;')"/>
+                      </xsl:call-template>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </p>
+                <p>
+                  <xsl:choose>
+                    <xsl:when test="contains($txt,'&#10;')">
+                      <xsl:call-template name="addLineBreaksAndHyperlinks">
+                        <xsl:with-param name="txt" select="substring-after($txt,'&#10;')"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:call-template name="addHyperlinksAndLineBreaks">
+                        <xsl:with-param name="txt" select="substring-after($txt,'&#10;')"/>
+                      </xsl:call-template>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </p>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:call-template name="addHyperlinksAndLineBreaks">
+                  <xsl:with-param name="txt"  select="$txt"/>
+                </xsl:call-template>
+              </xsl:otherwise>
+            </xsl:choose>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="$txt"/>
+            <xsl:choose>
+              <xsl:when test="contains($txt,'&#13;&#10;')">
+                <p>
+                  <xsl:value-of select="substring-before($txt,'&#13;&#10;')"/>
+                </p><p>
+                <xsl:call-template name="addLineBreaksAndHyperlinks">
+                  <xsl:with-param name="txt"  select="substring-after($txt,'&#13;&#10;')"/>
+                </xsl:call-template>
+              </p>
+              </xsl:when>
+              <xsl:when test="contains($txt,'&#13;')">
+                <p><xsl:value-of select="substring-before($txt,'&#13;')"/>
+                </p><p>
+                <xsl:call-template name="addLineBreaksAndHyperlinks">
+                  <xsl:with-param name="txt"  select="substring-after($txt,'&#13;')"/>
+                </xsl:call-template>
+              </p>
+              </xsl:when>
+              <xsl:when test="contains($txt,'&#10;')">
+                <p><xsl:value-of select="substring-before($txt,'&#10;')"/>
+                </p><p>
+                <xsl:call-template name="addLineBreaksAndHyperlinks">
+                  <xsl:with-param name="txt"  select="substring-after($txt,'&#10;')"/>
+                </xsl:call-template>
+              </p>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="$txt"/>
+              </xsl:otherwise>
+            </xsl:choose>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:otherwise>

--- a/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
+++ b/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
@@ -121,7 +121,7 @@
               </xsl:when>
 
               <xsl:otherwise>
-                <xsl:value-of select="concat($nodeUrl, 'api/records/', $uuid)"/>
+                <xsl:value-of select="concat($nodeUrl, 'api/records/', $uuid, '?language=all')"/>
               </xsl:otherwise>
             </xsl:choose>
           </loc>


### PR DESCRIPTION
Landing page is displayed by default taking into account the Accept-Language of the browser. Then translations are displayed depending on that language if available. A specific language can be forced using the `language` parameter but the user does not know in which languages the record is described by default.

The `language=all` parameter can now be set to return the record description in all languages used in the record. 

![image](https://user-images.githubusercontent.com/1701393/89890061-04015500-dbd3-11ea-9029-8185022122f5.png)


All element language is identified by using `xml:lang` attribute.

![image](https://user-images.githubusercontent.com/1701393/89890066-06fc4580-dbd3-11ea-8853-247e08970c50.png)


A language switcher allows to display one language or all translations.

![image](https://user-images.githubusercontent.com/1701393/89890149-2b582200-dbd3-11ea-8b7f-40eb65a8bafb.png)


The HTML page meta is improved by providing `link` to all translations page representing the same resource (as described in https://support.google.com/webmasters/answer/189077). Search engine will be aware that different pages describe the same resource but in different languages (to avoid to create duplicates in search results).

![image](https://user-images.githubusercontent.com/1701393/89890087-0c599000-dbd3-11ea-803b-2d5029c29e77.png)


The sitemap now point to this page by default.