### PR TITLE
Map / Add mouse position widget.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -160,7 +160,7 @@
             gnOwsContextService.loadContextFromUrl(url,
                 gnSearchSettings.viewerMap);
 
-            gnSearchLocation.setMap();
+            gnSearchLocation.setMap('legend');
           };
 
           var openMd = function(r, md, siteUrl) {

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -120,10 +120,13 @@
         }
       };
 
-      this.setMap = function() {
+      this.setMap = function(tool) {
         if (gnGlobalSettings.isMapViewerEnabled &&
             !gnExternalViewer.isEnabled()) {
           $location.path(this.MAP);
+          if (tool != undefined) {
+            $location.search('tool', tool);
+          }
         }
       };
 

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -291,21 +291,23 @@
                   }
                 }
 
-                if (activateCmd || addCmd) {
+                // Define which tool is active
+                var toolCmd = $location.search()['tool'];
+                if (toolCmd) {
+                  scope.activeTools[$location.search()['tool']] = true;
+                }
+
+                if (activateCmd || addCmd || toolCmd) {
                   // Replace location with action by a stateless path
                   // to not being able to replay the action with browser
                   // history.
                   $location.path('/map')
                       .search('add', null)
                       .search('activate', null)
+                      .search('tool', null)
                       .replace();
                 }
 
-
-                // Define which tool is active
-                if ($location.search()['tool']) {
-                  scope.activeTools[$location.search()['tool']] = true;
-                }
 
                 if ($location.search()['extent']) {
                   scope.map.getView().fit(

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -99,7 +99,7 @@
               if(gnViewerSettings.mapConfig.switcherProjectionList.length < 2) {
                 scope.disabledTools.projectionSwitcher = true;
               }
-              
+
               /** wps process tabs */
               scope.wpsTabs = {
                 byUrl: true,
@@ -380,7 +380,6 @@
                   scope.selectedWps.url = openedTool.url;
                 }
 
-
                 openedTool.name = '';
               }, true);
 
@@ -400,6 +399,81 @@
         }
       };
     }]);
