### PR TITLE
Trigger metadata delete event in 3.10.x branch

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -28,6 +28,7 @@ import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
@@ -48,6 +49,7 @@ import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.domain.StatusValueType;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.userfeedback.RatingsSetting;
+import org.fao.geonet.events.history.RecordDeletedEvent;
 import org.fao.geonet.events.md.MetadataIndexCompleted;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.IndexMetadataTask;
@@ -87,7 +89,6 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.interceptor.TransactionAspectSupport;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -101,7 +102,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 
 public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPublisherAware {
 
@@ -201,9 +201,14 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
             try {
                 store.delResources(ServiceContext.get(), md.getUuid());
                 metadataManager.deleteMetadata(ServiceContext.get(), String.valueOf(md.getId()));
+
+                UserSession userSession = ServiceContext.get().getUserSession();
+
+                String xmlBefore = md.getData();
+                new RecordDeletedEvent(md.getId(), userSession.getUserIdAsInt(), xmlBefore).publish(ApplicationContextHolder.get());
             } catch (Exception e) {
                 Log.warning(Geonet.DATA_MANAGER, String.format(
-                    
+
                     "Error during removal of metadata %s part of batch delete operation. " +
                     "This error may create a ghost record (ie. not in the index " +
                     "but still present in the database). " +


### PR DESCRIPTION
In `master` this pull request: https://github.com/geonetwork/core-geonetwork/pull/4817 added support for the metadata delete event to track the metadata history.

In `3.10.x` the event is available, but was not triggered. This pull request triggers the metadata delete event when a metadata is deleted. 

In `3.10.x` there's no event implementation, but custom projects can at least implement it if required.