### PR TITLE
Index / Set default index properly if custom name is used.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -136,8 +136,12 @@ public class EsSearchManager implements ISearchManager {
     @Value("${es.index.records.type:records}")
     private String indexType = "records";
 
-    public String getIndex() {
+    public String getDefaultIndex() {
         return defaultIndex;
+    }
+
+    public void setDefaultIndex(String defaultIndex) {
+        this.defaultIndex = defaultIndex;
     }
 
     public String getIndexType() {
@@ -157,10 +161,6 @@ public class EsSearchManager implements ISearchManager {
     public Map<String, String> listOfDocumentsToIndex =
         Collections.synchronizedMap(new HashMap<>());
     private Map<String, String> indexList;
-
-    public String getDefaultIndex() {
-        return defaultIndex;
-    }
 
     private Path getXSLTForIndexing(Path schemaDir, MetadataType metadataType) {
         Path xsltForIndexing = schemaDir

--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -74,6 +74,7 @@
         class="org.fao.geonet.kernel.search.EsSearchManager"
         lazy-init="false">
     <property name="indexList" ref="indexList"/>
+    <property name="defaultIndex" value="\${es.index.records}"/>
   </bean>
 
 

--- a/core/src/test/resources/core-repository-test-context.xml
+++ b/core/src/test/resources/core-repository-test-context.xml
@@ -78,6 +78,7 @@
         class="org.fao.geonet.kernel.search.EsSearchManager"
         lazy-init="false">
     <property name="indexList" ref="indexList"/>
+    <property name="defaultIndex" value="${es.index.records}"/>
   </bean>
 
   <bean id="esClient"


### PR DESCRIPTION
If not using `gn-records`, user may have issue reindexing if restrictions are set on ES side.