### PR TITLE
Do not show workflow related messages when workflow is not enabled

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -28,15 +28,18 @@
                 <small class="text-muted"
                        data-gn-humanize-time="{{md['geonet:info'].changeDate}}"
                        data-from-now=""></small>
-                &centerdot;
-                <small class="text-muted gn-status"
-                      data-ng-class="{'text-success': md.mdStatus == 2, 'text-warning': md.mdStatus == 4}"
-                      data-ng-if="md.mdStatus < 50 && isMdWorkflowEnable">{{('status-' + md.mdStatus) | translate}}</small>
 
-                <small class="text-muted gn-status"
-                      data-ng-class="text-warning"
-                      data-ng-if="!md.mdStatus"
-                      data-ng-translate="">{{'status-no-status' | translate}}</small>
+                <span data-ng-if="isMdWorkflowEnable">
+                  &centerdot;
+                  <small class="text-muted gn-status"
+                        data-ng-class="{'text-success': md.mdStatus == 2, 'text-warning': md.mdStatus == 4}"
+                        data-ng-if="md.mdStatus < 50 && isMdWorkflowEnable">{{('status-' + md.mdStatus) | translate}}</small>
+
+                  <small class="text-muted gn-status"
+                        data-ng-class="text-warning"
+                        data-ng-if="!md.mdStatus"
+                        data-ng-translate="">{{'status-no-status' | translate}}</small>
+                </span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR hides the workflow related messages in the 'contribute dashboard' when the workflow is not enabled in the admin.

**Before**

![gn-workflow-before](https://user-images.githubusercontent.com/19608667/102776203-9c33f580-438e-11eb-97fd-e85915df3921.png)

**After**

![gn-workflow-after](https://user-images.githubusercontent.com/19608667/102776236-ae159880-438e-11eb-927f-d144564125c1.png)

