### PR TITLE
Use the portal/source label as the name in the menu

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -679,18 +679,6 @@ goog.require('gn_alert');
               });
         });
 
-        // Retreive portal information
-        var getPortalSources = promiseStart.then(function(value) {
-          return $http.get('../api/sources').
-            success(function(data) {
-              for (var i = 0; i < data.length; i++) {
-                if (data[i].type === 'portal') {
-                  $scope.portal = data[i];
-                }
-              }
-            });
-        });
-
         // Utility functions for user
         var userFn = {
           isAnonymous: function() {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -679,7 +679,17 @@ goog.require('gn_alert');
               });
         });
 
-
+        // Retreive portal information
+        var getPortalSources = promiseStart.then(function(value) {
+          return $http.get('../api/sources').
+            success(function(data) {
+              for (var i = 0; i < data.length; i++) {
+                if (data[i].type === 'portal') {
+                  $scope.portal = data[i];
+                }
+              }
+            });
+        });
 
         // Utility functions for user
         var userFn = {

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -9,7 +9,7 @@
        data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
       <span class="gn-name"
             data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
-            title="{{portal.label[lang]}}">{{info['node/name'] || portal.label[lang]}}</span>
+            title="{{info['system/site/name']}}">{{info['node/name'] || info['system/site/name']}}</span>
     </a>
     <button type="button"
             class="navbar-toggle collapsed"
@@ -36,8 +36,8 @@
           <span class="gn-name hidden-sm hidden-md gn-margin-left"
                 data-ng-if="gnCfg.mods.header.showGNName"
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
-                title="{{info['node/name'] || portal.label[lang]}}">
-            {{info['node/name'].split('|')[0] || portal.label[lang]}}
+                title="{{info['node/name'] || info['system/site/name']}}">
+            {{info['node/name'].split('|')[0] || info['system/site/name']}}
           </span>
         </a>
       </li>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -9,7 +9,7 @@
        data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
       <span class="gn-name"
             data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
-            title="{{info['system/site/name']}}">{{info['node/name'] || info['system/site/name']}}</span>
+            title="{{portal.label[lang]}}">{{info['node/name'] || portal.label[lang]}}</span>
     </a>
     <button type="button"
             class="navbar-toggle collapsed"
@@ -36,8 +36,8 @@
           <span class="gn-name hidden-sm hidden-md gn-margin-left"
                 data-ng-if="gnCfg.mods.header.showGNName"
                 data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
-                title="{{info['node/name'] || info['system/site/name']}}">
-            {{info['node/name'].split('|')[0] || info['system/site/name']}}
+                title="{{info['node/name'] || portal.label[lang]}}">
+            {{info['node/name'].split('|')[0] || portal.label[lang]}}
           </span>
         </a>
       </li>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -60,7 +60,7 @@
   .gn-logo-link {
     padding: 10px 15px;
     .gn-logo {
-      margin: 0;
+      margin: 2px 0;
     }
     .gn-name {
       margin-top: 4px;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -60,10 +60,11 @@
   .gn-logo-link {
     padding: 10px 15px;
     .gn-logo {
-      margin: 2px 0;
+      margin-top: -12px;
     }
     .gn-name {
-      margin-top: 4px;
+      margin-top: 5px;
+      display: inline-block;
       &.gn-truncate {
         @media (min-width: @screen-lg-min) {
           max-width: 230px;


### PR DESCRIPTION
This PR uses the label for the portal as name in the `menu`/`navigation` (before it was the GeoNetwork name). This enables the use of a translated labels in the navigation.

**Set the label in the admin:**
![gn-portal-label](https://user-images.githubusercontent.com/19608667/101359210-3d558300-389c-11eb-8a48-90edc16f8827.png)

**The label in the menu:**

![gn-label-for-menu](https://user-images.githubusercontent.com/19608667/101359281-55c59d80-389c-11eb-878d-5035634c0123.png)
