### PR TITLE
Change to 3.10-SNAPSHOT

### DIFF
--- a/cachingxslt/pom.xml
+++ b/cachingxslt/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -430,9 +430,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-iso19139</artifactId>
-      <version>${gn.schemas.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency> <!-- dummy API for ARC SDE stuff -->
       <groupId>${project.groupId}</groupId>

--- a/csw-server/pom.xml
+++ b/csw-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>docs</artifactId>

--- a/doi/pom.xml
+++ b/doi/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/es/es-core/pom.xml
+++ b/es/es-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>es</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>es-core</artifactId>

--- a/es/es-dashboards/pom.xml
+++ b/es/es-dashboards/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>es</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <profiles>
     <profile>

--- a/es/pom.xml
+++ b/es/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>es</artifactId>

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
   <name>GeoNetwork Events</name>

--- a/harvesters/pom.xml
+++ b/harvesters/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/healthmonitor/pom.xml
+++ b/healthmonitor/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/inspire-atom/pom.xml
+++ b/inspire-atom/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/jmeter/pom.xml
+++ b/jmeter/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <!-- =========================================================== -->
   <!--     Module Description                                      -->

--- a/listeners/pom.xml
+++ b/listeners/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
   <name>GeoNetwork Events</name>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/oaipmh/pom.xml
+++ b/oaipmh/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <groupId>org.geonetwork-opensource</groupId>
   <artifactId>geonetwork</artifactId>
   <packaging>pom</packaging>
-  <version>3.10.7-SNAPSHOT</version>
+  <version>3.10-SNAPSHOT</version>
   <name>GeoNetwork opensource</name>
   <description>GeoNetwork opensource is a standards based, Free and
     Open Source catalog application to manage spatially referenced
@@ -269,6 +269,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
+        <version>3.1.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
         </configuration>
@@ -1553,6 +1554,5 @@
     <xbean.version>3.18</xbean.version>
     <jolokia.version>1.6.0</jolokia.version>
     <httpcomponents.version>4.5.9</httpcomponents.version>
-    <gn.schemas.version>3.7</gn.schemas.version>
   </properties>
 </project>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>release</artifactId>

--- a/schemas-test/pom.xml
+++ b/schemas-test/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -68,9 +68,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-iso19139</artifactId>
-      <version>${gn.schemas.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/schemas/csw-record/pom.xml
+++ b/schemas/csw-record/pom.xml
@@ -4,18 +4,42 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>schemas</artifactId>
-    <groupId>org.geonetwork-opensource</groupId>
-    <version>3.7</version>
+    <groupId>org.geonetwork-opensource.schemas</groupId>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>schema-csw-record</artifactId>
   <name>GeoNetwork schema plugin for Dublin Core records retrieved by CSW</name>
+
   <build>
-  <resources>
-    <resource>
-      <directory>src/main/config/translations</directory>
-      <targetPath>META-INF/catalog/locales</targetPath>
-    </resource>
-  </resources>
+
+    <resources>
+      <resource>
+        <directory>src/main/config/translations</directory>
+        <targetPath>META-INF/catalog/locales</targetPath>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>plugin-assembly</id>
+            <phase>package</phase>
+            <goals><goal>single</goal></goals>
+            <inherited>false</inherited>
+            <configuration>
+             <appendAssemblyId>false</appendAssemblyId>
+             <descriptors>
+              <descriptor>src/assembly/schema-plugin.xml</descriptor>
+             </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
   </build>
+
 </project>

--- a/schemas/csw-record/src/assembly/schema-plugin.xml
+++ b/schemas/csw-record/src/assembly/schema-plugin.xml
@@ -1,0 +1,16 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>plugin</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/plugin/</directory>
+      <outputDirectory></outputDirectory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/schemas/dublin-core/pom.xml
+++ b/schemas/dublin-core/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>schemas</artifactId>
-    <groupId>org.geonetwork-opensource</groupId>
-    <version>3.7</version>
+    <groupId>org.geonetwork-opensource.schemas</groupId>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-core</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -30,7 +30,9 @@
         <directory>src/main/resources</directory>
       </resource>
     </resources>
+
     <plugins>
+
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
@@ -42,6 +44,26 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- package up plugin folder as a zip -->
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>plugin-assembly</id>
+            <phase>package</phase>
+            <goals><goal>single</goal></goals>
+            <inherited>false</inherited>
+            <configuration>
+             <appendAssemblyId>false</appendAssemblyId>
+             <descriptors>
+              <descriptor>src/assembly/schema-plugin.xml</descriptor>
+             </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/schemas/dublin-core/src/assembly/schema-plugin.xml
+++ b/schemas/dublin-core/src/assembly/schema-plugin.xml
@@ -1,0 +1,16 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>plugin</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/plugin/</directory>
+      <outputDirectory></outputDirectory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/schemas/iso19110/pom.xml
+++ b/schemas/iso19110/pom.xml
@@ -27,8 +27,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>schemas</artifactId>
-    <groupId>org.geonetwork-opensource</groupId>
-    <version>3.7</version>
+    <groupId>org.geonetwork-opensource.schemas</groupId>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -37,18 +37,19 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-iso19139</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>
 
   <build>
+
     <resources>
       <resource>
         <directory>src/main/config/translations</directory>
@@ -58,7 +59,9 @@
         <directory>src/main/resources</directory>
       </resource>
     </resources>
+
     <plugins>
+
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
@@ -70,6 +73,25 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>plugin-assembly</id>
+            <phase>package</phase>
+            <goals><goal>single</goal></goals>
+            <inherited>false</inherited>
+            <configuration>
+             <appendAssemblyId>false</appendAssemblyId>
+             <descriptors>
+              <descriptor>src/assembly/schema-plugin.xml</descriptor>
+             </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/schemas/iso19110/src/assembly/schema-plugin.xml
+++ b/schemas/iso19110/src/assembly/schema-plugin.xml
@@ -1,0 +1,16 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>plugin</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/plugin/</directory>
+      <outputDirectory></outputDirectory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/schemas/iso19115-3.2018/pom.xml
+++ b/schemas/iso19115-3.2018/pom.xml
@@ -5,8 +5,8 @@
 
  <parent>
     <artifactId>schemas</artifactId>
-    <groupId>org.geonetwork-opensource</groupId>
-    <version>3.7</version>
+    <groupId>org.geonetwork-opensource.schemas</groupId>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -15,13 +15,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-core</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>
 
   <build>
+
     <resources>
       <resource>
         <directory>src/main/config/translations</directory>
@@ -31,10 +32,11 @@
         <directory>src/main/resources</directory>
       </resource>
     </resources>
+
     <plugins>
+
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
         <executions>
           <execution>
             <id>test-jar</id>
@@ -44,6 +46,25 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>plugin-assembly</id>
+            <phase>package</phase>
+            <goals><goal>single</goal></goals>
+            <inherited>false</inherited>
+            <configuration>
+             <appendAssemblyId>false</appendAssemblyId>
+             <descriptors>
+              <descriptor>src/assembly/schema-plugin.xml</descriptor>
+             </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/schemas/iso19115-3.2018/src/assembly/schema-plugin.xml
+++ b/schemas/iso19115-3.2018/src/assembly/schema-plugin.xml
@@ -1,0 +1,16 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>plugin</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/plugin/</directory>
+      <outputDirectory></outputDirectory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/schemas/iso19139/pom.xml
+++ b/schemas/iso19139/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>schemas</artifactId>
-    <groupId>org.geonetwork-opensource</groupId>
-    <version>3.7</version>
+    <groupId>org.geonetwork-opensource.schemas</groupId>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,12 +14,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-core</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
@@ -53,6 +53,27 @@
         <directory>src/main/plugin/iso19139</directory>
       </testResource>
     </testResources>
+
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>plugin-assembly</id>
+            <phase>package</phase>
+            <goals><goal>single</goal></goals>
+            <inherited>false</inherited>
+            <configuration>
+             <appendAssemblyId>false</appendAssemblyId>
+             <descriptors>
+              <descriptor>src/assembly/schema-plugin.xml</descriptor>
+             </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
   </build>
 
   <profiles>

--- a/schemas/iso19139/src/assembly/schema-plugin.xml
+++ b/schemas/iso19139/src/assembly/schema-plugin.xml
@@ -1,0 +1,16 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>plugin</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/plugin/</directory>
+      <outputDirectory></outputDirectory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -28,12 +28,11 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
-  <version>3.7</version>
-
   <modelVersion>4.0.0</modelVersion>
+  <groupId>org.geonetwork-opensource.schemas</groupId>
   <artifactId>schemas</artifactId>
   <name>GeoNetwork schema plugins</name>
   <packaging>pom</packaging>
@@ -55,7 +54,7 @@
   </modules>
   <properties>
     <rootProjectDir>../..</rootProjectDir>
-    <gn.project.version>3.10.7-SNAPSHOT</gn.project.version>
+    <gn.project.version>3.10-SNAPSHOT</gn.project.version>
   </properties>
 
 </project>

--- a/schemas/schema-core/pom.xml
+++ b/schemas/schema-core/pom.xml
@@ -27,8 +27,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>schemas</artifactId>
-    <groupId>org.geonetwork-opensource</groupId>
-    <version>3.7</version>
+    <groupId>org.geonetwork-opensource.schemas</groupId>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -56,9 +56,9 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource</groupId>
       <artifactId>common</artifactId>
-      <version>${gn.project.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/sde/pom.xml
+++ b/sde/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/slave/pom.xml
+++ b/slave/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
   <name>GeoNetwork Slave</name>

--- a/update-version.sh
+++ b/update-version.sh
@@ -38,23 +38,27 @@ then
 fi
 
 
-if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9x]+(-SNAPSHOT|-RC[0-2]|-[0-9]+)?$ ]]; then
+if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9x]$  || $1 =~ ^[0-9]+.[0-9]+(-SNAPSHOT|-RC[0-2]|-[0-9]+)$ ]]; then
     echo
 else
 	echo
 	echo 'Update failed due to incorrect versionnumber format: ' $1
