### PR TITLE
DOI / Store it as resource identifier.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/doi-add.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/doi-add.xsl
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                exclude-result-prefixes="#all">
+
+  <!-- Insert a DOI in the metadata record as a resource identifier. -->
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:param name="doi"
+             select="''"/>
+
+  <xsl:variable name="isDoiAlreadySet"
+                select="count(//mdb:identificationInfo/*/mri:citation/*/
+                              cit:identifier/*/mcc:code[
+                                contains(*/text(), 'doi.org')
+                                or contains(*/@xlink:href, 'doi.org')]) > 0"/>
+
+
+  <xsl:template match="mdb:identificationInfo[1]/*/mri:citation/*[not($isDoiAlreadySet)]"
+                priority="2">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+
+      <xsl:copy-of select="cit:title
+                           |cit:alternateTitle
+                           |cit:date
+                           |cit:edition
+                           |cit:editionDate
+                           |cit:identifier
+                          "/>
+      <cit:identifier>
+        <mcc:MD_Identifier>
+          <mcc:code>
+            <gcx:Anchor xlink:href="{$doi}">
+              <xsl:value-of select="$doi"/>
+            </gcx:Anchor>
+          </mcc:code>
+          <mcc:codeSpace>
+            <gco:CharacterString>doi.org</gco:CharacterString>
+          </mcc:codeSpace>
+          <mcc:description>
+            <gco:CharacterString>Digital Object Identifier (DOI)</gco:CharacterString>
+          </mcc:description>
+        </mcc:MD_Identifier>
+      </cit:identifier>
+
+      <xsl:copy-of select="cit:citedResponsibleParty
+                           |cit:presentationForm
+                           |cit:series
+                           |cit:otherCitationDetails
+                           |cit:collectiveTitle
+                           |cit:ISBN
+                           |cit:ISSN
+                           |cit:onlineResource
+                           |cit:graphic
+                          "/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/doi-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/doi-add.xsl
@@ -2,13 +2,16 @@
 <xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
                   xmlns:gco="http://www.isotc211.org/2005/gco"
                   xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                  xmlns:xlink="http://www.w3.org/1999/xlink"
                   xmlns:geonet="http://www.fao.org/geonetwork"
                   exclude-result-prefixes="#all">
 
   <!-- Insert a DOI in the metadata record.
 
-  The default mode here is to add the DOI in the distribution info section
-  with a "DOI" protocol.
+  The default mode here is to add the DOI as a resource identifier.
+  Another mode was to insert it in the distribution info section
+  with a "DOI" protocol. Check commented lines below to change the mode.
   -->
   <xsl:output method="xml" indent="yes"/>
 
@@ -23,13 +26,54 @@
                 select="'Digital Object Identifier (DOI)'"/>
 
 
-  <xsl:variable name="isDoiAlreadSet"
-                select="count(//gmd:distributionInfo//gmd:onLine/*[matches(gmd:protocol/gco:CharacterString, $doiProtocolRegex)]/gmd:linkage/gmd:URL[. != '']) > 0"/>
+  <xsl:variable name="isDoiAlreadySet"
+                select="count(//gmd:identificationInfo/*/gmd:citation/*/
+                              gmd:identifier/*/gmd:code[
+                                contains(*/text(), 'doi.org')
+                                or contains(*/@xlink:href, 'doi.org')]) > 0"/>
+
+  <!--<xsl:variable name="isDoiAlreadySet"
+                select="count(//gmd:distributionInfo//gmd:onLine/*[matches(gmd:protocol/gco:CharacterString, $doiProtocolRegex)]/gmd:linkage/gmd:URL[. != '']) > 0"/>-->
+
+
+  <xsl:template match="gmd:identificationInfo[1]/*/gmd:citation/*[not($isDoiAlreadySet)]"
+                priority="2">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+
+      <xsl:copy-of select="gmd:title
+                           |gmd:alternateTitle
+                           |gmd:date
+                           |gmd:edition
+                           |gmd:editionDate
+                           |gmd:identifier
+                          "/>
+      <gmd:identifier>
+        <gmd:MD_Identifier>
+          <gmd:code>
+            <gmx:Anchor xlink:href="{$doi}">
+              <xsl:value-of select="$doi"/>
+            </gmx:Anchor>
+<!--            <gco:CharacterString><xsl:value-of select="$doi"/></gco:CharacterString>-->
+          </gmd:code>
+        </gmd:MD_Identifier>
+      </gmd:identifier>
+
+      <xsl:copy-of select="gmd:citedResponsibleParty
+                           |gmd:presentationForm
+                           |gmd:series
+                           |gmd:otherCitationDetails
+                           |gmd:collectiveTitle
+                           |gmd:ISBN
+                           |gmd:ISSN
+                          "/>
+    </xsl:copy>
+  </xsl:template>
 
   <!-- Insert the DOI after the last onLine element of the first distributionInfo section.
-   This expect to have one onLine element at least. -->
+   This expect to have one onLine element at least.
   <xsl:template match="gmd:distributionInfo[1]/*/gmd:transferOptions/*/gmd:onLine[
-                              not($isDoiAlreadSet) and
+                              not($isDoiAlreadySet) and
                               name(following-sibling::*[1]) != 'gmd:onLine']"
                 priority="2">
     <xsl:copy-of select="."/>
@@ -47,6 +91,8 @@
       </gmd:CI_OnlineResource>
     </gmd:onLine>
   </xsl:template>
+  -->
+
 
   <!-- Do a copy of every nodes and attributes -->
   <xsl:template match="@*|node()">


### PR DESCRIPTION
As the DOI is a permanent identifier, a common practice is
to store the DOI as a resource identifier instead of
a link in distribution section.

Add support for ISO19115-3 too.


Relates to https://github.com/geonetwork/core-geonetwork/pull/3281