### PR TITLE
release cleanup

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -1,20 +1,30 @@
 Release
 =======
 
-The release module for GeoNetwork.
+The release module for GeoNetwork requires jetty to be downloaded before it will package an installer for use.
 
-Open a terminal window and execute the following steps from within the ``release`` folder.
+1. Build geonetwork if you have not done so already
+   
+   ```
+   mvn clean install -DskipTests
+   ```
 
+2. From the release folder, download jetty (you only need to do this once):
 
-* Once GeoNetwork has been built (run Maven in the repository root), download Jetty:
+   ```
+   mvn process-resources -Djetty-download
+   ```
 
-    `
-    mvn clean install -Djetty-download
-    `
+3. Once the `jetty` folder is in place the release module will package the `zip` installer:
 
-* Next, create the ZIP distributions and copy the WAR:
+   ```
+   mvn package
+   ```
+    
+4. The installer is created in `target` folder.
 
-    `
-    ant
-    `
-
+3. To clean up the `jetty` folder:
+   
+   ```
+   mvn clean:clean@reset
+   ```

--- a/release/build.xml
+++ b/release/build.xml
@@ -144,11 +144,11 @@
   <!-- Create ZIP distribution for GeoNetwork + Jetty + shell scripts -->
   <target name="zip">
     <property file="../web/src/main/webapp/WEB-INF/server.prop"/>
-    <mkdir dir="target"/>
+    <mkdir dir="target/${appName}-${release}"/>
 
     <echo message="Creating ZIP file for ${appName} ${release}..."/>
 
-    <zip destfile="target/${appName}-${release}-${subVersion}.zip">
+    <zip destfile="target/${appName}-${release}/${appName}-${release}-${subVersion}.zip">
       <zipfileset dir="./bin" excludes="**.sh" prefix="bin" />
       <zipfileset dir="./bin" includes="**.sh" prefix="bin" filemode="774"/>
       <zipfileset dir="${propsdir}" includes="readme.html, license.html" />
@@ -159,7 +159,7 @@
     </zip>
 
     <checksum
-      file="target/${appName}-${release}-${subVersion}.zip"
+      file="target/${appName}-${release}/${appName}-${release}-${subVersion}.zip"
       forceOverwrite="yes"/>
 
   </target>
@@ -168,9 +168,9 @@
   <target name="war" depends="zip">
 
     <copy file="../web/target/geonetwork.war"
-          tofile="../${appName}-${release}/${appName}-${release}-${subVersion}.war" />
+          tofile="target/${appName}-${release}/${appName}-${release}-${subVersion}.war" />
 
-    <checksum file="../${appName}-${release}/${appName}-${release}-${subVersion}.war"
+    <checksum file="target/${appName}-${release}/${appName}-${release}-${subVersion}.war"
               forceOverwrite="yes"/>
 
   </target>

--- a/release/build.xml
+++ b/release/build.xml
@@ -52,7 +52,7 @@
   <property name="javaVersion" value="1.8.0"/>
   <property name="jreUrl" value="http://openjdk.java.net/"/>
   <property name="OS" value="Compiled on ${os.name} (${osys})"/>
-  <property name="propsdir" value="../.props"/>
+  <property name="propsdir" value="target/props"/>
   <property name="ant.build.javac.target" value="1.8"/>
   <property name="debugOn" value="on"/>
 
@@ -113,11 +113,11 @@
     <copy file="readme.html"
           tofile="${propsdir}/readme.html"
           filtering="on" overwrite="yes"/>
-    
+
     <!-- license file -->
     <copy file="license.html"
           tofile="${propsdir}/license.html"
-          filtering="on" overwrite="yes"/>    
+          filtering="on" overwrite="yes"/>
 
     <echo message="Replacing template variables in readme files..."/>
     <replace file="${propsdir}/readme.html"
@@ -132,7 +132,7 @@
     <replace file="${propsdir}/readme.html" token="@appName@" value="${appName}"/>
     <replace file="${propsdir}/readme.html" token="@displayName@" value="${displayName}"/>
     <replace file="${propsdir}/readme.html" token="@homepage@" value="${homepage}"/>
-    <replace file="${propsdir}/readme.html" token="@year@" value="${year}"/> 
+    <replace file="${propsdir}/readme.html" token="@year@" value="${year}"/>
     <echo message="Done"/>
   </target>
 
