### PR TITLE
Improvements fc editor

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -309,7 +309,7 @@
   <xsl:template mode="render-value" match="gmx:Anchor">
     <xsl:choose>
       <xsl:when test="starts-with(./@xlink:href,'http')">
-        <a href="{./@xlink:href}"><xsl:value-of select="gfc:code/*/text()"/></a>
+        <a href="{./@xlink:href}"><xsl:value-of select="./text()"/></a>
       </xsl:when> 
       <xsl:otherwise><xsl:value-of select="./text()"/></xsl:otherwise>
     </xsl:choose>

--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -307,11 +307,9 @@
   </xsl:template>
 
   <xsl:template mode="render-value" match="gmx:Anchor">
-    <xsl:message>faa</xsl:message>
     <xsl:choose>
       <xsl:when test="starts-with(./@xlink:href,'http')">
         <a href="{./@xlink:href}"><xsl:value-of select="gfc:code/*/text()"/></a>
-        <xsl:message>foo</xsl:message>
       </xsl:when> 
       <xsl:otherwise><xsl:value-of select="./text()"/></xsl:otherwise>
     </xsl:choose>

--- a/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/formatter/xsl-view/view.xsl
@@ -27,6 +27,7 @@
                 xmlns:gfc="http://www.isotc211.org/2005/gfc"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:gml="http://www.opengis.net/gml"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:tr="java:org.fao.geonet.api.records.formatters.SchemaLocalizations"
@@ -303,6 +304,18 @@
        gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|
        gco:LocalName|gml:beginPosition|gml:endPosition">
     <xsl:value-of select="."/>
+  </xsl:template>
+
+  <xsl:template mode="render-value" match="gmx:Anchor">
+    <xsl:message>faa</xsl:message>
+    <xsl:choose>
+      <xsl:when test="starts-with(./@xlink:href,'http')">
+        <a href="{./@xlink:href}"><xsl:value-of select="gfc:code/*/text()"/></a>
+        <xsl:message>foo</xsl:message>
+      </xsl:when> 
+      <xsl:otherwise><xsl:value-of select="./text()"/></xsl:otherwise>
+    </xsl:choose>
+
   </xsl:template>
 
   <xsl:template mode="render-value" match="gmd:PT_FreeText">

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/config-editor.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/config-editor.xml
@@ -37,6 +37,8 @@
     <for name="gfc:functionalLanguage" use="data-gn-language-picker"/>
     <for name="gmd:languageCode" use="data-gn-language-picker"/>
 
+    <!--<for name="gfc:code" use="data-gn-anchor-switcher"/>-->
+
     <for name="gfc:producer" addDirective="data-gn-directory-entry-selector">
       <directiveAttributes
         data-template-add-action="true"
@@ -50,13 +52,18 @@
 
   <fieldsWithFieldset>
     <name>gfc:producer</name>
-    <name>gfc:featureType</name>
-    <name>gfc:carrierOfCharacteristics</name>
+    <name>gfc:FC_FeatureType</name>
+    <!--<name>gfc:carrierOfCharacteristics</name>-->
     <name>gfc:listedValue</name>
     <name>gfc:constrainedBy</name>
     <name>gfc:inheritsFrom</name>
     <name>gfc:inheritsTo</name>
     <name>gco:range</name>
+    <name>gfc:FC_FeatureAttribute</name>
+    <name>gfc:FC_FeatureAssociation</name>
+    <name>gmx:subCatalogue</name>
+    <name>gfc:FC_AssociationRole</name>
+    <name>gfc:FC_FeatureOperation</name>
   </fieldsWithFieldset>
 
   <fieldsWithAnchorOption>
@@ -97,8 +104,11 @@
         </section>
       </tab>
       <flatModeExceptions>
-        <for name="gfc:code"/>
-        <for name="gfc:listedValue"/>
+        <for name="gfc:definition" />
+        <for name="gfc:code" />
+        <for name="gfc:featureType" />
+        <for name="gfc:listedValue" />
+        <for name="gfc:carrierOfCharacteristics" />
       </flatModeExceptions>
     </view>
     <view name="advanced">

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/layout.xsl
@@ -27,6 +27,7 @@
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:gfc="http://www.isotc211.org/2005/gfc"
                 xmlns:gn="http://www.fao.org/geonetwork"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
                 xmlns:gn-fn-iso19110="http://geonetwork-opensource.org/xsl/functions/profiles/iso19110"
                 xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
@@ -75,7 +76,7 @@
     <xsl:apply-templates mode="mode-iso19110" select="*|@*"/>
   </xsl:template>
 
-  <xsl:template mode="mode-iso19110" match="gmd:*|gmx:*">
+  <xsl:template mode="mode-iso19110" match="gmd:*|gmx:*|gco:*|xlink:*">
     <xsl:apply-templates mode="mode-iso19139" select="*|@*">
       <xsl:with-param name="schema" select="'iso19139'"/>
       <xsl:with-param name="labels" select="$iso19139labels"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/loc/eng/labels.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/loc/eng/labels.xml
