### PR TITLE
Facet / Do not capitalize the title

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -10,7 +10,7 @@
   <a href
      class="flex-row flex-align-center flex-shrink width-100"
      ng-class="ctrl.isInSearch(ctrl.facet, ctrl.item) ? 'gn-facet-checked' + (ctrl.item.inverted ? '-inverted' : '') : ''"
-     title="{{::ctrl.item.value | capitalize}}"
+     title="{{::ctrl.item.value}}"
      ng-click="ctrl.filter(ctrl.facet, ctrl.item)">
     <span class="fa fa-fw"
           ng-class="ctrl.isInSearch(ctrl.facet, ctrl.item) ? 'fa-check-square' : 'fa-square-o'">


### PR DESCRIPTION
For keywords, duplicates may popup in facets (due to the KeywordAnalyzer - maybe something to improve). 
User can not really figure out why without having the possibility to see the index value without the client side capitalize filter.

![image](https://user-images.githubusercontent.com/1701393/97428755-bc0ee600-1916-11eb-8efe-475744bcb3ac.png)

Note that the facet filter is also case sensitive for now (see Elasticsearch doc) but Regex can be use eg. `[Ll]and` even if can be slow.