### PR TITLE
CMIS: Performance improvements.

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -46,6 +46,7 @@ import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.resources.CMISConfiguration;
+import org.fao.geonet.resources.CMISUtils;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,6 +64,9 @@ public class CMISStore extends AbstractStore {
 
     @Autowired
     CMISConfiguration CMISConfiguration;
+
+    @Autowired
+    CMISUtils cmisUtils;
 
     @Override
     public List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid,
@@ -83,7 +87,7 @@ public class CMISStore extends AbstractStore {
         try {
             Folder parentFolder = (Folder) CMISConfiguration.getClient().getObjectByPath(resourceTypeDir);
 
-            Map<String, Document> documentMap = getCmisObjectMap(parentFolder, null);
+            Map<String, Document> documentMap = cmisUtils.getCmisObjectMap(parentFolder, null);
             for (Map.Entry<String, Document> entry : documentMap.entrySet()) {
                 Document object = entry.getValue();
                 String cmisFilePath = entry.getKey();
@@ -93,7 +97,7 @@ public class CMISStore extends AbstractStore {
                     if (matcher.matches(keyPath)) {
                         final String filename = getFilename(cmisFilePath);
                         MetadataResource resource = createResourceDescription(context, settingManager, metadataUuid, visibility, filename, object.getContentStreamLength(),
-                                object.getLastModificationDate().getTime(), object.getVersionLabel(), metadataId, approved);
+                                object.getLastModificationDate().getTime(), object.getVersionLabel(), object.getId(), metadataId, approved);
                         resourceList.add(resource);
                     }
                 }
@@ -109,8 +113,8 @@ public class CMISStore extends AbstractStore {
     }
 
     private MetadataResource createResourceDescription(final ServiceContext context, final SettingManager settingManager, final String metadataUuid,
-                                                       final MetadataResourceVisibility visibility, final String resourceId, long size, Date lastModification, String version, int metadataId,
-                                                       boolean approved) {
+                                                       final MetadataResourceVisibility visibility, final String resourceId, long size, Date lastModification, String version,
+                                                       String cmisObjectId, int metadataId, boolean approved) {
         String filename = getFilename(metadataUuid, resourceId);
 
         String versionValue = null;
@@ -119,7 +123,7 @@ public class CMISStore extends AbstractStore {
         }
 
         MetadataResource.ExternalResourceManagementProperties externalResourceManagementProperties =
-            getExternalResourceManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, version);
+            getExternalResourceManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, version, cmisObjectId);
 
         return new FilesystemStoreResource(metadataUuid, metadataId, filename,
             settingManager.getNodeURL() + "api/records/", visibility, size, lastModification, versionValue, externalResourceManagementProperties, approved);
@@ -140,7 +144,7 @@ public class CMISStore extends AbstractStore {
             final SettingManager settingManager = context.getBean(SettingManager.class);
             return new ResourceHolderImpl(object, createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId,
                 ((Document) object).getContentStreamLength(),
-                object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), metadataId, approved));
+                object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), object.getId(), metadataId, approved));
         } catch (CmisObjectNotFoundException e) {
             Log.warning(Geonet.RESOURCES, String.format("Error getting metadata resource. '%s' not found for metadata '%s'", resourceId, metadataUuid));
             throw new ResourceNotFoundException(
@@ -163,7 +167,7 @@ public class CMISStore extends AbstractStore {
         String key = getKey(context, metadataUuid, metadataId, visibility, filename);
 
         // Don't use caching for this process.
-        OperationContext oc = CMISConfiguration.getClient().createOperationContext();
+        OperationContext oc = cmisUtils.createOperationContext();
         oc.setCacheEnabled(false);
 
         // Split the filename and parent folder from the key.
@@ -211,20 +215,8 @@ public class CMISStore extends AbstractStore {
             // If the document is not found then we are adding a new document.
 
             // Get parent folder.
-            Folder parentFolder;
-            // synchronize folder creation.
-            // This will prevent cases where multiple files are uploaded on the interface
-            // In this case there will be a race condition to create the same folder.
-            // And if this is not synchronized then there will be a lot or CmisContentAlreadyExistsException errors.
-            synchronized (this) {
-                try {
-                    parentFolder = (Folder) CMISConfiguration.getClient().getObjectByPath(parentKey, oc);
-                } catch (CmisObjectNotFoundException ex) {
-                    // Create parent folder if it does not exists.
-                    ObjectId objectId = CMISConfiguration.getClient().createPath(parentKey, "cmis:folder");
-                    parentFolder = (Folder) CMISConfiguration.getClient().getObject(objectId, oc);
-                }
-            }
+            Folder parentFolder = cmisUtils.getFolderCache(parentKey, true);
+
             try {
                 doc = parentFolder.createDocument(properties, contentStream, VersioningState.MAJOR);
                 // Avoid CMIS API call is info is not enabled.
@@ -256,7 +248,7 @@ public class CMISStore extends AbstractStore {
         }
 
         return createResourceDescription(context, settingManager, metadataUuid, visibility, filename, isLength,
-                doc.getLastModificationDate().getTime(), doc.getVersionLabel(), metadataId, approved);
+                doc.getLastModificationDate().getTime(), doc.getVersionLabel(), doc.getId(), metadataId, approved);
     }
 
     private void setCmisMetadataUUIDPrimary(Map<String, Object> properties, String metadataUuid) {
@@ -296,21 +288,23 @@ public class CMISStore extends AbstractStore {
         int metadataId = canEdit(context, metadataUuid, approved);
 
         // Don't use caching for this process.
-        OperationContext oc = CMISConfiguration.getClient().createOperationContext();
+        OperationContext oc = cmisUtils.createOperationContext();
         oc.setCacheEnabled(false);
 
         String sourceKey = null;
+        CmisObject sourceObject =  null;
         for (MetadataResourceVisibility sourceVisibility : MetadataResourceVisibility.values()) {
             final String key = getKey(context, metadataUuid, metadataId, sourceVisibility, resourceId);
             try {
                 final CmisObject object = CMISConfiguration.getClient().getObjectByPath(key, oc);
                 if (sourceVisibility != visibility) {
                     sourceKey = key;
+                    sourceObject = object;
                     break;
                 } else {
                     // already the good visibility
                     return createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId, ((Document) object).getContentStreamLength(),
-                        object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), metadataId, approved);
+                        object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), object.getId(), metadataId, approved);
                 }
             } catch (CmisObjectNotFoundException ignored) {
                 // ignored
@@ -319,39 +313,24 @@ public class CMISStore extends AbstractStore {
         if (sourceKey != null) {
             final String destKey = getKey(context, metadataUuid, metadataId, visibility, resourceId);
 
-            final CmisObject sourceObject = CMISConfiguration.getClient().getObjectByPath(sourceKey, oc);
-
             // Get the parent folder object id.
             int lastFolderDelimiterSourceKeyIndex = sourceKey.lastIndexOf(CMISConfiguration.getFolderDelimiter());
             String parentSourceKey = sourceKey.substring(0, lastFolderDelimiterSourceKeyIndex);
 
-            // Get the parent source folder id.
-            Folder parentSourceFolder;
-            try {
-                parentSourceFolder = (Folder) CMISConfiguration.getClient().getObjectByPath(parentSourceKey, oc);
-            } catch (CmisObjectNotFoundException e) {
-                // Create parent folder if it does not exists.
-                ObjectId objectId = CMISConfiguration.getClient().createPath(parentSourceKey, "cmis:folder");
-                parentSourceFolder = (Folder) CMISConfiguration.getClient().getObject(objectId, oc);
-            }
+            Folder parentSourceFolder = cmisUtils.getFolderCache(parentSourceKey);
 
             // Get the parent destination folder id.
             int lastFolderDelimiterDestKeyIndex = destKey.lastIndexOf(CMISConfiguration.getFolderDelimiter());
-            String parentDestKey = destKey.substring(0, lastFolderDelimiterDestKeyIndex);
+            String parentDestFolderKey = destKey.substring(0, lastFolderDelimiterDestKeyIndex);
 
-            // Get parent folder.
-            Folder parentDestFolder;
-            try {
-                parentDestFolder = (Folder) CMISConfiguration.getClient().getObjectByPath(parentDestKey, oc);
-            } catch (CmisObjectNotFoundException e) {
-                // Create parent folder if it does not exists.
-                ObjectId objectId = CMISConfiguration.getClient().createPath(parentDestKey, "cmis:folder");
-                parentDestFolder = (Folder) CMISConfiguration.getClient().getObject(objectId, oc);
-            }
+            Folder parentDestFolder = cmisUtils.getFolderCache(parentDestFolderKey, true);
 
             // Move the object from source to destination
+            CmisObject object;
             try {
-                ((Document) sourceObject).move(parentSourceFolder, parentDestFolder);
+                object = ((Document) sourceObject).move(parentSourceFolder, parentDestFolder, oc);
+                Log.info(Geonet.RESOURCES,
+                    String.format("moved resource '%s' to '%s'.", parentSourceFolder.getPaths().get(0), parentDestFolder.getPaths().get(0)));
             } catch (CmisPermissionDeniedException e) {
                 Log.warning(Geonet.RESOURCES, String.format(
                         "No permissions to modify metadata resource '%s' for metadata '%s'.", resourceId, metadataUuid));
@@ -359,10 +338,8 @@ public class CMISStore extends AbstractStore {
                         "No permissions to modify metadata resource '%s' for metadata '%s'.", resourceId, metadataUuid));
             }
 
-            final CmisObject object = CMISConfiguration.getClient().getObjectByPath(destKey, oc);
-
             return createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId, ((Document) object).getContentStreamLength(),
-                    object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), metadataId, approved);
+                    object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), object.getId(), metadataId, approved);
         } else {
             Log.warning(Geonet.RESOURCES,
                     String.format("Could not update permissions. Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid));
@@ -378,25 +355,33 @@ public class CMISStore extends AbstractStore {
         oc.setCacheEnabled(false);
 
         int metadataId = canEdit(context, metadataUuid, approved);
+        String folderKey = null;
         try {
-            final CmisObject folderObject = CMISConfiguration.getClient().getObjectByPath(getMetadataDir(context, metadataId), oc);
+            folderKey = getMetadataDir(context, metadataId);
+            final Folder folder = (Folder) CMISConfiguration.getClient().getObjectByPath(folderKey, oc);
 
-            ((Folder) folderObject).deleteTree(true, UnfileObject.DELETE, true);
+            folder.deleteTree(true, UnfileObject.DELETE, true);
+            cmisUtils.invalidateFolderCache(folderKey);
+
             Log.info(Geonet.RESOURCES,
                     String.format("Metadata '%s' directory removed.", metadataId));
             return String.format("Metadata '%s' directory removed.", metadataId);
         } catch (CmisObjectNotFoundException e) {
             Log.warning(Geonet.RESOURCES,
-                    String.format("Unable to located metadata '%s' directory to be removed.", metadataId));
-            return String.format("Unable to located metadata '%s' directory to be removed.", metadataId);
+                    String.format("Unable to located metadata '%s' directory '%s' to be removed.", metadataId, folderKey));
+            return String.format("Unable to located metadata '%s' directory '%s' to be removed.", metadataId, folderKey);
+        } catch (ResourceNotFoundException e) {
+            Log.warning(Geonet.RESOURCES,
+                String.format("Unable to located metadata '%s' directory '%s' to be removed.", metadataId, folderKey));
+            return String.format("Unable to located metadata '%s' directory '%s' to be removed.", metadataId, folderKey);
         } catch (CmisPermissionDeniedException e) {
             Log.warning(Geonet.RESOURCES,
-                    String.format("Insufficient privileges, unable to remove metadata '%s' directory.", metadataId));
-            return String.format("Insufficient privileges, unable to remove metadata '%s' directory.", metadataId);
+                    String.format("Insufficient privileges, unable to remove directory '%s'.", metadataId, folderKey));
+            return String.format("Insufficient privileges, unable to remove directory '%s'.", metadataId, folderKey);
         } catch (CmisConstraintException e) {
             Log.warning(Geonet.RESOURCES,
-                    String.format("Unable to remove metadata '%s' directory due so constraint violation or locks.", metadataId));
-            return String.format("Unable to remove metadata '%s' directory due so constraint violation or locks.", metadataId);
+                    String.format("Unable to remove metadata '%s' directory '%s' due so constraint violation or locks.", metadataId, folderKey));
+            return String.format("Unable to remove metadata '%s' directory '%s' due so constraint violation or locks.", metadataId, folderKey);
         }
     }
 