@@ -144,16 +144,14 @@
   <!-- Create ZIP distribution for GeoNetwork + Jetty + shell scripts -->
   <target name="zip">
     <property file="../web/src/main/webapp/WEB-INF/server.prop"/>
-
-    <delete dir="../${appName}-${release}"/>
-    <mkdir dir="../${appName}-${release}"/>
+    <mkdir dir="target"/>
 
     <echo message="Creating ZIP file for ${appName} ${release}..."/>
 
-    <zip destfile="../${appName}-${release}/${appName}-${release}-${subVersion}.zip">
+    <zip destfile="target/${appName}-${release}-${subVersion}.zip">
       <zipfileset dir="./bin" excludes="**.sh" prefix="bin" />
       <zipfileset dir="./bin" includes="**.sh" prefix="bin" filemode="774"/>
-      <zipfileset dir="../.props" includes="readme.html, license.html" />
+      <zipfileset dir="${propsdir}" includes="readme.html, license.html" />
       <zipfileset dir="./jetty" prefix="jetty" excludes="logs/*.log, logs/archive/*.log" />
       <zipfileset dir="../web/target/geonetwork" prefix="web/geonetwork" />
       <zipfileset dir="./data" prefix="web/geonetwork/data" />
@@ -161,7 +159,7 @@
     </zip>
 
     <checksum
-      file="../${appName}-${release}/${appName}-${release}-${subVersion}.zip"
+      file="target/${appName}-${release}-${subVersion}.zip"
       forceOverwrite="yes"/>
 
   </target>
@@ -169,11 +167,11 @@
   <!-- Copy and rename WAR file and calculate checksum -->
   <target name="war" depends="zip">
 
-    <copy file="../web/target/geonetwork.war" 
-          tofile="../${appName}-${release}/${appName}-${release}-${subVersion}.war" />    
+    <copy file="../web/target/geonetwork.war"
+          tofile="../${appName}-${release}/${appName}-${release}-${subVersion}.war" />
 
     <checksum file="../${appName}-${release}/${appName}-${release}-${subVersion}.war"
-              forceOverwrite="yes"/> 
+              forceOverwrite="yes"/>
 
   </target>
 

--- a/release/build.xml
+++ b/release/build.xml
@@ -69,17 +69,17 @@
     <mkdir dir="${propsdir}"/>
 
     <!-- Extract Git properties -->
-    <exec executable="git" dir=".." output="git.properties">
+    <exec executable="git" dir=".." output="target/git.properties">
       <arg value="remote"/>
       <arg value="-v"/>
     </exec>
-    <property prefix="git" file="git.properties"/>
+    <property prefix="git" file="target/git.properties"/>
 
-    <exec executable="git" dir=".." output="git2.properties">
+    <exec executable="git" dir=".." output="target/git2.properties">
       <arg value="log"/>
       <arg value="--max-count=1"/>
     </exec>
-    <property prefix="git2" file="git2.properties"/>
+    <property prefix="git2" file="target/git2.properties"/>
 
     <!-- Update the properties file -->
     <propertyfile

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -23,14 +23,44 @@
     </license>
   </licenses>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reset</id>
