### PR TITLE
Differentiate between linktype and nilReason in the editor

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -430,8 +430,10 @@
         // Toggle class on all gn-attr widgets
         if (gnCurrentEdit.displayAttributes) {
           $('.gn-attr').removeClass('hidden');
+          $('.btn-nil').removeClass('hidden');
         } else {
           $('.gn-attr').addClass('hidden');
+          $('.btn-nil').addClass('hidden');
         }
       };
 

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1549,7 +1549,27 @@
   -->
   <xsl:template mode="render-for-field-for-attribute"
                 match="gn:attribute[not(@name = ('ref', 'parent', 'id', 'uuid', 'type', 'uuidref',
-    'xlink:show', 'xlink:actuate', 'xlink:arcrole', 'xlink:role', 'xlink:title', 'xlink:href'))]"
+    'xlink:show', 'xlink:actuate', 'xlink:arcrole', 'xlink:role', 'xlink:title', 'xlink:href', 'xlink:type'))]"
+                priority="4">
+    <xsl:param name="ref"/>
+    <xsl:param name="insertRef" select="''"/>
+
+    <xsl:variable name="attributeLabel" select="gn-fn-metadata:getLabel($schema, @name, $labels)"/>
+    <xsl:variable name="fieldName"
+                  select="concat(replace(@name, ':', 'COLON'), '_', $insertRef)"/>
+    <button type="button" class="btn btn-default btn-xs btn-attr btn-nil btn-xs gn-attr-{replace(@name, ':', '_')} {if ($isDisplayingAttributes = true()) then '' else 'hidden'}"
+            id="gn-attr-add-button-{$fieldName}"
+            data-gn-click-and-spin="add('{$ref}', '{@name}', '{$insertRef}', null, true)"
+            title="{$attributeLabel/description}">
+      <i class="fa fa-plus fa-fw"/>
+      <xsl:value-of select="$attributeLabel/label"/>
+    </button>
+  </xsl:template>
+
+  <!-- add attribute for link type -->
+  <xsl:template mode="render-for-field-for-attribute"
+                match="gn:attribute[not(@name = ('ref', 'parent', 'id', 'uuid', 'type', 'uuidref',
+    'xlink:show', 'xlink:actuate', 'xlink:arcrole', 'xlink:role', 'xlink:title', 'xlink:href', 'gco:nilReason'))]"
                 priority="4">
     <xsl:param name="ref"/>
     <xsl:param name="insertRef" select="''"/>


### PR DESCRIPTION
At the moment the `nil reason` button is shown for 'link type' (named anchor) fields, while the attributes are hidden (toggle with 'more details'), and therefore the `nil reason` button should be hidden.

![gn-both-buttons](https://user-images.githubusercontent.com/19608667/102784061-220a6d80-439c-11eb-999e-7fdefef1e39a.png)

This PR differentiates between the 'linktype' and 'nil' buttons and start with a different display state: hidden/shown. Both buttons also get a different class. When you now open the editor the 'linktype' field is shown, the 'nil' button isn't.

When a user clicks on the `More Details` button the extra buttons are shown, the 'linktype' button is untouched.

**Screenshot of the new situation**

![gn-no-nil](https://user-images.githubusercontent.com/19608667/102784090-2b93d580-439c-11eb-92cb-6afe27d26783.png)
