### PR TITLE
Import / Fix lock and reduce indexing

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -543,7 +543,7 @@ public class Importer {
         //
         int userid = context.getUserSession().getUserIdAsInt();
         String docType = null, category = null;
-        boolean ufo = false, indexImmediate = true;
+        boolean ufo = false, indexImmediate = false;
 
         String metadataId = metadataManager
             .insertMetadata(context, schema, md.get(index), uuid, userid, groupId, source, isTemplate.codeString, docType, category,


### PR DESCRIPTION
When importing, record is indexed 3 times - on insert, on set template, at the end.

Skip on insert.