### PR TITLE
Move release build properties to separate file

### DIFF
--- a/release/build.properties
+++ b/release/build.properties
@@ -1,0 +1,15 @@
+# General properties
+appName=GeoNetwork
+displayName=GeoNetwork opensource
+homepage=https://geonetwork-opensource.org
+supportEmail=geonetwork-users@lists.sourceforge.net
+
+# Application version properties
+version=3.11.0
+subVersion=SNAPSHOT
+
+# Java runtime properties
+javaVersion=1.8.0
+javaDisplayVersion=8
+jreUrl=https://adoptopenjdk.net/?variant=openjdk8
+jreName=AdoptOpenJDK

--- a/release/build.xml
+++ b/release/build.xml
@@ -43,23 +43,19 @@
     <os family="unix"/>
   </condition>
 
-  <!-- Project build properties -->
-  <property name="appName" value="GeoNetwork"/>
+  <!-- Import global build properties -->
+  <property file="./build.properties"/>
+
+  <!-- Additional build properties -->
   <property name="bundleName" value="geonetwork-bundle"/>
-  <property name="displayName" value="GeoNetwork opensource"/>
-  <property name="homepage" value="https://geonetwork-opensource.org"/>
-  <property name="version" value="3.11.0"/>
-  <property name="subVersion" value="SNAPSHOT"/>
-  <property name="javaVersion" value="1.8.0"/>
-  <property name="jreUrl" value="http://openjdk.java.net/"/>
-  <property name="OS" value="Compiled on ${os.name} (${osys})"/>
   <property name="propsdir" value="target/props"/>
   <property name="ant.build.javac.target" value="1.8"/>
   <property name="debugOn" value="on"/>
 
-  <!-- Used for copyright year -->
+  <!-- Copyright year and build date properties -->
   <tstamp>
     <format property="year" pattern="yyyy"/>
+    <format property="buildDate" pattern="dd-M-yyyy" />
   </tstamp>
 
   <!-- =================================================================================== -->
@@ -96,17 +92,11 @@
 
     <echo message="Replacing template variables in readme files..."/>
 
-    <tstamp>
-      <format property="buildDate" pattern="dd-M-yyyy" />
-    </tstamp>
-
     <replace file="${propsdir}/readme.html" token="@version@" value="${version}"/>
-    <replace file="${propsdir}/readme.html" token="@subVersion@" value="${subVersion}"/>
     <replace file="${propsdir}/readme.html" token="@subVersion@" value="${subVersion}"/>
     <replace file="${propsdir}/readme.html" token="@day@" value="${buildDate}" />
     <replace file="${propsdir}/readme.html" token="@jreUrl@" value="${jreUrl}"/>
     <replace file="${propsdir}/readme.html" token="@javaVersion@" value="${javaVersion}"/>
-
     <replace file="${propsdir}/readme.html" token="@appName@" value="${appName}"/>
     <replace file="${propsdir}/readme.html" token="@displayName@" value="${displayName}"/>
     <replace file="${propsdir}/readme.html" token="@homepage@" value="${homepage}"/>

--- a/resetReleaseVersions.sh
+++ b/resetReleaseVersions.sh
@@ -30,7 +30,9 @@ then
 fi
 
 
-if [[ $1 != [0-9].[0-9].[0-9] ]]; then 
+if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+    echo
+else
 	echo
 	echo 'Update failed due to incorrect versionnumber format: ' $1
 	echo 'The format should be three numbers separated by dots. e.g.: 2.7.0'
@@ -40,7 +42,9 @@ if [[ $1 != [0-9].[0-9].[0-9] ]]; then
 	exit
 fi
 
