### PR TITLE
Addresses metadata101/iso19115-3:2018#87

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
@@ -1092,20 +1092,20 @@
 
     <xsl:variable name="uuid" select="@uuid"/>
     <xsl:variable name="role" select="../../cit:role/*/@codeListValue"/>
-    <xsl:variable name="email" select="cit:contactInfo/cit:CI_Contact/
+    <xsl:variable name="email" select="cit:contactInfo[1]/cit:CI_Contact/
                              cit:address/cit:CI_Address/
-                             cit:electronicMailAddress/gco:CharacterString|
-                 cit:individual//cit:contactInfo/cit:CI_Contact/
+                             cit:electronicMailAddress/gco:CharacterString[normalize-space()!='']|
+                 cit:individual//cit:contactInfo[1]/cit:CI_Contact/
                                 cit:address/cit:CI_Address/
-                                cit:electronicMailAddress/gco:CharacterString"/>
+                                cit:electronicMailAddress/gco:CharacterString[normalize-space()!='']"/>
     <xsl:variable name="roleTranslation" select="util:getCodelistTranslation('cit:CI_RoleCode', string($role), string($lang))"/>
     <xsl:variable name="logo" select="cit:logo/mcc:MD_BrowseGraphic/mcc:fileName/gco:CharacterString"/>
-    <xsl:variable name="website" select=".//cit:onlineResource/*/cit:linkage/gco:CharacterString"/>
+    <xsl:variable name="website" select="cit:contactInfo[1]//cit:onlineResource[1]/*/cit:linkage/gco:CharacterString"/>
     <xsl:variable name="phones"
-                  select=".//cit:contactInfo/cit:CI_Contact/cit:phone/*/cit:number/gco:CharacterString"/>
+                  select="cit:contactInfo[1]/cit:CI_Contact/cit:phone/*/cit:number/gco:CharacterString"/>
     <!--<xsl:variable name="phones"
                   select="cit:contactInfo/cit:CI_Contact/cit:phone/concat(*/cit:numberType/*/@codeListValue, ':', */cit:number/gco:CharacterString)"/>-->
-    <xsl:variable name="address" select="string-join(cit:contactInfo/*/cit:address/*/(
+    <xsl:variable name="address" select="string-join(cit:contactInfo[1]/*/cit:address/*/(
                                           cit:deliveryPoint|cit:postalCode|cit:city|
                                           cit:administrativeArea|cit:country)/gco:CharacterString/text(), ', ')"/>
     <xsl:variable name="individualNames" select="cit:individual//cit:name/gco:CharacterString"/>


### PR DESCRIPTION
Only include details from the first contactInfo element when indexing responsible party's to more align with the way 19139 records are indexed until
until gmMetadataContact is reworked to handle 19115-3:2018 responsible parties
Difficult to handle all possible combinations until that rework is done.