### PR TITLE
API / Region / Avoid similar property in model

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/regions/ListRegionsResponse.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/ListRegionsResponse.java
@@ -41,7 +41,7 @@ import java.util.Map;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ListRegionsResponse {
     @XmlAttribute
-    @JsonProperty("@count")
+    @JsonProperty("count")
     private int count;
 
     @XmlElement
@@ -79,13 +79,13 @@ public class ListRegionsResponse {
     @XmlAccessorType(XmlAccessType.FIELD)
     public static class RegionResponse {
         @XmlAttribute
-        @JsonProperty("@hasGeom")
+        @JsonProperty("hasGeom")
         private boolean hasGeom;
         @XmlAttribute
-        @JsonProperty("@categoryId")
+        @JsonProperty("categoryId")
         private String categoryId;
         @XmlAttribute
-        @JsonProperty("@id")
+        @JsonProperty("id")
         private String id;
         @XmlElement
         @JsonProperty
@@ -107,10 +107,7 @@ public class ListRegionsResponse {
             this.categoryId = input.getCategoryId();
             this.hasGeom = input.hasGeom();
         }
-
-        @XmlElement(name = "id")
-        @JsonProperty("id")
-        public String getIdElement() {
+        public String getId() {
             return id;
         }
     }


### PR DESCRIPTION
It looks like some tools used to generate client from the API does not make distinction between `id` and `@id` which BTW was the same thing. So keeping this simple.

```
      '@id':
          type: string
          xml:
            attribute: true
        id:
          type: string
``` 

After
```
RegionResponse: {
type: "object",
properties: {
north: {
type: "number",
format: "double"
},
east: {
type: "number",
format: "double"
},
south: {
type: "number",
format: "double"
},
west: {
type: "number",
format: "double"
},
label: {
type: "object",
additionalProperties: {
type: "string"
}
},
hasGeom: {
type: "boolean",
xml: {
attribute: true
}
},
categoryId: {
type: "string",
xml: {
attribute: true
}
},
id: {
type: "string",
xml: {
attribute: true
}
}
}
},
```

Related to https://github.com/geonetwork/geonetwork-ui/pull/46