### PR TITLE
Record view / Use timeline to render resource events, temporal extent and vertical extent

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
@@ -135,7 +135,7 @@
 
   <!-- ... Dates  -->
   <xsl:template mode="render-value" match="*[matches(., '^[0-9]{4}-[0-9]{2}-[0-9]{2}$')]">
-    <span data-gn-humanize-time="{.}" data-format="DD MMM YYYY">
+    <span data-gn-humanize-time="{.}">
       <xsl:value-of select="."/>
     </span>
   </xsl:template>

--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -320,7 +320,7 @@
 
   <!-- ... Dates -->
   <xsl:template mode="render-value" match="gco:Date[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]">
-    <span data-gn-humanize-time="{.}" data-format="DD MMM YYYY">
+    <span data-gn-humanize-time="{.}">
       <xsl:value-of select="."/>
     </span>
   </xsl:template>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -814,7 +814,7 @@
 
   <!-- Display thesaurus name and the list of keywords -->
   <xsl:template mode="render-field"
-                match="mri:descriptiveKeywords[  
+                match="mri:descriptiveKeywords[
                   normalize-space(string-join(*/mri:keyword//text(), '')) = ''
                   or count(*/mri:keyword) = 0]" priority="200"/>
   <xsl:template mode="render-field"
@@ -1137,7 +1137,7 @@
                 match="gco:Date[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]
                       |gml:beginPosition[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]
                       |gml:endPosition[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]">
-    <span data-gn-humanize-time="{.}" data-format="DD MMM YYYY">
+    <span data-gn-humanize-time="{.}">
       <xsl:value-of select="."/>
     </span>
   </xsl:template>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -309,6 +309,18 @@
             </xsl:element>
           </xsl:for-each>
 
+          <xsl:for-each select="cit:date/cit:CI_Date[gn-fn-index:is-isoDate(cit:date/*/text())]">
+              <xsl:variable name="dateType"
+                            select="cit:dateType/cit:CI_DateTypeCode/@codeListValue"
+                            as="xs:string?"/>
+              <xsl:variable name="date"
+                            select="string(cit:date/gco:Date|cit:date/gco:DateTime)"/>
+            <resourceDate type="object">
+              {"type": "<xsl:value-of select="$dateType"/>", "date": "<xsl:value-of select="$date"/>"}
+            </resourceDate>
+          </xsl:for-each>
+
+
           <xsl:if test="$useDateAsTemporalExtent">
             <xsl:for-each-group select="cit:date/cit:CI_Date[gn-fn-index:is-isoDate(cit:date/*/text())]/cit:date/*/text()"
                                 group-by=".">
@@ -860,6 +872,20 @@
                   Date range not indexed.</indexingErrorMsg>
               </xsl:if>
             </xsl:if>
+          </xsl:for-each>
+
+          <xsl:for-each select=".//gex:verticalElement/*">
+            <xsl:variable name="min"
+                          select="gex:minimumValue/*/text()"/>
+            <xsl:variable name="max"
+                          select="gex:maximumValue/*/text()"/>
+
+            <resourceVerticalRange type="object">{
+              "gte": "<xsl:value-of select="normalize-space($min)"/>"
+              <xsl:if test="$min &lt; $max">
+                ,"lte": "<xsl:value-of select="normalize-space($max)"/>"
+              </xsl:if>
+              }</resourceVerticalRange>
           </xsl:for-each>
         </xsl:for-each>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -1149,7 +1149,7 @@
                 match="gco:Date[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]
                       |gml:beginPosition[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]
                       |gml:endPosition[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]">
-    <span data-gn-humanize-time="{.}" data-format="DD MMM YYYY"><xsl:comment select="name()"/>
+    <span data-gn-humanize-time="{.}"><xsl:comment select="name()"/>
       <xsl:value-of select="."/>
     </span>
   </xsl:template>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -308,8 +308,19 @@
             <xsl:element name="{$dateType}MonthForResource">
               <xsl:value-of select="substring($date, 0, 8)"/>
             </xsl:element>
+          </xsl:for-each>
 
 
+          <xsl:for-each select="gmd:date/gmd:CI_Date[gn-fn-index:is-isoDate(gmd:date/*/text())]">
+            <xsl:variable name="dateType"
+                          select="gmd:dateType[1]/gmd:CI_DateTypeCode/@codeListValue"
+                          as="xs:string?"/>
+            <xsl:variable name="date"
+                          select="string(gmd:date[1]/gco:Date|gmd:date[1]/gco:DateTime)"/>
+
+            <resourceDate type="object">
+              {"type": "<xsl:value-of select="$dateType"/>", "date": "<xsl:value-of select="$date"/>"}
+            </resourceDate>
           </xsl:for-each>
 
           <xsl:if test="$useDateAsTemporalExtent">
@@ -866,6 +877,20 @@
                   Date range not indexed.</indexingErrorMsg>
               </xsl:if>
             </xsl:if>
+          </xsl:for-each>
+
+          <xsl:for-each select=".//gmd:verticalElement/*">
+            <xsl:variable name="min"
+                          select="gmd:minimumValue/*/text()"/>
+            <xsl:variable name="max"
+                          select="gmd:maximumValue/*/text()"/>
+
+            <resourceVerticalRange type="object">{
+              "gte": "<xsl:value-of select="normalize-space($min)"/>"
+              <xsl:if test="$min &lt; $max">
+                ,"lte": "<xsl:value-of select="normalize-space($max)"/>"
+              </xsl:if>
+              }</resourceVerticalRange>
           </xsl:for-each>
         </xsl:for-each>
 

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -618,7 +618,14 @@
         this.isPublishedToAll = this.isPublished() ?
             'false' : 'true';
       },
