### PR TITLE
User feedback / Can't save feedback

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v402/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v402/migrate-default.sql
@@ -35,6 +35,8 @@ UPDATE Settings SET value = 'Etc/UTC' WHERE name = 'system/server/timeZone' AND 
 --          AT TIME ZONE (SELECT value FROM Settings WHERE name = 'system/server/timeZone')), 'YYYY-MM-DDThh24:mi:ssZ')
 --        ) WHERE length(createdate) = 19 AND length(changedate) = 19;
 
+ALTER TABLE guf_userfeedbacks_guf_rating DROP COLUMN GUF_UserFeedbacks_uuid;
+
 
 UPDATE Settings SET value='4.0.2' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
Error is:

```
could not execute batch; SQL [insert into GUF_UserFeedbacks_GUF_Rating (GUF_UserFeedback_uuid, detailedRatingList_id) values (?, ?)]; constraint [guf_userfeedbacks_uuid]
```

Probably related to JPA update. Column name is different from 3.x.

V3 is
![image](https://user-images.githubusercontent.com/1701393/102856352-95f15800-4426-11eb-8e5f-1f2f55f04713.png)


V4 (after this migration) is
![image](https://user-images.githubusercontent.com/1701393/102856371-9be73900-4426-11eb-9b44-3a06e197645d.png)
