### PR TITLE
Fix: Improved nesting of DIVS to solve issue of overlapping footer in list items on results page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -27,47 +27,49 @@
             {{md.resourceTitle}}</a>
         </h1>
       </div>
-      <div class="panel-body gn-card-body">
-        <div class="row">
-          <div class="col-lg-2 col-md-3 col-sm-3">
-            <div class="gn-md-thumbnail">
-              <div class="gn-md-no-thumbnail"
-                   data-ng-if="!md.overview[0].url"></div>
-              <img class="gn-img-thumbnail"
-                   alt="{{md.title || md.defaultTitle}}"
-                   data-ng-src="{{md.overview[0].url}}?size=250"
-                   data-ng-if="md.overview[0].url"/>
-            </div>
+    </div>
+    <!-- /.gn-card-heading -->
+    <div class="panel-body gn-card-body">
+      <div class="row">
+        <div class="col-lg-2 col-md-3 col-sm-3">
+          <div class="gn-md-thumbnail">
+            <div class="gn-md-no-thumbnail"
+                  data-ng-if="!md.overview[0].url"></div>
+            <img class="gn-img-thumbnail"
+                  alt="{{md.title || md.defaultTitle}}"
+                  data-ng-src="{{md.overview[0].url}}?size=250"
+                  data-ng-if="md.overview[0].url"/>
           </div>
-          <div class="col-lg-6 col-md-6 col-sm-6">
-            <div class="gn-md-abstract text-muted">
-              <p title="{{md.resourceAbstract}}">{{md.resourceAbstract.split('.')[0] | striptags}}.</p>
-              <div gn-grid-related=""
-                   gn-grid-related-uuid="::md.uuid"
-                   template="../../catalog/views/default/templates/gridRelatedList.html"></div>
-            </div>
+        </div>
+        <div class="col-lg-6 col-md-6 col-sm-6">
+          <div class="gn-md-abstract text-muted">
+            <p title="{{md.resourceAbstract}}">{{md.resourceAbstract.split('.')[0] | striptags}}.</p>
+            <div gn-grid-related=""
+                 gn-grid-related-uuid="::md.uuid"
+                 template="../../catalog/views/default/templates/gridRelatedList.html"></div>
           </div>
-          <div class="col-lg-4 col-md-3 col-sm-3">
-            <div class="gn-md-contact">
-              <p data-ng-repeat="c in ::md.getAllContacts().resource | limitTo: 4 track by $index">
-                <img data-ng-if="::c.logo"
-                     data-ng-src="{{::c.logo}}"
-                     class="gn-source-logo"
-                     title="{{::c.organisation}} ({{::c.role}})"/>
-                {{::c.organisation}} ({{::c.role | translate}})
-              </p>
-            </div>
+        </div>
+        <div class="col-lg-4 col-md-3 col-sm-3">
+          <div class="gn-md-contact">
+            <p data-ng-repeat="c in ::md.getAllContacts().resource | limitTo: 4 track by $index">
+              <img data-ng-if="::c.logo"
+                    data-ng-src="{{::c.logo}}"
+                    class="gn-source-logo"
+                    title="{{::c.organisation}} ({{::c.role}})"/>
+              {{::c.organisation}} ({{::c.role | translate}})
+            </p>
           </div>
         </div>
       </div>
     </div>
+    <!-- /.gn-card-body -->
     <div class="panel-footer gn-card-footer clearfix">
       <div class="gn-toolbar">
         <div class="pull-left gn-md-category"
              title="{{'listOfCategories' | translate}}"
              data-ng-class="md.category.length > 0 ||
-                                md.topic.length > 0 ||
-                                md.inspireThemeUri.length > 0 ? '' : 'invisible'">
+                            md.topic.length > 0 ||
+                            md.inspireThemeUri.length > 0 ? '' : 'invisible'">
           <i class="fa"
              data-ng-repeat="cat in ::md.category"
              title="{{('cat-' + cat) | translate}}"
@@ -95,6 +97,6 @@
         </div>
       </div>
     </div>
