### PR TITLE
Event handling improvements

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -28,6 +28,7 @@ import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
@@ -47,6 +48,7 @@ import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.domain.StatusValueType;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.userfeedback.RatingsSetting;
+import org.fao.geonet.events.history.RecordDeletedEvent;
 import org.fao.geonet.events.md.MetadataIndexCompleted;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.IndexMetadataTask;
@@ -86,12 +88,12 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.interceptor.TransactionAspectSupport;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
@@ -100,7 +102,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 
 public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPublisherAware {
 
@@ -200,9 +201,15 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
             try {
                 store.delResources(ServiceContext.get(), md.getUuid());
                 metadataManager.deleteMetadata(ServiceContext.get(), String.valueOf(md.getId()));
+
+                // Trigger RecordDeletedEvent
+                UserSession userSession = ServiceContext.get().getUserSession();
+                LinkedHashMap<String, String> titles = metadataUtils.extractTitles(Integer.toString(md.getId()));
+                String xmlBefore = md.getData();
+                new RecordDeletedEvent(md.getId(), md.getUuid(), titles, userSession.getUserIdAsInt(), xmlBefore).publish(ApplicationContextHolder.get());
             } catch (Exception e) {
                 Log.warning(Geonet.DATA_MANAGER, String.format(
-                    
+
                     "Error during removal of metadata %s part of batch delete operation. " +
                     "This error may create a ghost record (ie. not in the index " +
                     "but still present in the database). " +

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -199,13 +199,15 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
         // So delete one by one even if slower
         metadataToDelete.forEach(md -> {
             try {
+                // Extract information for RecordDeletedEvent
+                LinkedHashMap<String, String> titles = metadataUtils.extractTitles(Integer.toString(md.getId()));
+                UserSession userSession = ServiceContext.get().getUserSession();
+                String xmlBefore = md.getData();
+
                 store.delResources(ServiceContext.get(), md.getUuid());
                 metadataManager.deleteMetadata(ServiceContext.get(), String.valueOf(md.getId()));
 
                 // Trigger RecordDeletedEvent
-                UserSession userSession = ServiceContext.get().getUserSession();
-                LinkedHashMap<String, String> titles = metadataUtils.extractTitles(Integer.toString(md.getId()));
-                String xmlBefore = md.getData();
                 new RecordDeletedEvent(md.getId(), md.getUuid(), titles, userSession.getUserIdAsInt(), xmlBefore).publish(ApplicationContextHolder.get());
             } catch (Exception e) {
                 Log.warning(Geonet.DATA_MANAGER, String.format(

--- a/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.listener.metadata.draft;
 
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
@@ -30,12 +31,15 @@ import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataDraft;
 import org.fao.geonet.domain.MetadataStatus;
 import org.fao.geonet.domain.StatusValue;
+import org.fao.geonet.events.history.RecordUpdatedEvent;
 import org.fao.geonet.events.md.MetadataStatusChanged;
 import org.fao.geonet.kernel.datamanager.IMetadataStatus;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataDraftRepository;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.utils.Log;
+import org.jdom.Element;
+import org.jdom.output.XMLOutputter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
@@ -153,6 +157,13 @@ public class ApproveRecord implements ApplicationListener<MetadataStatusChanged>
         if (draft != null) {
             Log.trace(Geonet.DATA_MANAGER, "Approving record " + md.getId() + " which has a draft " + draft.getId());
             md = draftUtilities.replaceMetadataWithDraft(md, draft);
+
+            // Throw RecordUpdatedEvent for the published version
+            Element afterMetadata = draft.getXmlData(false);
+            XMLOutputter outp = new XMLOutputter();
+            String xmlBefore = outp.outputString(md.getXmlData(false));
+            String xmlAfter = outp.outputString(afterMetadata);
+            new RecordUpdatedEvent(md.getId(), event.getUser(), xmlBefore, xmlAfter).publish(ApplicationContextHolder.get());
         }
 
         return md;

--- a/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
@@ -156,12 +156,14 @@ public class ApproveRecord implements ApplicationListener<MetadataStatusChanged>
 
         if (draft != null) {
             Log.trace(Geonet.DATA_MANAGER, "Approving record " + md.getId() + " which has a draft " + draft.getId());
+
+            XMLOutputter outp = new XMLOutputter();
+            String xmlBefore = outp.outputString(md.getXmlData(false));
+
             md = draftUtilities.replaceMetadataWithDraft(md, draft);
 
             // Throw RecordUpdatedEvent for the published version
             Element afterMetadata = draft.getXmlData(false);
-            XMLOutputter outp = new XMLOutputter();
-            String xmlBefore = outp.outputString(md.getXmlData(false));
             String xmlAfter = outp.outputString(afterMetadata);
             new RecordUpdatedEvent(md.getId(), event.getUser(), xmlBefore, xmlAfter).publish(ApplicationContextHolder.get());
         }


### PR DESCRIPTION
- Throw RecordUpdatedEvent when a draft metadata is approved to notify about the change.
- Throw RecordDeletedEvent when doing a batch delete of metadata records related to a harvester