### PR TITLE
Restyle search results and search results toolbar

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -1,131 +1,64 @@
 <ul class="list-group gn-resultview gn-resultview-sumup">
-  <li class="list-group-item gn-grid"
+  <li class="list-group-item gn-grid panel panel-default gn-card"
       data-ng-repeat="md in searchResults.records"
       data-gn-fix-mdlinks=""
       data-gn-displayextent-onhover=""
       data-gn-zoomto-onclick="">
 
-    <!--start top row-->
-    <div class="row">
-      <input data-gn-selection-md type="checkbox"
-             data-ng-model="md.selected"
-             aria-label="{{'clickToSelect' | translate}}"
-             data-ng-change="change()"/>
-
-      <small class="gn-score">score:{{md._score}}</small>
-      <!--Source catalog Logo-->
-      <a data-ng-if="md.groupWebsite"
-         href="{{md.groupWebsite}}"
-         target="_blank">
-        <img data-ng-src="{{gnUrl}}..{{md.logo}}"
-             alt="{{'siteLogo' | translate}}"
-             class="gn-source-logo"/>
-      </a>
-      <img data-ng-if="!md.groupWebsite && md.logo"
-           data-ng-src="{{gnUrl}}..{{md.logo}}"
-           alt="{{'siteLogo' | translate}}"
-           class="gn-source-logo"/>
-
-      <div class="gn-md-category"
-           data-ng-class="md.category.length > 0 ||
-                            md.topicCat.length > 0 ||
-                            md.inspirethemewithac.length > 0 ? '' : 'invisible'">
-        <span data-translate="">listOfCategories</span>
-        <a data-ng-repeat="cat in ::md.category"
-           title="{{('cat-' + cat) | translate}}"
-           aria-label="{{('cat-' + cat) | translate}}"
-           data-ng-href="#/search?_cat={{cat}}">
-          <i class="fa">
-            <span class="fa gn-icon-{{cat}}"></span>
-          </i>
-        </a>
-        <a data-ng-repeat="t in md.inspirethemewithac"
-           data-ng-href="#/search?inspiretheme={{t.split('|')[1]}}">
-          <i class="fa" title="{{t.split('|')[1]}}">
-            <span class="fa iti-{{t.split('|')[0]}}"></span>
-          </i>
-        </a>
-        <a data-ng-repeat="t in md.topicCat"
-           data-ng-href="#/search?topicCat={{t}}"
-           title="{{t | translate}}"
-           aria-label="{{t | translate}}">
-          <i class="fa">
-            <span class="fa gn-icon-{{t}}"></span>
-          </i>
-        </a>
+    <div class="panel-heading gn-card-heading">
+      <div class="gn-md-title">
+        <div class="gn-md-select">
+          <input data-gn-selection-md 
+                 type="checkbox"
+                 data-ng-model="md.selected"
+                 aria-label="{{'clickToSelect' | translate}}"
+                 data-ng-change="change()"/>
+        </div>
+        <span class="fa gn-icon-{{md.resourceType[0]}}" title="{{md.resourceType[0] | translate}}"></span>
+        <h1>
+          <a href=""
+             gn-metadata-open="md"
+             gn-records="searchResults.records"
+             gn-formatter="formatter.defaultUrl"
+             title="{{md.resourceTitle}}">
+            {{(md.resourceTitle) | characters:50}}
+          </a>
+        </h1>
       </div>
-      <div data-gn-metadata-rate="md"
-           data-readonly="true"
-           class="pull-right"/>
     </div>
-    <!--end top row-->
-    <div class="row gn-md-title">
-      <h3>
-        <a href=""
+    <!-- /.gn-card-heading -->
+
+    <div class="panel-body gn-card-body">
+      <div title="{{(md.resourceAbstract) | striptags}}"
+           class="gn-md-contents"
            gn-metadata-open="md"
            gn-records="searchResults.records"
-           gn-formatter="formatter.defaultUrl"
-           title="{{md.resourceTitle}}">
-
-          <i class="fa gn-icon-{{md.resourceType[0]}}" title="{{md.resourceType[0] | translate}}"/>
-          {{(md.resourceTitle) | characters:80}}</a>
-      </h3>
-    </div>
-
-    <!--start middle row-->
-    <div title="{{(md.resourceAbstract) | striptags}}"
-         gn-metadata-open="md"
-         gn-records="searchResults.records"
-         gn-formatter="formatter.defaultUrl">
-      <!-- Thumbnail -->
-      <div class="gn-md-thumbnail">
+           gn-formatter="formatter.defaultUrl">
+        <!-- Thumbnail -->
         <div class="gn-md-thumbnail"