@@ -56,27 +56,29 @@
     <description>Catalogue date</description>
   </element>
   <element name="gfc:producer">
-    <label>Catalogue producer</label>
-    <description>Catalogue responsible</description>
+    <label>Producer</label>
+    <description>Feature catalogue responsible</description>
   </element>
   <element name="gfc:featureType">
-    <label>Property description</label>
-    <description>Property description</description>
+    <label>Featuretype</label>
+    <btnLabel>Add featuretype</btnLabel>
+    <description>Describes a type of features</description>
   </element>
   <element name="gfc:isAbstract">
     <label>Abstract</label>
-    <description>Is this element an abstract element ?</description>
+    <description>Is this element an abstract element?</description>
   </element>
   <element name="gfc:FC_FeatureType">
-    <label>Attribute table description</label>
-    <description>Attribute table description</description>
+    <label>Featuretype</label>
+    <description>Description of a type of features</description>
   </element>
   <element name="gfc:typeName">
-    <label>Property name</label>
-    <description></description>
+    <label>Typename</label>
+    <description>Describes a type of feature</description>
   </element>
   <element name="gfc:carrierOfCharacteristics">
-    <label>Elements</label>
+    <label>Carrier of Characteristics</label>
+    <btnLabel>Add carrier</btnLabel>
     <description>Association, attribute, operation, ...</description>
   </element>
   <element name="gfc:definition">
@@ -112,7 +114,8 @@
     <description/>
   </element>
   <element name="gfc:listedValue">
-    <label>Codelist</label>
+    <label>Codelist value</label>
+    <btnLabel>Add codelist value</btnLabel>
     <description>List of values for this element.</description>
   </element>
   <element name="gfc:constrainedBy">
@@ -261,22 +264,102 @@
     <label>Scope</label>
     <description>Scope definition</description>
   </element>
-  <element name="gmx:versionNumber">
-    <label>Version</label>
-    <description>Catalogue version</description>
+
+  <element name="gmx:subCatalogue">
+    <label>Sub catalogue</label>
+    <btnLabel>Add sub catalogue</btnLabel>
+    <description>Describes a sub catalogue</description>
   </element>
-  <element name="gmx:versionDate">
-    <label>Date</label>
-    <description>Catalogue date</description>
-  </element>
-  <element name="gmx:fieldOfApplication">
-    <label>Field of application</label>
-    <description>Field of application</description>
-  </element>
+
   <element name="gco:nilReason">
     <label>Nil reason</label>
-    <description/>
-    <help/>
-    <condition/>
   </element>
+
+<element name="codeSpace">
+    <label>Codespace</label>
+</element>
+<element name="gfc:FC_Binding">
+    <label>Binding</label>
+</element>
+<element name="gfc:FC_BoundFeatureAttribute">
+    <label>Bound Feature Attribute</label>
+</element>
+<element name="gfc:FC_BoundAssociationRole">
+    <label>Bound Association Role</label>
+</element>
+
+<element name="isInfinite">
+    <label>Infinite</label>
+</element>
+<element name="xsi:nil">
+    <label>Nill</label>
+</element>
+
+<element name="gml:BaseUnit">
+    <label>BaseUnit</label>
+</element>
+<element name="gmx:ML_BaseUnit">
+    <label>BaseUnit</label>
+</element>
+<element name="gml:DerivedUnit">
+    <label>DerivedUnit</label>
+</element>
+<element name="gmx:ML_DerivedUnit">
+    <label>DerivedUnit</label>
+</element>
+<element name="gml:ConventionalUnit">
+    <label>ConventionalUnit</label>
+</element>
+<element name="gmx:ML_ConventionalUnit">
+    <label>ConventionalUnit</label>
+</element>
+<element name="gmx:ML_UnitDefinition">
+    <label>UnitDefinition</label>
+</element>
+<element name="gml:UnitDefinition">
+    <label>UnitDefinition</label>
+</element>
+<element name="gmd:individualName">
+    <label>Individual</label>
+</element>
+<element name="gmd:organisationName">
+    <label>Organisation</label>
+</element>
+<element name="gmd:positionName">
+    <label>Position</label>
+</element>
+<element name="gmd:voice">
+    <label>Telephone</label>
+</element>
+<element name="gmd:facsimile">
+    <label>Fax</label>
+</element>
+<element name="gmd:deliveryPoint">
+    <label>Delivery point</label>
+</element>
+<element name="gmd:city">
+    <label>City</label>
+</element>
+<element name="gmd:administrativeArea">
+    <label>Administrative area</label>
+</element>
+<element name="gmd:postalCode">
+    <label>Postalcode</label>
+</element>
+<element name="gmd:country">
+    <label>country</label>
+</element>
+<element name="gmd:electronicMailAddress">
+    <label>Email Address</label>
+</element>
+<element name="gmx:fieldOfApplication">
+    <label>Field Of Application</label>
+</element>
+<element name="gmx:versionDate">
+    <label>Version Date</label>
+</element>
+<element name="xlink:href">
+    <label>Link</label>
+</element>
+
 </labels>

