### PR TITLE
Import & new metadata / Consistent group list.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -314,19 +314,21 @@
                     scope.groups = data;
                   }
 
-                  // Select by default the first group.
-                  if (setDefaultValue && (angular.isUndefined(scope.ownerGroup) ||
-                    scope.ownerGroup === '' ||
-                    scope.ownerGroup === null) && data) {
-                    // Requires to be converted to string, otherwise
-                    // angularjs adds empty non valid option
-                    scope.ownerGroup = scope.groups[0].id + "";
-                  }
                   if (optional) {
                     scope.groups.unshift({
                       id: 'undefined',
                       name: ''
                     });
+                  }
+
+                  // Select by default the first group.
+                  if (setDefaultValue && (
+                    angular.isUndefined(scope.ownerGroup) ||
+                    scope.ownerGroup === '' ||
+                    scope.ownerGroup === null) && data) {
+                    // Requires to be converted to string, otherwise
+                    // angularjs adds empty non valid option
+                    scope.ownerGroup = scope.groups[0].id + "";
                   }
                 });
           }

--- a/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
@@ -69,14 +69,6 @@
         dataset: 'fa-file'
       };
 
-      $scope.$watchCollection('groups', function() {
-        if (!angular.isUndefined($scope.groups)) {
-          if ($scope.groups.length == 1) {
-            $scope.ownerGroup = $scope.groups[0].id;
-          }
-        }
-      });
-
       // List of record type to not take into account
       // Could be avoided if a new index field is created FIXME ?
       var dataTypesToExclude = ['staticMap', 'theme', 'place'];

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -272,6 +272,7 @@
                 <div id="gn-import-assigngroup-list"
                      data-groups-combo=""
                      data-owner-group="params.group"
+                     data-optional="{{user.isAdministrator()}}"
                      lang="lang"
                      data-groups="groups" data-exclude-special-groups="true"/>
                 <input id="gn-import-assigngroup-input"

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -272,7 +272,7 @@
                 <div id="gn-import-assigngroup-list"
                      data-groups-combo=""
                      data-owner-group="params.group"
-                     data-optional="{{user.isAdministrator()}}"
+                     data-optional="false"
                      lang="lang"
                      data-groups="groups" data-exclude-special-groups="true"/>
                 <input id="gn-import-assigngroup-input"

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
@@ -69,7 +69,7 @@
         </div>
         <div class="panel-body">
           <div data-groups-combo=""
-               data-optional="{{user.isAdministrator()}}"
+               data-optional="false"
                data-owner-group="ownerGroup"
                lang="lang"
                data-groups="groups"

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
@@ -68,7 +68,7 @@
     </div>
     <div class="col-sm-8">
       <div data-groups-combo=""
-         data-optional="{{user.isAdministrator()}}"
+         data-optional="false"
          data-owner-group="ownerGroup"
          lang="lang"
          data-groups="groups"


### PR DESCRIPTION
* Import / Group contains blank value only if admin (like in new
metadata)
* Avoid duplicated empty option in list (add optional first and select first item)
* New metadata / Don't select first user group in the list - let the group combo directive take care of the default based on its config.