### PR TITLE
Remove unused icons from the static pages links

### DIFF
--- a/web-ui/src/main/resources/catalog/components/pages/partials/footer.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/footer.html
@@ -1,10 +1,8 @@
 <li data-ng-repeat="page in pagesList">
   <a data-ng-show="{{page.format=='LINK'}}" title="{{page.linkText}}" href="{{page.link}}" target="_blank" >
-    <i class="fa fa-fw hidden-sm"></i>
     <span>{{page.linkText}}</span>
   </a>
   <a data-ng-show="{{page.format!='LINK'}}" data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.linkText}}?page={{page.linkText}}" title="{{page.linkText}}" data-ng-click="changePage($event)">
-    <i class="fa fa-fw hidden-sm"></i>
     <span>{{page.linkText}}</span>
   </a>
 </li>

--- a/web-ui/src/main/resources/catalog/components/pages/partials/menu.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/menu.html
@@ -1,10 +1,8 @@
 <li data-ng-repeat="page in pagesList">
   <a data-ng-show="{{page.format=='LINK'}}" title="{{page.linkText}}" href="{{page.link}}" target="_blank" >
-    <i class="fa fa-fw hidden-sm"></i>
     <span>{{page.linkText}}</span>
   </a>
   <a data-ng-show="{{page.format!='LINK'}}" data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.linkText}}?page={{page.linkText}}" title="{{page.linkText}}" data-ng-click="changePage($event)">
-    <i class="fa fa-fw hidden-sm"></i>
     <span>{{page.linkText}}</span>
   </a>
 </li>

--- a/web-ui/src/main/resources/catalog/components/pages/partials/top.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/top.html
@@ -1,10 +1,8 @@
 <li data-ng-repeat="page in pagesList">
   <a data-ng-show="{{page.format=='LINK'}}" title="{{page.linkText}}" href="{{page.link}}" target="_blank" >
-    <i class="fa fa-fw hidden-sm"></i>
     <span>{{page.linkText}}</span>
   </a>
   <a data-ng-show="{{page.format!='LINK'}}" data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.linkText}}?page={{page.linkText}}" title="{{page.linkText}}" data-ng-click="changePage($event)">
-    <i class="fa fa-fw hidden-sm"></i>
     <span>{{page.linkText}}</span>
   </a>
 </li>


### PR DESCRIPTION
This PR removes the unused icons from the links for the static pages. 

The placeholders for the icons were there, but never used. These placeholders were taking up space because of the `.fa-fw` class used. This caused unwanted whitespace at the left side of links.

![gn-static-pages](https://user-images.githubusercontent.com/19608667/96865156-d9046e80-1469-11eb-89a5-1fd0139f3746.png)