### PR TITLE
Make Info blocks on the homepage look more like the blocks on the results page

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_infolist.less
+++ b/web-ui/src/main/resources/catalog/style/gn_infolist.less
@@ -37,7 +37,7 @@
         padding: 10px;
         h4 {
           font-size: 18px;
-          font-weight: 300;
+          font-weight: 500;
           margin: 0;
         }
       }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_infolist_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_infolist_default.less
@@ -3,44 +3,59 @@
 
 // row for the info lists
 .gn-row-info {
-    padding: 30px 20px 40px 20px;
-    background-color: @gn-info-background-color;
-    .nav-pills {
-      text-align: left !important;
-      border-bottom: 1px solid #ddd;
-      padding-bottom: 10px;
-    }
+  padding: 30px 20px 40px 20px;
+  background-color: @gn-info-background-color;
+  .nav-pills {
+    text-align: left !important;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 10px;
   }
-  
-  // custom colors for the blocks in the info list
-  .gn-info-list-blocks {
-    .gn-info-list {
-      li {
-        .resultcard {
-          .title {
-            background: @gn-resultcard-title-background-color;
-            border: @gn-resultcard-title-border;
-            border-bottom: 0;
+}
+
+// custom colors for the blocks in the info list
+.gn-info-list-blocks {
+  .gn-info-list {
+    li {
+      .resultcard {
+        .title {
+          background: @gn-resultcard-title-background-color;
+          border: @gn-resultcard-title-border;
+          border-bottom: 0;
+          a {
             h4 {
               color: @gn-resultcard-title-color;
-              font-weight: normal;
+              font-size: 14px;
+              font-weight: 700;
+              &:hover {
+                text-decoration: none !important;
+              }
+            }
+            &:hover {
+              text-decoration: none !important;
+              h4 {
+                color: #428bca !important;
+                text-decoration: none !important;
+              }
             }
           }
         }
-        .resultcard.hasThumbnail {
-          &:hover {
-            .title {
-              background: @gn-resultcard-title-background-color-hover;
-            }
-          }
-        }
+      }
+      .resultcard.hasThumbnail {
         &:hover {
-          .resultcard {
-            .title {
-              background: @gn-resultcard-title-background-color-hover;
-            }
+          .title {
+            transition: background-color ease 0.5s;
+            background-color: @gn-resultcard-title-background-color-hover;
+          }
+        }
+      }
+      &:hover {
+        .resultcard {
+          .title {
+            transition: background-color ease 0.5s;
+            background-color: @gn-resultcard-title-background-color-hover;
           }
         }
       }
     }
   }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -145,6 +145,7 @@ ul.gn-resultview {
     .gn-card-heading {
       height: @gn-card-header-height;
       padding-left: 0;
+      border-radius: 0;
       .gn-md-title {
         .fa {
           display: table-cell;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -64,7 +64,7 @@
 // ----- resultcards
 @gn-resultcard-background-color: @body-bg;
 @gn-resultcard-title-background-color: @panel-default-heading-bg;
-@gn-resultcard-title-background-color-hover: @panel-default-heading-bg;
+@gn-resultcard-title-background-color-hover: darken(@panel-default-heading-bg, 5%);;
 @gn-resultcard-title-color: @panel-default-text;
 @gn-resultcard-title-border: 1px solid @panel-default-border;
 


### PR DESCRIPTION
This PR aims to make `Info blocks` on the homepage look more like the blocks on the results page:
- same font size
- same color
- same title background color on hover