### PR TITLE
Map / Layer / Preserve link to metadata record.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterDirective.js
@@ -283,7 +283,11 @@
            * @return {HttpPromise} promise
            */
           scope.checkWFSServerUrl = function() {
-            return $http.get(scope.url)
+            var url = scope.url;
+            if (url.indexOf('GetCapabilities') === -1) {
+              url = url + (url.indexOf('?') === -1 ? '?' : '&') + 'request=GetCapabilities';
+            }
+            return $http.get(url)
               .then(function() {
                 scope.isWfsAvailable = true;
               }, function() {

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -105,14 +105,14 @@
               data-ng-click="initIndexRequest()">
         <i class="fa fa-refresh"></i>
       </button>
-      <button data-ng-if="user.canEditRecord(md) || md.isHarvested == 'y'"
+      <button data-ng-if="user.canEditRecord(md) || md.isHarvested == 'true'"
               type="button" class="btn btn-default btn-xs dropdown-toggle"
               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="fa fa-cog"></i>
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" aria-labelledby="dropdownMenu1"
-          data-ng-if="user.canEditRecord(md) || md.isHarvested == 'y'">
+          data-ng-if="user.canEditRecord(md) || md.isHarvested == 'true'">
         <li>
           <a href="" data-ng-click="indexWFSFeatures('1.1.0')">
             <i class="fa fa-pie-chart"></i>&nbsp;


### PR DESCRIPTION
When saving or restoring map, the layer is not linked anymore to the corresponding metadata record.
Adding a uuid and label in the OWS context layer extension to preserve this link.

```xml
<ows-context:Layer name="unesco:Unesco_point" hidden="false" opacity="1">
  <ows-context:Server service="urn:ogc:serviceType:WMS" version="1.3.0"> 
    <ows-context:OnlineResource xlink:href="https://demo.geo-solutions.it:443/geoserver/ows?SERVICE=WMS&"/>
  </ows-context:Server>
  <ows-context:Extension>{
  "uuid":"27d794393a02e795416f9801a3685d8b1862dae4",
  "label":"Unesco Items"}</ows-context:Extension>
</ows-context:Layer>
```

If not preserved, then layer contextual menu has no link to metadata 

![image](https://user-images.githubusercontent.com/1701393/103663292-3b511380-4f71-11eb-9fc4-ea8dd46f18d2.png)


and WFS filter directive does not work.


![image](https://user-images.githubusercontent.com/1701393/103663241-2bd1ca80-4f71-11eb-94e1-74c64a208840.png)
