### PR TITLE
CMIS: Make version state configurable.

### DIFF
--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.chemistry.opencmis.client.api.SessionFactory;
 import org.apache.chemistry.opencmis.client.runtime.SessionFactoryImpl;
 import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
+import org.apache.chemistry.opencmis.commons.enums.VersioningState;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
@@ -84,6 +85,8 @@ public class CMISConfiguration {
      * Enable option to add versioning in the link to the resource.
      */
     private Boolean versioningEnabled = BooleanUtils.toBooleanObject(System.getenv("CMIS_VERSIONING_ENABLED"));
+    private VersioningState versioningState = null;
+    private Boolean versioningMajorOnUpdate = BooleanUtils.toBooleanObject(System.getenv("CMIS_VERSIONING_MAJOR_ON_UPDATE"));
 
     private String webservicesRepositoryService = System.getenv("CMIS_WEBSERVICES_REPOSITORY_SERVICE");
     private String webservicesNavigationService = System.getenv("CMIS_WEBSERVICES_NAVIGATION_SERVICE");
@@ -205,6 +208,43 @@ public class CMISConfiguration {
 
     public void setExternalResourceManagementModalEnabled(String externalResourceManagementModalEnabled) {
         this.externalResourceManagementModalEnabled = BooleanUtils.toBooleanObject(externalResourceManagementModalEnabled);;
+    }
+
+    @Nonnull
+    public VersioningState getVersioningState() {
+        if (versioningState == null) {
+            return VersioningState.MAJOR;
+        } else {
+            return this.versioningState;
+        }
+    }
+
+    public void setVersioningState(VersioningState versioningState) {
+        if (versioningState.equals(VersioningState.CHECKEDOUT)) {
+            throw new IllegalArgumentException("Versioning state CHECKEDOUT is not supported in this context");
+        }
+        this.versioningState = versioningState;
+    }
+
+    public void setVersioningState(String versioningState) {
+        setVersioningState(StringUtils.isEmpty(versioningState)?null:VersioningState.valueOf(versioningState.toUpperCase()));
+    }
+
+    @Nonnull
+    public Boolean isVersioningMajorOnUpdate() {
+        if (versioningMajorOnUpdate == null) {
+            return false;
+        } else {
+            return versioningMajorOnUpdate;
+        }
+    }
+
+    public void setVersioningMajorOnUpdate(Boolean versioningMajorOnUpdate) {
+        this.versioningMajorOnUpdate = versioningMajorOnUpdate;
+    }
+
+    public void setVersioningMajorOnUpdate(String versioningMajorOnUpdate) {
+        this.versioningMajorOnUpdate = BooleanUtils.toBooleanObject(versioningMajorOnUpdate);;
     }
 
     @Nonnull
@@ -364,6 +404,10 @@ public class CMISConfiguration {
 
     @PostConstruct
     public void init() {
+        if (this.versioningState==null) {
+            setVersioningState(System.getenv("CMIS_VERSIONING_STATE"));
+        }
+
         // If we have a cmisMetadataUUIDPropertyName then call the set so that it also validates the value.
         if (cmisMetadataUUIDPropertyName != null) {
             setCmisMetadataUUIDPropertyName(cmisMetadataUUIDPropertyName);

--- a/core/src/main/java/org/fao/geonet/resources/CMISResources.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISResources.java
@@ -481,8 +481,22 @@ public class CMISResources extends Resources {
                         try {
                             // If the document is found then we are updating the existing document.
                             Document doc = (Document) CMISConfiguration.getClient().getObjectByPath(key, oc);
-                            doc.updateProperties(properties, true);
-                            doc.setContentStream(contentStream, true, true);
+
+                            // If using major versioning then we have the option of making next version a minor or major.
+                            // The CMIS default it to create minor versions on updates.  If we are to create major versions on update then we need to update the document a little different.
+                            if (CMISConfiguration.getVersioningState().equals(VersioningState.MAJOR) && CMISConfiguration.isVersioningMajorOnUpdate() && doc.isVersionable() && doc.isMajorVersion()) {
+                                // If there is an existing checkout then cancel it.
+                                if (doc.isVersionSeriesCheckedOut()) {
+                                    doc.cancelCheckOut();
+                                }
+
+                                ObjectId objectID = doc.checkOut();
+                                CmisObject o = CMISConfiguration.getClient().getObject(objectID, oc);
+                                ((Document) o).checkIn(true, properties, contentStream, null);
+                            } else {
+                                doc.updateProperties(properties, true);
+                                doc.setContentStream(contentStream, true, true);
+                            }
 
                             Log.info(Geonet.RESOURCES,
                                 String.format("Updated resource '%s'. Current version '%s'.", key, doc.getVersionLabel()));
@@ -504,7 +518,7 @@ public class CMISResources extends Resources {
                                 parentFolder = (Folder) CMISConfiguration.getClient().getObject(objectId, oc);
                             }
 
-                            Document doc = parentFolder.createDocument(properties, contentStream, VersioningState.MAJOR);
+                            Document doc = parentFolder.createDocument(properties, contentStream, CMISConfiguration.getVersioningState());
 
                             Log.info(Geonet.RESOURCES,
                                 String.format("Added resource '%s'.", doc.getPaths().get(0)));

--- a/core/src/main/resources/config-store/config-cmis.xml
+++ b/core/src/main/resources/config-store/config-cmis.xml
@@ -73,6 +73,8 @@
        CMIS_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS=toolbar=0,width=600,height=600
        CMIS_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED=true
        CMIS_VERSIONING_ENABLED=true
+       CMIS_VERSIONING_STATE=MAJOR
+       CMIS_VERSIONING_MAJOR_ON_UPDATE=false
     -->
     <bean id="cmisconfiguration" class="org.fao.geonet.resources.CMISConfiguration">
     </bean>


### PR DESCRIPTION
Versions states were currently hard coded to use MAJOR version for the version state.

The change make it possible to change the states by using 2 new variables.
`CMIS_VERSIONING_STATE`
Can be a value from the VersioningState Class (NONE, MAJOR, MINOR)
`CMIS_VERSIONING_MAJOR_ON_UPDATE`
Only applies to `MAJOR` - indicates if the next version should be another major version(true) or a minor version(false)

Here are the expected version generations from different software.
`NONE` is the only one that seems to behave differently on different systems.  Possibly different default configurations and interpretations.
It can be tested by uploading the same file multiple times in the metadata file store

Application | Version State | Values
------------ | ------------- | -------------
Alfresco | NONE | 1.0, 1.0, 1.0, ...
Open text | NONE | 1, 2, 3, 4, ... 
Alfresco | MAJOR (VERSIONING_MAJOR_ON_UPDATE=false) | 1.0 1.1, 1.2, ...
Open text | MAJOR (VERSIONING_MAJOR_ON_UPDATE=false) | 1.0 1.1, 1.2, ...
Alfresco | MAJOR (VERSIONING_MAJOR_ON_UPDATE=true) | 1.0 2.0, 3.0, ...
Open text | MAJOR (VERSIONING_MAJOR_ON_UPDATE=true) | 1.0 2.0, 3.0, ...
Alfresco | MINOR | 0.1, 0.2, 0.3, ...
Open text | MINOR | 0.1, 0.2, 0.3, ...


Note: When changing Versioning State the old documents that were previously updated will still follow the old versioning state.
i.e. If system is configured to NONE and test.jpg is uploaded and then system is stopped and started again using MAJOR.  Then uploading a new test.jpg file will still use NONE version state when updating that document.  Only new documents will use the MAJOR option.  This can only be corrected by dropping and recreating the data.