### PR TITLE
Indexing / Improvements

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -103,11 +103,7 @@ public final class IndexMetadataTask implements Runnable {
             for (Object metadataId : _metadataIds) {
                 this.indexed.incrementAndGet();
                 if (this.indexed.compareAndSet(500, 0)) {
-                    try {
-                        searchManager.forceIndexChanges();
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
+                    searchManager.forceIndexChanges();
                 }
 
                 try {
@@ -121,8 +117,6 @@ public final class IndexMetadataTask implements Runnable {
                 _context.getUserSession().loginAs(_user);
             }
             searchManager.forceIndexChanges();
-        } catch (IOException e) {
-            Log.error(Geonet.INDEX_ENGINE, "Error occurred indexing metadata", e);
         } finally {
             _batchIndex.remove(this);
         }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -176,7 +176,7 @@ public class BaseMetadataManager implements IMetadataManager {
      * @param force Force reindexing all from scratch
      * @param asynchronous
      **/
-    public synchronized void synchronizeDbWithIndex(ServiceContext context, Boolean force, Boolean asynchronous) throws Exception {
+    public void synchronizeDbWithIndex(ServiceContext context, Boolean force, Boolean asynchronous) throws Exception {
 
         // get lastchangedate of all metadata in index
         Map<String, String> docs = searchManager.getDocsChangeDate();

--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -153,7 +153,8 @@ public class EsSearchManager implements ISearchManager {
     private int commitInterval = 200;
 
     // public for test, to be private or protected
-    public Map<String, String> listOfDocumentsToIndex = new HashMap<>();
+    public Map<String, String> listOfDocumentsToIndex =
+        Collections.synchronizedMap(new HashMap<>());
     private Map<String, String> indexList;
 
     public String getDefaultIndex() {
@@ -391,73 +392,86 @@ public class EsSearchManager implements ISearchManager {
         if (StringUtils.isNotEmpty(catalog)) {
             doc.put("sourceCatalogue", catalog);
         }
-//        doc.put("indexingDate", new Date());
 
         String jsonDocument = mapper.writeValueAsString(doc);
-        listOfDocumentsToIndex.put(id, jsonDocument);
-        if (listOfDocumentsToIndex.size() == commitInterval || forceRefreshReaders) {
-            sendDocumentsToIndex();
+
+        if (forceRefreshReaders) {
+            HashMap<String, String> document = new HashMap<>();
+            document.put(id, jsonDocument);
+            final BulkResponse bulkItemResponses = client.bulkRequest(defaultIndex, document);
+            checkIndexResponse(bulkItemResponses, document);
+        } else {
+            listOfDocumentsToIndex.put(id, jsonDocument);
+            if (listOfDocumentsToIndex.size() == commitInterval) {
+                sendDocumentsToIndex();
+            }
         }
     }
 
     private void sendDocumentsToIndex() {
-        synchronized (this) {
-            if (listOfDocumentsToIndex.size() > 0) {
-                // TODOES: Report status of failures
-                try {
-                    final BulkResponse bulkItemResponses = client.bulkRequest(defaultIndex, listOfDocumentsToIndex);
-                    int responseStatus = bulkItemResponses.status().getStatus();
-                    if (bulkItemResponses.hasFailures()) {
-                        Map<String, String> listErrorOfDocumentsToIndex = new HashMap<>(bulkItemResponses.getItems().length);
-                        List<String> errorDocumentIds = new ArrayList<>();
-                        // Add information in index that some items were not properly indexed
-                        Arrays.stream(bulkItemResponses.getItems()).forEach(e -> {
-                            if (e.status() != OK
-                                && e.status() != CREATED) {
-                                errorDocumentIds.add(e.getId());
-                                ObjectMapper mapper = new ObjectMapper();
-                                ObjectNode docWithErrorInfo = mapper.createObjectNode();
-                                docWithErrorInfo.put(IndexFields.DBID, e.getId());
-                                String resourceTitle = String.format("Document #%s", e.getId());
+        Map<String, String> documents = new HashMap<>(listOfDocumentsToIndex);
+        listOfDocumentsToIndex.clear();
+        if (documents.size() > 0) {
+            try {
+                final BulkResponse bulkItemResponses = client
+                    .bulkRequest(defaultIndex, documents);
+                checkIndexResponse(bulkItemResponses, documents);
+            } catch (Exception e) {
+                LOGGER.error(
+                    "An error occurred while indexing {} documents in current indexing list. Error is {}.",
+                    new Object[]{listOfDocumentsToIndex.size(), e.getMessage()});
+            } finally {
+                //                listOfDocumentsToIndex.clear();
+            }
+        }
+    }
 
-                                String failureDoc = listOfDocumentsToIndex.get(e.getId());
-                                try {
-                                    JsonNode node = mapper.readTree(failureDoc);
-                                    resourceTitle = node.get("resourceTitleObject").get("default").asText();
-                                } catch (Exception ignoredException) {
-                                }
-                                docWithErrorInfo.put(IndexFields.RESOURCE_TITLE, resourceTitle);
-                                docWithErrorInfo.put(IndexFields.DRAFT, "n");
-                                docWithErrorInfo.put(IndexFields.INDEXING_ERROR_FIELD, true);
-                                docWithErrorInfo.put(IndexFields.INDEXING_ERROR_MSG, e.getFailureMessage());
-                                // TODO: Report the JSON which was causing the error ?
+    private void checkIndexResponse(BulkResponse bulkItemResponses,
+                                    Map<String, String> documents) throws IOException {
+        if (bulkItemResponses.hasFailures()) {
+            Map<String, String> listErrorOfDocumentsToIndex = new HashMap<>(bulkItemResponses.getItems().length);
+            List<String> errorDocumentIds = new ArrayList<>();
+            // Add information in index that some items were not properly indexed
+            Arrays.stream(bulkItemResponses.getItems()).forEach(e -> {
+                if (e.status() != OK
+                    && e.status() != CREATED) {
+                    errorDocumentIds.add(e.getId());
+                    ObjectMapper mapper = new ObjectMapper();
+                    ObjectNode docWithErrorInfo = mapper.createObjectNode();
+                    docWithErrorInfo.put(IndexFields.DBID, e.getId());
+                    String resourceTitle = String.format("Document #%s", e.getId());
 
-                                LOGGER.error("Document with error #{}: {}.",
-                                    new Object[]{e.getId(), e.getFailureMessage()});
-                                LOGGER.error(failureDoc);
-
-                                try {
-                                    listErrorOfDocumentsToIndex.put(e.getId(), mapper.writeValueAsString(docWithErrorInfo));
-                                } catch (JsonProcessingException e1) {
-                                    LOGGER.error("Generated document for the index is not properly formatted. Check document #{}: {}.",
-                                        new Object[]{e.getId(), e1.getMessage()});
-                                }
-                            }
-                        });
-
-                        if (listErrorOfDocumentsToIndex.size() > 0) {
-                            BulkResponse response = client.bulkRequest(defaultIndex, listErrorOfDocumentsToIndex);
-                            if (!(response.status().getStatus() != 201)) {
-                                LOGGER.error("Failed to save error documents {}.",
-                                    new Object[]{errorDocumentIds.toArray().toString()});
-                            }
-                        }
+                    String failureDoc = documents.get(e.getId());
+                    try {
+                        JsonNode node = mapper.readTree(failureDoc);
+                        resourceTitle = node.get("resourceTitleObject").get("default").asText();
+                    } catch (Exception ignoredException) {
                     }
-                } catch (IOException e) {
-                    // TODOES: Probably ES not accessible ?
-                    // Report errors
+                    docWithErrorInfo.put(IndexFields.RESOURCE_TITLE, resourceTitle);
+                    docWithErrorInfo.put(IndexFields.DRAFT, "n");
+                    docWithErrorInfo.put(IndexFields.INDEXING_ERROR_FIELD, true);
+                    docWithErrorInfo.put(IndexFields.INDEXING_ERROR_MSG, e.getFailureMessage());
+                    // TODO: Report the JSON which was causing the error ?
+
+                    LOGGER.error("Document with error #{}: {}.",
+                        new Object[]{e.getId(), e.getFailureMessage()});
+                    LOGGER.error(failureDoc);
+
+                    try {
+                        listErrorOfDocumentsToIndex.put(e.getId(), mapper.writeValueAsString(docWithErrorInfo));
+                    } catch (JsonProcessingException e1) {
+                        LOGGER.error("Generated document for the index is not properly formatted. Check document #{}: {}.",
+                            new Object[]{e.getId(), e1.getMessage()});
+                    }
                 }
-                listOfDocumentsToIndex.clear();
+            });
+
+            if (listErrorOfDocumentsToIndex.size() > 0) {
+                BulkResponse response = client.bulkRequest(defaultIndex, listErrorOfDocumentsToIndex);
+                if (!(response.status().getStatus() != 201)) {
+                    LOGGER.error("Failed to save error documents {}.",
+                        new Object[]{errorDocumentIds.toArray().toString()});
+                }
             }
         }
     }
@@ -496,16 +510,15 @@ public class EsSearchManager implements ISearchManager {
             .add("MD_ConstraintsUseLimitation")
             .add("resourceType")
             .add("type")
+            .add("resourceDates")
             .add("link")
             .add("crsDetails")
             .add("format")
-            .add("creationDateForResource")
-            .add("publicationDateForResource")
-            .add("revisionDateForResource")
             .add("contact")
             .add("contactForResource")
             .add("OrgForResource")
             .add("resourceProviderOrgForResource")
+            .add("resourceVerticalRange")
             .add("resourceTemporalDateRange")
             .add("resourceTemporalExtentDateRange")
             .build();
@@ -560,6 +573,7 @@ public class EsSearchManager implements ISearchManager {
 
             boolean isArray = nodeElements.size() > 1
                 || arrayFields.contains(propertyName)
+                || propertyName.endsWith("DateForResource")
                 || propertyName.startsWith("codelist_");
             if (isArray) {
                 ArrayNode arrayNode = doc.putArray(propertyName);
@@ -625,7 +639,7 @@ public class EsSearchManager implements ISearchManager {
     }
 
     @Override
-    public void forceIndexChanges() throws IOException {
+    public void forceIndexChanges() {
         sendDocumentsToIndex();
     }
 
@@ -953,5 +967,9 @@ public class EsSearchManager implements ISearchManager {
             ApplicationContextHolder.get().getBean(EsSearchManager.class).getDefaultIndex(),
             analyzer,
             fieldValue);
+    }
+
+    public boolean isIndexing() {
+        return listOfDocumentsToIndex.size() > 0;
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/BatchOpsMetadataReindexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/BatchOpsMetadataReindexer.java
@@ -51,7 +51,6 @@ import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.MetadataIndexerProcessor;
 import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.util.ThreadUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/BatchOpsMetadataReindexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/BatchOpsMetadataReindexer.java
@@ -49,7 +49,9 @@ import com.google.common.util.concurrent.MoreExecutors;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.MetadataIndexerProcessor;
+import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.util.ThreadUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
@@ -196,14 +198,14 @@ public class BatchOpsMetadataReindexer extends MetadataIndexerProcessor implemen
         @Override
         public void run() {
             for (int i = beginIndex; i < beginIndex + count; i++) {
-                boolean doIndex = beginIndex + count - 1 == i;
                 try {
-                    dm.indexMetadata(ids[i] + "", doIndex);
+                    dm.indexMetadata(ids[i] + "", false);
                     processed.incrementAndGet();
                 } catch (Exception e) {
                     inError.incrementAndGet();
                 }
             }
+            ApplicationContextHolder.get().getBean(EsSearchManager.class).forceIndexChanges();
         }
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
@@ -77,11 +77,7 @@ public class IndexingTask extends QuartzJobBean {
                         + metadataIdentifier + ". Error: " + e.getMessage(), e);
                 }
             }
-            try {
-                this.applicationContext.getBean(EsSearchManager.class).forceIndexChanges();
-            } catch (IOException e) {
-                Log.error(Geonet.INDEX_ENGINE, "Error forcing index changes", e);
-            }
+            this.applicationContext.getBean(EsSearchManager.class).forceIndexChanges();
         }
     }
 

--- a/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
@@ -241,54 +241,6 @@ public class EsRestClient implements InitializingBean {
             e.printStackTrace();
             throw e;
         }
-//        BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
-//        BulkResponse response = null;
-//        int counter = 0;
-//
-//        Map<String, String> errors = new HashMap<>();
-//        Iterator iterator = docs.keySet().iterator();
-//        while (iterator.hasNext()) {
-//            String id = (String)iterator.next();
-//            try {
-//
-//                bulkRequestBuilder.add(
-//                    client.prepareIndex(index, index, id).setSource(docs.get(id))
-//                );
-//                counter ++;
-//
-//                if (bulkRequestBuilder.numberOfActions() % commitInterval == 0) {
-//                    response = bulkRequestBuilder.execute().actionGet();
-//                    logger.info(String.format(
-//                        "Importing %s: %d actions performed. Has errors: %s",
-//                        index,
-//                        counter,
-//                        response.hasFailures()
-//                    ));
-//                    if (response.hasFailures()) {
-//                        errors.put(counter + "", response.buildFailureMessage());
-//                        success = false;
-//                    }
-//                    bulkRequestBuilder = client.prepareBulk();
-//                }
-//            } catch (Exception ex) {
-//                ex.printStackTrace();
-//            }
-//        }
-//        if (bulkRequestBuilder.numberOfActions() > 0) {
-//            bulkRequestBuilder
-//                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-//            response = bulkRequestBuilder.execute().actionGet();
-//            logger.info(String.format(
-//                "Importing %s: %d actions performed. Has errors: %s",
-//                index,
-//                counter,
-//                response.hasFailures()
-//            ));
-//            if (response.hasFailures()) {
-//                errors.put(counter + "", response.buildFailureMessage());
-//                success = false;
-//            }
-//        }
     }
 
 //

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -238,13 +239,11 @@ public class EsHTTPProxy {
         @Parameter(hidden = true)
             HttpServletResponse response,
         @RequestBody(description = "JSON request based on Elasticsearch API.")
-            String body) throws Exception {
-
+            String body,
+        @Parameter(hidden = true)
+        HttpEntity<String> httpEntity) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
-
-        // Retrieve request body with ElasticSearch query and parse JSON
-        body = IOUtils.toString(request.getReader());
-        call(context, httpSession, request, response, "_search", body, bucket);
+        call(context, httpSession, request, response, "_search", httpEntity.getBody(), bucket);
     }
 
 
@@ -273,13 +272,12 @@ public class EsHTTPProxy {
         @Parameter(hidden = true)
             HttpServletResponse response,
         @RequestBody(description = "JSON request based on Elasticsearch API.")
-        String body) throws Exception {
+            String body,
+        @Parameter(hidden = true)
+            HttpEntity<String> httpEntity) throws Exception {
 
         ServiceContext context = ApiUtils.createServiceContext(request);
-
-        // Retrieve request body with ElasticSearch query and parse JSON
-        body = IOUtils.toString(request.getReader());
-        call(context, httpSession, request, response, endPoint, body, bucket);
+        call(context, httpSession, request, response, endPoint, httpEntity.getBody(), bucket);
     }
 
     public void call(ServiceContext context, HttpSession httpSession, HttpServletRequest request,

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -404,7 +404,7 @@ public class MetadataEditingApi {
 
             if (reindex) {
                 Log.trace(Geonet.DATA_MANAGER, " > Reindexing record");
-                dataMan.indexMetadata(id, true);
+           //     dataMan.indexMetadata(id, true);
             }
 
             ajaxEditUtils.removeMetadataEmbedded(session, id);

--- a/services/src/test/java/org/fao/geonet/services/metadata/BatchOpsMetadatReindexerTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/BatchOpsMetadatReindexerTest.java
@@ -2,6 +2,7 @@ package org.fao.geonet.services.metadata;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.kernel.search.ISearchManager;
 import org.fao.geonet.kernel.search.index.BatchOpsMetadataReindexer;
 import org.fao.geonet.util.ThreadUtils;
@@ -173,7 +174,8 @@ public class BatchOpsMetadatReindexerTest {
 
         PowerMockito.mockStatic(ApplicationContextHolder.class);
         PowerMockito.when(ApplicationContextHolder.get()).thenReturn(mockAppContext);
-
+        EsSearchManager searchManager = Mockito.mock(EsSearchManager.class);
+        Mockito.when(mockAppContext.getBean(Mockito.eq((EsSearchManager.class)))).thenReturn(searchManager);
 
         PowerMockito.mockStatic(ThreadUtils.class);
         PowerMockito.when(ThreadUtils.getNumberOfThreads()).thenReturn(numberOfAvailableThreads);
@@ -188,7 +190,7 @@ public class BatchOpsMetadatReindexerTest {
                 usedTread.add(Thread.currentThread());
                 return null;
             }
-        }).when(mockDataMan).indexMetadata(Mockito.anyString(), Mockito.eq(true));
+        }).when(mockDataMan).indexMetadata(Mockito.anyString(), Mockito.anyBoolean());
         return mockDataMan;
     }
 
@@ -202,7 +204,7 @@ public class BatchOpsMetadatReindexerTest {
                 latch.await();
                 return null;
             }
-        }).when(mockDataMan).indexMetadata(Mockito.anyString(), Mockito.eq(true));
+        }).when(mockDataMan).indexMetadata(Mockito.anyString(), Mockito.anyBoolean());
         return mockDataMan;
     }
 


### PR DESCRIPTION
* Avoid lock - when synchronizeDbWithIndex was triggered, editing a metadata was waiting for the lock
* Remove indexing list in data manager - Now EsSearchManager is in charge of indicating if indexing is in progress or not
* Avoid sharing of the batch list of document (may make multithread indexing to work - need more test)
* former forceRefreshReaders now trigger index of one document directly
* batch indexing trigger final batch indexing at the end if needed.