@@ -436,12 +421,15 @@ public class CMISStore extends AbstractStore {
         final String key = getKey(context, metadataUuid, metadataId, visibility, resourceId);
 
         // Don't use caching for this process.
-        OperationContext oc = CMISConfiguration.getClient().createOperationContext();
+        OperationContext oc = cmisUtils.createOperationContext();
         oc.setCacheEnabled(false);
 
         try {
             final CmisObject object = CMISConfiguration.getClient().getObjectByPath(key, oc);
             object.delete();
+            if (object instanceof Folder) {
+                cmisUtils.invalidateFolderCacheItem(key);
+            }
             return true;
             //CmisObjectNotFoundException when file not found
             //CmisPermissionDeniedException when user does not have permissions.
@@ -460,11 +448,12 @@ public class CMISStore extends AbstractStore {
         try {
             final CmisObject object = CMISConfiguration.getClient().getObjectByPath(key);
             return createResourceDescription(context, settingManager, metadataUuid, visibility, filename, ((Document) object).getContentStreamLength(),
-                object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), metadataId, approved);
+                object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), object.getId(), metadataId, approved);
         } catch (CmisObjectNotFoundException e) {
             return null;
         }
     }
+
 
     private String getMetadataDir(ServiceContext context, final int metadataId) {
 
@@ -535,7 +524,8 @@ public class CMISStore extends AbstractStore {
                                                     final MetadataResourceVisibility visibility,
                                                     final String resourceId,
                                                     String filename,
-                                                    String version
+                                                    String version,
+                                                    String cmisObjectId
     ) {
         String externalResourceManagementUrl = CMISConfiguration.getExternalResourceManagementUrl();
         if (!StringUtils.isEmpty(externalResourceManagementUrl)) {
@@ -565,8 +555,7 @@ public class CMISStore extends AbstractStore {
             }
             // {cmisobjectid}  cmis object id
             if (externalResourceManagementUrl.contains("{cmisobjectid}")) {
-                final CmisObject cmisObject = CMISConfiguration.getClient().getObjectByPath(getKey(context, metadataUuid, metadataId, visibility, resourceId));
-                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{cmisobjectid\\})", ((Document) cmisObject).getVersionSeriesId());
+                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{cmisobjectid\\})", cmisObjectId);
             }
 
             if (externalResourceManagementUrl.contains("{lang}") || externalResourceManagementUrl.contains("{ISO3lang}")) {
@@ -645,23 +634,5 @@ public class CMISStore extends AbstractStore {
             close();
             super.finalize();
         }
-    }
-
-    private Map<String, Document> getCmisObjectMap(Folder folder, String baseFolder) {
-        if (baseFolder == null) {
-            baseFolder = "";
-        }
-        Map<String, Document> documentMap = new HashMap<>();
-        for (CmisObject cmisObject : folder.getChildren()) {
-            if (cmisObject instanceof Folder) {
-                documentMap.putAll(getCmisObjectMap((Folder) cmisObject, baseFolder + CMISConfiguration.getFolderDelimiter() + cmisObject.getName()));
-                return documentMap;
-            } else {
-                if (cmisObject instanceof Document) {
-                    documentMap.put(baseFolder + CMISConfiguration.getFolderDelimiter() + cmisObject.getName(), (Document) cmisObject);
-                }
-            }
-        }
-        return documentMap;
     }
 }

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.chemistry.opencmis.client.api.SessionFactory;
 import org.apache.chemistry.opencmis.client.runtime.SessionFactoryImpl;
 import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
