### PR TITLE
[a11y] Add a new accessible menubar: clickable and keyboard accessible

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -759,6 +759,18 @@
            {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <div data-ng-switch-when="isMenubarAccessible">
+        <input type="checkbox"
+               id="{{key}}-checkbox"
+               data-ng-model="mCfg[key]"/>&nbsp;
+        <label class="control-label"
+               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+           {{('ui-' + key + '-help') | translate}} </p>
+      </div>
+
       <div data-ng-switch-when="logoInHeaderPosition">
           <label class="control-label">{{('ui-' + key) | translate}}</label>
 

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -97,7 +97,8 @@ goog.require('gn_alert');
           'logoInHeaderPosition': 'left',
           'fluidHeaderLayout': true,
           'showGNName': true,
-          'isHeaderFixed': false
+          'isHeaderFixed': false,
+          'isMenubarAccessible': true
         },
         'cookieWarning': {
           'enabled': true,
@@ -489,6 +490,7 @@ goog.require('gn_alert');
       $scope.fluidHeaderLayout = gnGlobalSettings.gnCfg.mods.header.fluidHeaderLayout;
       $scope.showGNName = gnGlobalSettings.gnCfg.mods.header.showGNName;
       $scope.isHeaderFixed = gnGlobalSettings.gnCfg.mods.header.isHeaderFixed;
+      $scope.isMenubarAccessible = gnGlobalSettings.gnCfg.mods.header.isMenubarAccessible;
       $scope.isLogoInHeader = gnGlobalSettings.gnCfg.mods.header.isLogoInHeader;
 
       // If gnLangs current already set by config, do not use URL

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1373,6 +1373,8 @@
     "ui-logoInHeaderPosition-help": "Position of the logo in the header",
     "ui-isHeaderFixed": "Fix the header",
     "ui-isHeaderFixed-help": "The header is fixed and stays at the top of the page. Attention: when the option [Show the logo in header] is also selected, the header needs a set height. This can be done under [CSS & Style] > [Header] > [Height]",
+    "ui-isMenubarAccessible": "Make menubar Accessible",
+    "ui-isMenubarAccessible-help": "Make menubar item open on click, not on hover. This means that the menuitems will be accessible by keyboard.",
     "left": "Left",
     "center": "Center",
     "right": "Right",

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -229,8 +229,14 @@ a {
  * Logo in nav bar can't be big
  */
 .gn-logo {
-  max-height: 28px;
-  margin: -8px 0px;
+  max-height: 24px;
+  margin: -12px 0px 0px 0px;
+  @media (max-width: @screen-md-max) {
+    margin-top: -6px;
+  }
+  @media (max-width: @screen-xs-max) {  
+    margin-top: 0;
+  }
 }
 
 .gn-logo-lg {

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
@@ -1,0 +1,281 @@
+<div data-ng-class="fluidHeaderLayout ? 'container-fluid' : 'container'">
+  <div class="navbar-header">
+    <a class="hidden-sm hidden-md hidden-lg pull-left gn-logo-link" data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}" data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}">
+      <img class="gn-logo"
+           alt="{{'siteLogo' | translate}}"
+           data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
+    </a>
+    <a class="hidden-sm hidden-md hidden-lg btn btn-link pull-left"
+       data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
+      <span class="gn-name"
+            data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
+            title="{{info['system/site/name']}}">{{info['node/name'] || info['system/site/name']}}</span>
+    </a>
+    <button type="button"
+            class="navbar-toggle collapsed"
+            data-toggle="collapse"
+            data-target="#navbar"
+            title="{{'toggleNavigation' | translate}}"
+            aria-expanded="false"
+            aria-controls="navbar">
+      <span class="sr-only" data-translate>toggleNavigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+  <div id="navbar" class="navbar-accessible navbar-collapse collapse">
+    <ul class="nav navbar-nav gn-menu-xs" role="menu">
+      <li class="clearfix hidden-xs" data-ng-if="gnCfg.mods.home.enabled">
+        <a class="pull-left gn-logo-link" 
+           data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
+          <img class="gn-logo"
+               data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}"
+               alt="{{'siteLogo' | translate}}"
+               data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
+          <span class="gn-name gn-margin-left hidden-sm"
+                data-ng-if="gnCfg.mods.header.showGNName"
+                data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
+                title="{{info['node/name'] || info['system/site/name']}}">
+            {{info['node/name'].split('|')[0] || info['system/site/name']}}
+          </span>
+        </a>
+      </li>
+      <li class="gn-menuitem-xs" data-ng-if="gnCfg.mods.search.enabled">
+        <a data-gn-active-tb-item="{{gnCfg.mods.search.appUrl}}"
+          title="{{'search' | translate}}">
+          <span class="fa fa-fw fa-search hidden-sm"></span>
+          <span translate>search</span>
+        </a>
+      </li>
+      <li class="gn-menuitem-xs" data-ng-if="gnCfg.mods.map.enabled">
+        <a data-gn-active-tb-item="{{isExternalViewerEnabled ? externalViewerUrl : gnCfg.mods.map.appUrl}}"
+          title="{{'map' | translate}}">
+          <span class="fa fa-fw fa-globe hidden-sm"></span>
+          <span translate>makeYourMap</span>
+          <span data-gnv-layer-indicator=""/>
+        </a>
+      </li>
+      <li class="dropdown gn-clear-xs" data-ng-if="gnCfg.mods.editor.enabled"
+          data-ng-show="authenticated && user.isEditorOrMore()"
+          id="gn-login-dropdown">
+        <a title="{{'editorBoard' | translate}}"
+           href
+           class="dropdown-toggle gn-menuheader-xs"
+           role="button"
+           data-toggle="dropdown"
+           aria-haspopup="true"
+           aria-expanded="false">
+          <span class="fa fa-fw fa-pencil hidden-xs"></span>
+          <span translate>contribute</span>
+          <span class="caret hidden-xs"></span>
+        </a>
+        <ul class="dropdown-menu gn-menu-xs clearfix" role="menu">
+          <li class="gn-menuitem-xs" role="menuitem">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/board">
+              <span class="fa fa-fw fa-bars"></span><span translate>editorHome</span>
+            </a>
+          </li>
+          <li role="separator" class="divider gn-separator-xs"></li>
+          <li class="gn-menuitem-xs" role="menuitem">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/create">
+              <span class="fa fa-fw fa-plus"></span>&nbsp;<span translate>addRecord</span>
+            </a>
+          </li>
+          <li class="gn-menuitem-xs" role="menuitem">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/import">
+              <span class="fa fa-fw fa-upload"></span><span translate>ImportRecord</span>
+            </a>
+          </li>
+          <li class="gn-menuitem-xs" role="menuitem">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/directory">
+              <span class="fa fa-fw fa-bookmark"></span><span translate>directoryManager</span>
+            </a>
+          </li>
+          <li class="gn-menuitem-xs" role="menuitem">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/batchedit">
+              <span class="fa fa-fw fa-pencil"></span><span translate>batchEditing</span>
+            </a>
+          </li>
+          <li class="gn-menuitem-xs" role="menuitem" ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
+            <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/accessManager">
+              <span class="fa fa-fw fa-lock"/><span data-translate="">accessManager</span>
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li class="dropdown" data-ng-show="user.isUserAdminOrMore()">
+        <a title="{{'adminConsole' | translate}}"
+           href
+           class="dropdown-toggle gn-menuheader-xs"
+           role="button"
+           data-toggle="dropdown"
+           aria-haspopup="true"
+           aria-expanded="false">
+          <span class="fa fa-fw fa-wrench hidden-xs"></span>
+          <span translate>adminConsole</span>
+          <span class="caret hidden-xs"></span>
+        </a>
+        <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu gn-menu-xs" role="menu">
+          <li class="gn-menuitem-xs" role="menuitem">
+            <a data-gn-active-tb-item="admin.console#/home">
+              <span class="fa fa-fw fa-th"></span><span translate>adminHome</span>
+            </a>
+          </li>
+          <li role="separator" class="divider gn-separator-xs"></li>
+          <li class="gn-menuitem-xs" role="menuitem" data-ng-repeat="t in userAdminMenu">
+            <a data-gn-active-tb-item="admin.console{{t.route}}">
+              <span class="fa fa-fw {{t.icon}}"></span><span translate>{{t.name | translate}}</span>
+            </a>
+          </li>
+        </ul>
+        <ul data-ng-if="user.isAdministrator()" class="dropdown-menu gn-menu-xs" role="menu">
+          <li class="gn-menuitem-xs" role="menuitem">
+            <a data-gn-active-tb-item="admin.console#/home">
+              <span class="fa fa-fw fa-th"></span><span translate>adminHome</span>
+            </a>
+          </li>
+          <li role="separator" class="divider gn-separator-xs"></li>
+          <li class="gn-menuitem-xs" role="menuitem" data-ng-repeat="t in adminMenu">
+            <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}{{t.route}}">
+              <span class="fa fa-fw {{t.icon}}"></span><span translate>{{t.name | translate}}</span>
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li gn-static-pages-list-viewer data-section="top" data-language="{{lang}}" />
+    </ul>
+
+    <div class="navbar-right">
+      <ul data-ng-if="gnCfg.mods.signin.enabled"
+          class="nav navbar-nav username-dropdown">
+        <!-- logged in -->
+        <li class="dropdown" data-ng-show="authenticated">
+          <a title="{{'userDetails' | translate}}"
+             href
+             class="dropdown-toggle gn-menuitem-xs"
+             role="button"
+             data-toggle="dropdown"
+             aria-haspopup="true"
+             aria-expanded="false">
+            <img class="img-circle"
+              alt="{{'avatar' | translate}}"
+              data-ng-src="../api/users/{{(user.id)}}.png?size=18"/>
+            <div class="gn-user-info hidden-sm hidden-md">
+              <span class="gn-user-name">{{user.name}} {{user.surname}}</span><br>
+              <span class="gn-user-role">{{user.profile | translate}}</span>
+            </div>
+            <span class="caret"></span>
+            <span class="alert alert-danger ng-hide"
+                  data-ng-show="session.remainingTime > 0 &&
+                      session.remainingTime < session.alertInTitleWhen"
+                  translate
+                  data-translate-values="{remainingTime: '{{session.remainingTime}}'}">
+              sessionWillExpireIn
+            </span>
+          </a>
+          <ul class="dropdown-menu gn-menuitem-xs" role="menu">
+            <li class="text-center hidden-xs" role="menuitem">
+              <img class="img-circle"
+                  alt="{{'avatar' | translate}}"
+                  data-ng-src="../api/users/{{(user.id)}}.png?size=56"/>
+            </li>
+            <li role="separator" class="divider hidden-xs"></li>
+            <li class="dropdown-header hidden-xs" role="menuitem" translate>username</li>
+            <li class="hidden-xs" role="menuitem">
+              <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}">{{user.name}} {{user.surname}}</a>
+            </li>
+            <li class="dropdown-header hidden-xs" role="menuitem" translate>profile</li>
+            <li class="hidden-xs" role="menuitem">
+              <a style="text-transform: lowercase" data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}">{{user.profile | translate}}</a>
+            </li>
+            <li role="separator" class="divider hidden-xs"></li>
+            <li role="menuitem">
+              <a href="{{signoutUrl}}"
+                title="{{'signout' | translate}}">
+                <span class="fa fa-fw fa-sign-out"></span>
+                {{'signout' | translate}}
+              </a>
+            </li>
+          </ul>
+        </li>
+        <!-- not logged in -->
+        <li class="dropdown signin-dropdown"
+          data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && (!shibbolethEnabled || (shibbolethEnabled && !shibbolethHideLogin))">
+          <a href="{{gnCfg.mods.signin.appUrl | signInLink}}"
+             title="{{'signIn'|translate}}"
+             class="dropdown-toggle gn-menuheader-xs"
+             data-ng-keypress="$event"
+             data-toggle="dropdown"
+             aria-haspopup="true"
+             data-ng-mouseover="focusLoginPopup()">
+            <span class="fa fa-fw fa-sign-in hidden-sm"></span>
+            {{'signIn' | translate}}
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" role="menu">
+            <li role="menuitem">
+              <form name="gnSigninForm" class="navbar-form flex-row"
+                action="{{signInFormAction}}" method="post" role="form">
+                <input type="hidden" name="_csrf" value="{{csrf}}"/>
+                <div class="form-group form-group-sm">
+                  <div class="input-group">
+                    <span class="input-group-addon">
+                      <span class="fa fa-fw fa-user"></span>
+                    </span>
+                    <input type="text"
+                          class="form-control"
+                          id="inputUsername"
+                          name="username"
+                          autofocus=""
+                          aria-label="{{'username' | translate}}"
+                          placeholder="{{'username' | translate}}"
+                          data-ng-model="signinUsername"
+                          required=""/>
+                  </div>
+                </div>
+                <div class="flex-spacer hidden-xs"></div>
+                <div class="form-group form-group-sm">
+                  <div class="input-group">
+                    <span class="input-group-addon">
+                      <span class="fa fa-fw fa-lock"></span>
+                    </span>
+                    <input type="password"
+                          class="form-control"
+                          id="inputPassword"
+                          name="password"
+                          autocomplete="off"
+                          data-ng-model="signinPassword"
+                          aria-label="{{'password' | translate}}"
+                          placeholder="{{'password' | translate}}"
+                          required=""/>
+                  </div>
+                </div>
+                <div class="flex-spacer hidden-xs"></div>
+
+                <input type="hidden" name="redirectUrl" value="{{redirectUrlAfterSign}}"/>
+
+                <button type="submit" class="btn btn-primary btn-sm pull-right"
+                        aria-label="{{'signIn' | translate}}"
+                        data-ng-disabled="!gnSigninForm.$valid">
+                  <span class="fa fa-sign-in"></span>
+                </button>
+              </form>
+            </li>
+          </ul>
+        </li>
+      </ul>
+
+      <form class="navbar-form language-switcher pull-right">
+        <span class="gn-menuheader-xs visible-xs"
+              data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && (!shibbolethEnabled || (shibbolethEnabled && !shibbolethHideLogin))"
+              data-translate="">language</span>
+        <div class="form-group"
+            data-gn-language-switcher="lang"
+            data-langs="langs"
+            data-lang-labels="langLabels">
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -29,11 +29,11 @@
       <li class="clearfix hidden-xs" data-ng-if="gnCfg.mods.home.enabled">
         <a class="pull-left gn-logo-link" 
            data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
