### PR TITLE
INSPIRE Validation / Add support to validate using GetRecordById url

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/processing/MInspireEtfValidateProcess.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/MInspireEtfValidateProcess.java
@@ -185,7 +185,7 @@ public class MInspireEtfValidateProcess implements SelfNaming {
                                                 if (StringUtils.isEmpty(mode)) {
                                                     testId = inspireValidatorUtils.submitFile(serviceContext, URL,
                                                         new ByteArrayInputStream(mdToValidate.getBytes()), entry.getKey(), record.getUuid());
-                                                } else if (StringUtils.isNotEmpty(mode)) {
+                                                } else {
                                                     String portal = null;
                                                     if (!NodeInfo.DEFAULT_NODE.equals(mode)) {
                                                         Source source = appContext.getBean(SourceRepository.class).findOneByUuid(mode);

--- a/services/src/main/java/org/fao/geonet/api/processing/MInspireEtfValidateProcess.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/MInspireEtfValidateProcess.java
@@ -182,7 +182,7 @@ public class MInspireEtfValidateProcess implements SelfNaming {
 
                                                 String testId = null;
                                                 String getRecordByIdUrl = null;
-                                                if (mode == null) {
+                                                if (StringUtils.isEmpty(mode)) {
                                                     testId = inspireValidatorUtils.submitFile(serviceContext, URL,
                                                         new ByteArrayInputStream(mdToValidate.getBytes()), entry.getKey(), record.getUuid());
                                                 } else if (StringUtils.isNotEmpty(mode)) {

--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -264,7 +264,7 @@ public class InspireValidationApi {
 
                 InputStream metadataToTest = convertElement2InputStream(md);
                 testId = inspireValidatorUtils.submitFile(context, URL, metadataToTest, testsuite, metadata.getUuid());
-            } else if (StringUtils.isNotEmpty(mode)) {
+            } else {
                 String portal = NodeInfo.DEFAULT_NODE;
                 if (!NodeInfo.DEFAULT_NODE.equals(mode)) {
                     Source source = sourceRepository.findOneByUuid(mode);

--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -29,8 +29,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.context.ServiceContext;
 import jeeves.services.ReadWriteController;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
 import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.NodeInfo;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
@@ -43,6 +45,7 @@ import org.fao.geonet.api.records.formatters.cache.Key;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.Source;
 import org.fao.geonet.events.history.RecordValidationTriggeredEvent;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.EditLib;
@@ -50,6 +53,8 @@ import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.MetadataValidationRepository;
+import org.fao.geonet.repository.SourceRepository;
+import org.fao.geonet.schema.iso19139.ISO19139Namespaces;
 import org.fao.geonet.util.ThreadPool;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
@@ -90,17 +95,30 @@ import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 @ReadWriteController
 public class InspireValidationApi {
 
+    public static final String API_PARAM_INSPIRE_VALIDATION_MODE = "Define the encoding of the record to use. "
+        + "By default, ISO19139 are used as is and "
+        + "ISO19115-3 are converted to ISO19139."
+        + "If mode = csw, a GetRecordById request is used."
+        + "If mode = any portal id, then a GetRecordById request is used on this portal "
+        + "CSW entry point which may define custom CSW post processing. "
+        + "See https://github.com/geonetwork/core-geonetwork/pull/4493.";
     @Autowired
     SettingManager settingManager;
+
     @Autowired
     InspireValidatorUtils inspireValidatorUtils;
+
     @Autowired
     LanguageUtils languageUtils;
+
+    @Autowired
+    SourceRepository sourceRepository;
+
     String supportedSchemaRegex = "(iso19139|iso19115-3).*";
+
     @Autowired
     private SchemaManager schemaManager;
-    @Autowired
-    private MetadataValidationRepository metadataValidationRepository;
+
     @Autowired
     private ThreadPool threadPool;
 
@@ -160,6 +178,11 @@ public class InspireValidationApi {
             required = false)
         @RequestParam
             String testsuite,
+        @Parameter(
+            description = API_PARAM_INSPIRE_VALIDATION_MODE,
+            required = false)
+        @RequestParam(required = false)
+            String mode,
         HttpServletResponse response,
         @Parameter(hidden = true)
             HttpServletRequest request,
@@ -188,6 +211,9 @@ public class InspireValidationApi {
         String id = String.valueOf(metadata.getId());
 
         String URL = settingManager.getValue(Settings.SYSTEM_INSPIRE_REMOTE_VALIDATION_URL);
+        ServiceContext context = ApiUtils.createServiceContext(request);
+        String getRecordByIdUrl = null;
+        String testId = null;
 
         try {
             Element md = (Element) ApiUtils.getUserSession(session).getProperty(Geonet.Session.METADATA_EDITING + id);
@@ -197,49 +223,68 @@ public class InspireValidationApi {
                 // TODO: Add support for such validation from not editing session ?
             }
 
-            // Use formatter to convert the record
-            if (!schema.equals("iso19139")) {
-                try {
-                    ServiceContext context = ApiUtils.createServiceContext(request);
-                    Key key = new Key(metadata.getId(), "eng", FormatType.xml, "iso19139", true, FormatterWidth._100);
+            if (mode == null) {
+                // Use formatter to convert the record
+                if (!schema.equals("iso19139")) {
+                    try {
+                        Key key = new Key(metadata.getId(), "eng", FormatType.xml, "iso19139", true, FormatterWidth._100);
 
-                    final FormatterApi.FormatMetadata formatMetadata =
-                        new FormatterApi().new FormatMetadata(context, key, nativeRequest);
-                    final byte[] data = formatMetadata.call().data;
-                    md = Xml.loadString(new String(data, StandardCharsets.UTF_8), false);
-                } catch (Exception e) {
-                    response.setStatus(HttpStatus.SC_NOT_FOUND);
-                    return String.format("Metadata with id '%s' is in schema '%s'. No iso19139 formatter found. Error is %s", id, schema, e.getMessage());
+                        final FormatterApi.FormatMetadata formatMetadata =
+                            new FormatterApi().new FormatMetadata(context, key, nativeRequest);
+                        final byte[] data = formatMetadata.call().data;
+                        md = Xml.loadString(new String(data, StandardCharsets.UTF_8), false);
+                    } catch (Exception e) {
+                        response.setStatus(HttpStatus.SC_NOT_FOUND);
+                        return String.format("Metadata with id '%s' is in schema '%s'. No iso19139 formatter found. Error is %s", id, schema, e.getMessage());
+                    }
+                } else {
+                    // Cleanup metadocument elements
+                    EditLib editLib = appContext.getBean(DataManager.class).getEditLib();
+                    editLib.removeEditingInfo(md);
+                    editLib.contractElements(md);
                 }
-            } else {
-                // Cleanup metadocument elements
-                EditLib editLib = appContext.getBean(DataManager.class).getEditLib();
-                editLib.removeEditingInfo(md);
-                editLib.contractElements(md);
-            }
 
 
-            md.detach();
-            ServiceContext context = ApiUtils.createServiceContext(request);
-            Attribute schemaLocAtt = schemaManager.getSchemaLocation(
-                "iso19139", context);
+                md.detach();
+                Attribute schemaLocAtt = schemaManager.getSchemaLocation(
+                    "iso19139", context);
 
-            if (schemaLocAtt != null) {
-                if (md.getAttribute(
-                    schemaLocAtt.getName(),
-                    schemaLocAtt.getNamespace()) == null) {
-                    md.setAttribute(schemaLocAtt);
-                    // make sure namespace declaration for schemalocation is present -
-                    // remove it first (does nothing if not there) then add it
-                    md.removeNamespaceDeclaration(schemaLocAtt.getNamespace());
-                    md.addNamespaceDeclaration(schemaLocAtt.getNamespace());
+                if (schemaLocAtt != null) {
+                    if (md.getAttribute(
+                        schemaLocAtt.getName(),
+                        schemaLocAtt.getNamespace()) == null) {
+                        md.setAttribute(schemaLocAtt);
+                        // make sure namespace declaration for schemalocation is present -
+                        // remove it first (does nothing if not there) then add it
+                        md.removeNamespaceDeclaration(schemaLocAtt.getNamespace());
+                        md.addNamespaceDeclaration(schemaLocAtt.getNamespace());
+                    }
                 }
+
+
+                InputStream metadataToTest = convertElement2InputStream(md);
+                testId = inspireValidatorUtils.submitFile(context, URL, metadataToTest, testsuite, metadata.getUuid());
+            } else if (StringUtils.isNotEmpty(mode)) {
+                String portal = NodeInfo.DEFAULT_NODE;
+                if (!NodeInfo.DEFAULT_NODE.equals(mode)) {
+                    Source source = sourceRepository.findOneByUuid(mode);
+                    if (source == null) {
+                        response.setStatus(HttpStatus.SC_NOT_FOUND);
+                        return String.format(
+                            "Portal %s not found. There is no CSW endpoint at this URL " +
+                                "that we can send to the validator.", mode);
+                    }
+                    portal = mode;
+                }
+                getRecordByIdUrl = String.format(
+                    "%s%s/eng/csw?SERVICE=CSW&REQUEST=GetRecordById&VERSION=2.0.2&" +
+                        "OUTPUTSCHEMA=%s&ELEMENTSETNAME=full&ID=%s",
+                    settingManager.getBaseURL(),
+                    portal,
+                    ISO19139Namespaces.GMD.getURI(),
+                    metadataUuid);
+                testId = inspireValidatorUtils.submitUrl(context, URL, getRecordByIdUrl, testsuite, metadata.getUuid());
             }
-
-
-            InputStream metadataToTest = convertElement2InputStream(md);
-
-            String testId = inspireValidatorUtils.submitFile(context, URL, metadataToTest, testsuite, metadata.getUuid());
 
             threadPool.runTask(new InspireValidationRunnable(context, URL, testId, metadata.getId()));
 

--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -223,7 +223,7 @@ public class InspireValidationApi {
                 // TODO: Add support for such validation from not editing session ?
             }
 
-            if (mode == null) {
+            if (StringUtils.isEmpty(mode)) {
                 // Use formatter to convert the record
                 if (!schema.equals("iso19139")) {
                     try {

--- a/services/src/main/java/org/fao/geonet/api/records/editing/InspireValidatorUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/InspireValidatorUtils.java
@@ -580,8 +580,6 @@ public class InspireValidatorUtils {
                 Log.error(Log.SERVICE, "Service unavailable.", ex);
                 throw ex;
             }
-        } finally {
-            // client.close();
         }
     }
 

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -477,20 +477,36 @@
        * Validates the current selection of metadata records.
        * @param {String} bucket
        */
-      this.validateMdInspire = function(bucket) {
+      this.validateMdInspire = function(bucket, mode) {
 
         $rootScope.$broadcast('operationOnSelectionStart');
         $rootScope.$broadcast('inspireMdValidationStart');
 
-        return gnHttp.callService('../api/records/validate/inspire?' +
-          'bucket=' + bucket, null, {
+        var url = '../api/records/validate/inspire?' +
+          'bucket=' + bucket;
+        if (angular.isDefined(mode)) {
+          url += '&mode=' + mode;
+        }
+        return gnHttp.callService(url, null, {
           method: 'PUT'
         }).then(function(data) {
           $rootScope.$broadcast('inspireMdValidationStop');
           $rootScope.$broadcast('operationOnSelectionStop');
           $rootScope.$broadcast('search');
         });
+      };
 
+
+      this.clearValidationStatus = function(bucket) {
+        $rootScope.$broadcast('operationOnSelectionStart');
+        var url = '../api/records/validate?' +
+          'bucket=' + bucket;
+        return gnHttp.callService(url, null, {
+          method: 'DELETE'
+        }).then(function(data) {
+          $rootScope.$broadcast('operationOnSelectionStop');
+          $rootScope.$broadcast('search');
+        });
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -114,6 +114,19 @@
           <i class="fa fa-check"></i>&nbsp;<span translate>validateInspire</span>
         </a>
       </li>
+      <!--<li  data-ng-show="!excludePattern.test('validate')"
+           data-ng-if="user.isEditorOrMore() && isInspireValidationEnabled">
+        <a href="" data-ng-click="mdService.validateMdInspire(searchResults.selectionBucket, 'inspire')"
+           data-gn-confirm-click="{{'validateSelectedRecordINSPIREConfirm' | translate:searchResults}}">
+          <i class="fa fa-check"></i>&nbsp;<span translate>validateInspire</span>
+        </a>
+      </li>-->
+      <li  data-ng-show="!excludePattern.test('validate')"
+           data-ng-if="user.isAdministrator() && isInspireValidationEnabled">
+        <a href="" data-ng-click="mdService.clearValidationStatus(searchResults.selectionBucket)">
+          <i class="fa fa-eraser"></i>&nbsp;<span translate>clearValidationStatus</span>
+        </a>
+      </li>
 
       <li class="divider" data-ng-if="user.isConnected()"></li>
       <li  data-ng-show="!excludePattern.test('updateCategories')"

--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -73,17 +73,20 @@
                 });
               });
 
-              scope.validateInspire = function(test) {
+              scope.validateInspire = function(test, mode) {
 
                 if (scope.isEnabled) {
 
                   scope.isDownloadingRecord = true;
                   scope.token = null;
-
+                  var url = '../api/records/' + scope.inspMdUuid +
+                    '/validate/inspire?testsuite=' + test;
+                  if (angular.isDefined(mode)) {
+                    url += '&mode=' + mode;
+                  }
                   $http({
                     method: 'PUT',
-                    url: '../api/records/' + scope.inspMdUuid +
-                    '/validate/inspire?testsuite=' + test
+                    url: url
                   }).then(function mySucces(response) {
                     if (angular.isDefined(response.data) && response.data != null) {
                       scope.checkInBackgroud(response.data);

--- a/web-ui/src/main/resources/catalog/components/validationtools/partials/mdValidationTools.html
+++ b/web-ui/src/main/resources/catalog/components/validationtools/partials/mdValidationTools.html
@@ -44,7 +44,12 @@
             class="fa fa-chevron-right"/>&nbsp;
 
           <span>{{key}}</span>
-      </a>
+        </a>
+        <!--
+        Validation using main CSW entry point.
+        <a class="btn btn-link pull-right" data-gn-click-and-spin="validateInspire(key, 'srv')">using csw</a>
+        Validation using "inspire" portal CSW entry point (which may post process outputs).
+        <a class="btn btn-link pull-right" data-gn-click-and-spin="validateInspire(key, 'inspire')">using INSPIRE endpoint</a>-->
       </li>
 
       <li role="presentation" data-ng-show="isDownloadingRecord">

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -123,5 +123,6 @@
   "wfsHarvesterActions": "Actions",
   "clearCheckboxFormChanges": "Clear modified checkbox state. Checkboxes with '*' means that those values will be removed from the selection.",
   "addThoseCategories-help": "Add (checked) or remove (checkbox with *) selected categories.",
-  "replaceByThoseCategories-help": "Remove record categories and then add (checked) or remove (checkbox with *) selected categories."
+  "replaceByThoseCategories-help": "Remove record categories and then add (checked) or remove (checkbox with *) selected categories.",
+  "clearValidationStatus": "Clear validation status"
 }


### PR DESCRIPTION
Current validation mechanism always upload the record first. Default mode is unchanged.

Add a mode parameter to the API (on one record or on a selection) to define the encoding of the record to use:

* By default, ISO19139 are used as is and others like ISO19115-3 are converted to ISO19139 if a formatter is available.
* If mode = csw, a GetRecordById request pointing to the main portal is used.
* If mode = any portal id, then a GetRecordById request is used on this portal.

CSW entry point which may define custom CSW post processing. See https://github.com/geonetwork/core-geonetwork/pull/4493.

When using CSW mode, the record has to be publicly accessible for the validator to retrieve it.

Add also an API operation to clear current validation status.