### PR TITLE
Import metadata samples and templates - set the same uuid in the xml and in the database for templates

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
@@ -295,6 +295,10 @@ public class MetadataSampleApi {
                                 setSourceId(siteId).
                                 setOwner(owner).
                                 setGroupOwner(1);
+                            // Set the UUID explicitly, insertMetadata doesn't update the xml with the generated UUID for templates
+                            if (MetadataType.lookup(isTemplate) == MetadataType.TEMPLATE) {
+                                xml = dataManager.setUUID(schemaName, uuid, xml);
+                            }
                             dataManager.insertMetadata(context, metadata, xml, true, true, true, UpdateDatestamp.NO, false, false);
                             report.addMetadataInfos(metadata,
                             String.format(


### PR DESCRIPTION
When importing the samples & templates for metadata schemas with the related Administration option, it's created a new uuid that is stored in the database, but for templates the uuid is not updated in the xml, so the database record ends with a different uuid than the related xml content:

![Screenshot 2020-12-22 at 11 36 15](https://user-images.githubusercontent.com/1695003/102881602-643fb780-444d-11eb-8f19-fba16132a961.png)

The code relies in ` dataManager.insertMetadata` that doesn't apply `update-fixed-info` process for templates.

When importing a template with the Metadata Insert option, it handles it properly using the `set-uuid` process:

https://github.com/geonetwork/core-geonetwork/blob/a0d3083673a588cdd51815d3023213d83d15af58/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java#L846-L850

This pull request updates the import of the samples & templates to unify the behavior.