### PR TITLE
Thesaurus / Use API path for default namespace.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -693,7 +693,7 @@ public class Thesaurus {
         String namespaceSkos = "http://www.w3.org/2004/02/skos/core#";
         String namespaceDC = "http://purl.org/dc/elements/1.1/";
 
-        URI mySubject = myFactory.createURI(this.getDefaultNamespace(), thesaurusTitle);
+        URI mySubject = myFactory.createURI(this.getDefaultNamespace());
         URI skosClass = myFactory.createURI(namespaceSkos, "ConceptScheme");
         URI titleURI = myFactory.createURI(namespaceDC, "title");
 

--- a/core/src/test/java/org/fao/geonet/kernel/AbstractThesaurusBasedTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AbstractThesaurusBasedTest.java
@@ -36,7 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 @NotThreadSafe  // randomly failing without that
-public abstract class AbstractThesaurusBasedTest {
+public abstract class AbstractThesaurusBasedTest extends org.fao.geonet.AbstractCoreIntegrationTest {
     protected static final String THESAURUS_KEYWORD_NS = "http://abstract.thesaurus.test#";
     protected static final IsoLanguagesMapper isoLangMapper = new IsoLanguagesMapper() {
         {

--- a/core/src/test/java/org/fao/geonet/kernel/AllThesaurusTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AllThesaurusTest.java
@@ -25,6 +25,8 @@ package org.fao.geonet.kernel;
 
 import com.google.common.collect.Maps;
 
+import org.fao.geonet.AbstractCoreIntegrationTest;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.exceptions.TermNotFoundException;
 import org.fao.geonet.kernel.search.keyword.KeywordRelation;
 import org.fao.geonet.kernel.search.keyword.KeywordSearchParamsBuilder;
@@ -36,6 +38,8 @@ import org.openrdf.sesame.config.AccessDeniedException;
 import org.openrdf.sesame.query.MalformedQueryException;
 import org.openrdf.sesame.query.QueryEvaluationException;
 import org.openrdf.sesame.repository.local.LocalRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -63,6 +67,9 @@ public class AllThesaurusTest extends AbstractThesaurusBasedTest {
 
     @Before
     public void setUp() throws Exception {
+        final ConfigurableApplicationContext applicationContext = Mockito.mock(ConfigurableApplicationContext.class);
+        ApplicationContextHolder.set(applicationContext);
+
         Path gcThesaurusFile = this.folder.getRoot().toPath().resolve("secondThesaurus.rdf");
         this.secondThesaurus = new Thesaurus(isoLangMapper, gcThesaurusFile.getFileName().toString(), null, null, "external",
             "local", gcThesaurusFile, "http://org.fao.geonet", true);

--- a/core/src/test/java/org/fao/geonet/kernel/AllThesaurusTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AllThesaurusTest.java
@@ -30,6 +30,8 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.exceptions.TermNotFoundException;
 import org.fao.geonet.kernel.search.keyword.KeywordRelation;
 import org.fao.geonet.kernel.search.keyword.KeywordSearchParamsBuilder;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.utils.IO;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,6 +56,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AllThesaurusTest extends AbstractThesaurusBasedTest {
     public static final int SECOND_THES_WORDS = 5;
@@ -69,6 +73,12 @@ public class AllThesaurusTest extends AbstractThesaurusBasedTest {
     public void setUp() throws Exception {
         final ConfigurableApplicationContext applicationContext = Mockito.mock(ConfigurableApplicationContext.class);
         ApplicationContextHolder.set(applicationContext);
+
+        SettingManager settingManager = mock(SettingManager.class);
+        when(settingManager.getNodeURL())
+            .thenReturn("http://localhost:8080/geonetwork/srv/");
+        Mockito.when(applicationContext.getBean(SettingManager.class)).thenReturn(settingManager);
+
 
         Path gcThesaurusFile = this.folder.getRoot().toPath().resolve("secondThesaurus.rdf");
         this.secondThesaurus = new Thesaurus(isoLangMapper, gcThesaurusFile.getFileName().toString(), null, null, "external",
@@ -229,7 +239,7 @@ public class AllThesaurusTest extends AbstractThesaurusBasedTest {
     @Test
     public void testIsFreeCode() throws Exception {
         final KeywordBean keywordBean = getExistingKeywordBean();
-        assertFalse(this.allThesaurus.isFreeCode(keywordBean.getNameSpaceCode(), keywordBean.getRelativeCode()));
+        assertFalse(this.allThesaurus.isFreeCode(null, keywordBean.getRelativeCode()));
 
         assertTrue(this.allThesaurus.isFreeCode("non existant", "non existant"));
     }

--- a/core/src/test/java/org/fao/geonet/kernel/ThesaurusTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/ThesaurusTest.java
@@ -438,7 +438,7 @@ public class ThesaurusTest extends AbstractThesaurusBasedTest {
     public void testHasConceptSchemeTrue() throws Exception {
         writableThesaurus.addTitleElement("testScheme");
 
-        boolean hasConceptScheme = writableThesaurus.hasConceptScheme("http://localhost:8080/srv/api/registries/vocabularies/local.ThesaurusTest_empyt.rdf.ThesaurusTest_empyttestScheme");
+        boolean hasConceptScheme = writableThesaurus.hasConceptScheme(writableThesaurus.getDefaultNamespace());
 
         assertTrue(hasConceptScheme);
     }

--- a/core/src/test/java/org/fao/geonet/kernel/ThesaurusTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/ThesaurusTest.java
@@ -438,7 +438,7 @@ public class ThesaurusTest extends AbstractThesaurusBasedTest {
     public void testHasConceptSchemeTrue() throws Exception {
         writableThesaurus.addTitleElement("testScheme");
 
-        boolean hasConceptScheme = writableThesaurus.hasConceptScheme("http://geonetwork-opensource.org/testScheme");
+        boolean hasConceptScheme = writableThesaurus.hasConceptScheme("http://localhost:8080/srv/api/registries/vocabularies/local.ThesaurusTest_empyt.rdf.ThesaurusTest_empyttestScheme");
 
         assertTrue(hasConceptScheme);
     }

--- a/core/src/test/java/org/fao/geonet/kernel/search/TermUriTranslatorTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/TermUriTranslatorTest.java
@@ -23,18 +23,25 @@
 
 package org.fao.geonet.kernel.search;
 
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.kernel.SingleThesaurusFinder;
 import org.fao.geonet.kernel.Thesaurus;
 import org.fao.geonet.kernel.ThesaurusFinder;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.openrdf.sesame.config.ConfigurationException;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TermUriTranslatorTest {
 
@@ -44,6 +51,17 @@ public class TermUriTranslatorTest {
             _isoLanguagesMap639.put("de", "ger");
         }
     };
+
+    @Before
+    public void setup() {
+        final ConfigurableApplicationContext applicationContext = Mockito.mock(ConfigurableApplicationContext.class);
+        ApplicationContextHolder.set(applicationContext);
+
+        SettingManager settingManager = mock(SettingManager.class);
+        when(settingManager.getNodeURL())
+            .thenReturn("http://localhost:8080/geonetwork/srv/");
+        Mockito.when(applicationContext.getBean(SettingManager.class)).thenReturn(settingManager);
+    }
 
     @Test
     public void testTermWithPreferredLabelForLanguage() throws IOException, ConfigurationException {

--- a/core/src/test/java/org/fao/geonet/kernel/search/classifier/TermLabelTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/classifier/TermLabelTest.java
@@ -24,13 +24,19 @@ package org.fao.geonet.kernel.search.classifier;
 
 import static org.fao.geonet.test.CategoryTestHelper.assertCategoryListEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.apache.lucene.facet.taxonomy.CategoryPath;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.kernel.ThesaurusManager;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.context.ConfigurableApplicationContext;
 
 public class TermLabelTest extends AbstractTermTest {
 
@@ -38,6 +44,14 @@ public class TermLabelTest extends AbstractTermTest {
 
     @Before
     public void setup() throws Exception {
+        final ConfigurableApplicationContext applicationContext = Mockito.mock(ConfigurableApplicationContext.class);
+        ApplicationContextHolder.set(applicationContext);
+
+        SettingManager settingManager = mock(SettingManager.class);
+        when(settingManager.getNodeURL())
+            .thenReturn("http://localhost:8080/geonetwork/srv/");
+        Mockito.when(applicationContext.getBean(SettingManager.class)).thenReturn(settingManager);
+
         ThesaurusManager manager = mockThesaurusManagerWith("BroaderTerm.rdf");
         termLabelClassifier = new TermLabel(manager, "scheme", "eng");
     }

--- a/core/src/test/java/org/fao/geonet/kernel/search/classifier/TermUriTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/classifier/TermUriTest.java
@@ -24,13 +24,19 @@ package org.fao.geonet.kernel.search.classifier;
 
 import static org.fao.geonet.test.CategoryTestHelper.assertCategoryListEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.apache.lucene.facet.taxonomy.CategoryPath;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.kernel.ThesaurusManager;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.context.ConfigurableApplicationContext;
 
 public class TermUriTest extends AbstractTermTest {
 
@@ -38,6 +44,14 @@ public class TermUriTest extends AbstractTermTest {
 
     @Before
     public void setup() throws Exception {
+        final ConfigurableApplicationContext applicationContext = Mockito.mock(ConfigurableApplicationContext.class);
+        ApplicationContextHolder.set(applicationContext);
+
+        SettingManager settingManager = mock(SettingManager.class);
+        when(settingManager.getNodeURL())
+            .thenReturn("http://localhost:8080/geonetwork/srv/");
+        Mockito.when(applicationContext.getBean(SettingManager.class)).thenReturn(settingManager);
+
         ThesaurusManager manager = mockThesaurusManagerWith("BroaderTerm.rdf");
         termUriClassifier = new TermUri(manager, "scheme");
     }

--- a/services/src/main/java/org/fao/geonet/services/thesaurus/Add.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/Add.java
@@ -62,7 +62,7 @@ public class Add extends NotInReadOnlyModeService {
 
         String fname = Util.getParam(params, "fname");
         String tname = Util.getParam(params, "tname");
-        String tnamespace = Util.getParam(params, "tns");
+        String tnamespace = Util.getParam(params, "tns", "");
         String dname = Util.getParam(params, "dname");
         String type = Util.getParam(params, "type");
         String activated = Util.getParam(params, "activated", "y");

--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -251,7 +251,7 @@
        * and filename. eg. http://localhost:8080/thesaurus/theme/commune
        */
       $scope.computeThesaurusNs = function() {
-        $scope.thesaurusSuggestedNs =+
+        $scope.thesaurusSuggestedNs =
           location.href.split($scope.nodeId)[0] + $scope.nodeId
             + "/api/registries/vocabularies/local."
             + $scope.thesaurusSelected.dname.trim().replace(/[^\d\w-\.]/gi, '') + '.'

--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -219,7 +219,7 @@
         $scope.thesaurusSelected = {
           title: '',
           filename: '',
-          defaultNamespace: 'http://www.mysite.org/thesaurus',
+          defaultNamespace: '',
           dname: 'theme',
           type: 'local'
         };
@@ -251,10 +251,11 @@
        * and filename. eg. http://localhost:8080/thesaurus/theme/commune
        */
       $scope.computeThesaurusNs = function() {
-        $scope.thesaurusSuggestedNs =
-            location.origin +
-            '/thesaurus/' + $scope.thesaurusSelected.dname.trim().replace(/[^\d\w-\.]/gi, '') + '/' +
-            $scope.thesaurusSelected.filename.trim().replace(/[^\d\w-\.]/gi, '');
+        $scope.thesaurusSuggestedNs =+
+          location.href.split($scope.nodeId)[0] + $scope.nodeId
+            + "/api/registries/vocabularies/local."
+            + $scope.thesaurusSelected.dname.trim().replace(/[^\d\w-\.]/gi, '') + '.'
+            + $scope.thesaurusSelected.filename.replace(/[^\d\w-\.]/gi, '');
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -383,7 +383,7 @@
               <button class="btn btn-link"
                       data-ng-show="isNew() && thesaurusSuggestedNs != ''"
                       data-ng-click="useSuggestedNs()">
-                {{"use"|translate}} {{thesaurusSuggestedNs}} {{"asThesaurusIdentifier"|translate}}
+                {{"use"|translate}} {{thesaurusSuggestedNs | limitTo: 90}}{{thesaurusSuggestedNs.length > 90 ? '...' : ''}}
                 <i class="fa fa-double-angle-up"/>
               </button>
             </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -359,14 +359,6 @@
                      id="gn-thesaurus-title" data-ng-model="thesaurusSelected.title"
                      data-ng-required="true" />
             </div>
-
-            <div class="form-group" data-ng-class="gnCreateThesaurus.filename.$error.required ? 'has-error' : ''">
-              <label class="control-label" data-translate="">thesaurusIdentifier</label>
-              <input type="text" name="filename" class="form-control" data-ng-disabled="!isNew()"
-                     data-ng-keyup="computeThesaurusNs()"
-                     data-ng-model="thesaurusSelected.filename"
-                     data-ng-required="true"/>
-            </div>
             <div class="form-group">
               <label class="control-label" data-translate="">thesaurusClass</label>
               <div
@@ -375,18 +367,25 @@
                 data-gn-schema-info="gmd:MD_KeywordTypeCode"
                 lang="lang"></div>
             </div>
-
+            <div class="form-group" data-ng-class="gnCreateThesaurus.filename.$error.required ? 'has-error' : ''">
+              <label class="control-label" data-translate="">thesaurusIdentifier</label>
+              <input type="text" name="filename" class="form-control" data-ng-disabled="!isNew()"
+                     data-ng-keyup="computeThesaurusNs()"
+                     data-ng-model="thesaurusSelected.filename"
+                     data-ng-required="true"/>
+            </div>
             <div class="form-group" data-ng-class="gnCreateThesaurus.defaultNamespace.$error.required ? 'has-error' : ''">
               <label class="control-label" data-translate="">thesaurusNamespace</label>
               <input type="text" name="defaultNamespace" class="form-control"
                      data-ng-disabled="!isNew()"
                      data-ng-model="thesaurusSelected.defaultNamespace"
                      data-ng-required="true"/>
-              <p class="help-block" data-ng-show="isNew() && thesaurusSuggestedNs != ''"
-                data-ng-click="useSuggestedNs()">
+              <button class="btn btn-link"
+                      data-ng-show="isNew() && thesaurusSuggestedNs != ''"
+                      data-ng-click="useSuggestedNs()">
                 {{"use"|translate}} {{thesaurusSuggestedNs}} {{"asThesaurusIdentifier"|translate}}
                 <i class="fa fa-double-angle-up"/>
-              </p>
+              </button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
Remove hard coded references to `http://custom.shared.obj.ch/concept#`, `http://geonetwork-opensource.org/` and `http://www.mysite.org/thesaurus` which are defaults when creating a local thesaurus from the admin without taking time to customize the value properly.

Defaults are now using the GeoNetwork API path, so the namespace will point to the thesaurus download link.
Also namespace is preserved if you export and import the thesaurus in another instance.

![image](https://user-images.githubusercontent.com/1701393/109798203-c3266780-7c1a-11eb-91ac-4d6bf9651b5d.png)
