### PR TITLE
Metadata CSV export - Remove non letter/number characters in thesaurus identifier processing

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/tpl-csv.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/tpl-csv.xsl
@@ -78,7 +78,7 @@
       <!-- One column per thesaurus -->
       <xsl:for-each select="mdb:identificationInfo/*/mri:descriptiveKeywords/*[mri:thesaurusName]">
         <xsl:variable name="thesaurusId" select="mri:thesaurusName/*/cit:identifier/*/mcc:code/*/text()"/>
-        <xsl:variable name="thesaurusKey" select="if ($thesaurusId != '') then $thesaurusId else position()"/>
+        <xsl:variable name="thesaurusKey" select="if ($thesaurusId != '') then replace($thesaurusId, '[^a-zA-Z0-9]', '') else position()"/>
 
         <xsl:for-each select="mri:keyword[not(@gco:nilReason)]">
           <xsl:element name="keyword-{$thesaurusKey}">

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/tpl-csv.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/tpl-csv.xsl
@@ -90,7 +90,7 @@
       <!-- One column per thesaurus -->
       <xsl:for-each select="gmd:identificationInfo/*/gmd:descriptiveKeywords/*[gmd:thesaurusName]">
         <xsl:variable name="thesaurusId" select="normalize-space(gmd:thesaurusName/*/gmd:identifier/*/gmd:code/*/text())"/>
-        <xsl:variable name="thesaurusKey" select="if ($thesaurusId != '') then $thesaurusId else position()"/>
+        <xsl:variable name="thesaurusKey" select="if ($thesaurusId != '') then replace($thesaurusId, '[^a-zA-Z0-9]', '') else position()"/>
 
         <xsl:for-each select="gmd:keyword[not(@gco:nilReason)]">
           <xsl:element name="keyword-{$thesaurusKey}">


### PR DESCRIPTION
CSV export uses thesaurus identifier as the name for xml element to create the CSV report. This pull request removes non letter/numbers to avoid invalid xml element names, for example if the identifier has character `:`, that causes an error in the export.