### PR TITLE
Indexing / improvements and doc

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -377,7 +377,9 @@ public class EsSearchManager implements ISearchManager {
                       boolean forceRefreshReaders) throws Exception {
 
         Element docs = new Element("doc");
-        addMDFields(docs, schemaDir, metadata, metadataType);
+        if (schemaDir != null) {
+            addMDFields(docs, schemaDir, metadata, metadataType);
+        }
         addMoreFields(docs, dbFields);
 
         ObjectMapper mapper = new ObjectMapper();
@@ -393,7 +395,6 @@ public class EsSearchManager implements ISearchManager {
 
         String jsonDocument = mapper.writeValueAsString(doc);
         listOfDocumentsToIndex.put(id, jsonDocument);
-
         if (listOfDocumentsToIndex.size() == commitInterval || forceRefreshReaders) {
             sendDocumentsToIndex();
         }

--- a/es/README.md
+++ b/es/README.md
@@ -73,3 +73,20 @@ Configure ES to start on server startup. It is recommended to protect `gn-record
 
  * Note that for debian-based servers the current deb download (7.3.2) can be installed rather than installing manually and can be configured to run as a service using the instructions here: https://www.elastic.co/guide/en/elasticsearch/reference/current/starting-elasticsearch.html
 
+
+## Errors
+
+* Max number of fields: As we are using dynamic fields, when having a large number of records, the system may reach the maximum number of fields in Elasticsearch. In this situation, Elasticsearch is reporting: 
+```
+java.lang.IllegalArgumentException: Limit of total fields [1000] in index [gn-records] has been exceeded
+```
+
+Increase the limit using:
+```
+curl -X PUT http://localhost:9200/gn-records/_settings -H "Content-Type:application/json"  -d '
+{
+  "index.mapping.total_fields.limit": 6000
+}'
+```
+
+See https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping.html#mapping

--- a/es/README.md
+++ b/es/README.md
@@ -7,7 +7,7 @@ and copy it to the ES module. eg. es/elasticsearch-7.6.2
  
 Start ES using:
 
-```
+```shell script
 ./bin/elasticsearch
 ```
 
@@ -21,7 +21,7 @@ Maven can take care of the installation steps:
 
 Use the following commands:
 
-```
+```shell script
 cd es
 mvn install -Pes-download
 mvn exec:exec -Des-start
@@ -31,7 +31,7 @@ Optionally you can manually create index but they will be created by the catalog
 the Elastic instance is available and if index does not exist.
 
 
-```
+```shell script
 IDX_PREFIX=gn
 curl -X PUT http://localhost:9200/$IDX_PREFIX-records -H "Content-Type:application/json"  -d @../web/src/main/webapp/WEB-INF/data/config/index/records.json
 curl -X PUT http://localhost:9200/$IDX_PREFIX-features -H "Content-Type:application/json" -d @../web/src/main/webapp/WEB-INF/data/config/index/features.json
@@ -40,7 +40,7 @@ curl -X PUT http://localhost:9200/$IDX_PREFIX-searchlogs -H "Content-Type:applic
 
 To delete your index:
 
-```
+```shell script
 IDX_PREFIX=gn
 curl -X DELETE http://localhost:9200/$IDX_PREFIX-records
 curl -X DELETE http://localhost:9200/$IDX_PREFIX-features
@@ -55,14 +55,17 @@ curl -X DELETE http://localhost:9200/$IDX_PREFIX-searchlogs
 * Stop Elasticsearch
 * Define which analyzer to use https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-analyzers.html depending on the language(s) used in your catalogue
 * Build the application with the default analyzer to use (or configure it in `data/index/records.json`)
-```
+
+```shell script
 mvn clean install -Des.default.analyzer=french_heavy
 ```
-* Install ICU plugin (if needed)
-```
-elasticsearch-plugin install analysis-icu
 
+* Install ICU plugin (if needed)
+
+```shell script
+elasticsearch-plugin install analysis-icu
 ```
+
 * Start Elasticsearch
 * Drop and rebuild your index
 
@@ -77,16 +80,24 @@ Configure ES to start on server startup. It is recommended to protect `gn-record
 ## Errors
 
 * Max number of fields: As we are using dynamic fields, when having a large number of records, the system may reach the maximum number of fields in Elasticsearch. In this situation, Elasticsearch is reporting: 
+
 ```
 java.lang.IllegalArgumentException: Limit of total fields [1000] in index [gn-records] has been exceeded
 ```
 
 Increase the limit using:
-```
-curl -X PUT http://localhost:9200/gn-records/_settings -H "Content-Type:application/json"  -d '
+
+```shell script
+curl -X PUT localhost:9200/gn-records/_settings -H "Content-Type:application/json"  -d '
 {
   "index.mapping.total_fields.limit": 6000
 }'
+```
+
+To check the current number of fields in the index use:
+
+```shell script
+curl -s -XGET localhost:9200/gn-records/_mapping?pretty | grep type | wc -l
 ```
 
 See https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping.html#mapping

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
-   
+
       <!-- run integration tests after unit tests -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -1412,6 +1412,7 @@
     <!-- Define the default analyzer for full text search. -->
     <es.index.analyzer.default>standard</es.index.analyzer.default>
 <!--    <es.default.analyzer>french_light</es.default.analyzer>-->
+    <es.index.mapping.total_fields.limit>4000</es.index.mapping.total_fields.limit>
 
     <es.username></es.username>
     <es.password></es.password>

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index.mapping.total_fields.limit": ${es.index.mapping.total_fields.limit},
     "index": {
       "analysis": {
         "analyzer": {

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3990/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3990/migrate-default.sql
@@ -12,5 +12,7 @@ UPDATE metadata
     SET data = REGEXP_REPLACE(data, '[a-z]{3}\/thesaurus\.download\?ref=', 'api/registries/vocabularies/', 'g')
     WHERE data LIKE '%thesaurus.download?ref=%';
 
+UPDATE settings SET value = '1' WHERE name = 'system/threadedindexing/maxthreads';
+
 UPDATE Settings SET value='3.99.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
* Indexing / Avoid losing records using a non registered schema.
    
    Instead of only reporting exception in the log, check first that schema
    of the record is available. If not create a document with an indexing
    error status:
    
    ```
    2020-09-16 15:38:36,365 ERROR [geonetwork.datamanager] - Record 163548661 / Schema 'iso19115-3' is not registerd in this catalog. Install it or remove those records. Record is indexed indexing error flag.
    ```
    
    This is useful when using a database with records in non default
    standards.

![image](https://user-images.githubusercontent.com/1701393/93345595-4aca1680-f833-11ea-99e3-1febf9e4e22b.png)


* Indexing / Multithread indexing is not supported.
* Indexing / Explain what to do in case of Limit of total fields has been exceeded.

