### PR TITLE
User searches / Add portals with filter in the list.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
@@ -33,9 +33,9 @@
    */
   module.directive('gnUserSearchesList', [
     'gnUserSearchesService', 'gnConfigService', 'gnConfig', 'gnLangs',
-    '$http', '$translate', '$location',
+    '$http', '$translate', '$location', 'gnGlobalSettings',
     function(gnUserSearchesService, gnConfigService, gnConfig, gnLangs,
-             $http, $translate, $location) {
+             $http, $translate, $location, gnGlobalSettings) {
       return {
         restrict: 'A',
         replace: true,
@@ -46,10 +46,13 @@
         link: function postLink(scope, element, attrs) {
           scope.lang = gnLangs.current;
           scope.type = attrs['type'] || 'h';
+          scope.withPortal = scope.isDefaultNode
+            && gnGlobalSettings.gnCfg.mods.search.usersearches.includePortals;
+
           scope.sortByLabel = function(i) {
             return i.names[scope.lang];
           };
-          gnUserSearchesService.loadFeaturedUserSearches(scope.type).then(
+          gnUserSearchesService.loadFeaturedUserSearches(scope.type, scope.withPortal).then(
             function(featuredSearchesCollection) {
               scope.featuredSearches = featuredSearchesCollection.data;
             }, function() {

--- a/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesService.js
+++ b/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesService.js
@@ -30,8 +30,37 @@
   module.service('gnUserSearchesService', [
     '$http', '$q',
     function($http, $q) {
-      this.loadFeaturedUserSearches = function(type) {
-        return $http.get('../api/usersearches/featured?type=' + type);
+      this.loadFeaturedUserSearches = function(type, withPortal) {
+        var deferred = $q.defer(),
+            usersearches = $http.get('../api/usersearches/featured?type=' + type);
+            apiCalls = [usersearches];
+        if (withPortal) {
+          apiCalls.push($http.get('../api/sources/subportal'));
+        }
+        $q.all(apiCalls).then(function(alldata) {
+          var usersearches = [];
+          usersearches = usersearches.concat(alldata[0].data)
+          if (alldata[1]) {
+            deferred.resolve({
+              data:
+                usersearches.concat(alldata[1].data
+                .filter(p => {
+                  return p.filter != ''
+                })
+                .map(p => {
+                  return {
+                    names: p.label,
+                    url: 'any=' + encodeURIComponent('q(' + p.filter + ')'),
+                    logo: '../../images/harvesting/' + p.logo,
+                    featuredType: 'p'
+                  }
+                }))
+            });
+          } else {
+            deferred.resolve({data: usersearches});
+          }
+        });
+        return deferred.promise;
       };
 
       this.loadUserSearches = function () {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -441,6 +441,7 @@ goog.require('gn_alert');
           'isFilterTagsDisplayedInSearch': true,
           'usersearches': {
             'enabled': false,
+            'includePortals': true,
             'displayFeaturedSearchesPanel': false
           },
           'savedSelection': {


### PR DESCRIPTION
Usually portals define a search filter and allow quick access to a subset of records. It is quite similar to a user searches and lots of users are duplicating portal definition in user searches. To avoid this, add an option to append portal list to the usersearches list.

![image](https://user-images.githubusercontent.com/1701393/98689647-6bfb3f00-236c-11eb-831d-f1fd7c99dc42.png)


They are also combined in the home page panel.

![image](https://user-images.githubusercontent.com/1701393/98689664-6ef62f80-236c-11eb-823e-ac451aa22e2c.png)

Portals are only displayed as user searches in the default node srv