### PR TITLE
Xslt formatter - resolve section names with meteadata element names using labels.xml

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -18,6 +18,17 @@
                           else $key"/>
   </xsl:function>
 
+  <xsl:function name="gn-fn-render:get-schema-labels" as="xs:string">
+    <xsl:param name="strings" as="node()"/>
+    <xsl:param name="key" as="xs:string"/>
+
+    <xsl:variable name="nameInStrings"
+                  select="$strings/element[@name= $key]/label"/>
+    <xsl:value-of select="if ($nameInStrings != '')
+                          then $nameInStrings
+                          else $key"/>
+  </xsl:function>
+
   <!-- Render coordinates of bbox and an images of the geometry
   using the region API -->
   <xsl:function name="gn-fn-render:bbox">

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -407,7 +407,10 @@
       <div id="gn-section-{generate-id()}" class="gn-tab-content">
         <xsl:if test="@name">
           <xsl:variable name="title"
-                        select="gn-fn-render:get-schema-strings($schemaStrings, @name)"/>
+                        select="
+                        if (contains( @name, ':'))
+                        then gn-fn-render:get-schema-labels($schemaLabels, @name)
+                        else gn-fn-render:get-schema-strings($schemaStrings, @name) "/>
           <xsl:element name="h{1 + count(ancestor-or-self::*[name(.) = 'section'])}">
             <xsl:value-of select="$title"/>
           </xsl:element>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-variables.xsl
@@ -77,6 +77,9 @@
   <xsl:variable name="schemaStrings"
                 select="/root/schemas/*[name() = $schema]/strings"/>
 
+  <xsl:variable name="schemaLabels"
+                select="/root/schemas/*[name() = $schema]/labels"/>
+
   <!-- Get params from requests parameters or use the first view configured -->
   <xsl:variable name="viewConfig" select="$configuration/editor/views/view[@name = $view]"/>
 


### PR DESCRIPTION
Xslt formatter is not resolving names like: ` <section name="gmd:MD_Metadata">` to display the element label (as the editor does), instead displays the value `gmd:MD_Metadata`.

For example, PDF export:

![name-not-resolved](https://user-images.githubusercontent.com/1695003/97592001-7a5a6a00-1a00-11eb-92b5-d71190ff56fb.png)

With the change:

![name-resolved](https://user-images.githubusercontent.com/1695003/97592081-8fcf9400-1a00-11eb-9ba6-ba5d4974c194.png)
