### PR TITLE
Use sequence for MessageProducerEntity id

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/MessageProducerEntity.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MessageProducerEntity.java
@@ -28,21 +28,23 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"url", "typeName"}))
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "url", "typeName" }))
+@SequenceGenerator(name = MessageProducerEntity.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class MessageProducerEntity {
+    public static final String ID_SEQ_NAME = "message_producer_entity_id_seq";
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
     private Long id;
 
     private WfsHarvesterParamEntity wfsHarvesterParamEntity;
 
-    @Nullable
-    private String cronExpression;
+    @Nullable private String cronExpression;
 
     public WfsHarvesterParamEntity getWfsHarvesterParam() {
         return wfsHarvesterParamEntity;

--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -279,6 +279,7 @@
     </entry>
     <entry key="4.0.2">
       <list>
+        <value>java:v402.SetSequenceValueToMaxOfMessageProducerEntity</value>
         <value>WEB-INF/classes/setup/sql/migrate/v402/migrate-</value>
       </list>
     </entry>

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v400/UpdateAllSequenceValueToMax.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v400/UpdateAllSequenceValueToMax.java
@@ -100,6 +100,9 @@ public class UpdateAllSequenceValueToMax extends DatabaseMigrationTask {
         String tablename;
         if (cl.isAnnotationPresent(Table.class)) {
             tablename = cl.getAnnotation(Table.class).name();
+            if (StringUtils.isEmpty(tablename)) {
+                tablename = cl.getSimpleName();
+            }
         } else {
             tablename = cl.getSimpleName();
         }

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v400/UpdateAllSequenceValueToMax.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v400/UpdateAllSequenceValueToMax.java
@@ -83,7 +83,7 @@ public class UpdateAllSequenceValueToMax extends DatabaseMigrationTask {
         updateTableSequence(connection, MetadataDraft.TABLENAME, "id", AbstractMetadata.ID_SEQ_NAME);
     }
 
-    private void processClass(final Connection connection, final Class<?> cl) throws SQLException {
+    public static void processClass(final Connection connection, final Class<?> cl) throws SQLException {
 
         // Get sequence name
         String sequenceName = cl.getAnnotation(SequenceGenerator.class).sequenceName();
@@ -136,7 +136,7 @@ public class UpdateAllSequenceValueToMax extends DatabaseMigrationTask {
         updateTableSequence(connection, tablename, keyColumnName, sequenceName);
     }
 
-    private void updateTableSequence(final Connection connection, final String tableName, final String keyColumnName, final String sequenceName) throws SQLException {
+    private static void updateTableSequence(final Connection connection, final String tableName, final String keyColumnName, final String sequenceName) throws SQLException {
         try (Statement statement = connection.createStatement()) {
             final String tableMaxIdSQL = "SELECT max(" + keyColumnName + ") as NB FROM " + tableName;
 
@@ -166,7 +166,7 @@ public class UpdateAllSequenceValueToMax extends DatabaseMigrationTask {
         }
     }
 
-    private void updateSequence(final Connection connection, final String sequenceName, long desiredVal) throws SQLException {
+    private static void updateSequence(final Connection connection, final String sequenceName, long desiredVal) throws SQLException {
         DialectResolutionInfo dialectResolutionInfo = new DatabaseMetaDataDialectResolutionInfoAdapter(connection.getMetaData());
         Dialect dialect = new StandardDialectResolver().resolveDialect(dialectResolutionInfo);
         PreparedStatement preparedStatement = null;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v402/SetSequenceValueToMaxOfMessageProducerEntity.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v402/SetSequenceValueToMaxOfMessageProducerEntity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2001-2020 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package v402;
+
+import org.fao.geonet.DatabaseMigrationTask;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.MessageProducerEntity;
+import org.fao.geonet.utils.Log;
+import v400.UpdateAllSequenceValueToMax;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class SetSequenceValueToMaxOfMessageProducerEntity extends DatabaseMigrationTask {
+    @Override
+    public void update(Connection connection) throws SQLException {
+        Log.info(Geonet.DB, "Executing migration SetSequenceValueToMaxOfMessageProducerEntity");
+        UpdateAllSequenceValueToMax.processClass(connection, MessageProducerEntity.class);
+    }
+
+}


### PR DESCRIPTION
In Oracle 11g the identity method for the id column doesn't work and the table isn't create. This commit changes the class to use a sequence instead and adds a migration to set the next value of the sequence to the max value of the id in the table.
The migration reuses part of the login used in `v400.UpdateAllSequenceValueToMax` migration.

Discovered in #5141. 