### PR TITLE
[#5234] Fix for overflowing CSW Harvester filter list

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -61,6 +61,7 @@ fieldset.cswCriteriaInfo, ul.list-group {
   overflow-y: auto;
   overflow-x: hidden;
   max-height: 40em;
+  margin-bottom: 51px;
 }
 
 fieldset.cswCriteriaInfo, ul.criteria-list-group {


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/issues/5234

In the latest version(s) of the Chrome browser the CSW Harvester filter settings list was overflowing. This PR adds a small fix to prevent this.

**No more overflow:**
![gn-csw-no-overflow](https://user-images.githubusercontent.com/19608667/101365115-abea0f00-38a3-11eb-8202-5f2515190115.png)
