### PR TITLE
Home / Aggregation config

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -239,6 +239,7 @@
                 var itemPath = facetModel.path.concat([bucket.key + '']);
                 var facet = {
                   value: bucket.key,
+                  meta: bucket.meta,
                   count: bucket.doc_count,
                   path: itemPath
                 };

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -651,6 +651,7 @@ goog.require('gn_alert');
 
           this.gnCfg.mods.search.scoreConfig = config.mods.search.scoreConfig;
           this.gnCfg.mods.search.facetConfig = config.mods.search.facetConfig;
+          this.gnCfg.mods.home.facetConfig = config.mods.home.facetConfig;
         }
 
         this.gnUrl = gnUrl || '../';

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -93,13 +93,15 @@
         </h4>
         <div class="row">
           <span data-ng-show="homeFacet.key !== 'inspireThemeUri'"
+                data-ng-init="aggResponse = searchInfo.aggregations[homeFacet.key]"
                 data-ng-repeat="facet in searchInfo.aggregations[homeFacet.key].buckets"
                 class="col-xs-12 col-sm-6 col-md-4 chips-card">
             <div class="badge-result badge-result-topic clearfix">
               <a class="pull-left clearfix"
                 title="{{facet.key}}"
                 role="link"
-                data-ng-href='#/search?query_string={"{{homeFacet.key}}": {"{{facet.key}}": true} }'>
+                data-ng-init="field = (aggResponse.meta && aggResponse.meta.field) || homeFacet.key"
+                data-ng-href='#/search?query_string={"{{field}}": {"{{facet.key}}": true} }'>
 
                 <!-- TODOES Link label to icons? -->
                 <span class="badge-icon badge-result-topic pull-left">


### PR DESCRIPTION
* Always gives priority to custom config (inspiretheme and topic config was merged into custom)
* Preserve aggregations meta element in response (see https://www.elastic.co/guide/en/elasticsearch/reference/current/agg-metadata.html)
* Add possibility to create a facet with a custom name and properly
target the proper field

eg. Aggregations on a subset of tag field with a custom label
```json

{
  "IDP_DPSIR": {
    "terms": {
      "field": "tag",
      "size": 34,
      "include": "IDP_DPSIR.*|IDP_dpsir."
    },
    "meta": {
      "field": "tag"
    }
  },
  "IDP_TOPICS": {
    "terms": {
      "field": "thesaurus_EEAkeywordlist",
      "size": 34,
      "include": "IDP_topics.*"
    },
    "meta": {
      "field": "tag"
    }
  }
}

```

![image](https://user-images.githubusercontent.com/1701393/90118558-b6aef000-dd58-11ea-8a0a-efd3e74612c3.png)
