### PR TITLE
Formatter / Display all keywords excluding those of type place.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -115,7 +115,7 @@
       <xsl:variable name="tags">
         <xsl:for-each select="$metadata/mdb:identificationInfo/*/mri:descriptiveKeywords/
                                           *[
-                                          mri:type/*/@codeListValue = 'theme'
+                                          mri:type/*/@codeListValue != 'place'
                                             and normalize-space(string-join(mri:keyword//text(), '')) != ''
                                             and (not(mri:thesaurusName/*/cit:identifier/*/mcc:code)
                                             or mri:thesaurusName/*/cit:identifier/*/mcc:code/*/

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -125,7 +125,7 @@
       <xsl:variable name="tags">
         <xsl:for-each select="$metadata/gmd:identificationInfo/*/gmd:descriptiveKeywords/
                                           *[
-                                          gmd:type/*/@codeListValue = 'theme'
+                                          gmd:type/*/@codeListValue != 'place'
                                             and normalize-space(string-join(gmd:keyword//text(), '')) != ''
                                             and (not(gmd:thesaurusName/*/gmd:identifier/*/gmd:code)
                                             or gmd:thesaurusName/*/gmd:identifier/*/gmd:code/*/


### PR DESCRIPTION
Some catalogues have various type of thesaurus. Only theme thesaurus type was displayed in full view

![image](https://user-images.githubusercontent.com/1701393/104887483-a0423b80-596b-11eb-82b1-cf365920230c.png)

Only exclude place keyword which might be displayed next to the extent of the record.