### PR TITLE
[a11y] Improve the cookie message

### DIFF
--- a/web-ui/src/main/resources/catalog/components/cookieWarning/partials/cookieWarning.html
+++ b/web-ui/src/main/resources/catalog/components/cookieWarning/partials/cookieWarning.html
@@ -8,8 +8,8 @@
        data-translate="">moreOnCookie</a>
   </p>
   <p class="cookie-warning-actions">
-    <span data-ng-click="acceptCookies()" data-translate="">acceptCookie</span>&nbsp;
-    <span data-translate="">or</span>&nbsp;
-    <span data-ng-click="goAway()" data-translate="">rejectCookie</span>
+    <button class="btn btn-info" data-ng-click="acceptCookies()" data-translate="">acceptCookie</button>
+    <span data-translate="">or</span>
+    <button class="btn btn-info" data-ng-click="goAway()" data-translate="">rejectCookie</button>
   </p>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -86,4 +86,6 @@ html, body {
 .cookie-warning {
   .alert;
   .alert-info;
+  position: absolute;
+  z-index: 100;
 }


### PR DESCRIPTION
There were small issues with displaying the cookie message, it falls behind the map, and can't be closed with the keyboard. This PR fixes both issues.

**The cookie message after the changes**:
![gn-cookie-message](https://user-images.githubusercontent.com/19608667/93756784-eed20a00-fc05-11ea-80e4-bd3ed9dec864.png)

Changes:
- change`<span>` elements into `<button>`s
- add a `z-index` to display the cookie message on top of other elements