### PR TITLE
Translate AccessDeniedException description to French language and parse to Javascript Controller accordingly.

### DIFF
--- a/core/src/main/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages.properties
@@ -130,3 +130,4 @@ self_registration_disabled=User self-registration is disabled
 recaptcha_not_valid=Recaptcha is not valid
 metadata.title.createdFromTemplate=Copy of template %s created at %s
 metadata.title.createdFromRecord=Copy of record %s created at %s
+access.denied.error=Access is denied

--- a/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
@@ -103,3 +103,4 @@ self_registration_disabled=User self-registration is disabled
 recaptcha_not_valid=Recaptcha is not valid
 metadata.title.createdFromTemplate=Copie du mod\u00e8le %s cr\u00E9\u00E9e le %s
 metadata.title.createdFromRecord=Copie de la fiche %s cr\u00E9\u00E9e le %s
+access.denied.error=L'acc\u0350s est refus\u0351

--- a/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
+++ b/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
@@ -25,11 +25,13 @@ package org.fao.geonet.api;
 
 import com.google.common.collect.Sets;
 import org.fao.geonet.api.exception.*;
+import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.doi.client.DoiClientException;
 import org.fao.geonet.exceptions.ServiceNotAllowedEx;
 import org.fao.geonet.exceptions.UserNotFoundEx;
 import org.fao.geonet.exceptions.XSDValidationErrorEx;
 import org.json.JSONException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.InvalidMediaTypeException;
@@ -57,6 +59,9 @@ import java.util.stream.Collectors;
  */
 @ControllerAdvice
 public class GlobalExceptionController {
+
+    @Autowired
+    private LanguageUtils languageUtils;
 
     @ResponseBody
     @ResponseStatus(HttpStatus.FORBIDDEN)
@@ -86,8 +91,14 @@ public class GlobalExceptionController {
         SecurityException.class,
         AccessDeniedException.class
     })
-    public Object securityHandler(final Exception exception) {
-        return new ApiError("forbidden", exception.getClass().getSimpleName(), exception.getMessage());
+    public Object securityHandler(final HttpServletRequest request, final Exception exception) {
+        //Translate error description to front end.
+        Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
+        String language = locale.getISO3Language();
+        ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
+
+        return new ApiError("forbidden", exception.getClass().getSimpleName(), messages.getString("access.denied.error"));
+
     }
 
     @ResponseBody

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -519,7 +519,7 @@
               $scope.saveError = true;
               $rootScope.$broadcast('StatusUpdated', {
                 title: $translate.instant('saveMetadataError'),
-                error: error,
+                error: error.message.toString().contains("AccessDeniedException")? $translate.instant('accessDenied'):error,
                 timeout: 0,
                 type: 'danger'});
             });
@@ -559,7 +559,8 @@
                 closeEditor();
               }, function(reason) {
                 $rootScope.$broadcast('StatusUpdated', {
-                  title: $translate.instant(reason.data.error.message),
+                  title: $translate.instant('cancelMetadataError'),
+                  error: reason.data.message.toString().contains("AccessDeniedException")? $translate.instant('accessDenied'):reason.data.message,
                   timeout: 0,
                   type: 'danger'
                 });
@@ -579,7 +580,7 @@
                 $scope.savedStatus = gnCurrentEdit.savedStatus;
                 $rootScope.$broadcast('StatusUpdated', {
                   title: $translate.instant('cancelMetadataError'),
-                  error: error,
+                  error: error.toString().contains("AccessDeniedException")? $translate.instant('accessDenied'):error,
                   timeout: 0,
                   type: 'danger'});
               });
@@ -619,8 +620,8 @@
               $scope.saveError = true;
 
               $rootScope.$broadcast('StatusUpdated', {
-                title: error ? error.message : $translate.instant('saveMetadataError'),
-                error: error,
+                title: error.message.toString().contains("AccessDeniedException") ? $translate.instant('saveMetadataError'): error.message,
+                error: error.message.toString().contains("AccessDeniedException")? $translate.instant('accessDenied'):error,
                 timeout: 0,
                 type: 'danger'});
             });

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -519,7 +519,7 @@
               $scope.saveError = true;
               $rootScope.$broadcast('StatusUpdated', {
                 title: $translate.instant('saveMetadataError'),
-                error: error.message.toString().contains("AccessDeniedException")? $translate.instant('accessDenied'):error,
+                error: error.description,
                 timeout: 0,
                 type: 'danger'});
             });
