### PR TITLE
Change to 3.11-SNAPSHOT

### DIFF
--- a/cachingxslt/pom.xml
+++ b/cachingxslt/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/csw-server/pom.xml
+++ b/csw-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>docs</artifactId>

--- a/doi/pom.xml
+++ b/doi/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/es/es-core/pom.xml
+++ b/es/es-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>es</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>es-core</artifactId>

--- a/es/es-dashboards/pom.xml
+++ b/es/es-dashboards/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>es</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <profiles>
     <profile>

--- a/es/pom.xml
+++ b/es/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>es</artifactId>

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
   <name>GeoNetwork Events</name>

--- a/harvesters/pom.xml
+++ b/harvesters/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/healthmonitor/pom.xml
+++ b/healthmonitor/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/inspire-atom/pom.xml
+++ b/inspire-atom/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/jmeter/pom.xml
+++ b/jmeter/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <!-- =========================================================== -->
   <!--     Module Description                                      -->

--- a/listeners/pom.xml
+++ b/listeners/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
   <name>GeoNetwork Events</name>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/oaipmh/pom.xml
+++ b/oaipmh/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <groupId>org.geonetwork-opensource</groupId>
   <artifactId>geonetwork</artifactId>
   <packaging>pom</packaging>
-  <version>3.11.0-SNAPSHOT</version>
+  <version>3.11-SNAPSHOT</version>
 
   <name>GeoNetwork opensource</name>
   <description>GeoNetwork opensource is a standards based, Free and

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>release</artifactId>

--- a/schemas-test/pom.xml
+++ b/schemas-test/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>

--- a/schemas/csw-record/pom.xml
+++ b/schemas/csw-record/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>schema-csw-record</artifactId>

--- a/schemas/dublin-core/pom.xml
+++ b/schemas/dublin-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -47,24 +47,6 @@
       </plugin>
 
       <!-- package up plugin folder as a zip -->
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>plugin-assembly</id>
-            <phase>package</phase>
-            <goals><goal>single</goal></goals>
-            <inherited>false</inherited>
-            <configuration>
-             <appendAssemblyId>false</appendAssemblyId>
-             <descriptors>
-              <descriptor>src/assembly/schema-plugin.xml</descriptor>
-             </descriptors>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>

--- a/schemas/iso19110/pom.xml
+++ b/schemas/iso19110/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/schemas/iso19115-3.2018/pom.xml
+++ b/schemas/iso19115-3.2018/pom.xml
@@ -6,7 +6,7 @@
  <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/schemas/iso19139/pom.xml
+++ b/schemas/iso19139/pom.xml
@@ -5,13 +5,12 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>schema-iso19139</artifactId>
   <name>GeoNetwork schema plugin for ISO19139/119 standards</name>
-  <packaging>jar</packaging>
 
   <dependencies>
     <dependency>

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/schemas/schema-core/pom.xml
+++ b/schemas/schema-core/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/sde/pom.xml
+++ b/sde/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/slave/pom.xml
+++ b/slave/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
   <name>GeoNetwork Slave</name>

--- a/updateBranchVersions.sh
+++ b/updateBranchVersions.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 
-# Usage to update branch from a release 2.6.2 version to 2.6.3-SNAPSHOT version 		
-# In root folder of branch code: ./updateBranchVersion.sh 2.6.2 2.6.3
+# Usage to update branch from a release 3.10.0 version to 3.10-SNAPSHOT version
+# In root folder of branch code: ./updateBranchVersion.sh 3.10.0
 
-function showUsage 
+function showUsage
 {
-  echo -e "\nThis script is used to update branch from a release version to next SNAPSHOT version. Should be used in branch after creating a new release (tag)." 
+  echo -e "\nThis script is used to update branch from a release version to next SNAPSHOT version. Should be used in branch after creating a new release (tag)."
   echo
-  echo -e "Usage: ./`basename $0 $1` actual_version next_version"
+  echo -e "Usage: ./`basename $0 $1` actual_version"
   echo
-  echo -e "Example to update file versions from 2.7.0 to 2.7.1-SNAPSHOT:"
-  echo -e "\t./`basename $0 $1` 2.7.0 2.7.1"
+  echo -e "Example to update file versions from 3.10.0 to 3.10-SNAPSHOT:"
+  echo -e "\t./`basename $0 $1` 3.10.0"
   echo
 }
 
-if [ "$1" = "-h" ] 
+if [ "$1" = "-h" ]
 then
 	showUsage
 	exit
 fi
 
