### PR TITLE
Add clean:clean@reset target for web module

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -120,5 +120,9 @@ While schema plugins can be built independently, they can be conditionally inclu
    </profiles>
    ```
    
-3. The `add-schema.sh` script automates these changes.
+3. The `add-schema.sh` script automates these changes:
+
+   ```
+   ./add-schema.sh iso19139.ca.HNAP https://github.com/metadata101/iso19139.ca.HNAP 3.11.x"
+   ```
 

--- a/software_development/BUILDING.md
+++ b/software_development/BUILDING.md
@@ -82,21 +82,22 @@ Run embedded Jetty server
 
 Maven comes with built-in support for Jetty via a [jetty-maven-plugin](https://www.eclipse.org/jetty/documentation/current/jetty-maven-plugin.html).
 
-To run GeoNetwork with the embedded Jetty server you have to change directory to the root of the **web** module,
-and then execute the following maven command:
+To run GeoNetwork with the embedded Jetty server you have to change directory to the root of the **web** module, and then execute the following maven command:
 
 ```
 cd web
 mvn jetty:run -Penv-dev
 ```
 
-After a moment, GeoNetwork should be accessible at: http://localhost:8080/geonetwork
+After startup, GeoNetwork is accessible at: http://localhost:8080/geonetwork
 
 For changes related to the user interface in the `web-ui` module or the metadata schemas in the `schemas` module, can be deployed in jetty executing the following maven command in the **web** module:
 
 ```
 mvn process-resources
 ```
+
+For additional information see web [readme](../web/README.md).
 
 Tool chain
 ----------

--- a/web/README.md
+++ b/web/README.md
@@ -2,6 +2,9 @@
 
 The web module gathers the static resources and configuration files for building the final web application WAR.
 
+
+## Jetty
+
 1. Run embedded Jetty server:
    
    ```
@@ -10,7 +13,7 @@ The web module gathers the static resources and configuration files for building
    
    The `env-dev` profile above ensures geonetwork runs without a javascript cache allowing testing of changes to `web-ui`.
 
-2. After a moment, GeoNetwork should be accessible at:
+2. After startup, GeoNetwork is accessible at:
    
    * http://localhost:8080/geonetwork
 
@@ -22,11 +25,16 @@ The web module gathers the static resources and configuration files for building
      mvn process-resources
      ```
    
-   * For changes to schema plugins:
+   * For changes to schema plugins compile:
    
      ```
      cd ../schemas
      mvn install
+     ```
+     
+     And then load:
+     
+     ```
      cd ../web
      mvn process-resources
      ```
@@ -37,7 +45,26 @@ The web module gathers the static resources and configuration files for building
      mvn process-resources -DschemasCopy=true
      ```
 
-# Managing Schema Plugins
+## Clean
+
+The build generates, processes and compile files into:
+
+* ``src/main/webapp/WEB-INF/data/config/schema_plugin``
+* ``target/``
+
+Use ``mvn clean`` to remove these files.
+
+In addition running Jetty makes use of a database, data directory and cache:
+
+* ``gn.h2.db``
+* ``gn.trace.db``
+* ``images/``
+* ``jcs_caching/``
+* ``logs/``
+
+Use `mvn clean:clean@reset` to remove these files (or ``mvn clean:clean@js`` to clear the javascript cache).
+
+## Managing Schema Plugins
 
 The web application `src/main/webapp` contains `WEB-INF/data/config/schema_plugins` used
 by the application.
@@ -46,7 +73,6 @@ If your plugin is in the `schemas` folder:
 
 1. The `web/pom.xml` is setup to run jetty and automatically include any additional
    schema plugins in the `schemas` folder.
-   
 
 If your plugin is not in the `schemas` folder:
 
@@ -84,14 +110,14 @@ To include your schema plugin in `web/pom.xml`:
 
 1.  Add a profile to `web/pom.xml` unpacking your schema plugin.
 
