### PR TITLE
Associated resource / Feature catalog / Missing list of values

### DIFF
--- a/web/src/main/webapp/xslt/services/metadata/relation.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/relation.xsl
@@ -139,8 +139,8 @@
                             select="*/gfc:valueType/gco:TypeName/gco:aName/*/text()"/>
                         </type>
                         <xsl:if test="*/gfc:listedValue">
-                          <values>
-                            <xsl:for-each select="*/gfc:listedValue">
+                          <xsl:for-each select="*/gfc:listedValue">
+                            <values>
                               <label>
                                 <xsl:value-of select="*/gfc:label/*/text()"/>
                               </label>
@@ -150,8 +150,8 @@
                               <definition>
                                 <xsl:value-of select="*/gfc:definition/*/text()"/>
                               </definition>
-                            </xsl:for-each>
-                          </values>
+                            </values>
+                          </xsl:for-each>
                         </xsl:if>
                       </element>
                     </xsl:for-each>


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/2333

Can be tested with http://localhost:8080/geonetwork/srv/api/records/189/related?type=fcats

List of values was not returned.

![image](https://user-images.githubusercontent.com/1701393/95756001-7232c880-0ca5-11eb-89cc-87c8b40b38df.png)

See https://github.com/geonetwork/core-geonetwork/blob/master/services/src/main/java/org/fao/geonet/api/records/model/related/FCRelatedMetadataItem.java#L254 for the model