--- a/schemas/iso19110/src/main/plugin/iso19110/loc/eng/labels.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/loc/eng/labels.xml
@@ -39,10 +39,6 @@
     <label>Name</label>
     <description>Feature catalogue name</description>
   </element>
-  <element name="gco:range">
-    <label>Range</label>
-    <description></description>
-  </element>
   <element name="gfc:scope">
     <label>Scope</label>
     <description>Scope definition</description>
@@ -88,22 +84,6 @@
   <element name="gfc:fieldOfApplication">
     <label>Field of application</label>
     <description>Field of application</description>
-  </element>
-  <element name="gmd:responsibleParty">
-    <label>Responsible party</label>
-    <description>Responsible party</description>
-  </element>
-  <element name="gmd:CI_ResponsibleParty">
-    <label>Responsible party</label>
-    <description>Responsible party</description>
-  </element>
-  <element name="gco:lower">
-    <label>Lower cardinality</label>
-    <description>Lower cardinality</description>
-  </element>
-  <element name="gco:upper">
-    <label>Upper cardinality</label>
-    <description>Upper cardinality</description>
   </element>
   <element name="gfc:cardinality">
     <label>Cardinalities</label>
@@ -243,123 +223,39 @@
   <element name="gfc:valueMeasurementUnit">
     <label>Value measurement unit</label>
   </element>
-  <element name="gco:CharacterString">
-    <label>Text</label>
-    <description></description>
+  <element name="gfc:FC_Binding">
+      <label>Binding</label>
   </element>
-  <element name="gmx:Anchor">
-    <label>Anchor</label>
-    <description></description>
+  <element name="gfc:FC_BoundFeatureAttribute">
+      <label>Bound Feature Attribute</label>
   </element>
-  <element name="gmx:FileName">
-    <label>File name</label>
-    <description></description>
-  </element>
-  <!-- ==================================================== -->
-  <element name="gmx:name">
-    <label>Name</label>
-    <description>Feature catalogue name</description>
-  </element>
-  <element name="gmx:scope">
-    <label>Scope</label>
-    <description>Scope definition</description>
+  <element name="gfc:FC_BoundAssociationRole">
+      <label>Bound Association Role</label>
   </element>
 
-  <element name="gmx:subCatalogue">
+  <element name="isInfinite">
+      <label>Infinite</label>
+  </element>
+  <element name="xsi:nil">
+      <label>Nill</label>
+  </element>
+  <element name="codeSpace">
+      <label>Codespace</label>
+  </element>
+  <element name="gco:nilReason">
+      <label>Nil Reason</label>
+  </element>
+  <element name="xlink:href">
+      <label>Link</label>
+  </element>
+    <element name="gmx:subCatalogue">
     <label>Sub catalogue</label>
     <btnLabel>Add sub catalogue</btnLabel>
     <description>Describes a sub catalogue</description>
   </element>
-
-  <element name="gco:nilReason">
-    <label>Nil reason</label>
+  <element name="gmx:versionDate">
+    <label>Version date</label>
+    <btnLabel>Add date</btnLabel>
+    <description>Describes the date of the version</description>
   </element>
