### PR TITLE
Add missing 3.10 migration script

### DIFF
--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -251,6 +251,21 @@
         <value>WEB-INF/classes/setup/sql/migrate/v3101/migrate-</value>
       </list>
     </entry>
+    <entry key="3.10.2">
+      <list>
+        <value>WEB-INF/classes/setup/sql/migrate/v3102/migrate-</value>
+      </list>
+    </entry>
+    <entry key="3.10.3">
+      <list>
+        <value>WEB-INF/classes/setup/sql/migrate/v3103/migrate-</value>
+      </list>
+    </entry>
+    <entry key="3.10.4">
+      <list>
+        <value>WEB-INF/classes/setup/sql/migrate/v3104/migrate-</value>
+      </list>
+    </entry>
     <entry key="3.11.0">
       <list>
         <value>WEB-INF/classes/setup/sql/migrate/v3110/migrate-</value>

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3103/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3103/migrate-default.sql
@@ -1,0 +1,14 @@
+UPDATE Settings SET value='3.10.3' WHERE name='system/platform/version';
+UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
+
+ALTER TABLE groupsdes ALTER COLUMN label TYPE varchar(255);
+ALTER TABLE sourcesdes ALTER COLUMN label TYPE varchar(255);
+ALTER TABLE schematrondes ALTER COLUMN label TYPE varchar(255);
+
+-- New setting for server timezone
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');
+
+-- keep these at the bottom of the file!
+DROP INDEX idx_metadatafiledownloads_metadataid;
+DROP INDEX idx_metadatafileuploads_metadataid;
+DROP INDEX idx_operationallowed_metadataid;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3103/migrate-mysql.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3103/migrate-mysql.sql
@@ -1,0 +1,13 @@
+UPDATE Settings SET value='3.10.3' WHERE name='system/platform/version';
+UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
+
+ALTER TABLE groupsdes ALTER COLUMN label TYPE varchar(255);
+ALTER TABLE sourcesdes ALTER COLUMN label TYPE varchar(255);
+ALTER TABLE schematrondes ALTER COLUMN label TYPE varchar(255);
+
+-- New setting for server timezone
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');
+
+DROP INDEX idx_metadatafiledownloads_metadataid ON MetadataFileDownloads;
+DROP INDEX idx_metadatafileuploads_metadataid ON MetadataFileUploads;
+DROP INDEX idx_operationallowed_metadataid ON OperationAllowed;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3103/migrate-oracle.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3103/migrate-oracle.sql
@@ -1,0 +1,9 @@
+UPDATE Settings SET value='3.10.3' WHERE name='system/platform/version';
+UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
+
+ALTER TABLE groupsdes ALTER COLUMN label TYPE varchar(255);
+ALTER TABLE sourcesdes ALTER COLUMN label TYPE varchar(255);
+ALTER TABLE schematrondes ALTER COLUMN label TYPE varchar(255);
+
+-- New setting for server timezone
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3104/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3104/migrate-default.sql
@@ -1,0 +1,4 @@
+UPDATE Settings SET value='3.10.4' WHERE name='system/platform/version';
+UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
+
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/users/identicon', 'gravatar:mp', 0, 9110, 'n');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
@@ -1,21 +1,9 @@
 
-ALTER TABLE groupsdes ALTER COLUMN label TYPE varchar(255);
-ALTER TABLE sourcesdes ALTER COLUMN label TYPE varchar(255);
-ALTER TABLE schematrondes ALTER COLUMN label TYPE varchar(255);
-
 UPDATE Settings SET value='3.11.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 
 -- Increase the length of Validation type (where the schematron file name is stored)
 ALTER TABLE Validation ALTER COLUMN valType TYPE varchar(128);
 
--- New setting for server timezone
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/users/identicon', 'gravatar:mp', 0, 9110, 'n');
-
 ALTER TABLE usersearch ALTER COLUMN url TYPE text;
 
--- keep these at the bottom of the file!
-DROP INDEX idx_metadatafiledownloads_metadataid;
-DROP INDEX idx_metadatafileuploads_metadataid;
-DROP INDEX idx_operationallowed_metadataid;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-mysql.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-mysql.sql
@@ -1,21 +1,9 @@
 
-ALTER TABLE groupsdes ALTER COLUMN label TYPE varchar(255);
-ALTER TABLE sourcesdes ALTER COLUMN label TYPE varchar(255);
-ALTER TABLE schematrondes ALTER COLUMN label TYPE varchar(255);
-
 UPDATE Settings SET value='3.11.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 
 -- Increase the length of Validation type (where the schematron file name is stored)
 ALTER TABLE Validation ALTER COLUMN valType TYPE varchar(128);
 
--- New setting for server timezone
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');
-
 ALTER TABLE usersearch MODIFY url TEXT
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/users/identicon', 'gravatar:mp', 0, 9110, 'n');
-
-DROP INDEX idx_metadatafiledownloads_metadataid ON MetadataFileDownloads;
-DROP INDEX idx_metadatafileuploads_metadataid ON MetadataFileUploads;
-DROP INDEX idx_operationallowed_metadataid ON OperationAllowed;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-oracle.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-oracle.sql
@@ -1,20 +1,12 @@
 
-ALTER TABLE groupsdes ALTER COLUMN label TYPE varchar(255);
-ALTER TABLE sourcesdes ALTER COLUMN label TYPE varchar(255);
-ALTER TABLE schematrondes ALTER COLUMN label TYPE varchar(255);
-
 UPDATE Settings SET value='3.11.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 
 -- Increase the length of Validation type (where the schematron file name is stored)
 ALTER TABLE Validation ALTER COLUMN valType TYPE varchar(128);
 
--- New setting for server timezone
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');
-
 ALTER TABLE usersearch ADD (tempurl clob);
 ALTER TABLE usersearch SET tempurl = url, url = null;
 ALTER TABLE usersearch DROP COLUMN url;
 ALTER TABLE usersearch RENAME COLUMN tempurl to url;
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/users/identicon', 'gravatar:mp', 0, 9110, 'n');


### PR DESCRIPTION
Add missing migration scripts from 3.10.x releases.

Looks like it was not updated in the last releases.

Without these changes if attempting to migrate from 3.10.4 to current master branch there will be some errors.

i.e. 

```
org.h2.jdbc.JdbcSQLException: Unique index or primary key violation: "PRIMARY_KEY_842 ON PUBLIC.SETTINGS(NAME) VALUES ( /* 138 */ 'system/server/timeZone' )"; SQL statement:
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n') [23505-174]
```

See the following for more details.
https://github.com/geonetwork/core-geonetwork/pull/4817#issuecomment-706148783