### PR TITLE
Locale / Avoid double loading / Fix extra ',' causing Wro4J error

### DIFF
--- a/web-ui/src/main/resources/catalog/js/GnLocale.js
+++ b/web-ui/src/main/resources/catalog/js/GnLocale.js
@@ -104,7 +104,7 @@
             method: 'GET',
             url: langUrl,
             headers: {
-              'Accept-Language': options.key,
+              'Accept-Language': options.key
             },
             cache: true
           }).success(function(data) {


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/4965