### PR TITLE
Fix tabs for useradmin - Statistics and Status

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/DashboardController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardController.js
@@ -44,31 +44,41 @@
   module.controller('GnDashboardController', [
     '$scope', '$http', 'gnGlobalSettings',
     function($scope, $http, gnGlobalSettings) {
-      $scope.pageMenu = {tabs: {}};
       $scope.info = {};
       $scope.gnUrl = gnGlobalSettings.gnUrl;
 
-      $scope.pageMenu.tabs = [{
-        type: 'status',
-        label: 'status',
-        icon: 'fa-dashboard',
-        href: '#/dashboard/status'
-      },{
+      var userAdminTabs = [{
         type: 'record-links',
         label: 'record-links',
         icon: 'fa-link',
         href: '#/dashboard/record-links'
-      },{
-        type: 'information',
-        label: 'information',
-        icon: 'fa-list-ul',
-        href: '#/dashboard/information'
-      },{
-        type: 'versioning',
-        label: 'versioning',
-        icon: 'fa-rss',
-        href: '#/dashboard/versioning'
       }];
+
+      $scope.pageMenu = {
+        folder: 'dashboard/',
+        defaultTab: 'status',
+        tabs:
+          [{
+            type: 'status',
+            label: 'status',
+            icon: 'fa-dashboard',
+            href: '#/dashboard/status'
+          }, {
+            type: 'record-links',
+            label: 'record-links',
+            icon: 'fa-link',
+            href: '#/dashboard/record-links'
+          }, {
+            type: 'information',
+            label: 'information',
+            icon: 'fa-list-ul',
+            href: '#/dashboard/information'
+          }, {
+            type: 'versioning',
+            label: 'versioning',
+            icon: 'fa-rss',
+            href: '#/dashboard/versioning'
+          }]};
 
       var dashboards = [{
         type: 'statistics',
@@ -93,32 +103,26 @@
       //       '5b407790-4fa1-11e7-a577-3197d1592a1d?embed=true&_g=()')
       }];
 
-
-
       function loadConditionalTabs() {
         if ($scope.user.profile === 'UserAdmin') {
-          $scope.pageMenu.tabs = [{
-            type: 'record-links',
-            label: 'record-links',
-            icon: 'fa-link',
-            href: '#/dashboard/record-links'
-          }];
+          $scope.pageMenu.tabs = userAdminTabs;
           $scope.pageMenu.defaultTab = 'record-links';
         }
+
         if ($scope.healthCheck.DashboardAppHealthCheck === true) {
           $scope.pageMenu.tabs = $scope.pageMenu.tabs.concat(dashboards);
         }
       }
 
-      $scope.pageMenu = {
-        folder: 'dashboard/',
-        defaultTab: 'status',
-        tabs: $scope.pageMenu.tabs
-      };
-
       loadConditionalTabs();
 
       $scope.$watch('healthCheck.DashboardAppHealthCheck', function (n, o) {
+        if (n !== o) {
+          loadConditionalTabs();
+        }
+      });
+
+      $scope.$watchCollection('user', function (n, o) {
         if (n !== o) {
           loadConditionalTabs();
         }


### PR DESCRIPTION
Fix tabs for useradmin which were sometimes showing all options when reloading the page.

If you login as a useradmin user and go to the Statistics and Status you should see the following.

![image](https://user-images.githubusercontent.com/1868233/106186464-b37ab580-617a-11eb-8ee2-ab8c03007a14.png)

Click on any link excep for "record links analysis" i.e. versioning

And the tabs change to the following

![image](https://user-images.githubusercontent.com/1868233/106186697-018fb900-617b-11eb-97ef-d95a4cfddd77.png)

Hit reload and it reverts back to the first list.  But it will also show the versioning form.

![image](https://user-images.githubusercontent.com/1868233/106186871-4156a080-617b-11eb-98fc-a4475dd0bcb0.png)

This fix makes it so that the tabs are displayed correctly.

Updated code so that it is similar to the settings tabs which seems to be cleaner code.
Also added "`$scope.$watchCollection('user', function (n, o) {`" code which seems to be the real fix for this issue.

I also noticed that the dashboard seams to have editor as the default permissions. Maybe that should be changed to useradmin unless we want the editors to have access to one of these tabs?

https://github.com/geonetwork/core-geonetwork/blob/457a342698c211e3e37a284ef4d86d8c60f2e66a/web-ui/src/main/resources/catalog/js/admin/AdminController.js#L153-L170
