### PR TITLE
Formatter / Render element as table when configured in edit mode

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -419,11 +419,9 @@
                           count(*/@codeListValue) = 0
                         ]"
                 priority="50">
-
     <xsl:apply-templates mode="render-value" select="@*"/>
     <xsl:apply-templates mode="render-field" select="*"/>
   </xsl:template>
-
 
   <!-- Some major sections are boxed -->
   <xsl:template mode="render-field"
@@ -434,7 +432,6 @@
       gmd:extent[name(..)!='gmd:EX_TemporalExtent']|
       *[$isFlatMode = false() and gmd:* and
         not(gco:CharacterString) and not(gmd:URL)]">
-
     <div class="entry name">
       <h2>
         <xsl:value-of select="tr:nodeLabel(tr:create($schema), name(), null)"/>
@@ -936,9 +933,9 @@
   </xsl:template>
 
   <xsl:template mode="render-value"
-                match="*[gmx:Anchor]">
+                match="*[gmx:Anchor|gmd:URL]">
     <xsl:apply-templates mode="render-value"
-                         select="gmx:Anchor"/>
+                         select="gmx:Anchor|gmd:URL"/>
   </xsl:template>
 
   <xsl:template mode="render-value"

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -68,6 +68,16 @@ header div.gn-abstract {
       }
     }
   }
+
+  dl.gn-table {
+    dt, dd {
+      width: 100% !important;
+      .table {
+        font-size: 14px;
+      }
+    }
+  }
+
   .badge {
     word-break: break-all;
     white-space: normal;

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -31,6 +31,7 @@
                          data-typeahead="address for address in getAnySuggestions($viewValue, searchObj)"
                          data-typeahead-loading="anyLoading"
                          data-typeahead-focus-first="false"
+                         data-typeahead-wait-ms="600"
                          data-typeahead-min-length="1"/>
                   <div class="input-group-btn">
                     <button type="button"


### PR DESCRIPTION
`config-editor.xml` can be used to configure table layout in editor
but it was not use in view mode.

eg.
```xml
<tableFields>
    <table for="gmd:CI_ResponsibleParty">
      <header>
        <col label="gmd:organisationName"/>
```

Render element as table in XSL formatter if configured in editing mode.

* Contact

![image](https://user-images.githubusercontent.com/1701393/92207183-1f394a80-ee89-11ea-8a56-c8fc0280a0e5.png)

* Online resource

![image](https://user-images.githubusercontent.com/1701393/92207162-147eb580-ee89-11ea-88da-1b77dc9991a0.png)

* Custom editor / Instruments & platforms

![image](https://user-images.githubusercontent.com/1701393/92220311-1dc54d80-ee9c-11ea-8111-4c6392b9b24c.png)