-             data-ng-class="{'gn-md-no-thumbnail': !md.overview[0]}"></div>
-        <img class="gn-img-thumbnail"
-             alt="{{md.resourceTitle}}"
-             data-ng-src="{{md.overview[0].url}}?size=140"
-             data-ng-if="md.overview[0]"/>
-      </div>
+             data-ng-class="{'gn-md-no-thumbnail': !md.overview[0]}">
+          <img class="gn-img-thumbnail"
+               alt="{{md.resourceTitle}}"
+               data-ng-src="{{md.overview[0].url}}?size=140"
+               data-ng-if="md.overview[0]"/>
+        </div>
 
-
-      <div style="float:left; display:block; width: calc(100% - 162px)">
-
-        <div class="text-justify gn-md-abstract ellipsis">
-          <div>
-            <p>{{md.resourceAbstract  | striptags}}</p>
+        <div class="gn-md-details">
+          <div class="gn-md-abstract ">
+            <div class="ellipsis">
+              <p>{{md.resourceAbstract | striptags}}</p>
+            </div>
+            <p class="text-muted">
+              {{md.OrgForResource[0]}}
+            </p>
           </div>
         </div>
 
-        <div class="row gn-md-details">
-          <p ng-if="::!md.OrgForResource">&nbsp;</p>
-          <!--<p ng-if="::!md.getAllContacts().resource">&nbsp;</p>
-          <p data-ng-repeat="c in ::md.getAllContacts().resource track by $index">
-            <img data-ng-if="::c.logo"
-                 data-ng-src="{{::c.logo}}"
-                 class="gn-source-logo"
-                 title="{{::c.organisation}} ({{::c.role}})"/>
-            {{::c.organisation}}
-          </p>-->
-          <p data-ng-repeat="o in ::md.OrgForResource | unique"
-             title="{{::o}}">
-            {{::o}}
-          </p>
-        </div>
       </div>
-
-
-      <!--<div>
-        <span data-ng-repeat="h in md.inner_hits.others.hits.hits">
-          <i class="fa fa-fw {{h._source.docType === 'feature' ? 'fa-map-pin' : 'gn-icon-' + h._source.resourceType}}"></i> {{h._source.resourceTitle}},
-        </span>
-      </div>-->
-
     </div>
-    <!--end middle row-->
+    <!-- /.gn-card-body -->
 
-    <!--start bottom row-->
-    <div>
-      <!-- Display the first metadata status (apply to ISO19139 record) -->
+    <div class="panel-footer gn-card-footer clearfix">
       <div data-ng-if="md.status_text.length > 0"
            title="{{md.status_text[0]}}"
            class="gn-status gn-status-{{md.status[0]}}">{{md.status_text[0]}}
@@ -143,8 +76,7 @@
         </div>
       </div>
     </div>
-
-    <!--end bottom row-->
-    <div style="clear: both;"></div>
+    <!-- /.gn-card-footer -->
   </li>
+  <!-- /.gn-card -->
 </ul>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -5,95 +5,13 @@
       gn-zoomto-onclick=""
       gn-fix-mdlinks="">
     <div class="row">
-      <div class="col-md-1">
-        <!--Catalog or group Logo-->
-        <div class="gn-md-logo">
-          <a class="pull-left" ng-if="md.groupWebsite" href="{{md.groupWebsite}}" target="_blank">
-            <img ng-src="../..{{md.logo}}"
-                alt="{{'siteLogo' | translate}}"
-                class="media-object"/>
-          </a>
-          <a class="pull-left" ng-if="!md.groupWebsite">
-            <img ng-src="../..{{md.logo}}"
-                alt="{{'siteLogo' | translate}}"
-                class="media-object"/>
-          </a>
-        </div>
-      </div>
-      <div class="col-md-9">
-        <div class="gn-md-title">
-          <input gn-selection-md type="checkbox" ng-model="md.selected"
+      <div class="col-md-2 clearfix">
+        <div class="gn-md-select">
+          <input gn-selection-md type="checkbox"
+                 ng-model="md.selected"
                  aria-label="{{'clickToSelect' | translate}}"
                  ng-change="change()"/>
