### PR TITLE
Metadata editor - ignore elements with geonet namespace for render-element value parameter

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
@@ -167,7 +167,7 @@
 
     <xsl:call-template name="render-element">
       <xsl:with-param name="label" select="$labelConfig"/>
-      <xsl:with-param name="value" select="*"/>
+      <xsl:with-param name="value" select="*[namespace-uri(.) != $gnUri]"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <!--<xsl:with-param name="widget"/>
       <xsl:with-param name="widgetParams"/>-->
@@ -235,7 +235,7 @@
 
     <xsl:call-template name="render-element">
       <xsl:with-param name="label" select="$labelConfig"/>
-      <xsl:with-param name="value" select="*"/>
+      <xsl:with-param name="value" select="*[namespace-uri(.) != $gnUri]"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <!--<xsl:with-param name="widget"/>
       <xsl:with-param name="widgetParams"/>-->

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
@@ -369,7 +369,7 @@
 
     <xsl:call-template name="render-element">
       <xsl:with-param name="label" select="$labelCfg/*"/>
-      <xsl:with-param name="value" select="if ($isMultilingualElement) then $values else *"/>
+      <xsl:with-param name="value" select="if ($isMultilingualElement) then $values else *[namespace-uri(.) != $gnUri]"/>
       <xsl:with-param name="errors" select="$errors"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <!--<xsl:with-param name="widget"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -374,7 +374,7 @@
     <xsl:call-template name="render-element">
       <xsl:with-param name="label"
                       select="$labelConfig/*"/>
-      <xsl:with-param name="value" select="if ($isMultilingualElement) then $values else *"/>
+      <xsl:with-param name="value" select="if ($isMultilingualElement) then $values else *[namespace-uri(.) != $gnUri]"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <!--<xsl:with-param name="widget"/>
         <xsl:with-param name="widgetParams"/>-->


### PR DESCRIPTION
This occurs only when adding a new element that uses a directive, causing to add the `geonet:info` information as part of the directive attribute value. In fields using standard HTML controls seem fine.

```
<span data-gn-field-duration-div="136iso191392020-09-22T16:09:082020-09-22T16:38:23n692bc013-e858-4e22-9093-8f05da3b87769fe0d837-...." data-ref="_185"  ...>
```

If the attribute value is used in the directive causes rendering issues.

With this change when adding an element the `geonet:info` information is ignored as expected:

```
<span data-gn-field-duration-div="" data-ref="_185"  ...>
```
