### PR TITLE
Fix bug related to canceling working copy removes approved resource (#5214)

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
@@ -40,19 +40,19 @@ public abstract class StoreUtils {
      * @param context
      * @param oldMetadataId               The source metadata ID
      * @param newMetadataId               The destination metadata ID
-     * @param oldApproved                 Old approved flag to use for the source.
      * @param newApproved                 New approved flag to use on the destination.
+     *                                    Used when creating a working copy where the destination will have the approved flag to false.
      * @throws Exception
      */
-    public static void copyDataDir(ServiceContext context, int oldMetadataId, int newMetadataId, boolean oldApproved, boolean newApproved) throws Exception {
+    public static void copyDataDir(ServiceContext context, int oldMetadataId, int newMetadataId, boolean newApproved) throws Exception {
         final Store store = context.getBean("resourceStore", Store.class);
         final IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
         final String oldUuid = metadataUtils.getMetadataUuid(String.valueOf(oldMetadataId));
         final String newUuid = metadataUtils.getMetadataUuid(String.valueOf(newMetadataId));
         for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
-            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, oldApproved);
+            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, true);
             for (MetadataResource resource: resources) {
-                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), oldApproved)) {
+                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), true)) {
                     store.putResource(context, newUuid, holder.getPath(), visibility, newApproved);
                 }
             }
@@ -64,16 +64,16 @@ public abstract class StoreUtils {
      * @param context
      * @param oldUuid               The source metadata ID
      * @param newUuid               The destination metadata ID
-     * @param oldApproved                 Old approved flag to use for the source.
-     * @param newApproved                 New approved flag to use on the destination.
+     * @param newApproved           New approved flag to use on the destination.
+     *                              Used when creating a working copy where the destination will have the approved flag to false.
      * @throws Exception
      */
-    public static void copyDataDir(ServiceContext context, String oldUuid, String newUuid, boolean oldApproved, boolean newApproved) throws Exception {
+    public static void copyDataDir(ServiceContext context, String oldUuid, String newUuid, boolean newApproved) throws Exception {
         final Store store = context.getBean("resourceStore", Store.class);
         for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
-            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, oldApproved);
+            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, true);
             for (MetadataResource resource: resources) {
-                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), oldApproved)) {
+                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), true)) {
                     store.putResource(context, newUuid, holder.getPath(), visibility, newApproved);
                 }
             }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
@@ -40,18 +40,20 @@ public abstract class StoreUtils {
      * @param context
      * @param oldMetadataId               The source metadata ID
      * @param newMetadataId               The destination metadata ID
+     * @param oldApproved                 Old approved flag to use for the source.
+     * @param newApproved                 New approved flag to use on the destination.
      * @throws Exception
      */
-    public static void copyDataDir(ServiceContext context, int oldMetadataId, int newMetadataId, boolean approved) throws Exception {
+    public static void copyDataDir(ServiceContext context, int oldMetadataId, int newMetadataId, boolean oldApproved, boolean newApproved) throws Exception {
         final Store store = context.getBean("resourceStore", Store.class);
         final IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
         final String oldUuid = metadataUtils.getMetadataUuid(String.valueOf(oldMetadataId));
         final String newUuid = metadataUtils.getMetadataUuid(String.valueOf(newMetadataId));
         for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
-            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, approved);
+            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, oldApproved);
             for (MetadataResource resource: resources) {
-                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), approved)) {
-                    store.putResource(context, newUuid, holder.getPath(), visibility, approved);
+                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), oldApproved)) {
+                    store.putResource(context, newUuid, holder.getPath(), visibility, newApproved);
                 }
             }
         }
@@ -62,15 +64,17 @@ public abstract class StoreUtils {
      * @param context
      * @param oldUuid               The source metadata ID
      * @param newUuid               The destination metadata ID
+     * @param oldApproved                 Old approved flag to use for the source.
+     * @param newApproved                 New approved flag to use on the destination.
      * @throws Exception
      */
-    public static void copyDataDir(ServiceContext context, String oldUuid, String newUuid, boolean approved) throws Exception {
+    public static void copyDataDir(ServiceContext context, String oldUuid, String newUuid, boolean oldApproved, boolean newApproved) throws Exception {
         final Store store = context.getBean("resourceStore", Store.class);
         for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
-            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, approved);
+            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, oldApproved);
             for (MetadataResource resource: resources) {
-                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), approved)) {
-                    store.putResource(context, newUuid, holder.getPath(), visibility, approved);
+                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), oldApproved)) {
+                    store.putResource(context, newUuid, holder.getPath(), visibility, newApproved);
                 }
             }
         }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
