### PR TITLE
homepage: same typeahead option as in search page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -14,7 +14,9 @@
                 data-ng-keyup="$event.keyCode == 13 && goToSearch(homeAnyField)"
                 data-typeahead="address for address in getAnySuggestions($viewValue)"
                 data-typeahead-loading="anyLoading"
-                data-typeahead-min-length="1"/>
+                data-typeahead-min-length="1"
+                data-typeahead-focus-first="false"
+                data-typeahead-wait-ms="300"/>
           <span class="input-group-btn">
             <a class="btn btn-primary btn-lg"
               type="button"


### PR DESCRIPTION
Adjust typehead home page full text input behavior, to have same as search page behavior.

When we enter text in the main input, we don't want the first suggestion is selected, cause it takes the lead on the "enter" key press over the search action.
We want, when we enter text and we press "enter" that it performs a search with the entered text, and not on the first typehead suggestion.
