### PR TITLE
Harvester / Local file system / Restore possibility to import subtemplates

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -177,14 +177,25 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult, L
 
         AbstractMetadata metadata = new Metadata();
         metadata.setUuid(uuid);
-        String xmlUuid = metadataUtils.extractUUID(schema, md);
+
+        MetadataType metadataType = MetadataType.lookup(params.recordType);
+
+        String xmlUuid = null;
+        if (metadataType == MetadataType.METADATA) {
+            xmlUuid = metadataUtils.extractUUID(schema, md);
+        } else if (metadataType == MetadataType.SUB_TEMPLATE) {
+            xmlUuid = md.getAttributeValue("uuid");
+        } else if (metadataType == MetadataType.TEMPLATE_OF_SUB_TEMPLATE) {
+            xmlUuid = md.getAttributeValue("uuid");
+        }
+
         if (!uuid.equals(xmlUuid)) {
             md = metadataUtils.setUUID(schema, uuid, md);
         }
         metadata.getDataInfo().
             setSchemaId(schema).
             setRoot(xml.getQualifiedName()).
-            setType(MetadataType.lookup(params.recordType)).
+            setType(metadataType).
             setCreateDate(new ISODate(createDate)).
             setChangeDate(new ISODate(createDate));
         metadata.getSourceInfo().


### PR DESCRIPTION

With https://github.com/geonetwork/core-geonetwork/commit/20693c711a6404d49208364adc2a63202d1ec6ad importing subtemplate using local filesystem harvester does not work.