-    </div>
+    <!-- /.gn-card-footer -->
   </li>
 </ul>

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -706,14 +706,13 @@ button.active [role=tooltip] {
   border: none;
 }
 .gn-related-list {
-  padding: 0;
+  padding: 2px 0;
   list-style: none;
   > li {
-    padding-left: 15px;
     &:hover {
       text-decoration: none;
       color: #262626;
-      background-color: #f5f5f5;
+      background-color: transparent;
     }
     &.gn-related-type {
       padding-left: 15px;
@@ -726,9 +725,6 @@ button.active [role=tooltip] {
       &:first-letter {
         text-transform: uppercase;
       }
-    }
-    &:not(.gn-related-type) {
-      font-size: 12px;
     }
   }
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -136,6 +136,7 @@ ul.gn-resultview {
   }
 
   @gn-card-height: 24em;
+  @gn-card-list-height: 300px;
   @gn-card-header-height: 60px;
   @gn-card-footer-height: 52px;
 
@@ -236,6 +237,12 @@ ul.gn-resultview {
                 }
               }
             }
+            .dropdown-header {
+              &:hover {
+                background: none;
+                cursor: auto;
+              }
+            }
           }
         }
       }
@@ -263,9 +270,10 @@ ul.gn-resultview {
   }
 
   li.gn-list {
-    &.panel {
-      margin-bottom: 10px;
-      height: 250px;
+    padding: 0;
+    margin-right: 15px;
+    &:first-child {
+      margin-top: 15px;
     }
     &:hover {
       background-color: #eee;
@@ -275,12 +283,15 @@ ul.gn-resultview {
       padding-left: 10px;
       height: 40px;
       line-height: 1.2em;
+      .fa {
+        padding-left: 0 !important;
+      }
     }
-    .panel-heading, h1 {
+    .gn-card-heading, h1 {
       height: 40px !important;
       line-height: 1.2em;
     }
-    .panel-body {
+    .gn-card-body {
       padding-top: 2px;
       padding-bottom: 2px;
       .col-md-2 {
@@ -296,39 +307,19 @@ ul.gn-resultview {
       .gn-md-contact {
         margin-top: 15px;
       }
-    }
-    padding: 0 0 5px 0;
-    margin-right: 15px;
-    &:first-child {
-      margin-top: 15px;
-    }
-    .gn-md-title {
-      .fa {
-        padding-left: 0 !important;
+      .gn-md-thumbnail {
+        margin-top: 15px;
+        margin-bottom: 15px;
       }
     }
-    .gn-md-thumbnail {
-      margin-top: 15px;
-      margin-bottom: 15px;
-    }
-    .gn-card {
-      // recalculate the height for list items
-      @gn-card-height: 100%;
-
-      height: @gn-card-height;
-      .gn-card-body {
-        height: calc(~"@{gn-card-height} - @{gn-card-header-height} - @{gn-card-footer-height}");
-        .gn-md-abstract {
-          .ellipsis, .ellipsis:before {
-            height: calc(~"@{gn-card-height} - @{gn-card-header-height} - @{gn-card-footer-height} - 25px");
-          }
+    // recalculate the height for list items
+    .gn-card-body {
+      height: calc(~"@{gn-card-list-height} - @{gn-card-header-height} - @{gn-card-footer-height}");
+      .gn-md-abstract {
+        .ellipsis, .ellipsis:before {
+          height: calc(~"@{gn-card-list-height} - @{gn-card-header-height} - @{gn-card-footer-height} - 25px");
         }
       }
-    }
-    .panel-footer {
-      position: absolute;
-      bottom: 0px;
-      width: 100%;
     }
   }
 }


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/pull/4929#issuecomment-674842278

Improved nesting of `<div>`s to solve the overlapping footer issue in the list view on the results page. 

When there's a lot of content in the list view, there will be a scrollbar.

**Screenshot with scrollbar** (dummy links)
![gn-list-scrollbar](https://user-images.githubusercontent.com/19608667/90494287-a37a9680-e143-11ea-8f8b-eda53272c016.png)

Other changes:
- changed padding and background color for the links in the list view.
- no hover background for list dividers in dropdown menu