### PR TITLE
Allow the use of ThesaurusService in search page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -129,6 +129,9 @@
                                               gnGlobalSettings
                                             );
                   var result = [currentUILang_3char];
+                  if (angular.isUndefined(gnCurrentEdit.allLanguages)) {
+                      return result;
+                  }
 
                   var currentUILang2_3char = gnCurrentEdit.allLanguages.iso2code[currentUILang_3char];
                   if (currentUILang2_3char) {


### PR DESCRIPTION
Don't asume that ThesaususService is always used inside the editor.