### PR TITLE
create metadata/template title - add timezone GMT

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -142,6 +142,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import static org.springframework.data.jpa.domain.Specifications.where;
@@ -507,13 +508,15 @@ public class BaseMetadataManager implements IMetadataManager {
                 List<?> titleNodes = null;
                 try {
                     titleNodes = Xml.selectNodes(xml, path, new ArrayList<Namespace>(schemaPlugin.getNamespaces()));
-
+                    // Use ISO 8601 GMT
+                    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+                    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
                     for (Object o : titleNodes) {
                         if (o instanceof Element) {
                             Element title = (Element) o;
                             title.setText(String
                                 .format(messages.getString("metadata.title.createdFrom" + (fromTemplate ? "Template" : "Record")),
-                                    title.getTextTrim(), new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())));
+                                    title.getTextTrim(), simpleDateFormat.format(new Date())));
                         }
                     }
                 } catch (JDOMException e) {


### PR DESCRIPTION
Update date format in title to contain the time zone as ISO 8601 GMT.  This will help eliminate confusion as to when the template/metadata was created.

This is related to #4752

Before the change - the title when creating a new metadata record would be something like the following.

`Copy of template Template for Vector data in ISO19139 created at 2020-11-02 15:39:38`

After the change, it should be something similar to the following.

`Copy of template Template for Vector data in ISO19139 created at 2020-11-02T15:39:38Z`