### PR TITLE
Fixed issue with possible endless redirect to  /accessDenied.jsp

### DIFF
--- a/common/src/main/java/org/fao/geonet/NodeInfo.java
+++ b/common/src/main/java/org/fao/geonet/NodeInfo.java
@@ -52,6 +52,8 @@ public class NodeInfo implements Serializable {
             .add("xml")
             .add("xsl")
             .add("xslt")
+            .add("accessDenied.jsp")
+            .add("service-not-allowed")
             .build();
     }
 


### PR DESCRIPTION
Fixed issue where links to /accessDenied.jsp/eng/service-not-allowed?referer=UNKNOWN could cause endless redirects as accessDenied.jsp is not a recognized node and should be redirected to /srv

When running the latest master with keycloak of schibboleth when a new user is created it will default to guest.  When a guest users is logged in and they click on to see their profile they get a couple errors.
![image](https://user-images.githubusercontent.com/1868233/101673968-41190f00-3a2e-11eb-9640-bb9ead525c60.png)

Clicking on testFirstName testLastName before the fix gives the following.

![image](https://user-images.githubusercontent.com/1868233/101673489-9bfe3680-3a2d-11eb-91f1-9d73fc7de4cb.png)

Clicking on it after the fix give the following.

![image](https://user-images.githubusercontent.com/1868233/101672531-5ab95700-3a2c-11eb-98ea-8ebdc58fbe4f.png)

It is odd that I can always reproduce it locally on my builds but I cannot reproduce the exact issue on the test sites (see other tests below).

Issue seems to be related to accessDenied.jsp not being a real node and in some cases it will keep redirecting to the same place.  In other cases it gets switched to srv node and works correctly.

So this fix identifies this as not being a node.  When it is not a node then it will redirect to srv.  Not sure if this is the best fix?

### related issues
There are 2 other issues related to this that will be fixed in separate PR.
- #5252 
- #4981 

### Other test
- I tested on GN 4.X using the following url after login in as the admin user and it seems to work as expected. I get the same results as after this fix is applied.
https://apps.titellus.net/geonetwork/srv/eng/service-not-allowed?referer=UNKNOW

- When I tested on the following 3.6.x url after login in as the admin user.
https://vanilla.geocat.net/geonetwork/accessDenied.jsp/eng/service-not-allowed?referer=UNKNOWN
I get a 403 access denied
![image](https://user-images.githubusercontent.com/1868233/101674465-ecc25f00-3a2e-11eb-819e-cd149476d81e.png)

