### PR TITLE
Allow GeoNetwork datadir from tomcat context Parameter

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -161,9 +161,9 @@ public class GeonetworkDataDirectory {
                 case 1:
                     if (jeevesServlet != null) {
                         value = jeevesServlet.getInitParameter(keyToUse);
-                    }
-                    if ( (value == null) && (jeevesServlet != null) && (jeevesServlet.getServletContext() != null) ){
-                        value = jeevesServlet.getServletContext().getInitParameter(keyToUse);
+                        if ( (value == null) && (jeevesServlet.getServletContext() != null) ){
+                            value = jeevesServlet.getServletContext().getInitParameter(keyToUse);
+                        }
                     }
                     break;
                 case 2:

--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -162,7 +162,7 @@ public class GeonetworkDataDirectory {
                     if (jeevesServlet != null) {
                         value = jeevesServlet.getInitParameter(keyToUse);
                     }
-                    if ( (value == null) && (jeevesServlet.getServletContext() != null) ){
+                    if ( (value == null) && (jeevesServlet != null) && (jeevesServlet.getServletContext() != null) ){
                         value = jeevesServlet.getServletContext().getInitParameter(keyToUse);
                     }
                     break;

--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -162,6 +162,9 @@ public class GeonetworkDataDirectory {
                     if (jeevesServlet != null) {
                         value = jeevesServlet.getInitParameter(keyToUse);
                     }
+                    if ( (value == null) && (jeevesServlet.getServletContext() != null) ){
+                        value = jeevesServlet.getServletContext().getInitParameter(keyToUse);
+                    }
                     break;
                 case 2:
                     value = handlerConfig.getValue(keyToUse);


### PR DESCRIPTION
If you put this in your geonetwork.xml (tomcat context file - TOMCATHOME/conf/Catalina/localhost/geonetwork.xml)

   \<Parameter name="geonetwork.dir" value="C:\\ProgramData\\GeoNetwork\\Data" type="java.lang.String" override="false"/>


It is now read and used to configure the data directory.  Before it was just getting null (and using the default).

This shouldn't cause any backwards compatibility...