-	echo 'The format should be three numbers separated by dots with optional -SNAPSHOT. e.g.: 2.7.0 or 2.7.0-SNAPSHOT or 2.7.x-SNAPSHOT'
+	echo 'The format should be three numbers separated by dots or 2 numbers separated by dot with -SNAPSHOT. e.g.: 3.10.0 or 3.10-SNAPSHOT'
 	echo
-	echo "Usage: ./`basename $0 $1` 2.7.0 2.7.0-RC0"
+	echo "Usage: ./`basename $0 $1` 3.10.0 3.10-SNAPSHOT"
 	echo
 	exit
 fi
 
-if [[ $2 =~ ^[0-9]+.[0-9]+.[0-9x]+(-SNAPSHOT|-RC[0-2]|-[0-9]+)?$ ]]; then
+if [[ $2 =~ ^[0-9]+.[0-9]+.[0-9x]$  || $2 =~ ^[0-9]+.[0-9]+(-SNAPSHOT|-RC[0-2]|-[0-9]+)$ ]]; then
     # Retrieve version and subversion
-    if [[ $2 =~ ^[0-9]+.[0-9]+.[0-9]+-.*$ ]]; then
-        new_version_main=`echo $2 | cut -d- -f1`
+    if [[ $2 =~ ^[0-9]+.[0-9]+-.*$ ]]; then
+        patch=${version##*.}
+        patch=$(($patch + 1))
+
+        new_version_main=`echo $2 | cut -d- -f1`.${patch}
         sub_version=`echo $2 | cut -d- -f2`
+
     else
         new_version_main=$2
         sub_version="0"
@@ -63,9 +67,9 @@ if [[ $2 =~ ^[0-9]+.[0-9]+.[0-9x]+(-SNAPSHOT|-RC[0-2]|-[0-9]+)?$ ]]; then
 else
 	echo
 	echo 'Update failed due to incorrect new versionnumber format (' $2 ')'
-	echo 'The format should be three numbers separated by dots with optional -SNAPSHOT. e.g.: 2.7.0 or 2.7.0-SNAPSHOT'
+  echo 'The format should be three numbers separated by dots or 2 numbers separated by dot with -SNAPSHOT. e.g.: 3.10.0 or 3.10-SNAPSHOT'
 	echo
-	echo "Usage: ./`basename $0 $1` 2.7.0 2.7.0-RC0"
+	echo "Usage: ./`basename $0 $1` 3.10.0 3.10-SNAPSHOT"
 	echo
 	exit
 fi
@@ -100,11 +104,12 @@ echo ' * updating docs/manuals/source/conf.py'
 sed $sedopt "s/${version}/${new_version_main}/g" docs/manuals/source/conf.py
 echo
 
-# Update ZIP distro
-echo 'ZIP distribution'
-echo '  * updating release/build.xml'
-sed $sedopt "s/property name=\"version\" value=\".*\"/property name=\"version\" value=\"${new_version_main}\"/g" release/build.xml
-sed $sedopt "s/property name=\"subVersion\" value=\".*\"/property name=\"subVersion\" value=\"${sub_version}\"/g" release/build.xml
+
+# Update release properties
+echo 'Release (ZIP bundle)'
+echo '  * updating release/build.properties'
+sed $sedopt "s/version=.*/version=${new_version_main}/g" release/build.properties
+sed $sedopt "s/subVersion=.*/subVersion=${sub_version}/g" release/build.properties
 echo
 
 # Update SQL - needs improvements
@@ -112,8 +117,9 @@ echo 'SQL script'
 sed $sedopt "s/'system\/platform\/version', '.*', 0/'system\/platform\/version', '${new_version_main}', 0/g" web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
 sed $sedopt "s/'system\/platform\/subVersion', '.*', 0/'system\/platform\/subVersion', '${sub_version}', 0/g" web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
 
-find . -wholename *v${version//[.]/}/migrate-default.sql -exec sed $sedopt "s/value='${version}' WHERE name='system\/platform\/version'/value='${new_version_main}' WHERE name='system\/platform\/version'/g" {} \;
-find . -wholename *v${version//[.]/}/migrate-default.sql -exec sed $sedopt "s/value='.*' WHERE name='system\/platform\/subVersion'/value='${sub_version}' WHERE name='system\/platform\/subVersion'/g" {} \;
+find . -wholename *v${new_version_main_nopoint//[.]/}/migrate-default.sql -exec sed $sedopt "s/value='${version}' WHERE name='system\/platform\/version'/value='${new_version_main}' WHERE name='system\/platform\/version'/g" {} \;
+find . -wholename *v${new_version_main_nopoint//[.]/}/migrate-default.sql -exec sed $sedopt "s/value='.*' WHERE name='system\/platform\/subVersion'/value='${sub_version}' WHERE name='system\/platform\/subVersion'/g" {} \;
+
 
 # Update version pom files
 mvn versions:set-property -Dproperty=gn.project.version -DnewVersion=${new_version}

--- a/updateBranchVersions.sh
+++ b/updateBranchVersions.sh
@@ -1,50 +1,43 @@
 #!/bin/bash
 
-# Usage to update branch from a release 2.6.2 version to 2.6.3-SNAPSHOT version 		
-# In root folder of branch code: ./updateBranchVersion.sh 2.6.2 2.6.3
+# Usage to update branch from a release 3.10.0 version to 3.10-SNAPSHOT version
+# In root folder of branch code: ./updateBranchVersion.sh 3.10.0
 
-function showUsage 
+function showUsage
 {
-  echo -e "\nThis script is used to update branch from a release version to next SNAPSHOT version. Should be used in branch after creating a new release (tag)." 
+  echo -e "\nThis script is used to update branch from a release version to next SNAPSHOT version. Should be used in branch after creating a new release (tag)."
   echo
-  echo -e "Usage: ./`basename $0 $1` actual_version next_version"
+  echo -e "Usage: ./`basename $0 $1` actual_version"
   echo
-  echo -e "Example to update file versions from 2.7.0 to 2.7.1-SNAPSHOT:"
-  echo -e "\t./`basename $0 $1` 2.7.0 2.7.1"
+  echo -e "Example to update file versions from 3.10.0 to 3.10-SNAPSHOT:"
+  echo -e "\t./`basename $0 $1` 3.10.0"
   echo
 }
 
-if [ "$1" = "-h" ] 
+if [ "$1" = "-h" ]
 then
 	showUsage
 	exit
 fi
 
-if [ $# -ne 2 ]
+if [ $# -ne 1 ]
 then
   showUsage
   exit
 fi
 
-if [[ $1 != [0-9].[0-9].[0-9] ]]; then 
+if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+    echo
+else
 	echo
 	echo 'Update failed due to incorrect versionnumber format (' $1 ')'
-	echo 'The format should be three numbers separated by dots. e.g.: 2.7.0'
+	echo 'The format should be three numbers separated by dots. e.g.: 3.10.0'
 	echo
-	echo "Usage: ./`basename $0 $1` 2.7.0 2.7.1"
+	echo "Usage: ./`basename $0 $1` 3.10.0"
 	echo
 	exit
 fi
 
-if [[ $2 != [0-9].[0-9].[0-9] ]]; then 
-	echo
-	echo 'Update failed due to incorrect new versionnumber format (' $2 ')'
-	echo 'The format should be three numbers separated by dots. e.g.: 2.7.1'
-	echo
-	echo "Usage: ./`basename $0 $1` 2.7.0 2.7.1"
-	echo
-	exit
-fi
 
 # Note: In MacOS (darwin10.0) sed requires -i .bak as option to work properly
 if grep -q "darwin" <<< $OSTYPE ; then
@@ -54,20 +47,23 @@ else
 fi
 
 echo
-echo 'Your Operating System is' $OSTYPE 
+echo 'Your Operating System is' $OSTYPE
 echo 'sed will use the following option: ' $sedopt
 echo
 
 version="$1"
-new_version="$2"
+# Remove patch number for SNAPSHOT version
+new_version="${version%.*}"
 
 # Update version in sphinx doc files
-sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/eng/users/source/conf.py 
-sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/eng/developer/source/conf.py
+sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/manuals/source/conf.py
 
-# Update ZIP distribution
-sed $sedopt "s/\<property name=\"version\" value=\"${version}\" \/\>/\<property name=\"version\" value=\"${new_version}\" \/\>/g" release/build.xml
-sed $sedopt "s/\<property name=\"subVersion\" value=\"0\" \/\>/\<property name=\"subVersion\" value=\"SNAPSHOT\" \/\>/g" release/build.xml
+# Update release properties
+sed $sedopt "s/version=${version}/version=${new_version}/g" release/build.properties
+sed $sedopt "s/subVersion=0/subVersion=SNAPSHOT/g" release/build.properties
 
 # Update version pom files
-find . -name pom.xml -exec sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" {} \;
+mvn versions:set-property -Dproperty=gn.project.version -DnewVersion=${new_version}-SNAPSHOT
+echo 'Module'
+mvn versions:set -DnewVersion=${new_version}-SNAPSHOT -DgenerateBackupPoms=false -Pwith-doc
+echo

--- a/updateReleaseVersions.sh
+++ b/updateReleaseVersions.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-# Usage to create 2.6.2 release version from 2.6.2-SNAPSHOT
-# In root folder of branch code: ./updateReleaseVersion.sh 2.6.2
+# Usage to create 3.10.2 release version from 3.10-SNAPSHOT
+# In root folder of branch code: ./updateReleaseVersion.sh 3.10.2
 
 function showUsage
 {
-  echo -e "\nThis script is used to update branch from a SNAPSHOT version to a release version. Should be used in branch before creating a new release (tag)." 
+  echo -e "\nThis script is used to update branch from a SNAPSHOT version to a release version. Should be used in branch before creating a new release (tag)."
   echo
   echo -e "Usage: `basename $0 $1` version"
   echo
-  echo -e "Example to update file versions from 2.7.0-SNAPSHOT to 2.7.0:"
-  echo -e "\t`basename $0 $1` 2.7.0"
+  echo -e "Example to update file versions from 2.7.0-SNAPSHOT to 3.10.2:"
+  echo -e "\t`basename $0 $1` 3.10.2"
   echo
 }
 
-if [ "$1" = "-h" ] 
+if [ "$1" = "-h" ]
 then
 	showUsage
 	exit
@@ -26,8 +26,9 @@ then
   exit
 fi
 
-if [[ $1 != [0-9].[0-9].[0-9] ]]; then 
-	echo
+if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+    echo
+else
 	echo 'Update failed due to incorrect versionnumber format: ' $1
 	echo 'The format should be three numbers separated by dots. e.g.: 2.7.0'
 	echo
@@ -44,18 +45,23 @@ else
 fi
 
 echo
-echo 'Your Operating System is' $OSTYPE 
+echo 'Your Operating System is' $OSTYPE
 echo 'sed will use the following option: ' $sedopt
 echo
 
 version="$1"
+# Remove the patch version: 3.10.2 --> 3.10
+versionnopatchinfo="${version%.*}"
 
 # Update version in sphinx doc files
-sed $sedopt "s/${version}-SNAPSHOT/${version}/g" docs/eng/users/source/conf.py 
-sed $sedopt "s/${version}-SNAPSHOT/${version}/g" docs/eng/developer/source/conf.py
+sed $sedopt "s/${versionnopatchinfo}-SNAPSHOT/${version}/g" docs/manuals/source/conf.py
 
-# Update ZIP distribution
-sed $sedopt "s/\<property name=\"subVersion\" value=\"SNAPSHOT\" \/\>/\<property name=\"subVersion\" value=\"0\" \/\>/g" release/build.xml
+# Update release subversion
+sed $sedopt "s/version=.*/version=${version}/g" release/build.properties
+sed $sedopt "s/subVersion=SNAPSHOT/subVersion=0/g" release/build.properties
 
 # Update version pom files
-find . -name pom.xml -exec sed $sedopt "s/${version}-SNAPSHOT/${version}/g" {} \;
+mvn versions:set-property -Dproperty=gn.project.version -DnewVersion=${version}
+echo 'Module'
+mvn versions:set -DnewVersion=${version} -DgenerateBackupPoms=false -Pwith-doc
+echo

--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
   <groupId>org.geonetwork-opensource</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
 
@@ -558,29 +558,29 @@
     <!-- Add dependencies to schema plugin
     having a custom Bean to be loaded. -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-iso19139</artifactId>
-      <version>${gn.schemas.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-csw-record</artifactId>
-      <version>${gn.schemas.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-iso19110</artifactId>
-      <version>${gn.schemas.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-dublin-core</artifactId>
-      <version>${gn.schemas.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
       <artifactId>schema-iso19115-3.2018</artifactId>
-      <version>${gn.schemas.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/workers/pom.xml
+++ b/workers/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>geonetwork</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/workers/wfsfeature-harvester/pom.xml
+++ b/workers/wfsfeature-harvester/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>workers</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wro4j/pom.xml
+++ b/wro4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-    <version>3.10.7-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
 


### PR DESCRIPTION
This allows dependent projects to depend on the branch, without interruption each time a release is made.

This is especially useful for schema plugins referencing geonetwork via parent, and transitive dependencies.

See https://github.com/geonetwork/core-geonetwork/pull/5095

This change also double checks schema plugins produce a jar and zip as is already done on master

----

After this pull request the 3.10.6 release cycle looks like:

* ⛔  GeoNetwork `3.10.6-SNAPSHOT`, schemas/pom.xml `3.7`, schema plugin parent reference `3.7` reference
* ⛔  GeoNetwork `3.10.6-0`, schemas/pom.xml `3.7`, schema plugin parent `3.7` reference
* ✅  GeoNetwork `3.10-SNAPSHOT`, schemas/pom.xml `3.10-SNAPSHOT`, schema plugin parent `3.10-SNAPSHOT` osgeo snapshot repository reference
* ✅  GeoNetwork `3.10.7`, schemas/pom.xml `3.10.7`, schema plugin parent `3.10.7` osgeo release repository reference 
* ✅  GeoNetwork `3.10-SNAPSHOT`, schemas/pom.xml `3.10-SNAPSHOT`, schema plugin parent `3.10-SNAPSHOT` osgeo snapshot repository reference

As shown above schema plugin developers no longer have to change their `pom.xml` parent reference each time geonetwork releases. Indeed they only need to change when the schema plugin wishes to make a release.