### PR TITLE
ES / Search / Wrong query results if query base is using OR

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -69,7 +69,7 @@
             var queryExpression = p.any.match(/^q\((.*)\)$/);
             if (queryExpression == null) {
               // var queryBase = '${any} resourceTitleObject.default:(${any})^2',
-              var queryBase = gnGlobalSettings.gnCfg.mods.search.queryBase,
+              var queryBase = '(' + gnGlobalSettings.gnCfg.mods.search.queryBase + ')',
                   defaultQuery = '${any}';
               if (queryBase.indexOf(defaultQuery) === -1) {
                 console.warn('Check your configuration. Query base \'' +


### PR DESCRIPTION
Base query is combined with facet with AND operator and needs to be grouped first.