### PR TITLE
Don't remove geographic description for multilingual data 

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -306,7 +306,7 @@
   <!-- In flat mode do not display geographic identifier and description
   because it is part of the map widget - see previous template. -->
   <xsl:template mode="mode-iso19139"
-                match="gmd:extent/*/gmd:description[$isFlatMode]|
+                match="gmd:extent/*/gmd:description[$isFlatMode and not($metadataIsMultilingual)]|
                        gmd:geographicElement[
                           $isFlatMode and
                           preceding-sibling::gmd:geographicElement/gmd:EX_GeographicBoundingBox


### PR DESCRIPTION
Don't remove geographic description for multilingual data since the widget does not support multilingual data.

For more information on this issue see the following related issue.

https://github.com/metadata101/iso19139.ca.HNAP/issues/122