### PR TITLE
Validation / Inspire / Slot name

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/processing/EmptySlotBatch.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/EmptySlotBatch.java
@@ -13,7 +13,7 @@ public class EmptySlotBatch implements SelfNaming {
 
     public EmptySlotBatch(String name, int i) {
         try {
-            objectName = new ObjectName(String.format("geonetwork:name=' + name + ',idx=empty-slot-%d", i));
+            objectName = new ObjectName(String.format("geonetwork:name=%s,idx=empty-slot-%d", name, i));
         } catch (MalformedObjectNameException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
On some setup INSPIRE validation does not start (at some point? - not sure when/why). Exceptions raised are: 

```
stacktrace: "javax.management.InstanceNotFoundException: 
No MBean with pattern geonetwork:name=batch-etf-inspire,idx=* found for reading attributes
at org.jolokia.handler.ReadHandler.searchMBeans(ReadHandler.java:160)

{"message":"BeanCreationException","code":"runtime_exception",
"description":"Error creating bean with name 'processValidate':
 Invocation of init method failed; nested exception is org.springframework.jmx.export.UnableToRegisterMBeanException: 
Unable to register MBean [org.fao.geonet.api.processing.EmptySlotBatch@5998544c] 
with object name [geonetwork:name=' + name + ',idx=empty-slot-0]; nested exception is
 javax.management.InstanceAlreadyExistsException:
 geonetwork:name=' + name + ',idx=empty-slot-0"}
```

This at least fix the name of the validation task for monitoring progress.