### PR TITLE
Add translation for "sample" on search module.

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -1,6 +1,7 @@
 {
     "Administrator": "Administrator",
     "all": "all",
+    "sample": "Sample",
     "allInPage": "all in page",
     "addToSelection": "Add to ...",
     "removeFromSelection": "Remove from ...",

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -1,7 +1,6 @@
 {
     "Administrator": "Administrator",
     "all": "all",
-    "sample": "Sample",
     "allInPage": "all in page",
     "addToSelection": "Add to ...",
     "removeFromSelection": "Remove from ...",

--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -1,6 +1,7 @@
 {
     "Administrator": "Administrateur",
     "all": "Tout sélectionner",
+    "sample": "Exemple",
     "allInPage": "Tout sélectionner dans la page",
     "addToSelection": "Ajouter à ...",
     "removeFromSelection": "Supprimer de ...",

--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -1,7 +1,6 @@
 {
     "Administrator": "Administrateur",
     "all": "Tout sélectionner",
-    "sample": "Exemple",
     "allInPage": "Tout sélectionner dans la page",
     "addToSelection": "Ajouter à ...",
     "removeFromSelection": "Supprimer de ...",

--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -180,7 +180,7 @@
             translator="db:org.fao.geonet.repository.GroupRepository:findOne:int"/>
       <item facet="recordOwner" max="45" sortBy="value"/>
       <item facet="publishedForGroup" max="199" sortBy="value"
-            translator="db:org.fao.geonet.repository.GroupRepository:findOneByName"/>
+            translator="db:org.fao.geonet.repository.GroupRepository:findByName"/>
       <item facet="standard" max="15" sortBy="value"/>
       <item facet="isHarvested" max="2" sortBy="value" translator="apploc:"/>
       <item facet="metadataType" max="3" sortBy="value" translator="apploc:recordType-"/>


### PR DESCRIPTION
There is an untranslated text "sample" on side search module.

![image](https://user-images.githubusercontent.com/74916635/103311112-78545d80-49e7-11eb-926a-4f952d751e0a.png)

The fix is to add the translation to core.json and it will be handled by Angular translation filter factory. It's similar to the "Tout sélectionner" French text in the same JSON file.