### PR TITLE
ISO19139 / ISO19115-3.2018 - Force gco:DateTime on elements that doesn't support gco:Date

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -7,11 +7,13 @@
   xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
   xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
   xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+  xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
   xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
   xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
   xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
   xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
   xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0"
+  xmlns:dqc="http://standards.iso.org/iso/19157/-2/dqc/1.0"
   xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
   xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -238,6 +240,18 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- Force element with DateTime_PropertyType to have gco:DateTime -->
+  <xsl:template match="mac:time|mac:expiryDate|mac:requestedDateOfCollection
+                      |mac:latestAcceptableDate|cit:editionDate
+                      |mrd:plannedAvailableDateTime|mdq:dateTime"
+                priority="200">
+    <xsl:variable name="value" select="gco:Date|gco:DateTime" />
+    <xsl:copy>
+      <gco:DateTime>
+        <xsl:value-of select="$value" /><xsl:if test="string-length($value) = 10">T00:00:00</xsl:if>
+      </gco:DateTime>
+    </xsl:copy>
+  </xsl:template>
 
   <xsl:template match="@gml:id">
     <xsl:choose>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -770,8 +770,9 @@
     </xsl:if>
   </xsl:template>
 
-  <!-- gmd:dateTime requires gco:DateTime -->
-  <xsl:template match="gmd:dateTime" priority="200">
+  <!-- Force element with DateTime_PropertyType to have gco:DateTime -->
+  <xsl:template match="gmd:dateTime|gmd:plannedAvailableDateTime|gmd:usageDateTime"
+                priority="200">
     <xsl:variable name="value" select="gco:Date|gco:DateTime" />
     <xsl:copy>
       <gco:DateTime>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -770,4 +770,13 @@
     </xsl:if>
   </xsl:template>
 
+  <!-- gmd:dateTime requires gco:DateTime -->
+  <xsl:template match="gmd:dateTime" priority="200">
+    <xsl:variable name="value" select="gco:Date|gco:DateTime" />
+    <xsl:copy>
+      <gco:DateTime>
+        <xsl:value-of select="$value" /><xsl:if test="string-length($value) = 10">T00:00:00</xsl:if>
+      </gco:DateTime>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Date fields in the metadata editor use the directive `gn-date-picker`, this directive adds for ISO19139 the element `gco:Date` if the time part is set to empy, but `gmd:dateTime` requires `gco:DateTime` (see http://www.datypic.com/sc/niem21/e-gmd_dateTime-1.html). 

Similar stuff happens with the directive if it's configured in the editor views to hide the time part with the attribute `hideTimeInCalendar="true"`.

This pull request updates the update-fixed-info process to use `gco:DateTime` for `gmd:dateTime` and set the time part as `T00:00:00` if it's empty. 

To test add in the data quality section a processstep date/time element.