### PR TITLE
ISO19139/ISO19115-3 index updates to improve build of jsonld/dcat formats

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -187,6 +187,10 @@
       <xsl:for-each
         select="mdb:metadataStandard/cit:CI_Citation/cit:title">
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('standardName', ., $allLanguages)"/>
+
+        <xsl:for-each select="../cit:edition/*">
+          <xsl:copy-of select="gn-fn-index:add-multilingual-field('standardVersion', ., $allLanguages)"/>
+        </xsl:for-each>
       </xsl:for-each>
 
 
@@ -209,7 +213,6 @@
       </xsl:for-each>
 
 
-      <!-- # Languages -->
       <xsl:copy-of select="gn-fn-index:add-field('mainLanguage', $mainLanguage)"/>
 
       <xsl:for-each select="$otherLanguages">
@@ -217,19 +220,19 @@
         <xsl:copy-of select="gn-fn-index:add-field('otherLanguageId', ../../../@id)"/>
       </xsl:for-each>
 
-      <!-- # Characterset -->
-      <xsl:if test="mdb:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode">
+
+      <xsl:for-each select="mdb:defaultLocale/*/lan:characterEncoding/*[@codeListValue != '']">
         <xsl:copy-of select="gn-fn-index:add-codelist-field(
-                                'cl_characterSet', mdb:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode, $allLanguages)"/>
-      </xsl:if>
-      <!-- # Resource type -->
+                                'cl_characterSet', ., $allLanguages)"/>
+      </xsl:for-each>
+
+
       <xsl:choose>
         <xsl:when test="$isDataset">
           <resourceType>dataset</resourceType>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:for-each select="mdb:metadataScope/mdb:MD_MetadataScope/
-                                  mdb:resourceScope/mcc:MD_ScopeCode/@codeListValue[normalize-space(.) != '']">
+          <xsl:for-each select="mdb:metadataScope/*/mdb:resourceScope/*/@codeListValue[. != '']">
             <resourceType>
               <xsl:value-of select="."/>
             </resourceType>
@@ -341,9 +344,15 @@
               <xsl:value-of select="."/>
             </presentationForm>
           </xsl:for-each>
+
+          <xsl:for-each select="cit:edition/*">
+            <xsl:copy-of select="gn-fn-index:add-field('resourceEdition', .)"/>
+          </xsl:for-each>
         </xsl:for-each>
 
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAbstract', mri:abstract, $allLanguages)"/>
+
+
 
         <!-- # Characterset -->
         <xsl:if test="mri:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -185,8 +185,8 @@
       </xsl:if>-->
 
       <xsl:for-each
-        select="mdb:metadataStandard/cit:CI_Citation/cit:title/gco:CharacterString">
-        <xsl:copy-of select="gn-fn-index:add-field('standardName', normalize-space(.))"/>
+        select="mdb:metadataStandard/cit:CI_Citation/cit:title">
+        <xsl:copy-of select="gn-fn-index:add-multilingual-field('standardName', ., $allLanguages)"/>
       </xsl:for-each>
 
 
@@ -217,7 +217,11 @@
         <xsl:copy-of select="gn-fn-index:add-field('otherLanguageId', ../../../@id)"/>
       </xsl:for-each>
 
-
+      <!-- # Characterset -->
+      <xsl:if test="mdb:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode">
+        <xsl:copy-of select="gn-fn-index:add-codelist-field(
+                                'cl_characterSet', mdb:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode, $allLanguages)"/>
+      </xsl:if>
       <!-- # Resource type -->
       <xsl:choose>
         <xsl:when test="$isDataset">
@@ -253,6 +257,7 @@
       <xsl:for-each-group select=".//*[@codeListValue != '' and
                             name() != 'cit:CI_RoleCode' and
                             name() != 'cit:CI_DateTypeCode' and
+                            name() != 'lan:MD_CharacterSetCode' and
                             name() != 'lan:LanguageCode'
                             ]"
                           group-by="@codeListValue">
@@ -320,9 +325,12 @@
             </xsl:for-each-group>
           </xsl:if>
 
-          <!-- TODO: Add support for Anchor, can be a DOI -->
-          <xsl:for-each select="cit:identifier/*/mcc:code/(gco:CharacterString|gcx:Anchor)">
-            <resourceIdentifier>
+          <xsl:for-each select="cit:identifier/*">
+            <resourceIdentifier type="object">{
+              "code": "<xsl:value-of select="mcc:code/(gco:CharacterString|gcx:Anchor)"/>",
+              "codeSpace": "<xsl:value-of select="mcc:codeSpace/(gco:CharacterString|gcx:Anchor)"/>",
+              "link": "<xsl:value-of select="mcc:code/gcx:Anchor/@xlink:href"/>"
+              }
               <xsl:value-of select="."/>
             </resourceIdentifier>
           </xsl:for-each>
