### PR TITLE
Show an error message when invalid XML is entered for Manage Directory Template

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -377,20 +377,27 @@
 
       $scope.importEntry = function(xml) {
         gnMetadataManager.importFromXml(
-            gnUrlUtils.toKeyValue($scope.importData), xml).then(
-            function(r) {
-              if (r.status === 400) {
-                $rootScope.$broadcast('StatusUpdated', {
-                  title: $translate.instant('saveMetadataError'),
-                  error: r.data,
-                  timeout: 0,
-                  type: 'danger'});
-              } else {
-                refreshEntriesInfo();
-                $scope.closeEditor();
-              }
+          gnUrlUtils.toKeyValue($scope.importData), xml).then(function(r) {
+            if (r.status === 400) {
+              $rootScope.$broadcast('StatusUpdated', {
+                title: $translate.instant('directoryManagerError'),
+                error: r.data,
+                timeout: 0,
+                type: 'danger'});
+            } else {
+              refreshEntriesInfo();
+              $scope.closeEditor();
             }
-        );
+          })
+          .catch(function(f) {
+            if (f.status === 400) {
+              $rootScope.$broadcast('StatusUpdated', {
+                title: $translate.instant('directoryManagerError'),
+                error: f.data,
+                timeout: 0,
+                type: 'danger'});
+            }
+          });
       };
 
       // ACTIONS

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -368,6 +368,7 @@
     "linkToXmlTab": "Some kind of errors can be fixed using <a href=\"#/metadata/{{metadataId}}?tab=xml\">XML editor</a>.",
     "directoryManagerSubtitle": "This screen allows you to edit directory entries such as contacts, formats, etc. including template management.",
     "directoryManagerSubtitleImport": "Enter here the full XML content of an entry to import it to the database.",
+    "directoryManagerError": "Error when importing the full XML",
     "directoryEntryTypes": "Entry Types",
     "directoryTemplates": "Templates",
     "addNewDirectoryEntry": "Add New Entry",


### PR DESCRIPTION
It is possible to enter manually XML for a `template` when managing a new Directory.

![gn-manage-directory](https://user-images.githubusercontent.com/19608667/90752569-dbb2de00-e2d7-11ea-8046-5c2ad8fd863a.png)

However it is possible to enter invalid XML. When this is done, there is no error message. This PR adds an extra fallback option to show the error message. The contents of the message are also changed to reflect the action done better.

Changes:
- added fallback function
- changed error message