### PR TITLE
Thumbnail / Improve size filter.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -40,7 +40,7 @@
              data-ng-class="{'gn-md-no-thumbnail': !md.overview[0]}">
           <img class="gn-img-thumbnail"
                alt="{{md.resourceTitle}}"
-               data-ng-src="{{md.overview[0].url}}?size=140"
+               data-ng-src="{{md.overview[0].url | thumbnailUrlSize}}"
                data-ng-if="md.overview[0]"/>
         </div>
 

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1374,6 +1374,20 @@
         return href;
       }}
   ]);
+  /**
+   * Append size parameter to request a smaller thumbnail.
+   */
+  module.filter('thumbnailUrlSize', function() {
+      return function(href, size) {
+        if(href.indexOf('api/records/') !== -1) {
+          var suffix = 'size=' + (size || 140);
+          return href.indexOf('?') !== -1 ?
+            href + '&' + suffix :
+            href + '?' + suffix;
+        } else {
+          return href;
+        }
+      }});
   module.filter('newlines', function() {
     return function(value) {
       if (angular.isArray(value)) {


### PR DESCRIPTION
Thumbnail API allows to return the overview with a custom size (see https://github.com/geonetwork/core-geonetwork/pull/4593) mainly to avoid to load big images in search results page.

Improve the filter URL to be able to customize easily the size of the image to return and avoid to append this parameter to URL not pointing to a GeoNetwork instance.