### PR TITLE
Modify spring security so that it can be set at runtime startup

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-security/config-security-default.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-default.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<beans
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
+          http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
+  xmlns="http://www.springframework.org/schema/beans">
+
+  <!-- Location to add any specific configuration required for default configuration only -->
+
+</beans>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security.xml
@@ -32,6 +32,29 @@
   <!-- <sec:debug/> -->
   <import resource="config-security-core.xml"/>
   <import resource="config-security-mapping.xml"/>
+
+  <!-- Security options
+
+  geonetwork.security.type can be supplied
+  using the -Dgeonetwork.security.type
+  or via env as GEONETWORK_SECURITY_TYPE
+  If not supplied it will default to "default" security type.
+
+  i.e. -Dgeonetwork.security.type=keycloak
+
+  Option include
+     default         - Default security
+     keycloak        - Keycloak security (see config-security-keycloak.xml for more details)
+     ldap            - ldap security (see config-security-ldap.xml for more details)
+     ldap-recursive  - ldap-recursive security (see config-security-ldap-recursive.xml for more details)
+     ecas            - ecas security (see config-security-ecas.xml for more details)
+     cas             - cas security (see config-security-cas.xml for more details)
+     cas-ldap        - cas-ldap security (see config-security-cas-ldap.xml for more details)
+     cas-database    - cas-database security (see config-security-cas-database.xml for more details)
+     shibboleth      - Shibboleth security (see config-security-shibboleth.xml for more details)
+  -->
+
+  <import resource="config-security-${geonetwork.security.type:default}.xml"/>
   <!--<import resource="config-security-keycloak.xml"/> -->
   <!--<import resource="config-security-ldap.xml"/>-->
   <!--<import resource="config-security-ldap-recursive.xml"/>-->


### PR DESCRIPTION
Modify spring security so that it can be set at runtime startup by setting -Dgeonetwork.security.type or via env GEONETWORK_SECURITY_TYPE