### PR TITLE
ISO19139 - Preserve locale codes in metadata. Fixes #5060

### DIFF
--- a/core/src/test/java/org/fao/geonet/kernel/DataManagerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/DataManagerIntegrationTest.java
@@ -298,7 +298,7 @@ public class DataManagerIntegrationTest extends AbstractCoreIntegrationTest {
         assertEquals(uuid, Xml.selectString(updateMd, "gmd:fileIdentifier/gco:CharacterString", namespaces));
         assertEquals(parentUuid, Xml.selectString(updateMd, "gmd:parentIdentifier/gco:CharacterString", namespaces));
         assertEquals(0, Xml.selectNodes(updateMd, "*//node()[string-length(@locale) > 3]").size());
-        assertEquals(0, Xml.selectNodes(updateMd, "*//gmd:PT_Locale[string-length(@id) > 2]").size());
+        assertEquals(0, Xml.selectNodes(updateMd, "*//gmd:PT_Locale[string-length(@id) > 3]").size());
     }
 
     private int numDocs(SearchManager searchManager, String lang) throws IOException, InterruptedException {

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -86,8 +86,50 @@
   <xsl:variable name="isMultilingual"
                 select="count(/root/*/gmd:locale[*/gmd:languageCode/*/@codeListValue != $mainLanguage]) > 0"/>
 
-  <xsl:variable name="mainLanguageId"
-                select="upper-case(java:twoCharLangCode($mainLanguage))"/>
+  <xsl:variable name="mainLanguageId">
+    <!-- Potential options include 3 char or 2 char code in both upper and lower. -->
+
+    <xsl:variable name="localeList"
+                  select="/root/*/gmd:locale/gmd:PT_Locale"/>
+    <xsl:variable name="twoCharMainLangCode"
+                  select="java:twoCharLangCode($mainLanguage)"/>
+    <xsl:variable name="nextThreeCharLangCode"
+                  select="substring(concat($localeList[1]/@id, '   '), 1, 3)"/>
+    <xsl:variable name="nextTwoCharLangCode"
+                  select="java:twoCharLangCode($localeList[1]/@id)"/>
+
+    <xsl:choose>
+      <!-- If one of the locales is equal to the main language then that is the id that will be used. -->
+      <xsl:when test="$localeList[upper-case(@id) = upper-case($mainLanguage)]">
+        <xsl:value-of  select="$localeList[upper-case(@id) = upper-case($mainLanguage)]/@id"/>
+      </xsl:when>
+      <!-- If one of the locales is equal to the 2 Char main language then that is the id that will be used. -->
+      <xsl:when test="$localeList[upper-case(@id) = upper-case($twoCharMainLangCode)]">
+        <xsl:value-of  select="$localeList[upper-case(@id) = upper-case($twoCharMainLangCode)]/@id"/>
+      </xsl:when>
+
+      <!-- If one of the locales is equal to the upper case version then the codes are assumed to be in uppercase. -->
+      <xsl:when test="$localeList[@id = upper-case($nextThreeCharLangCode)]">
+        <xsl:value-of  select="upper-case($mainLanguage)"/>
+      </xsl:when>
+      <!-- If one of the locales is equal to the lower case version then the codes are assumed to be in lowercase. -->
+      <xsl:when test="$localeList[@id = lower-case($nextThreeCharLangCode)]">
+        <xsl:value-of  select="lower-case($mainLanguage)"/>
+      </xsl:when>
+
+      <!-- If one of the locales is equal to the 2 char upper case version then the codes are assumed to be in uppercase 2 char. -->
+      <xsl:when test="$localeList[@id = upper-case($nextTwoCharLangCode)]">
+        <xsl:value-of  select="upper-case($twoCharMainLangCode)"/>
+      </xsl:when>
+      <!-- If one of the locales is equal to the 2 char lower case version then the codes are assumed to be in lowercase 2 char. -->
+      <xsl:when test="$localeList[@id = lower-case($nextTwoCharLangCode)]">
+        <xsl:value-of  select="lower-case($twoCharMainLangCode)"/>
+      </xsl:when>
+
+      <!-- If we did not find an option then just use the main language as the code. -->
+      <xsl:otherwise><xsl:value-of select="$mainLanguage"/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
 
   <xsl:variable name="locales"
                 select="/root/*/gmd:locale/gmd:PT_Locale"/>
@@ -613,13 +655,22 @@
     -->
   <xsl:template match="gmd:PT_Locale">
     <xsl:element name="gmd:{local-name()}">
-      <xsl:variable name="id"
-                    select="upper-case(java:twoCharLangCode(gmd:languageCode/gmd:LanguageCode/@codeListValue, ''))"/>
+      <xsl:variable name="id">
+        <xsl:choose>
+          <xsl:when test="string-length($mainLanguageId) = 2">
+            <xsl:value-of select="upper-case(java:twoCharLangCode(gmd:languageCode/gmd:LanguageCode/@codeListValue, ''))" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="substring(gmd:languageCode/gmd:LanguageCode/@codeListValue, 1, 3)" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
 
       <xsl:apply-templates select="@*"/>
-      <xsl:if test="normalize-space(@id)='' or normalize-space(@id)!=$id">
+      <!-- Assign the code only if missing: new language added -->
+      <xsl:if test="normalize-space(@id)=''">
         <xsl:attribute name="id">
-          <xsl:value-of select="$id"/>
+          <xsl:value-of select="normalize-space($id)"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:apply-templates select="node()"/>

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryEntriesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryEntriesApi.java
@@ -214,13 +214,13 @@ public class DirectoryEntriesApi {
         }
         // Multilingual record: Remove all localizedString from the subtemplate for langs that are not in the metadata and set the gco:CharacterString
         // Monolingual record: Remove all localized strings and extract main gco:CharacterString
-        List<String> twoCharLangs = new ArrayList<String>();
+        List<String> templateLangs = new ArrayList<String>();
         for(String l : langs) {
-            twoCharLangs.add("#" + XslUtil.twoCharLangCode(l).toUpperCase());
+            templateLangs.add("#" + l);
         }
         MultilingualSchemaPlugin plugin = (MultilingualSchemaPlugin)schemaManager.getSchema(schema).getSchemaPlugin();
         if (plugin != null) {
-            plugin.removeTranslationFromElement(tpl, twoCharLangs);
+            plugin.removeTranslationFromElement(tpl, templateLangs);
         }
 
         if (transformation != null) {


### PR DESCRIPTION
Code to calculate the main language locale code reused from https://github.com/metadata101/iso19139.ca.HNAP