### PR TITLE
Fixed unhandled error and its xsl regular expression. Fixed root element in Schematron title translation.

### DIFF
--- a/web/src/main/webapp/xslt/common/utility-tpl-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl-metadata.xsl
@@ -146,7 +146,7 @@
         <errors>
           <xsl:for-each select="gn:validationReport|*/gn:validationReport">
             <error type="xsd">
-              <xsl:value-of select="gn:parse-xsd-error(@gn:message, $schema, $labels, $strings)"/>
+              <xsl:value-of select="gn:parse-xsd-error(@gn:message, $schema, $labels, $codelists, $strings)"/>
             </error>
           </xsl:for-each>
 

--- a/web/src/main/webapp/xslt/common/utility-tpl-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl-metadata.xsl
@@ -146,7 +146,7 @@
         <errors>
           <xsl:for-each select="gn:validationReport|*/gn:validationReport">
             <error type="xsd">
-              <xsl:value-of select="gn:parse-xsd-error(@gn:message, $schema, $labels, $codelists, $strings)"/>
+              <xsl:value-of select="gn:parse-xsd-error(@gn:message, $schema, $labels, $strings)"/>
             </error>
           </xsl:for-each>
 

--- a/web/src/main/webapp/xslt/services/metadata/validate-fn.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/validate-fn.xsl
@@ -80,6 +80,7 @@
     <xsl:param name="error" as="xs:string"/>
     <xsl:param name="schema" as="xs:string"/>
     <xsl:param name="labels" as="node()"/>
+    <xsl:param name="codelists" as="node()"/>
     <xsl:param name="strings" as="node()"/>
 
     <!-- Set of rules processed : -->
@@ -91,13 +92,13 @@
       <rule errorType="complex-type.2.4.bwithparent">The content of element '(.*)' is not complete. One of '\{"(.*)\}' is expected\. \(Element: (.*) with parent element: (.*)\)</rule>
       <rule errorType="complex-type.2.4.b">The content of element '(.*)' is not complete. One of '\{"(.*)\}' is expected\.</rule>
       <!--cvc-datatype-valid.1.2.1: '' is not a valid value for 'dateTime'. (Element: gco:DateTime with parent element: gmd:date)-->
-      <!--cvc-datatype-valid.1.2.1: 'DUMMY_DENOMINATOR' is not a valid value for 'integer'. (Element: gco:Integer with parent element: gmd:denominator)-->
-      <rule errorType="datatype-valid.1.2.1withparent">'(.*)' is not a valid value for '(.*)'\. \(Element: ([a-z]{3}):(.*) with parent element: (.*)\)</rule>
+      <!--cvc-datatype-valid.1.2.1: 'DUMMY_DENOMINATOR' is not a valid value for 'integer'.-->
+      <rule errorType="datatype-valid.1.2.1withparent">'(.*)' is not a valid value for '(.*)'\.</rule>
       <rule errorType="datatype-valid.1.2.1">'(.*)' is not a valid value for '(.*)'\.</rule>
-      <!--cvc-type.3.1.3: The value 'DUMMY_DENOMINATOR' of element 'gco:Integer' is not valid. (Element: gco:Integer with parent element: gmd:denominator)-->
-      <rule errorType="type.3.1.3withparent">The value '(.*)' of element '(.*)' is not valid\. \(Element: ([a-z]{3}):(.*) with parent element: (.*)\)</rule>
+      <!--cvc-type.3.1.3: The value 'DUMMY_DENOMINATOR' of element 'gco:Integer' is not valid.-->
+      <rule errorType="type.3.1.3withparent">The value '(.*)' of element '(.*)' is not valid\.</rule>
       <rule errorType="type.3.1.3">The value '(.*)' of element '(.*)' is not valid\.</rule>
-      <rule errorType="enumeration-valid">Value '(.*)' is not facet-valid with respect to enumeration '\[(.*)\]'\. It must be a value from the enumeration\. \(Element: ([a-z]{3}):(.*) with parent element: (.*)\)</rule>
+      <rule errorType="enumeration-valid">Value '(.*)' is not facet-valid with respect to enumeration '\[(.*)\]'\. It must be a value from the enumeration\.</rule>
     </xsl:variable>
 
     <xsl:variable name="errorWithParentName"
@@ -186,14 +187,10 @@
                   </xsl:if>
                 </xsl:when>
                 <xsl:when test="$errorType = 'enumeration-valid'">
-                  <xsl:value-of select="$strings/enum1"/> '<xsl:value-of
-                  select="regex-group(1)"/>'
-                  <xsl:value-of select="$strings/enum2"/>
-                  <xsl:value-of
-                    select="geonet:getTitleWithoutContext($schema, concat(regex-group(3), ':', regex-group(4)), $labels)"
-                  /> (<xsl:value-of select="concat(regex-group(3), ':', regex-group(4))"/>).
+                  <!--The topic category must be found in the following list-->
                   <xsl:value-of select="$strings/enum3"/>
