### PR TITLE
Fixed broken site logo image on fresh installation.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -206,37 +206,28 @@ public class SiteApi {
             Settings.SYSTEM_PLATFORM_VERSION,
             Settings.SYSTEM_PLATFORM_SUBVERSION
         }));
-        if (!NodeInfo.DEFAULT_NODE.equals(node.getId())) {
-            Source source = sourceRepository.findOne(node.getId());
-            if (source != null) {
-                String iso3langCode = languageUtils.getIso3langCode(request.getLocales());
-                final List<Setting> settings = response.getSettings();
-                settings.add(
-                    new Setting().setName(Settings.NODE_DEFAULT)
-                        .setValue("false"));
-                settings.add(
-                    new Setting().setName(Settings.NODE)
-                        .setValue(source.getUuid()));
-                settings.add(
-                    new Setting().setName(Settings.NODE_NAME)
-                        .setValue(source != null ? source.getLabel(iso3langCode) : source.getName()));
-            }
+        Source source;
+        String nodeDefault;
+        if (NodeInfo.DEFAULT_NODE.equals(node.getId())) {
+            source = sourceRepository.findOne(settingManager.getSiteId());
+            nodeDefault = "true";
         } else {
-            String defaultSiteId = settingManager.getSiteId();
-            Source source = sourceRepository.findOne(defaultSiteId);
-            if (source != null) {
-                String iso3langCode = languageUtils.getIso3langCode(request.getLocales());
-                final List<Setting> settings = response.getSettings();
-                settings.add(
-                    new Setting().setName(Settings.NODE_DEFAULT)
-                        .setValue("true"));
-                settings.add(
-                    new Setting().setName(Settings.NODE)
-                        .setValue(NodeInfo.DEFAULT_NODE));
-                settings.add(
-                    new Setting().setName(Settings.NODE_NAME)
-                        .setValue(source != null ? source.getLabel(iso3langCode) : source.getName()));
-            }
+            source = sourceRepository.findOne(node.getId());
+            nodeDefault = "false";
+        }
+        if (source != null) {
+            final List<Setting> settings = response.getSettings();
+            String iso3langCode = languageUtils.getIso3langCode(request.getLocales());
+
+            settings.add(
+                new Setting().setName(Settings.NODE_DEFAULT)
+                    .setValue(nodeDefault));
+            settings.add(
+                new Setting().setName(Settings.NODE)
+                    .setValue(source.getUuid()));
+            settings.add(
+                new Setting().setName(Settings.NODE_NAME)
+                    .setValue(StringUtils.isEmpty(source.getLabel(iso3langCode)) ? source.getName() : source.getLabel(iso3langCode)));
         }
         return response;
     }


### PR DESCRIPTION
Fixed broken site logo on fresh install.
Seems like regression from https://github.com/geonetwork/core-geonetwork/pull/5245

![image](https://user-images.githubusercontent.com/1868233/104378632-ae710180-54fe-11eb-9c42-4d46a1e86dbe.png)

In a fresh install the site name is the source.getUuid() not the NodeInfo.DEFAULT_NODE.

Fixed impossible condition with 
`  .setValue(source != null ? `
as that will always be true as identified in previous if statement.
I'm assuming it was supposed to be the following.
`  .setValue(StringUtils.isEmpty(source.getLabel(iso3langCode)) ?`
so that if the translated value is null, it should default to the name

Also cleaned up the code so there was less duplicate code.