### PR TITLE
[a11y] Make the subbar on the record view accessible (by keyboard)

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -8,7 +8,7 @@
             data-toggle="dropdown"
             aria-label="{{'manageRecord' | translate}}"
             aria-expanded="false">
-      <i class="fa fa-fw fa-cog"></i>
+      <span class="fa fa-fw fa-cog"></span>
       <span data-translate="" class="hidden-xs">manageRecord</span>
       <span class="caret"></span>
     </button>
@@ -17,7 +17,7 @@
         <a href=""
            data-ng-if="user.canEditRecord(md) && user.isEditorOrMore() && md.draft != 'y'"
            data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())">
-          <i class="fa fa-fw fa-key"></i>&nbsp;
+          <span class="fa fa-fw fa-key"></span>&nbsp;
           <span data-translate="">privileges</span>
         </a>
       </li>
@@ -25,7 +25,7 @@
           data-ng-if="md.isOwned() && user.isUserAdminOrMore()">
         <a href=""
            data-ng-click="mdService.openTransferOwnership(md, null, getCatScope())">
-          <i class="fa fa-fw fa-user"></i>&nbsp;
+          <span class="fa fa-fw fa-user"></span>&nbsp;
           <span data-translate="">transferOwnership</span>
         </a></li>
       <li role="menuitem"
@@ -38,18 +38,18 @@
             (!md.hasValidation() ? 'mdnovalidation':
             (allowPublishInvalidMd() === false ? 'mdinvalidcantpublish' : 'mdinvalid'))) : '') | translate }}">
         <a href="" data-ng-click="mdService.publish(md, undefined, undefined, getCatScope())">
-          <i class="fa fa-fw"
-             data-ng-class="md.isPublished() ? 'fa-lock' : 'fa-unlock'"></i>&nbsp;
+          <span class="fa fa-fw"
+             data-ng-class="md.isPublished() ? 'fa-lock' : 'fa-unlock'"></span>&nbsp;
           <span data-ng-if="md.isPublished()"
                 data-translate="">unpublish</span>
           <span data-ng-if="!md.isPublished()"
                 data-translate="">publish</span>&nbsp;
 
-          <i class="fa fa-fw"
+          <span class="fa fa-fw"
              data-ng-if="!md.isPublished() && md.hasValidation()"
-             data-ng-class="md.isValid() ? 'gn-recordtype-n text-success' : 'gn-recordtype-n text-danger'"></i>
-          <i class="fa fa-fw gn-recordtype-n text-muted"
-             data-ng-if="!md.isPublished() && !md.hasValidation()"></i>
+             data-ng-class="md.isValid() ? 'gn-recordtype-n text-success' : 'gn-recordtype-n text-danger'"></span>
+          <span class="fa fa-fw gn-recordtype-n text-muted"
+             data-ng-if="!md.isPublished() && !md.hasValidation()"></span>
         </a>
 
       </li>
@@ -82,7 +82,7 @@
           user.isEditorForGroup(md.groupOwner)) && md.mdStatus == 1 && isMdWorkflowEnable && md.isWorkflowEnabled()">
         <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 4, 14)">
-          <i class="fa fa-fw fa-file-o"></i>&nbsp;
+          <span class="fa fa-fw fa-file-o"></span>&nbsp;
           <span data-translate="">mdStatusTitle-14</span>
         </a>
       </li>
@@ -91,7 +91,7 @@
           user.isEditorForGroup(md.groupOwner)) && md.mdStatus == 3 && isMdWorkflowEnable && md.isWorkflowEnabled()">
         <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 1, 31)">
-          <i class="fa fa-fw fa-file-o"></i>&nbsp;
+          <span class="fa fa-fw fa-file-o"></span>&nbsp;
           <span data-translate="">mdStatusTitle-31</span>
         </a>
       </li>
@@ -101,7 +101,7 @@
           user.isEditorForGroup(md.groupOwner) && md.mdStatus == 4  && isMdWorkflowEnable && md.isWorkflowEnabled()">
         <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 1, 41)">
-          <i class="fa fa-fw fa-undo"></i>&nbsp;
+          <span class="fa fa-fw fa-undo"></span>&nbsp;
           <span data-translate="">mdStatusTitle-41</span>
         </a>
       </li>
