### PR TITLE
extend extract-gml to add point as boundingpolygon

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
@@ -276,7 +276,7 @@
       <xsl:with-param name="subTreeSnippet">
 
         <xsl:variable name="geometry">
-          <xsl:apply-templates select="gex:polygon/gml:MultiSurface|gex:polygon/gml:LineString"
+          <xsl:apply-templates select="gex:polygon/gml:MultiSurface|gex:polygon/gml:LineString|gex:polygon/gml:Point"
                                mode="gn-element-cleaner"/>
         </xsl:variable>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -285,6 +285,7 @@
   <!-- Add required gml attributes if missing -->
   <xsl:template match="gml:Polygon[not(@gml:id) and not(@srsName)]|
                        gml:MultiSurface[not(@gml:id) and not(@srsName)]|
+                       gml:Point[not(@gml:id) and not(@srsName)]|
                        gml:LineString[not(@gml:id) and not(@srsName)]">
     <xsl:copy>
       <xsl:attribute name="gml:id">

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-gml.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-gml.xsl
@@ -52,8 +52,8 @@
           -->
     <xsl:for-each select="gmd:polygon/(gml:*|gml320:*)[
                             local-name() != 'MultiCurve' and
-                            count(*) > 0 and
-                            .//(gml:posList|gml320:posList) != '']">
+                            count(*) > 0 and (
+                            .//(gml:posList|gml320:posList) != '' or .//(gml:pos|gml320:pos) != '')]">
       <xsl:copy-of copy-namespaces="no" select="."/>
     </xsl:for-each>
   </xsl:template>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -285,8 +285,8 @@
       <xsl:with-param name="subTreeSnippet">
 
         <xsl:variable name="geometry">
-          <xsl:apply-templates select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:LineString|gml:Point|
-                                       gmd:polygon/gml320:MultiSurface|gmd:polygon/gml320:LineString|gml320:Point"
+          <xsl:apply-templates select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:LineString|gmd:polygon/gml:Point|
+                                       gmd:polygon/gml320:MultiSurface|gmd:polygon/gml320:LineString|gmd:polygon/gml320:Point"
                                mode="gn-element-cleaner"/>
         </xsl:variable>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -285,8 +285,8 @@
       <xsl:with-param name="subTreeSnippet">
 
         <xsl:variable name="geometry">
-          <xsl:apply-templates select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:LineString|
-                                       gmd:polygon/gml320:MultiSurface|gmd:polygon/gml320:LineString"
+          <xsl:apply-templates select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:LineString|gml:Point|
+                                       gmd:polygon/gml320:MultiSurface|gmd:polygon/gml320:LineString|gml320:Point"
                                mode="gn-element-cleaner"/>
         </xsl:variable>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -338,9 +338,11 @@
   <xsl:template match="gml:Polygon[not(@gml:id) or not(@srsName)]|
                        gml:MultiSurface[not(@gml:id) or not(@srsName)]|
                        gml:LineString[not(@gml:id) or not(@srsName)]|
+                       gml:Point[not(@gml:id) or not(@srsName)]|
                        gml320:Polygon[not(@gml320:id) or not(@srsName)]|
                        gml320:MultiSurface[not(@gml:id) or not(@srsName)]|
-                       gml320:LineString[not(@gml:id) or not(@srsName)]">
+                       gml320:LineString[not(@gml:id) or not(@srsName)]|
+                       gml320:Point[not(@gml320:id) or not(@srsName)]">
     <xsl:element name="gml:{local-name()}"
                  namespace="{if($isUsing2005Schema)
                              then 'http://www.opengis.net/gml'


### PR DESCRIPTION
this work builds on #5367, the extract-gml (on iso19139) did not consider submission of a point geometry
also preparing some of the cleaning/checking methods for point. #5367 creates a box around a point (previously storing failed) now we can see the extend image as 
![image](https://user-images.githubusercontent.com/299829/105836401-673e4280-5fcd-11eb-9f66-3600474189ef.png)
Part of solution for #4811 