### PR TITLE
Change the `btn-success` class to the more used 'save & close' button

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -58,7 +58,7 @@
     </div>
     <div class="btn-group">
       <button type="button"
-              class="btn btn-default navbar-btn"
+              class="btn btn-success navbar-btn"
               aria-label="{{'closeEditor' | translate}}"
               title="{{'closeEditor'|translate}}"
               gn-click-and-spin="close(false, false)"
@@ -67,7 +67,7 @@
         <span class="visible-lg" data-translate="">closeEditor</span>
       </button>
       <button type="button"
-              class="btn btn-default navbar-btn dropdown-toggle"
+              class="btn btn-success navbar-btn dropdown-toggle"
               data-ng-if="((user.isEditorForGroup(gnCurrentEdit.metadata.groupOwner) || user.isAdmin()) && gnCurrentEdit.metadata.mdStatus == 1 && isMdWorkflowEnable) ||
               ((user.isReviewerForGroup(gnCurrentEdit.metadata.groupOwner) || user.isAdmin()) && gnCurrentEdit.metadata.mdStatus == 4)"
               aria-label="{{'showOptions' | translate}}"
@@ -98,13 +98,13 @@
               data-gn-click-and-spin="save(true, false)"
               id="gn-editor-btn-save"
               aria-label="{{(isTemplate() ? 'saveTemplate' : (gnCurrentEdit.metadata.draft === 'y' ? 'saveDraft' : 'saveMetadata')) | translate}}"
-              class="btn btn-success navbar-btn">
+              class="btn btn-default navbar-btn">
         <i class="fa fa-fw fa-save"/>
         <span class="visible-lg">{{(isTemplate() ? 'saveTemplate' : (gnCurrentEdit.metadata.draft === 'y' ? 'saveDraft' : 'saveMetadata')) | translate}}</span>
       </button>
       <button type="button"
               data-ng-disabled="gnCurrentEdit.metadata.draft === 'y'"
-              class="btn btn-success navbar-btn dropdown-toggle"
+              class="btn btn-default navbar-btn dropdown-toggle"
               aria-label="{{'showOptions' | translate}}"
               title="{{(gnCurrentEdit.metadata.draft === 'y' ? 'draftCanNoBeATemplateOrMinorEdit' : 'showOptions') | translate}}"
               data-toggle="dropdown"

--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -58,7 +58,7 @@
     </div>
     <div class="btn-group">
       <button type="button"
-              class="btn btn-success navbar-btn"
+              class="btn btn-default navbar-btn"
               aria-label="{{'closeEditor' | translate}}"
               title="{{'closeEditor'|translate}}"
               gn-click-and-spin="close(false, false)"
@@ -67,7 +67,7 @@
         <span class="visible-lg" data-translate="">closeEditor</span>
       </button>
       <button type="button"
-              class="btn btn-success navbar-btn dropdown-toggle"
+              class="btn btn-default navbar-btn dropdown-toggle"
               data-ng-if="((user.isEditorForGroup(gnCurrentEdit.metadata.groupOwner) || user.isAdmin()) && gnCurrentEdit.metadata.mdStatus == 1 && isMdWorkflowEnable) ||
               ((user.isReviewerForGroup(gnCurrentEdit.metadata.groupOwner) || user.isAdmin()) && gnCurrentEdit.metadata.mdStatus == 4)"
               aria-label="{{'showOptions' | translate}}"


### PR DESCRIPTION
This PR changes the `btn-success` class form the `Save` to the more used `Save & close` button.

**Before**
![gn-success-before](https://user-images.githubusercontent.com/19608667/102765511-02178180-437d-11eb-8f9a-0277a86a72c2.png)

**After**
![gn-success-after](https://user-images.githubusercontent.com/19608667/102765541-093e8f80-437d-11eb-866a-490f9c15a977.png)