-    Use the `iso19115-3.2018` as an example, at the time of writing:
+    Using `iso19115-xyz` as an example:
    
    ```xml
     <profile>
       <id>schema-iso19115-xyz</id>
       <activation>
         <property><name>schemasCopy</name><value>!true</value></property>
-        <file><exists>../schemas/iso19115-3.2018</exists></file>
+        <file><exists>../schemas/iso19115-xyz</exists></file>
       </activation>
       <dependencies>
         <dependency>
@@ -181,4 +207,8 @@ To add your schema plugin to the `schemas-copy` profile:
    * If your plugin is inheriting its version number from `schemas/pom.xml` you may use
      the property `gn.schemas.version`.
 
-6. The `add-schema.sh` script automates these changes.
+6. The `add-schema.sh` script automates these changes:
+
+   ```
+   ./add-schema.sh iso19139.ca.HNAP https://github.com/metadata101/iso19139.ca.HNAP 3.11.x"
+   ```

--- a/web/README.md
+++ b/web/README.md
@@ -49,20 +49,24 @@ The web module gathers the static resources and configuration files for building
 
 The build generates, processes and compile files into:
 
-* ``src/main/webapp/WEB-INF/data/config/schema_plugin``
+* ``src/main/webapp/WEB-INF/data/config/schema_plugins``
 * ``target/``
 
 Use ``mvn clean`` to remove these files.
 
-In addition running Jetty makes use of a database, data directory and cache:
+In addition running jetty makes use of a database, data directory and cache, notably: 
 
-* ``gn.h2.db``
-* ``gn.trace.db``
-* ``images/``
-* ``jcs_caching/``
-* ``logs/``
+* ``*.db``
+* ``images/`` ...
+* ``jcs_caching/`` ...
+* ``logs/`` ...
+* ``src/main/webapp/WEB-INF/data/config/schema_plugins/`` ...
+* ``src/main/webapp/WEB-INF/data/data/`` ...
+* ``src/main/webapp/WEB-INF/data/wro4j*.db``
+* ``src/main/webapp/WEB-INF/doc/en/`` ...
+* ``src/main/webapp/WEB-INF/doc/fn/`` ...
 
-Use `mvn clean:clean@reset` to remove these files (or ``mvn clean:clean@js`` to clear the javascript cache).
+Use `mvn clean:clean@reset` to remove these files.
 
 ## Managing Schema Plugins
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -717,7 +717,6 @@
               <includes>
                 <include>**/*</include>
               </includes>
-              <followSymlinks>false</followSymlinks>
             </fileset>
           </filesets>
         </configuration>
@@ -725,44 +724,54 @@
           <execution>
             <id>reset</id>
             <goals><goal>clean</goal></goals>
+            <!-- reset working files covered by .gitignore -->
             <configuration>
               <filesets>
-                <fileset> <!-- database -->
+                <fileset>
                   <directory>.</directory>
                   <includes>
-                    <include>gn*</include>
+                    <include>*.db</include>
+                    <include>*.db.old</include>
+                    <include>images/**</include>
+                    <include>jcs_caching/**</include>
+                    <include>logs/**</include>
                   </includes>
                 </fileset>
                 <fileset>
-                  <directory>jcs_caching</directory>
+                  <directory>src/main/webapp/</directory>
                   <includes>
-                    <include>**</include>
+                    <include>META-INF/MANIFEST.MF</include>
+                    <include>data/**</include>
+                    <include>doc/en/**</include>
+                    <include>doc/fr/**</include>
+                    <include>images/logos/*</include>
+                    <include>images/logos/statTmp</include>
+                    <include>scripts/lib/**</include>
                   </includes>
                 </fileset>
                 <fileset>
-                  <directory>logs</directory>
+                  <directory>src/main/webapp/WEB-INF/</directory>
                   <includes>
-                    <include>**</include>
-                  </includes>
-                </fileset>
-                <fileset>
-                  <directory>images</directory>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                </fileset>
-              </filesets>
-            </configuration>
-          </execution>
-          <execution>
-            <id>js</id>
-            <goals><goal>clean</goal></goals>
-            <configuration>
-              <filesets>
-                <fileset>
-                  <directory>jcs_caching</directory>
-                  <includes>
-                    <include>**</include>
+                    <include>data/0*</include>
+                    <include>data/config/schema_plugins/**</include>
+                    <include>data/config/schemaplugin-uri-catalog.xml</include>
+                    <include>data/data/backup/**</include>
+                    <include>data/data/metadata_data/**</include>
+                    <include>data/data/metadata_subversion/**</include>
+                    <include>data/data/resources/htmlcache/**</include>
+                    <include>data/data/resources/images/**</include>
+                    <include>data/data/schema_plugins/**</include>
+                    <include>data/data/resources/xml/**</include>
+                    <include>data/data/upload/**</include>
+                    <include>data/harvester_*</include>
+                    <include>data/index/**</include>
+                    <include>data/node_less_files/**</include>
+                    <include>data/removed/**</include>
+                    <include>data/wro4j*.db</include>
+                    <include>data/wro4j-cache*</include>
+                    <include>data/data_*</include>
+                    <include>data/lucene/**</include>
+                    <include>metadata_subversion/</include>
                   </includes>
                 </fileset>
               </filesets>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -721,6 +721,54 @@
             </fileset>
           </filesets>
         </configuration>
+        <executions>
+          <execution>
+            <id>reset</id>
+            <goals><goal>clean</goal></goals>
+            <configuration>
+              <filesets>
+                <fileset> <!-- database -->
+                  <directory>.</directory>
+                  <includes>
+                    <include>gn*</include>
+                  </includes>
+                </fileset>
+                <fileset>
+                  <directory>jcs_caching</directory>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </fileset>
+                <fileset>
+                  <directory>logs</directory>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </fileset>
+                <fileset>
+                  <directory>images</directory>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+          <execution>
+            <id>js</id>
+            <goals><goal>clean</goal></goals>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>jcs_caching</directory>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Adding some build functionality to make local jetty testing easier to manage.

To reset the database, jcs_cache, images and logs and anything else mentioned by `.gitignore` (helpful when switching branches):
```
mvn clean:clean@reset
```