@@ -560,7 +560,7 @@
               }, function(reason) {
                 $rootScope.$broadcast('StatusUpdated', {
                   title: $translate.instant('cancelMetadataError'),
-                  error: reason.data.message.toString().contains("AccessDeniedException")? $translate.instant('accessDenied'):reason.data.message,
+                  error: reason.data.description,
                   timeout: 0,
                   type: 'danger'
                 });
@@ -577,10 +577,12 @@
                 //  gnEditor.refreshEditorForm(null, true);
                 closeEditor();
               }, function(error) {
+                var xmlDoc = $.parseXML(error);
+                var description = xmlDoc.getElementsByTagName("description")[0];
                 $scope.savedStatus = gnCurrentEdit.savedStatus;
                 $rootScope.$broadcast('StatusUpdated', {
                   title: $translate.instant('cancelMetadataError'),
-                  error: error.toString().contains("AccessDeniedException")? $translate.instant('accessDenied'):error,
+                  error: description.childNodes[0].nodeValue,
                   timeout: 0,
                   type: 'danger'});
               });
@@ -621,7 +623,7 @@
 
               $rootScope.$broadcast('StatusUpdated', {
                 title: error.message.toString().contains("AccessDeniedException") ? $translate.instant('saveMetadataError'): error.message,
-                error: error.message.toString().contains("AccessDeniedException")? $translate.instant('accessDenied'):error,
+                error: error.description,
                 timeout: 0,
                 type: 'danger'});
             });

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -420,6 +420,5 @@
     "badGmlProjectionCode": "  The geometry projection <b>{{srsName}}</b> defined in the XML is not valid. Please edit the xml to fix the srs name or enter a new geometry.\n",
     "draft": "Working copy",
     "link": "Link",
-    "link-text": "Link text",
-    "accessDenied": "Access is denied"
+    "link-text": "Link text"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -420,5 +420,6 @@
     "badGmlProjectionCode": "  The geometry projection <b>{{srsName}}</b> defined in the XML is not valid. Please edit the xml to fix the srs name or enter a new geometry.\n",
     "draft": "Working copy",
     "link": "Link",
-    "link-text": "Link text"
+    "link-text": "Link text",
+    "accessDenied": "Access is denied"
 }

--- a/web-ui/src/main/resources/catalog/locales/fr-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-editor.json
@@ -420,6 +420,5 @@
     "badGmlProjectionCode": "The geometry projection <b>{{srsName}}</b> defined in the XML is not valid. Please edit the xml to fix the srs name or enter a new geometry.",
     "draft": "Brouillon",
     "link": "Lien",
-    "link-text": "Link text",
-    "accessDenied": "L'accès est refusé"
+    "link-text": "Link text"
 }

--- a/web-ui/src/main/resources/catalog/locales/fr-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-editor.json
@@ -420,5 +420,6 @@
     "badGmlProjectionCode": "The geometry projection <b>{{srsName}}</b> defined in the XML is not valid. Please edit the xml to fix the srs name or enter a new geometry.",
     "draft": "Brouillon",
     "link": "Lien",
-    "link-text": "Link text"
+    "link-text": "Link text",
+    "accessDenied": "L'accès est refusé"
 }


### PR DESCRIPTION
There were some untranslated text from backend Java and Spring framework to the web page.

![image](https://user-images.githubusercontent.com/74916635/101191408-a7192700-3627-11eb-8830-dc695a15b2ee.png)

The change is done in editorController of Angular to recognize string pattern "AccessDeniedException" and translate them accordingly.

Here is the results:
![image](https://user-images.githubusercontent.com/74916635/101191590-ddef3d00-3627-11eb-9373-dcccdb8ea85e.png)

![image](https://user-images.githubusercontent.com/74916635/101191613-e5aee180-3627-11eb-84f6-6fb65de61dc8.png)
