### PR TITLE
Facet / Filter / Case insensitive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -434,13 +434,23 @@
               aggregations.aggregations[key].terms.size = newSize;
             }
             if (angular.isDefined(include)){
-              var isARegex = include.match(/^\/.*\/$/) != null;
-              aggregations.aggregations[key].terms.include =
-                isARegex ?
-                  include.substr(1, include.length - 2) :
-                  '.*' + include + '.*';
+              var isARegex = include.match(/^\/.*\/$/) != null,
+                  filter = '';
+
               // Note that ES filter on terms can not be case insensitive
               // See https://discuss.elastic.co/t/terms-aggregation-with-include-filter/50976/10
+              // but we can still build a case insensitive regex.
+              if (facetConfig[key].meta && facetConfig[key].meta.caseInsensitiveInclude) {
+                filter = '.*' + include
+                  .split('')
+                  .map(function(l) {return '['+ l.toLowerCase() + l.toUpperCase() + ']'})
+                  .join('') + '.*';
+              } else {
+                filter = isARegex ?
+                          include.substr(1, include.length - 2) :
+                          '.*' + include + '.*'
+              }
+              aggregations.aggregations[key].terms.include = filter;
             }
             if (angular.isDefined(exclude)){
               aggregations.aggregations[key].terms.exclude = exclude;

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -25,12 +25,12 @@
   </div>
 
   <div class="panel-body">
-    <div ng-if="!isTabMode"
-        ng-repeat="facet in ctrl.list track by facet.key"
-        ng-show="::ctrl.isVisibleForUser(facet) && (
+    <div ng-repeat="facet in ctrl.list track by facet.key"
+         ng-show="!isTabMode && ctrl.isVisibleForUser(facet) && (
                   facet.items.length > 0 ||
+                  facet.include.length > 0 ||
                   (facet.dates && facet.dates.length > 0))"
-        class="gn-facet">
+         class="gn-facet">
       <a href
         title="::{{facet.key | translate}}"
         class="gn-facet-header flex-row width-100"
@@ -43,11 +43,11 @@
       <div class="gn-facet-root-container"
           ng-class="{'collapse': ctrl.fLvlCollapse[facet.key]}">
 
-        <div>
+        <div ng-if="facet.type === 'terms' && facet.includeFilter
+                    && (facet.more || facet.include.length > 0)">
           <input title="{{'facetIncludeFilter' | translate}}"
-                ng-if="facet.type === 'terms' && facet.includeFilter"
                 ng-model="facet.include"
-                ng-model-options="{debounce: 200}"
+                ng-model-options="{debounce: 300}"
                 ng-change="ctrl.filterTerms(facet)"
                 autocomplete="nope"
                 class="form-control input-sm"

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -350,6 +350,9 @@ goog.require('gn_alert');
                 'field': 'tag.default',
                 'include': '.*',
                 'size': 10
+              },
+              'meta': {
+                'caseInsensitiveInclude': true
               }
             },
             'th_regions_tree.default': {
@@ -406,7 +409,11 @@ goog.require('gn_alert');
             'OrgForResource': {
               'terms': {
                 'field': 'OrgForResource',
+                'include': '.*',
                 'size': 15
+              },
+              'meta': {
+                'caseInsensitiveInclude': true
               }
             },
             'cl_maintenanceAndUpdateFrequency.key': {


### PR DESCRIPTION
Add support for filter to be case insensitive. By default it is case sensitive (as Elasticsearch include parameter works). Add a `meta` > `caseInsensitiveInclude` to turn on case insensitive mode. It will build case insensitive regexp.

![image](https://user-images.githubusercontent.com/1701393/104219753-ced98700-543e-11eb-93fd-eef4d794442f.png)


Configuration 

```json
'tag.default': {
  'terms': {
    'field': 'tag.default',
    'include': '.*',
    'size': 10
  },
  'meta': {
    'caseInsensitiveInclude': true
  }
},
```

Do not display filter if the number of items is limited (ie. no more).

Do not display facet if it has no items.

![image](https://user-images.githubusercontent.com/1701393/104219729-c8e3a600-543e-11eb-89cb-1b4bde81f4d0.png)
