### PR TITLE
Protect AccessManager code using user session

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
@@ -125,7 +125,7 @@ public class AccessManager {
             }
 
             UserSession us = context.getUserSession();
-            if (us.isAuthenticated() && us.getProfile() == Profile.Editor && us.getProfile() == Profile.Reviewer) {
+            if ((us != null) && us.isAuthenticated() && us.getProfile() == Profile.Editor && us.getProfile() == Profile.Reviewer) {
                 results.add(operationRepository.findReservedOperation(ReservedOperation.view));
             }
         }
@@ -175,7 +175,7 @@ public class AccessManager {
             hs.add(ReservedGroup.intranet.getId());
 
         // get other groups
-        if (usrSess.isAuthenticated()) {
+        if ((usrSess != null) && usrSess.isAuthenticated()) {
             // add (-1) GUEST group
             hs.add(ReservedGroup.guest.getId());
 
@@ -216,7 +216,7 @@ public class AccessManager {
         Set<Integer> hs = new HashSet<Integer>();
 
         // get other groups
-        if (usrSess.isAuthenticated()) {
+        if ((usrSess != null) && usrSess.isAuthenticated()) {
             Specification<UserGroup> spec =
                 UserGroupSpecs.hasUserId(usrSess.getUserIdAsInt());
             spec = Specifications


### PR DESCRIPTION
ISO19139 indexing uses `XslUtil.getRecord` to check during service metadata indexing if the metadata referenced in `srv:operatesOn` are also available in the current portal:

https://github.com/geonetwork/core-geonetwork/blob/f7d08216c7973025a347c8f3399f9709ec326035/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl#L1148

This code uses:

https://github.com/geonetwork/core-geonetwork/blob/f7d08216c7973025a347c8f3399f9709ec326035/core/src/main/java/org/fao/geonet/util/XslUtil.java#L789

That uses `AccessManager`  to add the privileges depending on the user session.

Seems when done the indexing in the metadata editor and in other cases, the indexing is synchronous and the user session is available in the `ServiceContext`, but when the indexing is done in a thread, to increase popularity, it's created a dummy context without user session:

https://github.com/geonetwork/core-geonetwork/blob/f7d08216c7973025a347c8f3399f9709ec326035/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java#L90-L92

That causes a `NullPointerException` that is captured in `XslUtil.getRecord`, but returns `false` even if the metadata exists.

This change protects the usage of user session in AccessManager to check if it's `null`.