### PR TITLE
Don't cleanup versions map in EditLib constructor as it's a static resource shared between all the EditLib instances

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -904,6 +904,15 @@ public class EditLib {
         }
     }
 
+    /**
+     * Removes the version of the edit session for a metadata. Used when the edit session is finished.
+     *
+     * @param id
+     */
+    public void clearVersion(String id) {
+        htVersions.remove(id);
+    }
+
     //--------------------------------------------------------------------------
     //---
     //--- Private methods

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -94,7 +94,6 @@ public class EditLib {
 
     public EditLib(SchemaManager scm) {
         this.scm = scm;
-        htVersions.clear();
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -249,6 +249,8 @@ public class BaseMetadataUtils implements IMetadataUtils {
             Log.debug(Geonet.EDITOR_SESSION, "Editing session end.");
         }
         session.removeProperty(Geonet.Session.METADATA_BEFORE_ANY_CHANGES + id);
+
+        metadataManager.getEditLib().clearVersion(id);
     }
 
     /**

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -360,12 +360,12 @@ public class Aligner extends BaseAligner<CswParams> {
 
     private void applyBatchEdits(RecordInfo ri, Element md, String schema) throws JDOMException, IOException {
         if (StringUtils.isNotEmpty(params.getBatchEdits())) {
-            SchemaManager _schemaManager = context.getBean(SchemaManager.class);
-            EditLib editLib = new EditLib(_schemaManager);
             ObjectMapper mapper = new ObjectMapper();
 
             BatchEditParameter[] listOfUpdates = mapper.readValue(params.getBatchEdits(), BatchEditParameter[].class);
             if (listOfUpdates.length > 0) {
+                SchemaManager _schemaManager = context.getBean(SchemaManager.class);
+                EditLib editLib = new EditLib(_schemaManager);
                 boolean metadataChanged = false;
                 boolean createXpathNodeIfNotExists =
                     context.getBean(SettingManager.class).getValueAsBool(SYSTEM_CSW_TRANSACTION_XPATH_UPDATE_CREATE_NEW_ELEMENTS);


### PR DESCRIPTION
https://github.com/geonetwork/core-geonetwork/blob/582d49f0f5791452a39eaacacce7699e3a807866/core/src/main/java/org/fao/geonet/kernel/EditLib.java#L93-L98

The versions map was done static in https://github.com/geonetwork/core-geonetwork/commit/e8cd87abdf07f7839b65d5c2c326465f30827ea1, what seem fine, but the constructor should not clear it. `EditLib` is instantiated in several places, among others in the CSW harvester when are configured batch editing values. 

https://github.com/geonetwork/core-geonetwork/blob/582d49f0f5791452a39eaacacce7699e3a807866/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java#L364

The code  cleanups the map with all the edit sessions and if a user was editing the metadata while the harvester is executed and tries to save the metadata, a `ConcurrentUpdate` exception is returned due to this code.


---

Test case:

- Edit a metadata record
- In other browser tab create a CSW harvester and define some batch edits, seem just with an empty list can be reproduced: `[]`.
- Execute the harvester.
- In the edit metadata browser tab, click `Save metadata` -->`ConcurrentUpdate` exception.