### PR TITLE
ISO19115-3 / Formatter / Missing uom attribute when rendering Distance.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -1100,6 +1100,12 @@
 
 
 
+
+  <xsl:template mode="render-value"
+                match="*[gco:Distance|gco:Measure]">
+    <xsl:apply-templates mode="render-value"
+                         select="gco:Distance|gco:Measure"/>
+  </xsl:template>
   <xsl:template mode="render-value"
                 match="gco:Distance|gco:Measure">
     <span><xsl:value-of select="."/>&#10;<xsl:value-of select="@uom"/></span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1701393/94032183-fa693080-fdbf-11ea-997d-90ab96286168.png)
