### PR TITLE
Get related datasets - ignore if the dataset uuid is empty. Related to #4844

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -244,12 +244,16 @@ public class MetadataUtils {
                     if (StringUtils.isNotEmpty(dataset.getValue())) {
                         String[] datasetInfo = dataset.getValue().split("\\|");
                         String datasetUuid = datasetInfo[0];
-                        String refType = (datasetInfo.length > 1)?datasetInfo[1]:"L";
 
-                        if (!refType.equals("R")) {
-                            listOfUUIDs.add(datasetUuid);
-                        } else {
-                            listOfRemoteDatasets.add(dataset.getValue());
+                        // Ignore if datasetUuid is empty
+                        if (StringUtils.isNotEmpty(datasetUuid)) {
+                            String refType = (datasetInfo.length > 1)?datasetInfo[1]:"L";
+
+                            if (!refType.equals("R")) {
+                                listOfUUIDs.add(datasetUuid);
+                            } else {
+                                listOfRemoteDatasets.add(dataset.getValue());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Without this fix, if the dataset uuid is empty in the `srv:operatesOn` the Lucene query send empty value for the uuid, retrieving all elements.