### PR TITLE
Map / WPS / Set crs attribute of wps:BoundingBoxData.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -206,10 +206,11 @@
               // {type=bing_aerial} (mapquest, osm ...)
               // {type=arcgis,name=0,1,2}
               // type=wms,name=lll
-              type = layer.name.match(reT) ? reT.exec(layer.name)[1] : null;
+              type = layer.name && layer.name.match(reT) ?
+                reT.exec(layer.name)[1] : null;
               if (type && type != 'wmts' && type != 'wms' && type != 'arcgis') {
                 var opt;
-                if (layer.name.match(reL)) {
+                if (layer.name && layer.name.match(reL)) {
                   var lyr = reL.exec(layer.name)[1];
 
                   if (layer.server) {
@@ -619,7 +620,7 @@
         var res = server.onlineResource[0];
         var createOnly = angular.isDefined(bgIdx) || angular.isDefined(index);
 
-        if (layer.name.match(reT)) {
+        if (layer.name && layer.name.match(reT)) {
           var type = reT.exec(layer.name)[1];
           var name = reL.exec(layer.name)[1];
           var promise;

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -247,6 +247,7 @@
               data: {
                 boundingBoxData: {
                   dimensions: 2,
+                  crs: 'EPSG:4326',
                   lowerCorner: [bbox[0], bbox[1]],
                   upperCorner: [bbox[2], bbox[3]]
                 }


### PR DESCRIPTION
It is usually good practice to indicate CRS of coordinates

```
 <wps:DataInputs>
    <wps:Input>
      <ows:Identifier>bbox</ows:Identifier>
      <wps:Data>
        <wps:BoundingBoxData dimensions="2" crs="EPSG:4326">
          <ows:LowerCorner>0.237 40.562</ows:LowerCorner>
          <ows:UpperCorner>14.593 44.55</ows:UpperCorner>
        </wps:BoundingBoxData>
      </wps:Data>
    </wps:Input>
```

Also fix issue on map context loading if layername is undefined.