+import org.apache.chemistry.opencmis.commons.enums.IncludeRelationships;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
@@ -460,6 +461,38 @@ public class CMISConfiguration {
         Log.info(Geonet.RESOURCES, "Connected to CMIS using binding '" + client.getBinding().getBindingType().value() + "' with base url '" +
                 repositoryUrl + "' using product '" + client.getRepositoryInfo().getProductName() + "' version '" +
                 client.getRepositoryInfo().getProductVersion() + "'.");
+
+        // Setup default options
+        // Ensure caching is on.
+        if (!client.getDefaultContext().isCacheEnabled()) {
+            Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context cache to enabled.");
+            client.getDefaultContext().setCacheEnabled(true);
+        }
+        // Don't get allowable actions by default
+        if (client.getDefaultContext().isIncludeAllowableActions()) {
+            Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context to not include allowable actions.");
+            client.getDefaultContext().setIncludeAllowableActions(false);
+        }
+        // Don't get ACLS by default
+        if (client.getDefaultContext().isIncludeAcls()) {
+            Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context to not include acls.");
+            client.getDefaultContext().setIncludeAcls(false);
+        }
+        // Don't include path segments by default
+        if (client.getDefaultContext().isIncludePathSegments()) {
+            Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context to not include path segments.");
+            client.getDefaultContext().setIncludePathSegments(false);
+        }
+        // Don't include policies by default
+        if (client.getDefaultContext().isIncludePolicies()) {
+            Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context to not include policies.");
+            client.getDefaultContext().setIncludePolicies(false);
+        }
+        // IncludeRelationships should be NONE
+        if (client.getDefaultContext().getIncludeRelationships().equals(IncludeRelationships.NONE)) {
+            Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context to not include relationships.");
+            client.getDefaultContext().setIncludeRelationships(IncludeRelationships.NONE);
+        }
     }
 
     @Nonnull

