### PR TITLE
java 8 only

### DIFF
--- a/core/src/main/java/jeeves/config/springutil/JeevesContextLoaderListener.java
+++ b/core/src/main/java/jeeves/config/springutil/JeevesContextLoaderListener.java
@@ -57,6 +57,12 @@ public class JeevesContextLoaderListener implements ServletContextListener {
             final Pattern nodeNamePattern = Pattern.compile("[a-zA-Z0-9_\\-]+");
             final ServletContext servletContext = sce.getServletContext();
 
+            String javaVersion = System.getProperty("java.version");
+            if(!javaVersion.startsWith("1.8")){
+                // GeoNetwork does not support Java 11 at this time
+                throw new RuntimeException("Java 8 required, cannot start with \""+javaVersion+"\"");
+            }
+
             File node = new File(servletContext.getRealPath("/WEB-INF/config-node/srv.xml"));
 
             ConfigurationOverrides overrides = ConfigurationOverrides.DEFAULT;

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
@@ -242,11 +246,16 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0-M5</version>
         </plugin>
-
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-toolchains-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -254,6 +263,7 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <compilerVersion>1.8</compilerVersion>
           <debug>true</debug>   <!-- Whether to include debugging information.   -->
           <encoding>UTF-8</encoding> <!-- The -encoding argument for the Java compiler. -->
           <compilerArgument>-proc:none
@@ -265,12 +275,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
-   
+
       <!-- run integration tests after unit tests -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -1309,6 +1318,37 @@
 
   <profiles>
     <profile>
+      <!-- force use of java 8 if available in toolchains.xml -->
+      <id>toolchain</id>
+      <activation>
+        <file>
+          <exists>${user.home}/.m2/toolchains.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-toolchains-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>toolchain</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <toolchains>
+                <jdk>
+                  <version>8</version>
+                </jdk>
+              </toolchains>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>with-doc</id>
       <modules>
         <module>docs</module>
@@ -1401,7 +1441,8 @@
     <application.name>geonetwork</application.name>
     <app.properties>WEB-INF/config.properties</app.properties>
     <!--<app.properties>file:/${geonetwork.dir}/config.properties</app.properties>-->
-
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <!-- Configure database config file to use. Could be
      h2, postgres, sqlserver, mysql, oracle, db2, postgres-postgis, jndi
      -->

--- a/software_development/BUILDING.md
+++ b/software_development/BUILDING.md
@@ -80,7 +80,7 @@ mvn clean install -Pes
 Run embedded Jetty server
 -------------------------
 
-Maven comes with built-in support for Jetty via a [plug-in](https://www.eclipse.org/jetty/documentation/current/jetty-maven-plugin.html)
+Maven comes with built-in support for Jetty via a [jetty-maven-plugin](https://www.eclipse.org/jetty/documentation/current/jetty-maven-plugin.html).
 
 To run GeoNetwork with the embedded Jetty server you have to change directory to the root of the **web** module,
 and then execute the following maven command:
@@ -97,3 +97,26 @@ For changes related to the user interface in the `web-ui` module or the metadata
 ```
 mvn process-resources
 ```
+
+Tool chain
+----------
+
+GeoNetwork requires Java 8 at this time. If you have multiple JDK environments installed
+our build can make use of an optional `~/.m2/toolchains.xml` file.
+
+```xml
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>8</version>
+    </provides>
+    <configuration>
+    <jdkHome>/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>
+```
+
+If the `toolchains.xml` file is available a profile will be engaged to ensure a JDK `8` is used. For more information see [guide to using toolchains](https://maven.apache.org/guides/mini/guide-using-toolchains.html).


### PR DESCRIPTION
The `master` branch requires JDK 8 for building and running. This PR adds a couple checks to ensure Java 8 is used.

With this PR, when tomcat is configured with Java 11, geonetwork will refuse to start with `geonetwork.log`:
```
2020-10-22 21:18:54,047 FATAL [jeeves.engine] - Raised exception during init
2020-10-22 21:18:54,047 FATAL [jeeves.engine] -    Exception : java.lang.RuntimeException: Java 8 required, cannot start with "11.0.7"
2020-10-22 21:18:54,047 FATAL [jeeves.engine] -    Message   : Java 8 required, cannot start with "11.0.7"
2020-10-22 21:18:54,052 FATAL [jeeves.engine] -    Stack     : java.lang.RuntimeException: Java 8 required, cannot start with "11.0.7"
```