### PR TITLE
LDAP changes for AD and other configurations

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/AbstractLDAPUserDetailsContextMapper.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/AbstractLDAPUserDetailsContextMapper.java
@@ -41,10 +41,7 @@ import org.springframework.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Map LDAP user information to GeoNetworkUser information.
@@ -112,6 +109,16 @@ public abstract class AbstractLDAPUserDetailsContextMapper implements
 
         if (this.isLdapUsernameCaseInsensitive()) {
             username = username.toLowerCase();
+        }
+
+        //pass DN along.
+        // NOTE: LDAPUser doesn't allow you to set DN!!!
+        if (!userInfo.containsKey("dn")) {
+            ArrayList dns = new ArrayList(Arrays.asList(
+                    userCtx.getDn().toString(),   //will not include base
+                    userCtx.getNameInNamespace() // includes base
+                ));
+            userInfo.put("dn", dns);
         }
 
         LDAPUser userDetails = new LDAPUser(username);

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
@@ -120,7 +120,7 @@ public class LDAPUtils {
             toSave = user.getUser();
         }
         toSave.getSecurity().setAuthType(LDAPConstants.LDAP_FLAG);
-        toSave.getSecurity().setPassword(User.getRandomPassword()); //Oracle doesn't allow a password as '' (interpreted as null)
+        toSave.getSecurity().setPassword("NULL"); //Oracle doesn't allow a password as '' (interpreted as null)
         toSave = userRepo.save(toSave);
         user.setUser(toSave);
         return toSave;

--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
@@ -120,6 +120,7 @@ public class LDAPUtils {
             toSave = user.getUser();
         }
         toSave.getSecurity().setAuthType(LDAPConstants.LDAP_FLAG);
+        toSave.getSecurity().setPassword(User.getRandomPassword()); //Oracle doesn't allow a password as '' (interpreted as null)
         toSave = userRepo.save(toSave);
         user.setUser(toSave);
         return toSave;


### PR DESCRIPTION
I noticed there were some differences between (Active Directory) AD and the test LDAP that is used in the test cases.

a) I gave more options for full-name CNs for membership searching
b) I am ignoring PartialResultException 
       These occur when you search from the very top of the AD LDAP.
        Its, basically, a link that says "go get results from over here."
        In almost all cases, you don't need to follow these (but it will throw an exception).

Fixed bug - LDAP sets passwords as '' (empty string).  Oracle interprets '' as NULL.  This causes a constraint error since password cannot be null.  I've replaced '' with a random password.