@@ -111,7 +111,7 @@
           md.mdStatus == 4  && isMdWorkflowEnable && md.isWorkflowEnabled()">
         <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 2, 42)">
-          <i class="fa fa-fw fa-thumbs-o-up"></i>&nbsp;
+          <span class="fa fa-fw fa-thumbs-o-up"></span>&nbsp;
           <span data-translate="">mdStatusTitle-42</span>
         </a>
       </li>
@@ -120,7 +120,7 @@
           md.mdStatus == 1  && isMdWorkflowEnable && md.isWorkflowEnabled()">
         <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 2, 12)">
-          <i class="fa fa-fw fa-thumbs-o-up"></i>&nbsp;
+          <span class="fa fa-fw fa-thumbs-o-up"></span>&nbsp;
           <span data-translate="">mdStatusTitle-12</span>
         </a>
       </li>
@@ -130,7 +130,7 @@
           md.mdStatus == 4  && isMdWorkflowEnable && md.isWorkflowEnabled()">
         <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 1, 411)">
-          <i class="fa fa-fw fa-thumbs-o-down"></i>&nbsp;
+          <span class="fa fa-fw fa-thumbs-o-down"></span>&nbsp;
           <span data-translate="">mdStatusTitle-411</span>
         </a>
       </li>
@@ -140,7 +140,7 @@
           md.mdStatus == 4  && isMdWorkflowEnable && md.isWorkflowEnabled()">
         <a href=""
            data-ng-click="mdService.openUpdateStatusPanel(getScope(), 'workflow', null, 3, 33)">
-          <i class="fa fa-fw fa-archive"></i>&nbsp;
+          <span class="fa fa-fw fa-archive"></span>&nbsp;
           <span data-translate="">mdStatusTitle-33</span>
         </a>
       </li>
@@ -148,7 +148,7 @@
         <a role="menuitem"
            href=""
            data-ng-click="mdService.startWorkflow(md, getCatScope())">
-          <i class="fa fa-fw fa-code-fork"></i>&nbsp;
+          <span class="fa fa-fw fa-code-fork"></span>&nbsp;
           <span data-translate="">enableWorkflow</span>
         </a>
       </li>
@@ -161,7 +161,7 @@
           data-ng-show="taskConfiguration[t.name] && taskConfiguration[t.name].isVisible && taskConfiguration[t.name].isVisible(md)"
           data-ng-class="::{'disabled': !taskConfiguration[t.name].isApplicable(md)}">
         <a href="" data-ng-click="mdService.openUpdateStatusPanel(getScope(md), 'task', t)">
-          <i class="fa fa-fw"></i>&nbsp;
+          <span class="fa fa-fw"></span>&nbsp;
           <span>{{t.label | gnLocalized}}</span>
         </a>
       </li>
@@ -173,7 +173,7 @@
         <a href=""
            data-ng-if="user.isEditorOrMore() && md.draft != 'y'"
            data-ng-click="mdService.duplicate(md)">
-          <i class="fa fa-fw fa-copy"></i>&nbsp;
+          <span class="fa fa-fw fa-copy"></span>&nbsp;
           <span data-translate="">duplicate</span>
         </a>
       </li>
@@ -181,7 +181,7 @@
         <a href=""
            data-ng-if="user.isEditorOrMore() && md.draft != 'y'"
            data-ng-click="mdService.createChild(md)">
-          <i class="fa fa-fw fa-sitemap"></i>&nbsp;
+          <span class="fa fa-fw fa-sitemap"></span>&nbsp;
           <span data-translate="">createChild</span>
         </a>
       </li>
@@ -194,7 +194,7 @@
             data-toggle="dropdown"
             aria-label="{{'download' | translate}}"
             aria-expanded="false">
-      <i class="fa fa-fw fa-download"></i>
+      <span class="fa fa-fw fa-download"></span>
       <span data-translate="" class="hidden-xs">download</span>
       <span class="caret"></span>
     </button>
@@ -202,14 +202,14 @@
       <li data-ng-class="{'disabled': md.draft === 'y'}">
         <a href=""
            data-ng-click="mdService.getPermalink(md)">
