### PR TITLE
Add a logout option for a logged-in user

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -245,6 +245,7 @@
     "signIn": "Sign in",
     "signedInAs": "Signed in as",
     "signout": "Sign out",
+    "signoutDescription": "You are already logged in, click the button to logout.",
     "somethingWrong": "Something went wrong!",
     "south": "South",
     "siblings": "Other resources",

--- a/web-ui/src/main/resources/catalog/templates/signin.html
+++ b/web-ui/src/main/resources/catalog/templates/signin.html
@@ -1,6 +1,24 @@
 <div class="container" data-ng-controller="GnLoginController" role="main">
   <div class="row">
-    <div class="col-lg-4 col-md-4 col-md-offset-4 col-lg-offset-4">
+
+    <div data-ng-show="authenticated" class="col-lg-4 col-md-4 col-md-offset-4 col-lg-offset-4">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h1 data-translate="">signout</h1>
+        </div>
+        <div class="panel-body">
+          <p data-translate="">signoutDescription</p>
+          <input type="hidden" name="redirectUrl" data-ng-model="redirectUrl" value="{{redirectUrl}}"/>
+          <a href="{{gnCfg.mods.signout.appUrl}}"
+             class="btn btn-primary btn-block">
+            <i class="fa fa-fw fa-sign-out"/>
+            <span data-translate="">signout</span>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div data-ng-hide="authenticated" class="col-lg-4 col-md-4 col-md-offset-4 col-lg-offset-4">
       <div class="panel panel-default">
         <div class="panel-heading">
           <h1 data-translate="">loginTitle</h1>


### PR DESCRIPTION
It's possible for a logged-in user to visit the `signin` page again. The user would then see the same login options as a not logged-in user. That causes confusion.

This PR shows a logout option for logged-in users, and keeps the login option for other users.

![gn-signout](https://user-images.githubusercontent.com/19608667/100083844-48df8d80-2e4a-11eb-8bc7-585e623fd9db.png)
