### PR TITLE
Map / Improve support for ESRI ArcGIS REST layers

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/esriService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/esriService.js
@@ -42,7 +42,7 @@
          * @param {string} [layerId] optional, legend will be filtered on this layer
          * @return {Promise<string>} data url
          */
-        renderLegend(json, layerId) {
+        renderLegend: function(json, layerId) {
           var $this = this;
 
           var singleLayer = !!layerId;
@@ -94,7 +94,7 @@
          * @param {Object[]} rules
          * @return {Promise<number>} current y
          */
-        renderRules(startY, context, rules) {
+        renderRules: function(startY, context, rules) {
           var promises = [];
 
           // chain one promise for each rule
@@ -124,7 +124,7 @@
          * @param {string} format, defaults to 'image/png'
          * @return {Promise<Image>} image
          */
-        renderImageData(imageData, format) {
+        renderImageData: function(imageData, format) {
           var defer = $q.defer();
           var image = new Image();
           image.onload = function() {
@@ -141,7 +141,7 @@
          * @param {boolean} skipLayerName
          * @return {[number, number]} width and height
          */
-        measureLegend(context, json, skipLayerName) {
+        measureLegend: function(context, json, skipLayerName) {
           var width = 100;
           var height = 0;
           for (var i = 0; i < json.layers.length; i++) {

--- a/web-ui/src/main/resources/catalog/components/common/map/esriService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/esriService.js
@@ -43,7 +43,8 @@
         renderLegend(json, layerId) {
           var $this = this;
 
-          var legend = !!layerId ? {
+          var singleLayer = !!layerId;
+          var legend = singleLayer ? {
             layers: json.layers.filter(function (layer) {
               return layer.layerId == layerId;
             })
@@ -53,7 +54,7 @@
           var context = canvas.getContext('2d');
           context.textBaseline = 'middle';
           context.font = FONT_SIZE + 'px sans-serif';
-          var size = this.measureLegend(context, legend);
+          var size = this.measureLegend(context, legend, singleLayer);
 
           // size canvas & draw background
           canvas.width = size[0];
@@ -69,12 +70,16 @@
             var layer = json.layers[i];
             promise = promise.then(function (y) {
               var layer = this;
-              y += TITLE_PADDING;
-              context.fillStyle = 'black';
-              context.textBaseline = 'middle';
-              context.font = 'bold ' + FONT_SIZE + 'px sans-serif';
-              context.fillText(layer.layerName, PADDING, y + FONT_SIZE / 2);
-              y += FONT_SIZE;
+
+              if (!singleLayer) {
+                y += TITLE_PADDING;
+                context.fillStyle = 'black';
+                context.textBaseline = 'middle';
+                context.font = 'bold ' + FONT_SIZE + 'px sans-serif';
+                context.fillText(layer.layerName, PADDING, y + FONT_SIZE / 2);
+                y += FONT_SIZE;
+              }
+
               return $this.renderRules(y, context, layer.legend);
             }.bind(layer));
           }
@@ -135,16 +140,19 @@
          * Returns the expected size of the legend
          * @param {CanvasRenderingContext2D} context
          * @param {Object} json
+         * @param {boolean} skipLayerName
          * @return {[number, number]} width and height
          */
-        measureLegend(context, json) {
+        measureLegend(context, json, skipLayerName) {
           var width = 100;
           var height = 0;
           for (var i = 0; i < json.layers.length; i++) {
             var layer = json.layers[i];
-            var nameMetrics = context.measureText(layer.layerName);
-            width = Math.max(width, nameMetrics.width + PADDING * 2);
-            height += TITLE_PADDING + FONT_SIZE;
+            if (!skipLayerName) {
+              var nameMetrics = context.measureText(layer.layerName);
+              width = Math.max(width, nameMetrics.width + PADDING * 2);
+              height += TITLE_PADDING + FONT_SIZE;
+            }
 
             for (var j = 0; j < layer.legend.length; j++) {
               var rule = layer.legend[j];

--- a/web-ui/src/main/resources/catalog/components/common/map/esriService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/esriService.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_esri_service');
+
+  var module = angular.module('gn_esri_service', []);
+
+  var PADDING = 5;
+  var FONT_SIZE = 12;
+  var TMP_IMAGE = new Image();
+
+  module.service('gnEsriUtils', ['$q',
+    function($q) {
+      return {
+        /**
+         * Renders a JSON legend asynchronously to an image
+         * @param {Object} json
+         * @return {Promise<string>} data url
+         */
+        renderLegend(json) {
+          var $this = this;
+
+          var canvas = document.createElement('canvas');
+          canvas.width = 200;
+          canvas.height = 500;
+          var context = canvas.getContext('2d');
+          context.textBaseline = 'middle';
+          var promise = $q.resolve(0);
+
+          // chain one promise per legend
+          for (var i = 0; i < json.layers.length; i++) {
+            var layer = json.layers[i];
+            promise = promise.then(function (y) {
+              var layer = this;
+              y += PADDING;
+              context.font = 'bold ' + FONT_SIZE + 'px sans-serif';
+              context.fillText(layer.layerName, PADDING, y + PADDING + FONT_SIZE / 2);
+              y += PADDING + FONT_SIZE;
+              return $this.renderRules(y, context, layer.legend);
+            }.bind(layer));
+          }
+
+          return promise.then(function() {
+            return canvas.toDataURL('image/png');
+          });
+        },
+
+        /**
+         * Renders a array of rules asynchronously
+         * @param {number} currentY
+         * @param {CanvasRenderingContext2D} context
+         * @param {Object[]} rules
+         * @return {Promise<number>} current y
+         */
+        renderRules(currentY, context, rules) {
+          var $this = this;
+          var promise = $q.resolve(currentY);
+
+          // chain one promise for each rule
+          for (var i = 0; i < rules.length; i++) {
+            var rule = rules[i];
+            promise = promise.then(function (y) {
+              var rule = this;
+              return $this.renderImageData(rule.imageData, rule.contentType).then(function (image) {
+                context.drawImage(image, PADDING, y + PADDING);
+                context.fillStyle = 'black';
+                context.font = FONT_SIZE + 'px sans-serif';
+                context.fillText(rule.label, PADDING * 2 + image.width, y + PADDING + image.height / 2);
+                y += image.height + PADDING;
+                return y;
+              })
+            }.bind(rule));
+          }
+
+          return promise;
+        },
+
+        /**
+         * Returns a promise resolving on an Image element
+         * with the data loaded
+         * @param {string} imageData base-64 encoded image data
+         * @param {string} format, defaults to 'image/png'
+         * @return {Promise<Image>} image
+         */
+        renderImageData(imageData, format) {
+          var defer = $q.defer();
+          TMP_IMAGE.onload = function() {
+            defer.resolve(this);
+          };
+          TMP_IMAGE.src = 'data:' + (format || 'image/png') + ';base64,' + imageData;
+          return defer.promise;
+        }
+      }
+    }
+  ]);
+})();

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1458,8 +1458,7 @@
               olL.set('name', name);
               olL.set('label', name);
               olL.displayInLayerManager = true;
-              // FIXME: Layer tree visibility toggle does not work
-              olL.visible = layerOptions.visible;
+              olDecorateLayer(olL);
 
               var finishCreation = function() {
                 $q.resolve(olL).

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1496,7 +1496,7 @@
 
             var legendUrl = serviceUrl + '/legend?f=json';
             var legendPromise = $http.get(legendUrl).then(function (response) {
-              return gnEsriUtils.renderLegend(response.data);
+              return gnEsriUtils.renderLegend(response.data, layer);
             })
 
             // layer title and extent are set after the layer info promise resolves

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1435,7 +1435,7 @@
 
           addEsriRestFromScratch: function(map, url, name, createOnly, md) {
             var serviceUrl = url.replace(/(.*\/MapServer).*/, '$1')
-            var layer = url.replace(/.*\/([^\/]*)\/MapServer\/?(.*)/, '$2');
+            var layer = !!name ? name : url.replace(/.*\/([^\/]*)\/MapServer\/?(.*)/, '$2');
             name = url.replace(/.*\/([^\/]*)\/MapServer\/?(.*)/, '$1 $2');
 
             var olLayer = getTheLayerFromMap(map, name, url);
@@ -1963,6 +1963,23 @@
                   break;
                 }
                 this.addWmsFromScratch(map, opt.url, opt.name)
+                    .then(function(layer) {
+                      if (title) {
+                        layer.set('title', title);
+                        layer.set('label', title);
+                      }
+                      return layer;
+                    });
+                break;
+
+              case 'arcgis':
+                if (!opt.url) {
+                  $log.warn('A required parameter (url) ' +
+                      'is missing in the specified ArcGIS layer:',
+                      opt);
+                  break;
+                }
+                this.addEsriRestFromScratch(map, opt.url, opt.name)
                     .then(function(layer) {
                       if (title) {
                         layer.set('title', title);

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -195,6 +195,11 @@
 
     $scope.printing = false;
 
+    $scope.unsupportedLayers = gnPrint.getUnsupportedLayerTypes($scope.map);
+    $scope.map.getLayers().on('change:length', function() {
+      $scope.unsupportedLayers = gnPrint.getUnsupportedLayerTypes($scope.map);
+    });
+
     $scope.submit = function() {
       if (!$scope.printActive) {
         return;

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -316,11 +316,7 @@
           } else if (src instanceof ol.source.XYZ) {
             encLayer = gnPrint.encoders.layers['XYZ'].call(this,
                 layer, layerConfig, proj);
-          } else if (src instanceof ol.source.Vector ||
-              src instanceof ol.source.ImageVector) {
-            if (src instanceof ol.source.ImageVector) {
-              src = src.getSource();
-            }
+          } else if (src instanceof ol.source.Vector) {
             var features = [];
             src.forEachFeatureInExtent(ext, function(feat) {
               features.push(feat);

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -60,7 +60,7 @@
         overlayCanvas.width = width;
         overlayCanvas.height = height;
         var ctx = overlayCanvas.getContext('2d');
-        
+
 
         var minx, miny, maxx, maxy;
         minx = printRectangle[0], miny = printRectangle[1],
@@ -122,6 +122,8 @@
     };
 
     this.activate = function() {
+      $scope.unsupportedLayers = gnPrint.getUnsupportedLayerTypes($scope.map);
+
       var initMapEvents = function() {
         deregister = [
           $scope.map.getView().on('change:resolution', function(event) {
@@ -196,9 +198,6 @@
     $scope.printing = false;
 
     $scope.unsupportedLayers = gnPrint.getUnsupportedLayerTypes($scope.map);
-    $scope.map.getLayers().on('change:length', function() {
-      $scope.unsupportedLayers = gnPrint.getUnsupportedLayerTypes($scope.map);
-    });
 
     $scope.submit = function() {
       if (!$scope.printActive) {
@@ -372,17 +371,17 @@
             scope.defaultLayout = attrs.layout;
             scope.auto = true;
             scope.activatedOnce = false;
-            
+
             scope.layersWithWhiteSpaces = false;
-            
+
             scope.$watchCollection(
                 function() {
                   return scope.map.getLayers().getArray();
-                }, 
+                },
                 function(layers) {
                   scope.layersWithWhiteSpaces = false;
                   layers.forEach(function(layer) {
-                    if(layer.getSource() 
+                    if(layer.getSource()
                         && layer.getSource() instanceof ol.source.TileWMS
                         && layer.getSource().getParams()
                         && layer.getSource().getParams().LAYERS

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
@@ -547,5 +547,25 @@
 
       return literal;
     };
+
+    /**
+     * Returns an array of unsupported layer types
+     * @param map
+     * @return {string[]}
+     */
+    this.getUnsupportedLayerTypes = function(map) {
+      return map.getLayers().getArray().reduce(function(prev, layer) {
+        var unsupported;
+        if (layer.getSource() instanceof ol.source.BingMaps) {
+          unsupported = 'Bing Maps';
+        } else if (layer.getSource() instanceof ol.source.ImageArcGISRest) {
+          unsupported = 'ArcGIS REST';
+        }
+        if (!!unsupported && prev.indexOf(unsupported) === -1) {
+          return prev.concat([unsupported]);
+        }
+        return prev;
+      }, []);
+    };
   }]);
 })();

--- a/web-ui/src/main/resources/catalog/components/common/map/print/partials/printmap.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/partials/printmap.html
@@ -65,6 +65,16 @@
       <textarea class="form-control" aria-label="{{'mapComment'|translate}}" data-ng-model="mapComment"></textarea>
     </div>
   </div>
+
+  <div class="alert alert-warning flex-row flex-align-center small" role="alert" ng-if="unsupportedLayers.length">
+    <span class="fa fa-warning"></span>
+    <div class="flex-spacer"></div>
+    <div>
+      <span translate>printUnsupportedLayerTypes</span>:
+      <strong>{{unsupportedLayers.join(', ')}}</strong>
+    </div>
+  </div>
+
   <button class="btn btn-default btn-block" ng-class="{'disabled': printing}"
           data-ng-click="submit()">
     <i class="fa fa-print" ng-if="!printing"></i>

--- a/web-ui/src/main/resources/catalog/components/common/map/print/partials/printmap.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/partials/printmap.html
@@ -66,7 +66,7 @@
     </div>
   </div>
 
-  <div class="alert alert-warning flex-row flex-align-center small" role="alert" ng-if="unsupportedLayers.length">
+  <div class="alert alert-warning flex-row flex-align-center small" role="alert" ng-if="unsupportedLayers.length > 0">
     <span class="fa fa-warning"></span>
     <div class="flex-spacer"></div>
     <div>

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -296,7 +296,7 @@
   };
 
   geonetwork.GnFeaturesGFILoader.prototype.getFeatureFromRow = function(row) {
-    var geoms = ['the_geom', 'thegeom', 'boundedBy'];
+    var geoms = ['the_geom', 'thegeom', 'boundedBy', 'geometry'];
     for (var i = 0; i < geoms.length; i++) {
       var geom = row[geoms[i]];
       if (geoms[i] == 'boundedBy' && jQuery.isArray(geom)) {
@@ -496,6 +496,68 @@
   };
 
 
+  /**
+   * Features loader tailored for the ESRI ArcGis REST API
+   * @constructor
+   */
+  geonetwork.GnFeaturesESRILoader = function(config, $injector) {
+    geonetwork.GnFeaturesGFILoader.call(this, config, $injector);
+
+    this.coordinates = config.coordinates;
+  };
+
+  geonetwork.inherits(geonetwork.GnFeaturesESRILoader,
+    geonetwork.GnFeaturesGFILoader);
+
+  geonetwork.GnFeaturesESRILoader.prototype.loadAll = function() {
+    var layer = this.layer;
+    var map = this.map;
+    var coordinates = this.coordinates;
+
+    var uuid;
+    if(layer.get('md')) {
+      uuid = layer.get('md').getUuid();
+    } else if(layer.get('metadataUuid')) {
+      uuid = layer.get('metadataUuid');
+    }
+
+    this.loading = true;
+    var mapExtent = map.getView().calculateExtent();
+    var mapSize = map.getSize();
+
+    // we use the identify operation on the image service, see:
+    // https://developers.arcgis.com/rest/services-reference/identify-map-service-.htm
+    var identifyUrl = layer.getSource().getUrl() +
+      '/identify?geometryType=esriGeometryPoint&geometry=' + coordinates[0] + ',' + coordinates[1] +
+      '&tolerance=4&mapExtent=' + mapExtent.join(',') + '&imageDisplay=' + mapSize.join(',') + ',96' +
+      '&f=json';
+
+    var format = new ol.format.EsriJSON();
+
+    this.promise = this.$http.get(identifyUrl).then(function (response) {
+      this.loading = false;
+      this.features = response.data.results.map(function (result) {
+        return format.readFeature(result, {
+          featureProjection: map.getView().getProjection()
+        });
+      });
+      return this.features;
+    }.bind(this));
+
+    this.dictionary = null;
+
+    if(uuid) {
+      this.dictionary = this.$http.get('../api/records/'+uuid+'/featureCatalog?_content_type=json')
+        .then(function(response) {
+          if(response.data['decodeMap']!=null) {
+            return response.data['decodeMap'];
+          }
+        }, function () {
+          return null;
+        });
+    }
+
+  };
 
   /**
    *

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -524,13 +524,19 @@
     this.loading = true;
     var mapExtent = map.getView().calculateExtent();
     var mapSize = map.getSize();
+    var layerId = layer.getSource().getParams().LAYERS;
+
+    var layerParam = 'top'; // only the top most features will be returned
+    if (!!layerId) {
+      layerParam = 'all:' + layerId; // look into the specified layer instead
+    }
 
     // we use the identify operation on the image service, see:
     // https://developers.arcgis.com/rest/services-reference/identify-map-service-.htm
     var identifyUrl = layer.getSource().getUrl() +
       '/identify?geometryType=esriGeometryPoint&geometry=' + coordinates[0] + ',' + coordinates[1] +
       '&tolerance=4&mapExtent=' + mapExtent.join(',') + '&imageDisplay=' + mapSize.join(',') + ',96' +
-      '&f=json';
+      '&f=json&layers=' + layerParam;
 
     var format = new ol.format.EsriJSON();
 

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
@@ -143,7 +143,8 @@
         }
         var layers = map.getLayers().getArray().filter(function(layer) {
           return (layer.getSource() instanceof ol.source.ImageWMS ||
-              layer.getSource() instanceof ol.source.TileWMS) &&
+              layer.getSource() instanceof ol.source.TileWMS ||
+              layer.getSource() instanceof ol.source.ImageArcGISRest) &&
               layer.getVisible();
         }).reverse();
 
@@ -182,7 +183,13 @@
     layers.forEach(function(layer) {
 
       var indexObject = layer.get('indexObject');
-      var type = indexObject ? 'index' : 'gfi';
+      var isArcGis = layer.getSource() instanceof ol.source.ImageArcGISRest;
+      var type = 'gfi';
+      if (!!indexObject) {
+        type = 'index';
+      } else if (isArcGis) {
+        type = 'esri';
+      }
 
       this.gnFeaturesTableManager.addTable({
         name: layer.get('label') || layer.get('name'),

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -200,6 +200,11 @@
             }
           }
 
+          scope.hasDownload = true;
+          if (layer.getSource() instanceof ol.source.ImageArcGISRest) {
+            scope.hasDownload = false;
+          }
+
           scope.showWPS = function(process) {
             ctrl.setWPS(process, layer, element);
           };

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
@@ -75,10 +75,10 @@
               </li>
 
               <!--Download-->
-              <li class="" data-gn-wfs-download="layer"
+              <li class="" ng-if="hasDownload"
+                           data-gn-wfs-download="layer"
                            data-init-on-demand="true"
                            data-mode="select"
-                           ng-show="hasDownload"
                            has-download="hasDownload" data-map="map" role="menuitem">
               </li>
 

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -524,5 +524,6 @@
   "geometryFilter": "Bounding Box",
   "GUFname": "Your Name",
   "GUFemail": "Your Email address",
-  "GUForganization": "Your Organization"
+  "GUForganization": "Your Organization",
+  "printUnsupportedLayerTypes": "The following layer types are present but cannot be printed"
 }


### PR DESCRIPTION
This PR improves the support for ArcGIS layers in the map viewer in the following ways:
* fix broken visibility/opacity changes
* layer title and extent are read from the REST API
* generates a image legend dynamically
![image](https://user-images.githubusercontent.com/10629150/94170901-ec371500-fe90-11ea-9220-f850216e3f6c.png)

* returns results on map click (similar to GetFeatureInfo for WMS layers)
![image](https://user-images.githubusercontent.com/10629150/94171093-1f79a400-fe91-11ea-8ff2-d03c7c6c5080.png)

* ArcGIS layers can be read from and written to an OWS context, meaning they will not disappear when reloading the page
* MapFish Print does not support these layers; as such, a warning was added in the print panel when such a layer is present:
![image](https://user-images.githubusercontent.com/10629150/94170797-cc9fec80-fe90-11ea-9a27-cc0782071368.png)

* The download option in the layer tree was removed for these layers as data download is not supported yet:
![image](https://user-images.githubusercontent.com/10629150/94171163-391aeb80-fe91-11ea-8d17-f1f5d7e9bc3d.png)

Here is an example URL for testing purposes: https://air.discomap.eea.europa.eu/arcgis/rest/services/AirQuality/AirQualityZones/MapServer (note that this URL should be added as an online resource in a record, as the map viewer is not yet capable of adding ArcGIS layers from the add layer panel)

This work was funded by the [EEA](https://www.eea.europa.eu/).