### PR TITLE
Support of remote associated resources in ISO19115-3 #4805

### DIFF
--- a/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018Namespaces.java
+++ b/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018Namespaces.java
@@ -35,4 +35,11 @@ public class ISO19115_3_2018Namespaces {
                     "http://standards.iso.org/iso/19115/-3/gcx/1.0");
     public static final Namespace XLINK =
         Namespace.getNamespace("xlink", "http://www.w3.org/1999/xlink");
+    public static final Namespace CIT =
+        Namespace.getNamespace("cit",
+            "http://standards.iso.org/iso/19115/-3/cit/2.0");
+    public static final Namespace MCC =
+        Namespace.getNamespace("mcc",
+            "http://standards.iso.org/iso/19115/-3/mcc/1.0");
+
 }

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
@@ -540,7 +540,10 @@
         <xsl:variable name="code"
                       select="if (mri:metadataReference/@uuidref != '')
                               then mri:metadataReference/@uuidref
-                              else mri:metadataReference/cit:CI_Citation/cit:identifier/mcc:MD_Identifier/mcc:code/gco:CharacterString"/>
+                              else if (mri:metadataReference/cit:CI_Citation/cit:identifier/mcc:MD_Identifier/mcc:code/gco:CharacterString != '')
+                              then mri:metadataReference/cit:CI_Citation/cit:identifier/mcc:MD_Identifier/mcc:code/gco:CharacterString
+                              else mri:name/cit:CI_Citation/cit:identifier/mcc:MD_Identifier/mcc:code/gcx:Anchor/@xlink:href"/>
+
         <xsl:if test="$code != ''">
           <xsl:variable name="associationType" select="mri:associationType/mri:DS_AssociationTypeCode/@codeListValue"/>
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -181,16 +181,29 @@ public class MetadataUtils {
             if (listOfAssociatedResources != null) {
                 for (AssociatedResource resource : listOfAssociatedResources) {
                     String origin;
-                    // Search in the index to use the portal filter and verify the metadata is available for the portal
-                    Element searchResult = search(resource.getUuid(), RelatedItemType.siblings.value(), context, from, to, fast, null, false);
-                    // If can't be find, skip the result.
-                    if (hasResult(searchResult)) {
-                        origin = ORIGIN_PORTAL;
-                    } else {
-                        origin = ORIGIN_CATALOG;
-                    }
 
-                    Element sibContent = getRecord(resource.getUuid(), context, dm);
+                    Element sibContent;
+
+                    // If can't be find, skip the result.
+                    if (resource.getUuid().startsWith("http")) {
+                        origin = ORIGIN_REMOTE;
+
+                        sibContent = new Element("metadata");
+                        sibContent.setAttribute("origin", ORIGIN_REMOTE);
+                        sibContent.addContent(new Element("url").setText(resource.getUuid()));
+                        sibContent.addContent(new Element("title").setText(resource.getUuid()));
+                    } else {
+                        // Search in the index to use the portal filter and verify the metadata is available for the portal
+                        Element searchResult = search(resource.getUuid(), RelatedItemType.siblings.value(), context, from, to, fast, null, false);
+
+                        if (hasResult(searchResult)) {
+                            origin = ORIGIN_PORTAL;
+                        } else {
+                            origin = ORIGIN_CATALOG;
+                        }
+                        sibContent = getRecord(resource.getUuid(), context, dm);
+
+                    }
 
                     if (sibContent != null) {
                         Element sibling = new Element("sibling");


### PR DESCRIPTION
if associated resource links to a remote url, the url is indexed instead of the metadata identifier

![image](https://user-images.githubusercontent.com/299829/106443740-25097b00-647d-11eb-8e3c-5eee5c612a0a.png)