-if [[ $2 != [0-9].[0-9].[0-9] ]]; then 
+if [[ $2 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+    echo
+else
 	echo
 	echo 'Update failed due to incorrect new versionnumber format (' $2 ')'
 	echo 'The format should be three numbers separated by dots. e.g.: 2.7.1'
@@ -63,8 +67,7 @@ echo 'sed will use the following option: ' $sedopt
 echo
 
 # Update version in sphinx doc files
-sed $sedopt "s/${version}/${new_version}/g" docs/eng/users/source/conf.py 
-sed $sedopt "s/${version}/${new_version}/g" docs/eng/developer/source/conf.py
+sed $sedopt "s/${version}/${new_version}/g" docs/manuals/source/conf.py
 
 # Update release version
 sed $sedopt "s/version=${version}/version=${new_version}/g" release/build.properties

--- a/resetReleaseVersions.sh
+++ b/resetReleaseVersions.sh
@@ -66,8 +66,8 @@ echo
 sed $sedopt "s/${version}/${new_version}/g" docs/eng/users/source/conf.py 
 sed $sedopt "s/${version}/${new_version}/g" docs/eng/developer/source/conf.py
 
-# Update ZIP distribution
-sed $sedopt "s/\<property name=\"version\" value=\"${version}\" \/\>/\<property name=\"version\" value=\"${new_version}\" \/\>/g" release/build.xml
+# Update release version
+sed $sedopt "s/version=${version}/version=${new_version}/g" release/build.properties
 
 # Update version pom files
 find . -name pom.xml -exec sed $sedopt "s/${version}/${new_version}/g" {} \;

--- a/update-version.sh
+++ b/update-version.sh
@@ -100,11 +100,11 @@ echo ' * updating docs/manuals/source/conf.py'
 sed $sedopt "s/${version}/${new_version_main}/g" docs/manuals/source/conf.py
 echo
 
-# Update ZIP distro
-echo 'ZIP distribution'
-echo '  * updating release/build.xml'
-sed $sedopt "s/property name=\"version\" value=\".*\"/property name=\"version\" value=\"${new_version_main}\"/g" release/build.xml
-sed $sedopt "s/property name=\"subVersion\" value=\".*\"/property name=\"subVersion\" value=\"${sub_version}\"/g" release/build.xml
+# Update release properties
+echo 'Release (ZIP bundle)'
+echo '  * updating release/build.properties'
+sed $sedopt "s/version=.*/version=${new_version_main}/g" release/build.properties
+sed $sedopt "s/subVersion=.*/subVersion=${sub_version}/g" release/build.properties
 echo
 
 # Update SQL - needs improvements

--- a/updateBranchVersions.sh
+++ b/updateBranchVersions.sh
@@ -65,9 +65,9 @@ new_version="$2"
 sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/eng/users/source/conf.py 
 sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/eng/developer/source/conf.py
 
-# Update ZIP distribution
-sed $sedopt "s/\<property name=\"version\" value=\"${version}\" \/\>/\<property name=\"version\" value=\"${new_version}\" \/\>/g" release/build.xml
-sed $sedopt "s/\<property name=\"subVersion\" value=\"0\" \/\>/\<property name=\"subVersion\" value=\"SNAPSHOT\" \/\>/g" release/build.xml
+# Update release properties
+sed $sedopt "s/version=${version}/version=${new_version}/g" release/build.properties
+sed $sedopt "s/subVersion=0/subVersion=SNAPSHOT/g" release/build.properties
 
 # Update version pom files
 find . -name pom.xml -exec sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" {} \;

--- a/updateBranchVersions.sh
+++ b/updateBranchVersions.sh
@@ -26,7 +26,9 @@ then
   exit
 fi
 
-if [[ $1 != [0-9].[0-9].[0-9] ]]; then 
+if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+    echo
+else
 	echo
 	echo 'Update failed due to incorrect versionnumber format (' $1 ')'
 	echo 'The format should be three numbers separated by dots. e.g.: 2.7.0'
@@ -36,7 +38,9 @@ if [[ $1 != [0-9].[0-9].[0-9] ]]; then
 	exit
 fi
 
-if [[ $2 != [0-9].[0-9].[0-9] ]]; then 
+if [[ $2 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+    echo
+else
 	echo
 	echo 'Update failed due to incorrect new versionnumber format (' $2 ')'
 	echo 'The format should be three numbers separated by dots. e.g.: 2.7.1'
@@ -62,8 +66,7 @@ version="$1"
 new_version="$2"
 
 # Update version in sphinx doc files
-sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/eng/users/source/conf.py 
-sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/eng/developer/source/conf.py
+sed $sedopt "s/${version}/${new_version}-SNAPSHOT/g" docs/manuals/source/conf.py
 
 # Update release properties
 sed $sedopt "s/version=${version}/version=${new_version}/g" release/build.properties

--- a/updateReleaseVersions.sh
+++ b/updateReleaseVersions.sh
@@ -26,8 +26,9 @@ then
   exit
 fi
 
-if [[ $1 != [0-9].[0-9].[0-9] ]]; then 
-	echo
+if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9x]+$ ]]; then
+    echo
+else
 	echo 'Update failed due to incorrect versionnumber format: ' $1
 	echo 'The format should be three numbers separated by dots. e.g.: 2.7.0'
 	echo
@@ -51,8 +52,7 @@ echo
 version="$1"
 
 # Update version in sphinx doc files
-sed $sedopt "s/${version}-SNAPSHOT/${version}/g" docs/eng/users/source/conf.py 
-sed $sedopt "s/${version}-SNAPSHOT/${version}/g" docs/eng/developer/source/conf.py
+sed $sedopt "s/${version}-SNAPSHOT/${version}/g" docs/manuals/source/conf.py
 
 # Update release subversion
 sed $sedopt "s/subVersion=SNAPSHOT/subVersion=0/g" release/build.properties

--- a/updateReleaseVersions.sh
+++ b/updateReleaseVersions.sh
@@ -26,7 +26,7 @@ then
   exit
 fi
 
-if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9x]+$ ]]; then
+if [[ $1 =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
     echo
 else
 	echo 'Update failed due to incorrect versionnumber format: ' $1

--- a/updateReleaseVersions.sh
+++ b/updateReleaseVersions.sh
@@ -54,8 +54,8 @@ version="$1"
 sed $sedopt "s/${version}-SNAPSHOT/${version}/g" docs/eng/users/source/conf.py 
 sed $sedopt "s/${version}-SNAPSHOT/${version}/g" docs/eng/developer/source/conf.py
 
-# Update ZIP distribution
-sed $sedopt "s/\<property name=\"subVersion\" value=\"SNAPSHOT\" \/\>/\<property name=\"subVersion\" value=\"0\" \/\>/g" release/build.xml
+# Update release subversion
+sed $sedopt "s/subVersion=SNAPSHOT/subVersion=0/g" release/build.properties
 
 # Update version pom files
 find . -name pom.xml -exec sed $sedopt "s/${version}-SNAPSHOT/${version}/g" {} \;


### PR DESCRIPTION
Several "global" properties that are stored as `<property>` elements inside the release `build.xml` file should be stored inside a separate `build.properties` file that can be easily imported by other build files as well (e.g. for the Windows installer).