### PR TITLE
Updated validation api so that it supports working copy and fixed other validation bugs

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -281,6 +281,12 @@ public interface IMetadataUtils {
      */
     boolean existsMetadata(int id) throws Exception;
 
+    boolean isMetadataPublished(int metadataId) throws Exception;
+
+    boolean isMetadataApproved(int metadataId) throws Exception;
+
+    boolean isMetadataDraft(int metadataId) throws Exception;
+
     /**
      * Returns all the keywords in the system.
      */

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -33,38 +33,24 @@ import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.AbstractMetadata;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataDataInfo;
-import org.fao.geonet.domain.MetadataHarvestInfo;
-import org.fao.geonet.domain.MetadataRatingByIp;
-import org.fao.geonet.domain.MetadataRatingByIpId;
-import org.fao.geonet.domain.MetadataSourceInfo;
-import org.fao.geonet.domain.MetadataType;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.XmlSerializer;
-import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
-import org.fao.geonet.kernel.datamanager.IMetadataManager;
-import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
-import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.datamanager.*;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.search.index.IndexingList;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.notifier.MetadataNotifierManager;
-import org.fao.geonet.repository.MetadataRatingByIpRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.SimpleMetadata;
-import org.fao.geonet.repository.Updater;
+import org.fao.geonet.repository.*;
 import org.fao.geonet.repository.reports.MetadataReportsQueries;
+import org.fao.geonet.repository.specification.OperationAllowedSpecs;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
@@ -81,6 +67,7 @@ import com.google.common.base.Optional;
 
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
+import org.springframework.data.jpa.domain.Specifications;
 
 public class BaseMetadataUtils implements IMetadataUtils {
     @Autowired
@@ -634,6 +621,33 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Override
     public boolean existsMetadataUuid(String uuid) throws Exception {
         return !findAllIdsBy(hasMetadataUuid(uuid)).isEmpty();
+    }
+
+    @Override
+    public boolean isMetadataPublished(int metadataId) throws Exception {
+        // For metadata records)
+        // It will be a draft if the record is not viewable by public
+        final Specification<OperationAllowed> isMdPublished = OperationAllowedSpecs.isPublic(ReservedOperation.view);
+        final Specification<OperationAllowed> hasMdId = OperationAllowedSpecs.hasMetadataId(metadataId);
+        final OperationAllowed one = ApplicationContextHolder.get().getBean(OperationAllowedRepository.class).findOne(Specifications.where(hasMdId).and(isMdPublished));
+        return (one != null);
+    }
+
+    @Override
+    public boolean isMetadataApproved(int metadataId) throws Exception {
+        boolean isApproved = false;
+        MetadataStatus metadataStatus = ApplicationContextHolder.get().getBean(IMetadataStatus.class).getStatus(metadataId);
+        if (metadataStatus != null) {
+            String statusId = metadataStatus.getStatusValue().getId() + "";
+            isApproved = statusId.equals(StatusValue.Status.APPROVED);
+        }
+        return isApproved;
+    }
+
+    @Override
+    public boolean isMetadataDraft(int metadataId) throws Exception {
+        // It will be a draft if the record is not viewable by public and it is not approved record.
+        return !(isMetadataApproved(metadataId) || isMetadataPublished(metadataId));
     }
 
     /**

--- a/services/src/main/java/org/fao/geonet/api/processing/MetadataSearchAndReplace.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/MetadataSearchAndReplace.java
@@ -199,7 +199,7 @@ public class MetadataSearchAndReplace extends MetadataIndexerProcessor {
                 if (hasChanges) {
                     report.addMetadataChanges(iId, changesEl);
                 } else {
-                    report.addMetadataInfos(iId, "No changes.");
+                    report.addMetadataInfos(metadataEntity, "No changes.");
                 }
 
                 // --- save metadata and return status
@@ -243,7 +243,7 @@ public class MetadataSearchAndReplace extends MetadataIndexerProcessor {
                     }
                 }
             } catch (Exception e) {
-                report.addMetadataError(iId, e);
+                report.addMetadataError(metadataEntity, e);
             }
             return processedMetadata;
         }

--- a/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
@@ -162,6 +162,11 @@ public class ValidateApi {
             example = "")
         @RequestParam(required = false)
             String[] uuids,
+        @ApiParam(value = "Use approved version or not", example = "true")
+        @RequestParam(
+            required = false,
+            defaultValue = "")
+            Boolean approved,
         @ApiParam(
             value = ApiParams.API_PARAM_BUCKET_NAME,
             required = false)
@@ -183,26 +188,39 @@ public class ValidateApi {
             ServiceContext serviceContext = ApiUtils.createServiceContext(request);
 
             Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, userSession);
+            report.setTotalRecords(records.size());
 
             for (String uuid : records) {
-                if (!metadataRepository.existsMetadataUuid(uuid)) {
-                    report.incrementNullRecords();
-                }
+                int loopConditionCount = 0;
                 for (AbstractMetadata record : metadataRepository.findAllByUuid(uuid)) {
-                    if (!accessMan.canEdit(serviceContext, String.valueOf(record.getId()))) {
-                        report.addNotEditableMetadataId(record.getId());
-                    } else {
-                        boolean isValid = validator.doValidate(record, serviceContext.getLanguage());
-                        if (isValid) {
-                            report.addMetadataInfos(record.getId(), "Is valid");
-                            new RecordValidationTriggeredEvent(record.getId(), ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(), "1").publish(applicationContext);
-                        } else {
-                            report.addMetadataError(record.getId(), "Is invalid");
-                            new RecordValidationTriggeredEvent(record.getId(), ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(), "0").publish(applicationContext);
+                    if (approved == null ||
+                        (approved == true && !(record instanceof MetadataDraft)) ||
+                        (approved == false && record instanceof MetadataDraft)) {
+                        loopConditionCount++;
+                        // If we processed more than one record in this loop then we will also increase the total records
+                        // as it means that we are processing both and approved and draft and that was not calculated in the original total.
+                        if (loopConditionCount > 1) {
+                            report.setTotalRecords(report.getNumberOfRecords() + 1);
                         }
-                        report.addMetadataId(record.getId());
-                        report.incrementProcessedRecords();
+                        if (!accessMan.canEdit(serviceContext, String.valueOf(record.getId()))) {
+                            report.addNotEditableMetadataId(record.getId());
+                        } else {
+                            boolean isValid = validator.doValidate(record, serviceContext.getLanguage());
+                            if (isValid) {
+                                report.addMetadataInfos(record, "Is valid");
+                                new RecordValidationTriggeredEvent(record.getId(), ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(), "1").publish(applicationContext);
+                            } else {
+                                report.addMetadataError(record, "Is invalid");
+                                new RecordValidationTriggeredEvent(record.getId(), ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(), "0").publish(applicationContext);
+                            }
+                            report.addMetadataId(record.getId());
+                            report.incrementProcessedRecords();
+                        }
                     }
+                }
+                // If loopConditionCount is 0 then no data was identified for that uuid.
+                if (loopConditionCount == 0) {
+                    report.incrementNullRecords();
                 }
             }
 

--- a/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
@@ -120,6 +120,9 @@ public class ValidateApi {
     MetadataValidationRepository metadataValidationRepository;
 
     @Autowired
+    IMetadataUtils metadataUtils;
+
+    @Autowired
     protected ApplicationContext appContext;
 
     @Autowired
@@ -193,9 +196,12 @@ public class ValidateApi {
             for (String uuid : records) {
                 int loopConditionCount = 0;
                 for (AbstractMetadata record : metadataRepository.findAllByUuid(uuid)) {
+                    //determine if this is an approved record.
+                    Boolean isMetadataApproved = metadataUtils.isMetadataApproved(record.getId());
+
                     if (approved == null ||
-                        (approved == true && !(record instanceof MetadataDraft)) ||
-                        (approved == false && record instanceof MetadataDraft)) {
+                        (approved == true && isMetadataApproved) ||
+                        (approved == false && !isMetadataApproved)) {
                         loopConditionCount++;
                         // If we processed more than one record in this loop then we will also increase the total records
                         // as it means that we are processing both and approved and draft and that was not calculated in the original total.

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
@@ -187,7 +187,7 @@ public class XslProcessUtils {
                 // if there was any change in the record or not.
                 // Using hash on processMd and metadata ?
             } catch (Exception e) {
-                report.addMetadataError(iId, e);
+                report.addMetadataError(info, e);
                 context.error("  Processing failed with error " + e.getMessage());
                 context.error(e);
             }
@@ -290,7 +290,7 @@ public class XslProcessUtils {
                 // if there was any change in the record or not.
                 // Using hash on processMd and metadata ?
             } catch (Exception e) {
-                report.addMetadataError(iId, e);
+                report.addMetadataError(info, e);
                 context.error("  Processing failed with error " + e.getMessage());
                 context.error(e);
             }

--- a/services/src/main/java/org/fao/geonet/api/processing/report/MetadataProcessingReport.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/report/MetadataProcessingReport.java
@@ -173,7 +173,7 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
         try {
             metadataApproved = ApplicationContextHolder.get().getBean(IMetadataUtils.class).isMetadataApproved(metadataId);
         } catch (Exception e) {
-            throw new RuntimeException("Error detecting if metadata is draft");
+            throw new RuntimeException("Error detecting if metadata is approved");
         }
         return metadataApproved;
     }

--- a/services/src/main/java/org/fao/geonet/api/processing/report/MetadataProcessingReport.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/report/MetadataProcessingReport.java
@@ -23,6 +23,9 @@
 
 package org.fao.geonet.api.processing.report;
 
+import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.MetadataDraft;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -89,24 +92,38 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
         return metadataErrors;
     }
 
-    public synchronized void addMetadataError(int metadataId, Exception error) {
+    public synchronized void addMetadataError(int metadataId, String metadataUUID, boolean draft, Exception error) {
+        Report errorReport = new ErrorReport(error);
+        errorReport.setUuid(metadataUUID);
+        errorReport.setDraft(draft);
         if (this.metadataErrors.get(metadataId) == null) {
             List<Report> errors = new ArrayList<>();
-            errors.add(new ErrorReport(error));
+            errors.add(errorReport);
             this.metadataErrors.put(metadataId, errors);
         } else {
-            this.metadataErrors.get(metadataId).add(new ErrorReport(error));
+            this.metadataErrors.get(metadataId).add(errorReport);
         }
     }
 
-    public synchronized void addMetadataError(int metadataId, String error) {
+    public void addMetadataError(AbstractMetadata metadata, Exception error) {
+        addMetadataError(metadata.getId(), metadata.getUuid(), metadata instanceof MetadataDraft, error);
+    }
+
+    public synchronized void addMetadataError(int metadataId, String metadataUUID, boolean draft, String error) {
+        Report errorReport = new ErrorReport(error);
+        errorReport.setUuid(metadataUUID);
+        errorReport.setDraft(draft);
         if (this.metadataErrors.get(metadataId) == null) {
             List<Report> errors = new ArrayList<>();
-            errors.add(new ErrorReport(error));
+            errors.add(errorReport);
             this.metadataErrors.put(metadataId, errors);
         } else {
-            this.metadataErrors.get(metadataId).add(new ErrorReport(error));
+            this.metadataErrors.get(metadataId).add(errorReport);
         }
+    }
+
+    public void addMetadataError(AbstractMetadata metadata, String error) {
+        addMetadataError(metadata.getId(), metadata.getUuid(), metadata instanceof MetadataDraft, error);
     }
 
     @XmlElement(name = "infos")
@@ -114,14 +131,21 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
         return metadataInfos;
     }
 
-    public void addMetadataInfos(int metadataId, String message) {
+    public void addMetadataInfos(int metadataId, String metadataUUID, boolean draft, String message) {
+        InfoReport infoReport = new InfoReport(message);
+        infoReport.setUuid(metadataUUID);
+        infoReport.setDraft(draft);
         if (this.metadataInfos.get(metadataId) == null) {
             List<InfoReport> infos = new ArrayList<>();
-            infos.add(new InfoReport(message));
+            infos.add(infoReport);
             this.metadataInfos.put(metadataId, infos);
         } else {
-            this.metadataInfos.get(metadataId).add(new InfoReport(message));
+            this.metadataInfos.get(metadataId).add(infoReport);
         }
+    }
+
+    public void addMetadataInfos(AbstractMetadata metadata, String message) {
+        addMetadataInfos(metadata.getId(), metadata.getUuid(), metadata instanceof MetadataDraft, message);
     }
 
     @XmlTransient

--- a/services/src/main/java/org/fao/geonet/api/processing/report/MetadataProcessingReport.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/report/MetadataProcessingReport.java
@@ -23,8 +23,10 @@
 
 package org.fao.geonet.api.processing.report;
 
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.MetadataDraft;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -92,10 +94,12 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
         return metadataErrors;
     }
 
-    public synchronized void addMetadataError(int metadataId, String metadataUUID, boolean draft, Exception error) {
+    public synchronized void addMetadataError(int metadataId, String metadataUUID, boolean draft, boolean approved,
+                                              Exception error) {
         Report errorReport = new ErrorReport(error);
         errorReport.setUuid(metadataUUID);
         errorReport.setDraft(draft);
+        errorReport.setApproved(approved);
         if (this.metadataErrors.get(metadataId) == null) {
             List<Report> errors = new ArrayList<>();
             errors.add(errorReport);
@@ -106,13 +110,16 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
     }
 
     public void addMetadataError(AbstractMetadata metadata, Exception error) {
-        addMetadataError(metadata.getId(), metadata.getUuid(), metadata instanceof MetadataDraft, error);
+        addMetadataError(metadata.getId(), metadata.getUuid(), isMetadataDraft(metadata.getId()),
+            isMetadataApproved(metadata.getId()), error);
     }
 
-    public synchronized void addMetadataError(int metadataId, String metadataUUID, boolean draft, String error) {
+    public synchronized void addMetadataError(int metadataId, String metadataUUID, boolean draft, boolean approved,
+                                              String error) {
         Report errorReport = new ErrorReport(error);
         errorReport.setUuid(metadataUUID);
         errorReport.setDraft(draft);
+        errorReport.setApproved(approved);
         if (this.metadataErrors.get(metadataId) == null) {
             List<Report> errors = new ArrayList<>();
             errors.add(errorReport);
@@ -123,7 +130,8 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
     }
 
     public void addMetadataError(AbstractMetadata metadata, String error) {
-        addMetadataError(metadata.getId(), metadata.getUuid(), metadata instanceof MetadataDraft, error);
+        addMetadataError(metadata.getId(), metadata.getUuid(), isMetadataDraft(metadata.getId()),
+            isMetadataApproved(metadata.getId()), error);
     }
 
     @XmlElement(name = "infos")
@@ -131,10 +139,11 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
         return metadataInfos;
     }
 
-    public void addMetadataInfos(int metadataId, String metadataUUID, boolean draft, String message) {
+    public void addMetadataInfos(int metadataId, String metadataUUID, boolean draft, boolean approved, String message) {
         InfoReport infoReport = new InfoReport(message);
         infoReport.setUuid(metadataUUID);
         infoReport.setDraft(draft);
+        infoReport.setApproved(approved);
         if (this.metadataInfos.get(metadataId) == null) {
             List<InfoReport> infos = new ArrayList<>();
             infos.add(infoReport);
@@ -145,7 +154,28 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
     }
 
     public void addMetadataInfos(AbstractMetadata metadata, String message) {
-        addMetadataInfos(metadata.getId(), metadata.getUuid(), metadata instanceof MetadataDraft, message);
+        addMetadataInfos(metadata.getId(), metadata.getUuid(), isMetadataDraft(metadata.getId()),
+            isMetadataApproved(metadata.getId()), message);
+    }
+
+    private boolean isMetadataDraft(int metadataId) {
+        boolean metadataDraft = false;
+        try {
+            metadataDraft = ApplicationContextHolder.get().getBean(IMetadataUtils.class).isMetadataDraft(metadataId);
+        } catch (Exception e) {
+            throw new RuntimeException("Error detecting if metadata is draft");
+        }
+        return metadataDraft;
+    }
+
+    private boolean isMetadataApproved(int metadataId) {
+        boolean metadataApproved = false;
+        try {
+            metadataApproved = ApplicationContextHolder.get().getBean(IMetadataUtils.class).isMetadataApproved(metadataId);
+        } catch (Exception e) {
+            throw new RuntimeException("Error detecting if metadata is draft");
+        }
+        return metadataApproved;
     }
 
     @XmlTransient

--- a/services/src/main/java/org/fao/geonet/api/processing/report/Report.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/report/Report.java
@@ -31,6 +31,8 @@ import org.opengis.annotation.XmlElement;
  */
 public abstract class Report {
     private String message;
+    private String uuid;
+    private boolean draft;
     private ISODate date;
 
     public Report(String message) {
@@ -45,6 +47,26 @@ public abstract class Report {
 
     public Report setMessage(String message) {
         this.message = message;
+        return this;
+    }
+
+    @XmlElement(value = "uuid")
+    public String getUuid() {
+        return uuid;
+    }
+
+    public Report setUuid(String uuid) {
+        this.uuid = uuid;
+        return this;
+    }
+
+    @XmlElement(value = "isDraft")
+    public boolean isDraft() {
+        return draft;
+    }
+
+    public Report setDraft(boolean draft) {
+        this.draft = draft;
         return this;
     }
 

--- a/services/src/main/java/org/fao/geonet/api/processing/report/Report.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/report/Report.java
@@ -33,6 +33,7 @@ public abstract class Report {
     private String message;
     private String uuid;
     private boolean draft;
+    private boolean approved;
     private ISODate date;
 
     public Report(String message) {
@@ -60,13 +61,23 @@ public abstract class Report {
         return this;
     }
 
-    @XmlElement(value = "isDraft")
+    @XmlElement(value = "draft")
     public boolean isDraft() {
         return draft;
     }
 
     public Report setDraft(boolean draft) {
         this.draft = draft;
+        return this;
+    }
+
+    @XmlElement(value = "approved")
+    public boolean isApproved() {
+        return approved;
+    }
+
+    public Report setApproved(boolean approved) {
+        this.approved = approved;
         return this;
     }
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -308,7 +308,7 @@ public class MetadataInsertDeleteApi {
             }
             Pair<Integer, String> pair = loadRecord(metadataType, element, uuidProcessing, group, category,
                     rejectIfInvalid, publishToAll, transformWith, schema, extra, request);
-            report.addMetadataInfos(pair.one(), pair.two(), false, String.format("Metadata imported from XML with UUID '%s'", pair.two()));
+            report.addMetadataInfos(pair.one(), pair.two(), !publishToAll, false, String.format("Metadata imported from XML with UUID '%s'", pair.two()));
 
             triggerImportEvent(request, pair.two());
 
@@ -325,7 +325,7 @@ public class MetadataInsertDeleteApi {
                 if (xmlContent != null) {
                     Pair<Integer, String> pair = loadRecord(metadataType, xmlContent, uuidProcessing, group, category,
                             rejectIfInvalid, publishToAll, transformWith, schema, extra, request);
-                    report.addMetadataInfos(pair.one(), pair.two(), false,
+                    report.addMetadataInfos(pair.one(), pair.two(), !publishToAll, false,
                             String.format("Metadata imported from URL with UUID '%s'", pair.two()));
 
                     triggerImportEvent(request, pair.two());
@@ -371,7 +371,7 @@ public class MetadataInsertDeleteApi {
                                 uuidProcessing, transformWith, settingManager.getSiteId(), metadataType, category,
                                 group, rejectIfInvalid, assignToCatalog, context, f);
                         for (String id : ids) {
-                            report.addMetadataInfos(Integer.parseInt(id), id, false,
+                            report.addMetadataInfos(Integer.parseInt(id), id, !publishToAll, false,
                                     String.format("Metadata imported from MEF with id '%s'", id));
                             triggerCreationEvent(request, id);
 
@@ -386,7 +386,7 @@ public class MetadataInsertDeleteApi {
                     try {
                         Pair<Integer, String> pair = loadRecord(metadataType, Xml.loadFile(f), uuidProcessing, group,
                                 category, rejectIfInvalid, publishToAll, transformWith, schema, extra, request);
-                        report.addMetadataInfos(pair.one(), pair.two(), false,
+                        report.addMetadataInfos(pair.one(), pair.two(), !publishToAll, false,
                                 String.format("Metadata imported from server folder with UUID '%s'", pair.two()));
 
                         triggerCreationEvent(request, pair.two());
@@ -558,7 +558,7 @@ public class MetadataInsertDeleteApi {
                             throw new BadFormatEx("Import 0 record, check whether the importing file is a valid MEF archive.");
                         }
                         ids.forEach(e -> {
-                            report.addMetadataInfos(Integer.parseInt(e), e, false,
+                            report.addMetadataInfos(Integer.parseInt(e), e, !publishToAll, false,
                                     String.format("Metadata imported with ID '%s'", e));
 
                             try {
@@ -583,7 +583,7 @@ public class MetadataInsertDeleteApi {
                     Pair<Integer, String> pair = loadRecord(metadataType, Xml.loadStream(f.getInputStream()),
                             uuidProcessing, group, category, rejectIfInvalid, publishToAll, transformWith, schema,
                             extra, request);
-                    report.addMetadataInfos(pair.one(), pair.two(), false, String.format("Metadata imported with UUID '%s'", pair.two()));
+                    report.addMetadataInfos(pair.one(), pair.two(), !publishToAll, false, String.format("Metadata imported with UUID '%s'", pair.two()));
 
                     triggerImportEvent(request, pair.two());
 
@@ -724,7 +724,7 @@ public class MetadataInsertDeleteApi {
         }
 
         dataManager.indexMetadata(id);
-        report.addMetadataInfos(Integer.parseInt(id.get(0)), uuid, false, uuid);
+        report.addMetadataInfos(Integer.parseInt(id.get(0)), uuid, !publishToAll, false, uuid);
 
         triggerCreationEvent(request, uuid);
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -308,7 +308,7 @@ public class MetadataInsertDeleteApi {
             }
             Pair<Integer, String> pair = loadRecord(metadataType, element, uuidProcessing, group, category,
                     rejectIfInvalid, publishToAll, transformWith, schema, extra, request);
-            report.addMetadataInfos(pair.one(), String.format("Metadata imported from XML with UUID '%s'", pair.two()));
+            report.addMetadataInfos(pair.one(), pair.two(), false, String.format("Metadata imported from XML with UUID '%s'", pair.two()));
 
             triggerImportEvent(request, pair.two());
 
@@ -325,7 +325,7 @@ public class MetadataInsertDeleteApi {
                 if (xmlContent != null) {
                     Pair<Integer, String> pair = loadRecord(metadataType, xmlContent, uuidProcessing, group, category,
                             rejectIfInvalid, publishToAll, transformWith, schema, extra, request);
-                    report.addMetadataInfos(pair.one(),
+                    report.addMetadataInfos(pair.one(), pair.two(), false,
                             String.format("Metadata imported from URL with UUID '%s'", pair.two()));
 
                     triggerImportEvent(request, pair.two());
@@ -371,7 +371,7 @@ public class MetadataInsertDeleteApi {
                                 uuidProcessing, transformWith, settingManager.getSiteId(), metadataType, category,
                                 group, rejectIfInvalid, assignToCatalog, context, f);
                         for (String id : ids) {
-                            report.addMetadataInfos(Integer.parseInt(id),
+                            report.addMetadataInfos(Integer.parseInt(id), id, false,
                                     String.format("Metadata imported from MEF with id '%s'", id));
                             triggerCreationEvent(request, id);
 
@@ -386,7 +386,7 @@ public class MetadataInsertDeleteApi {
                     try {
                         Pair<Integer, String> pair = loadRecord(metadataType, Xml.loadFile(f), uuidProcessing, group,
                                 category, rejectIfInvalid, publishToAll, transformWith, schema, extra, request);
-                        report.addMetadataInfos(pair.one(),
+                        report.addMetadataInfos(pair.one(), pair.two(), false,
                                 String.format("Metadata imported from server folder with UUID '%s'", pair.two()));
 
                         triggerCreationEvent(request, pair.two());
@@ -558,7 +558,7 @@ public class MetadataInsertDeleteApi {
                             throw new BadFormatEx("Import 0 record, check whether the importing file is a valid MEF archive.");
                         }
                         ids.forEach(e -> {
-                            report.addMetadataInfos(Integer.parseInt(e),
+                            report.addMetadataInfos(Integer.parseInt(e), e, false,
                                     String.format("Metadata imported with ID '%s'", e));
 
                             try {
@@ -583,7 +583,7 @@ public class MetadataInsertDeleteApi {
                     Pair<Integer, String> pair = loadRecord(metadataType, Xml.loadStream(f.getInputStream()),
                             uuidProcessing, group, category, rejectIfInvalid, publishToAll, transformWith, schema,
                             extra, request);
-                    report.addMetadataInfos(pair.one(), String.format("Metadata imported with UUID '%s'", pair.two()));
+                    report.addMetadataInfos(pair.one(), pair.two(), false, String.format("Metadata imported with UUID '%s'", pair.two()));
 
                     triggerImportEvent(request, pair.two());
 
@@ -724,7 +724,7 @@ public class MetadataInsertDeleteApi {
         }
 
         dataManager.indexMetadata(id);
-        report.addMetadataInfos(Integer.parseInt(id.get(0)), uuid);
+        report.addMetadataInfos(Integer.parseInt(id.get(0)), uuid, false, uuid);
 
         triggerCreationEvent(request, uuid);
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
@@ -276,8 +276,8 @@ public class MetadataSampleApi {
                         }
                         if (dataManager.existsMetadataUuid(uuid)) {
                             String upid = dataManager.getMetadataId(uuid);
-                            dataManager.updateMetadata(context, upid, xml, false, true, false, context.getLanguage(), null, true); 
-                            report.addMetadataInfos(Integer.parseInt(upid), 
+                            AbstractMetadata metadata = dataManager.updateMetadata(context, upid, xml, false, true, false, context.getLanguage(), null, true);
+                            report.addMetadataInfos(metadata,
                             String.format(
                             "Template for schema '%s' with UUID '%s' updated.",
                             schemaName, uuid));
@@ -296,7 +296,7 @@ public class MetadataSampleApi {
                                 setOwner(owner).
                                 setGroupOwner(1);
                             dataManager.insertMetadata(context, metadata, xml, true, true, true, UpdateDatestamp.NO, false, false);
-                            report.addMetadataInfos(metadata.getId(), 
+                            report.addMetadataInfos(metadata,
                             String.format(
                             "Template for schema '%s' with UUID '%s' added.",
                             schemaName, metadata.getUuid()));

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -452,7 +452,7 @@ public class MetadataSharingApi {
                                 // If building a report of the sharing, annotate the error and continue
                                 // processing the other group privileges, otherwise throw the exception
                                 if (report != null) {
-                                    report.addMetadataError(metadata.getId(), ex.getMessage());
+                                    report.addMetadataError(metadata, ex.getMessage());
                                     break;
                                 } else {
                                     throw ex;
@@ -881,7 +881,7 @@ public class MetadataSharingApi {
                     String.valueOf(metadata.getId()),
                     String.valueOf(groupIdentifier),
                     false);
-                report.addMetadataInfos(metadata.getId(), String.format(
+                report.addMetadataInfos(metadata, String.format(
                     "No privileges for user '%s' on metadata '%s', so setting default privileges",
                     sourceUsr, metadata.getUuid()
                 ));

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -329,7 +329,7 @@ public class MetadataTagApi {
                                 info.getCategories().add(category);
                                 listOfUpdatedRecords.add(String.valueOf(info.getId()));
                             } else {
-                                report.addMetadataInfos(info.getId(), String.format(
+                                report.addMetadataInfos(info, String.format(
                                     "Can't assign non existing category with id '%d' to record '%s'",
                                     c, info.getUuid()
                                 ));

--- a/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
@@ -231,7 +231,7 @@ public class BatchEditsApi implements ApplicationContextAware {
                             validate, ufo, index,
                             "eng", // Not used when validate is false
                             changeDate, uds);
-                        report.addMetadataInfos(record.getId(), "Metadata updated.");
+                        report.addMetadataInfos(record, "Metadata updated.");
 
                         Element afterMetadata = dataMan.getMetadata(serviceContext, String.valueOf(record.getId()), false, false, false);
                         XMLOutputter outp = new XMLOutputter();
@@ -240,7 +240,7 @@ public class BatchEditsApi implements ApplicationContextAware {
                         new RecordUpdatedEvent(record.getId(), userSession.getUserIdAsInt(), xmlBefore, xmlAfter).publish(appContext);
                     }
                 } catch (Exception e) {
-                    report.addMetadataError(record.getId(), e);
+                    report.addMetadataError(record, e);
                 }
                 report.incrementProcessedRecords();
             }

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
@@ -310,7 +310,7 @@ public class DirectoryApi {
                             collectResults.getEntryIdentifiers().values()
                         );
                         report.incrementProcessedRecords();
-                        report.addMetadataInfos(record.getId(), String.format(
+                        report.addMetadataInfos(record, String.format(
                             "%d entry(ies) extracted from record '%s'. UUID(s): %s",
                             collectResults.getEntryIdentifiers().size(),
                             record.getUuid(),
@@ -320,7 +320,7 @@ public class DirectoryApi {
                         listOfEntries.addAll(collectResults.getEntries().values());
                     }
                 } catch (Exception ex) {
-                    report.addMetadataError(record.getId(), ex);
+                    report.addMetadataError(record, ex);
                 }
             }
         }
@@ -499,9 +499,9 @@ public class DirectoryApi {
                                 validate, ufo, index, context.getLanguage(),
                                 new ISODate().toString(), true);
                             listOfRecordInternalId.add(record.getId());
-                            report.addMetadataInfos(record.getId(), "Metadata updated.");
+                            report.addMetadataInfos(record, "Metadata updated.");
                         } catch (Exception e) {
-                            report.addMetadataError(record.getId(), e);
+                            report.addMetadataError(record, e);
                         }
                     } else {
                         if (collectResults.isRecordUpdated()) {
@@ -510,7 +510,7 @@ public class DirectoryApi {
                     }
                     report.incrementProcessedRecords();
                 } catch (Exception e) {
-                    report.addMetadataError(record.getId(), e);
+                    report.addMetadataError(record, e);
                 }
             }
         }


### PR DESCRIPTION
Updated validation api so that it supports passing the approved flag so that it is possible to validate approved records only when workflow is enabled and there is a working copy.

Also updated the report so that it indicates uuid of the record and if it is a draft or not.  This also help clarify the report so that we know what record is valid/invalid.

Also fixed bug where numberOfRecords was set to "0"

There was another bug in which all validations seemed to fail with errors if there was a report. It was only checking for the existence of the report instead of check if the report contained failedAssert or failedSchematronVerification errors.

Prior to this update validating a record with a working copy will produce something like the following.

```
{
  "errors": [],
  "infos": [],
  "uuid": "d96c8a52-79d3-486a-8f7f-fc46e9fbf224",
  "metadata": [
    116,
    135
  ],
  "metadataErrors": {
    "116": [
      {
        "message": "Is invalid",
        "date": "2020-12-02T07:41:32",
        "stack": ""
      }
    ],
    "135": [
      {
        "message": "Is invalid",
        "date": "2020-12-02T07:41:32",
        "stack": ""
      }
    ]
  },
  "metadataInfos": {},
  "numberOfRecordNotFound": 0,
  "numberOfRecordsNotEditable": 0,
  "numberOfRecordsWithErrors": 2,
  "numberOfRecords": 0,
  "numberOfNullRecords": 0,
  "numberOfRecordsProcessed": 2,
  "type": "SimpleMetadataProcessingReport",
  "running": false,
  "ellapsedTimeInSeconds": 2,
  "startIsoDateTime": "2020-12-02T07:41:31",
  "totalTimeInSeconds": 2,
  "endIsoDateTime": "2020-12-02T07:41:33"
}
```

Based on this, we don't know if this was just one metadata uuid or multiple? And we cannot tell which one is the draft/working copy.

After these changes are applied, the report will look like the following.

```
{
  "errors": [],
  "infos": [],
  "uuid": "626b8a49-621a-42cc-ba84-eaa67b7bf71b",
  "metadata": [
    116,
    135
  ],
  "metadataErrors": {
    "116": [
      {
        "message": "Is invalid",
        "uuid": "da165110-88fd-11da-a88f-000d939bc5d8",
        "draft": false,
        "date": "2020-12-02T12:03:16",
        "stack": ""
      }
    ]
  },
  "metadataInfos": {
    "135": [
      {
        "message": "Is valid",
        "uuid": "da165110-88fd-11da-a88f-000d939bc5d8",
        "draft": true,
        "date": "2020-12-02T12:03:29"
      }
    ]
  },
  "numberOfRecordsNotEditable": 0,
  "numberOfRecordNotFound": 0,
  "numberOfRecords": 2,
  "numberOfNullRecords": 0,
  "numberOfRecordsWithErrors": 1,
  "numberOfRecordsProcessed": 2,
  "type": "SimpleMetadataProcessingReport",
  "running": false,
  "totalTimeInSeconds": 26,
  "startIsoDateTime": "2020-12-02T12:03:06",
  "endIsoDateTime": "2020-12-02T12:03:32",
  "ellapsedTimeInSeconds": 26
}
```

