### PR TITLE
Guest users should be able to update their profile

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/AdminController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminController.js
@@ -182,7 +182,7 @@
             controller: 'GnUserGroupController',
             resolve: {
               permission: function() {
-                authorizationService.$get[0]().check('Editor');
+                authorizationService.$get[0]().check('Guest');
               }
             }
           }).
@@ -191,7 +191,7 @@
             controller: 'GnUserGroupController',
             resolve: {
               permission: function() {
-                authorizationService.$get[0]().check('RegisteredUser');
+                authorizationService.$get[0]().check('Guest');
               }
             }
           }).

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -436,9 +436,9 @@
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.list!?.*"
                            access="hasRole('RegisteredUser')"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.update!?.*"
-                           access="hasRole('RegisteredUser')"/>
+                           access="hasRole('Guest')"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.resetpassword"
-                           access="hasRole('RegisteredUser')"/>
+                           access="hasRole('Guest')"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.user.remove!?.*"
                            access="hasRole('UserAdmin')"/>
 
@@ -750,7 +750,7 @@
                            access="permitAll"/>
 
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/admin.console!?.*"
-                           access="hasRole('RegisteredUser')"/>
+                           access="hasRole('Guest')"/>
 
         <!-- Formatter services -->
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/[a-z]{2,3}/md.format.public..[^?]+(\?.*)?"


### PR DESCRIPTION
Fix permission issue related to guest users. Guest users were not able to update their profile or change their password. 
Fixes issue #5252

Note: '/organization/:tab' was restricted to Editor.  This was also restricting registered users from editing their profile as it would go to the page and then redirect back to the search page.  I did change that to guest as well and to make it works.
I thought that this may have been related to issue #4981 and maybe if the correct user id was in the url it would work. 
I tried adding the username by using a url similar to the following.
`http://localhost:8080/geonetwork/srv/eng/admin.console#/organization/users?userOrGroup=username`
It would display the users profile momentarily and then it was still redirecting the user back to the search page.
