### PR TITLE
Map / WMS-T / Fix error due to dates leading space char

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -966,10 +966,22 @@
                       units: dimension.units,
                       values: dimension.values.split(',')
                     });
+
+                    if (dimension.default) {
+                      layer.getSource().updateParams({ ELEVATION: dimension.default });
+                    }
                   }
                   if (dimension.name == 'time') {
-                    layer.set('time',
-                        dimension.values.split(','));
+                    layer.set('time', {
+                      units: dimension.units,
+                      values: dimension.values
+                        .split(',')
+                        .map(function(e){return e.trim()})
+                    });
+
+                    if (dimension.default) {
+                        layer.getSource().updateParams({ TIME: dimension.default });
+                    }
                   }
                 }
               }


### PR DESCRIPTION
eg. 

```
<Dimension nearestValue="48" name="time" units="ISO8601" default="2020/01/01 00:00:00.000" multipleValue="49">2001/01/01 00:00:00.000, 2002/01/01 00:00:00.000, 2003/01/01 00:00:00.000, 2004/01/01 00:00:00.000, 2005/01/01 00:00:00.000, 2006/01/01 00:00:00.000, 2007/01/01 00:00:00.000, 2008/01/01 00:00:00.000, 2009/01/01 00:00:00.000, 2010/01/01 00:00:00.000, 2011/01/01 00:00:00.000, 2012/01/01 00:00:00.000, 2013/01/01 00:00:00.000, 2014/01/01 00:00:00.000, 2015/01/01 00:00:00.000, 2016/01/01 00:00:00.000, 2017/01/01 00:00:00.000, 2018/01/01 00:00:00.000, 2019/01/01 00:00:00.000, 2020/01/01 00:00:00.000</Dimension>
```
may then generate invalid GetMap request due to leading space.


Layer time property structure changed but it is not used yet - some layer time directive selector to backport in GeoNetwork?