### PR TITLE
Fix some working copy merge issues

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
@@ -78,7 +78,7 @@ public abstract class StoreUtils {
     }
 
     /**
-     * Ues to to remove items from a metadataResource list
+     * Used to remove items from a metadataResource list
      *
      * @param l left list
      * @param r right list
@@ -109,7 +109,7 @@ public abstract class StoreUtils {
 
     /**
      * Replace the attachments of one source metadata to the other target metadata
-     * Ued for moving draft to approved metadata
+     * Used for moving draft metadata resources to approved metadata resources
      *
      *
      * @param context

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
@@ -88,20 +88,23 @@ public abstract class StoreUtils {
         Map<String,MetadataResource> rMap = new HashMap<>();
         for (MetadataResource mr : r) rMap.put(mr.getId(),mr);
 
-        Iterator<MetadataResource> itr = l.iterator();
+        // Start the results with a copy of the l list.
+        List<MetadataResource> results = new ArrayList<>(l);
+
+        Iterator<MetadataResource> itResults = results.iterator();
         // remove all that exist in rMap
-        while (itr.hasNext()) {
-            MetadataResource m = itr.next();
+        while (itResults.hasNext()) {
+            MetadataResource m = itResults.next();
             if (rMap.containsKey(m.getId())) {
                 MetadataResource mCheck = rMap.get(m.getId());
                 if (mCheck.getFilename().equals(m.getFilename())
                     && mCheck.getMetadataUuid().equals(m.getMetadataUuid())
                     && mCheck.getVisibility().equals(m.getVisibility())) {
-                    itr.remove();
+                    itResults.remove();
                 }
             }
         }
-        return l;
+        return results;
     }
 
     /**
@@ -126,9 +129,9 @@ public abstract class StoreUtils {
             final List<MetadataResource> targetResources = store.getResources(context, targetUuid, visibility, null, targetApproved);
 
             // In order to sync the 2 folders, we need to identify the records to be added, deleted and updated.
-            List<MetadataResource> targetDeleteResources  = exceptMetadataResource(new ArrayList<>(targetResources), sourceResources);
-            List<MetadataResource> targetAddResources = exceptMetadataResource(new ArrayList<>(sourceResources), targetResources);
-            List<MetadataResource> targetUpdateResources = exceptMetadataResource(new ArrayList<>(targetResources), targetDeleteResources);
+            List<MetadataResource> targetDeleteResources  = exceptMetadataResource(targetResources, sourceResources);
+            List<MetadataResource> targetAddResources = exceptMetadataResource(sourceResources, targetResources);
+            List<MetadataResource> targetUpdateResources = exceptMetadataResource(targetResources, targetDeleteResources);
 
             // Add new records
             for (MetadataResource resource: targetAddResources) {

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -567,4 +567,14 @@ public interface IMetadataUtils {
      * @param dest
      */
     void cloneFiles(AbstractMetadata original, AbstractMetadata dest);
+
+    /**
+     * merge the files from the original metadata to the destination metadata.
+     * Used when merging creating a draft version to approved copy
+     * In this case the files that no longer exists in the draft will be removed from the dest
+     *
+     * @param original
+     * @param dest
+     */
+    void replaceFiles(AbstractMetadata original, AbstractMetadata dest);
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -575,7 +575,7 @@ public interface IMetadataUtils {
     void cloneFiles(AbstractMetadata original, AbstractMetadata dest);
 
     /**
-     * merge the files from the original metadata to the destination metadata.
+     * Merge the files from the original metadata to the destination metadata.
      * Used when merging creating a draft version to approved copy
      * In this case the files that no longer exists in the draft will be removed from the dest
      *

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -1043,4 +1043,9 @@ public class BaseMetadataUtils implements IMetadataUtils {
     public void cloneFiles(AbstractMetadata original, AbstractMetadata dest) {
         // Empty implementation for non-draft mode as not used
     }
+
+    @Override
+    public void replaceFiles(AbstractMetadata original, AbstractMetadata dest) {
+        // Empty implementation for non-draft mode as not used
+    }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
@@ -609,6 +609,27 @@ public class DraftMetadataUtils extends BaseMetadataUtils {
     }
 
     @Override
+    public void replaceFiles(AbstractMetadata original, AbstractMetadata dest) {
+        try {
+            boolean oldApproved=true;
+            boolean newApproved=false;
+
+            // If destination is approved then this is a working copy so the original will not be approved.
+            if (metadataUtils.isMetadataApproved(dest.getId())) {
+                oldApproved=false;
+                newApproved=true;
+            }
+            StoreUtils.replaceDataDir(context, original.getUuid(), dest.getUuid(), oldApproved, newApproved);
+            cloneStoreFileUploadRequests(original, dest);
+
+        } catch (Exception ex) {
+            Log.error(Geonet.RESOURCES, "Failed copy of resources: " + ex.getMessage(), ex);
+            throw new RuntimeIOException(ex);
+        }
+    }
+
+
+    @Override
     public void cancelEditingSession(ServiceContext context, String id) throws Exception {
         super.cancelEditingSession(context, id);
 


### PR DESCRIPTION
Create replaceDataDir to be used when merging a draft back to approved record. The previous copyDataDir would just copy the data and not remove the records that were deleted in the draft. 

Also added cleanup of draft resources after the draft is merged to the approved record.

Prior to this release it was not possible to remove a resource.
- Enable workflow
- Create new metadata and add thumbnail image (image1)
- Approve/publish the metadata
- Edit metadata - it should create a new working copy
- In the file store remove the image - but keep the thumbnail link in the metadata record.  Thumbnail should show up as broken image.
- Also add a new thumbnail - different image (image2).
- Save the metadata record and approve

2 Bugs that are fixed with these changes.
- The thumbnail in the approved version is visible even when it should have been removed.  (image1 was not removed from approved metadata folder)
- If you go on the filesystem - you will see (image2) still exists in the draft metadata folder when it should have been removed when draft was removed after the approval.

