### PR TITLE
Add classes to related rows and add to map buttons in the Detail View

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -5,9 +5,9 @@
   <div class=""
        data-ng-repeat="(type, items) in relations track by $index"
        data-ng-if="type && type !== 'thumbnails'">
-    <div class="row list-group-item gn-related-item gn-related-{{type}}"
-         data-ng-repeat="r in items track by $index"
-         data-ng-init="mainType = config.getType(r, type);">
+    <div data-ng-init="mainType = config.getType(r, type);"
+         class="row list-group-item gn-related-item gn-related-{{type}} gn-relation-type-{{mainType}}"
+         data-ng-repeat="r in items track by $index">
       <div class="col-xs-1 col-sm-1">
         <!-- OWS have their name overlaid over the globe icon -->
         <strong data-ng-if="(mainType === 'WMS') || (mainType === 'WMSSERVICE') || (mainType === 'WMTS') ||
@@ -181,7 +181,7 @@
 
       <div class="col-xs-12 col-sm-3">
         <button type="button"
-                class="btn btn-default btn-sm btn-block text-wrap"
+                class="btn btn-default btn-sm btn-block gn-btn-addtomap text-wrap"
                 data-ng-show="hasAction(mainType)"
                 data-ng-click="config.doAction(mainType, r, md)">
 
@@ -196,7 +196,7 @@
         </button>
 
         <button type="button"
-                class="btn btn-default btn-sm btn-block text-wrap"
+                class="btn btn-default btn-sm btn-block gn-btn-addtoexternal text-wrap"
                 data-ng-if="externalViewerActionEnabled
                           && (mainType === 'WMS' || mainType === 'WMSSERVICE')"
                 data-ng-click="externalViewerAction(mainType, r, md)"


### PR DESCRIPTION
PR for adding classes for `TYPE` to related rows and `add to map` buttons in the Detail/Metadata View.

This PR adds classes for `maintype` to the related rows (downloads, etc) and to the `add` buttons on this row. This enables you to target a specific `maintype`.

An example of a class name: 
```
.gn-relation-type-WFS
```
