### PR TITLE
Update-fixed-info / Use db dates 

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -938,8 +938,8 @@ public class BaseMetadataManager implements IMetadataManager {
                 String changeDate = new ISODate().toString();
                 String createDate = "";
                 if (metadata != null) {
-                    changeDate = record.get().getDataInfo().getChangeDate().getDateAndTime();
-                    createDate = record.get().getDataInfo().getCreateDate().getDateAndTime();
+                    changeDate = metadata.getDataInfo().getChangeDate().getDateAndTime();
+                    createDate = metadata.getDataInfo().getCreateDate().getDateAndTime();
                 }
                 env.addContent(new Element("changeDate").setText(changeDate));
                 env.addContent(new Element("createDate").setText(createDate));

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -937,12 +937,9 @@ public class BaseMetadataManager implements IMetadataManager {
             if (updateDatestamp == UpdateDatestamp.YES) {
                 String changeDate = new ISODate().toString();
                 String createDate = "";
-                if (metadataId.isPresent()) {
-                    java.util.Optional<Metadata> record = metadataRepository.findById(metadataId.get());
-                    if (record.isPresent()) {
-                        changeDate = record.get().getDataInfo().getChangeDate().getDateAndTime();
-                        createDate = record.get().getDataInfo().getCreateDate().getDateAndTime();
-                    }
+                if (metadata != null) {
+                    changeDate = record.get().getDataInfo().getChangeDate().getDateAndTime();
+                    createDate = record.get().getDataInfo().getCreateDate().getDateAndTime();
                 }
                 env.addContent(new Element("changeDate").setText(changeDate));
                 env.addContent(new Element("createDate").setText(createDate));

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -935,7 +935,17 @@ public class BaseMetadataManager implements IMetadataManager {
             env.addContent(schemaLoc);
 
             if (updateDatestamp == UpdateDatestamp.YES) {
-                env.addContent(new Element("changeDate").setText(new ISODate().toString()));
+                String changeDate = new ISODate().toString();
+                String createDate = "";
+                if (metadataId.isPresent()) {
+                    java.util.Optional<Metadata> record = metadataRepository.findById(metadataId.get());
+                    if (record.isPresent()) {
+                        changeDate = record.get().getDataInfo().getChangeDate().getDateAndTime();
+                        createDate = record.get().getDataInfo().getCreateDate().getDateAndTime();
+                    }
+                }
+                env.addContent(new Element("changeDate").setText(changeDate));
+                env.addContent(new Element("createDate").setText(createDate));
             }
             if (parentUuid != null) {
                 env.addContent(new Element("parentUuid").setText(parentUuid));

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -108,7 +108,7 @@
         <mdb:dateInfo>
           <cit:CI_Date>
             <cit:date>
-              <gco:DateTime><xsl:value-of select="/root/env/changeDate"/></gco:DateTime>
+              <gco:DateTime><xsl:value-of select="/root/env/createDate"/></gco:DateTime>
             </cit:date>
             <cit:dateType>
               <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="creation"/>


### PR DESCRIPTION

* Set the update date to the same date as in the database.
* In ISO19115-3, also set record creation date from the database date.


The issue here is that if you duplicate an ISO19115-3 records, the create date of the record is the one from the copy.
This change allow user to remove the creation date in the editor and then the db date is used to set the value. Not an optimal option.

@josegar74 any other suggestion to handle that case?