### PR TITLE
Facet / Configuration / UI props in meta

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -167,17 +167,9 @@
       var esFacet = this, aggs = typeof type === 'string' ?
         angular.copy(this.configs[type].facets, {}) :
         type;
-      angular.forEach(aggs, function(facet) {
-        esFacet.removeInternalFacetConfig(facet);
-      });
       esParams.aggregations = aggs;
     };
 
-    this.removeInternalFacetConfig = function (facet) {
-      delete facet.userHasRole;
-      delete facet.collapsed;
-      return facet;
-    };
 
     this.addSourceConfiguration = function(esParams, type) {
       if (type === undefined) {
@@ -220,10 +212,12 @@
           key: fieldId,
           userHasRole: configId && this.configs[configId].facets
             && this.configs[configId].facets[fieldId]
-            && this.configs[configId].facets[fieldId].userHasRole,
+            && this.configs[configId].facets[fieldId].meta
+            && this.configs[configId].facets[fieldId].meta.userHasRole,
           collapsed: configId && this.configs[configId].facets
             && this.configs[configId].facets[fieldId]
-            && this.configs[configId].facets[fieldId].collapsed,
+            && this.configs[configId].facets[fieldId].meta
+            && this.configs[configId].facets[fieldId].meta.collapsed,
           items: [],
           path: (path || []).concat([fieldId])
         };

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -483,8 +483,7 @@
       for (var i = 0; i < facet.path.length; i++) {
         if ((i + 1) % 2 === 0) continue;
         var key = facet.path[i];
-        facetConfigs[key] =
-          gnESFacet.removeInternalFacetConfig($scope.facetConfig[key]);
+        facetConfigs[key] = $scope.facetConfig[key];
       }
       var request = gnESService.generateEsRequest($scope.finalParams, $scope.searchObj.state,
         $scope.searchObj.configId, $scope.searchObj.filters);
@@ -502,8 +501,7 @@
       for (var i = 0; i < facet.path.length; i++) {
         if ((i + 1) % 2 === 0) continue;
         var key = facet.path[i];
-        facetConfigs[key] =
-          gnESFacet.removeInternalFacetConfig($scope.facetConfig[key]);
+        facetConfigs[key] = $scope.facetConfig[key];
       }
       var request = gnESService.generateEsRequest($scope.finalParams, $scope.searchObj.state,
         $scope.searchObj.configId, $scope.searchObj.filters)

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -373,12 +373,14 @@ goog.require('gn_alert');
             //   }
             // },
             "resolutionScaleDenominator": {
-              'collapsed': true,
               "histogram": {
                 "field": "resolutionScaleDenominator",
                 "interval": 10000,
                 "keyed" : true,
                 'min_doc_count': 1
+              },
+              'meta': {
+                'collapsed': true
               }
             },
             // "serviceType": {
@@ -389,12 +391,14 @@ goog.require('gn_alert');
             //   }
             // },
             "creationYearForResource": {
-              'collapsed': true,
               "histogram": {
                 "field": "creationYearForResource",
                 "interval": 5,
                 "keyed" : true,
                 'min_doc_count': 1
+              },
+              'meta': {
+                'collapsed': true
               }
             },
             // "creationYearForResource": {
@@ -417,10 +421,12 @@ goog.require('gn_alert');
               }
             },
             'cl_maintenanceAndUpdateFrequency.key': {
-              'collapsed': true,
               'terms': {
                 'field': 'cl_maintenanceAndUpdateFrequency.key',
                 'size': 10
+              },
+              "meta": {
+                "collapsed": true
               }
             },
             'cl_status.key': {
@@ -430,11 +436,13 @@ goog.require('gn_alert');
               }
             },
             'dateStamp' : {
-              'userHasRole': 'isReviewerOrMore',
-              // 'collapsed': true,
               'auto_date_histogram' : {
                 'field' : 'dateStamp',
                 'buckets': 50
+              },
+              "meta": {
+                'userHasRole': 'isReviewerOrMore',
+                'collapsed': true
               }
             }
           },


### PR DESCRIPTION
Some facet config related to the UI eg. collapsed, userHasRole,
caseInsensitiveInclude were attached to the root of the facet config.

Use the meta properties that can be send to server and returned in
response.

The point here is to converge config between GeoNetwork 4 and GN-UI
See https://github.com/geonetwork/geonetwork-ui/blob/95b73af468363d0bb9da3a11d379a59381ab7955/libs/common/src/lib/services/bootstrap.service.ts#L35-L61

eg.
```
'cat': {
              'terms': {
                'field': 'cat.keyword',
                'size': 10
              },
              'meta': {
                'userHasRole': 'isAdministratorOrMore',
                'collapsed': true
              }
            }
```