-          <i class="fa fa-fw fa-link"></i>&nbsp;
+          <span class="fa fa-fw fa-link"></span>&nbsp;
           <span data-translate="">permalink</span>
         </a>
       </li>
       <li role="menuitem" data-ng-repeat="f in formatterList">
         <a data-ng-href="../api/records/{{md.getUuid()}}{{f.url.replace('${lang}', lang)}}{{f.url.indexOf('?') !== -1 ? '&': '?'}}approved={{mdView.current.record.draft != 'y'}}"
            target="_blank">
-          <i class="fa fa-fw {{f.class}}"></i>&nbsp;
+          <span class="fa fa-fw {{f.class}}"></span>&nbsp;
           <span data-translate="">{{f.label | translate}}</span>
         </a>
       </li>
@@ -218,7 +218,7 @@
       <li role="menuitem">
         <a href=""
            data-ng-click="mdService.metadataRDF(md.getUuid(), mdView.current.record.draft != 'y')">
-          <i class="fa fa-fw fa-share-alt"></i>&nbsp;
+          <span class="fa fa-fw fa-share-alt"></span>&nbsp;
           <span data-translate="">exportRDF</span>
         </a>
       </li>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -70,3 +70,9 @@
     max-width: 150px;
   }
 }
+.btn, .dropdown-toggle {
+  &:focus {
+    outline: 2px auto -webkit-focus-ring-color;
+    outline-offset: 0;
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -39,14 +39,16 @@
 
       <div class="btn-toolbar" role="toolbar">
 
+        <!-- back -->
         <div class="btn-group" role="group">
           <button class="btn btn-default"
                   data-ng-click="closeRecord(mdView.current.record)">
-            <i class="fa fa-fw fa-search"></i> <span><span>
-            {{'backTo' + (fromView || 'search') | translate}}</span></span>
+            <span class="fa fa-fw fa-search"></span>
+            {{'backTo' + (fromView || 'search') | translate}}
           </button>
         </div>
 
+        <!-- next/previous -->
         <div class="btn-group" role="group">
           <a class="btn btn-default"
              title="{{mdView.records[mdView.current.index - 1].defaultTitle}}"
@@ -55,9 +57,8 @@
              gn-formatter="formatter.defaultUrl"
              data-ng-class="{'disabled': searchObj.params.from == (mdView.current.index + 1)}"
              data-ng-show="mdView.records.length > 1">
-            <i class="fa fa-fw fa-angle-left"></i>
-<!--            <span data-ng-show="mdView.current.index === 0" data-translate="">previousPage</span>-->
-            <span data-translate="">previous</span>
+            <span class="fa fa-fw fa-angle-left"></span>
+            <span data-translate="" class="hidden-sm hidden-sm">previous</span>
           </a>
           <a class="btn btn-default"
              title="{{mdView.records[mdView.current.index + 1].defaultTitle}}"
@@ -68,58 +69,64 @@
                             searchObj.params.to > searchInfo.count &&
                             searchInfo.count > searchObj.params.from}"
              data-ng-show="mdView.records.length > 1">
-<!--            <span data-ng-show="mdView.current.index === mdView.records.length - 1" data-translate="">nextPage</span>-->
-            <span data-translate="">next</span>
-            <i class="fa fa-fw fa-angle-right"></i>
+            <span data-translate="" class="hidden-sm hidden-sm">next</span>
+            <span class="fa fa-fw fa-angle-right"></span>
           </a>
         </div>
 
-      <div class="btn-group pull-right gn-view-menu-button">
-          <button type="button" class="btn btn-default dropdown-toggle"
-                  data-toggle="dropdown"
-                  aria-label="{{'chooseAView' | translate}}"
-                  aria-expanded="false">
-            <i class="fa fa-fw fa-eye"></i>
-            <span data-translate="" class="hidden-sm hidden-xs">chooseAView</span>
-            <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu" role="menu">
-            <li role="menuitem"
-                data-ng-repeat="f in formatter.list"
-                data-ng-class="currentFormatter === f.url ? 'disabled' : ''">
-              <a href=""
-                 gn-metadata-open="mdView.current.record"
-                 gn-records="mdView.records"
-                 gn-formatter="f && f.url">
-                {{f.label | translate}}
-              </a>
-            </li>
-          </ul>
-        </div>
+        <div class="pull-right">
+          <!-- edit -->
+          <div class="btn-group pull-left" role="group">
+            <a class="btn btn-default gn-md-edit-btn"
+               data-ng-show="user.canEditRecord(mdView.current.record) && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
+               data-ng-href="catalog.edit#/metadata/{{mdView.current.record.getId()}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.getUuid()}}"
+               title="{{'edit' | translate}}">
+              <span class="fa fa-fw fa-pencil"></span>
+              <span data-translate="" class="hidden-sm hidden-xs">edit</span>
+            </a>
+          </div>
 
-        <div class="gn-md-actions-btn pull-right"
-            data-gn-md-actions-menu="mdView.current.record"/>
+          <!-- delete -->
+          <div class="btn-group pull-left" role="group">
+            <a class="btn btn-default"
+               href
+               data-ng-show="user.canEditRecord(mdView.current.record) && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
+               data-gn-click-and-spin="deleteRecord(mdView.current.record)"
+               data-gn-confirm-click="{{(mdView.current.record.draft != 'y') ? 'deleteRecordConfirm' : 'deleteWorkingCopyRecordConfirm' | translate:mdView.current.record}}"
+               title="{{(mdView.current.record.draft != 'y') ? 'delete' : 'cancelWorkingCopy' | translate}}">
+              <span class="fa fa-fw fa-times"></span>
+              <span data-translate="" class="hidden-sm hidden-xs" data-ng-if="mdView.current.record.draft == 'y'">cancelWorkingCopy</span>
+              <span data-translate="" class="hidden-sm hidden-xs" data-ng-if="mdView.current.record.draft != 'y'">delete</span>
+            </a>
+          </div>
 
-        <div class="btn-group pull-right" role="group">
-          <a class="btn btn-default"
-            data-ng-show="user.canEditRecord(mdView.current.record) && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
-            data-gn-click-and-spin="deleteRecord(mdView.current.record)"
-            data-gn-confirm-click="{{(mdView.current.record.draft != 'y') ? 'deleteRecordConfirm' : 'deleteWorkingCopyRecordConfirm' | translate:mdView.current.record}}"
-            title="{{(mdView.current.record.draft != 'y') ? 'delete' : 'cancelWorkingCopy' | translate}}">
-            <i class="fa fa-fw fa-times"></i>
-            <span data-translate="" class="hidden-sm hidden-xs" data-ng-if="mdView.current.record.draft == 'y'">cancelWorkingCopy</span>
-            <span data-translate="" class="hidden-sm hidden-xs" data-ng-if="mdView.current.record.draft != 'y'">delete</span>
-          </a>
-        </div>
+          <!-- manage -->
+          <div class="gn-md-actions-btn pull-left"
+               data-gn-md-actions-menu="mdView.current.record"/>
 
-        <div class="btn-group pull-right" role="group">
-          <a class="btn btn-default gn-md-edit-btn"
-            data-ng-show="user.canEditRecord(mdView.current.record) && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
-            data-ng-href="catalog.edit#/metadata/{{mdView.current.record.getId()}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.getUuid()}}"
-            title="{{'edit' | translate}}">
-            <i class="fa fa-fw fa-pencil"></i>
-            <span data-translate="" class="hidden-sm hidden-xs">edit</span>
-          </a>
+          <!-- display mode -->
+          <div class="btn-group gn-view-menu-button pull-left">
+            <button type="button" class="btn btn-default dropdown-toggle"
+                    data-toggle="dropdown"
+                    aria-label="{{'chooseAView' | translate}}"
+                    aria-expanded="false">
+              <span class="fa fa-fw fa-eye"></span>
+              <span data-translate="" class="hidden-sm hidden-xs">chooseAView</span>
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu">
+              <li role="menuitem"
+                  data-ng-repeat="f in formatter.list"
+                  data-ng-class="currentFormatter === f.url ? 'disabled' : ''">
+                <a href=""
+                   gn-metadata-open="mdView.current.record"
+                   gn-records="mdView.records"
+                   gn-formatter="f && f.url">
+                  {{f.label | translate}}
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
This PR makes the subbar on the record view accessible (by keyboard). 

![gn-a11y-subbar-focus](https://user-images.githubusercontent.com/19608667/94823571-4b060c80-0404-11eb-8a47-d55d6220df03.png)

Changes to make it happen:
- improve focus style (to see which element has the focus)
- add `href` so you can access a link with the `tab` button (delete button)
- change `<i>` into `<span>`
- reorganise buttons to get a logical `tab` order