### PR TITLE
Improvements to Link to other resources - list of suggested datasets

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1693,10 +1693,20 @@
                     scope.selection = [];
                   });
 
+                  // Clear the search params and input
+                  scope.clearSearch = function() {
+                    $('#siblingdd input').val('');
+                    scope.$broadcast('resetSearch');
+                  };
+
                   // Append * for like search
                   scope.updateParams = function() {
-                    scope.searchObj.params.any =
-                        '*' + scope.searchObj.any + '*';
+                    if (scope.searchObj.any == '') {
+                      scope.$broadcast('resetSearch');
+                    } else {
+                      scope.searchObj.params.any =
+                      '*' + scope.searchObj.any + '*';
+                    }
                   };
 
                   // Based on initiative type and association type

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
@@ -29,64 +29,75 @@
                data-allow-blank="true"></div>
         </div>
       </div>
-      <div class="form-group">
+      <div class="form-group gn-nomargin-bottom">
         <label class="col-sm-2 control-label">
           <span data-translate="">chooseACatalogRecord</span>
         </label>
         <div class="col-sm-10">
-          <div class="input-group dropdown" id="siblingdd">
+          <div class="input-group" id="siblingdd">
             <span class="input-group-addon">
               <i class="fa fa-search"/>
             </span>
             <input class="form-control"
-                   data-ng-change="updateParams();triggerSearch();" type="text"
-                   data-toggle="dropdown"
+                   data-ng-change="updateParams();triggerSearch();" 
+                   type="text"
                    data-ng-model="searchObj.any"
                    data-ng-model-options="modelOptions"
                    autocomplete="off"
                    placeholder="{{'anyPlaceHolder' | translate}}"
                    aria-label="{{'anyPlaceHolder' | translate}}"/>
-            <ul class="dropdown-menu" role="menu">
-              <li data-ng-repeat="md in searchResults.records">
-                <a href=""
-                   data-ng-click="addToSelection(md, config.associationType, config.initiativeType)">
-                  {{md.resourceTitle}}
-                </a>
-              </li>
-            </ul>
+            <span class="input-group-btn">
+              <button class="btn btn-default" type="button"
+                      data-ng-click="clearSearch()">
+                <span class="fa fa-fw fa-times text-danger"></span>
+              </button>
+            </span>
           </div>
+          <div>
+            <div class="list-group fixed gn-nopadding-left gn-nopadding-right">
+              <a href=""
+                 data-ng-repeat="md in searchResults.records"
+                 class="list-group-item"
+                 data-ng-click="addToSelection(md, config.associationType, config.initiativeType)">
+                {{md.resourceTitle}}
+                <span class="fa fa-plus pull-right"></span>
+              </a>
+            </div>
+          </div>
+          <div data-gn-pagination="paginationInfo"/>
         </div>
       </div>
-      <div class="form-group">
-        <div class="col-sm-12"
-             data-gn-remote-record-selector=""></div>
-      </div>
-      <div data-ng-if="selection.length > 0">
-        <h2 data-translate="">siblingListToAdd</h2>
-        <table class="table table-striped"
-               >
-          <thead>
-            <tr>
-              <th data-translate="">associationType</th>
-              <th data-translate="">initiativeType</th>
-              <th data-translate="">metadata</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr data-ng-repeat="obj in selection">
-              <td>{{obj.md.resourceTitle}}</td>
-              <td>{{obj.associationType | translate}}</td>
-              <td>{{obj.initiativeType | translate}}</td>
-              <td>
-                <a title="{{'removeFromSelection' | translate}}"
-                   data-ng-click="removeFromSelection(obj)" href="">
-                  <i class="btn fa fa-times text-danger"></i>
-                </a>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <div data-gn-remote-record-selector=""></div>
+      <div data-ng-if="selection.length > 0" class="form-group">
+        <label class="col-sm-2 control-label">
+          <span data-translate="">siblingListToAdd</span>
+        </label>
+        <div class="col-sm-10">
+          <table class="table table-striped table-bordered">
+            <thead>
+              <tr>
+                <th data-translate="">associationType</th>
+                <th data-translate="">initiativeType</th>
+                <th data-translate="">metadata</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-ng-repeat="obj in selection">
+                <td>{{obj.md.resourceTitle}}</td>
+                <td>{{obj.associationType | translate}}</td>
+                <td>{{obj.initiativeType | translate}}</td>
+                <td class="text-center">
+                  <a title="{{'removeFromSelection' | translate}}"
+                     data-ng-click="removeFromSelection(obj)"
+                     href="">
+                    <i class="fa fa-times text-danger"></i>
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
       <div class="">
         <button type="button" class="btn navbar-btn btn-success"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
@@ -1,5 +1,4 @@
 <div data-ng-if="allowRemoteRecordLink">
-  <br/>
   <form class="form-horizontal">
     <div class="form-group">
       <label for="gnRemoteRecordUrl"


### PR DESCRIPTION
The popup to link to other resources uses one dropdown for all resources. Searching for the right link can be hard.

This PR changes this dropdown in a paginated list and adds reset options to the search to make searching easier. The rest of the functionality is the same as before.

**Screenshot of the new popup:**

![gn-link-to-other-resources](https://user-images.githubusercontent.com/19608667/104329949-d1df8080-54ed-11eb-8763-b8d40097bb0b.png)

Changes:
- dropdown list changed to paginated list
- add reset search button
- deleting search object resets the search (full list is shown again)
- minor visual improvements