@@ -336,6 +344,12 @@
         </xsl:for-each>
 
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAbstract', mri:abstract, $allLanguages)"/>
+
+        <!-- # Characterset -->
+        <xsl:if test="mri:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode">
+          <xsl:copy-of select="gn-fn-index:add-codelist-field(
+                                  'cl_resourceCharacterSet', mri:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode, $allLanguages)"/>
+        </xsl:if>
 
         <!-- Indexing resource contact -->
         <xsl:apply-templates mode="index-contact"
@@ -689,6 +703,9 @@
           <xsl:copy-of select="gn-fn-index:add-multilingual-field(concat($fieldPrefix, 'UseLimitation'), mco:useLimitation, $allLanguages)"/>
         </xsl:for-each>
 
+        <xsl:for-each select="mri:resourceConstraints/mco:MD_LegalConstraints/mco:otherConstraints">
+          <xsl:copy-of select="gn-fn-index:add-multilingual-field('license', ., $allLanguages)"/>
+        </xsl:for-each>
 
         <xsl:if test="*/gex:EX_Extent/*/gex:EX_BoundingPolygon">
           <hasBoundingPolygon>true</hasBoundingPolygon>
@@ -898,14 +915,22 @@
                           select="if ($inspireRegulationLaxCheck)
                                   then daobs:search-in-contains($eu9762009/*, $title)
                                   else daobs:search-in($eu9762009/*, $title)"/>
-            <xsl:if test="count($matchingEUText) = 1">
 
-              <xsl:variable name="pass"
-                            select="*/mdq:result/*/mdq:pass/gco:Boolean"/>
+            <xsl:variable name="pass"
+                          select="*/mdq:result/*/mdq:pass/gco:Boolean"/>
+
+            <xsl:if test="count($matchingEUText) = 1">
               <inspireConformResource>
                 <xsl:value-of select="$pass"/>
               </inspireConformResource>
             </xsl:if>
+
+            <specificationConformance type="object">{
+              "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
+              "date": "<xsl:value-of select="/mdq:result/*/mdq:specification/cit:CI_Citation/cit:date/cit:CI_Date/cit:date/gco:Date" />",
+              "pass": "<xsl:value-of select="$pass" />"
+              }
+            </specificationConformance>
           </xsl:for-each-group>
         </xsl:when>
         <xsl:otherwise>
@@ -920,14 +945,21 @@
                                   then daobs:search-in-contains($eu10892010/*, $title)
                                   else daobs:search-in($eu10892010/*, $title)"/>
 
-            <xsl:if test="count($matchingEUText) = 1">
+            <xsl:variable name="pass"
+                          select="*/mdq:result/*/mdq:pass/gco:Boolean"/>
 
-              <xsl:variable name="pass"
-                            select="*/mdq:result/*/mdq:pass/gco:Boolean"/>
+            <xsl:if test="count($matchingEUText) = 1">
               <inspireConformResource>
                 <xsl:value-of select="$pass"/>
               </inspireConformResource>
             </xsl:if>
+
+            <specificationConformance type="object">{
+              "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
+              "date": "<xsl:value-of select="/mdq:result/*/mdq:specification/cit:CI_Citation/cit:date/cit:CI_Date/cit:date/gco:Date" />",
+              "pass": "<xsl:value-of select="$pass" />"
+              }
+            </specificationConformance>
           </xsl:for-each-group>
         </xsl:otherwise>
       </xsl:choose>
