### PR TITLE
Processing / XSL process name may contains .

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
@@ -99,7 +99,7 @@ public class XslProcessApi {
         description = ApiParams.API_OP_NOTE_PROCESS_PREVIEW +
             " When errors occur during processing, the processing report is returned in JSON format.")
     @RequestMapping(
-        value = "/{process}",
+        value = "/{process:.+}",
         method = RequestMethod.GET,
         consumes = {
             MediaType.TEXT_HTML_VALUE,
@@ -234,7 +234,7 @@ public class XslProcessApi {
         summary = "Apply a process to one or more records",
         description = ApiParams.API_OP_NOTE_PROCESS)
     @RequestMapping(
-        value = "/{process}",
+        value = "/{process:.+}",
         method = RequestMethod.POST,
         produces = {
             MediaType.APPLICATION_JSON_VALUE

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
@@ -133,7 +133,7 @@ public class MetadataProcessApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Preview process result", description =API_OP_NOTE_PROCESS)
-    @RequestMapping(value = "/{metadataUuid}/processes/{process}", method = {
+    @RequestMapping(value = "/{metadataUuid}/processes/{process:.+}", method = {
         RequestMethod.GET}, produces = MediaType.APPLICATION_XML_VALUE)
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)
@@ -158,7 +158,7 @@ public class MetadataProcessApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Apply a process", description =API_OP_NOTE_PROCESS)
-    @RequestMapping(value = "/{metadataUuid}/processes/{process}", method = {
+    @RequestMapping(value = "/{metadataUuid}/processes/{process:.+}", method = {
         RequestMethod.POST,}, produces = MediaType.APPLICATION_XML_VALUE)
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)


### PR DESCRIPTION
eg. iso19115-3.2018-schemaupgrade

Process was not found because parameter truncated at '.'