### PR TITLE
Indexing / Error / In case of ES error create a better error document

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -83,6 +83,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.*;
 
 import static org.elasticsearch.rest.RestStatus.*;
+import static org.fao.geonet.constants.Geonet.IndexFieldNames.IS_TEMPLATE;
 
 
 public class EsSearchManager implements ISearchManager {
@@ -438,18 +439,23 @@ public class EsSearchManager implements ISearchManager {
                     errorDocumentIds.add(e.getId());
                     ObjectMapper mapper = new ObjectMapper();
                     ObjectNode docWithErrorInfo = mapper.createObjectNode();
-                    docWithErrorInfo.put(IndexFields.DBID, e.getId());
                     String resourceTitle = String.format("Document #%s", e.getId());
+                    String id = "";
+                    String isTemplate = "";
 
                     String failureDoc = documents.get(e.getId());
                     try {
                         JsonNode node = mapper.readTree(failureDoc);
                         resourceTitle = node.get("resourceTitleObject").get("default").asText();
+                        id = node.get(IndexFields.DBID).asText();
+                        isTemplate = node.get(IS_TEMPLATE).asText();
                     } catch (Exception ignoredException) {
                     }
+                    docWithErrorInfo.put(IndexFields.DBID, id);
                     docWithErrorInfo.put(IndexFields.RESOURCE_TITLE, resourceTitle);
+                    docWithErrorInfo.put(IS_TEMPLATE, isTemplate);
                     docWithErrorInfo.put(IndexFields.DRAFT, "n");
-                    docWithErrorInfo.put(IndexFields.INDEXING_ERROR_FIELD, true);
+                    docWithErrorInfo.put(IndexFields.INDEXING_ERROR_FIELD, "true");
                     docWithErrorInfo.put(IndexFields.INDEXING_ERROR_MSG, e.getFailureMessage());
                     // TODO: Report the JSON which was causing the error ?
 

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/status.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/status.html
@@ -103,11 +103,15 @@
                     <div class="pull-right">
                       <a target="_blank"
                          data-ng-href="catalog.search#/metadata/{{::md._id}}">
-                        <i class="fa fa-eye"></i>
+                        <i class="fa fa-fw fa-eye"></i>
                       </a>&nbsp;
                       <a target="_blank"
                          data-ng-href="../api/records/{{::md._id}}/formatters/xml?output=xml">
-                        <i class="fa fa-file-code-o"></i>
+                        <i class="fa fa-fw fa-file-code-o"></i>
+                      </a>
+                      <a target="_blank"
+                         data-ng-href="catalog.edit#/metadata/{{::md.id}}?tab=xml">
+                        <i class="fa fa-fw fa-pencil"></i>
                       </a>
                     </div>
 


### PR DESCRIPTION
* Add db id (which will be used to open editor). 
* Add isTemplate field which is checked when opening the editor.
* Add link to the editor in XML mode (usually if there is indexing error, editor XSLT also fails for similar reason. XML mode usually is ok to open whatever messy records eg. invalid date formats) 


![image](https://user-images.githubusercontent.com/1701393/97300493-d2556d00-1856-11eb-9e11-4f7801a031e0.png)