-          <img class="gn-logo gn-margin-right"
+          <img class="gn-logo"
                data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}"
                alt="{{'siteLogo' | translate}}"
                data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
-          <span class="gn-name"
+          <span class="gn-name gn-margin-left hidden-sm"
                 data-ng-if="gnCfg.mods.header.showGNName"
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
                 title="{{info['node/name'] || info['system/site/name']}}">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -35,6 +35,15 @@
       color: @gn-menubar-color-hover;
       background-color: @gn-menubar-background-hover;
     }
+    &:focus {
+      outline: 2px auto -webkit-focus-ring-color;
+    }
+  }
+  .btn {
+    &:focus {
+      outline: 2px auto -webkit-focus-ring-color;
+      outline-offset: 0;
+    }
   }
   .navbar-nav li.dropdown-hover.open:not(.active) > .dropdown-toggle {
     &:hover, &:focus {
@@ -42,15 +51,30 @@
     }
     
   }
+  .language-switcher {
+    .form-control {
+      &:focus {
+        box-shadow: none;
+        outline: 2px auto -webkit-focus-ring-color;
+      }
+    }
+  }
   .dropdown-menu {
     > li {
       > a {
         padding: 8px 20px;
+        &:focus {
+          box-shadow: none;
+          outline: 2px auto -webkit-focus-ring-color;
+        }
       }
     }
     .dropdown-header {
       color: @gray;
       cursor: text !important;
+    }
+    .fa-fw {
+      width: 2em;
     }
   }
   .navbar-nav > .active > a {
@@ -58,12 +82,7 @@
     color: @gn-menubar-color-active;
   }
   .gn-logo-link {
-    padding: 10px 15px;
-    .gn-logo {
-      margin: 0;
-    }
     .gn-name {
-      margin-top: 4px;
       &.gn-truncate {
         @media (min-width: @screen-lg-min) {
           max-width: 230px;
@@ -79,9 +98,10 @@
     display: none
   }
   input.ng-invalid, .has-error .form-control {
-    border-color: #f98258;
+    border-color: @brand-danger;
     &:focus {
-      box-shadow: none; // inset 0 1px 1px rgba(0,0,0,.075), 0 0 4px rgb(250, 140, 99);
+      box-shadow: none;
+      outline: 2px auto @brand-danger;
     }
   }
   .gn-user-info {
@@ -114,6 +134,29 @@
     }
     .navbar-nav .open .dropdown-menu > li > a {
       min-width: 0;
+    }
+    .navbar-accessible {
+      .dropdown-menu {
+        display: block;
+        position: static;
+        float: none;
+        width: auto;
+        margin-top: 0;
+        background-color: transparent;
+        border: 0;
+        box-shadow: none;
+        .gn-menuitem-xs {
+          a {
+            min-width: 0;
+          }
+        }
+      }
+      .username-dropdown {
+        margin-top: 10px;
+      }
+      .navbar-form {
+        width: calc(~"100% + 30px");
+      }
     }
     .gn-clear-xs {
       clear: both;
@@ -155,16 +198,17 @@
           display: block;
           padding: 7px 20px !important;
           height: auto;
-          i {
-            font-size: 22px;
-            margin: 3px 0;
-          }
           span {
             display: block;
             max-width: 100%;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+          }
+          .fa {
+            display: inline-block;
+            font-size: 22px;
+            // margin: 3px auto;
           }
           [data-gnv-layer-indicator] {
             display: none;

--- a/web-ui/src/main/resources/catalog/views/default/templates/index.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/index.html
@@ -12,12 +12,12 @@
     </div>
   </div>
 </header>
-<div class="navbar navbar-default gn-top-bar"
+<nav class="navbar navbar-default gn-top-bar"
      role="navigation"
      data-ng-show="gnCfg.mods.header.enabled"
-     data-ng-include="'../../catalog/templates/top-toolbar.html'"
+     data-ng-include="isMenubarAccessible ? '../../catalog/templates/top-toolbar-accessible.html' : '../../catalog/templates/top-toolbar.html'"
      xmlns="http://www.w3.org/1999/html">
-</div>
+</nav>
 
 <div class="gn-search-page"
      role="main"

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -88,7 +88,7 @@
               <div class="navbar navbar-default gn-top-bar"
                    role="navigation"
                    data-ng-hide="layout.hideTopToolBar"
-                   data-ng-include="'{$uiResourcesPath}templates/top-toolbar.html'"></div>
+                   data-ng-include="isMenubarAccessible ? '{$uiResourcesPath}templates/top-toolbar-accessible.html' : '{$uiResourcesPath}templates/top-toolbar.html'"></div>
             </xsl:if>
 
             <xsl:apply-templates mode="content" select="."/>


### PR DESCRIPTION
This PR adds a new menubar targeted at accessibility. It's clickable and not opening on hover anymore. This means you can now access with a keyboard (`tab`, `arrow` and `enter` keys). 

Extra attention has been paid to the focus state of the elements, it's now more clear which menu item has the focus.

![gn-new-meny-focus](https://user-images.githubusercontent.com/19608667/94805516-c956b480-03ec-11eb-87a1-64493a7d354a.png)


You can activate this toolbar with a setting in the admin:

![gn-new-menu-setting](https://user-images.githubusercontent.com/19608667/94805329-81d02880-03ec-11eb-903a-814be1e20076.png)

Changes made:
- settings in admin
- new toolbar HTML file
- fix for logo and name padding glitches
- fix for all menubars on smaller tablet sizes