### PR TITLE
Fix bug in validation report where errors are not identified as errors

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
@@ -197,7 +197,7 @@ public class ValidateApi {
                             report.addMetadataInfos(record.getId(), "Is valid");
                             new RecordValidationTriggeredEvent(record.getId(), ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(), "1").publish(applicationContext);
                         } else {
-                            report.addMetadataInfos(record.getId(), "Is invalid");
+                            report.addMetadataError(record.getId(), "Is invalid");
                             new RecordValidationTriggeredEvent(record.getId(), ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(), "0").publish(applicationContext);
                         }
                         report.addMetadataId(record.getId());


### PR DESCRIPTION
Prior to this fix the report with errors on a metadata record will look like this.

```
{
  "errors": [],
  "infos": [],
  "uuid": "3d420e57-7ecb-47ad-b8d6-068083bd0b63",
  "metadata": [
    18865,
    17847
  ],
  "metadataErrors": {},
  "metadataInfos": {
    "17847": [
      {
        "message": "Is invalid",
        "date": "2020-11-05T13:53:52"
      }
    ],
    "18865": [
      {
        "message": "Is valid",
        "date": "2020-11-05T13:53:57"
      }
    ]
  },
  "numberOfRecordNotFound": 0,
  "numberOfRecordsNotEditable": 0,
  "numberOfNullRecords": 0,
  "numberOfRecords": 0,
  "numberOfRecordsProcessed": 2,
  "numberOfRecordsWithErrors": 0,
  "startIsoDateTime": "2020-11-05T13:53:48",
  "endIsoDateTime": "2020-11-05T13:54:07",
  "ellapsedTimeInSeconds": 19,
  "totalTimeInSeconds": 19,
  "running": false,
  "type": "SimpleMetadataProcessingReport"
}

```
Notice that even though there were errors,  numberOfRecordsWithErrors  is 0 and metadataErrors is empty.

After the fix, the report looks like this.

```

{
  "errors": [],
  "infos": [],
  "uuid": "3d420e57-7ecb-47ad-b8d6-068083bd0b63",
  "metadata": [
    18865,
    17847
  ],
  "metadataErrors": {
    "17847": [
      {
        "message": "Is invalid",
        "date": "2020-11-05T13:53:52"
      }
    ]},
  "metadataInfos": {
    "18865": [
      {
        "message": "Is valid",
        "date": "2020-11-05T13:53:57"
      }
    ]
  },
  "numberOfRecordNotFound": 0,
  "numberOfRecordsNotEditable": 0,
  "numberOfNullRecords": 0,
  "numberOfRecords": 0,
  "numberOfRecordsProcessed": 2,
  "numberOfRecordsWithErrors": 1,
  "startIsoDateTime": "2020-11-05T13:53:48",
  "endIsoDateTime": "2020-11-05T13:54:07",
  "ellapsedTimeInSeconds": 19,
  "totalTimeInSeconds": 19,
  "running": false,
  "type": "SimpleMetadataProcessingReport"
}
```