### PR TITLE
Don't rotate harvester log files if a harvester is running during midnight

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -26,8 +26,8 @@ package org.fao.geonet.kernel.harvest.harvester;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.DailyRollingFileAppender;
 import org.apache.log4j.EnhancedPatternLayout;
+import org.apache.log4j.FileAppender;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.csw.common.exceptions.InvalidParameterValueEx;
@@ -202,7 +202,7 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
             directory = d.getParent() + File.separator;
         }
 
-        DailyRollingFileAppender fa = new DailyRollingFileAppender();
+        FileAppender fa = new FileAppender();
         fa.setName(harvesterName);
         String logfile = directory + "harvester_" + packageType + "_"
             + harvesterName + "_"


### PR DESCRIPTION
Previous implementation with `RollingFileAppender` created a new log file for a harvester if this start running and the execution goes beyond midnight. With this change all the output related to a harvester execution is kept in the same log file.

Reference: https://sourceforge.net/p/geonetwork/mailman/geonetwork-users/thread/CAEOgqt%2BiYnjP%2B8VLuk%3D83qVwitBupJq9Zy_8iQXUsXe6ztGy8w%40mail.gmail.com/#msg37084379