### PR TITLE
Portal / Related record displayed in search results do not take record origin in account.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/gridRelated.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/gridRelated.js
@@ -62,9 +62,9 @@
     }]);
 
   module.directive('gnGridRelated', [
-    'gnGlobalSettings', 'gnRelatedService', 'gnGridRelatedList',
+    'gnGlobalSettings', 'gnRelatedResources', 'gnGridRelatedList',
     'gnConfigService', 'gnConfig',
-    function(gnGlobalSettings, gnRelatedService, gnGridRelatedList,
+    function(gnGlobalSettings, gnRelatedResources, gnGridRelatedList,
              gnConfigService, gnConfig) {
       return {
         restrict: 'A',
@@ -80,6 +80,7 @@
           scope.location = window.location;
           scope.max = attrs['max'] || 5;
           scope.displayState = {};
+          scope.config = gnRelatedResources;
 
           gnConfigService.load().then(function(c) {
             scope.indexingTimeRecordLink = gnConfig['system.index.indexingTimeRecordLink'];

--- a/web-ui/src/main/resources/catalog/views/default/templates/gridRelatedList.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/gridRelatedList.html
@@ -19,12 +19,13 @@
       <!--<li class="gn-related-type">
         {{::relations[type].length}}&nbsp;{{type | translate}}
       </li>-->
-      <li ng-repeat="r in ::relations[type]" >
+      <li ng-repeat="r in ::relations[type]"
+          data-ng-init="mainType = config.getType(r, type);">
         <a ng-show="$index < max || displayState[type]"
-           href="{{location.origin}}{{location.pathname}}#/metadata/{{r.id}}"
+           data-ng-click="config.doAction(mainType, r, md)"
            title="{{('link-' + type) | translate}} > -{{r.title | gnLocalized: lang}}">
           <i class="fa fa-fw gn-icon-{{type}}"></i>
-          {{r.title | gnLocalized: lang | characters:80}}
+          {{r.title | gnLocalized: lang | characters:60}}
         </a>
       </li>
       <li ng-if="relations[type].length > max && !display">


### PR DESCRIPTION

Depending of the origin catalog/portal/remote the link has to be adapted to open the target link in current app or main portal or another window. Relates to https://github.com/geonetwork/core-geonetwork/pull/4608.

This probably does not affect many users. It is in search result with list mode with relation:

![image](https://user-images.githubusercontent.com/1701393/103904923-39688b00-50fe-11eb-9b48-4b79cece7180.png)