+
+  module.directive('gnMapMousePosition', function() {
+    return {
+      restrict: 'A',
+      replace: true,
+      templateUrl : '../../catalog/components/viewer/partials/mouseposition.html',
+      controller: ['gnViewerSettings', 'hotkeys', 'gnAlertService', '$translate', '$scope',
+        function(gnViewerSettings, hotkeys, gnAlertService, $translate, scope) {
+
+        scope.switchMousePosition = function() {
+          scope.displayMousePosition = !scope.displayMousePosition;
+        };
+
+        scope.displayMousePosition = false;
+        if (gnViewerSettings.mapConfig.disabledTools.mousePosition === false) {
+
+          scope.coordinateFormats = ['DD', 'DMS'];
+          scope.coordinateFormat = scope.coordinateFormats[0];
+          scope.coordinateFormatPrecision = 4;
+          scope.projectionList =
+            gnViewerSettings.mapConfig.projectionList.flatMap(function(p) {
+            return p.code.endsWith(':4326') ?
+              [].concat(angular.extend({format: 'DD'}, p),
+                        angular.extend({format: 'DMS'}, p)) :
+              angular.extend({format: 'DD'}, p);});
+          scope.coordinateProjectionCode = scope.projectionList[0].code;
+          scope.displayMousePosition = true;
+          scope.mousePosition = '';
+
+          scope.setMousePositionFormat = function(f) {
+            scope.coordinateFormat = f;
+          }
+
+          scope.setMousePositionProjection = function(c) {
+            scope.coordinateProjectionCode = c.code;
+            scope.coordinateFormat = c.format;
+            scope.mousePositionControl.setProjection(c.code);
+          }
+
+          scope.mousePositionControl = new ol.control.MousePosition({
+            coordinateFormat: function(c) {
+              scope.mousePosition =
+                scope.coordinateFormat === 'DD' ?
+                  ol.coordinate.format(c,'{x}, {y}', scope.coordinateFormatPrecision) :
+                  ol.coordinate.toStringHDMS(c,scope.coordinateFormatPrecision);
+              return scope.mousePosition;
+            },
+            projection: scope.coordinateProjectionCode,
+            target: document.getElementById('gn-map-mouse-position'),
+            undefinedHTML: '&nbsp;'
+          });
+          scope.map.addControl(scope.mousePositionControl);
+
+
+          hotkeys.bindTo(scope)
+            .add({
+              combo: 'c',
+              description: $translate.instant('copyMousePosition'),
+              callback: function(event) {
+                if (scope.mousePosition != '') {
+                  navigator.clipboard.writeText(scope.mousePosition).then(function() {
+                    gnAlertService.addAlert({
+                      msg: $translate.instant(
+                        "mousePositionCopiedToClipboard",
+                        {position: scope.mousePosition}),
+                      type: 'success'
+                    }, 2);
+                  });
+                }
+              }
+            });
+        }
+      }]
+    };
+  });
 
   // TODO : to remove those directives when ngeo allow null class
   module.directive('giBtnGroup', function() {

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -129,6 +129,9 @@
             graticule-ogc-service="graticuleOgcService"></button>
   </div>
 
+  <div gn-map-mouse-position=""/>
+
+
   <!-- Add layers -->
   <div class="panel panel-default panel-tools"
        ng-show="activeTools.addLayers">
@@ -160,7 +163,7 @@
         <tab heading="{{'addLayerFromServices' | translate}}"
              active="addLayerTabs.services"
              role="tab">
-          <br/>   
+          <br/>
           <div gn-wms-import="wms"
                gn-wms-import-map="map"
                gn-wms-import-url="addLayerUrl.wms"

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mouseposition.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mouseposition.html
@@ -1,0 +1,34 @@
+<div class="gn-map-mouse-position"
+     ng-hide="disabledTools.mousePosition">
+    <span id="gn-map-mouse-position"
+          ng-show="displayMousePosition"
+          aria-label="{{'mousePosition' | translate}}">
+    </span>
+  <div class="btn-group" role="group" aria-label="...">
+    <button type="button"
+            title="{{'displayMousePosition' | translate}}"
+            ng-click="switchMousePosition()"
+            ng-class="displayMousePosition ? 'active' : ''"
+            class="btn btn-default btn-xs">
+      <span class="fa fa-map-marker fa-fw"/>
+    </button>
+    <div class="btn-group">
+      <button class="btn btn-default btn-xs dropdown-toggle"
+              ng-class="displayMousePosition ? '' : 'disabled'"
+              type="button" data-toggle="dropdown"
+              aria-haspopup="true" aria-expanded="false">
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li class="dropdown-header" data-translate="">coordinateFormat</li>
+        <li data-ng-repeat="p in projectionList"
+            data-ng-class="{'disabled': p.code === coordinateProjectionCode && p.format === coordinateFormat}">
+          <a data-ng-click="setMousePositionProjection(p)">
+            {{p.label}}
+            <span data-ng-hide="p.format == 'DD'">({{p.format}})</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -488,6 +488,7 @@ goog.require('gn_alert');
             'print': false,
             'mInteraction': false,
             'graticule': false,
+            'mousePosition': true,
             'syncAllLayers': false,
             'drawVector': false
           },

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -441,6 +441,7 @@
     "legendTool": "Legend",
     "mInteractionTool": "Measures",
     "graticuleTool": "Display graticules",
+    "mousePositionTool": "Mouse position",
     "syncAllLayersTool": "Synchronize search and main map",
     "drawVectorTool": "Annotate map",
     "collapseAllFacetLabel": "Collapse",

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -525,5 +525,10 @@
   "geometryFilter": "Bounding Box",
   "GUFname": "Your Name",
   "GUFemail": "Your Email address",
-  "GUForganization": "Your Organization"
+  "GUForganization": "Your Organization",
+  "mousePositionCopiedToClipboard": "Coordinates {{position}} copied to clipboard.",
+  "mousePosition": "Position",
+  "coordinateFormat": "Projection & format",
+  "displayMousePosition": "Display mouse position (Use 'c' shortcut to copy position to clipboard).",
+  "copyMousePosition": "Copy mouse position to clipboard"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -110,7 +110,6 @@
       position: absolute;
       top: 3px;
       right: 20px;
-      font-style: italic;
     }
   }
   .search-container {

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -92,11 +92,25 @@
     .dropdown-menu {
       max-height: 45vh;
       overflow: auto;
-
     }
     .dropdown-toggle {
       padding: 0;
       border: none;
+    }
+  }
+  .gn-map-mouse-position {
+    position: absolute;
+    top: 4em;
+    left: 1em;
+    margin: 2px;
+    width: 25em;
+    max-width: 75%;
+    font-size: 12px;
+    .ol-mouse-position {
+      position: absolute;
+      top: 3px;
+      right: 20px;
+      font-style: italic;
     }
   }
   .search-container {

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -78,8 +78,8 @@
 
 
   module.controller('gnsSearchTopEntriesController', [
-    '$scope', 'gnGlobalSettings',
-    function($scope, gnGlobalSettings) {
+    '$scope', 'gnRelatedResources',
+    function($scope, gnRelatedResources) {
       $scope.resultTemplate = '../../catalog/components/' +
         'search/resultsview/partials/viewtemplates/grid4maps.html';
       $scope.searchObj = {
@@ -97,6 +97,10 @@
           from: 1,
           to: 30
         }
+      };
+
+      $scope.loadMap = function(map, md) {
+        gnRelatedResources.getAction('MAP')(map, md);
       };
     }]);
 


### PR DESCRIPTION
* Mouse position is not displayed by default 

* Mouse position is displayed below gazetter

![image](https://user-images.githubusercontent.com/1701393/93870465-91a18b80-fccd-11ea-8ed6-cad0cc1705f6.png)


* User can choose projection and format based on projection list
configuration

![image](https://user-images.githubusercontent.com/1701393/93870407-7a629e00-fccd-11ea-8359-8f8ec5a47c43.png)


* WGS84 can be displayed in DD or DMS mode

![image](https://user-images.githubusercontent.com/1701393/93870387-72a2f980-fccd-11ea-9fac-c085d1f1a36c.png)


* `c` shortcut can be used to copy current mouse cursor location

![image](https://user-images.githubusercontent.com/1701393/93870403-7767ad80-fccd-11ea-9789-b7a8f255bad5.png)

![image](https://user-images.githubusercontent.com/1701393/93870431-83ec0600-fccd-11ea-97b9-ccc029ae12ad.png)

![image](https://user-images.githubusercontent.com/1701393/93870447-88b0ba00-fccd-11ea-8413-c8c310902e65.png)

* Coordinates can be used to zoom to location using gazetter

![image](https://user-images.githubusercontent.com/1701393/93870439-86e6f680-fccd-11ea-8a7c-12612a5d2580.png)


* Map / When loading a map, display legend panel by default

* Home page / Latest maps / Fix click to load the map