### PR TITLE
[a11y] Fix for aligning logo and GN name

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -60,7 +60,7 @@
   .gn-logo-link {
     padding: 10px 15px;
     .gn-logo {
-      margin: -14px 0 0 0;
+      margin: 0;
     }
     .gn-name {
       margin-top: 4px;


### PR DESCRIPTION
This PR fixes the misalignement of the Logo image and GeoNetwork name in the menubar. 

This misalignement was cause by PR: https://github.com/geonetwork/core-geonetwork/pull/4950