+            <goals><goal>clean</goal></goals>
+            <!-- reset working files covered by .gitignore -->
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>.</directory>
+                  <includes>
+                    <include>jetty/**</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>jetty-download</id>
       <activation>
+        <property>
+          <name>jetty-download</name>
+        </property>
+      </activation>
+      <!--activation>
         <file>
             <missing>jetty</missing>
         </file>
-      </activation>
+      </activation-->
       <build>
         <plugins>
           <plugin>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -27,9 +27,9 @@
     <profile>
       <id>jetty-download</id>
       <activation>
-        <property>
-          <name>jetty-download</name>
-        </property>
+        <file>
+            <missing>jetty</missing>
+        </file>
       </activation>
       <build>
         <plugins>
@@ -39,7 +39,7 @@
             <executions>
               <execution>
                 <id>download-jetty</id>
-                <phase>pre-integration-test</phase>
+                <phase>generate-resources</phase>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -56,7 +56,7 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
-                <phase>install</phase>
+                <phase>process-resources</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>
@@ -68,6 +68,38 @@
                     <replace file="${project.basedir}/jetty/etc/jetty-deploy.xml">
                       <replacefilter token='default="webapps"' value='default="../web"'/>
                     </replace>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>bundle</id>
+      <activation>
+        <file>
+            <exists>jetty</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <ant antfile="build.xml" dir="${basedir}" target="distributions">
+                      <property name="build.directory" value="${project.build.directory}"/>
+                      <property name="project.version" value="${project.version}"/>
+                    </ant>
                   </target>
                 </configuration>
               </execution>

--- a/web/src/main/webapp/WEB-INF/server.prop
+++ b/web/src/main/webapp/WEB-INF/server.prop
@@ -1,5 +1,5 @@
 #GeoNetwork opensource properties. These are also used by geonetwork at runtime
-#Mon, 11 Jan 2021 01:26:56 -0800
+#Mon, 11 Jan 2021 01:50:01 -0800
 
 version=3.11.0
 subVersion=SNAPSHOT
@@ -7,10 +7,10 @@ release=3.11.0
 javaVersion=1.8.0
 jre_url=http\://openjdk.java.net/
 ant.build.javac.target=1.8
-buildDate=2021-01-11T01\:26\:56-0800
-date=2126110126
+buildDate=2021-01-11T01\:50\:01-0800
+date=2150110150
 day=11-1-2021
 OS=Compiled on Mac OS X (macosx)
 debugOn=on
-git_revision=76bb9a799db529cde966030f13d200aac56f939d
+git_revision=85523a235d868de4a5e791d2a1bc635cbb9480f4
 git_url=git@github.com\:jodygarnett/core-geonetwork.git (push)

--- a/web/src/main/webapp/WEB-INF/server.prop
+++ b/web/src/main/webapp/WEB-INF/server.prop
@@ -1,16 +1,16 @@
 #GeoNetwork opensource properties. These are also used by geonetwork at runtime
-#Fri, 04 May 2018 10:16:18 +0200
+#Mon, 11 Jan 2021 01:01:54 -0800
 
-version=3.4.2
-subVersion=0
-release=3.4.2
+version=3.11.0
+subVersion=SNAPSHOT
+release=3.11.0
 javaVersion=1.8.0
 jre_url=http\://openjdk.java.net/
 ant.build.javac.target=1.8
-buildDate=2018-05-04T10\:16\:18+0200
-date=1816041016
-day=04-5-2018
+buildDate=2021-01-11T01\:01\:54-0800
+date=2101110101
+day=11-1-2021
 OS=Compiled on Mac OS X (macosx)
 debugOn=on
-git_revision=87eac0e99f21a41e01fbdea485d4f03b80b1ae7a
-git_url=https\://github.com/geonetwork/core-geonetwork.git (push)
+git_revision=f0dee37f36a92795830e58bd88742b68e52b33d3
+git_url=git@github.com\:jodygarnett/core-geonetwork.git (push)

--- a/web/src/main/webapp/WEB-INF/server.prop
+++ b/web/src/main/webapp/WEB-INF/server.prop
@@ -1,5 +1,5 @@
 #GeoNetwork opensource properties. These are also used by geonetwork at runtime
-#Mon, 11 Jan 2021 01:01:54 -0800
+#Mon, 11 Jan 2021 01:26:56 -0800
 
 version=3.11.0
 subVersion=SNAPSHOT
@@ -7,10 +7,10 @@ release=3.11.0
 javaVersion=1.8.0
 jre_url=http\://openjdk.java.net/
 ant.build.javac.target=1.8
-buildDate=2021-01-11T01\:01\:54-0800
-date=2101110101
+buildDate=2021-01-11T01\:26\:56-0800
+date=2126110126
 day=11-1-2021
 OS=Compiled on Mac OS X (macosx)
 debugOn=on
-git_revision=f0dee37f36a92795830e58bd88742b68e52b33d3
+git_revision=76bb9a799db529cde966030f13d200aac56f939d
 git_url=git@github.com\:jodygarnett/core-geonetwork.git (push)


### PR DESCRIPTION
This is a follow on from web clean:clean@reset activity, noticed the release build was creating some folders that were not being cleaned up.

-----

1. Build geonetwork if you have not done so already
   
   ```
   mvn clean install -DskipTests
   ```

2. From the release folder, download jetty (you only need to do this once):

   ```
   mvn process-resources -Djetty-download
   ```

3. Once the `jetty` folder is in place the release module will package the `zip` installer:

   ```
   mvn package
   ```
    
4. The installer is created in `target` folder.

3. To clean up the `jetty` folder:
   
   ```
   mvn clean:clean@reset
   ```