### PR TITLE
Review ServiceContext resource leak

### DIFF
--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -472,6 +472,10 @@ public class JeevesEngine {
                     serviceMan.setStartupErrors(errors);
                 }
             }
+            finally {
+                srvContext.clearAsThreadLocal();
+                srvContext.clear();
+            }
         }
     }
 

--- a/core/src/main/java/jeeves/server/context/BasicContext.java
+++ b/core/src/main/java/jeeves/server/context/BasicContext.java
@@ -43,9 +43,8 @@ import javax.persistence.EntityManager;
 //=============================================================================
 
 /**
- * Contains a minimun context for a job execution (schedule, service etc...)
+ * Contains a minimum context for a job execution (schedule, service etc...)
  */
-
 public class BasicContext implements Logger {
 
     private final ConfigurableApplicationContext jeevesApplicationContext;

--- a/core/src/main/java/jeeves/server/context/ServiceContext.java
+++ b/core/src/main/java/jeeves/server/context/ServiceContext.java
@@ -38,6 +38,7 @@ import org.fao.geonet.Logger;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.transaction.TransactionStatus;
 
@@ -52,10 +53,54 @@ import javax.persistence.EntityManager;
 
 /**
  * Contains the context for a service execution.
+ *
+ * When creating a ServiceContext you are responsible for manging its use on the current thread and any cleanup:
+ * <pre><code>
+ * try {
+ *    context = serviceMan.createServiceContext("AppHandler", appContext);
+ *    context.setAsThreadLocal();
+ *    ...
+ * } finally {
+ *    context.clearAsThreadLocal();
+ *    context.clear();
+ * }</code></pre>
+ *
+ * @see ServiceManager
  */
 public class ServiceContext extends BasicContext {
 
+    public static enum ThreadLocalPolicy { DIRECT, TRACE, STRICT };
+    /**
+     * Use -Djeeves.server.context.service.policy to define policy:
+     * <ul>
+     *     <li>direct: direct management of thread local with no checking</li>
+     *     <li>trace: check behavior and log unusal use</li>
+     *     <li>strict: raise illegal state exception for unusual behavior</li>
+     * </ul>
+     */
+    private static final ThreadLocalPolicy POLICY;
+    static {
+        String property = System.getProperty("jeeves.server.context.policy", "DIRECT");
+        ThreadLocalPolicy policy;
+        try {
+            policy = ThreadLocalPolicy.valueOf(property.toUpperCase());
+        }
+        catch (IllegalArgumentException defaultToDirect) {
+            policy = ThreadLocalPolicy.DIRECT;
+        }
+        POLICY = policy;
+    }
+
+    /**
+     * Be careful with thread local to avoid leaking resources, set POLICY above to trace allocation.
+     */
     private static final InheritableThreadLocal<ServiceContext> THREAD_LOCAL_INSTANCE = new InheritableThreadLocal<ServiceContext>();
+
+    /**
+     * Trace allocation via {@link #setAsThreadLocal()}.
+     */
+    private Throwable allocation = null;
+
     private UserSession _userSession = new UserSession();
     private InputMethod _input;
     private OutputMethod _output;
@@ -115,10 +160,168 @@ public class ServiceContext extends BasicContext {
 
     /**
      * Called to set the Service context for this thread and inherited threads.
+     *
+     * If you call this method you are responsible for thread context management and {@link #clearAsThreadLocal()}.
+     * <pre>
+     * try {
+     *     context.setAsThreadLocal();
+     * }
+     * finally {
+     *     context.clearAsThreadLocal();
+     * }
+     * </pre>
      */
     public void setAsThreadLocal() {
+        ServiceContext check = THREAD_LOCAL_INSTANCE.get();
+
+        if( POLICY == ThreadLocalPolicy.DIRECT || check == null){
+            // step one set thread local
+            THREAD_LOCAL_INSTANCE.set(this);
+            // step two ensure ApplicationContextHolder thread local kept in sync
+            ApplicationContextHolder.set(this.getApplicationContext());
+            // step three details on allocation
+            allocation = new Throwable("ServiceContext allocated to thread");
+
+            return;
+        }
+
+        if (this == check) {
+            String unexpected = "Service " + _service + " Context: already in use for this thread";
+            if( allocation != null ){
+                // details on prior allocation
+                unexpected += "\n\tContext '"+check._service+"' conflict: " + check.allocation.getStackTrace()[1];
+            }
+            // step one set thread local
+            // (already done)
+            // step two ensure ApplicationContextHolder thread local kept in sync
+            if( ApplicationContextHolder.get() != null ){
+                ApplicationContextHolder.clear();
+            }
+            ApplicationContextHolder.set(this.getApplicationContext());
+            // step three detail on re-allocation
+            allocation = new Throwable("ServiceContext allocated to thread");
+
+            unexpected += "\n\tService '"+_service+"' allocate: " + allocation.getStackTrace()[1];
+            checkUnexpectedState( unexpected );
+            return;
+        }
+
+        // thread being recycled or reused for new service context
+        //
+        THREAD_LOCAL_INSTANCE.remove();
+
+        String unexpected = "Service " + _service + " Context: Clearing prior service context " + check._service;
+        if( check.allocation != null ){
+            // details on prior allocation
+            unexpected += "\n\tContext '"+check._service+"' conflict: " + check.allocation.getStackTrace()[1];
+        }
+
+        // step one set thread local
         THREAD_LOCAL_INSTANCE.set(this);
+        // step two ensure ApplicationContextHolder thread local kept in sync
+        if( ApplicationContextHolder.get() != null ){
+            ApplicationContextHolder.clear();
+        }
         ApplicationContextHolder.set(this.getApplicationContext());
+        // step three detail on present re-allocation
+        allocation = new Throwable("ServiceContext allocated to thread");
+
+        unexpected += "\n\tService '"+_service+"' allocate: " + allocation.getStackTrace()[1];
+        checkUnexpectedState( unexpected );
+    }
+
+    /** Log or raise exception based on {@link POLICY} */
+    public void checkUnexpectedState( String unexpected ){
+        if( unexpected == null ){
+            return; // nothing unexpected to report
+        }
+        switch( POLICY ){
+            case DIRECT:
+                break; // ignore
+            case TRACE:
+                debug(unexpected);
+                break;
+            case STRICT:
+                throw new IllegalStateException(unexpected);
+        }
+    }
+
+    /**
+     * Called to clear the Service context for this thread and inherited threads.
+     *
+     * In general code that creates ServiceContext is responsible thread management and any cleanup:
+     * <pre>
+     * try {
+     *     context.setAsThreadLocal();
+     * }
+     * finally {
+     *     context.clearAsThreadLocal();
+     * }
+     * </pre>
+     */
+    public void clearAsThreadLocal() {
+        ServiceContext check = THREAD_LOCAL_INSTANCE.get();
+
+        // clean up thread local
+        if( POLICY == ThreadLocalPolicy.DIRECT){
+            if( check != null ){
+                check.allocation = null;
+                check = null;
+            }
+            THREAD_LOCAL_INSTANCE.remove();
+            allocation = null;
+            // ApplicationContextHolder.clear();
+            return;
+        }
+        if( check == null ){
+            String unexpected = "ServiceContext "+_service+" clearAsThreadLocal: '"+_service+"' unexpected state, thread local already cleared";
+            if( allocation != null ){
+                unexpected += "\n\tContext '"+_service+"' allocation: " + allocation.getStackTrace()[1];
+            }
+            allocation = null;
+            // ApplicationContextHolder.clear();
+            checkUnexpectedState( unexpected );
+            return;
+        }
+        if (check == this){
+            THREAD_LOCAL_INSTANCE.remove();
+            allocation = null;
+            // ApplicationContextHolder.clear();
+            return;
+        }
+
+        String unexpected = "ServiceContext clearAsThreadLocal: \"+_service+\" unexpected state, thread local presently used by service context '"+check._service+"'";
+        if( check.allocation != null ){
+            unexpected += "\n\tContext '"+check._service+"' conflict: " + check.allocation.getStackTrace()[1];
+        }
+        if( allocation != null ){
+            unexpected += "\n\tContext '"+_service+"' allocation: " + allocation.getStackTrace()[1];
+        }
+        THREAD_LOCAL_INSTANCE.remove();
+        allocation = null;
+        // ApplicationContextHolder.clear();
+        if( ApplicationContextHolder.get() != null && ApplicationContextHolder.get() != getApplicationContext() ){
+            unexpected += "\n\tApplicationContext '"+ApplicationContextHolder.get().getApplicationName()+"' conflict detected";
+            unexpected += "\n\tApplicationContext '"+getApplicationContext().getApplicationName()+"' expected";
+            ApplicationContextHolder.clear();
+        }
+        checkUnexpectedState( unexpected );
+    }
+
+    /**
+     * Release any resources tied up by this service context.
+     */
+    public void clear(){
+        if( this._service != null) {
+            this._service = null;
+            this._headers = null;
+            this._responseHeaders = null;
+            this._servlet = null;
+            this._userSession = null;
+        }
+        else {
+            debug("Service unexpectedly cleared twice");
+        }
     }
 
     //--------------------------------------------------------------------------

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -63,6 +63,7 @@ import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.SOAPUtil;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import javax.persistence.EntityManager;
@@ -342,6 +343,24 @@ public class ServiceManager {
         vErrorPipe.add(buildErrorPage(err));
     }
 
+    /**
+     * Used to create a ServiceContext.
+     *
+     * When creating a ServiceContext you are responsible for manging its use on the current thread and any cleanup:
+     * <pre><code>
+     * try {
+     *    context = serviceMan.createServiceContext("AppHandler", appContext);
+     *    context.setAsThreadLocal();
+     *    ...
+     * } finally {
+     *    context.clearAsThreadLocal();
+     *    context.clear();
+     * }</code></pre>
+     *
+     * @param name context name
+     * @param appContext application context
+     * @return ServiceContext
+     */
     public ServiceContext createServiceContext(String name, ConfigurableApplicationContext appContext) {
         ServiceContext context = new ServiceContext(name, appContext, htContexts,
             entityManager);
@@ -356,6 +375,27 @@ public class ServiceManager {
         return context;
     }
 
+    /**
+     * Used to create a ServiceContext.
+     *
+     * When creating a ServiceContext you are responsible for manging its use on the current thread and any cleanup:
+     * <pre><code>
+     * try {
+     *    context = serviceMan.createServiceContext("md.thumbnail.upload", lang, request);
+     *    context.setAsThreadLocal();
+     *    ...
+     * } finally {
+     *    context.clearAsThreadLocal();
+     *    context.clear();
+     * }</code></pre>
+     *
+     * The serviceContext is creating using the ApplicationContext from {@link ApplicationContextHolder}.
+     *
+     * @param name context name
+     * @param lang
+     * @param request servlet request
+     * @return ServiceContext
+     */
     public ServiceContext createServiceContext(String name, String lang, HttpServletRequest request) {
         ServiceContext context = new ServiceContext(name, ApplicationContextHolder.get(), htContexts, entityManager);
 
@@ -408,6 +448,11 @@ public class ServiceManager {
         context.setServlet(servlet);
         if (startupError) context.setStartupErrors(startupErrors);
 
+        ServiceContext priorContext = ServiceContext.get();
+        if( priorContext != null){
+            priorContext.debug("ServiceManger dispatch replacing current ServiceContext");
+            priorContext.clearAsThreadLocal();
+        }
         context.setAsThreadLocal();
 
         //--- invoke service and build result
@@ -503,6 +548,20 @@ public class ServiceManager {
                 throw (NotAllowedEx) e;
             } else {
                 handleError(req, response, context, srvInfo, e);
+            }
+        }
+        finally {
+            ServiceContext checkContext = ServiceContext.get();
+            if( checkContext == context ) {
+                context.clearAsThreadLocal();
+            }
+            else {
+                context.debug("ServiceManager dispatch context was replaced before cleanup");
+            }
+            context.clear();
+            if( priorContext != null){
+                priorContext.debug("ServiceManger dispatch restoring ServiceContext");
+                priorContext.setAsThreadLocal();
             }
         }
     }
@@ -844,7 +903,7 @@ public class ServiceManager {
                                 } finally {
                                     timerContext.stop();
                                 }
-                                
+
                                 if (outPage.getContentType() != null
                                     && outPage.getContentType().startsWith("text/plain")) {
                                     req.beginStream(outPage.getContentType(), -1, "attachment;", cache);

--- a/core/src/main/java/jeeves/server/sources/ServiceRequest.java
+++ b/core/src/main/java/jeeves/server/sources/ServiceRequest.java
@@ -197,7 +197,7 @@ public class ServiceRequest {
     }
 
     /**
-     * Write provided response element.
+     * Write provided response element, ending the stream.
      *
      * @param response
      * @throws IOException

--- a/core/src/main/java/jeeves/server/sources/ServiceRequest.java
+++ b/core/src/main/java/jeeves/server/sources/ServiceRequest.java
@@ -196,21 +196,36 @@ public class ServiceRequest {
         return jsonOutput;
     }
 
+    /**
+     * Write provided response element.
+     *
+     * @param response
+     * @throws IOException
+     */
     public void write(Element response) throws IOException {
         Xml.writeResponse(new Document(response), outStream);
         endStream();
     }
 
     /**
-     * called when the system starts streaming data
+     * Called when the system starts streaming data
+     * @param contentType mime type
+     * @param cache true if content can be cached, false to disable caching for dynamic content
      */
-
     public void beginStream(String contentType, boolean cache) {
     }
 
     //---------------------------------------------------------------------------
 
-    public void beginStream(String contentType, int contentLength, String contentDisp,
+    /**
+     * Called when the system starts streaming data,  filling in appropriate header details supported by protocol.
+     *
+     * @param contentType mime type
+     * @param contentLength content length in bytes if known, -1 if unknown
+     * @param contentDisposition content disposition (inline|attachment|attachment;filename=&quot;filename.jpg&quot;)
+     * @param cache true if content can be cached, false to disable caching for dynamic content
+     */
+    public void beginStream(String contentType, int contentLength, String contentDisposition ,
                             boolean cache) {
     }
 
@@ -219,7 +234,6 @@ public class ServiceRequest {
     /**
      * called when the system ends streaming data
      */
-
     public void endStream() throws IOException {
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -125,6 +125,7 @@ public final class IndexMetadataTask implements Runnable {
             Log.error(Geonet.INDEX_ENGINE, "Error occurred indexing metadata", e);
         } finally {
             _batchIndex.remove(this);
+            _context.clearAsThreadLocal();
         }
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -124,7 +124,17 @@ public class ThesaurusManager implements ThesaurusFinder {
         try {
             Runnable worker = new InitThesauriTableTask(context, thesauriDir);
             if (synchRun) {
+                ServiceContext restore = ServiceContext.get();
+              try {
+                if( restore != null){
+                    restore.clearAsThreadLocal();
+                }
                 worker.run();
+              } finally {
+                if( restore != null){
+                    restore.setAsThreadLocal();
+                }
+              }
             } else {
                 executor = Executors.newFixedThreadPool(1);
                 executor.execute(worker);
@@ -552,6 +562,9 @@ public class ThesaurusManager implements ThesaurusFinder {
                 }
             } catch (Exception e) {
                 Log.debug(Geonet.THESAURUS_MAN, "Thesaurus table rebuilding thread threw exception", e);
+            }
+            finally {
+                context.clearAsThreadLocal();
             }
         }
     }

--- a/core/src/main/java/org/fao/geonet/kernel/backup/ArchiveAllMetadataJob.java
+++ b/core/src/main/java/org/fao/geonet/kernel/backup/ArchiveAllMetadataJob.java
@@ -91,8 +91,10 @@ public class ArchiveAllMetadataJob extends QuartzJobBean {
     protected void executeInternal(JobExecutionContext jobContext) throws JobExecutionException {
         ServiceContext serviceContext = serviceManager.createServiceContext("backuparchive", context);
         serviceContext.setLanguage("eng");
+      try {
         serviceContext.setAsThreadLocal();
 
+        // note: perhaps already done by setAsThreadLocal() above
         ApplicationContextHolder.set(this.context);
 
         if(!settingManager.getValueAsBool(Settings.METADATA_BACKUPARCHIVE_ENABLE)) {
@@ -105,6 +107,10 @@ public class ArchiveAllMetadataJob extends QuartzJobBean {
         } catch (Exception e) {
             Log.error(Geonet.GEONETWORK, "Error running " + ArchiveAllMetadataJob.class.getSimpleName(), e);
         }
+      } finally {
+        serviceContext.clearAsThreadLocal();
+        serviceContext.clear(); // prevents further use
+      }
     }
 
     public void createBackup(ServiceContext serviceContext) throws Exception {

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
@@ -89,6 +89,7 @@ public class IndexingTask extends QuartzJobBean {
     protected void executeInternal(JobExecutionContext jobContext) throws JobExecutionException {
         ServiceContext serviceContext = serviceManager.createServiceContext("indexing", applicationContext);
         serviceContext.setLanguage("eng");
+      try {
         serviceContext.setAsThreadLocal();
 
         if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
@@ -96,5 +97,9 @@ public class IndexingTask extends QuartzJobBean {
                 + new Date() + ". Checking if any records need to be indexed ...");
         }
         indexRecords();
+      } finally {
+        serviceContext.clearAsThreadLocal();
+        serviceContext.clear(); // prevents further use
+      }
     }
 }

--- a/core/src/main/java/org/fao/geonet/services/thumbnail/Set.java
+++ b/core/src/main/java/org/fao/geonet/services/thumbnail/Set.java
@@ -100,6 +100,8 @@ public class Set {
         ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
         ServiceContext context = serviceManager.createServiceContext("md.thumbnail.upload", lang, request);
 
+        // This is an example of a ServiceContext used as a parameter, and not being assigned to the current thread
+      try {
         Lib.resource.checkEditPrivilege(context, id);
 
         //-----------------------------------------------------------------------
@@ -149,6 +151,9 @@ public class Set {
         dataMan.indexMetadata(id, true, null);
 
         return new Response(id, dataMan.getNewVersion(id));
+      } finally {
+        context.clear(); // prevent further use
+      }
     }
 
     // FIXME : not elegant

--- a/core/src/main/java/org/fao/geonet/web/XFrameOptionsFilter.java
+++ b/core/src/main/java/org/fao/geonet/web/XFrameOptionsFilter.java
@@ -55,9 +55,9 @@ import java.net.URL;
  * @author Jose García
  */
 public class XFrameOptionsFilter implements Filter {
-    private static String MODE_DENY = "DENY";
-    private static String MODE_SAMEORIGIN = "SAMEORIGIN";
-    private static String MODE_ALLOWFROM = "ALLOW-FROM";
+    private static final String MODE_DENY = "DENY";
+    private static final String MODE_SAMEORIGIN = "SAMEORIGIN";
+    private static final String MODE_ALLOWFROM = "ALLOW-FROM";
 
     private String mode;
     private String url;
@@ -112,8 +112,12 @@ public class XFrameOptionsFilter implements Filter {
 
 
     public void destroy() {
+        xFrameOptionsValueCache = null;
+        contentSecurityPolicyFramAncestorsValueCache = null;
     }
 
+
+    private String xFrameOptionsValueCache = null;
 
     /**
      * Calculates the X-Frame-Options header value.
@@ -122,13 +126,16 @@ public class XFrameOptionsFilter implements Filter {
      */
     private String getXFrameOptionsValue() {
         if (mode.equals(MODE_ALLOWFROM)) {
-            return mode + " " + url;
+            if( xFrameOptionsValueCache == null){
+                xFrameOptionsValueCache = mode + " " + url;
+            }
+            return xFrameOptionsValueCache;
         } else {
             return mode;
         }
     }
 
-
+    private String contentSecurityPolicyFramAncestorsValueCache = null;
     /**
      * Calculates the Content-Security-Policy header frame-ancestors value.
      *
@@ -138,7 +145,10 @@ public class XFrameOptionsFilter implements Filter {
         if (mode.equals(MODE_SAMEORIGIN)) {
             return "frame-ancestors 'self'";
         } else if (mode.equals(MODE_ALLOWFROM)) {
-            return "frame-ancestors " + domain;
+            if( contentSecurityPolicyFramAncestorsValueCache == null ){
+                contentSecurityPolicyFramAncestorsValueCache = "frame-ancestors " + domain;
+            }
+            return contentSecurityPolicyFramAncestorsValueCache;
         } else {
             return "frame-ancestors 'none'";
         }

--- a/core/src/test/java/org/fao/geonet/AbstractCoreIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/AbstractCoreIntegrationTest.java
@@ -189,6 +189,15 @@ public abstract class AbstractCoreIntegrationTest extends AbstractSpringDataTest
 
     /**
      * Create a Service context without a user session but otherwise ready to use.
+     *
+     * This method assigns the created service context to the current thread, you are responsible for managing cleanup.
+     * <pre><code>
+     * try {
+     *   context = createServiceContext();
+     * finally {
+     *     context.clearAsThreadLocal();
+     * }
+     * </code></pre>
      */
     protected ServiceContext createServiceContext() throws Exception {
         final HashMap<String, Object> contexts = new HashMap<String, Object>();

--- a/core/src/test/java/org/fao/geonet/DataManagerWorksWithoutTransactionIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/DataManagerWorksWithoutTransactionIntegrationTest.java
@@ -58,6 +58,7 @@ public class DataManagerWorksWithoutTransactionIntegrationTest extends AbstractC
             @Override
             public void run() throws Exception {
                 final ServiceContext serviceContext = createServiceContext();
+              try {
                 loginAsAdmin(serviceContext);
 
                 final Element sampleMetadataXml = getSampleMetadataXml();
@@ -74,6 +75,9 @@ public class DataManagerWorksWithoutTransactionIntegrationTest extends AbstractC
                 assertNotNull(updateMd);
                 final boolean hasNext = updateMd.getCategories().iterator().hasNext();
                 assertTrue(hasNext);
+              } finally {
+                serviceContext.clearAsThreadLocal();
+              }
             }
         });
 

--- a/core/src/test/java/org/fao/geonet/GeonetTestFixture.java
+++ b/core/src/test/java/org/fao/geonet/GeonetTestFixture.java
@@ -167,8 +167,9 @@ public class GeonetTestFixture {
 
         ServiceContext serviceContext = test.createServiceContext();
 
+      try {
         ApplicationContextHolder.set(_applicationContext);
-        serviceContext.setAsThreadLocal();
+        //serviceContext.setAsThreadLocal();
 
         _applicationContext.getBean(LuceneConfig.class).configure("WEB-INF/config-lucene.xml");
         _applicationContext.getBean(SearchManager.class).initNonStaticData(100);
@@ -183,6 +184,10 @@ public class GeonetTestFixture {
             ThreadUtils.init(conn.getMetaData().getURL(), _applicationContext.getBean(SettingManager.class));
         }
 
+      } finally {
+        serviceContext.clearAsThreadLocal();
+        //ApplicationContextHolder.clear();
+      }
     }
 
 

--- a/core/src/test/java/org/fao/geonet/MergeUsersByUsernameDatabaseMigrationTest.java
+++ b/core/src/test/java/org/fao/geonet/MergeUsersByUsernameDatabaseMigrationTest.java
@@ -86,6 +86,7 @@ public class MergeUsersByUsernameDatabaseMigrationTest extends AbstractCoreInteg
 
 
         ServiceContext serviceContext = createServiceContext();
+      try {
         loginAs(user1, serviceContext);
         final Element sampleMetadataXml = getSampleMetadataXml();
         byte[] xmlBytes = Xml.getString(sampleMetadataXml).getBytes("UTF-8");
@@ -105,6 +106,9 @@ public class MergeUsersByUsernameDatabaseMigrationTest extends AbstractCoreInteg
         loginAs(user4, serviceContext);
         metadataIdList.put(importMetadataXML(serviceContext, "uuid", new ByteArrayInputStream(xmlBytes),
             MetadataType.METADATA, group1.getId(), Params.GENERATE_UUID), group1.getId());
+      } finally {
+        serviceContext.clearAsThreadLocal();
+      }
     }
 
     @Test

--- a/core/src/test/java/org/fao/geonet/kernel/DataManagerWorksWithoutTransactionIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/DataManagerWorksWithoutTransactionIntegrationTest.java
@@ -63,7 +63,12 @@ public class DataManagerWorksWithoutTransactionIntegrationTest extends AbstractC
             (new TestTask() {
                 @Override
                 public void run() throws Exception {
+                    ServiceContext restore = ServiceContext.get();
+                    if( restore != null ){
+                        restore.clearAsThreadLocal();
+                    }
                     final ServiceContext serviceContext = createServiceContext();
+                  try {
                     loginAsAdmin(serviceContext);
 
                     final String metadataCategory = metadataCategoryRepository.findAll().get(0).getName();
@@ -84,6 +89,12 @@ public class DataManagerWorksWithoutTransactionIntegrationTest extends AbstractC
                     assertNotNull(updateMd);
                     final boolean hasNext = updateMd.getCategories().iterator().hasNext();
                     assertTrue(hasNext);
+                  } finally {
+                    serviceContext.clearAsThreadLocal();
+                    if( restore != null ){
+                        restore.setAsThreadLocal();
+                    }
+                  }
                 }
             });
 

--- a/core/src/test/java/org/fao/geonet/kernel/LocalXLinksInMetadataIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/LocalXLinksInMetadataIntegrationTest.java
@@ -93,7 +93,8 @@ public class LocalXLinksInMetadataIntegrationTest extends AbstractIntegrationTes
         final Element metadata = getSampleMetadataXml().setContent(content);
 
         ServiceContext context = createServiceContext();
-        context.setAsThreadLocal();
+      try {
+        // context.setAsThreadLocal();
         loginAsAdmin(context);
 
         _settingManager.setValue(Settings.SYSTEM_XLINKRESOLVER_ENABLE, true);
@@ -144,5 +145,8 @@ public class LocalXLinksInMetadataIntegrationTest extends AbstractIntegrationTes
         final Element newLoad = _dataManager.getMetadata(context, id, false, true, true);
         assertEqualsText(keyword2, newLoad, xpath, GCO, GMD);
         verify(mockInvoker, times(5)).invoke(any(String.class));
+      } finally {
+        context.clear();
+      }
     }
 }

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
@@ -106,6 +106,7 @@ public class AtomPredefinedFeed {
 
         ServiceContext context = createServiceContext(Geonet.DEFAULT_LANGUAGE, webRequest.getNativeRequest(HttpServletRequest.class));
 
+      try {
         SettingManager sm = context.getBean(SettingManager.class);
         boolean inspireEnable = sm.getValueAsBool(Settings.SYSTEM_INSPIRE_ENABLE);
         if (!inspireEnable) {
@@ -115,6 +116,9 @@ public class AtomPredefinedFeed {
 
         Element feed = getServiceFeed(context, uuid, language);
         return writeOutResponse(Xml.getString(feed),"application", "atom+xml");
+      } finally {
+        context.clear(); // prevent further use
+      }
     }
 
     /**
@@ -139,6 +143,7 @@ public class AtomPredefinedFeed {
     {
         ServiceContext context = createServiceContext("eng", webRequest.getNativeRequest(HttpServletRequest.class));
 
+      try {
         SettingManager sm = context.getBean(SettingManager.class);
         boolean inspireEnable = sm.getValueAsBool(Settings.SYSTEM_INSPIRE_ENABLE);
         if (!inspireEnable) {
@@ -152,6 +157,9 @@ public class AtomPredefinedFeed {
         }
         Element feed = InspireAtomUtil.getDatasetFeed(context, spIdentifier, spNamespace, params, language);
         return writeOutResponse(Xml.getString(feed), "application", "atom+xml");
+      } finally {
+        context.clear(); // prevent further use
+      }
     }
 
     private Element getServiceFeed(ServiceContext context, final String uuid, final String language) throws Exception {
@@ -204,6 +212,15 @@ public class AtomPredefinedFeed {
         return params;
     }
 
+    /**
+     * Service context for atom.service.
+     *
+     * When creating a new service context you are responsible for thread local management and any cleanup.
+     *
+     * @param lang
+     * @param request
+     * @return service context for atom.service
+     */
     private ServiceContext createServiceContext(String lang, HttpServletRequest request) {
         final ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
         return serviceManager.createServiceContext("atom.service", lang, request);
@@ -243,6 +260,7 @@ public class AtomPredefinedFeed {
     {
         ServiceContext context = createServiceContext(Geonet.DEFAULT_LANGUAGE, webRequest.getNativeRequest(HttpServletRequest.class));
 
+      try {
         SettingManager sm = context.getBean(SettingManager.class);
         boolean inspireEnable = sm.getValueAsBool(Settings.SYSTEM_INSPIRE_ENABLE);
         if (!inspireEnable) {
@@ -293,6 +311,9 @@ public class AtomPredefinedFeed {
             InspireAtomUtil.filterDatasetFeedByCrs(feed, crs);
             return writeOutResponse(Xml.getString(feed),"application", "atom+xml");
         }
+      } finally {
+        context.clear(); // prevent further use
+      }
     }
 
     private HttpEntity<byte[]> redirectResponse(String location) throws Exception {
@@ -339,6 +360,7 @@ public class AtomPredefinedFeed {
 
         ServiceContext context = createServiceContext(Geonet.DEFAULT_LANGUAGE, webRequest.getNativeRequest(HttpServletRequest.class));
 
+      try {
         SettingManager sm = context.getBean(SettingManager.class);
         boolean inspireEnable = sm.getValueAsBool(Settings.SYSTEM_INSPIRE_ENABLE);
         if (!inspireEnable) {
@@ -348,6 +370,9 @@ public class AtomPredefinedFeed {
 
         Element description = getOpenSearchDescription(context, uuid);
         return writeOutResponse(Xml.getString(description), "application", "opensearchdescription+xml");
+      } finally {
+        context.clear(); // prevent further use
+      }
     }
 
     private Element getOpenSearchDescription(ServiceContext context, final String uuid) throws Exception {

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -206,6 +206,12 @@ public class ApiUtils {
     /**
      * If you really need a ServiceContext use this. Try to avoid in order to reduce dependency on
      * Jeeves.
+     *
+     * If you create a service context you are responsible for managing on the current thread and any cleanup.
+     * This method has a side effect of setting the created service context for the current thread.
+     *
+     * @param request
+     * @return new sevice context, assigned to the current thread
      */
     static public ServiceContext createServiceContext(HttpServletRequest request) {
         String iso3langCode = ApplicationContextHolder.get().getBean(LanguageUtils.class)
@@ -213,6 +219,26 @@ public class ApiUtils {
         return createServiceContext(request, iso3langCode);
     }
 
+    /**
+     * If you really need a ServiceContext use this. Try to avoid in order to reduce dependency on
+     * Jeeves.
+     * If you create a service context you are responsible for managing on the current thread and any cleanup.
+     * This method has a side effect of setting the created service context for the current thread:
+     *
+     * <pre><code>
+     * ServiceContext context = ApiUtils.createServiceContext(request, iso3langCode);
+     * try {
+     *     ...
+     * }
+     * finally {
+     *     serviceContext.clear();
+     * }
+     * </code></pre>
+     *
+     * @param request
+     * @param iso3langCode
+     * @return new sevice context, assigned to the current thread
+     */
     static public ServiceContext createServiceContext(HttpServletRequest request, String iso3langCode) {
         ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
         ServiceContext serviceContext = serviceManager.createServiceContext("Api", iso3langCode, request);

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/Register.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/Register.java
@@ -86,6 +86,7 @@ public class Register extends AbstractFormatService {
         ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
         ServiceContext context = serviceManager.createServiceContext("md.formatter.register", lang, request);
 
+      try {
         if (xslid == null) {
             xslid = file.getOriginalFilename();
             int extentionIdx = xslid.lastIndexOf('.');
@@ -146,6 +147,9 @@ public class Register extends AbstractFormatService {
         } finally {
             IO.deleteFile(uploadedFile, false, Geonet.FORMATTER);
         }
+      } finally {
+        context.clear();
+      }
     }
 
     private Path findViewXslContainerDir(Path dir) throws IOException {

--- a/services/src/main/java/org/fao/geonet/guiservices/metadata/GetRelated.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/metadata/GetRelated.java
@@ -159,8 +159,10 @@ public class GetRelated implements Service, RelatedMetadata {
         GeonetworkDataDirectory dataDirectory = appContext.getBean(GeonetworkDataDirectory.class);
         MetadataRepository metadataRepository = appContext.getBean(MetadataRepository.class);
 
+        // context used as parameter, not set as threadlocale
         final ServiceContext context = serviceManager.createServiceContext("xml.relation", lang, request);
 
+      try {
         AbstractMetadata md;
         if (id != null) {
             md = metadataRepository.findOne(id);
@@ -209,6 +211,9 @@ public class GetRelated implements Service, RelatedMetadata {
         headers.add("Content-Type", contentType);
 
         return new HttpEntity<>(response, headers);
+      } finally {
+        context.clear();
+      }
     }
 
     private boolean acceptsType(Set<String> acceptContentType, String toCheck) {

--- a/services/src/main/java/org/fao/geonet/services/metadata/BatchNewOwner.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/BatchNewOwner.java
@@ -78,6 +78,7 @@ public class BatchNewOwner {
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
 
         ServiceContext context = serviceManager.createServiceContext("metadata.batch.newowner", lang, request);
+      try {
         UserSession session = context.getUserSession();
 
         context.info("Get selected metadata");
@@ -97,6 +98,9 @@ public class BatchNewOwner {
         r.process();
 
         return result;
+      } finally {
+        context.clear();
+      }
     }
 
     private NewOwnerResult setNewOwner(ServiceContext context, String targetUsr, String targetGrp,

--- a/services/src/main/java/org/fao/geonet/services/metadata/ExtractServicesLayers.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/ExtractServicesLayers.java
@@ -68,6 +68,7 @@ public class ExtractServicesLayers {
         final ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
         ServiceContext context = serviceManager.createServiceContext("selection.layers", lang, webRequest.getNativeRequest(HttpServletRequest.class));
 
+      try {
         DataManager dm = context.getBean(DataManager.class);
         UserSession us = context.getUserSession();
         SelectionManager sm = SelectionManager.getManager(us);
@@ -183,6 +184,9 @@ public class ExtractServicesLayers {
         ret.put("services", services);
 
         return ret;
+      } finally {
+        context.clear();;
+      }
 
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
@@ -101,7 +101,11 @@ public class Publish {
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
         final ServiceContext serviceContext = serviceManager.createServiceContext("md.publish", lang, request);
 
+      try {
         return exec(commaSeparatedIds, true, skipIntranet, serviceContext);
+      } finally {
+        serviceContext.clear();
+      }
     }
 
 
@@ -117,7 +121,11 @@ public class Publish {
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
         final ServiceContext serviceContext = serviceManager.createServiceContext("md.publish", lang, request);
 
+      try {
         return exec(commaSeparatedIds, false, skipIntranet, serviceContext);
+      } finally {
+        serviceContext.clear();
+      }
     }
 
     /**
@@ -127,6 +135,7 @@ public class Publish {
      * @param commaSeparatedIds the ids of the metadata to publish/unpublish.
      * @param publish           if true the metadata will be published otherwise unpublished
      * @param skipIntranet      if true then metadata only the all group will be affected
+     * @param serviceContext    service context
      */
     private PublishReport exec(String commaSeparatedIds, boolean publish, boolean skipIntranet, ServiceContext serviceContext) throws
         Exception {

--- a/services/src/main/java/org/fao/geonet/services/metadata/XslProcessing.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/XslProcessing.java
@@ -93,6 +93,7 @@ public class XslProcessing {
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
 
         ServiceContext context = serviceManager.createServiceContext("md.processing", lang, request);
+      try {
         XsltMetadataProcessingReport report = new XsltMetadataProcessingReport(process);
 
         if (id.isEmpty()) {
@@ -116,5 +117,8 @@ public class XslProcessing {
 
         // and the processed metadata if not saved.
         return report;
+      } finally {
+        context.clear();
+      }
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/region/GetMap.java
+++ b/services/src/main/java/org/fao/geonet/services/region/GetMap.java
@@ -155,6 +155,7 @@ public class GetMap {
         ServiceContext context = serviceManager.createServiceContext("region.getmap." + imageFormat, lang,
             request.getNativeRequest(HttpServletRequest.class));
 
+      try {
         if (id == null && geomParam == null) {
             throw new BadParameterEx(Params.ID, "Either " + GEOM_PARAM + " or " + Params.ID + " is required");
         }
@@ -227,6 +228,9 @@ public class GetMap {
             headers.add("Content-Type", "image/" + imageFormat);
             return new HttpEntity<>(out.toByteArray(), headers);
         }
+      } finally {
+        context.clear();
+      }
     }
 
 }

--- a/services/src/main/java/org/fao/geonet/services/region/List.java
+++ b/services/src/main/java/org/fao/geonet/services/region/List.java
@@ -153,6 +153,7 @@ public class List {
 
         final HttpServletRequest nativeRequest = webRequest.getNativeRequest(HttpServletRequest.class);
         ServiceContext context = serviceManager.createServiceContext("regions.list", lang, nativeRequest);
+      try {
         Collection<RegionsDAO> daos = context.getApplicationContext().getBeansOfType(RegionsDAO.class).values();
 
         long lastModified = -1;
@@ -186,6 +187,9 @@ public class List {
         nativeResponse.setHeader("Cache-Control", "no-cache");
 
         return new ListRegionsResponse(regions);
+      } finally {
+        context.clear();
+      }
     }
 
 }

--- a/services/src/main/java/org/fao/geonet/services/resources/Download.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/Download.java
@@ -93,6 +93,7 @@ public class Download {
         final ServiceContext context = serviceManager.createServiceContext("resources.get", lang, httpServletRequest);
         boolean doNotify = false;
 
+      try {
         FilePathChecker.verify(fname);
 
 		if (access.equals(Params.Access.PRIVATE))
@@ -172,6 +173,9 @@ public class Download {
             IResourceDownloadHandler downloadHook = (IResourceDownloadHandler) context.getApplicationContext().getBean("resourceDownloadHandler");
             return downloadHook.onDownload(context, request, Integer.parseInt(id), fname, file);
         }
+      } finally {
+        context.clear();
+      }
     }
 }
 

--- a/services/src/main/java/org/fao/geonet/services/resources/RemoveAndProcess.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/RemoveAndProcess.java
@@ -79,6 +79,7 @@ public class RemoveAndProcess {
                                    @RequestParam(defaultValue = "") String uuid)
         throws Exception {
         ServiceContext context = serviceManager.createServiceContext("resource.del.and.detach", lang, request);
+      try {
         if (id.trim().isEmpty()) {
             id = dm.getMetadataId(uuid);
         }
@@ -130,5 +131,8 @@ public class RemoveAndProcess {
         }
 
         return new IdResponse(id);
+      } finally {
+        context.clear();
+      }
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/resources/UploadAndProcess.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/UploadAndProcess.java
@@ -82,7 +82,7 @@ public class UploadAndProcess {
                            @RequestParam(value = Params.OVERWRITE, defaultValue = "no") String overwrite)
         throws Exception {
         ServiceContext context = serviceManager.createServiceContext("resource.upload.and.link", lang, request);
-
+      try {
         if (id.trim().isEmpty()) {
             id = dm.getMetadataId(uuid);
         }
@@ -130,5 +130,8 @@ public class UploadAndProcess {
         // -- return the processed metadata id
 
         return new IdResponse(id);
+      } finally {
+        context.clear();
+      }
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/thesaurus/GetKeywords.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/GetKeywords.java
@@ -115,6 +115,7 @@ public class GetKeywords {
         ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         ServiceContext context = applicationContext.getBean(ServiceManager.class).createServiceContext("keywords", uiLang,
             webRequest.getNativeRequest(HttpServletRequest.class));
+      try {
         Element responseXml = new Element(Jeeves.Elem.RESPONSE);
         UserSession session = context.getUserSession();
 
@@ -189,6 +190,10 @@ public class GetKeywords {
         headers.add("Cache-Control", "no-cache");
 
         return new HttpEntity<>(response, headers);
+      } finally {
+        context.clear();
+      }
+
     }
 
     private boolean checkModified(NativeWebRequest webRequest, ThesaurusManager thesaurusMan, KeywordSearchParamsBuilder builder) {

--- a/services/src/test/java/org/fao/geonet/services/user/UserUpdateIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/services/user/UserUpdateIntegrationTest.java
@@ -438,6 +438,7 @@ public class UserUpdateIntegrationTest extends AbstractServiceIntegrationTest {
 
         final UserSession userSession = new UserSession();
         final ServiceContext serviceContext = createServiceContext();
+      try {
         userSession.loginAs(updatingUser);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.getSession();
@@ -450,6 +451,9 @@ public class UserUpdateIntegrationTest extends AbstractServiceIntegrationTest {
             Integer.toString(toUpdateUser.getId()), null, password, null,
             null, null, null, null, null, null, null, null, null, null, null);
 
+      } finally {
+        serviceContext.clearAsThreadLocal();
+      }
     }
 
     public void testUpdateUserByUserAdmin() throws Exception {

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -424,6 +424,7 @@ public class Geonetwork implements ApplicationHandler {
                 final ServletContext servletContext = context.getServlet().getServletContext();
                 context.setAsThreadLocal();
                 ApplicationContextHolder.set(_applicationContext);
+              try {
                 GeonetWro4jFilter filter = (GeonetWro4jFilter) servletContext.getAttribute(GeonetWro4jFilter.GEONET_WRO4J_FILTER_KEY);
 
                 @SuppressWarnings("unchecked")
@@ -451,7 +452,7 @@ public class Geonetwork implements ApplicationHandler {
                     for (String formatterName : formattersToInitialize) {
                         Log.info(Geonet.GEONETWORK, "Initializing the Formatter with id: " + formatterName);
                         final MockHttpSession servletSession = new MockHttpSession(servletContext);
-                        servletSession.setAttribute(Jeeves.Elem.SESSION,  context.getUserSession());
+                        servletSession.setAttribute(Jeeves.Elem.SESSION, context.getUserSession());
                         final MockHttpServletRequest servletRequest = new MockHttpServletRequest(servletContext);
                         servletRequest.setSession(servletSession);
                         final MockHttpServletResponse response = new MockHttpServletResponse();
@@ -463,6 +464,9 @@ public class Geonetwork implements ApplicationHandler {
                         }
                     }
                 }
+              } finally {
+                context.clearAsThreadLocal();
+              }
             }
         });
         fillCaches.setDaemon(true);

--- a/web/src/main/java/org/fao/geonet/GeonetworkHttpSessionListener.java
+++ b/web/src/main/java/org/fao/geonet/GeonetworkHttpSessionListener.java
@@ -1,0 +1,111 @@
+//=============================================================================
+//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+package org.fao.geonet;
+
+import jeeves.config.springutil.JeevesApplicationContext;
+import jeeves.constants.Jeeves;
+import jeeves.server.UserSession;
+import org.fao.geonet.utils.Log;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Used to keep track of the number of active sessions.\
+ */
+public class GeonetworkHttpSessionListener implements HttpSessionListener {
+
+    private final AtomicInteger activeSessions;
+    private final Logger LOGGER = Log.createLogger(Log.JEEVES);
+
+    public GeonetworkHttpSessionListener() {
+        activeSessions = new AtomicInteger();
+    }
+
+
+    public int getTotalActiveSession() {
+        return activeSessions.get();
+    }
+
+    public void sessionCreated(final HttpSessionEvent event) {
+        activeSessions.incrementAndGet();
+        if( LOGGER.isDebugEnabled()) {
+            HttpSession session = event.getSession();
+
+            ServletContext context = session.getServletContext();
+            review(context);
+
+            LOGGER.debug("sessions " + getTotalActiveSession() +": session created");
+        }
+    }
+
+    public void sessionDestroyed(final HttpSessionEvent event) {
+        activeSessions.decrementAndGet();
+        if( LOGGER.isDebugEnabled()) {
+            HttpSession session = event.getSession();
+
+            ServletContext context = session.getServletContext();
+            review(context);
+
+            LOGGER.debug("sessions " + getTotalActiveSession() +": session destroyed");
+        }
+    }
+
+    /**
+     * Debug messages reviewing current servlet health and happiness.
+     * <p>
+     * This is primarily used to check on resource use and identify resources leaks over time.
+     * </p>
+     */
+    protected void review( ServletContext context){
+        Enumeration<String> e = context.getAttributeNames();
+        while (e.hasMoreElements()) {
+            String attributeName = e.nextElement();
+
+            StringBuilder build = new StringBuilder();
+
+            build.append("sessionContent: ");
+            build.append(attributeName);
+
+            Object attribute = context.getAttribute(attributeName);
+            if( attribute == null ){
+                build.append( " --> null");
+            }
+            else if( "jeevesNodeApplicationContext_".equals(attributeName)){
+                build.append(" -- jeeves application context");
+            }
+            else if (Jeeves.Elem.SESSION.equals(attributeName)){
+                build.append(" -- jeeves session");
+            }
+            else {
+                build.append(" --> ");
+                build.append(attribute);
+            }
+            LOGGER.debug(build.toString());
+        }
+    }
+}

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -39,6 +39,9 @@
       org.springframework.web.context.request.RequestContextListener
     </listener-class>
   </listener>
+  <listener>
+    <listener-class>org.fao.geonet.GeonetworkHttpSessionListener</listener-class>
+  </listener>
 
   <!-- shut down java cache used for xlinks and spatial index -->
   <listener>


### PR DESCRIPTION
This pull request introduce some logic to review handling of service context thread local, control using:
```
-Djeeves.server.context.policy=TRACE
```
The default DIRECT policy reflects the 3.10.x handling of service context, TRACE logs any unexpected state (indicating possible resource leak), and STRICT throws an exception when enchanting an unexpected state.

Using this setting I have introduced ``try`` / ``finally`` logic around the use of ServiceContext with respect to thread local, examples are included in the javadocs of each method that creates a ServiceContext.

Example:
```
try {
     context = serviceMan.createServiceContext("AppHandler", appContext);
     context.setAsThreadLocal();
     ...
} finally {
     context.clearAsThreadLocal();
     context.clear();
 }
```

Example of a method that creates a service context and allocates it to the current thread:
```
ServiceContext context = ApiUtils.createServiceContext(request, iso3langCode);
try {
     ...
}
finally {
     serviceContext.clearAsThreadLocal();
     serviceContext.clear();
}
```

The use of `clear` is to help the garbage collector with explicitly setting to null ServiceContext fields when no longer in use.
* Use of `finalize` not considered as we want to control resource allocation
* Use of `close` considered for try-with-resource syntax but would of resulted in greater disruption to code base
* In some cases a ServiceContext is shared over to another thread, so you may find a few examples of tasks where clear() is not called
* In general the party making the serviceContext is responsible for cleaning up, add comments to document any examples where this is not the case 

Updates:
- Branch has been rebased to avoid sharing a mess of experimenting
- TransactionManager updated with debug messages to check rolledBack and committed