### PR TITLE
[a11y] Combine GN logo and name in one link in the top menu

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -27,19 +27,18 @@
   <div id="navbar" class="navbar-collapse collapse">
     <ul class="nav navbar-nav gn-menu-xs" role="menu">
       <li class="clearfix hidden-xs" data-ng-if="gnCfg.mods.home.enabled">
-        <a class="pull-left gn-logo-link" data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}" data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}">
-          <img class="gn-logo"
-                alt="{{'siteLogo' | translate}}"
-                data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
-        </a>
-        <a class="pull-left hidden-sm"
-           data-ng-if="gnCfg.mods.header.showGNName"
-           data-ng-class="gnCfg.mods.header.isLogoInHeader ? '' : 'gn-nopadding-left'"
+        <a class="pull-left gn-logo-link" 
            data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
+          <img class="gn-logo gn-margin-right"
+               data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}"
+               alt="{{'siteLogo' | translate}}"
+               data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
           <span class="gn-name"
+                data-ng-if="gnCfg.mods.header.showGNName"
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
                 title="{{info['node/name'] || info['system/site/name']}}">
-            {{info['node/name'].split('|')[0] || info['system/site/name']}}</span>
+            {{info['node/name'].split('|')[0] || info['system/site/name']}}
+          </span>
         </a>
       </li>
       <li class="gn-menuitem-xs" data-ng-if="gnCfg.mods.search.enabled">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -57,13 +57,23 @@
     background-color: @gn-menubar-background-active;
     color: @gn-menubar-color-active;
   }
-  .gn-name.gn-truncate {
-    @media (min-width: @screen-lg-min) {
-      max-width: 230px;
-      display: inline-block;
-      .text-overflow();
+  .gn-logo-link {
+    padding: 10px 15px;
+    .gn-logo {
+      margin: -14px 0 0 0;
+    }
+    .gn-name {
+      margin-top: 4px;
+      &.gn-truncate {
+        @media (min-width: @screen-lg-min) {
+          max-width: 230px;
+          display: inline-block;
+          .text-overflow();
+        }
+      }
     }
   }
+
   // also add `display:none`, this doesn't take whitespace on the navbar
   .badge.invisible {
     display: none


### PR DESCRIPTION
This PR combines the 2 links (`<a>`) in the top menu in to 1. The GeoNetwork logo and name are now combined into one. According to Accessibility guidelines this is the preferred way (do not have 2 links with the same URL).