### PR TITLE
Fix for the Admin Settings getting stuck

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -84,12 +84,9 @@
              e.offset().top :
              e.position().top;
           }
-          $('body,html').animate({scrollTop: top},
-           duration, easing, function() {
-              if (e.length == 1) {
-                e.fadeOut('slow', function() {e.fadeIn()});
-              }
-            });
+
+          $('body,html').scrollTop(top);
+
           $location.search('scrollTo', elementId);
         };
 

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -197,7 +197,7 @@
                 if (target) {
                   $timeout(function () {
                     gnUtilityService.scrollTo(target);
-                  }, 300);
+                  }, 900);
                 }
               }
             }).error(function(data) {


### PR DESCRIPTION
In the admin settings page you can open a table of content on the right side of the page (by clicking the button in the lower right corner). Clicking on one of the links takes you the section in the page. This has a smooth scrolling effect. The section ID is added in the url.

However when you refresh the page, or some other browsing on the page and the menu can get stuck. This prevents you from scrolling in the page.

With some trial and error the problem was in the combination of the animation effect and the ID in the url. Somehow the animation and trying to scroll to the section from the url got stuck in some sort of loop. The animation wasn't finished yet and the script for going to the section in the page was already triggered, causing the scrolling to get stuck. _It is difficult to explain_.

This PR solves the problem by removing the animation, so going to the section is fast, and increasing the timeout for scrolling to the ID from the url.

**The settings menu:**
![gn-admin-settings](https://user-images.githubusercontent.com/19608667/90526507-c40d1580-e170-11ea-9b49-2532f9f26ca5.png)

Changes:
- remove the scroll. animation
- increase the timeout