### PR TITLE
Update message if metadata is not found

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -367,6 +367,8 @@
   "shareByEmail": "Share by email",
   "zoomto": "Zoom To",
   "recordNotFound": "The record with identifier <strong>{{uuid}}</strong> was not found or is not shared with you. Try to <a href=\"catalog.signin?redirect={{url}}\">sign in</a> if you've an account.",
+  "recordNotFoundAuthenticatedUser": "The record with identifier <strong>{{uuid}}</strong> was not found or is not shared with you.",
+  "recordNotFoundAuthenticatedAdministrator":"The record with identifier <strong>{{uuid}}</strong> was not found",
   "intersectWith": "Intersects with",
   "fullyOutsideOf": "Fully outside of",
   "encloses": "Enclosing",

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -368,7 +368,7 @@
   "zoomto": "Zoom To",
   "recordNotFound": "The record with identifier <strong>{{uuid}}</strong> was not found or is not shared with you. Try to <a href=\"catalog.signin?redirect={{url}}\">sign in</a> if you've an account.",
   "recordNotFoundAuthenticatedUser": "The record with identifier <strong>{{uuid}}</strong> was not found or is not shared with you.",
-  "recordNotFoundAuthenticatedAdministrator":"The record with identifier <strong>{{uuid}}</strong> was not found",
+  "recordNotFoundAuthenticatedAdministrator": "The record with identifier <strong>{{uuid}}</strong> was not found",
   "intersectWith": "Intersects with",
   "fullyOutsideOf": "Fully outside of",
   "encloses": "Enclosing",

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -23,11 +23,23 @@
   </div>
 
   <div class="container">
-    <div class="alert alert-warning"
-        data-ng-hide="!mdView.loadDetailsFinished || mdView.current.record"
-        data-translate=""
-        data-translate-values="{uuid: '{{recordIdentifierRequested | htmlToPlaintext}}', url: '{{url | encodeURIComponent}}'}">
+    <div ng-if="!authenticated" class="alert alert-warning"
+         data-ng-hide="!mdView.loadDetailsFinished || mdView.current.record"
+         data-translate=""
+         data-translate-values="{uuid: '{{recordIdentifierRequested | htmlToPlaintext}}', url: '{{url | encodeURIComponent}}'}">
       recordNotFound
+    </div>
+    <div ng-if="authenticated && user.profile != 'Administrator'" class="alert alert-warning"
+         data-ng-hide="!mdView.loadDetailsFinished || mdView.current.record"
+         data-translate=""
+         data-translate-values="{uuid: '{{recordIdentifierRequested | htmlToPlaintext}}', url: '{{url | encodeURIComponent}}'}">
+      recordNotFoundAuthenticatedUser
+    </div>
+    <div ng-if="authenticated && user.profile === 'Administrator'" class="alert alert-warning"
+         data-ng-hide="!mdView.loadDetailsFinished || mdView.current.record"
+         data-translate=""
+         data-translate-values="{uuid: '{{recordIdentifierRequested | htmlToPlaintext}}', url: '{{url | encodeURIComponent}}'}">
+      recordNotFoundAuthenticatedAdministrator
     </div>
     <div class="row"
         data-ng-show="!mdView.loadDetailsFinished">


### PR DESCRIPTION
Depending on the profil of the user, the message is adapted. Three possibilities are : 
- the user is not logged (current warning)
![Screen Shot 2021-01-29 at 12 13 29](https://user-images.githubusercontent.com/576292/106272749-d61bd580-6231-11eb-9c95-e6418e7e0617.png)

- the user is logged as administrator
![Screen Shot 2021-01-29 at 12 13 58](https://user-images.githubusercontent.com/576292/106272819-f2b80d80-6231-11eb-831d-85690cb7287b.png)

- the user is logged as registered user or reviewer or editor or user administrator
![Screen Shot 2021-01-29 at 12 14 56](https://user-images.githubusercontent.com/576292/106272778-e16f0100-6231-11eb-820f-d6acae6e36c9.png)

Related to https://github.com/geonetwork/core-geonetwork/issues/4882. In the present improvement, the message to the registered user, reviewer, editor and user administrator doesn't give information about the existence of the metadata in the catalogue (restriction on the metadata).