### PR TITLE
ISO19115-3 / Fix multilingual editing.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl-multilingual.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl-multilingual.xsl
@@ -66,7 +66,7 @@
         <xsl:for-each select="$metadata/mdb:otherLocale/lan:PT_Locale">
           <lang id="{@id}" code="{lan:language/lan:LanguageCode/@codeListValue}"/>
         </xsl:for-each>
-        <xsl:for-each select="$metadata/mdb:defaultLocale/*">
+        <xsl:for-each select="$metadata/mdb:defaultLocale/lan:PT_Locale">
           <lang id="{@id}" code="{lan:language/lan:LanguageCode/@codeListValue}" default=""/>
         </xsl:for-each>
       </xsl:otherwise>

--- a/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
@@ -63,7 +63,7 @@
   <xsl:variable name="metadataOtherLanguagesAsJson">
     <saxon:call-template name="{concat('get-', $schema, '-other-languages-as-json')}"/>
   </xsl:variable>
-  <xsl:variable name="metadataIsMultilingual" select="count($metadataOtherLanguages/*) > 0"/>
+  <xsl:variable name="metadataIsMultilingual" select="count($metadataOtherLanguages/*[not(@default)]) > 0"/>
 
   <!-- The list of thesaurus -->
   <xsl:variable name="listOfThesaurus" select="/root/gui/thesaurus/thesauri"/>


### PR DESCRIPTION
* Avoid creating empty language when list of language is built in edit mode (due to geonet:* elements)
* Record isMultilingual only if none default language are defined.