### PR TITLE
Fixed some keycloak issues when calling API's 

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
@@ -36,6 +36,7 @@ import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.UserRepository;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.keycloak.KeycloakPrincipal;
+import org.keycloak.adapters.AdapterDeploymentContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -63,6 +64,8 @@ public class KeycloakUserUtils {
     @Autowired
     private KeycloakConfiguration keycloakConfiguration;
 
+    @Autowired
+    AdapterDeploymentContext adapterDeploymentContext;
     /**
      * @return the inserted/updated user or null if no valid user found or any error
      * happened
@@ -76,8 +79,8 @@ public class KeycloakUserUtils {
         Set<String> roleGroupList = new HashSet<>();
         // Get role that are in the format of group:role format access
         // Todo Reevaluate to see if this is how we want to get role groups. It may not be a good idea to place separator in group name and parse it this way.
-        if (keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(keycloakPrincipal.getKeycloakSecurityContext().getToken().issuedFor) != null) {
-            for (String role : keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(keycloakPrincipal.getKeycloakSecurityContext().getToken().issuedFor).getRoles()) {
+        if (keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(adapterDeploymentContext.resolveDeployment(null).getResourceName()) != null) {
+            for (String role : keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(adapterDeploymentContext.resolveDeployment(null).getResourceName()).getRoles()) {
                 // Only use the profiles we know off
                 if (role.contains(roleGroupSeparator)) {
                     roleGroupList.add(role);
@@ -281,8 +284,8 @@ public class KeycloakUserUtils {
                 Set<String> profileSet = new HashSet<>();
 
                 // Get role access
-                if (keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(keycloakPrincipal.getKeycloakSecurityContext().getToken().issuedFor) != null) {
-                    for (String role : keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(keycloakPrincipal.getKeycloakSecurityContext().getToken().issuedFor).getRoles()) {
+                if (keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(adapterDeploymentContext.resolveDeployment(null).getResourceName()) != null) {
+                    for (String role : keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(adapterDeploymentContext.resolveDeployment(null).getResourceName()).getRoles()) {
                         // Only use the profiles we know off
                         if (Profile.findProfileIgnoreCase(role) != null) {
                             profileSet.add(role);

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
@@ -31,6 +31,7 @@ import javax.transaction.Transactional.TxType;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.security.GeonetworkAuthenticationProvider;
 import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.LanguageRepository;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.UserRepository;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
@@ -49,6 +50,9 @@ public class KeycloakUserUtils {
 
     @Autowired
     private GroupRepository groupRepository;
+
+    @Autowired
+    private LanguageRepository langRepository;
 
     @Autowired
     private UserGroupRepository userGroupRepository;
@@ -167,6 +171,12 @@ public class KeycloakUserUtils {
             if (group == null) {
                 group = new Group();
                 group.setName(rgGroup);
+
+                // Populate languages for the group
+                for (Language l : langRepository.findAll()) {
+                    group.getLabelTranslations().put(l.getId(), group.getName());
+                }
+
                 groupRepository.save(group);
             }
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
@@ -27,6 +27,7 @@ import org.fao.geonet.Constants;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.keycloak.adapters.spi.UserSessionManagement;
 import org.keycloak.adapters.springsecurity.filter.KeycloakPreAuthActionsFilter;
+import org.keycloak.constants.AdapterConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -62,9 +63,14 @@ public class keycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
         HttpServletResponse servletResponse = (HttpServletResponse) response;
 
         if (servletRequest.getPathInfo() != null &&
-                !(servletRequest.getContextPath() + KeycloakUtil.getSigninPath()).equals(servletRequest.getRequestURI())  &&
-                !(servletRequest.getPathInfo()).equals("/k_logout")  &&
-                !isAuthenticated() ) {
+            !KeycloakAuthenticationProcessingFilter.DEFAULT_REQUEST_MATCHER.matches(servletRequest) &&
+            !isAuthenticated() &&
+            !(servletRequest.getContextPath() + KeycloakUtil.getSigninPath()).equals(servletRequest.getRequestURI())  &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_LOGOUT) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_PUSH_NOT_BEFORE) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_VERSION) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_TEST_AVAILABLE) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_JWKS)) {
 
             String returningUrl = servletRequest.getRequestURL().toString();
             // If the application is behind a proxy, it is possible that it will get an http request instead of https
@@ -75,11 +81,11 @@ public class keycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
 
             // Append query string
             if (servletRequest.getQueryString() != null) {
-                returningUrl =  returningUrl + "?" + servletRequest.getQueryString();
+                returningUrl = returningUrl + "?" + servletRequest.getQueryString();
             }
 
             String encodedRedirectURL = ((HttpServletResponse) response).encodeRedirectURL(
-                    servletRequest.getContextPath() + KeycloakUtil.getSigninPath() + "?redirectUrl=" + URLEncoder.encode(returningUrl, Constants.ENCODING));
+                servletRequest.getContextPath() + KeycloakUtil.getSigninPath() + "?redirectUrl=" + URLEncoder.encode(returningUrl, Constants.ENCODING));
 
             servletResponse.sendRedirect(encodedRedirectURL);
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
@@ -58,6 +58,12 @@ public class keycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
         HttpServletRequest servletRequest = (HttpServletRequest) request;
         HttpServletResponse servletResponse = (HttpServletResponse) response;
 
+        // Lets redirect the user to the signin page if
+        //     - The session is not authenticate
+        //     - This is not a request for the signin page (we don't want endless loop to sign in page)
+        //     - It does not match the default request matcher (which is mostly used to validate bearer tokens request for api's)
+        //       No sign in page required for api calls.
+        //     - and it is not an internal k_* request which should be processed by keycloak adapter and also don't required login page.
         if (servletRequest.getPathInfo() != null &&
             !KeycloakAuthenticationProcessingFilter.DEFAULT_REQUEST_MATCHER.matches(servletRequest) &&
             !isAuthenticated() &&

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
@@ -24,7 +24,6 @@
 package org.fao.geonet.kernel.security.keycloak;
 
 import org.fao.geonet.Constants;
-import org.fao.geonet.kernel.setting.SettingManager;
 import org.keycloak.adapters.spi.UserSessionManagement;
 import org.keycloak.adapters.springsecurity.filter.KeycloakPreAuthActionsFilter;
 import org.keycloak.constants.AdapterConstants;
@@ -49,9 +48,6 @@ public class keycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
     @Autowired
     LoginUrlAuthenticationEntryPoint loginUrlAuthenticationEntryPoint;
 
-    @Autowired
-    SettingManager settingManager;
-
     public keycloakPreAuthActionsLoginFilter(UserSessionManagement userSessionManagement) {
         super(userSessionManagement);
     }
@@ -73,11 +69,6 @@ public class keycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
             !servletRequest.getRequestURI().endsWith(AdapterConstants.K_JWKS)) {
 
             String returningUrl = servletRequest.getRequestURL().toString();
-            // If the application is behind a proxy, it is possible that it will get an http request instead of https
-            // As this redirect goes back to the client, we need to tell the client to use https
-            if (settingManager.getServerURL().startsWith("https://") && returningUrl.startsWith("http://")) {
-                returningUrl = returningUrl.replaceFirst("(?i)^http://", "https://");
-            }
 
             // Append query string
             if (servletRequest.getQueryString() != null) {

--- a/web/src/main/webapp/WEB-INF/config-security/keycloak.json
+++ b/web/src/main/webapp/WEB-INF/config-security/keycloak.json
@@ -12,6 +12,7 @@
   "enable-cors" : true,
   "cors-max-age" : 1000,
   "cors-allowed-methods" : "POST, PUT, DELETE, GET",
-  "cors-exposed-headers" : "WWW-Authenticate"
+  "cors-exposed-headers" : "WWW-Authenticate",
+  "autodetect-bearer-only" : true
 }
 


### PR DESCRIPTION
- autodetect-bearer-only needs to be set to true 

- query string was not in the redirect url so parameters were being dropped. Added query string to redirect. 

- Fixed bug with creating groups - it was missing labels.

- Fixed bearer token parsing - it was attempting to redirect bearer token request to signin page.

- Reverted this change (thank you @zoran995)
> - In a reverse proxy situation, the request could be http when the server is setup to use https and this was causing issues. Ensure it is using https if the server is configured that way.
> 
> For the reverse proxy issue - this fixed our issue with keycloak but I cannot help but think that this should be fixed at a global level? Or maybe there is already a configuration that would support this situation?


Also including a script that can be used to help test the api

[keycloak-api-test.zip](https://github.com/geonetwork/core-geonetwork/files/5661633/keycloak-api-test.zip)