-
-<element name="codeSpace">
-    <label>Codespace</label>
-</element>
-<element name="gfc:FC_Binding">
-    <label>Binding</label>
-</element>
-<element name="gfc:FC_BoundFeatureAttribute">
-    <label>Bound Feature Attribute</label>
-</element>
-<element name="gfc:FC_BoundAssociationRole">
-    <label>Bound Association Role</label>
-</element>
-
-<element name="isInfinite">
-    <label>Infinite</label>
-</element>
-<element name="xsi:nil">
-    <label>Nill</label>
-</element>
-
-<element name="gml:BaseUnit">
-    <label>BaseUnit</label>
-</element>
-<element name="gmx:ML_BaseUnit">
-    <label>BaseUnit</label>
-</element>
-<element name="gml:DerivedUnit">
-    <label>DerivedUnit</label>
-</element>
-<element name="gmx:ML_DerivedUnit">
-    <label>DerivedUnit</label>
-</element>
-<element name="gml:ConventionalUnit">
-    <label>ConventionalUnit</label>
-</element>
-<element name="gmx:ML_ConventionalUnit">
-    <label>ConventionalUnit</label>
-</element>
-<element name="gmx:ML_UnitDefinition">
-    <label>UnitDefinition</label>
-</element>
-<element name="gml:UnitDefinition">
-    <label>UnitDefinition</label>
-</element>
-<element name="gmd:individualName">
-    <label>Individual</label>
-</element>
-<element name="gmd:organisationName">
-    <label>Organisation</label>
-</element>
-<element name="gmd:positionName">
-    <label>Position</label>
-</element>
-<element name="gmd:voice">
-    <label>Telephone</label>
-</element>
-<element name="gmd:facsimile">
-    <label>Fax</label>
-</element>
-<element name="gmd:deliveryPoint">
-    <label>Delivery point</label>
-</element>
-<element name="gmd:city">
-    <label>City</label>
-</element>
-<element name="gmd:administrativeArea">
-    <label>Administrative area</label>
-</element>
-<element name="gmd:postalCode">
-    <label>Postalcode</label>
-</element>
-<element name="gmd:country">
-    <label>country</label>
-</element>
-<element name="gmd:electronicMailAddress">
-    <label>Email Address</label>
-</element>
-<element name="gmx:fieldOfApplication">
-    <label>Field Of Application</label>
-</element>
-<element name="gmx:versionDate">
-    <label>Version Date</label>
-</element>
-<element name="xlink:href">
-    <label>Link</label>
-</element>
-
 </labels>

--- a/schemas/iso19110/src/main/plugin/iso19110/present/metadata-view.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/present/metadata-view.xsl
@@ -22,7 +22,9 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:geonet="http://www.fao.org/geonetwork"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:gfc="http://www.isotc211.org/2005/gfc"
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
@@ -189,7 +191,12 @@
               </th>
               <td>
                 <xsl:value-of select="gfc:memberName/gco:LocalName"/>
-
+                <xsl:choose>
+                  <xsl:when test="starts-with(gfc:code/gmx:Anchor/@xlink:href,'http')">
+                    <a href="{gfc:code/gmx:Anchor/@xlink:href}"><xsl:value-of select="gfc:code/*/text()"/></a>
+                  </xsl:when> 
+                  <xsl:when test="string(gfc:code/*/text())">(<xsl:value-of select="gfc:code/*/text()"/>)</xsl:when>
+                </xsl:choose>
                 <xsl:if test="string(gfc:definition/gco:CharacterString)">
                   -
                   <xsl:value-of select="gfc:definition/gco:CharacterString"/>
@@ -276,7 +283,12 @@
 
                       <tr>
                         <td>
-                          <xsl:value-of select="gfc:code/gco:CharacterString"/>
+                          <xsl:choose>
+                            <xsl:when test="starts-with(gfc:code/gmx:Anchor/@xlink:href,'http')">
+                              <a href="{gfc:code/gmx:Anchor/@xlink:href}"><xsl:value-of select="gfc:code/*/text()"/></a>
+                            </xsl:when> 
+                            <xsl:when test="string(gfc:code/*/text())"><xsl:value-of select="gfc:code/*/text()"/></xsl:when>
+                          </xsl:choose>
                         </td>
                         <td>
                           <xsl:value-of select="gfc:label/gco:CharacterString"/>

--- a/schemas/iso19110/src/main/plugin/iso19110/schema-suggestions.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/schema-suggestions.xml
@@ -66,6 +66,7 @@
 
   <field name="gfc:FC_ListedValue">
     <suggest name="gfc:code"/>
+    <suggest name="gfc:definition"/>
   </field>
 
   <field name="gfc:FC_AssociationRole">
@@ -79,10 +80,13 @@
   <field name="gfc:FC_FeatureAttribute">
     <suggest name="gfc:code"/>
     <suggest name="gfc:memberName"/>
-    <suggest name="gfc:code"/>
     <suggest name="gfc:definition"/>
     <suggest name="gfc:valueType"/>
     <suggest name="gfc:featureType"/>
+  </field>
+  
+  <field name="gfc:definition">
+    <suggest name="gco:CharacterString"/>
   </field>
 
   <field name="gfc:code">

--- a/schemas/iso19110/src/main/plugin/iso19110/templates/metadata.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/templates/metadata.xml
@@ -27,6 +27,7 @@
                          xmlns:gco="http://www.isotc211.org/2005/gco"
                          xmlns:gmd="http://www.isotc211.org/2005/gmd"
                          xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                         xmlns:xlink="http://www.w3.org/1999/xlink"
                          uuid="56cf8277-e2be-48ef-9bb7-05a10dedf665">
   <gmx:name>
     <gco:CharacterString>Feature catalogue template in ISO19110</gco:CharacterString>


### PR DESCRIPTION
adds some missing translations
hides generic titles (carierofcharacteristics) and displays more specific (fc_featureattribute)
makes anchors clickable links in formatter
adds definition field when adding listvalue

i tried to use data-gn-anchor-switcher on gfc:code, but it seems not able to store anchors