### PR TITLE
ISODate UTC timezone fixes

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/ISODate.java
+++ b/domain/src/main/java/org/fao/geonet/domain/ISODate.java
@@ -448,7 +448,7 @@ public class ISODate
             // issues.
             String afterT = timeAndDate.substring(indexOfT + 1);
             boolean timeZoneInfo = afterT.contains("+") || afterT.contains("-")
-                || afterT.endsWith("Z") || afterT.endsWith("Z");
+                || afterT.toUpperCase().endsWith("Z");
 
             if (timeZoneInfo) {
                 timeAndDate = parseISODateTime(timeAndDate);

--- a/domain/src/main/java/org/fao/geonet/domain/ISODate.java
+++ b/domain/src/main/java/org/fao/geonet/domain/ISODate.java
@@ -104,13 +104,30 @@ public class ISODate
     }
 
     // ---------------------------------------------------------------------------
-
+    /**
+     * Create from milliseconds, local timezone.
+     * @param time Time in milliseconds, local timezone.
+     * @param shortDate True to use short yyyy-mm-dd format
+     */
     public ISODate(final long time, final boolean shortDate) {
         _calendar.setTimeInMillis(time);
         _shortDate = shortDate;
     }
 
+    /**
+     * Create from milliseconds (UTC).
+     * <p>
+     * Examples:
+     * <ul>
+     *     <li><code>new ISODate(System.currentTimeMillis())</code></li>
+     *     <li><code>new ISODate(new Date().getTime())</code></li>
+     * </ul>
+     * </p>
+     *
+     * @param time Time in milliseconds, UTC timezone
+     */
     public ISODate(final long time) {
+        _calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
         _calendar.setTimeInMillis(time);
         _shortDate = false;
     }
@@ -430,7 +447,8 @@ public class ISODate
             // JODAISODate. This class converts to UTC format to avoid timezones
             // issues.
             String afterT = timeAndDate.substring(indexOfT + 1);
-            boolean timeZoneInfo = afterT.contains("+") || afterT.contains("-");
+            boolean timeZoneInfo = afterT.contains("+") || afterT.contains("-")
+                || afterT.endsWith("Z") || afterT.endsWith("Z");
 
             if (timeZoneInfo) {
                 timeAndDate = parseISODateTime(timeAndDate);
@@ -633,6 +651,7 @@ public class ISODate
                 int indexOfZ = secondsToParse.toUpperCase().indexOf('Z');
                 if (indexOfZ > -1) {
                     secondsToParse = secondsToParse.substring(0, indexOfZ);
+                    _calendar.setTimeZone( TimeZone.getTimeZone("UTC"));
                 }
 
                 second = (int) Float.parseFloat(secondsToParse);

--- a/domain/src/test/java/org/fao/geonet/domain/ISODateTest.java
+++ b/domain/src/test/java/org/fao/geonet/domain/ISODateTest.java
@@ -470,17 +470,17 @@ public class ISODateTest {
 
         ZonedDateTime pstDateTime =
             ZonedDateTime.of(
-                2019, 6, 1, 0, 0, 0, 0, ZoneId.of("America/Vancouver").normalized());
+                2019, 6, 1, 0, 0, 0, 0, ZoneId.of("UTC-07:00").normalized());
         expected = pstDateTime.toInstant().truncatedTo(ChronoUnit.SECONDS);
-        assertEquals( "PST", expected, instant );
+        assertEquals( "UTC-07:00", expected, instant );
 
         ISODate estDate = new ISODate("2019-06-01T00:00-04:00");
         instant = estDate.toDate().toInstant().truncatedTo(ChronoUnit.SECONDS);
 
         ZonedDateTime estDateTime =
             ZonedDateTime.of(
-                2019, 6, 1, 0, 0, 0, 0, ZoneId.of("America/Toronto").normalized());
+                2019, 6, 1, 0, 0, 0, 0, ZoneId.of("UTC-04:00").normalized());
         expected = estDateTime.toInstant().truncatedTo(ChronoUnit.SECONDS);
-        assertEquals( "EST", expected, instant );
+        assertEquals( "UTC-04:00", expected, instant );
     }
 }

--- a/domain/src/test/java/org/fao/geonet/domain/ISODateTest.java
+++ b/domain/src/test/java/org/fao/geonet/domain/ISODateTest.java
@@ -28,6 +28,11 @@ import org.junit.Test;
 
 import java.util.Calendar;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import static java.util.Calendar.YEAR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -448,4 +453,34 @@ public class ISODateTest {
         org.junit.Assert.assertEquals(-60, isoDate2.timeDifferenceInSeconds(isoDate1));
     }
 
+
+    @Test
+    public void testZ() throws Exception {
+        ISODate isoDate = new ISODate("2019-06-01T00:00Z");
+        Instant instant = isoDate.toDate().toInstant().truncatedTo(ChronoUnit.SECONDS);
+
+        ZonedDateTime expectedDateTime =
+            ZonedDateTime.of(
+                2019, 6, 1, 0, 0, 0, 0, ZoneId.of("Z").normalized());
+        Instant expected = expectedDateTime.toInstant().truncatedTo(ChronoUnit.SECONDS);
+        assertEquals( "Z", expected, instant );
+
+        ISODate pstDate = new ISODate("2019-06-01T00:00-07:00");
+        instant = pstDate.toDate().toInstant().truncatedTo(ChronoUnit.SECONDS);
+
+        ZonedDateTime pstDateTime =
+            ZonedDateTime.of(
+                2019, 6, 1, 0, 0, 0, 0, ZoneId.of("America/Vancouver").normalized());
+        expected = pstDateTime.toInstant().truncatedTo(ChronoUnit.SECONDS);
+        assertEquals( "PST", expected, instant );
+
+        ISODate estDate = new ISODate("2019-06-01T00:00-04:00");
+        instant = estDate.toDate().toInstant().truncatedTo(ChronoUnit.SECONDS);
+
+        ZonedDateTime estDateTime =
+            ZonedDateTime.of(
+                2019, 6, 1, 0, 0, 0, 0, ZoneId.of("America/Toronto").normalized());
+        expected = estDateTime.toInstant().truncatedTo(ChronoUnit.SECONDS);
+        assertEquals( "EST", expected, instant );
+    }
 }


### PR DESCRIPTION
* [x] Fix ISODate parsing to respect use of Z suffix to indicate UTC timezone
* [x] Document ISODate constructor use of milliseconds against UTC timezone

For more information see https://github.com/geonetwork/core-geonetwork/issues/5016