-          <div class="pull-right gn-md-category"
-               data-ng-class="md.category.length > 0 ||
-                            md.topicCat.length > 0 ||
-                            md.inspirethemewithac.length > 0 ? '' : 'invisible'">
-            <span data-translate="">listOfCategories</span>
-            <a data-ng-repeat="cat in ::md.category"
-               title="{{('cat-' + cat) | translate}}"
-               aria-label="{{('cat-' + cat) | translate}}"
-               data-ng-href="#/search?_cat={{cat}}">
-              <i class="fa">
-                <span class="fa gn-icon-{{cat}}"></span>
-              </i>
-            </a>
-            <a data-ng-repeat="t in md.inspirethemewithac track by $index"
-               data-ng-href="#/search?inspiretheme={{t.split('|')[1]}}">
-              <i class="fa" title="{{t.split('|')[1]}}">
-                <span class="fa iti-{{t.split('|')[0]}}"></span>
-              </i>
-            </a>
-            <a data-ng-repeat="t in md.topicCat"
-               data-ng-href="#/search?topicCat={{t}}"
-               title="{{t | translate}}"
-               aria-label="{{t | translate}}">
-              <i class="fa" >
-                <span class="fa gn-icon-{{t}}"></span>
-              </i>
-            </a>
-          </div>
-
-          <h1>
-            <a href=""
-               gn-metadata-open="md"
-               gn-index="$index"
-               gn-records="searchResults.records"
-               gn-formatter="formatter.defaultUrl"
-               title="{{md.title || md.defaultTitle}}"
-               aria-label="{{md.resourceTitle}}">
-              <i class="fa gn-icon-{{md.resourceType[0]}}" title="{{md.resourceType[0] | translate}}"/>
-              {{md.resourceTitle}}</a>
-          </h1>
         </div>
-
-        <div class="gn-md-abstract"
-             gn-metadata-open="md"
-             gn-index="$index"
-             gn-records="searchResults.records"
-             gn-formatter="formatter.defaultUrl">
-          <p class="text-justify"
-            dd-text-collapse dd-text-collapse-max-length="350"
-            dd-text-collapse-text="{{md.resourceAbstract}}"></p>
-          <p ng-if="::!md.getAllContacts().resource">&nbsp;</p>
-          <p data-ng-repeat="c in ::md.getAllContacts().resource track by $index">
-            <img data-ng-if="::c.logo"
-                 data-ng-src="{{::c.logo}}"
-                 class="gn-source-logo"
-                 title="{{::c.name}} ({{::c.role}})"/>
-            {{::c.name}}
-          </p>
-        </div>
-
-        <div gn-grid-related="md.recordLink"
-             gn-grid-related-uuid="::md.uuid"
-             template="../../catalog/views/default/templates/gridRelatedList.html"></div>
-
-        <div class="gn-toolbar">
-          <gn-links-btn></gn-links-btn>
-        </div>
-      </div>
-      <div class="col-md-2 clearfix">
         <!-- Thumbnail -->
         <div class="gn-md-thumbnail">
           <div class="gn-md-no-thumbnail"
@@ -105,6 +23,95 @@
 
         </div>
 
