### PR TITLE
Fix for WFS download dropdown in Record view

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
@@ -23,13 +23,13 @@
             data-ng-model="downloadFormat"
             data-ng-change="downloadFormatChange(this)">
       <optgroup label="{{'downloadFeature'| translate}}">
-        <option data-ng-repeat="f in formats | orderBy:f"
+        <option data-ng-repeat="f in formats | orderBy:f track by $index"
                 value="{{f}}#false">
           {{f | lowercase}}
         </option>
       </optgroup>
       <optgroup label="{{'downloadInCurrentMapExtent'| translate}}">
-        <option data-ng-repeat="f in formats | orderBy:f"
+        <option data-ng-repeat="f in formats | orderBy:f track by $index"
                 value="{{f}}#true">
           {{f | lowercase}}
         </option>
@@ -49,7 +49,7 @@
         <li class="dropdown-header"
             data-translate="">downloadAllIn
         </li>
-        <li data-ng-repeat="f in formats | orderBy:f">
+        <li data-ng-repeat="f in formats | orderBy:f track by $index">
           <a data-gn-click-and-spin="download(f)">
             {{f | lowercase}}
           </a>
@@ -60,7 +60,7 @@
         data-ng-if="map"
         data-translate="">downloadInCurrentMapExtent</li>
         <li data-ng-if="map"
-            data-ng-repeat="f in formats | orderBy:f">
+            data-ng-repeat="f in formats | orderBy:f track by $index">
           <a data-gn-click-and-spin="download(f, true)">
             {{f | lowercase }}
           </a>


### PR DESCRIPTION
When a metadata record has WFS downloads, and if in the WFS capabilities there happen to be double/duplicate keys, the dropdown fails. It's breaks on these duplicate values.

This PR fixes this error by adding a `track by` to distinguish between same keys.

![gn-fix-wfs-download](https://user-images.githubusercontent.com/19608667/100203544-0a59d980-2f03-11eb-8902-c6821fc7f84e.png)
