### PR TITLE
Small fix and style improvements for the PDF output

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_metadata_pdf.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata_pdf.less
@@ -61,7 +61,7 @@
   Extent is already displayed in main view usually.
   Social and associated resources require JS.
   So hidden from side bar in PDF output. */
-  .gn-md-side-extent, .gn-md-side-social, .gn-md-side-associated {
+  .gn-md-side-extent, .gn-md-side-social, .gn-md-side-associated, .gn-md-side-access {
     display: none;
   }
   dl {
@@ -71,6 +71,7 @@
   dt, dd {
     line-height: 1.428571429;
     padding: 10px 0;
+    min-height: 24px;
   }
   dt {
     clear: left;
@@ -119,6 +120,11 @@
     padding-left: 1em;
     background: #eeeeee;
   }
+  .gn-contact {
+    border-top: 1px solid #999999;
+    padding: 10px 0;
+    line-height: 1.5em;
+  }
   table {
     width: 100%;
   }
@@ -141,24 +147,27 @@
     .coord{
       float: left;
       display: block;
-      border: 1px solid #ccc;
+      border: 2px solid #ccc;
       background: #fff;
       margin-right: 20px;
       margin-bottom: 20px;
+      pointer-events: none;
       input {
         text-align: left;
         border: 0;
-        padding: 6px;
-        width: 114px;
+        padding: 10px;
+        margin: 0;
+        // width: 100px;
         background: #fff;
       }
       span.input-group-addon {
         background-color: #eeeeee;
         border-left: 1px solid #ccc;
-        padding: 6px 10px 7px 10px;
+        padding: 15px;
         width: 15px;
         text-align: center;
         float: right;
+        font-weight: bold;
       }
     }
   }


### PR DESCRIPTION
Small fix and style improvements for the PDF output. Sometimes the table cell is empty which results in a lower table row, which in turn breaks the layout (because it's a `<dd>` and `<dl>` looking like a table cell).

This PR adds a minimum height, so the layout stays intact when the cell is empty

**Broken layout**

<img width="959" alt="gn-broken-pdf" src="https://user-images.githubusercontent.com/19608667/97597615-51d56e80-1a06-11eb-84dd-7ce31a0451eb.png">

Changes:
- minimum height for table cells (fix for empty cells)
- border and line-height for contacts