### PR TITLE
don't show language nav-pills if only one language(multi-entry-combiner)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner.html
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner.html
@@ -36,7 +36,7 @@
 
 
 
-  <div class="gn-multilingual-field ">
+  <div class="gn-multilingual-field" ng-if="langs.length > 1">
     <ul class="nav nav-pills">
       <li ng-repeat="langinfo in langs" data-ng-class="{'active': langinfo.lang === currentLang}">
           <a ng-click="changeLang(langinfo.lang)">{{langinfo.isolang|translate}}</a>


### PR DESCRIPTION
Minor change to the UX for multi-entry-combiner.
If there's only one language, don't show the nav pills for language (there's only one so no reason to).