### PR TITLE
Avoid empty attribute sections in the metadata editor

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -274,7 +274,7 @@
               <xsl:with-param name="domeElementToMoveRef" select="$editInfo/@ref"/>
             </xsl:call-template>
 
-            <xsl:if test="$attributesSnippet">
+            <xsl:if test="$attributesSnippet and count($attributesSnippet/*) > 0">
               <xsl:variable name="cssDefaultClass" select="'well well-sm'"/>
               <div class="{$cssDefaultClass}
                 {if ($forceDisplayAttributes) then 'gn-attr-mandatory' else 'gn-attr'}
@@ -392,7 +392,7 @@
         </xsl:if>
       </legend>
 
-      <xsl:if test="count($attributesSnippet/*) > 0">
+      <xsl:if test="count($attributesSnippet/*) > 0 and name($attributesSnippet/*[1]) != 'null'">
         <div class="well well-sm gn-attr {if ($isDisplayingAttributes = true()) then '' else 'hidden'}">
           <xsl:copy-of select="$attributesSnippet"/>
         </div>


### PR DESCRIPTION
In the editor, enable `More details` option to display the attributes.

Some elements display an empty section if the element has no attributes available:

![empty-sections](https://user-images.githubusercontent.com/1695003/93220538-f492a000-f76c-11ea-9b9a-7d77e3dcb031.png)

Changed to avoid displaying the attributes block in these cases:

![remove-empty-sections](https://user-images.githubusercontent.com/1695003/93220743-33c0f100-f76d-11ea-99de-74f758ee6e99.png)

