### PR TITLE
Fix null group bug if attempting to publish sample data.

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/specification/UserGroupSpecs.java
+++ b/domain/src/main/java/org/fao/geonet/repository/specification/UserGroupSpecs.java
@@ -37,12 +37,17 @@ public final class UserGroupSpecs {
         // don't permit instantiation
     }
 
-    public static Specification<UserGroup> hasGroupId(final int groupId) {
+    public static Specification<UserGroup> hasGroupId(final Integer groupId) {
         return new Specification<UserGroup>() {
             @Override
             public Predicate toPredicate(Root<UserGroup> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
                 Path<Integer> grpIdAttributePath = root.get(UserGroup_.id).get(UserGroupId_.groupId);
-                Predicate grpIdEqualPredicate = cb.equal(grpIdAttributePath, cb.literal(groupId));
+                Predicate grpIdEqualPredicate;
+                if (groupId == null) {
+                    grpIdEqualPredicate = cb.isNull(grpIdAttributePath);
+                } else {
+                    grpIdEqualPredicate = cb.equal(grpIdAttributePath, cb.literal(groupId));
+                }
                 return grpIdEqualPredicate;
             }
         };


### PR DESCRIPTION
When loading sample data from a template it set the groupowner to null.

If we then attempt to publish that record it will generate a null pointer because one of the queries does not support null values for the group.

This PR corrects that bug.

In general the groupowner should not be null. Maybe a better fix would be to make the groupowner field not null and correct sample data load to go into a group. That is a bigger fix so in the meantime, this will work.