@@ -599,7 +599,7 @@ public class DraftMetadataUtils extends BaseMetadataUtils {
     @Override
     public void cloneFiles(AbstractMetadata original, AbstractMetadata dest) {
         try {
-            StoreUtils.copyDataDir(context, original.getUuid(), dest.getUuid(), true);
+            StoreUtils.copyDataDir(context, original.getUuid(), dest.getUuid(), true, false);
             cloneStoreFileUploadRequests(original, dest);
 
         } catch (Exception ex) {

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
@@ -599,7 +599,7 @@ public class DraftMetadataUtils extends BaseMetadataUtils {
     @Override
     public void cloneFiles(AbstractMetadata original, AbstractMetadata dest) {
         try {
-            StoreUtils.copyDataDir(context, original.getUuid(), dest.getUuid(), true, false);
+            StoreUtils.copyDataDir(context, original.getUuid(), dest.getUuid(), false);
             cloneStoreFileUploadRequests(original, dest);
 
         } catch (Exception ex) {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -476,7 +476,7 @@ public class MetadataInsertDeleteApi {
         dataManager.activateWorkflowIfConfigured(context, newId, group);
 
         try {
-            StoreUtils.copyDataDir(context, sourceMetadata.getId(), Integer.parseInt(newId), true, true);
+            StoreUtils.copyDataDir(context, sourceMetadata.getId(), Integer.parseInt(newId), true);
         } catch (Exception e) {
             Log.warning(Geonet.DATA_MANAGER,
                     String.format(

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -47,17 +47,7 @@ import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.api.records.attachments.StoreUtils;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.AbstractMetadata;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataCategory;
-import org.fao.geonet.domain.MetadataResourceVisibility;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.domain.Profile;
-import org.fao.geonet.domain.ReservedGroup;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.domain.*;
 import org.fao.geonet.domain.utils.ObjectJSONUtils;
 import org.fao.geonet.events.history.RecordCreateEvent;
 import org.fao.geonet.events.history.RecordDeletedEvent;
@@ -204,7 +194,12 @@ public class MetadataInsertDeleteApi {
             MetadataUtils.backupRecord(metadata, context);
         }
 
-        store.delResources(context, metadata.getUuid(), true);
+        boolean approved=true;
+        if (metadata instanceof MetadataDraft) {
+            approved=false;
+        }
+
+        store.delResources(context, metadata.getUuid(), approved);
         RecordDeletedEvent recordDeletedEvent = triggerDeletionEvent(request, metadata.getId() + "");
         metadataManager.deleteMetadata(context, metadata.getId() + "");
         recordDeletedEvent.publish(appContext);
@@ -481,7 +476,7 @@ public class MetadataInsertDeleteApi {
         dataManager.activateWorkflowIfConfigured(context, newId, group);
 
         try {
-            StoreUtils.copyDataDir(context, sourceMetadata.getId(), Integer.parseInt(newId), true);
+            StoreUtils.copyDataDir(context, sourceMetadata.getId(), Integer.parseInt(newId), true, true);
         } catch (Exception e) {
             Log.warning(Geonet.DATA_MANAGER,
                     String.format(

--- a/services/src/main/java/org/fao/geonet/services/metadata/Create.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Create.java
@@ -146,7 +146,7 @@ public class Create extends NotInReadOnlyModeService {
 
 
         try {
-            StoreUtils.copyDataDir(context, Integer.parseInt(id), Integer.parseInt(newId), true, true);
+            StoreUtils.copyDataDir(context, Integer.parseInt(id), Integer.parseInt(newId), true);
         } catch (Exception e) {
             Log.warning(Geonet.DATA_MANAGER, "Error while copying metadata resources. " + e.toString() +
                 ". Metadata is created but without resources from record with id:" + id);

--- a/services/src/main/java/org/fao/geonet/services/metadata/Create.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Create.java
@@ -40,17 +40,13 @@ import org.fao.geonet.exceptions.ServiceNotAllowedEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.fao.geonet.services.NotInReadOnlyModeService;
-import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
 import org.springframework.data.jpa.domain.Specifications;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
@@ -150,7 +146,7 @@ public class Create extends NotInReadOnlyModeService {
 
 
         try {
-            StoreUtils.copyDataDir(context, Integer.parseInt(id), Integer.parseInt(newId), true);
+            StoreUtils.copyDataDir(context, Integer.parseInt(id), Integer.parseInt(newId), true, true);
         } catch (Exception e) {
             Log.warning(Geonet.DATA_MANAGER, "Error while copying metadata resources. " + e.toString() +
                 ". Metadata is created but without resources from record with id:" + id);


### PR DESCRIPTION
Fixes issue #5214

store.delResources was not passing the correct approved flag.
Also fixed issue related to creating a working copy. It was not copying the resources correctly to the new metadata record. Wrong approved flag was being passed.