@@ -1063,6 +1095,7 @@
             "url":"<xsl:value-of select="gn-fn-index:json-escape(cit:linkage/*/text())"/>",
             "name":"<xsl:value-of select="gn-fn-index:json-escape((cit:name/*/text())[1])"/>",
             "description":"<xsl:value-of select="gn-fn-index:json-escape((cit:description/*/text())[1])"/>",
+            "function":"<xsl:value-of select="cit:function/cit:CI_OnLineFunctionCode/@codeListValue"/>",
             "applicationProfile":"<xsl:value-of select="gn-fn-index:json-escape(cit:applicationProfile/gco:CharacterString/text())"/>",
             "group": <xsl:value-of select="$transferGroup"/>
             }

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -189,9 +189,10 @@
       </xsl:for-each>
 
 
-      <!-- # Characterset -->
-      <xsl:copy-of select="gn-fn-index:add-codelist-field(
-                                'cl_characterSet', gmd:characterSet/gmd:MD_CharacterSetCode, $allLanguages)"/>
+      <xsl:for-each select="gmd:characterSet/*[@codeListValue != '']">
+        <xsl:copy-of select="gn-fn-index:add-codelist-field(
+                                  'cl_characterSet', ., $allLanguages)"/>
+      </xsl:for-each>
 
       <!-- # Resource type -->
       <xsl:choose>
@@ -199,8 +200,7 @@
           <resourceType>dataset</resourceType>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:for-each select="gmd:hierarchyLevel/gmd:MD_ScopeCode/
-                              @codeListValue[normalize-space(.) != '']">
+          <xsl:for-each select="gmd:hierarchyLevel/*/@codeListValue[normalize-space(.) != '']">
             <resourceType>
               <xsl:value-of select="."/>
             </resourceType>
@@ -332,13 +332,18 @@
               <xsl:value-of select="."/>
             </resourceIdentifier>
           </xsl:for-each>
+
+          <xsl:for-each select="gmd:edition/*">
+            <xsl:copy-of select="gn-fn-index:add-field('resourceEdition', .)"/>
+          </xsl:for-each>
         </xsl:for-each>
 
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAbstract', gmd:abstract, $allLanguages)"/>
 
-        <!-- # Characterset -->
-        <xsl:copy-of select="gn-fn-index:add-codelist-field(
-                                'cl_resourceCharacterSet', gmd:characterSet/gmd:MD_CharacterSetCode, $allLanguages)"/>
+        <xsl:for-each select="gmd:characterSet/*[@codeListValue != '']">
+          <xsl:copy-of select="gn-fn-index:add-codelist-field(
+                                  'cl_resourceCharacterSet', ., $allLanguages)"/>
+        </xsl:for-each>
 
         <!-- Indexing resource contact -->
         <xsl:apply-templates mode="index-contact"

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -152,10 +152,13 @@
 
       <xsl:copy-of select="gn-fn-index:add-field('metadataIdentifier', $identifier)"/>
 
-      <xsl:for-each select="gmd:metadataStandardName/gco:CharacterString">
-        <xsl:copy-of select="gn-fn-index:add-field('standardName', normalize-space(.))"/>
+      <xsl:for-each select="gmd:metadataStandardName">
+        <xsl:copy-of select="gn-fn-index:add-multilingual-field('standardName', ., $allLanguages)"/>
       </xsl:for-each>
 
+      <xsl:for-each select="gmd:metadataStandardVersion">
+        <xsl:copy-of select="gn-fn-index:add-multilingual-field('standardVersion', ., $allLanguages)"/>
+      </xsl:for-each>
 
       <!-- Since GN sets the timezone in system/server/timeZone setting as Java system default
         timezone we can rely on XSLT functions to get current date in the right timezone -->
@@ -185,6 +188,10 @@
         <xsl:copy-of select="gn-fn-index:add-field('otherLanguageId', ../../../@id)"/>
       </xsl:for-each>
 
+
+      <!-- # Characterset -->
+      <xsl:copy-of select="gn-fn-index:add-codelist-field(
+                                'cl_characterSet', gmd:characterSet/gmd:MD_CharacterSetCode, $allLanguages)"/>
 
       <!-- # Resource type -->
       <xsl:choose>
@@ -240,6 +247,7 @@
       <xsl:for-each-group select=".//*[@codeListValue != '' and
                             name() != 'gmd:CI_RoleCode' and
                             name() != 'gmd:CI_DateTypeCode' and
+                            name() != 'gmd:MD_CharacterSetCode' and
                             name() != 'gmd:LanguageCode'
                             ]"
                           group-by="@codeListValue">
@@ -315,9 +323,12 @@
             </xsl:for-each-group>
           </xsl:if>
 
-          <!-- TODO: Add support for Anchor, can be a DOI -->
-          <xsl:for-each select="gmd:identifier/*/gmd:code/(gco:CharacterString|gmx:Anchor)">
-            <resourceIdentifier>
+          <xsl:for-each select="gmd:identifier/*">
+            <resourceIdentifier type="object">{
+              "code": "<xsl:value-of select="gmd:code/(gco:CharacterString|gmx:Anchor)"/>",
+              "codeSpace": "<xsl:value-of select="gmd:codeSpace/(gco:CharacterString|gmx:Anchor)"/>",
+              "link": "<xsl:value-of select="gmd:code/gmx:Anchor/@xlink:href"/>"
+              }
               <xsl:value-of select="."/>
             </resourceIdentifier>
           </xsl:for-each>