-
+      getFields: function(filter) {
+        var values = {}, props = this, keys = Object.keys(this)
+          .filter(function(name) {return new RegExp(filter).test(name)});
+        keys.forEach(function (k) {
+          values[k] = props[k];
+        });
+        return values;
+      },
       getLinks: function() {
         return this.link;
       },

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -330,7 +330,6 @@
           }
           scope.$watch('regionType', function(val) {
             if (scope.regionType) {
-
               if (scope.regionType.id == 'geonames') {
                 $(element).typeahead('destroy');
                 var url = gnViewerSettings.geocoder;
@@ -509,10 +508,13 @@
           fromNow: '@'
         },
         link: function linkFn(scope, element, attr) {
-          var useFromNowSetting = gnGlobalSettings.gnCfg.mods.global.humanizeDates;
+          var useFromNowSetting = gnGlobalSettings.gnCfg.mods.global.humanizeDates,
+              format = gnGlobalSettings.gnCfg.mods.global.dateFormat;
           scope.$watch('date', function(originalDate) {
             if (originalDate) {
-              var attempt = gnHumanizeTimeService(originalDate, scope.format, scope.fromNow !== undefined)
+              var attempt = gnHumanizeTimeService(originalDate,
+                scope.format || format,
+                scope.fromNow !== undefined)
               if (attempt !== undefined) {
                 scope.value = attempt.value;
                 scope.title = attempt.title;

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -68,7 +68,8 @@ goog.require('gn_alert');
       },
       'mods': {
         'global': {
-          'humanizeDates': true
+          'humanizeDates': true,
+          'dateFormat': 'YYYY-MM-DD'
         },
         'footer':{
           'enabled': true,

--- a/web-ui/src/main/resources/catalog/js/GnSearchModule.js
+++ b/web-ui/src/main/resources/catalog/js/GnSearchModule.js
@@ -61,6 +61,8 @@
         'codelists/gmd%3ADS_AssociationTypeCode');
     $LOCALES.push('/../api/standards/iso19139/' +
         'codelists/gmd%3ADS_InitiativeTypeCode');
+    $LOCALES.push('/../api/standards/iso19115-3.2018/' +
+        'codelists/cit%3ACI_DateTypeCode');
   }]);
 
 })();

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -96,5 +96,7 @@
   "ui-autocompleteConfig": "Autocompletion configuration",
   "ui-autocompleteConfig-help": "Configuration must have a query.multi_match.query which will be set on autocompletion.",
   "ui-facetConfig": "Facets configuration",
-  "ui-facetConfig-help": "This configuration is used to display facets, using either terms aggregations or filters. See <a href=\"https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html\">the documentation</a> for more information."
+  "ui-facetConfig-help": "This configuration is used to display facets, using either terms aggregations or filters. See <a href=\"https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html\">the documentation</a> for more information.",
+  "resourceEvents": "Resource events",
+  "resourceVerticalRange": "Vertical extent"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -340,6 +340,42 @@ header div.gn-abstract {
   }
 }
 
+.gn-period {
+  border-radius: 4px;
+  padding-left: 8px;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
+  margin-bottom: 5px;
+  background: rgb(255,255,255);
+  background: linear-gradient(90deg, rgba(255,255,255,1) 40%, rgba(204,204,204,1) 60%);
+
+  div:first-of-type {
+    width: 45%;
+    text-align: right;
+  }
+  div.spacer {
+    font-size: 28px;
+    color: #ccc;
+    text-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
+  }
+}
+
+.gn-vertical-range {
+  border-radius: 4px;
+  padding-left: 8px;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
+  margin-bottom: 5px;
+  min-height: 60px;
+
+  div.width-25 {
+    border-top: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
+    color: #ccc;
+  }
+  i {
+    font-size: 28px;
+  }
+}
+
 .gn-related-resources {
   .gn-related-item {
     h4 {

--- a/web-ui/src/main/resources/catalog/style/timeline.less
+++ b/web-ui/src/main/resources/catalog/style/timeline.less
@@ -1,6 +1,6 @@
 .timeline {
   list-style: none;
-  padding: 20px 0 20px;
+  padding: 0px 0 0px;
   position: relative;
   a {
     cursor: pointer;
@@ -38,11 +38,11 @@
   content: " ";
   width: 3px;
   background-color: #eeeeee;
-  margin-left: -1.5px;
+  margin-left: 4.5px;
 }
 
 .timeline > li {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   position: relative;
 }
 
@@ -71,7 +71,7 @@
   float: left;
   border: 1px solid #d4d4d4;
   border-radius: 2px;
-  padding: 20px;
+  padding: 8px;
   position: relative;
   -webkit-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
@@ -79,7 +79,7 @@
 
 .timeline > li > .timeline-panel:before {
   position: absolute;
-  top: 26px;
+  top: 3px;
   right: -15px;
   display: inline-block;
   border-top: 15px solid transparent;
@@ -91,7 +91,7 @@
 
 .timeline > li > .timeline-panel:after {
   position: absolute;
-  top: 27px;
+  top: 4px;
   right: -14px;
   display: inline-block;
   border-top: 14px solid transparent;
@@ -109,7 +109,7 @@
   font-size: 1.4em;
   text-align: center;
   position: absolute;
-  top: 16px;
+  top: 6px;
   margin-left: -25px;
   background-color: #999999;
   z-index: 100;
@@ -123,7 +123,7 @@
   height: 30px;
   padding-top: 5px;
   font-size: 1em;
-  top: 25px;
+  top: 4px;
   margin-left: -16px;
   z-index: 0;
 }

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -558,27 +558,20 @@
                 <span data-translate="">tempExtent</span>
               </h2>
 
-              <ul class="timeline timeline-1-col"
+              <div class="flex-row flex-align-center gn-period"
                   data-ng-repeat="range in mdView.current.record.resourceTemporalExtentDateRange">
-                <li class="timeline-inverted"
+                <div class="flex-start"
                     data-ng-show="range.gte">
-                  <div class="timeline-badge timeline-badge-small">
-                    <i class="fa fa-fw fa-play"/>
-                  </div>
-                  <div class="timeline-panel">
-                    <dd data-gn-humanize-time="{{range.gte}}"/>
-                  </div>
-                </li>
-                <li class="timeline-inverted"
+                  <dt data-gn-humanize-time="{{range.gte}}"/>
+                </div>
+                <div class="spacer">
+                  <i class="fa fa-chevron-right"></i>
+                </div>
+                <div class="flex-end"
                     data-ng-show="range.lte">
-                  <div class="timeline-badge timeline-badge-small">
-                    <i class="fa fa-fw fa-stop"/>
-                  </div>
-                  <div class="timeline-panel">
-                    <dd data-gn-humanize-time="{{range.lte}}"/>
-                  </div>
-                </li>
-              </ul>
+                  <dt data-gn-humanize-time="{{range.lte}}"/>
+                </div>
+              </div>
             </div>
 
             <div data-ng-show="mdView.current.record.resourceVerticalRange">
@@ -587,27 +580,20 @@
                 <span data-translate="">resourceVerticalRange</span>
               </h2>
 
-              <ul class="timeline timeline-1-col"
+              <div class="flex flex-row flex-align-center gn-vertical-range"
                   data-ng-repeat="range in mdView.current.record.resourceVerticalRange">
-                <li class="timeline-inverted"
-                    data-ng-show="range.lte">
-                  <div class="timeline-badge timeline-badge-small">
-                    <i class="fa fa-fw fa-chevron-down"/>
+                <div class="width-25">
+                  <i class="fa fa-fw fa-chevron-up"/>
+                </div>
+                <div class="width-75">
+                  <div data-ng-show="range.lte">
+                    <dt>{{range.lte}}</dt>
                   </div>
-                  <div class="timeline-panel">
-                    <dd>{{range.lte}}</dd>
+                  <div data-ng-show="range.gte">
+                    <dt>{{range.gte}}</dt>
                   </div>
-                </li>
-                <li class="timeline-inverted"
-                    data-ng-show="range.gte">
-                  <div class="timeline-badge timeline-badge-small">
-                    <i class="fa fa-fw fa-chevron-up"/>
-                  </div>
-                  <div class="timeline-panel">
-                    <dd>{{range.gte}}</dd>
-                  </div>
-                </li>
-              </ul>
+                </div>
+              </div>
             </div>
           </section>
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -540,9 +540,9 @@
                 <li class="timeline-inverted"
                     data-ng-repeat="date in mdView.current.record.resourceDate">
                   <div class="timeline-badge timeline-badge-small"
-                       data-ng-class="{'danger': date.type === 'superseded'}">
+                       data-ng-class="{'danger': date.type === 'deprecated'}">
                     <i class="fa fa-fw"
-                       data-ng-class="{'fa-chevron-right': date.type === 'creation','fa-ban': date.type === 'superseded', 'fa-retweet': date.type === 'revision', 'fa-check': date.type === 'publication', 'fa-calendar': date.type === 'nextUpdate'}"/>
+                       data-ng-class="{'fa-chevron-right': date.type === 'creation', 'fa-code-fork': date.type === 'superseded','fa-ban': date.type === 'deprecated', 'fa-retweet': date.type === 'revision', 'fa-check': date.type === 'publication', 'fa-calendar': date.type === 'nextUpdate'}"/>
                   </div>
                   <div class="timeline-panel">
                     <dt data-translate>{{date.type | translate}}</dt>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -376,11 +376,7 @@
 
           <table class="table table-striped">
             <tbody>
-<<<<<<< HEAD
             <tr data-ng-if="mdView.current.record.codelist_maintenanceAndUpdateFrequency_text.length > 0">
-=======
-            <tr data-ng-if="mdView.current.record.maintenanceAndUpdateFrequency_text">
->>>>>>> origin/master
               <th data-translate="">updateFrequency</th>
               <td>
                 <p data-ng-repeat="c in mdView.current.record.codelist_maintenanceAndUpdateFrequency_text">
@@ -531,46 +527,88 @@
           </section>
 
           <section class="gn-md-side-dates"
-                  data-ng-if="mdView.current.record.creationDateForResource ||
-                              mdView.current.record.publicationDateForResource ||
-                              mdView.current.record.revisionDateForResource ||
-                              mdView.current.record.resourceTemporalDateRange">
-            <h2>
-              <i class="fa fa-fw fa-clock-o"></i>
-              <span data-translate="">tempExtent</span>
-            </h2>
+                  data-ng-if="mdView.current.record.resourceDate.length > 0 ||
+                              mdView.current.record.resourceTemporalExtentDateRange ||
+                              mdView.current.record.resourceVerticalRange">
+            <div data-ng-show="mdView.current.record.resourceDate.length > 0">
+              <h2>
+                <i class="fa fa-fw fa-clock-o"></i>
+                <span data-translate="">resourceEvents</span>
+              </h2>
 
-            <p>
-            <dl data-ng-show="mdView.current.record.creationDateForResource.length > 0">
-              <dt data-translate>creationDate</dt>
-              <dd data-ng-repeat="creaDate in mdView.current.record.creationDateForResource track by $index"
-                  data-gn-humanize-time="{{creaDate}}"
-                  data-format="YYYY-MM-DD"/>
-            </dl>
-            <dl data-ng-show="mdView.current.record.publicationDateForResource.length > 0">
-              <dt data-translate>publicationDate</dt>
-              <dd data-ng-repeat="pubDate in mdView.current.record.publicationDateForResource track by $index"
-                  data-gn-humanize-time="{{pubDate}}"
-                  data-format="YYYY-MM-DD"/>
-            </dl>
-            <dl data-ng-show="mdView.current.record.revisionDateForResource.length > 0">
-              <dt data-translate>revisionDate</dt>
-              <dd data-ng-repeat="revDate in mdView.current.record.revisionDateForResource track by $index"
-                  data-gn-humanize-time="{{revDate}}"
-                  data-format="YYYY-MM-DD"/>
-            </dl>
-            <dl
-              data-ng-show="mdView.current.record.resourceTemporalExtentDateRange">
-              <dt data-translate>tempExtentBegin</dt>
-              <dd data-ng-repeat="range in mdView.current.record.resourceTemporalExtentDateRange">
-                <span data-gn-humanize-time="{{range.gte}}"
-                      data-format="YYYY-MM-DD"/>
-                &nbsp;<i class="fa fa-fw fa-forward"></i>
-                <span data-gn-humanize-time="{{range.lte}}"
-                      data-format="YYYY-MM-DD"/>
-              </dd>
-            </dl>
-            </p>
+              <ul class="timeline timeline-1-col">
+                <li class="timeline-inverted"
+                    data-ng-repeat="date in mdView.current.record.resourceDate">
+                  <div class="timeline-badge timeline-badge-small"
+                       data-ng-class="{'danger': date.type === 'superseded'}">
+                    <i class="fa fa-fw"
+                       data-ng-class="{'fa-chevron-right': date.type === 'creation','fa-ban': date.type === 'superseded', 'fa-retweet': date.type === 'revision', 'fa-check': date.type === 'publication', 'fa-calendar': date.type === 'nextUpdate'}"/>
+                  </div>
+                  <div class="timeline-panel">
+                    <dt data-translate>{{date.type | translate}}</dt>
+                    <dd data-gn-humanize-time="{{date.date}}"/>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <div data-ng-show="mdView.current.record.resourceTemporalExtentDateRange">
+              <h2>
+                <i class="fa fa-fw fa-clock-o"></i>
+                <span data-translate="">tempExtent</span>
+              </h2>
+
+              <ul class="timeline timeline-1-col"
+                  data-ng-repeat="range in mdView.current.record.resourceTemporalExtentDateRange">
+                <li class="timeline-inverted"
+                    data-ng-show="range.gte">
+                  <div class="timeline-badge timeline-badge-small">
+                    <i class="fa fa-fw fa-play"/>
+                  </div>
+                  <div class="timeline-panel">
+                    <dd data-gn-humanize-time="{{range.gte}}"/>
+                  </div>
+                </li>
+                <li class="timeline-inverted"
+                    data-ng-show="range.lte">
+                  <div class="timeline-badge timeline-badge-small">
+                    <i class="fa fa-fw fa-stop"/>
+                  </div>
+                  <div class="timeline-panel">
+                    <dd data-gn-humanize-time="{{range.lte}}"/>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <div data-ng-show="mdView.current.record.resourceVerticalRange">
+              <h2>
+                <i class="fa fa-fw fa-clock-o"></i>
+                <span data-translate="">resourceVerticalRange</span>
+              </h2>
+
+              <ul class="timeline timeline-1-col"
+                  data-ng-repeat="range in mdView.current.record.resourceVerticalRange">
+                <li class="timeline-inverted"
+                    data-ng-show="range.lte">
+                  <div class="timeline-badge timeline-badge-small">
+                    <i class="fa fa-fw fa-chevron-down"/>
+                  </div>
+                  <div class="timeline-panel">
+                    <dd>{{range.lte}}</dd>
+                  </div>
+                </li>
+                <li class="timeline-inverted"
+                    data-ng-show="range.gte">
+                  <div class="timeline-badge timeline-badge-small">
+                    <i class="fa fa-fw fa-chevron-up"/>
+                  </div>
+                  <div class="timeline-panel">
+                    <dd>{{range.gte}}</dd>
+                  </div>
+                </li>
+              </ul>
+            </div>
           </section>
 
           <section class="gn-md-side-providedby">

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1249,6 +1249,17 @@
       "resolutionScaleDenominator": {
         "type": "integer"
       },
+      "resourceDate": {
+        "type": "nested",
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "date": {
+            "type": "date"
+          }
+        }
+      },
       "link": {
         "type": "nested",
         "properties": {


### PR DESCRIPTION
In ISO19115-3, the resource lifecycle can capture a number of different type of dates (see https://github.com/geonetwork/core-geonetwork/blob/master/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/codelists.xml#L76-L177). Improve the record view in order to display all types of date using a timeline layout and highlight some of them with specific icons.

Also improve temporal extent and add vertical extent.

![image](https://user-images.githubusercontent.com/1701393/94777900-884aaa00-03c4-11eb-887e-bbe1f684a00c.png)

Add a UI settings to define date format (which will be further improved with https://github.com/geonetwork/core-geonetwork/issues/1970)


@MichelGabriel you may have better ideas for icons & layout?