### PR TITLE
Sort search entries in label alphabetic order instead of internal value.

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -243,7 +243,7 @@
       <item facet="createDateYear" sortOrder="asc" max="40"/>
     </summaryType>
     <summaryType name="suggestions">
-      <item facet="keyword"/>
+      <item facet="keyword" max="15"/>
       <item facet="title" sortOrder="desc" max="100"/>
       <item facet="inspireTheme" sortBy="value" sortOrder="asc"/>
       <item facet="denominator" sortBy="value" sortOrder="asc"/>

--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -137,19 +137,19 @@
 
   <summaryTypes>
     <summaryType name="details" format="DIMENSION">
-      <item facet="type" translator="codelist:gmd:MD_ScopeCode"/>
+      <item facet="type" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_ScopeCode"/>
       <item facet="mdActions"/>
-      <item facet="topicCat" translator="codelist:gmd:MD_TopicCategoryCode" max="20"/>
+      <item facet="topicCat" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_TopicCategoryCode" max="20"/>
       <item facet="inspireThemeURI" sortBy="value" sortOrder="asc" max="35"
             translator="term:http://inspire.ec.europa.eu/theme"/>
       <!--<item facet="inspireTheme" sortBy="value" sortOrder="asc" max="35"/>-->
       <!--<item facet="inspireThemeWithAc" sortBy="value" sortOrder="asc" max="35"/>-->
-      <item facet="keyword" max="15"/>
-      <item facet="orgName" max="25"/>
+      <item facet="keyword" sortBy="label" sortOrder="asc" max="15"/>
+      <item facet="orgName" sortBy="label" sortOrder="asc" max="25"/>
       <item facet="sourceCatalog"
             translator="db:org.fao.geonet.repository.SourceRepository:findOneByUuid"/>
       <item facet="createDateYear" sortBy="value" sortOrder="desc" max="40"/>
-      <item facet="format" max="15" sortBy="value" sortOrder="asc"/>
+      <item facet="format" max="15" sortBy="label" sortOrder="asc"/>
       <item facet="spatialRepresentationType"
             translator="codelist:gmd:MD_SpatialRepresentationTypeCode"/>
       <item facet="maintenanceAndUpdateFrequency"
@@ -167,8 +167,8 @@
     </summaryType>
 
     <summaryType name="manager" format="DIMENSION">
-      <item facet="type" translator="codelist:gmd:MD_ScopeCode"/>
-      <item facet="category" max="99" sortBy="value"
+      <item facet="type" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_ScopeCode"/>
+      <item facet="category" max="99" sortBy="label" sortOrder="asc"
             translator="db:org.fao.geonet.repository.MetadataCategoryRepository:findOneByName"/>
       <item facet="mdStatus" max="10" sortBy="value"
             translator="db:org.fao.geonet.repository.StatusValueRepository:findOne:int"/>
@@ -191,16 +191,16 @@
     flat facet. It's recommended to use format="DIMENSION" for facet.
     See above. -->
     <summaryType name="hits">
-      <item facet="type" translator="codelist:gmd:MD_ScopeCode"/>
-      <item facet="topicCat" translator="codelist:gmd:MD_TopicCategoryCode" max="20"/>
+      <item facet="type" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_ScopeCode"/>
+      <item facet="topicCat" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_TopicCategoryCode" max="20"/>
       <item facet="inspireTheme" sortBy="value" sortOrder="asc" max="35"/>
       <item facet="inspireThemeWithAc" sortBy="value" sortOrder="asc" max="35"/>
       <item facet="inspireThemeURI" sortBy="value" sortOrder="asc" max="35"
             translator="term:http://inspire.ec.europa.eu/theme"/>
-      <item facet="keyword" max="15"/>
+      <item facet="keyword" sortBy="label" sortOrder="asc" max="15"/>
       <item facet="orgName" max="25"/>
       <item facet="createDateYear" sortBy="value" sortOrder="desc" max="40"/>
