### PR TITLE
Map / WMS / Erdapp server support.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1238,8 +1238,8 @@
            * @param {Object} getCapLayer object to convert
            * @param {string} style of the style to use
            */
-          addWmsToMapFromCap: function(map, getCapLayer, style) {
-            var layer = this.createOlWMSFromCap(map, getCapLayer, null, style);
+          addWmsToMapFromCap: function(map, getCapLayer, url, style) {
+            var layer = this.createOlWMSFromCap(map, getCapLayer, url, style);
             map.addLayer(layer);
             return layer;
           },

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -80,7 +80,7 @@
             }
             if ($scope.format == 'wms') {
               var layer =
-                  gnMap.addWmsToMapFromCap($scope.map, getCapLayer, style);
+                  gnMap.addWmsToMapFromCap($scope.map, getCapLayer, $scope.url, style);
                   gnAlertService.addAlert({
                     msg: $translate.instant('layerAdded',
                         {layer: layer.get('label'), extent: layer.get('cextent').toString()}),


### PR DESCRIPTION
Some WMS implementations do not provide capLayer.url and fails with

```
`TypeError: Cannot read property 'slice' of null at Object.createOlWMSFromCap`
```


eg. http://www.ifremer.fr/erddap/wms/HF_600e_f9ff_938e/request?service=WMS&request=GetCapabilities

![image](https://user-images.githubusercontent.com/1701393/100748487-aabc6c00-33e3-11eb-9901-347d8ef7f6e7.png)


Fallback to use the capabilities URL provided by the user in that case.