### PR TITLE
Small improvements to the MiniMap

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
@@ -54,6 +54,11 @@
               var opt = scope.$eval(iAttrs['gnMapFieldOpt']) || {};
               scope.relations = opt.relations;
 
+              scope.autoTriggerSearch = true;
+              if (angular.isDefined(opt.autoTriggerSearch)) {
+                scope.autoTriggerSearch = opt.autoTriggerSearch;
+              }
+
               scope.gnMap = gnMap;
 
               /**
@@ -82,10 +87,21 @@
                */
               scope.setRelation = function (rel) {
                 scope.searchObj.params.relation = rel;
-                if (!!scope.searchObj.params.geometry) {
+                if (scope.autoTriggerSearch && !!scope.searchObj.params.geometry) {
                   scope.triggerSearch();
                 }
               };
+
+              scope.renderMap = function() {
+                scope.map.renderSync();
+              };
+
+              var loadPromise = scope.map.get('sizePromise');
+              if (loadPromise) {
+                loadPromise.then(function() {
+                  scope.renderMap();
+                });
+              }
             }
           };
         }
@@ -166,7 +182,9 @@
             scope.interaction.on('boxend', function () {
               scope.$apply(function () {
                 updateField(scope.interaction.getGeometry());
-                scope.triggerSearch();
+                if (scope.autoTriggerSearch) {
+                  scope.triggerSearch();
+                }
               });
             });
 
@@ -179,7 +197,7 @@
             scope.$watch('interaction.active', function (v, o) {
               if (!v && o) {
                 resetSpatialFilter();
-                if (!!scope.searchObj.params.geometry) {
+                if (scope.autoTriggerSearch && !!scope.searchObj.params.geometry) {
                   scope.triggerSearch();
                 }
               }

--- a/web-ui/src/main/resources/catalog/components/search/map/partials/mapfield.html
+++ b/web-ui/src/main/resources/catalog/components/search/map/partials/mapfield.html
@@ -10,6 +10,7 @@
     </button>-->
     <button data-ng-click="location.setMap()"
             data-ng-if="isMapViewerEnabled && !isExternalViewerEnabled"
+            type="button"
             title="{{'openLargeMap' | translate}}"
             aria-label="{{'openLargeMap' | translate}}"
             class="btn btn-default">
@@ -22,6 +23,7 @@
             gn-draw-bbox-btn="{{gnDrawBboxBtn}}"
             gn-draw-bbox-extent="{{gnDrawBboxExtent}}"
             gi-btn
+            type="button"
             title="{{getButtonTitle()}}"
             aria-label="{{getButtonTitle()}}"
             data-ng-class="{active: interaction.active}"
@@ -31,6 +33,7 @@
     </button>
     <button type="button"
             class="btn btn-default dropdown-toggle"
+            type="button"
             title="{{'chooseSpatialFilterType' | translate}}"
             aria-label="{{'chooseSpatialFilterType' | translate}}"
             data-toggle="dropdown"
@@ -62,6 +65,7 @@
           gn-draw-bbox-btn="{{gnDrawBboxBtn}}"
           gn-draw-bbox-extent="{{gnDrawBboxExtent}}"
           gi-btn
+          type="button"
           data-ng-model="interaction.active">
     <i class="fa fa-pencil"></i>
   </button>

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -343,7 +343,8 @@
         viewerMap: viewerMap,
         searchMap: searchMap,
         mapfieldOption: {
-          relations: ['within_bbox']
+          relations: ['within_bbox'],
+          autoTriggerSearch: true
         },
         hitsperpageValues: gnSearchSettings.hitsperpageValues,
         filters: gnSearchSettings.filters,


### PR DESCRIPTION
This PR adds some (small) improvements to the mini map on the search page.

The changes are:
- extra render option to prevent blank map on startup
- extra option to enable/disable direct search with extent (defaults to `true`)
- add `type="button"` to minimap buttons