### PR TITLE
[a11y] Change language picker into dropdown

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/languageswitcher/LanguageSwitcherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/languageswitcher/LanguageSwitcherDirective.js
@@ -39,13 +39,10 @@
           langLabels: '=',
           lang: '=gnLanguageSwitcher'
         },
-        template:
-            '<select class="form-control" ' +
-            ' aria-label=' + "{{'languageSwitcher'|translate}}" + '"' +
-            ' data-ng-show="isHidden()" ' +
-            ' data-ng-model="lang" ' +
-            ' data-ng-options="key as langLabels[key] ' +
-            ' for (key, value) in langs"/>',
+        templateUrl: function ($element, $attrs) {
+          return $attrs.templateUrl || '../../catalog/components/common/languageswitcher/partials/' +
+            'language-switcher.html'
+        },
         link: function(scope) {
           scope.$watch('lang', function(value, o) {
 
@@ -78,6 +75,10 @@
           scope.isHidden = function() {
             return Object.keys(scope.langs).length > 1;
           };
+
+          scope.switchLanguage = function(newLanguage) {
+            scope.lang = newLanguage;
+          }
         }
       };
     }]);

--- a/web-ui/src/main/resources/catalog/components/common/languageswitcher/partials/language-switcher.html
+++ b/web-ui/src/main/resources/catalog/components/common/languageswitcher/partials/language-switcher.html
@@ -1,0 +1,13 @@
+<div class="dropdown"
+     data-ng-show="isHidden()"
+     data-ng-model="lang">
+  <button class="btn btn-default dropdown-toggle" type="button" id="language-switcher" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+    {{langLabels[lang]}}
+    <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" aria-labelledby="language-switcher">
+    <li data-ng-repeat="(key, value) in langs" data-ng-class="{'active': key == lang, '': key != lang}">
+      <a data-ng-click="switchLanguage(key)" href>{{langLabels[key]}}</a>
+    </li>
+  </ul>
+</div>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -138,17 +138,15 @@
       <li gn-static-pages-list-viewer data-section="top" data-language="{{lang}}" />
     </ul>
 
-
-    <form class="navbar-form navbar-right language-switcher">
+    <div class="navbar-form navbar-right language-switcher">
       <span class="gn-menuheader-xs visible-xs"
             data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && (!shibbolethEnabled || (shibbolethEnabled && !shibbolethHideLogin))"
             data-translate="">language</span>
-      <div class="form-group"
-           data-gn-language-switcher="lang"
+      <div data-gn-language-switcher="lang"
            data-langs="langs"
            data-lang-labels="langLabels">
       </div>
-    </form>
+    </div>
 
     <ul data-ng-if="gnCfg.mods.signin.enabled"
         class="nav navbar-nav navbar-right username-dropdown">


### PR DESCRIPTION
The language picker is now a `<select>` element in a form. However this form has no submit button, and accessibility is having difficulties with this absence.

This PR changes the `<select>` (and `<form>`) into a Bootstrap **dropdown**. As a bonus you have a better select style to see the current language.

To customize it, you can choose another template like this:
```html
<div data-gn-language-switcher="lang"
     data-langs="langs"
     data-lang-labels="langLabels"
     data-template-url="../../catalog/views/default/templates/language-switcher-buttongroup.html">
</div>
```

**The 'new' language picker**
![gn-langauge-picker](https://user-images.githubusercontent.com/19608667/97577606-f0a2a080-19ef-11eb-89af-de2f12f77afd.png)

Thank you @josegar74 for doing the coding
