### PR TITLE
Thesaurus / Import from Linked Data Registry (LDRegistry).

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -869,7 +869,7 @@ public class KeywordsApi {
         if (lang != null) {
             Element documents = new Element("documents");
             if (registryType == REGISTRY_TYPE.ldRegistry) {
-                Path localRdf = getXMLContentFromUrl(registryUrl + "?_format=rdf", context);
+                Path localRdf = getXMLContentFromUrl(registryUrl + "?_view=with_metadata&_format=rdf", context);
                 Element ldRegistryCodelistAsRdf = Xml.loadFile(localRdf);
                 documents.addContent(ldRegistryCodelistAsRdf);
             } else {

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -702,6 +702,11 @@ public class KeywordsApi {
     }
 
 
+    public enum REGISTRY_TYPE {
+        re3gistry,
+        ldRegistry
+    }
+
     /**
      * Upload thesaurus.
      *
@@ -739,6 +744,11 @@ public class KeywordsApi {
             description = "If set, try to download from a registry.")
         @RequestParam(value = "registryUrl", required = false)
             String registryUrl,
+        @Parameter(
+            description = "If using registryUrl, then define the type of registry." +
+                " If not set, default mode is re3gistry.")
+        @RequestParam(value = "registryType", required = false)
+            REGISTRY_TYPE registryType,
         @Parameter(
             description = "Languages to download from a registry.")
         @RequestParam(value = "registryLanguage", required = false)
@@ -791,7 +801,7 @@ public class KeywordsApi {
 
             String itemName = registryUrl.substring((registryUrl.lastIndexOf("/") + 1));
 
-            rdfFile = extractSKOSFromRegistry(registryUrl, itemName, registryLanguage, context);
+            rdfFile = extractSKOSFromRegistry(registryUrl, registryType, itemName, registryLanguage, context);
             fname = registryUrl.replaceAll("[^A-Za-z]+", "") +
                 "-" +
                 itemName + ".rdf";
@@ -847,30 +857,39 @@ public class KeywordsApi {
      * them into one XML document which is then XSLT processed for SKOS conversion.
      *
      * @param registryUrl the registry url
+     * @param registryType
      * @param itemName    the item name
      * @param lang        the selected languages
      * @param context     the context
      * @return the path
      * @throws Exception the exception
      */
-    private Path extractSKOSFromRegistry(String registryUrl, String itemName, String[] lang, ServiceContext context)
+    private Path extractSKOSFromRegistry(String registryUrl, REGISTRY_TYPE registryType, String itemName, String[] lang, ServiceContext context)
         throws Exception {
         if (lang != null) {
             Element documents = new Element("documents");
-            for (String language : lang) {
-                try {
-                    String languageFileUrl = registryUrl + "/" + itemName + "." + language + ".xml";
-                    Path localRdf = getXMLContentFromUrl(languageFileUrl, context);
-                    Element codeList = Xml.loadFile(localRdf);
-                    documents.addContent(codeList);
-                } catch (Exception e) {
-                    Log.debug(Geonet.THESAURUS, "Thesaurus not found for the requested translation: " + itemName + " " + language);
-                    throw new ResourceNotFoundException("Thesaurus not found for the requested translation: " + itemName + " " + language);
+            if (registryType == REGISTRY_TYPE.ldRegistry) {
+                Path localRdf = getXMLContentFromUrl(registryUrl + "?_format=rdf", context);
+                Element ldRegistryCodelistAsRdf = Xml.loadFile(localRdf);
+                documents.addContent(ldRegistryCodelistAsRdf);
+            } else {
+                for (String language : lang) {
+                    try {
+                        String languageFileUrl = registryUrl + "/" + itemName + "." + language + ".xml";
+                        Path localRdf = getXMLContentFromUrl(languageFileUrl, context);
+                        Element codeList = Xml.loadFile(localRdf);
+                        documents.addContent(codeList);
+                    } catch (Exception e) {
+                        Log.debug(Geonet.THESAURUS, "Thesaurus not found for the requested translation: " + itemName + " " + language);
+                        throw new ResourceNotFoundException("Thesaurus not found for the requested translation: " + itemName + " " + language);
+                    }
                 }
             }
 
             // Convert to SKOS
-            Path skosTransform = dataDirectory.getWebappDir().resolve("xslt/services/thesaurus/registry-to-skos.xsl");
+            Path skosTransform = dataDirectory.getWebappDir().resolve(String.format(
+                "xslt/services/thesaurus/%s-to-skos.xsl",
+                registryType == REGISTRY_TYPE.ldRegistry ? "ldregistry" : "registry"));
             Element transform = Xml.transform(documents, skosTransform);
             // Convert to file and return
             Path rdfFile = Files.createTempFile("thesaurus", ".rdf");

--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
@@ -56,7 +56,7 @@
           scope.registryType = null;
           scope.registries = [{
               name: 'INSPIRE',
-              url: 'https://inspire.ec.europa.eu'
+              url: 'https://inspire.ec.europa.eu/registry'
             },
             {
               name: 'BRGM',

--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
@@ -54,10 +54,21 @@
           scope.registryUrl = '';
           // Can be re3gistry or ldRegistry
           scope.registryType = null;
-          scope.defaultRegistry = 'https://inspire.ec.europa.eu';
+          scope.registries = [{
+              name: 'INSPIRE',
+              url: 'https://inspire.ec.europa.eu'
+            },
+            {
+              name: 'BRGM',
+              url: 'https://data.geoscience.fr/ncl/'
+            },
+            {
+              name: 'CSIRO',
+              url: 'http://registry.it.csiro.au/'
+            }];
 
-          scope.setDefault = function() {
-            scope.registryUrl = scope.defaultRegistry;
+          scope.setDefault = function(url) {
+            scope.registryUrl = url;
           }
 
           function getMainLanguage() {
@@ -91,6 +102,10 @@
               return;
             }
 
+            scope.selectedClass = null;
+            scope.selectedCollection = null;
+            scope.itemCollection = [];
+
             scope.registryType = gnRegistryService.guessTool(scope.registryUrl)
               .then(function(TYPE) {
               scope.registryType = TYPE;
@@ -100,9 +115,6 @@
               gnRegistryService.loadLanguages(scope.registryUrl).then(
                 function (languages) {
                   scope.languages = languages;
-                  scope.selectedClass = null;
-                  scope.selectedCollection = null;
-                  scope.itemCollection = [];
 
                   if (languages.length > 0) {
                     selectPreferredLanguage();

--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
@@ -61,10 +61,6 @@
             {
               name: 'BRGM',
               url: 'https://data.geoscience.fr/ncl/'
-            },
-            {
-              name: 'CSIRO',
-              url: 'http://registry.it.csiro.au/'
             }];
 
           scope.setDefault = function(url) {

--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
@@ -52,6 +52,8 @@
           scope.loadingCollection = false;
 
           scope.registryUrl = '';
+          // Can be re3gistry or ldRegistry
+          scope.registryType = null;
           scope.defaultRegistry = 'https://inspire.ec.europa.eu';
 
           scope.setDefault = function() {
@@ -89,49 +91,52 @@
               return;
             }
 
+            scope.registryType = gnRegistryService.guessTool(scope.registryUrl)
+              .then(function(TYPE) {
+              scope.registryType = TYPE;
+              // On init,
+              // * load language first (select the first one)
+              // * load available itemClass (select the firs one)
+              gnRegistryService.loadLanguages(scope.registryUrl).then(
+                function (languages) {
+                  scope.languages = languages;
+                  scope.selectedClass = null;
+                  scope.selectedCollection = null;
+                  scope.itemCollection = [];
 
-            // On init,
-            // * load language first (select the first one)
-            // * load available itemClass (select the firs one)
-            gnRegistryService.loadLanguages(scope.registryUrl).then(
-              function (languages) {
-                scope.languages = languages;
-                scope.selectedClass = null;
-                scope.selectedCollection = null;
-                scope.itemCollection = [];
+                  if (languages.length > 0) {
+                    selectPreferredLanguage();
 
-                if (languages.length > 0) {
-                  selectPreferredLanguage();
+                    gnRegistryService.loadItemClass(
+                      scope.registryUrl, scope.registryType, getMainLanguage()).then(
+                      function (itemClass) {
+                        scope.itemClass = itemClass;
 
-                  gnRegistryService.loadItemClass(
-                    scope.registryUrl, getMainLanguage()).then(
-                    function (itemClass) {
-                      scope.itemClass = itemClass;
-
-                      if (itemClass.length > 0) {
-                        scope.selectedClassUrl = itemClass[0];
-                        loadCollection();
-                      } else {
+                        if (itemClass.length > 0) {
+                          scope.selectedClassUrl = itemClass[0];
+                          loadCollection();
+                        } else {
+                          $rootScope.$broadcast('StatusUpdated', {
+                            title: $translate.instant('registryNoClassFound'),
+                            timeout: 3,
+                            type: 'warning'});
+                        }
+                      }, function () {
                         $rootScope.$broadcast('StatusUpdated', {
-                          title: $translate.instant('registryNoClassFound'),
+                          title: $translate.instant('registryFailedToLoadClass'),
                           timeout: 3,
-                          type: 'warning'});
+                          type: 'danger'});
                       }
-                    }, function () {
-                      $rootScope.$broadcast('StatusUpdated', {
-                        title: $translate.instant('registryFailedToLoadClass'),
-                        timeout: 3,
-                        type: 'danger'});
-                    }
-                  );
-                } else {
-                  $rootScope.$broadcast('StatusUpdated', {
-                    title: $translate.instant('registryNoLanguage'),
-                    timeout: 3,
-                    type: 'warning'});
+                    );
+                  } else {
+                    $rootScope.$broadcast('StatusUpdated', {
+                      title: $translate.instant('registryNoLanguage'),
+                      timeout: 3,
+                      type: 'warning'});
+                  }
                 }
-              }
-            );
+              );
+            });
           }
 
           scope.$watch('registryUrl', function (n, o) {
@@ -161,7 +166,9 @@
           // TODO: Should be identified by analysing registry response ?
           scope.isSimple = false;
           function isSimpleList() {
-            if (scope.selectedClass.match(
+            if (scope.registryType === 'ldRegistry') {
+              scope.isSimple = true;
+            } else if (scope.selectedClass.match(
               'theme|applicationschema|featureconcept|' +
                 'document|glossary|layer|media-types|producers')) {
               scope.isSimple = true;

--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryService.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryService.js
@@ -83,9 +83,10 @@
         var itemClass = [];
 
         var deferred = $q.defer(),
+          urlToken = url.split('/'),
           urlForCollection =
             (type === 'ldRegistry') ? url + '?_format=jsonld'
-              : url + '/registry/registry.' + lang + responseFormat;
+              : url +  '/' + urlToken[urlToken.length - 1] + '.' + lang + responseFormat;
 
         $http({
           url: urlForCollection,

--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryService.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryService.js
@@ -36,6 +36,24 @@
     function($http, $q) {
       var responseFormat = '.json';
 
+      this.guessTool = function(url) {
+        var deferred = $q.defer();
+        $http({
+          url: url + '?_format=jsonld',
+          method: 'GET',
+          headers: {
+            "Accept": "application/ld+json"
+          },
+          cache: true
+        }).then(function (r) {
+          deferred.resolve(
+            r.data['@graph'] ? 'ldRegistry' : 're3gistry');
+        }, function (r) {
+          deferred.resolve('re3gistry');
+        });
+        return deferred.promise;
+      };
+
       this.loadLanguages = function (url) {
         var languages = [];
         var deferred = $q.defer();
@@ -61,25 +79,38 @@
         return deferred.promise;
       };
 
-      this.loadItemClass = function (url, lang) {
+      this.loadItemClass = function (url, type, lang) {
         var itemClass = [];
 
-        var deferred = $q.defer();
+        var deferred = $q.defer(),
+          urlForCollection =
+            (type === 'ldRegistry') ? url + '?_format=jsonld'
+              : url + '/registry/registry.' + lang + responseFormat;
 
         $http({
-          url: url + '/registry/registry.' + lang + responseFormat,
+          url: urlForCollection,
           method: 'GET',
           cache: true
         }).then(function (r) {
-          if (angular.isUndefined(r.data.registry)) {
-            deferred.reject(r);
-          } else {
+          if (type === 'ldRegistry' && r.data['@graph']) {
+            angular.forEach(r.data['@graph'], function (value, key) {
+              var label = value['rdfs:label'];
+              itemClass.push({
+                key: value['@id'],
+                label: angular.isArray(label) ? label[0]['@value']
+                  : (angular.isObject(label) ? label['@value'] : label)
+              });
+            });
+            deferred.resolve(itemClass);
+          } else if (type === 're3gistry' && r.data.registry) {
             angular.forEach(r.data.registry.registers, function (value, key) {
               itemClass.push({
                 key: value.register.id,
                 label: value.register.label.text})
             });
             deferred.resolve(itemClass);
+          } else {
+            deferred.reject(r);
           }
         }, function (r) {
           deferred.reject(r);

--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryService.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryService.js
@@ -95,19 +95,27 @@
         }).then(function (r) {
           if (type === 'ldRegistry' && r.data['@graph']) {
             angular.forEach(r.data['@graph'], function (value, key) {
-              var label = value['rdfs:label'];
-              itemClass.push({
-                key: value['@id'],
-                label: angular.isArray(label) ? label[0]['@value']
-                  : (angular.isObject(label) ? label['@value'] : label)
-              });
+              var labels = value['rdfs:label'],
+                descriptions = value['dct:description'],
+                label = angular.isArray(labels) ? labels[0]['@value']
+                  : (angular.isObject(labels) ? labels['@value'] : labels),
+                description = angular.isArray(descriptions) ? descriptions[0]['@value']
+                  : (angular.isObject(descriptions) ? descriptions['@value'] : descriptions);
+              if (label !== 'root') {
+                itemClass.push({
+                  key: value['@id'],
+                  label: label,
+                  description: description
+                });
+              }
             });
             deferred.resolve(itemClass);
           } else if (type === 're3gistry' && r.data.registry) {
             angular.forEach(r.data.registry.registers, function (value, key) {
               itemClass.push({
                 key: value.register.id,
-                label: value.register.label.text})
+                label: value.register.label.text,
+                description: ''})
             });
             deferred.resolve(itemClass);
           } else {

--- a/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
@@ -8,17 +8,30 @@
              data-ng-model="registryUrl"
              class="form-control"
              placeholder="https://"/>
-      <span class="input-group-btn">
-        <div class="btn btn-default"
-                data-ng-click="setDefault()"
-                data-translate="">registryUseInspireOne</div>
-      </span>
+
+      <div class="input-group-btn">
+        <button type="button"
+                class="btn btn-default dropdown-toggle"
+                title="{{::'registryList' | translate}}"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false">
+          <i class="fa fa-fw fa-th-list"></i>
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+          <li data-ng-repeat="r in registries">
+            <a data-ng-click="setDefault(r.url)"
+               title="{{r.url}}">{{r.name}}</a>
+          </li>
+        </ul>
+      </div>
     </div>
     <p class="help-block ng-scope" data-translate="">registry-help</p>
   </div>
 
   <div class="form-group"
-       data-ng-show="languages.length > 0">
+       data-ng-show="registryType === 're3gistry' && languages.length > 0">
     <label class="form-label"
            data-translate="">
       registryChooseLanguages
@@ -47,7 +60,7 @@
     registryChooseType
     </label>
     <select class="form-control"
-            data-ng-options="t as t.label for t in itemClass track by t.key"
+            data-ng-options="t as t.label for t in itemClass | orderBy:'label' track by t.key"
             data-ng-model="selectedClassUrl"/>
   </div>
 

--- a/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
@@ -17,7 +17,8 @@
     <p class="help-block ng-scope" data-translate="">registry-help</p>
   </div>
 
-  <div class="form-group">
+  <div class="form-group"
+       data-ng-show="languages.length > 0">
     <label class="form-label"
            data-translate="">
       registryChooseLanguages
@@ -39,7 +40,8 @@
     </div>
   </div>
 
-  <div class="form-group">
+  <div class="form-group"
+       data-ng-show="itemClass.length > 0">
     <label class="form-label"
            data-translate="">
     registryChooseType
@@ -50,7 +52,7 @@
   </div>
 
   <div class="form-group"
-       data-ng-show="!isSimple">
+       data-ng-show="itemClass.length > 0 && !isSimple">
     <label class="form-label"
            data-translate="">
       registryChooseItem
@@ -63,5 +65,6 @@
   </div>
 
   <input type="hidden" name="registryUrl" value="{{selectedCollection}}">
+  <input type="hidden" name="registryType" value="{{registryType}}">
 
 </div>

--- a/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
@@ -61,7 +61,10 @@
     </label>
     <select class="form-control"
             data-ng-options="t as t.label for t in itemClass | orderBy:'label' track by t.key"
-            data-ng-model="selectedClassUrl"/>
+            data-ng-model="selectedClassUrl">
+      <!--<option data-ng-repeat="t in itemClass | orderBy:'label' track by t.key"
+              value="{{t}}" title="{{t.description}}">{{t.label}}</option>-->
+    </select>
   </div>
 
   <div class="form-group"

--- a/web/src/main/webapp/xslt/services/thesaurus/ldregistry-to-skos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/ldregistry-to-skos.xsl
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:saxon="http://saxon.sf.net/"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dcterms="http://purl.org/dc/terms/"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:reg="http://purl.org/linked-data/registry#"
+                xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+                version="2.0"
+                extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all">
+
+  <!-- Convert LD-Registry RDF format into SKOS format for GeoNetwork. -->
+
+  <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+
+  <xsl:variable name="df">[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01]</xsl:variable>
+  <xsl:variable name="now"
+                select="format-dateTime(current-dateTime(),$df)"/>
+
+  <xsl:variable name="registryBase"
+                select="//(skos:ConceptScheme|reg:RegisterItem)"/>
+
+  <xsl:variable name="thesaurusId"
+                select="$registryBase/@rdf:about"/>
+
+  <xsl:variable name="thesaurusDate"
+                select="$registryBase/dcterms:modified"/>
+
+  <xsl:template match="/documents">
+
+    <rdf:RDF xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dc="http://purl.org/dc/elements/1.1/"
+             xmlns:dcterms="http://purl.org/dc/terms/">
+      <skos:ConceptScheme rdf:about="{$thesaurusId}">
+        <xsl:apply-templates mode="concept-scheme"
+                           select="$registryBase/rdfs:label
+                                   |$registryBase/dcterms:description"/>
+
+
+        <dcterms:issued><xsl:value-of select="if ($thesaurusDate != '') then $thesaurusDate else $now"/></dcterms:issued>
+        <dcterms:modified><xsl:value-of select="if ($thesaurusDate != '') then $thesaurusDate else $now"/></dcterms:modified>
+
+        <!-- Add top concepts for all items with no parent
+        <xsl:for-each select="*[1]/*:containeditems/*[not(*:parents)]">
+          <skos:hasTopConcept rdf:resource="{@id}"/>
+        </xsl:for-each>-->
+      </skos:ConceptScheme>
+
+      <!-- We assume that the first codelist contains the full
+      list of items to describes and that the following contains
+      translations for each items of the first one. -->
+      <xsl:apply-templates mode="concept"
+                           select="*//skos:Concept"/>
+
+    </rdf:RDF>
+  </xsl:template>
+
+
+  <xsl:template mode="concept-scheme"
+                match="rdfs:label">
+    <dc:title>
+      <xsl:copy-of select="@xml:lang"/>
+      <xsl:value-of select="."/>
+    </dc:title>
+  </xsl:template>
+
+
+  <xsl:template mode="concept-scheme"
+                match="dcterms:description">
+    <dc:description>
+      <xsl:copy-of select="@xml:lang"/>
+      <xsl:value-of select="."/>
+    </dc:description>
+  </xsl:template>
+
+
+  <xsl:template mode="concept-scheme"
+                match="*"/>
+
+
+  <xsl:template mode="concept"
+                match="skos:Concept">
+
+    <xsl:variable name="conceptId"
+                  select="@rdf:about"/>
+
+    <xsl:variable name="items"
+                  select="/documents/*[1]/*:containeditems/*"/>
+
+    <skos:Concept rdf:about="{$conceptId}">
+      <xsl:copy-of select="skos:prefLabel|skos:inScheme"
+                   copy-namespaces="no"/>
+      <xsl:for-each select="dcterms:description">
+        <skos:scopeNote>
+          <xsl:copy-of select="@xml:lang|text()"/>
+        </skos:scopeNote>
+      </xsl:for-each>
+
+      <!-- Add broader and narrower links
+      <xsl:if test="$hasBroaderNarrowerLinks">
+        <xsl:for-each select="*:parents/*:parent">
+          <skos:broader rdf:resource="{@id}"/>
+        </xsl:for-each>
+
+        <xsl:for-each select="$items[*:parents/*:parent/@id = $conceptId]">
+          <skos:narrower rdf:resource="{@id}"/>
+        </xsl:for-each>
+      </xsl:if>-->
+    </skos:Concept>
+  </xsl:template>
+
+  <xsl:template mode="concept"
+                match="*"/>
+</xsl:stylesheet>

--- a/web/src/main/webapp/xslt/services/thesaurus/registry-to-skos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/registry-to-skos.xsl
@@ -69,7 +69,7 @@
                 select="/documents/*[*:language = 'en']/*:label[@xml:lang = 'en']"/>
 
   <xsl:variable name="statusSuffix"
-                select="'registry/status/valid'"/>
+                select="'/status/valid'"/>
 
   <xsl:variable name="hasBroaderNarrowerLinks"
                 select="count(//*[1]/*:containeditems/*/*:parents) > 0"/>


### PR DESCRIPTION
Add support for thesaurus import from LD Registry (https://github.com/UKGovLD/registry-core). Mechanism is similar to re3gistry software. The list of available codelists are retrieved and then imported by conversion to SKOS.


![image](https://user-images.githubusercontent.com/1701393/98393940-5202e900-205a-11eb-87f9-2e86ba07b7b3.png)


Also fix https://github.com/geonetwork/core-geonetwork/issues/4836 related to re3gistry path.


Support simple flat list of keywords:

![image](https://user-images.githubusercontent.com/1701393/98394006-6ba43080-205a-11eb-8d5b-76a736bb18c7.png)


and hierarchy:

![image](https://user-images.githubusercontent.com/1701393/98394095-8a0a2c00-205a-11eb-84a8-6eefe5787c55.png)


Thesaurus created is composed of:
* concept scheme
* top concepts
* keywords with narrower/broader relations