-      <item facet="format" max="15" sortBy="value" sortOrder="asc"/>
+      <item facet="format" max="15" sortBy="label" sortOrder="asc"/>
       <item facet="spatialRepresentationType"
             translator="codelist:gmd:MD_SpatialRepresentationTypeCode"/>
       <item facet="maintenanceAndUpdateFrequency"

--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -138,24 +138,24 @@
   <summaryTypes>
     <summaryType name="details" format="DIMENSION">
       <item facet="type" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_ScopeCode"/>
-      <item facet="mdActions"/>
+      <item facet="mdActions" sortBy="label" sortOrder="asc"/>
       <item facet="topicCat" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_TopicCategoryCode" max="20"/>
-      <item facet="inspireThemeURI" sortBy="value" sortOrder="asc" max="35"
+      <item facet="inspireThemeURI" sortBy="label" sortOrder="asc" max="35"
             translator="term:http://inspire.ec.europa.eu/theme"/>
       <!--<item facet="inspireTheme" sortBy="value" sortOrder="asc" max="35"/>-->
       <!--<item facet="inspireThemeWithAc" sortBy="value" sortOrder="asc" max="35"/>-->
       <item facet="keyword" sortBy="label" sortOrder="asc" max="15"/>
       <item facet="orgName" sortBy="label" sortOrder="asc" max="25"/>
-      <item facet="sourceCatalog"
+      <item facet="sourceCatalog" sortBy="label" sortOrder="asc"
             translator="db:org.fao.geonet.repository.SourceRepository:findOneByUuid"/>
       <item facet="createDateYear" sortBy="value" sortOrder="desc" max="40"/>
       <item facet="format" max="15" sortBy="label" sortOrder="asc"/>
-      <item facet="spatialRepresentationType"
+      <item facet="spatialRepresentationType" sortBy="label" sortOrder="asc"
             translator="codelist:gmd:MD_SpatialRepresentationTypeCode"/>
-      <item facet="maintenanceAndUpdateFrequency"
+      <item facet="maintenanceAndUpdateFrequency" sortBy="label" sortOrder="asc"
             translator="codelist:gmd:MD_MaintenanceFrequencyCode"/>
-      <item facet="status" translator="codelist:gmd:MD_ProgressCode"/>
-      <item facet="serviceType"/>
+      <item facet="status" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_ProgressCode"/>
+      <item facet="serviceType" sortBy="label" sortOrder="asc"/>
       <item facet="denominator" sortBy="numValue" sortOrder="desc"/>
       <item facet="resolution" sortBy="numValue" sortOrder="desc"/>
       <!--
@@ -170,20 +170,20 @@
       <item facet="type" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_ScopeCode"/>
       <item facet="category" max="99" sortBy="label" sortOrder="asc"
             translator="db:org.fao.geonet.repository.MetadataCategoryRepository:findOneByName"/>
-      <item facet="mdStatus" max="10" sortBy="value"
+      <item facet="mdStatus" max="10" sortBy="label" sortOrder="asc"
             translator="db:org.fao.geonet.repository.StatusValueRepository:findOne:int"/>
-      <item facet="sourceCatalog"
+      <item facet="sourceCatalog" sortBy="label" sortOrder="asc"
             translator="db:org.fao.geonet.repository.SourceRepository:findOneByUuid"/>
-      <item facet="isValid" max="3" sortBy="value" translator="apploc:validStatus-"/>
-      <item facet="isValidInspire" max="3" sortBy="value" translator="apploc:validStatus-"/>
-      <item facet="groupOwner" max="199" sortBy="value"
+      <item facet="isValid" max="3" sortBy="label" sortOrder="asc" translator="apploc:validStatus-"/>
+      <item facet="isValidInspire" max="3" sortBy="label" sortOrder="asc" translator="apploc:validStatus-"/>
+      <item facet="groupOwner" max="199" sortBy="label" sortOrder="asc"
             translator="db:org.fao.geonet.repository.GroupRepository:findOne:int"/>
