### PR TITLE
Add basic support for WMS layers < 1.3.0, improve bbox handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.iml
 *.launch
 *.old
+*.log
 .DS_Store
 .project
 git*.properties
@@ -26,7 +27,6 @@ docs/schema-loc-*.rst
 eclipse/
 es/elasticsearch-*
 es/es-dashboards/kibana-*
-harvesters/harvester_*.log
 idea/
 jcs_caching/
 node_modules

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigModule.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigModule.js
@@ -25,7 +25,7 @@
   goog.provide('gn_ui_config');
 
   goog.require('gn_ui_config_directive');
-  goog.require('gn_projection_service')
+  goog.require('gn_projection_service');
 
   angular.module('gn_ui_config', [
     'gn_ui_config_directive',

--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -152,11 +152,17 @@
          */
         createMap: function(type) {
           var config = gnMap.getMapConfig()['map-' + type];
+          
+          var proj = gnMap.getMapConfig().projection;
+          if (type === this.VIEWER_MAP) {
+            gnMap.checkProj4Def(proj);
+          }
+
           var map = new ol.Map({
             layers: [],
             view: new ol.View({
               center: [0, 0],
-              projection: gnMap.getMapConfig().projection,
+              projection: proj,
               zoom: 2
             }),
             // show zoom control in editor maps only

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -99,7 +99,7 @@
               if(gnViewerSettings.mapConfig.switcherProjectionList.length < 2) {
                 scope.disabledTools.projectionSwitcher = true;
               }
-              
+
               /** wps process tabs */
               scope.wpsTabs = {
                 byUrl: true,
@@ -110,9 +110,17 @@
               scope.zoom = function(map, delta) {
                 gnMap.zoom(map, delta);
               };
+              
               scope.zoomToMaxExtent = function(map) {
-                map.getView().fit(map.getView().
-                    getProjection().getExtent(), map.getSize());
+                var proj = map.getView().getProjection();
+                var extent = proj.getExtent();
+                if (gnViewerSettings.initialExtent && gnViewerSettings.mapConfig.projection && 
+                  gnViewerSettings.mapConfig.projection !== proj.getCode()) {
+                  // Use reprojected initial extent if it is defined
+                  extent = ol.proj.transformExtent(
+                    gnViewerSettings.initialExtent, gnViewerSettings.mapConfig.projection, proj, 8)
+                }
+                map.getView().fit(extent, map.getSize());
               };
               scope.ol3d = null;
 
@@ -192,7 +200,7 @@
                     if (layer) {
                       gnMap.feedLayerWithRelated(layer, config.group);
 
-                      var extent = layer.get('cextent') || layer.get('extent');
+                      var extent = layer.get('extent');
                       var autofit = gnViewerSettings.mapConfig.autoFitOnLayer;
                       var message = extent && !autofit ? 'layerAdded' : 'layerAddedNoExtent';
 
@@ -236,7 +244,7 @@
                     var layer = gnMap.getLayerInMap(scope.map,
                         config.name, config.url);
                     if (layer !== null) {
-                      var extent = layer.get('cextent') || layer.get('extent');
+                      var extent = layer.get('extent');
                       gnAlertService.addAlert({
                         msg: $translate.instant('layerIsAlreadyInMap', {
                           layer: config.name,

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -174,9 +174,7 @@
             layer.set('currentStyle', style);
           };
           scope.zoomToExtent = function(layer, map) {
-            if (layer.get('cextent')) {
-              map.getView().fit(layer.get('cextent'), map.getSize());
-            } else if (layer.get('extent')) {
+            if (layer.get('extent')) {
               map.getView().fit(layer.get('extent'), map.getSize());
             }
           };

--- a/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/projectionSwitcher/ProjectionSwitcher.js
@@ -69,6 +69,8 @@
                                   this.changeLayerProjection(subLayer, oldProj,
                                       newProj);
                                 });
+                          } else if (layer instanceof ol.layer.Image) {
+                            gnMap.updateWmsLayerForProj(scope.map, layer, newProj);
                           } else if (layer instanceof ol.layer.Tile) {
                             var tileLoadFunc = layer.getSource()
                                 .getTileLoadFunction();
@@ -93,8 +95,7 @@
                             return;
                           }
 
-                          // First, get all the info to populate the map
-
+                          // Get all the info to populate the map
                           var projectionConfig = {};
 
                           gnViewerSettings.mapConfig.switcherProjectionList
@@ -107,10 +108,6 @@
                           var newExtent = ol.proj.transformExtent(view
                               .calculateExtent(scope.map.getSize()), oldProj,
                               newProj);
-
-                          if (newProj.getExtent()) {
-                            newExtent = newProj.getExtent();
-                          }
 
                           var mapsConfig = {
                             projection : newProj

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -78,22 +78,34 @@
             if ($.inArray(url, gnGlobalSettings.requireProxy) >= 0) {
               getCapLayer.useProxy = true;
             }
-            if ($scope.format == 'wms') {
-              var layer =
-                  gnMap.addWmsToMapFromCap($scope.map, getCapLayer, style);
+            if ($scope.format === 'wms') {
+              var layer = gnMap.addWmsToMapFromCap($scope.map, getCapLayer, style);
+              var wmsErrors = layer.get('errors');
+              if (!wmsErrors || wmsErrors.length === 0) {
+                gnAlertService.addAlert({
+                  msg: $translate.instant('layerAdded',
+                      {
+                        layer: layer.get('label'),
+                        extent: layer.get('extent') ? layer.get('extent').toString() : null
+                      }),
+                  type: 'success'
+                }, 5);
+              } else {
+                wmsErrors.forEach(function (errMsg) {
                   gnAlertService.addAlert({
-                    msg: $translate.instant('layerAdded',
-                        {layer: layer.get('label'), extent: layer.get('cextent').toString()}),
-                    type: 'success'
-                  },4);
+                    msg: errMsg,
+                    type: 'warning'
+                  }, 5);
+                });
+              }
               gnMap.feedLayerMd(layer);
               return layer;
-            } else if ($scope.format == 'wfs') {
+            } else if ($scope.format === 'wfs') {
               var layer = gnMap.addWfsToMapFromCap($scope.map, getCapLayer,
                   $scope.url);
               gnMap.feedLayerMd(layer);
               return layer;
-            } else if ($scope.format == 'wmts') {
+            } else if ($scope.format === 'wmts') {
               return gnMap.addWmtsToMapFromCap($scope.map, getCapLayer,
                   $scope.capability);
             } else {
@@ -425,7 +437,7 @@
           collection: '='
         },
         template: "<ul class='gn-layer-tree'><li data-ng-show='collection.length > 10' >" +
-            "<div class='input-group input-group-sm'><span class='input-group-addon'><i class='fa fa-filter'></i></span>" + 
+            "<div class='input-group input-group-sm'><span class='input-group-addon'><i class='fa fa-filter'></i></span>" +
             "<input class='form-control' aria-label='" + label + "' data-ng-model-options='{debounce: 200}' data-ng-model='layerSearchText'/></div>" +
             "</li>" +
             '<gn-cap-tree-elt ng-repeat="member in collection | filter:layerSearchText | orderBy: \'Title\'" member="member">' +

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -366,6 +366,7 @@
     "layerWillBeAddedToMapButRecordNotFound": "Record with UUID '{{uuid}}' referencing '{{layer}}' from service '{{url}}' was not found in the catalogue. Layer will be added to the map anyway and a metadata URL found in the capability document.",
     "layerNotfoundInCapability": "Layer '{{layer}}' not found in <a href='{{url}}'>{{type}} capability</a>. Try to <a href=\"#/map?add=[{%22url%22:%22{{url}}%22,%22type%22:%22{{type}}%22}]\">load another layer from the {{type}} service</a>?",
     "layerNotAvailableInMapProj": "The service does not provide the layer in the map projection '{{proj}}'. The layer will be added to the map but may not be displayed properly.",
+    "layerWmsInvalidExtent": "Failed to calculate a valid extent for custom projection '{{proj}}' from geographic bounds. The layer will be added to the map but may not be displayed properly.",
     "layerCRSNotFound": "The layer does not provide coordinate reference system information. This may be related to a WMS version lower than 1.3.0.",
     "layerTileLoadError": "Something went wrong while loading tile <a href='{{url}}' target='_blank'>'{{url | limitTo: 30}} ...'</a> for layer '{{layer}}'.",
     "getCapFailure":"The WMS getCapabilities request failed",


### PR DESCRIPTION
This PR adds basic support for WMS services prior to version 1.3.0, which are not supported by OpenLayers out-of-the-box.

### Parse missing properties
Some `GetCapabilities` properties of these older WMS services are ignored by the OL parser. This PR uses the `xml2json` lib to scan for and add the missing properties.

### Improve BBOX creation
WMS requests require a valid bounding box. Unfortunately, even though some EPSG codes might be standard, a user could define their own Proj4 definition for it. Because of that, this will result in an invalid `BBOX` and therefore invalid WMS request.
This PR checks if the Proj4 definition set by the user is a custom one. If it is, it will use the geographic bounds of the WMS layer `GetCapabilities` and reproject these to a valid `BBOX`. If it's not custom, it will use the bounds from the `GetCapabilities` CRS list (if a match is found).

### Maintain WMS layers after projection switch
Currently, WMS layers are not reprojected if the user uses the Projection Switcher in the viewer map. They are simply being ignored and re-appear if the user switches back to the original projection.
This PR tries to re-add all WMS layers once the projection has been switched. 