-if [ $# -ne 2 ]
+if [ $# -ne 1 ]
 then
   showUsage
   exit
@@ -31,24 +31,13 @@ if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
 else
 	echo
 	echo 'Update failed due to incorrect versionnumber format (' $1 ')'
-	echo 'The format should be three numbers separated by dots. e.g.: 2.7.0'
+	echo 'The format should be three numbers separated by dots. e.g.: 3.10.0'
 	echo
-	echo "Usage: ./`basename $0 $1` 2.7.0 2.7.1"
+	echo "Usage: ./`basename $0 $1` 3.10.0"
 	echo
 	exit
 fi
 
-if [[ $2 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-    echo
-else
-	echo
-	echo 'Update failed due to incorrect new versionnumber format (' $2 ')'
-	echo 'The format should be three numbers separated by dots. e.g.: 2.7.1'
-	echo
-	echo "Usage: ./`basename $0 $1` 2.7.0 2.7.1"
-	echo
-	exit
-fi
 
 # Note: In MacOS (darwin10.0) sed requires -i .bak as option to work properly
 if grep -q "darwin" <<< $OSTYPE ; then
@@ -58,12 +47,13 @@ else
 fi
 
 echo
-echo 'Your Operating System is' $OSTYPE 
+echo 'Your Operating System is' $OSTYPE
 echo 'sed will use the following option: ' $sedopt
 echo
 
 version="$1"
-new_version="$2"
+# Remove patch number for SNAPSHOT version
+new_version="${version%.*}"
 
 # Update version in sphinx doc files
 sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/manuals/source/conf.py
@@ -73,4 +63,7 @@ sed $sedopt "s/version=${version}/version=${new_version}/g" release/build.proper
 sed $sedopt "s/subVersion=0/subVersion=SNAPSHOT/g" release/build.properties
 
 # Update version pom files
-find . -name pom.xml -exec sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" {} \;
+mvn versions:set-property -Dproperty=gn.project.version -DnewVersion=${new_version}-SNAPSHOT
+echo 'Module'
+mvn versions:set -DnewVersion=${new_version}-SNAPSHOT -DgenerateBackupPoms=false -Pwith-doc
+echo

--- a/updateReleaseVersions.sh
+++ b/updateReleaseVersions.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-# Usage to create 2.6.2 release version from 2.6.2-SNAPSHOT
-# In root folder of branch code: ./updateReleaseVersion.sh 2.6.2
+# Usage to create 3.10.2 release version from 3.10-SNAPSHOT
+# In root folder of branch code: ./updateReleaseVersion.sh 3.10.2
 
 function showUsage
 {
-  echo -e "\nThis script is used to update branch from a SNAPSHOT version to a release version. Should be used in branch before creating a new release (tag)." 
+  echo -e "\nThis script is used to update branch from a SNAPSHOT version to a release version. Should be used in branch before creating a new release (tag)."
   echo
   echo -e "Usage: `basename $0 $1` version"
   echo
-  echo -e "Example to update file versions from 2.7.0-SNAPSHOT to 2.7.0:"
-  echo -e "\t`basename $0 $1` 2.7.0"
+  echo -e "Example to update file versions from 2.7.0-SNAPSHOT to 3.10.2:"
+  echo -e "\t`basename $0 $1` 3.10.2"
   echo
 }
 
-if [ "$1" = "-h" ] 
+if [ "$1" = "-h" ]
 then
 	showUsage
 	exit
@@ -45,17 +45,23 @@ else
 fi
 
 echo
-echo 'Your Operating System is' $OSTYPE 
+echo 'Your Operating System is' $OSTYPE
 echo 'sed will use the following option: ' $sedopt
 echo
 
 version="$1"
+# Remove the patch version: 3.10.2 --> 3.10
+versionnopatchinfo="${version%.*}"
 
 # Update version in sphinx doc files
-sed $sedopt "s/${version}-SNAPSHOT/${version}/g" docs/manuals/source/conf.py
+sed $sedopt "s/${versionnopatchinfo}-SNAPSHOT/${version}/g" docs/manuals/source/conf.py
 
 # Update release subversion
+sed $sedopt "s/version=.*/version=${version}/g" release/build.properties
 sed $sedopt "s/subVersion=SNAPSHOT/subVersion=0/g" release/build.properties
 
 # Update version pom files
-find . -name pom.xml -exec sed $sedopt "s/${version}-SNAPSHOT/${version}/g" {} \;
+mvn versions:set-property -Dproperty=gn.project.version -DnewVersion=${version}
+echo 'Module'
+mvn versions:set -DnewVersion=${version} -DgenerateBackupPoms=false -Pwith-doc
+echo

--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
   <groupId>org.geonetwork-opensource</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
 

--- a/workers/pom.xml
+++ b/workers/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/workers/wfsfeature-harvester/pom.xml
+++ b/workers/wfsfeature-harvester/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>workers</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wro4j/pom.xml
+++ b/wro4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.11.0-SNAPSHOT</version>
+    <version>3.11-SNAPSHOT</version>
   </parent>
 
 


### PR DESCRIPTION
This allows dependent projects to depend on the branch, without interruption each time a release is made.

This is especially useful for schema plugins referencing geonetwork via parent, and transitive dependencies.

See https://github.com/geonetwork/core-geonetwork/pull/5096