### PR TITLE
Build / Fix path for web.xml for maven Jetty plugin

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -851,8 +851,7 @@
             catalog/lib/bootstrap-table/*.md,
             catalog/lib/bootstrap-table/docs/**
           </packagingExcludes>
-          <!--          <warSourceDirectory>src/main/geonetwork</warSourceDirectory> -->
-          <webXml>${build.webapp.resources}/geonetwork/WEB-INF/web.xml</webXml>
+          <webXml>${build.webapp.resources}/WEB-INF/web.xml</webXml>
           <attachClasses>true</attachClasses>
           <warName>${application.name}</warName>
           <webappDirectory>${project.build.directory}/geonetwork</webappDirectory>
@@ -866,7 +865,7 @@
           <webAppSourceDirectory>${project.build.directory}/geonetwork</webAppSourceDirectory>
           <webApp>
             <contextPath>/${application.name}</contextPath>
-            <descriptor>${project.build.directory}/WEB-INF/web.xml</descriptor>
+            <descriptor>${project.build.directory}/geonetwork/WEB-INF/web.xml</descriptor>
             <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
               <resourcesAsCSV>
                 ${project.basedir}/src/main/webapp,

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -852,7 +852,7 @@
             catalog/lib/bootstrap-table/docs/**
           </packagingExcludes>
           <!--          <warSourceDirectory>src/main/geonetwork</warSourceDirectory> -->
-          <webXml>${build.webapp.resources}/WEB-INF/web.xml</webXml>
+          <webXml>${build.webapp.resources}/geonetwork/WEB-INF/web.xml</webXml>
           <attachClasses>true</attachClasses>
           <warName>${application.name}</warName>
           <webappDirectory>${project.build.directory}/geonetwork</webappDirectory>


### PR DESCRIPTION
On startup:

```
[INFO] Web overrides =  none
[INFO] web.xml file = /projects/core-geonetwork/web/target/WEB-INF/web.xml
[INFO] Webapp directory = /projects/core-geonetwork/web/target/geonetwork
```

The path ` /projects/core-geonetwork/web/target/WEB-INF/web.xml` is not valid, should be ` /projects/core-geonetwork/web/target/geonetwork/WEB-INF/web.xml`