-                  <xsl:value-of select="regex-group(2)"/>.
+                  <!--The code list with translation text-->
+                  (<xsl:value-of select="$codelists//codelist[@name='gmd:MD_TopicCategoryCode']/entry/value" separator=", " />)
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -219,13 +216,14 @@
     <xsl:param name="error" as="xs:string"/>
     <xsl:param name="schema" as="xs:string"/>
     <xsl:param name="labels" as="node()"/>
+    <xsl:param name="codelists" as="node()"/>
     <xsl:param name="strings" as="node()"/>
 
     <!-- Extract XSD error type and message-->
     <xsl:analyze-string select="$error" regex=".*cvc-([\w\-0-9\.]+): (.*)">
       <xsl:matching-substring>
         <xsl:value-of
-          select="geonet:parse-xsd-error-msg(regex-group(1), regex-group(2), $schema, $labels, $strings)"/>
+          select="geonet:parse-xsd-error-msg(regex-group(1), regex-group(2), $schema, $labels, $codelists, $strings)"/>
       </xsl:matching-substring>
       <xsl:non-matching-substring>
         <xsl:value-of select="$error"/>

--- a/web/src/main/webapp/xslt/services/metadata/validate-fn.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/validate-fn.xsl
@@ -80,7 +80,6 @@
     <xsl:param name="error" as="xs:string"/>
     <xsl:param name="schema" as="xs:string"/>
     <xsl:param name="labels" as="node()"/>
-    <xsl:param name="codelists" as="node()"/>
     <xsl:param name="strings" as="node()"/>
 
     <!-- Set of rules processed : -->
@@ -92,13 +91,18 @@
       <rule errorType="complex-type.2.4.bwithparent">The content of element '(.*)' is not complete. One of '\{"(.*)\}' is expected\. \(Element: (.*) with parent element: (.*)\)</rule>
       <rule errorType="complex-type.2.4.b">The content of element '(.*)' is not complete. One of '\{"(.*)\}' is expected\.</rule>
       <!--cvc-datatype-valid.1.2.1: '' is not a valid value for 'dateTime'. (Element: gco:DateTime with parent element: gmd:date)-->
-      <!--cvc-datatype-valid.1.2.1: 'DUMMY_DENOMINATOR' is not a valid value for 'integer'.-->
-      <rule errorType="datatype-valid.1.2.1withparent">'(.*)' is not a valid value for '(.*)'\.</rule>
+      <!--cvc-datatype-valid.1.2.1: 'DUMMY_DENOMINATOR' is not a valid value for 'integer'. (Element: gco:Integer with parent element: gmd:denominator)-->
+      <rule errorType="datatype-valid.1.2.1withparent">'(.*)' is not a valid value for '(.*)'\. \(Element: ([a-z]{3}):(.*) with parent element: (.*)\)</rule>
       <rule errorType="datatype-valid.1.2.1">'(.*)' is not a valid value for '(.*)'\.</rule>
-      <!--cvc-type.3.1.3: The value 'DUMMY_DENOMINATOR' of element 'gco:Integer' is not valid.-->
-      <rule errorType="type.3.1.3withparent">The value '(.*)' of element '(.*)' is not valid\.</rule>
+      <!--cvc-type.3.1.3: The value 'DUMMY_DENOMINATOR' of element 'gco:Integer' is not valid. (Element: gco:Integer with parent element: gmd:denominator)-->
+      <rule errorType="type.3.1.3withparent">The value '(.*)' of element '(.*)' is not valid\. \(Element: ([a-z]{3}):(.*) with parent element: (.*)\)</rule>
       <rule errorType="type.3.1.3">The value '(.*)' of element '(.*)' is not valid\.</rule>
+      <rule errorType="enumeration-validwithparent">Value '(.*)' is not facet-valid with respect to enumeration '\[(.*)\]'\. It must be a value from the enumeration\. \(Element: ([a-z]{3}):(.*) with parent element: (.*)\)</rule>
       <rule errorType="enumeration-valid">Value '(.*)' is not facet-valid with respect to enumeration '\[(.*)\]'\. It must be a value from the enumeration\.</rule>
+      <!--datatype-valid.1.2.3: '' is not a valid value of union type 'Date_Type'.-->
+      <rule errorType="datatype-valid.1.2.3withparent">'(.*)' is not a valid value of union type '(.*)'\. \(Element: ([a-z]{3}):(.*) with parent element:(.*)\)</rule>
+      <rule errorType="datatype-valid.1.2.3">'(.*)' is not a valid value of union type '(.*)'\.</rule>
+
     </xsl:variable>
 
     <xsl:variable name="errorWithParentName"