+      </div>
+      <div class="col-md-10">
+        <div class="gn-card">
+          <div class="gn-card-heading">
+            <div class="gn-md-title">
+              <div class="pull-right gn-md-category"
+                   data-ng-class="md.category.length > 0 ||
+                                md.topicCat.length > 0 ||
+                                md.inspirethemewithac.length > 0 ? '' : 'invisible'">
+                <span data-translate="">listOfCategories</span>
+                <a data-ng-repeat="cat in ::md.category"
+                   title="{{('cat-' + cat) | translate}}"
+                   aria-label="{{('cat-' + cat) | translate}}"
+                   data-ng-href="#/search?_cat={{cat}}">
+                  <i class="fa">
+                    <span class="fa gn-icon-{{cat}}"></span>
+                  </i>
+                </a>
+                <a data-ng-repeat="t in md.inspirethemewithac track by $index"
+                   data-ng-href="#/search?inspiretheme={{t.split('|')[1]}}">
+                  <i class="fa" title="{{t.split('|')[1]}}">
+                    <span class="fa iti-{{t.split('|')[0]}}"></span>
+                  </i>
+                </a>
+                <a data-ng-repeat="t in md.topicCat"
+                   data-ng-href="#/search?topicCat={{t}}"
+                   title="{{t | translate}}"
+                   aria-label="{{t | translate}}">
+                  <i class="fa" >
+                    <span class="fa gn-icon-{{t}}"></span>
+                  </i>
+                </a>
+              </div>
+
+              <i class="fa gn-icon-{{md.resourceType[0]}}" title="{{md.resourceType[0] | translate}}"/>
+              <h1>
+                <a href=""
+                   gn-metadata-open="md"
+                   gn-index="$index"
+                   gn-records="searchResults.records"
+                   gn-formatter="formatter.defaultUrl"
+                   title="{{md.title || md.defaultTitle}}"
+                   aria-label="{{md.resourceTitle}}">
+
+                  {{md.resourceTitle}}</a>
+              </h1>
+            </div>
+          </div>
+          <!-- /.gn-card-heading -->
+
+          <div class="gn-card-body">
+            <div class="gn-md-abstract"
+                 gn-metadata-open="md"
+                 gn-index="$index"
+                 gn-records="searchResults.records"
+                 gn-formatter="formatter.defaultUrl">
+              <p class="text-justify"
+                 dd-text-collapse dd-text-collapse-max-length="350"
+                 dd-text-collapse-text="{{md.resourceAbstract}}"></p>
+
+                 
+              <p data-ng-repeat="c in ::md.getAllContacts().resource track by $index">
+                <img data-ng-if="::c.logo"
+                     data-ng-src="{{::c.logo}}"
+                     class="gn-source-logo"
+                     title="{{::c.name}} ({{::c.role}})"/>
+                {{::c.name}}
+              </p>
+            </div>
+            <div gn-grid-related="md.recordLink"
+                 gn-grid-related-uuid="::md.uuid"
+                 template="../../catalog/views/default/templates/gridRelatedList.html"></div>
+          </div>
+          <!-- /.gn-card-body -->
+
+          <div class="gn-card-footer">
+            <div class="gn-toolbar">
+              <gn-links-btn></gn-links-btn>
+              <div data-ng-if="md.draft == 'e'"
+                   title="{{'workingCopy' | translate}}"
+                   class="gn-workingcopy-status">
+                <i class="fa fa-pencil"></i>
+                <span>{{'workingCopy' | translate}}</span>
+              </div>
+            </div>
+          </div>
+          <!-- /.gn-card-footer -->
+        </div>
+        <!-- /.gn-card -->
       </div>
     </div>
   </li>

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -447,9 +447,20 @@
   .gn-md-no-thumbnail {
     width: 140px;
     height: 140px;
-    background-size: 140px 140px;
-    background-image: url(../catalog/views/default/images/no-thumbnail.png);
-    height: 140px;
+    &:after {
+      content: "\f03e";
+      font-family: FontAwesome;
+      font-style: normal;
+      font-weight: normal;
+      text-decoration: inherit;
+      position: absolute;
+      font-size: 46px;
+      color: #eeeeee;
+      top: 50%;
+      left: 50%;
+      margin: -32px 0 0 -23px;
+      z-index: 1;
+    }
   }
 }
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_infolist_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_infolist_default.less
@@ -20,13 +20,22 @@
           .title {
             background: @gn-resultcard-title-background-color;
             border: @gn-resultcard-title-border;
+            border-bottom: 0;
             h4 {
               color: @gn-resultcard-title-color;
+              font-weight: normal;
             }
           }
         }
         .resultcard.hasThumbnail {
           &:hover {
+            .title {
+              background: @gn-resultcard-title-background-color-hover;
+            }
+          }
+        }
+        &:hover {
+          .resultcard {
             .title {
               background: @gn-resultcard-title-background-color-hover;
             }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -7,13 +7,31 @@
   background-color: @gn-results-background-color;
 }
 .gn-row-tools {
-  .btn-default, .pagination > li > a, .pagination > li > span {
-    border-color: @panel-default-border !important;
-    &:hover, &:active, &:focus {
-      background-color: @panel-default-heading-bg !important;
-      border-color: @btn-default-border !important;
-      span {
-        background: transparent;
+  .btn-default {
+    border: 0;
+    border-radius: 0;
+    border-right: 1px solid #ddd;
+    &:hover, &:focus, &:active {
+      background: 0;
+      box-shadow: none;
+      border-color: #ddd;
+    }
+    &:focus {
+      outline: @gn-outline;
+    }
+  }
+  .pagination {
+    > li > a, .pagination > li > span {
+      border: 0;
+      color: @btn-default-color;
+      &:hover {
+        color: @brand-primary;
+        background: none;
+      }
+      &:focus {
+        box-shadow: none;
+        background: none;
+        outline: @gn-outline;
       }
     }
   }
@@ -31,6 +49,7 @@ ul.gn-resultview, [data-gn-user-searches-list] {
 // styling for all search results
 ul.gn-resultview {
   @thumbnail-width: 140px;
+
   margin-right: -15px;
   
   .metadata {
@@ -41,232 +60,212 @@ ul.gn-resultview {
     height: 100%;
     z-index: 2050;
   }
-  li.list-group-item {
+  // select
+  .gn-md-select {
+    position: absolute;
+    margin-left: -15px;
+    padding: 5px 10px;
+    background-color: #fff;
+    border-right: 1px solid @panel-default-border;
+    border-bottom: 1px solid @panel-default-border;
+  }
+  // thumbnail
+  .gn-md-thumbnail {
+    overflow: hidden;
+    width: @thumbnail-width;
+    border-radius: 0;
+    background-color: #fff;
+    .gn-img-thumbnail {
+      border: 0;
+      max-width: 100%;
+      max-height: 140px;
+      min-height: 40px;
+      height: auto;
+    }
+  }
+  // status
+  .gn-status, .gn-workflow-status {
+    position: relative;
+    float: left;
+    color: darken(@brand-info, 25%);
+  }
+  .gn-status-completed {
+    color: darken(@brand-success, 20%);
+  }
+  .gn-status-historicalArchive {
+    color: darken(@brand-warning, 20%);
+  }
+  .gn-status-obsolete {
+    color: darken(@brand-danger, 20%);
+  }
+  .gn-workflow-status {
+    background-color: rgba(255, 255, 255 , 0.7);
+    border-color: darken(@brand-success, 5%);
+    color: @brand-success;
+  }
+  /* Decide here which status should be displayed
+  or not and with which colors */
+  .gn-workingcopy-status {
+    margin-top: 0;
+    i {
+      height: 34px;
+      width: 34px;
+      margin-top: -1px;
+    }
+  }
+    
+  @gn-card-height: 24em;
+  @gn-card-header-height: 60px;
+  @gn-card-footer-height: 52px;
+
+  .gn-card {
+    padding: 0;
+    border-radius: 2px;
+    .gn-card-heading {
+      height: @gn-card-header-height;
+      padding-left: 0;
+      .gn-md-title {
+        .fa {
+          display: table-cell;
+          font-size: 18px;
+          padding: 10px;
+          vertical-align: middle;
+        }
+        h1 {
+          margin: 0;
+          padding: 0 10px 0 0;
+          height: @gn-card-header-height;
+          font-size: 16px;
+          display: table-cell;
+          line-height: 1.3em;
+          vertical-align: middle;
+          font-weight: normal;
+          a {
+            color: #333333;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            display: block;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+          }
+          a:hover {
+            color: #428bca;
+            text-decoration: none;
+          }
+        }
+      }
+    }
+    .gn-card-body {
+      height: calc(~"@{gn-card-height} - @{gn-card-header-height} - @{gn-card-footer-height}");
+      overflow: auto;
+      .gn-md-thumbnail {
+        float: left;
+      }
+      .gn-md-details {
+        width: calc(~"100% - @{thumbnail-width} - 15px");
+        float: left;
+      }
+      .gn-md-category {
+        display: block;
+        float: left;
+        margin-left: 18px;
+      }
+      .gn-md-abstract {
+        p {
+          margin-bottom: 0;
+          &:empty {
+            display: none;
+          }
+        }
+        .ellipsis {
+          height: calc(~"@{gn-card-height} - @{gn-card-header-height} - @{gn-card-footer-height} - 98px");
+          p {
+            margin-bottom: 10px;
+          }
+          &:before {
+            height: calc(~"@{gn-card-height} - @{gn-card-header-height} - @{gn-card-footer-height} - 98px");
+          }
+          &:after {
+            background: none;
+            top: -19px;
+          }
+        }
+      }
+    }
+    .gn-card-footer {
+      padding: 5px 10px 5px 0;
+      height: calc(~"@{gn-card-footer-height} - 2px");
+      .gn-toolbar {
+        .gn-md-links {
+          background: none;
+          .dropdown-menu {
+            li {
+              a {
+                padding: 8px 20px;
+              }
+              &.divider {
+                &:hover {
+                  background-color: #e5e5e5;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    &:hover {
+      background: #fff;
+    }
+  }
+
+  li.gn-grid {
     margin-right: 15px;
     margin-bottom: 15px;
-    border-radius: 4px;
-    border: none;
-    &:hover {
-      background-color: rgba(10, 10, 10, 0.05);
-      cursor: default;
-    }
-    .row:first-of-type {
-      padding-left: 3px;
-    }
-    
-    .gn-md-thumbnail {
-      .gn-img-thumbnail {
-        max-width: @thumbnail-width;
-        height: auto;
-      }
-    }
-    .media {
-      a {
-        margin-left: 0;
-        &.gn-md-edit-btn {
-          width: 12px;
-          margin-left: 10px;
-          
-        }
-      }
-      h4 {
-        margin-top: 0;
-        font-weight: 700;
-        a {
-          color: rgb(51, 51, 51);
-        }
-      }
-    }
-  }
-  
-  .gn-md-title {
-    margin-top: 10px;
-    overflow: hidden;
-    cursor: pointer;
-    h3 {
-      margin-top: 0;
-      line-height: 1.1em;
-      a {
-        font-weight: normal;
-        font-size: 80%;
-        color: #333333;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        display: block;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-      }
-      a:hover {
-        color: #428bca;
-        text-decoration: none;
-      }
-    }
-  }
-  .gn-md-abstract {
-    cursor: pointer;
-    color: @gray-darker;
-  }
-  .gn-md-abstract.ellipsis:after {
-    background: none;
-  }
-  
-  li.gn-grid {
-    @grid-bottom-margin: 2px;
-    
     float: left;
-    border: 1px solid @list-group-border;
-    min-width: 300px;
-    max-width: 500px;
-    width: calc(~"100% - 15px");
-    height: 24em;
-    padding: 14px;
-    .gn-md-details {
-      color: #6a6a6a;
-      max-height: 50px;
-      overflow: hidden;
-      text-overflow: ellipsis;
+    .gn-md-select {
+      position: relative;
+      display: table-cell;
+      vertical-align: middle;
     }
-    /* Properly align category icons */
-    .fa img {
-      vertical-align: text-bottom;
-    }
-    .gn-md-title {
-      margin-bottom: 5px;
-      min-height: 4em;
-      max-height: 4em;
-    }
-    input {
-      float: left;
-    }
-    .gn-md-links {
-      background: none;
-      padding: 5px;
-    }
-    [gn-grid-related] {
-      padding: 5px;
-      margin: 2px;
-    }
-    .gn-toolbar {
-      position: absolute;
-      bottom: 0px;
-      right: 0px;
-    }
-    .gn-md-thumbnail {
-      overflow: hidden;
-      cursor: pointer;
-      .gn-img-thumbnail {
-        max-width: @thumbnail-width;
-        max-height: 140px;
-        min-height: 40px;
-        height: auto;
-      }
-    }
-    
-    .gn-md-category {
-      display: block;
-      float: left;
-      margin-left: 18px;
+    &:hover {
+      color: #000;
     }
   }
   li.gn-list {
+    padding: 0 0 5px 0;
+    margin-right: 15px;
+    &:hover {
+      background: #fff;
+      color: #000;
+    }
+    &:first-child {
+      margin-top: 15px;
+    }
     .gn-md-title {
-      h1 {
-        line-height: 1.3em;
-        font-size: 20px;
-        margin-top: 0;
-        padding-top: 5px;
-        a {
-          color: #333;
-          &:hover {
-            color: #000;
-          }
-          .fa {
-            display: inline;
-          }
-        }
-        .md-title {
-          display: block;
-          float: right;
-          width: calc(~"100% - 50px");
-        }
-      }
-    }
-    .gn-md-category {
-      a {
-        margin-left: 5px;
-      }
-    }
-    .gn-md-logo {
-      margin-top: 5px;
-      img {
-        max-width: 100%;
+      .fa {
+        padding-left: 0 !important;
       }
     }
     .gn-md-thumbnail {
-      border-radius: 0;
-      margin-top: 5px;
+      margin-top: 15px;
+      margin-bottom: 15px;
     }
-    .gn-status, .gn-workflow-status {
-      position: relative;
-      float: left;
-      color: darken(@brand-info, 25%);
-    }
-    .gn-status-completed {
-      color: darken(@brand-success, 20%);
-    }
-    .gn-status-historicalArchive {
-      color: darken(@brand-warning, 20%);
-    }
-    .gn-status-obsolete {
-      color: darken(@brand-danger, 20%);
-    }
-    .gn-workflow-status {
-      background-color: rgba(255, 255, 255 , 0.7);
-      border-color: darken(@brand-success, 5%);
-      color: @brand-success;
-    }
-    /* Decide here which status should be displayed
-    or not and with which colors */
-    .gn-workingcopy-status {
-      margin-top: 0;
-      i {
-        height: 34px;
-        width: 34px;
-        margin-top: -1px;
-      }
-    }
-    .gn-md-abstract {
-      p {
-        font-size: 1em;
-        color: @text-muted;
-        &:empty {
-          display: none;
+    .gn-card {
+      // recalculate the height for list items
+      @gn-card-height: 100%;
+
+      height: @gn-card-height;
+      .gn-card-body {
+        height: calc(~"@{gn-card-height} - @{gn-card-header-height} - @{gn-card-footer-height}");
+        .gn-md-abstract {
+          .ellipsis, .ellipsis:before {
+            height: calc(~"@{gn-card-height} - @{gn-card-header-height} - @{gn-card-footer-height} - 25px");
+          }
         }
       }
-      address {
-        margin-bottom: 5px;
-      }
-      .collapse-text-toggle {
-        color: @brand-primary;
-      }
-    }    
-    .gn-md-links {
-      background: 0;
-      margin-top: 10px;
-      border-bottom: 1px solid @list-group-border;
-      padding-bottom: 10px;
-      line-height: 1em;
-      .btn {
-        margin-right: 5px;
-        .caret {
-          margin-left: 3px;
-        }
-      }
-    }
-    &:hover {
-      background-color: rgba(240, 240, 240, 0.5)
     }
   }
+
 }
 
 /* Extra small devices (phones, less than 768px) */
@@ -281,7 +280,6 @@ ul.gn-resultview {
 
 /* Medium devices (desktops, 992px and up) */
 @media (min-width: @screen-md-min) {
-  
   ul.gn-resultview li.gn-grid {
     width: calc(~"50% - 15px");
   }
@@ -289,9 +287,8 @@ ul.gn-resultview {
 
 /* Large devices (large desktops, 1200px and up) */
 @media (min-width: @screen-lg-min) {
-  
   ul.gn-resultview li.gn-grid {
-    //width: calc(~"33% - 15px");
+    width: calc(~"(100% / 3) - 15px");
   }
 }
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -4,6 +4,7 @@
 
 // general
 @gn-border-radius: 3px;
+@gn-outline: 5px auto -webkit-focus-ring-color;
 
 // override bootstrap variables
 @badge-bg: @gray;
@@ -62,10 +63,10 @@
 @gn-info-background-color: @body-bg;
 // ----- resultcards
 @gn-resultcard-background-color: @body-bg;
-@gn-resultcard-title-background-color: #505050;
-@gn-resultcard-title-background-color-hover: #333;
-@gn-resultcard-title-color: #fff; // @navbar-default-link-color;
-@gn-resultcard-title-border: 0px solid @navbar-default-border;
+@gn-resultcard-title-background-color: @panel-default-heading-bg;
+@gn-resultcard-title-background-color-hover: @panel-default-heading-bg;
+@gn-resultcard-title-color: @panel-default-text;
+@gn-resultcard-title-border: 1px solid @panel-default-border;
 
 // search results page
 @gn-results-background-color: @body-bg;

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -8,7 +8,7 @@
       <div class="col-md-3 gn-search-facet">
 
         <div data-ng-show="searchResults.records.length > 0"
-            data-gn-saved-selections-panel="user"></div>
+             data-gn-saved-selections-panel="user"></div>
 
         <div data-gn-user-searches-panel="user"
              data-ng-if="isUserSearchesEnabled && user.isConnected()"></div>
@@ -21,71 +21,72 @@
 
         <div class="panel panel-default"
            data-ng-show="searchResults.records.length > 0">
-        <div class="panel-body">
-          <div data-es-facets="searchResults.facets"/>
+          <div class="panel-body">
+            <div data-es-facets="searchResults.facets"/>
           </div>
         </div>
       </div>
+      <!-- /.gn-search-facet -->
 
     <div class="col-md-9 container-fluid">
       <div class="row gn-row-tools">
         <div class="col-xs-12 col-sm-6 col-sm-push-3 text-center"
-          data-ng-show="searchResults.records.length > 0">
+             data-ng-show="searchResults.records.length > 0">
           <div class=""
-              data-gn-pagination="paginationInfo"
-              data-hits-values="searchObj.hitsperpageValues"
-              data-enable-hot-keys=""
-              data-enable-events=""></div>
+               data-gn-pagination="paginationInfo"
+               data-hits-values="searchObj.hitsperpageValues"
+               data-enable-hot-keys=""
+               data-enable-events=""></div>
         </div>
 
-        <div class="col-xs-6 col-sm-3 col-sm-pull-6 col-lg-pull-6"
+        <div class="col-xs-6 col-sm-3 col-sm-pull-6 col-lg-pull-6 gn-nopadding-left"
           data-ng-show="searchResults.records.length > 0">
           <div data-gn-selection-widget=""
-                data-results="searchResults"></div>
+               data-results="searchResults"></div>
         </div>
 
-        <div class="col-xs-6 col-sm-3"
+        <div class="col-xs-6 col-sm-3 gn-nopadding-right"
           data-ng-show="searchResults.records.length > 0">
           <div class="pull-right"
                data-gn-results-tpl-switcher=""></div>
           <div class="pull-right"
-              data-sortby-combo=""
-              data-params="searchObj.params"
-              data-gn-sortby-values="searchObj.sortbyValues"></div>
+               data-sortby-combo=""
+               data-params="searchObj.params"
+               data-gn-sortby-values="searchObj.sortbyValues"></div>
         </div>
-    </div>
+      </div>
+      <!-- /.gn-row-tools -->
 
+      <div class="row">
+        <div class="col-xs-12 gn-nopadding-left gn-nopadding-right">
+          <span class="loading fa fa-spinner fa-spin"
+                data-ng-show="searching"></span>
 
-    <div class="row">
-      <div class="col-xs-12">
-        <span class="loading fa fa-spinner fa-spin"
-              data-ng-show="searching"></span>
+          <div class="alert alert-warning" role="alert"
+               ng-if="!searching && searchResults.count == 0">
+            <i class="fa fa-frown-o"></i>
+            <span data-translate="">zarooResult</span>
+          </div>
 
-        <div class="alert alert-warning" role="alert"
-            ng-if="!searching && searchResults.count == 0">
-          <i class="fa fa-frown-o"></i>
-          <span data-translate="">zarooResult</span>
+          <div data-ng-show="searchResults.records.length > 0"
+               data-gn-results-container=""
+               data-search-results="searchResults"
+               data-template-url="resultTemplate"
+               data-map="searchObj.searchMap"></div>
         </div>
-
-        <div data-ng-show="searchResults.records.length > 0"
-            data-gn-results-container=""
-            data-search-results="searchResults"
-            data-template-url="resultTemplate"
-            data-map="searchObj.searchMap"></div>
       </div>
-    </div>
 
-    <div class="row">
-      <div class="col-xs-12 text-center"
-      data-ng-show="searchResults.records.length > 0">
-        <div class=""
-              data-gn-pagination="paginationInfo"
-              data-hits-values="searchObj.hitsperpageValues"
-              data-enable-hot-keys=""
-              data-enable-events=""></div>
+      <div class="row gn-row-tools">
+        <div class="col-xs-12 text-center"
+             data-ng-show="searchResults.records.length > 0">
+          <div class=""
+               data-gn-pagination="paginationInfo"
+               data-hits-values="searchObj.hitsperpageValues"
+               data-enable-hot-keys=""
+               data-enable-events=""></div>
+        </div>
       </div>
-    </div>
-    <br>
+      <br>
 
 
     </div>


### PR DESCRIPTION
Replaces https://github.com/geonetwork/core-geonetwork/pull/4917 and https://github.com/geonetwork/core-geonetwork/pull/4920

This PR restyles the search results. The aim was to simplify the look of the search page. The `List` and `Grid` are rewritten, a lot of information has been removed from the list items to get a cleaner look.

Furthermore, borders are removed from the toolbar (select, re-order) in order to make it lighter and put more focus on the results than on the toolbar.

Changes:
- rewrite cards and list style
- restyled and repositioned the select option (checkbox)
- 3 columns (was 2) on wider screens
- removed some information to declutter the card and list items
- toolbar buttons without borders

**`Grid` view after the changes**
![gn-grid-new](https://user-images.githubusercontent.com/19608667/89897220-0073cb00-dbdf-11ea-949a-25052db7eb85.png)

**`List` view after the changes**
![gn-list-new](https://user-images.githubusercontent.com/19608667/89897240-0669ac00-dbdf-11ea-905a-f51d3afa2593.png)