### PR TITLE
User search improvement.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchesbutton.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchesbutton.html
@@ -11,12 +11,14 @@
   <span class="sr-only" data-translate="">search</span>
   </button>
   <ul class="dropdown-menu">
-    <li data-ng-repeat="row in featuredSearches | orderBy:sortByLabel">
+    <li data-ng-repeat="row in featuredSearches | orderBy:sortByLabel"
+        data-ng-init="name = (row.names[lang] || row.names['eng'] || ('userSearchNameMissing' | translate))"
+        title="{{::name.indexOf('|') ? name.split('|')[1] : ''}}">
       <a data-ng-click="search(row.url)">
-        {{row.names[lang] || row.names['eng'] || ('userSearchNameMissing' | translate)}}
+        {{::name.indexOf('|') ? name.split('|')[0] : name}}
 
-        <img data-ng-if="row.logo"
-             data-ng-src="{{row.logo}}"
+        <img data-ng-if="::row.logo"
+             data-ng-src="{{::row.logo}}"
              class="gn-source-logo"/>
       </a>
     </li>

--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchescards.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchescards.html
@@ -2,19 +2,21 @@
   <li
     data-ng-repeat="row in featuredSearches"
     data-ng-click="search(row.url)"
+    data-ng-init="name = (row.names[lang] || row.names['eng'] || ('userSearchNameMissing' | translate))"
     id="gn-info-list-mw-{row.id}}">
     <section class="resultcard clearfix"
+             title="{{::name.indexOf('|') ? name.split('|')[1] : ''}}"
              data-ng-class="row.url ? 'hasThumbnail' : 'noThumbnail'">
 
       <div class="title">
         <a>
-          <h4>{{row.names[lang] || row.names['eng'] || ('userSearchNameMissing' | translate)}}&nbsp;</h4>
+          <h4>{{::name.indexOf('|') ? name.split('|')[0] : name}}</h4>
         </a>
       </div>
 
       <div class="gn-md-thumbnail">
         <div class="gn-img-thumbnail"
-             style="background-image: url({{row.logo}})">
+             style="background-image: url({{::row.logo}})">
         </div>
       </div>
     </section>

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -170,6 +170,9 @@
       .text-overflow();
     }
   }
+  [data-gn-user-searches-list] .dropdown-menu {
+    width: auto;
+  }
 }
 .gn-icon-bg {
   height: 130px;


### PR DESCRIPTION
* If portal use a description, use it as tooltip.

![image](https://user-images.githubusercontent.com/1701393/101025083-5517c900-3575-11eb-98a9-57b999c83688.png)


* Adjust menu size to text
.

Before was:

![image](https://user-images.githubusercontent.com/1701393/101025099-5a751380-3575-11eb-98a6-388deb2da16c.png)
