### PR TITLE
Configuration option to restrict the map services supported in map extent API's (region.getmap and {metadatauuid}/extents.png) the usage of non-predefined map services

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
@@ -41,6 +41,7 @@ import org.fao.geonet.utils.XPath;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -117,6 +118,9 @@ public class MetadataExtentApi {
 
     @Autowired
     SettingManager settingManager;
+
+    @Value("${metadata.extentApi.disableFullUrlBackgroundMapServices:true}")
+    private boolean disableFullUrlBackgroundMapServices;
 
     @ApiOperation(
         value = "Get all record extents as image",
@@ -270,6 +274,11 @@ public class MetadataExtentApi {
 
         if (width == null && height == null) {
             throw new BadParameterEx(WIDTH_PARAM, WIDTH_AND_HEIGHT_BOTH_MISSING_MESSAGE);
+        }
+
+        if ((background != null) && (background.startsWith("http")) && (disableFullUrlBackgroundMapServices)) {
+           throw new BadParameterEx(BACKGROUND_PARAM, "Background layers from provided are not supported, " +
+                "use a preconfigured background layers map service.");
         }
 
         String regionId;

--- a/services/src/main/java/org/fao/geonet/services/region/GetMap.java
+++ b/services/src/main/java/org/fao/geonet/services/region/GetMap.java
@@ -33,6 +33,7 @@ import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.region.RegionsDAO;
 import org.fao.geonet.kernel.region.Request;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
@@ -90,6 +91,9 @@ public class GetMap {
 
     @Autowired
     private ServiceManager serviceManager;
+
+    @Value("${metadata.extentApi.disableFullUrlBackgroundMapServices:true}")
+    private boolean disableFullUrlBackgroundMapServices;
 
     public static AffineTransform worldToScreenTransform(Envelope mapExtent, Dimension screenSize) {
         return MapRenderer.worldToScreenTransform(mapExtent, screenSize);
@@ -156,6 +160,11 @@ public class GetMap {
         }
         if (id != null && geomParam != null) {
             throw new BadParameterEx(Params.ID, "Only one of " + GEOM_PARAM + " or " + Params.ID + " is permitted");
+        }
+
+        if ((background != null) && (background.startsWith("http")) && (disableFullUrlBackgroundMapServices)) {
+            throw new BadParameterEx(BACKGROUND_PARAM, "Background layers from provided are not supported, " +
+                "use a preconfigured background layers map service.");
         }
 
         if (width != null && height != null) {

--- a/services/src/test/resources/WEB-INF/config.properties
+++ b/services/src/test/resources/WEB-INF/config.properties
@@ -9,3 +9,5 @@ usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}
 
 api.params.maxPageSize=20000
 api.params.maxUploadSize=100000000
+
+metadata.extentApi.disableFullUrlBackgroundMapServices=true

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -42,3 +42,7 @@ urlChecker.UserAgent=GeoNetwork Link Checker
 
 map.bbox.background.service=https://ows.terrestris.de/osm/service?SERVICE=WMS&amp;REQUEST=GetMap&amp;VERSION=1.1.0&amp;LAYERS=OSM-WMS&amp;STYLES=default&amp;SRS={srs}&amp;BBOX={minx},{miny},{maxx},{maxy}&amp;WIDTH={width}&amp;HEIGHT={height}&amp;FORMAT=image/png
 
+# Set to false to enable the services to draw map extents (region.getmap and {metadatauuid}/extents.png) accepting
+# urls for map services to provide the background layers. Otherwise the only allowed options are from the settings
+# configuration or a named bg layer from regionGetMapBackgroundLayers.
+metadata.extentApi.disableFullUrlBackgroundMapServices=true


### PR DESCRIPTION
Seem it can be problematic with SSRF (https://portswigger.net/web-security/ssrf)