### PR TITLE
Editor / Suggestions / Too large parameters

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/BatchService.js
+++ b/web-ui/src/main/resources/catalog/components/admin/BatchService.js
@@ -80,8 +80,9 @@
               .then(function() {
                 if (!skipSave) {
                   $http.post('../api/records/' + (params.id || params.uuid) +
-                    '/processes/' + params.process + '?' +
-                    gnUrlUtils.toKeyValue(params)
+                    '/processes/' + params.process,
+                    gnUrlUtils.toKeyValue(params),
+                    {headers : { 'Content-Type': 'application/x-www-form-urlencoded' }}
                   ).then(function(data) {
                     $http.get('../api/records/' + gnCurrentEdit.id + '/editor' +
                       '?currTab=' + gnCurrentEdit.tab).then(function(data) {
@@ -94,8 +95,9 @@
                   });
                 } else {
                   $http.post('../api/records/' + (params.id || params.uuid) +
-                    '/processes/' + params.process + '?' +
-                    gnUrlUtils.toKeyValue(params)
+                    '/processes/' + params.process,
+                    gnUrlUtils.toKeyValue(params),
+                    {headers : { 'Content-Type': 'application/x-www-form-urlencoded' }}
                   ).then(function(data) {
                     defer.resolve(data);
                   });


### PR DESCRIPTION
Some processes may have large parameters too long to be posted in URL depending on container config.
```
[WARNING] URI is too large >8192
```

eg. while adding feature catalogue with 128 columns definitions!
```

b_term;Terminus (Oui/Non);C;
c_mode;Mode de transport (MET : métro);C;
c_station;Station (B);C;
....
```
POST parameters in body instead.
 

Another option would be to increase `jetty.request.header.size`.