--- a/core/src/main/java/org/fao/geonet/resources/CMISUtils.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISUtils.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.resources;
+
+import java.util.ArrayList;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.chemistry.opencmis.client.api.CmisObject;
+import org.apache.chemistry.opencmis.client.api.Document;
+import org.apache.chemistry.opencmis.client.api.Folder;
+import org.apache.chemistry.opencmis.client.api.ObjectId;
+import org.apache.chemistry.opencmis.client.api.OperationContext;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisPermissionDeniedException;
+import org.fao.geonet.api.exception.ResourceNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+public class CMISUtils {
+    @Autowired
+    CMISConfiguration cmisConfiguration;
+
+    // Folder cache of 1000 to help speed up folder creation due slow performance executing CMIS multilevel folder.
+    private Cache<String, Folder> folderCache = CacheBuilder.newBuilder().maximumSize(1000).build();
+
+    public void invalidateFolderCache(String folderKey) throws ResourceNotFoundException {
+        // using for-each loop for iteration over folder cache and remove entries related to the folder.
+        // Need to create a copy of the folderCache keys instead of using the keySet() so that removals will not affect the looping of the list.
+        List<String> cachedKeys = new ArrayList<String>(folderCache.asMap().keySet());
+        for (String cachedKey : cachedKeys) {
+            if (cachedKey.startsWith(folderKey)) {
+                folderCache.invalidate(folderKey);
+            }
+        }
+    }
+
+    public void invalidateFolderCacheItem(String folderKey) {
+                folderCache.invalidate(folderKey);
+    }
+
+    public Folder getFolderCache(String folderKey) throws ResourceNotFoundException, CmisPermissionDeniedException {
+        return getFolderCache(folderKey, false);
+    }
+
+    public Folder getFolderCache(String folderKey, boolean refresh) throws ResourceNotFoundException, CmisPermissionDeniedException {
+        Folder folder = null;
+        // Primitive object declared as an object array so that it can be marked as final so it can be used in calling class.
+        // If it is set to true then it was already fetched without using cache so there is no need to refresh()
+        final boolean[] foundWithoutCache = {false};
+
+        try {
+            folder = folderCache.get(folderKey, new Callable<Folder>() {
+                @Override
+                public Folder call() throws Exception {
+                    try {
+                        OperationContext oc = cmisConfiguration.getClient().getDefaultContext();
+                        if (refresh) {
+                            oc = createOperationContext();
+                            oc.setCacheEnabled(false);
+                        }
+                        Folder folder = (Folder) cmisConfiguration.getClient().getObjectByPath(folderKey, oc);
+                        if (refresh) {
+                            foundWithoutCache[0] = true;
+                        }
+                        return folder;
+                    } catch (CmisObjectNotFoundException e) {
+                        String parentFolderKey = folderKey.substring(0, folderKey.lastIndexOf(cmisConfiguration.getFolderDelimiter()));
+                        Folder subFolder = getFolderCache(parentFolderKey, refresh);
+
+                        // synchronize folder creation.
+                        // This will prevent cases where multiple files are uploaded on the interface
+                        // In this case there will be a race condition to create the same folder.
+                        // And if this is not synchronized then there will be a lot or CmisContentAlreadyExistsException errors.
+                        Folder folder;
+                        synchronized (this) {
+                            ObjectId objectId = cmisConfiguration.getClient().createPath(subFolder, folderKey, "cmis:folder");
+                            folder = (Folder) cmisConfiguration.getClient().getObject(objectId);
+                        }
+                        if (refresh) {
+                            foundWithoutCache[0] = true;
+                        }
+                        return folder;
+                    }
+                }
+            });
+        } catch (ExecutionException e) {
+            throw new ResourceNotFoundException("Error getting resource from cache: " + folderKey, e);
+        }
+        if (refresh && !foundWithoutCache[0]) {
+            try {
+                folder.refresh();
+            } catch (CmisObjectNotFoundException e) {
+                folderCache.invalidate(folderKey);
+                folder = getFolderCache(folderKey, refresh);
+            }
+        }
+        return folder;
+    }
+
+
+    public OperationContext createOperationContext() {
+        // Create operational context based on defaults.
+        return cmisConfiguration.getClient().createOperationContext(
+            cmisConfiguration.getClient().getDefaultContext().getFilter(),
+            cmisConfiguration.getClient().getDefaultContext().isIncludeAcls(),
+            cmisConfiguration.getClient().getDefaultContext().isIncludeAllowableActions(),
+            cmisConfiguration.getClient().getDefaultContext().isIncludePolicies(),
+            cmisConfiguration.getClient().getDefaultContext().getIncludeRelationships(),
+            cmisConfiguration.getClient().getDefaultContext().getRenditionFilter(),
+            cmisConfiguration.getClient().getDefaultContext().isIncludePathSegments(),
+            cmisConfiguration.getClient().getDefaultContext().getOrderBy(),
+            cmisConfiguration.getClient().getDefaultContext().isCacheEnabled(),
+            cmisConfiguration.getClient().getDefaultContext().getMaxItemsPerPage()
+        );
+    }
+
+    public Map<String, Document> getCmisObjectMap(Folder folder, String baseFolder) {
+        return getCmisObjectMap(folder, baseFolder, null);
+    }
+    public Map<String, Document> getCmisObjectMap(Folder folder, String baseFolder, String suffixlessKeyFilename) {
+        if (baseFolder == null) {
+            baseFolder="";
+        }
+        Map<String, Document> documentMap = new HashMap<>();
+        for (CmisObject cmisObject : folder.getChildren()) {
+            if (cmisObject instanceof Folder) {
+                documentMap.putAll(getCmisObjectMap((Folder)cmisObject, baseFolder + cmisConfiguration.getFolderDelimiter() + cmisObject.getName(), suffixlessKeyFilename));
+                return documentMap;
+            } else {
+                if (cmisObject instanceof Document && (suffixlessKeyFilename == null || cmisObject.getName().startsWith(suffixlessKeyFilename))) {
+                    documentMap.put(baseFolder + cmisConfiguration.getFolderDelimiter()  + cmisObject.getName(), (Document)cmisObject);
+                }
+            }
+        }
+        return documentMap;
+    }
+
+}

