### PR TITLE
User-friendly message for metadata importing

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -62,6 +62,7 @@ import org.fao.geonet.domain.UserGroup;
 import org.fao.geonet.domain.utils.ObjectJSONUtils;
 import org.fao.geonet.events.history.RecordCreateEvent;
 import org.fao.geonet.events.history.RecordImportedEvent;
+import org.fao.geonet.exceptions.BadFormatEx;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.exceptions.XSDValidationErrorEx;
 import org.fao.geonet.kernel.AccessManager;
@@ -556,6 +557,11 @@ public class MetadataInsertDeleteApi {
                         List<String> ids = MEFLib.doImport(version == MEFLib.Version.V1 ? "mef" : "mef2",
                                 uuidProcessing, transformWith, settingManager.getSiteId(), metadataType, category,
                                 group, rejectIfInvalid, assignToCatalog, context, tempFile);
+                        if (ids.isEmpty()) {
+                            //we could have used a finer-grained error handling inside the MEFLib import call (MEF MD file processing)
+                            //This is a catch-for-call for the case when there is no record is imported, to notify the user the import is not successful.
+                            throw new BadFormatEx("Import 0 record, check whether the importing file is a valid MEF archive.");
+                        }
                         ids.forEach(e -> {
                             report.addMetadataInfos(Integer.parseInt(e),
                                     String.format("Metadata imported with ID '%s'", e));


### PR DESCRIPTION
Add a check at the metadata import API to report a user-friendly message instead of blank to the client console upon the event when importing did not succeeded due to somehow the invalid metadata archive.

Discussed with @ianwallen and we decided to submit this PR to address the importing invalid MEF issue our user reported to us. In a word, if the provided MEF file is invalid, the importing task complete without warning nor any information. GN should warn the user the importing is incomplete with some descriptive information. 

Before the change (note the blank message) at the red circle area:
![import_mef_before](https://user-images.githubusercontent.com/64438599/92664884-3043ea80-f2d3-11ea-89e7-b598849504a2.png)

After the change:
![import_mef_after](https://user-images.githubusercontent.com/64438599/92665083-a5172480-f2d3-11ea-92f5-5a784647c860.png)

We like this PR, if approved, be ported into 3.10.4 milestone if possible. Thanks!