### PR TITLE
Fixed another broken image related to #5299

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -93,7 +93,7 @@
           <div class="thumb-small"
                title="{{thumb.title | gnLocalized: lang}}"
                data-gn-img-modal="thumb"
-               style="background-image: url('{{thumb.lUrl || thumb.id}}')"/>
+               style="background-image: url('{{onlinesrcService.getApprovedUrl(thumb.lUrl || thumb.id)}}')"/>
 
           <a href=""
              class="onlinesrc-remove"


### PR DESCRIPTION
When editing an HNAP record within workingcopy the new thumbnail images added to the metadata don't display.

![image](https://user-images.githubusercontent.com/1868233/104470113-b75de380-558f-11eb-8b4a-d477792c5fa1.png)

This is a another patch related to #5299
