### PR TITLE
Validation / INSPIRE / Add configuration for Conformance Class 2b

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-etf-validator.xml
+++ b/web/src/main/webapp/WEB-INF/config-etf-validator.xml
@@ -45,6 +45,14 @@
         <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
       </array>
     </entry>
+    <entry key="TG version 2.0 - Data sets and series (for Monitoring)">
+      <array value-type="java.lang.String">
+        <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
+        <value>Conformance Class 1: INSPIRE data sets and data set series baseline metadata.</value>
+        <value>Conformance Class 2: INSPIRE data sets and data set series interoperability metadata.</value>
+        <value>Conformance Class 2b: INSPIRE data sets and data set series metadata for Monitoring</value>
+      </array>
+    </entry>
     <entry key="TG version 2.0 - Network services">
       <array value-type="java.lang.String">
         <value>Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records.</value>
@@ -89,7 +97,7 @@
         - Interval to wait until do a new check, in milliseconds.
   -->
   <util:map id="validatorAdditionalConfig">
-    <entry key="defaultTestSuite" value="TG version 1.3"/>
+    <entry key="defaultTestSuite" value="TG version 2.0 - Data sets and series"/>
     <entry key="maxNumberOfEtfChecks" value="20"/>
     <entry key="intervalBetweenEtfChecks" value="5000"/>
   </util:map>


### PR DESCRIPTION
Class 2b is used for the Monitoring (see https://github.com/inspire-eu-validation/metadata/tree/2.0/monitoring) and checks for spatial scope and priority dataset.

![image](https://user-images.githubusercontent.com/1701393/97169276-1464ad00-178a-11eb-96ca-8e64b529def9.png)


![image](https://user-images.githubusercontent.com/1701393/97169364-39592000-178a-11eb-838f-a58ff880dcac.png)



Set TG2 as default.