@@ -325,6 +336,9 @@
 
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAbstract', gmd:abstract, $allLanguages)"/>
 
+        <!-- # Characterset -->
+        <xsl:copy-of select="gn-fn-index:add-codelist-field(
+                                'cl_resourceCharacterSet', gmd:characterSet/gmd:MD_CharacterSetCode, $allLanguages)"/>
 
         <!-- Indexing resource contact -->
         <xsl:apply-templates mode="index-contact"
@@ -671,6 +685,9 @@
           </xsl:for-each>
         </xsl:for-each>
 
+        <xsl:for-each select="gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints">
+          <xsl:copy-of select="gn-fn-index:add-multilingual-field('license', ., $allLanguages)"/>
+        </xsl:for-each>
 
         <xsl:if test="*/gmd:EX_Extent/*/gmd:EX_BoundingPolygon/gmd:polygon">
           <hasBoundingPolygon>true</hasBoundingPolygon>
@@ -883,13 +900,22 @@
                           select="if ($inspireRegulationLaxCheck)
                                   then daobs:search-in-contains($eu9762009/*, $title)
                                   else daobs:search-in($eu9762009/*, $title)"/>
+
+            <xsl:variable name="pass"
+                          select="*/gmd:result/*/gmd:pass/gco:Boolean"/>
+
             <xsl:if test="count($matchingEUText) = 1">
-              <xsl:variable name="pass"
-                            select="*/gmd:result/*/gmd:pass/gco:Boolean"/>
               <inspireConformResource>
                 <xsl:value-of select="$pass"/>
               </inspireConformResource>
             </xsl:if>
+
+            <specificationConformance type="object">{
+              "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
+              "date": "<xsl:value-of select="*/gmd:result/*/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date" />",
+              "pass": "<xsl:value-of select="$pass" />"
+              }
+            </specificationConformance>
           </xsl:for-each-group>
         </xsl:when>
         <xsl:otherwise>
@@ -904,13 +930,21 @@
                                   then daobs:search-in-contains($eu10892010/*, $title)
                                   else daobs:search-in($eu10892010/*, $title)"/>
 
+            <xsl:variable name="pass"
+                          select="*/gmd:result/*/gmd:pass/gco:Boolean"/>
+
             <xsl:if test="count($matchingEUText) = 1">
-              <xsl:variable name="pass"
-                            select="*/gmd:result/*/gmd:pass/gco:Boolean"/>
               <inspireConformResource>
                 <xsl:value-of select="$pass"/>
               </inspireConformResource>
             </xsl:if>
+
+            <specificationConformance type="object">{
+              "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
+              "date": "<xsl:value-of select="*/gmd:result/*/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date" />",
+              "pass": "<xsl:value-of select="$pass" />"
+              }
+            </specificationConformance>
           </xsl:for-each-group>
         </xsl:otherwise>
       </xsl:choose>
@@ -1024,6 +1058,7 @@
             "url":"<xsl:value-of select="gn-fn-index:json-escape(gmd:linkage/gmd:URL)"/>",
             "name":"<xsl:value-of select="$linkName"/>",
             "description":"<xsl:value-of select="gn-fn-index:json-escape(gmd:description/gco:CharacterString/text())"/>",
+            "function":"<xsl:value-of select="gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue"/>",
             "applicationProfile":"<xsl:value-of select="gn-fn-index:json-escape(gmd:applicationProfile/gco:CharacterString/text())"/>",
             "group": <xsl:value-of select="$transferGroup"/>
             }

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1461,8 +1461,19 @@
         "type": "keyword"
       },
       "resourceIdentifier": {
-        "type": "keyword",
-        "copy_to": "any"
+        "type": "nested",
+        "properties": {
+          "code": {
+            "type": "keyword",
+            "copy_to": "any"
+          },
+          "codeSpace": {
+            "type": "keyword"
+          },
+          "link": {
+            "type": "keyword"
+          }
+        }
       },
       "serviceType": {
         "type": "keyword"
@@ -1471,9 +1482,6 @@
         "type": "keyword"
       },
       "spatialRepresentationType": {
-        "type": "keyword"
-      },
-      "standardName": {
         "type": "keyword"
       },
       "schema": {


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/wiki/GeoNetwork-UI-and-microservices-codesprint-January-2021#gn4-indexing


* Standard name is multilingual and may have xlink
* `standardVersion` missing in 19115-3
* Metadata and resource charset indexed in `cl_characterSet` and `cl_resourceCharacterSet`
* Resource identifier with link and codespace
* Resource edition in `resourceEdition`
* license
* specificationConformance
