### PR TITLE
Add a WMTS error message when the URL can't be parsed

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -145,12 +145,17 @@
         };
 
         var parseWMTSCapabilities = function(data) {
-          var parser = new ol.format.WMTSCapabilities();
-          var result = parser.read(data);
 
-          //result.contents.Layer = result.contents.layers;
-          result.Contents.operationsMetadata = result.OperationsMetadata;
-          return result.Contents;
+          try {
+            var parser = new ol.format.WMTSCapabilities();
+            var result = parser.read(data);
+
+            result.Contents.operationsMetadata = result.OperationsMetadata;
+            return result.Contents;
+          } catch(e) {
+            return e.message;
+          }
+
         };
 
         var parseWCSCapabilities = function(data) {
@@ -306,15 +311,16 @@
                   timeout: timeout
                 })
                     .success(function(data, status, headers, config) {
-                      if (data) {
-                        defer.resolve(parseWMTSCapabilities(data));
-                      }
-                      else {
-                        defer.reject();
+                      var wmtsCap = parseWMTSCapabilities(data);               
+
+                      if (!wmtsCap.operationsMetadata) {
+                        defer.reject($translate.instant('wmtsFailedToParseCapabilities'));
+                      } else {
+                        defer.resolve(wmtsCap);
                       }
                     })
                     .error(function(data, status, headers, config) {
-                      defer.reject(status);
+                      defer.reject($translate.instant('wmtsFailedToParseCapabilities'));
                     });
               }
             }

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -528,5 +528,6 @@
     "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
     "workingCopy": "Working copy",
     "metadataValidated": "Metadata validated.",
-    "wmtsLayerNoUsableMatrixSet": "The WMTS layer could not be added. This may be because none of the projections advertised in the service matches any of the known projections of the application."
+    "wmtsLayerNoUsableMatrixSet": "The WMTS layer could not be added. This may be because none of the projections advertised in the service matches any of the known projections of the application.",
+    "wmtsFailedToParseCapabilities": "Failed to parse GetCapabilities operation response."
 }


### PR DESCRIPTION
When you want to add a WMTS layer in the map, you add a URL to a WMTS service. However, when this URL is invalid, nothing happens and the 'wait' icon keeps spinning.

This PR adds a message for when the URL can't be parsed as a WMTS service.

![gn-wmts-message](https://user-images.githubusercontent.com/19608667/102888313-c9e57100-4458-11eb-812f-1b810b0158cb.png)
