### PR TITLE
[#5145] Fix for the 'empty' user icon on small screens

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -29,11 +29,11 @@
       <li class="clearfix hidden-xs" data-ng-if="gnCfg.mods.home.enabled">
         <a class="pull-left gn-logo-link" 
            data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
-          <img class="gn-logo gn-margin-right"
+          <img class="gn-logo"
                data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}"
                alt="{{'siteLogo' | translate}}"
                data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
-          <span class="gn-name"
+          <span class="gn-name hidden-sm gn-margin-left"
                 data-ng-if="gnCfg.mods.header.showGNName"
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
                 title="{{info['node/name'] || info['system/site/name']}}">
@@ -44,15 +44,15 @@
       <li class="gn-menuitem-xs" data-ng-if="gnCfg.mods.search.enabled">
         <a data-gn-active-tb-item="{{gnCfg.mods.search.appUrl}}"
           title="{{'search' | translate}}">
-          <i class="fa fa-fw fa-search hidden-sm"></i>
+          <i class="fa fa-fw fa-search"></i>
           <span translate>search</span>
         </a>
       </li>
       <li class="gn-menuitem-xs" data-ng-if="gnCfg.mods.map.enabled">
         <a data-gn-active-tb-item="{{isExternalViewerEnabled ? externalViewerUrl : gnCfg.mods.map.appUrl}}"
           title="{{'map' | translate}}">
-          <i class="fa fa-fw fa-globe hidden-sm"></i>
-          <span translate>makeYourMap</span>
+          <i class="fa fa-fw fa-globe"></i>
+          <span translate class="">makeYourMap</span>
           <span data-gnv-layer-indicator=""/>
         </a>
       </li>
@@ -63,8 +63,8 @@
            title="{{'editorBoard' | translate}}"
            class="dropdown-toggle gn-menuheader-xs"
            role="button" aria-expanded="false">
-          <i class="fa fa-fw fa-pencil hidden-sm"></i>
-          <span translate>contribute</span>
+          <i class="fa fa-fw fa-pencil"></i>
+          <span translate class="hidden-md hidden-sm">contribute</span>
         </a>
         <ul class="dropdown-menu gn-menu-xs clearfix" role="list">
           <li class="gn-menuitem-xs" role="menuitem">
@@ -105,8 +105,8 @@
            title="{{'adminConsole' | translate}}"
            class="dropdown-toggle gn-menuheader-xs"
            role="button" aria-expanded="false">
-          <i class="fa fa-fw fa-wrench hidden-sm"></i>
-          <span translate>adminConsole</span>
+          <i class="fa fa-fw fa-wrench"></i>
+          <span translate class="hidden-md hidden-sm">adminConsole</span>
         </a>
         <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu gn-menu-xs" role="list">
           <li class="gn-menuitem-xs" role="menuitem">
@@ -160,7 +160,7 @@
           <img class="img-circle"
             alt="{{'avatar' | translate}}"
             data-ng-src="../api/users/{{(user.id)}}.png?size=18"/>
-          <div class="gn-user-info hidden-sm hidden-md">
+          <div class="gn-user-info">
             <span class="gn-user-name">{{user.name}} {{user.surname}}</span><br>
             <span class="gn-user-role">{{user.profile | translate}}</span>
           </div>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -33,7 +33,7 @@
                data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}"
                alt="{{'siteLogo' | translate}}"
                data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
-          <span class="gn-name hidden-sm gn-margin-left"
+          <span class="gn-name hidden-sm hidden-md gn-margin-left"
                 data-ng-if="gnCfg.mods.header.showGNName"
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
                 title="{{info['node/name'] || info['system/site/name']}}">
@@ -45,14 +45,14 @@
         <a data-gn-active-tb-item="{{gnCfg.mods.search.appUrl}}"
           title="{{'search' | translate}}">
           <i class="fa fa-fw fa-search"></i>
-          <span translate>search</span>
+          <span translate class="hidden-sm">search</span>
         </a>
       </li>
       <li class="gn-menuitem-xs" data-ng-if="gnCfg.mods.map.enabled">
         <a data-gn-active-tb-item="{{isExternalViewerEnabled ? externalViewerUrl : gnCfg.mods.map.appUrl}}"
           title="{{'map' | translate}}">
           <i class="fa fa-fw fa-globe"></i>
-          <span translate class="">makeYourMap</span>
+          <span translate class="hidden-sm">makeYourMap</span>
           <span data-gnv-layer-indicator=""/>
         </a>
       </li>
@@ -64,7 +64,7 @@
            class="dropdown-toggle gn-menuheader-xs"
            role="button" aria-expanded="false">
           <i class="fa fa-fw fa-pencil"></i>
-          <span translate class="hidden-md hidden-sm">contribute</span>
+          <span translate class="hidden-sm">contribute</span>
         </a>
         <ul class="dropdown-menu gn-menu-xs clearfix" role="list">
           <li class="gn-menuitem-xs" role="menuitem">
@@ -106,7 +106,7 @@
            class="dropdown-toggle gn-menuheader-xs"
            role="button" aria-expanded="false">
           <i class="fa fa-fw fa-wrench"></i>
-          <span translate class="hidden-md hidden-sm">adminConsole</span>
+          <span translate class="hidden-sm">adminConsole</span>
         </a>
         <ul data-ng-if="user.isUserAdmin()" class="dropdown-menu gn-menu-xs" role="list">
           <li class="gn-menuitem-xs" role="menuitem">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -67,7 +67,6 @@
       &.gn-truncate {
         @media (min-width: @screen-lg-min) {
           max-width: 230px;
-          display: inline-block;
           .text-overflow();
         }
       }


### PR DESCRIPTION
This PR fixes the 'empty' user icon on small screens. See https://github.com/geonetwork/core-geonetwork/issues/5145

The top toolbar is reworked so the user name is always shown, the other labels are hidden on smaller screens but the icons stay visible (like the edit toolbar).

This was needed because when an empty string for the gravatar is chosen, there is a blank image used as user icon, this empty blank icon was shown on smaller screens and the label with the user name was hidden, resulting in an empty `menu item.

**The toolbar on small screens after the fix**

![gn-fix-username](https://user-images.githubusercontent.com/19608667/98112498-9b103d00-1ea2-11eb-8c56-c8d117efdbb3.png)