-      <item facet="recordOwner" max="45" sortBy="value"/>
-      <item facet="publishedForGroup" max="199" sortBy="value"
+      <item facet="recordOwner" max="45" sortBy="label" sortOrder="asc"/>
+      <item facet="publishedForGroup" max="199" sortBy="label" sortOrder="asc"
             translator="db:org.fao.geonet.repository.GroupRepository:findByName"/>
-      <item facet="standard" max="15" sortBy="value"/>
+      <item facet="standard" max="15" sortBy="label" sortOrder="asc"/>
       <item facet="isHarvested" max="2" sortBy="value" translator="apploc:"/>
-      <item facet="metadataType" max="3" sortBy="value" translator="apploc:recordType-"/>
+      <item facet="metadataType" max="3" sortBy="label" sortOrder="asc" translator="apploc:recordType-"/>
 	    <item facet="isPublishedToAll" max="2" sortBy="value" translator="apploc:"/>
     </summaryType>
 
@@ -193,20 +193,20 @@
     <summaryType name="hits">
       <item facet="type" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_ScopeCode"/>
       <item facet="topicCat" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_TopicCategoryCode" max="20"/>
-      <item facet="inspireTheme" sortBy="value" sortOrder="asc" max="35"/>
-      <item facet="inspireThemeWithAc" sortBy="value" sortOrder="asc" max="35"/>
-      <item facet="inspireThemeURI" sortBy="value" sortOrder="asc" max="35"
+      <item facet="inspireTheme" sortBy="label" sortOrder="asc" max="35"/>
+      <item facet="inspireThemeWithAc" sortBy="label" sortOrder="asc" max="35"/>
+      <item facet="inspireThemeURI" sortBy="label" sortOrder="asc" max="35"
             translator="term:http://inspire.ec.europa.eu/theme"/>
       <item facet="keyword" sortBy="label" sortOrder="asc" max="15"/>
-      <item facet="orgName" max="25"/>
+      <item facet="orgName" sortBy="label" sortOrder="asc" max="25"/>
       <item facet="createDateYear" sortBy="value" sortOrder="desc" max="40"/>
       <item facet="format" max="15" sortBy="label" sortOrder="asc"/>
-      <item facet="spatialRepresentationType"
+      <item facet="spatialRepresentationType" sortBy="label" sortOrder="asc"
             translator="codelist:gmd:MD_SpatialRepresentationTypeCode"/>
-      <item facet="maintenanceAndUpdateFrequency"
+      <item facet="maintenanceAndUpdateFrequency" sortBy="label" sortOrder="asc"
             translator="codelist:gmd:MD_MaintenanceFrequencyCode"/>
-      <item facet="status" translator="codelist:gmd:MD_ProgressCode"/>
-      <item facet="serviceType"/>
+      <item facet="status" sortBy="label" sortOrder="asc" translator="codelist:gmd:MD_ProgressCode"/>
+      <item facet="serviceType" sortBy="label" sortOrder="asc"/>
       <item facet="denominator" sortBy="numValue" sortOrder="desc"/>
       <item facet="resolution" sortBy="numValue" sortOrder="desc"/>
       <!--<item facet="metadataPOC" max="15"/>-->


### PR DESCRIPTION
Issue one: there are 15 pre-populated keywords on the side search bar
![image](https://user-images.githubusercontent.com/74916635/105750640-005c5300-5f13-11eb-9efa-835906c8499a.png)

The suggestion keywords drop-down uses the default which is 10. 
![image](https://user-images.githubusercontent.com/74916635/105750850-3bf71d00-5f13-11eb-9b2a-16d77803ba1f.png)

So it's better to keep consistent as well

Issue Two: The labels in search entry are mostly sorted by either the value which is internal ID of the search engine or count. It's not very user friendly as the business who is using the software suggest to sort in alphabetic way.
Here is an example of unsorted items:
![image](https://user-images.githubusercontent.com/74916635/106038144-8d371600-60a5-11eb-97dd-0a7a07ba5d9c.png)
