### PR TITLE
Add a security logger to geonetwork

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -81,6 +81,7 @@ public final class Geonet {
     public static final String SRU_SEARCH = SRU + ".search";
     public static final String USER_WATCHLIST = GEONETWORK + ".userwatchlist";
     public static final String OAI = GEONETWORK + ".oai";
+    public static final String SECURITY = GEONETWORK + ".security";
     public static final String OAI_HARVESTER = OAI + ".provider";
     // keys for logging search log
     public static final String SEARCH_LOGGER = GEONETWORK + ".search-logger";

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakAuthenticationProcessingFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakAuthenticationProcessingFilter.java
@@ -25,6 +25,7 @@ package org.fao.geonet.kernel.security.keycloak;
 
 import org.apache.commons.lang.LocaleUtils;
 
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.utils.Log;
 import org.keycloak.KeycloakPrincipal;
 
@@ -65,9 +66,9 @@ public class KeycloakAuthenticationProcessingFilter extends org.keycloak.adapter
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
 
-        if (Log.isDebugEnabled(Log.JEEVES)) {
+        if (Log.isDebugEnabled(Geonet.SECURITY)) {
             try {
-                Log.debug(Log.JEEVES,
+                Log.debug(Geonet.SECURITY,
                         "Performing Keycloak auth check. Existing auth is "
                                 + SecurityContextHolder.getContext().getAuthentication());
             } catch (Throwable t) {
@@ -83,9 +84,9 @@ public class KeycloakAuthenticationProcessingFilter extends org.keycloak.adapter
 
                 if (userDetails != null) {
                     username = userDetails.getUsername();
-                    if (Log.isDebugEnabled(Log.JEEVES)) {
+                    if (Log.isDebugEnabled(Geonet.SECURITY)) {
                         Log.debug(
-                                Log.JEEVES,
+                            Geonet.SECURITY,
                                 "Keycloak user found " + userDetails.getUsername()
                                         + " with authorities: "
                                         + userDetails.getAuthorities());
@@ -96,7 +97,7 @@ public class KeycloakAuthenticationProcessingFilter extends org.keycloak.adapter
                     auth.setDetails(keycloakPrincipal.getKeycloakSecurityContext());
                     SecurityContextHolder.getContext().setAuthentication(auth);
 
-                    Log.info(Log.JEEVES, "User '" + userDetails.getUsername()
+                    Log.info(Geonet.SECURITY, "User '" + userDetails.getUsername()
                             + "' properly authenticated via Keycloak");
 
 
@@ -107,14 +108,14 @@ public class KeycloakAuthenticationProcessingFilter extends org.keycloak.adapter
                                 response);
                         if (savedReq != null) {
                             redirect = savedReq.getRedirectUrl();
-                            Log.debug(Log.JEEVES,
+                            Log.debug(Geonet.SECURITY,
                                     "Found saved request location: " + redirect);
                         } else {
-                            Log.debug(Log.JEEVES, "No saved request found");
+                            Log.debug(Geonet.SECURITY, "No saved request found");
                         }
 
                         if (redirect != null) {
-                            Log.info(Log.JEEVES, "Redirecting to " + redirect);
+                            Log.info(Geonet.SECURITY, "Redirecting to " + redirect);
 
                             // Removing original request, since we want to
                             // retain current headers.
@@ -140,7 +141,7 @@ public class KeycloakAuthenticationProcessingFilter extends org.keycloak.adapter
                         try {
                             response.setLocale(LocaleUtils.toLocale(keycloakPrincipal.getKeycloakSecurityContext().getToken().getLocale()));
                         } catch (IllegalArgumentException e) {
-                            Log.warning(Log.JEEVES, "Unable to parse keycloak locale " + LocaleUtils.toLocale(keycloakPrincipal.getKeycloakSecurityContext().getToken().getLocale() +
+                            Log.warning(Geonet.SECURITY, "Unable to parse keycloak locale " + LocaleUtils.toLocale(keycloakPrincipal.getKeycloakSecurityContext().getToken().getLocale() +
                                     " for use " + username + ": " + e.getMessage()));
                         }
                     }
@@ -150,12 +151,13 @@ public class KeycloakAuthenticationProcessingFilter extends org.keycloak.adapter
                 // It may have been triggered at the beginning of the authentication when the user information was not available for new users.
                 // Firing the event again as the user information now exists.
                 if (this.eventPublisher != null) {
+                    Log.debug(Geonet.SECURITY, "publish the authentication success event");
                     eventPublisher.publishEvent(new InteractiveAuthenticationSuccessEvent(authResult, this.getClass()));
                 }
                 // No further action required as we are redirecting to new page
                 return;
             } catch (Exception ex) {
-                Log.warning(Log.JEEVES, "Error during Keycloak login for user "
+                Log.warning(Geonet.SECURITY, "Error during Keycloak login for user "
                         + username + ": " + ex.getMessage(), ex);
             }
         }

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakHttpSessionManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakHttpSessionManager.java
@@ -57,7 +57,7 @@ public class KeycloakHttpSessionManager implements ApplicationListener<Applicati
     private static final Logger log = LoggerFactory.getLogger(KeycloakHttpSessionManager.class);
     private SessionManagementStrategy sessions = new LocalSessionManagementStrategy();
 
-   
+
     @Override
     public void logoutAll() {
         log.info("Received request to log out all users.");

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakLogoutSuccessHandler.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakLogoutSuccessHandler.java
@@ -25,6 +25,8 @@ package org.fao.geonet.kernel.security.keycloak;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.Log;
 import org.keycloak.adapters.AdapterDeploymentContext;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,6 +55,7 @@ public class KeycloakLogoutSuccessHandler implements LogoutSuccessHandler {
         if (keycloakConfiguration.getIDPLogoutUrl() != null) {
             // The redirect url should be in the format similar to https://idp.example.com/logout?redirect={RedirecUrl} we need to replace {RedirecUrl}
             redirectUrl=keycloakConfiguration.getIDPLogoutUrl().replace(KeycloakConfiguration.REDIRECT_PLACEHOLDER, URLEncoder.encode(redirectUrl, Constants.ENCODING));
+            Log.debug(Geonet.SECURITY, "redirectUrl: " + redirectUrl);
         }
         response.setStatus(HttpStatus.OK.value());
         response.sendRedirect(redirectUrl);

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
@@ -28,12 +28,14 @@ import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.security.GeonetworkAuthenticationProvider;
 import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.UserRepository;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
+import org.fao.geonet.utils.Log;
 import org.keycloak.KeycloakPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -76,6 +78,7 @@ public class KeycloakUserUtils {
             for (String role : keycloakPrincipal.getKeycloakSecurityContext().getToken().getResourceAccess(keycloakPrincipal.getKeycloakSecurityContext().getToken().issuedFor).getRoles()) {
                 // Only use the profiles we know off
                 if (role.contains(roleGroupSeparator)) {
+                    Log.debug(Geonet.SECURITY, "Identified role " + role + " from user token.");
                     roleGroupList.add(role);
                 }
             }
@@ -92,6 +95,7 @@ public class KeycloakUserUtils {
                 user = new User();
                 user.setUsername(baselUser.getUsername());
                 newUserFlag = true;
+                Log.debug(Geonet.SECURITY, "Adding a new user: " + user);
             }
 
             if (!StringUtils.isEmpty(baselUser.getSurname())) {

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUtil.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.kernel.security.keycloak;
 
 import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,13 +50,14 @@ public class KeycloakUtil {
                 signinPath = loginUrlAuthenticationEntryPoint.getLoginFormUrl().split("\\?")[0];
             } catch(BeansException e) {
                 // If we cannot find the bean then we will just use a default.
+                Log.debug(Geonet.SECURITY, "Could not find the bean, using the default instead");
             }
             // If signinPath is null then something may have gone wrong.
             // This should generally not happen - if it does then lets set to what it currently expected and then log a warning.
             if (StringUtils.isEmpty(signinPath)) {
                 signinPath = "/signin";
-                Log.warning(Log.JEEVES,
-                        "Could not detect signin path from configuration. Using /signin");
+                Log.warning(Geonet.SECURITY,
+                    "Could not detect signin path from configuration. Using /signin");
             }
         }
         return signinPath;

--- a/web/src/main/webapp/WEB-INF/classes/log4j.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j.xml
@@ -136,6 +136,9 @@
   <logger name="geonetwork.backup">
     <level value="ERROR"/>
   </logger>
+  <logger name="geonetwork.security">
+    <level value="ERROR"/>
+  </logger>
 
   <!--  Jeeves module and submodule logger configuration -->
   <logger name="jeeves" additivity="false">


### PR DESCRIPTION
This commit introduce a new logger specifically used for the security service. We come up with the propose after lengthy discussion with @ianwallen This logger helps the admin to better capture the application's access activities for audit purpose.
The new logger would be in the Geonet.java:
public static final String SECURITY = GEONETWORK + ".security";

Note: merged in recent change @ianwallen added https://github.com/geonetwork/core-geonetwork/issues/5252 