@@ -171,7 +175,7 @@
                     (<xsl:value-of select="regex-group(4)"/>).
                   </xsl:if>
                 </xsl:when>
-                <xsl:when test="$errorType = 'datatype-valid.1.2.1' or $errorType = 'type.3.1.3'">
+                <xsl:when test="$errorType = 'datatype-valid.1.2.1' or $errorType = 'type.3.1.3' or $errorType = 'datatype-valid.1.2.3'">
                   <xsl:value-of select="$strings/invalidValue"/> '<xsl:value-of
                   select="regex-group(1)"/>'
                   <xsl:value-of select="$strings/notValidFor"/>
@@ -187,10 +191,14 @@
                   </xsl:if>
                 </xsl:when>
                 <xsl:when test="$errorType = 'enumeration-valid'">
-                  <!--The topic category must be found in the following list-->
+                  <xsl:value-of select="$strings/enum1"/> '<xsl:value-of
+                  select="regex-group(1)"/>'
+                  <xsl:value-of select="$strings/enum2"/>
+                  <xsl:value-of
+                    select="geonet:getTitleWithoutContext($schema, concat(regex-group(3), ':', regex-group(4)), $labels)"
+                  /> (<xsl:value-of select="concat(regex-group(3), ':', regex-group(4))"/>).
                   <xsl:value-of select="$strings/enum3"/>
-                  <!--The code list with translation text-->
-                  (<xsl:value-of select="$codelists//codelist[@name='gmd:MD_TopicCategoryCode']/entry/value" separator=", " />)
+                  <xsl:value-of select="regex-group(2)"/>.
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -216,14 +224,13 @@
     <xsl:param name="error" as="xs:string"/>
     <xsl:param name="schema" as="xs:string"/>
     <xsl:param name="labels" as="node()"/>
-    <xsl:param name="codelists" as="node()"/>
     <xsl:param name="strings" as="node()"/>
 
     <!-- Extract XSD error type and message-->
     <xsl:analyze-string select="$error" regex=".*cvc-([\w\-0-9\.]+): (.*)">
       <xsl:matching-substring>
         <xsl:value-of
-          select="geonet:parse-xsd-error-msg(regex-group(1), regex-group(2), $schema, $labels, $codelists, $strings)"/>
+          select="geonet:parse-xsd-error-msg(regex-group(1), regex-group(2), $schema, $labels, $strings)"/>
       </xsl:matching-substring>
       <xsl:non-matching-substring>
         <xsl:value-of select="$error"/>

--- a/web/src/main/webapp/xslt/services/metadata/validate.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/validate.xsl
@@ -137,7 +137,7 @@
       </displayPriority>
       <label>
         <xsl:variable name="translatedTitle"
-                      select="/response/schematronTranslations/*[name() = $rulename]/strings/schematron.title"/>
+                      select="/root/schematronTranslations/*[name() = $rulename]/strings/schematron.title"/>
         <xsl:variable name="defaultTitle"
                       select="svrl:schematron-output/@title"/>
         <xsl:choose>

--- a/web/src/main/webapp/xslt/services/metadata/validate.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/validate.xsl
@@ -106,6 +106,7 @@
             <xsl:value-of select="geonet:parse-xsd-error(geonet:message,
                         $metadataSchema,
                         /root/*[name() = $metadataSchema]/labels,
+                        /root/*[name() = $metadataSchema]/codelists,
                         /root/*[name() = $metadataSchema]/strings)"/>
           </title>
           <rules>
@@ -127,7 +128,7 @@
     <xsl:variable name="errors" select="count(.//svrl:failed-assert)"/>
     <xsl:variable name="successes" select="count(.//svrl:successful-report)"/>
     <xsl:variable name="schematronVerificationError" select="./geonet:schematronVerificationError"/>
-    
+
     <report>
       <id>
         <xsl:value-of select="$rulename"/>

--- a/web/src/main/webapp/xslt/services/metadata/validate.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/validate.xsl
@@ -106,7 +106,6 @@
             <xsl:value-of select="geonet:parse-xsd-error(geonet:message,
                         $metadataSchema,
                         /root/*[name() = $metadataSchema]/labels,
-                        /root/*[name() = $metadataSchema]/codelists,
                         /root/*[name() = $metadataSchema]/strings)"/>
           </title>
           <rules>


### PR DESCRIPTION
Fixed xsl regular expression due to the parser error message change to translate language text. Pass codelist into the validate-fn.xsl to get multilingual support for topic category list.