--- a/core/src/main/resources/config-store/config-cmis.xml
+++ b/core/src/main/resources/config-store/config-cmis.xml
@@ -77,6 +77,9 @@
     <bean id="cmisconfiguration" class="org.fao.geonet.resources.CMISConfiguration">
     </bean>
 
+    <bean id="cmisutils" class="org.fao.geonet.resources.CMISUtils">
+    </bean>
+
     <bean id="filesystemStore"
           class="org.fao.geonet.api.records.attachments.CMISStore" />
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
@@ -295,6 +295,10 @@ public class MetadataSampleApi {
                                 setSourceId(siteId).
                                 setOwner(owner).
                                 setGroupOwner(1);
+                            // Set the UUID explicitly, insertMetadata doesn't update the xml with the generated UUID for templates
+                            if (MetadataType.lookup(isTemplate) == MetadataType.TEMPLATE) {
+                                xml = dataManager.setUUID(schemaName, uuid, xml);
+                            }
                             dataManager.insertMetadata(context, metadata, xml, true, true, true, UpdateDatestamp.NO, false, false);
                             report.addMetadataInfos(metadata,
                             String.format(


### PR DESCRIPTION
Performance changes related to CMIS store implementation.

- Reduced API calls
   Reduced API calls by passing object to private function so that they don't need to be fetched again
   Remove call to fetch object when it was available in previous calls.
- Modify operational context.
   Update default operations context so that some options are turned off to increase performance.
   Modify createOperationContext so that it is based on the default context.
- Add Folder caching
   CMIS is slow creating multilevel folders.  So added caching to keep track of the last 1000 folders created/used and reuse the object when possible.
   Mostly used so that folders are created from previously known folders instead of always attempting to create the full folder.
- Refactored
   Moved common code between the Resource and Store to a utilities class.


Most of the performance issues were related to the usage in our cloud environment using Open Text.  When testing on a local system with Alfresco installed locally, there was not any noticeable performance issues.  So network traffic was most likely the main culprit. So the main goal of these performance enhancements was to reduce the number of API calls.

In some test it was previously taking 25 seconds to upload a new file and with the new changes, it took 5 seconds.
