### PR TITLE
WFS indexing / Add 3 modes for WFS url detection.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1098,13 +1098,16 @@
 
         <xsl:for-each select="mrd:transferOptions/*/
                                 mrd:onLine/*[cit:linkage/gco:CharacterString != '']">
-          <xsl:variable name="protocol" select="cit:protocol/gco:CharacterString/text()"/>
+          <xsl:variable name="transferGroup"
+                        select="count(ancestor::mrd:transferOptions/preceding-sibling::mrd:transferOptions)"/>
+
+          <xsl:variable name="protocol" select="cit:protocol/*/text()"/>
 
           <linkUrl>
             <xsl:value-of select="cit:linkage/gco:CharacterString"/>
           </linkUrl>
           <linkProtocol>
-            <xsl:value-of select="cit:protocol/gco:CharacterString/text()"/>
+            <xsl:value-of select="$protocol"/>
           </linkProtocol>
           <xsl:element name="linkUrlProtocol{replace($protocol, '[^a-zA-Z0-9]', '')}">
             <xsl:value-of select="cit:linkage/*/text()"/>
@@ -1113,7 +1116,9 @@
             "protocol":"<xsl:value-of select="gn-fn-index:json-escape(cit:protocol/*/text())"/>",
             "url":"<xsl:value-of select="gn-fn-index:json-escape(cit:linkage/*/text())"/>",
             "name":"<xsl:value-of select="gn-fn-index:json-escape((cit:name/*/text())[1])"/>",
-            "description":"<xsl:value-of select="gn-fn-index:json-escape((cit:description/*/text())[1])"/>"
+            "description":"<xsl:value-of select="gn-fn-index:json-escape((cit:description/*/text())[1])"/>",
+            "applicationProfile":"<xsl:value-of select="gn-fn-index:json-escape(cit:applicationProfile/gco:CharacterString/text())"/>",
+            "group": <xsl:value-of select="$transferGroup"/>
             }
           </link>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -1077,10 +1077,12 @@
         <xsl:for-each select="gmd:transferOptions/*/
                                 gmd:onLine/*[gmd:linkage/gmd:URL != '']">
 
+          <xsl:variable name="transferGroup"
+                        select="count(ancestor::gmd:transferOptions/preceding-sibling::gmd:transferOptions)"/>
           <xsl:variable name="protocol"
-                        select="gmd:protocol/gco:CharacterString/text()"/>
+                        select="gmd:protocol/*/text()"/>
           <xsl:variable name="linkName"
-                        select="gn-fn-index:json-escape(gmd:name/gco:CharacterString/text())"/>
+                        select="gn-fn-index:json-escape(gmd:name/*/text())"/>
 
           <linkUrl>
             <xsl:value-of select="gmd:linkage/gmd:URL"/>
@@ -1095,7 +1097,9 @@
             "protocol":"<xsl:value-of select="gn-fn-index:json-escape((gmd:protocol/*/text())[1])"/>",
             "url":"<xsl:value-of select="gn-fn-index:json-escape(gmd:linkage/gmd:URL)"/>",
             "name":"<xsl:value-of select="$linkName"/>",
-            "description":"<xsl:value-of select="gn-fn-index:json-escape(gmd:description/gco:CharacterString/text())"/>"
+            "description":"<xsl:value-of select="gn-fn-index:json-escape(gmd:description/gco:CharacterString/text())"/>",
+            "applicationProfile":"<xsl:value-of select="gn-fn-index:json-escape(gmd:applicationProfile/gco:CharacterString/text())"/>",
+            "group": <xsl:value-of select="$transferGroup"/>
             }
             <!--Link object in Angular used to be
             //     name: linkInfos[0],

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -675,15 +675,16 @@
           groupId = types[0];
           types.splice(0, 1);
         }
-        if (this.linksCache[key] && !groupId) {
+        if (this.linksCache[key] && groupId === undefined) {
           return this.linksCache[key];
         }
         angular.forEach(this.link, function(link) {
           if (types.length > 0) {
             types.forEach(function(type) {
               if (type.substr(0, 1) == '#') {
-                if (link.protocol == type.substr(1, type.length - 1) &&
-                    (!groupId || groupId == link.group)) {
+                var protocolMatch = link.protocol == type.substr(1, type.length - 1);
+                if ((protocolMatch && groupId === undefined) ||
+                    (protocolMatch && groupId != undefined && groupId == link.group)) {
                   ret.push(link);
                 }
               }


### PR DESCRIPTION
* Default is replace wms by wfs in URL and expect to have a feature type with same name as layer
* Force a wfsURL with 'scope'
* Use 'group' to check if a WFS is defined in the same transfert option group in the metadata record.


The benefit of the last mode is that user can use applicationProfile to customize the widget and the indexing:
* column labels
* field with hierarchy
* date graph

![image](https://user-images.githubusercontent.com/1701393/99086083-52a2fe80-25c9-11eb-929b-8c8d1b23846b.png)


eg.

```json
{
	"tokenizedFields": {
		"PROGRAMMES": ";",
		"PARAMETRES": ";",
		"SUPPORTS_NIVEAUX_PRELEVEMENT": ";"
	},
	"fields": [{
		"name": "PROGRAMMES",
		"label": {
			"fr": "Programme de suivi",
			"en": "Programme de suivi"
		}
	}, {
		"name": "PARAMETRES",
		"label": {
			"fr": "Paramètre",
			"en": "Paramètre"
		}
	}, {
		"name": "range_Date",
		"type": "rangeDate",
		"minField": "RESULTAT_DATE_MIN",
		"maxField": "RESULTAT_DATE_MAX",
		"label": {
			"fr": "Date",
			"en": "Date"
		},
		"display": "graph"
	}, {
		"name": "LIEU_LIBELLE",
		"label": {
			"fr": "Lieu",
			"en": "Lieu"
		}
	}],
	"treeFields": ["PARAMETRES"]
}
```
