### PR TITLE
Home / Latest news = Last created records

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -68,7 +68,7 @@
         filters: gnSearchSettings.filters,
         params: {
           isTemplate: 'n',
-          sortBy: 'changeDate',
+          sortBy: 'createDate',
           sortOrder: 'desc',
           from: 1,
           to: 12


### PR DESCRIPTION
Reported by some users, it may make more sense to display last created records under "latest news" instead of last updated records.

@archaeogeek , @pvgenuchten , do you think it is a better default?