### PR TITLE
Update Remote INSPIRE Atom feeds to process dataset feeds from service feeds

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
@@ -37,6 +37,7 @@ import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.InspireAtomFeed;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
+import org.fao.geonet.inspireatom.model.DatasetFeedInfo;
 import org.fao.geonet.inspireatom.util.InspireAtomUtil;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
@@ -119,9 +120,9 @@ public class InspireAtomHarvester {
             logger.info("ATOM feed harvest: processing service metadata feeds (" + serviceMetadataWithAtomFeeds.size() + ")");
 
             // Process SERVICE metadata feeds
-            //    datasetsInformation stores the dataset information for identifier and namespace for the services feed.
-            //    This information is not available in the datasets feeds
-            Map<String, String> datasetsInformation =
+            //    datasetsInformation stores the dataset information for identifier, namespace and feed url
+            //    described in the services feed. This information is not available in the datasets feeds.
+            List<DatasetFeedInfo> datasetsInformation =
                 processServiceMetadataFeeds(dataMan, serviceMetadataWithAtomFeeds, result);
 
             // Process DATASET metadata feeds related to the service metadata
@@ -157,8 +158,8 @@ public class InspireAtomHarvester {
         final IMetadataUtils metadataUtils = gc.getBean(IMetadataUtils.class);
         AbstractMetadata iso19139Metadata = metadataUtils.findOne(
         		Specifications.where((Specification<Metadata>) MetadataSpecs.isType(MetadataType.METADATA))
-        			.and((Specification<Metadata>) MetadataSpecs.isIso19139Schema()));
-
+        			.and((Specification<Metadata>) MetadataSpecs.isIso19139Schema())
+                    .and((Specification<Metadata>)MetadataSpecs.hasMetadataId(Integer.parseInt(metadataId))));
 
         Element result = new Element("response");
 
@@ -182,12 +183,12 @@ public class InspireAtomHarvester {
             Map<String, String> serviceMetadataWithAtomFeed =
                 InspireAtomUtil.retrieveServiceMetadataWithAtomFeed(dataMan, iso19139Metadata, atomProtocol);
 
-            Map<String, String> datasetsInformation =
+            List<DatasetFeedInfo> datasetsInformation =
                 processServiceMetadataFeeds(dataMan, serviceMetadataWithAtomFeed, result);
 
             // Process dataset metadata feeds related to the service metadata
             logger.info("ATOM feed harvest for metadata: " + metadataId + ",  processing dataset metadata feeds");
-            processDatasetsMetadataFeedsForService(context, dataMan, datasetsInformation, result);
+            processDatasetsMetadataFeeds(context, dataMan, datasetsInformation, result);
 
             logger.info("ATOM feed harvest finished for metadata: " + metadataId);
         } catch (Exception x) {
@@ -204,12 +205,12 @@ public class InspireAtomHarvester {
      * dataset-namespace). The namespace is only available in the service feeds. Dataset feeds seem
      * not containing this information.
      */
-    private Map<String, String> processServiceMetadataFeeds(final DataManager dataMan,
+    private List<DatasetFeedInfo> processServiceMetadataFeeds(final DataManager dataMan,
                                                             final Map<String, String> serviceMetadataWithAtomFeeds,
                                                             Element result)
         throws Exception {
 
-        Map<String, String> datasetsInformation = new HashMap<String, String>();
+        List<DatasetFeedInfo> datasetsInformation = new ArrayList<>();
 
         final InspireAtomFeedRepository repository = gc.getBean(InspireAtomFeedRepository.class);
 
@@ -244,7 +245,6 @@ public class InspireAtomHarvester {
                 inspireAtomFeed.setAtomDatasetid("");
                 inspireAtomFeed.setAtomDatasetns("");
 
-
                 repository.save(inspireAtomFeed);
 
                 // Index the metadata to store the atom feed information in the index
@@ -254,27 +254,18 @@ public class InspireAtomHarvester {
                 // Extract datasets information (identifier, namespace) from the service feed:
                 //      The namespace is only available in service feed and no in dataset feeds.
                 //      Also NGR metadata uses MD_Identifier instead of RS_Identifier so lacks of this information
-                logger.debug("Extract datasets information (identifier, namespace) from service atom feed for service metadata (" + metadataUuid + ")");
-                Element serviceFeed = Xml.loadString(atomFeedDocument, false);
+                logger.debug("Extract datasets information (identifier, namespace) from service atom feed  (" + atomUrl + ")");
 
-                java.nio.file.Path defaultStyleSheet = dataMan.getSchemaDir("iso19139").resolve(EXTRACT_DATASETS_FROM_SERVICE_XSLT);
+                datasetsInformation.addAll(InspireAtomUtil.extractRelatedDatasetsInfoFromServiceFeed(atomFeedDocument, dataMan));
 
-                Map<String, Object> params = new HashMap<String, Object>();
-                Element atomIndexFields = Xml.transform(serviceFeed, defaultStyleSheet, params);
-                logger.info("Number of datasets from service atom feed for service metadata (" + metadataUuid + "):" + atomIndexFields.getChildren().size());
-                for (Object field : atomIndexFields.getChildren()) {
-                    Element f = (Element) field;
-
-                    datasetsInformation.put(f.getChildText("identifier"), f.getChildText("namespace"));
-                    logger.debug("Dataset, id=" + f.getChildText("identifier") + ", namespace=" + f.getChildText("namespace"));
-                }
-
-                result.addContent(new Element("feed").setAttribute("uuid", metadataUuid).setAttribute("feed", atomUrl).setAttribute("status", "ok"));
+                result.addContent(new Element("feed").setAttribute("uuid", metadataUuid)
+                    .setAttribute("feed", atomUrl).setAttribute("status", "ok"));
             } catch (Exception ex) {
                 // Log exception and continue processing the other metadata
                 logger.error("Failed to process atom feed for service metadata: " + metadataUuid + " " + ex.getMessage());
                 logger.error(ex);
-                result.addContent(new Element("feed").setAttribute("uuid", metadataUuid).setAttribute("error", ex.getMessage()).setAttribute("status", "error"));
+                result.addContent(new Element("feed").setAttribute("uuid", metadataUuid)
+                    .setAttribute("error", ex.getMessage()).setAttribute("status", "error"));
             }
         }
 
@@ -286,44 +277,56 @@ public class InspireAtomHarvester {
      * Process dataset metadata feeds.
      */
     private void processDatasetsMetadataFeeds(final DataManager dataMan,
-                                              final Map<String, String> datasetsInformation,
+                                              final List<DatasetFeedInfo> datasetsFeedInformation,
                                               Element result)
         throws Exception {
 
-        // Retrieve the metadata referencing atom feed documents.
+        processDatasetsMetadataFeeds(ServiceContext.get(), dataMan, datasetsFeedInformation, result);
+    }
 
-        // Value used in metadata editor for online resources to identify an INSPIRE atom resource
-        String atomProtocol = gc.getBean(SettingManager.class).getValue(Settings.SYSTEM_INSPIRE_ATOM_PROTOCOL);
+    /**
+     * Process the feeds for a set datasets related to a service metadata.
+     *
+     * @param datasetsFeedInformation Datasets map (datasetid, namespace)
+     */
+    private void processDatasetsMetadataFeeds(final ServiceContext context,
+                                              final DataManager dataMan,
+                                              final List<DatasetFeedInfo> datasetsFeedInformation,
+                                              final Element result)
+        throws Exception {
 
         final InspireAtomFeedRepository repository = gc.getBean(InspireAtomFeedRepository.class);
 
-        List<AbstractMetadata> iso19139Metadata = InspireAtomUtil.searchMetadataByTypeAndProtocol(ServiceContext.get(),
-            gc.getBean(SearchManager.class), "dataset", atomProtocol);
-
-        Map<String, String> metadataWithAtomFeeds =
-            InspireAtomUtil.retrieveDatasetMetadataWithAtomFeeds(dataMan, iso19139Metadata, atomProtocol);
-
-        long total = metadataWithAtomFeeds.entrySet().size();
+        long total = datasetsFeedInformation.size();
         long i = 1;
 
         // Process the metadata retrieving the atom feed content and store it in the catalog.
-        for (Map.Entry<String, String> entry : metadataWithAtomFeeds.entrySet()) {
-            String metadataId = entry.getKey();
-            String metadataUuid = dataMan.getMetadataUuid(metadataId);
+        for(DatasetFeedInfo datasetFeedInfo: datasetsFeedInformation) {
+            String metadataUuid = "";
 
             try {
-                logger.info("Processing feed (" + i++ + "/"+ total + ") for dataset metadata with uuid:" + metadataUuid);
+                // Find the metadata UUID using the resource identifier gmd:MD_Identifier/gmd:code
+                metadataUuid = InspireAtomUtil.retrieveDatasetUuidFromIdentifier(ServiceContext.get(),
+                    gc.getBean(SearchManager.class), datasetFeedInfo.identifier);
 
-                Element md = dataMan.getMetadata(metadataId);
+                String atomUrl = datasetFeedInfo.feedUrl;
 
-                java.nio.file.Path styleSheet = dataMan.getSchemaDir("iso19139").resolve(EXTRACT_DATASET_ID_XSLT);
+                logger.info("Processing feed (" + i++ + "/"+ total + ") for dataset metadata with uuid:" + metadataUuid + ", feed url: " + atomUrl);
 
-                String atomDatasetId = Xml.transform(md, styleSheet).getText();
-                String atomDatasetNs = datasetsInformation.get(atomDatasetId);
-                logger.debug("Dataset, id=" + atomDatasetId + ", namespace=" + atomDatasetNs);
+                if (StringUtils.isEmpty(metadataUuid)) {
+                    logger.warning("Metadata with dataset identifier (" + datasetFeedInfo.identifier + ") is not available. Skip dataset feed processing");
+                    continue;
+                }
 
-                String atomUrl = entry.getValue();
-                logger.debug("Dataset, feedurl=" + atomUrl);
+                if (!atomUrl.toLowerCase().endsWith(".xml")) {
+                    logger.warning("Atom feed Document (" + atomUrl + ") for dataset metadata (" + metadataUuid + ") is not a valid feed");
+                    continue;
+                }
+
+                String metadataId = dataMan.getMetadataId(metadataUuid);
+
+                logger.debug("Dataset, id=" + datasetFeedInfo.identifier + ", namespace=" + datasetFeedInfo.namespace);
+
                 String atomFeedDocument = InspireAtomUtil.retrieveRemoteAtomFeedDocument(gc, atomUrl);
                 logger.debug("Dataset feed: " + atomFeedDocument);
 
@@ -337,8 +340,8 @@ public class InspireAtomHarvester {
 
                 InspireAtomFeed inspireAtomFeed = InspireAtomFeed.build(atomDoc);
                 inspireAtomFeed.setMetadataId(Integer.parseInt(metadataId));
-                inspireAtomFeed.setAtomDatasetid(atomDatasetId);
-                inspireAtomFeed.setAtomDatasetns(atomDatasetNs);
+                inspireAtomFeed.setAtomDatasetid(datasetFeedInfo.identifier);
+                inspireAtomFeed.setAtomDatasetns(datasetFeedInfo.namespace);
                 inspireAtomFeed.setAtomUrl(atomUrl);
                 inspireAtomFeed.setAtom(atomFeedDocument);
 
@@ -346,8 +349,8 @@ public class InspireAtomHarvester {
 
                 // Index the metadata to store the atom feed information in the index
                 dataMan.indexMetadata(Arrays.asList(new String[]{metadataId}));
-                result.addContent(new Element("feed").setAttribute("uuid", metadataUuid).setAttribute("feed", atomUrl).setAttribute("status", "ok"));
-
+                result.addContent(new Element("feed").setAttribute("uuid", metadataUuid)
+                    .setAttribute("feed", atomUrl).setAttribute("status", "ok"));
             } catch (Exception ex) {
                 // Log exception and continue processing the other metadata
                 logger.error("Failed to process atom feed for dataset metadata: " + metadataUuid + " " + ex.getMessage());
@@ -361,11 +364,10 @@ public class InspireAtomHarvester {
     /**
      * Process the feeds for a set datasets related to a service metadata.
      *
-     * @param datasetsInformation Datasets map (datasetid, namespace)
      */
     private void processDatasetsMetadataFeedsForService(final ServiceContext context,
                                                         final DataManager dataMan,
-                                                        final Map<String, String> datasetsInformation,
+                                                        final List<DatasetFeedInfo> datasetsFeedInformation,
                                                         final Element result)
         throws Exception {
 
@@ -376,21 +378,16 @@ public class InspireAtomHarvester {
 
         final InspireAtomFeedRepository repository = gc.getBean(InspireAtomFeedRepository.class);
 
-        long total = datasetsInformation.entrySet().size();
-        long i = 1;
-
         // Process the metadata retrieving the atom feed content and store it in the catalog.
-        for (Map.Entry<String, String> entry : datasetsInformation.entrySet()) {
-            String atomDatasetId = entry.getKey();
+        for(DatasetFeedInfo datasetFeedInfo: datasetsFeedInformation) {
+            String atomDatasetId = datasetFeedInfo.identifier;
             String metadataUuid = "";
 
             try {
                 metadataUuid = InspireAtomUtil.retrieveDatasetUuidFromIdentifier(context,
                     gc.getBean(SearchManager.class), atomDatasetId);
 
-                logger.info("Processing feed (" + i++ + "/"+ total + ") for dataset metadata with uuid:" + metadataUuid);
-
-                String atomDatasetNs = entry.getValue();
+                String atomDatasetNs = datasetFeedInfo.namespace;
                 logger.debug("Dataset, id=" + atomDatasetId + ", namespace=" + atomDatasetNs);
 
                 if (StringUtils.isEmpty(metadataUuid)) {
@@ -398,13 +395,12 @@ public class InspireAtomHarvester {
                     continue;
                 }
 
+                logger.info("Processing feed for dataset metadata with uuid:" + metadataUuid);
 
                 String metadataId = dataMan.getMetadataId(metadataUuid);
-                String schema = dataMan.getMetadataSchema(metadataId);
-                Element mdEl = dataMan.getMetadata(metadataId);
 
                 // Get the atom feed url for the dataset
-                String atomUrl = InspireAtomUtil.extractAtomFeedUrl(schema, mdEl, dataMan, atomProtocol);
+                String atomUrl = datasetFeedInfo.feedUrl;
                 logger.debug("Dataset, feedurl=" + atomUrl);
 
                 // Retrieve the atom document and store it.

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/model/DatasetFeedInfo.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/model/DatasetFeedInfo.java
@@ -1,0 +1,28 @@
+package org.fao.geonet.inspireatom.model;
+
+/**
+ * Dataset feed information.
+ */
+public class DatasetFeedInfo {
+    public String identifier;
+    public String namespace;
+    public String feedUrl;
+
+    public DatasetFeedInfo(String identifier, String namespace, String feedUrl) {
+        this.identifier = identifier;
+        this.namespace = namespace;
+        this.feedUrl = feedUrl;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getFeedUrl() {
+        return feedUrl;
+    }
+}

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-datasetinfo-from-service-feed.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-datasetinfo-from-service-feed.xsl
@@ -28,7 +28,7 @@
 >
   <xsl:template match="atom:feed">
     <datasets>
-      <xsl:for-each select="atom:entry[inspire_dls:spatial_dataset_identifier_code]">
+      <xsl:for-each select="atom:entry[inspire_dls:spatial_dataset_identifier_code and atom:link[@type='application/atom+xml']]">
         <dataset>
           <identifier>
             <xsl:value-of select="inspire_dls:spatial_dataset_identifier_code"/>
@@ -36,6 +36,9 @@
           <namespace>
             <xsl:value-of select="inspire_dls:spatial_dataset_identifier_namespace"/>
           </namespace>
+          <feedUrl>
+            <xsl:value-of select="atom:link[@type='application/atom+xml']/@href"/>
+          </feedUrl>
         </dataset>
       </xsl:for-each>
     </datasets>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -711,7 +711,7 @@
           <xsl:variable name="title"
                         select="normalize-space(gmd:name/gco:CharacterString|gmd:name/gmx:MimeFileType)"/>
           <xsl:variable name="desc" select="normalize-space(gmd:description/gco:CharacterString)"/>
-          <xsl:variable name="protocol" select="normalize-space(gmd:protocol/gco:CharacterString)"/>
+          <xsl:variable name="protocol" select="normalize-space(gmd:protocol/*/text())"/>
           <xsl:variable name="mimetype"
                         select="geonet:protocolMimeType($linkage, $protocol, gmd:name/gmx:MimeFileType/@type)"/>
 


### PR DESCRIPTION
This pull request updates remote INSPIRE Atom feeds processing to extract the dataset feeds directly from the service feeds referenced in the service metadata.

In the previous implementation, dataset feeds were extracted from the dataset metadata referenced in the service metadata, but it's not mandatory that dataset metadata references the feed documents, causing missing values in these cases.
