### PR TITLE
Fix the privileges value before the update for RecordPrivilegesChangeEvent in metadata sharing API

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -253,18 +253,14 @@ public class MetadataSharingApi {
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
 
-        boolean skip = false;
+        boolean skipAllReservedGroup = false;
 
         //--- in case of owner, privileges for groups 0,1 and GUEST are disabled
         //--- and are not sent to the server. So we cannot remove them
         UserSession us = ApiUtils.getUserSession(session);
         boolean isAdmin = Profile.Administrator == us.getProfile();
         if (!isAdmin && !accessManager.hasReviewPermission(context, Integer.toString(metadata.getId()))) {
-            skip = true;
-        }
-
-        if (sharing.isClear()) {
-            dataManager.deleteMetadataOper(context, String.valueOf(metadata.getId()), skip);
+            skipAllReservedGroup = true;
         }
 
         List<Operation> operationList = operationRepository.findAll();
@@ -274,7 +270,8 @@ public class MetadataSharingApi {
         }
 
         List<GroupOperations> privileges = sharing.getPrivileges();
-        setOperations(sharing, dataManager, context, appContext, metadata, operationMap, privileges, ApiUtils.getUserSession(session).getUserIdAsInt(), null, request);
+        setOperations(sharing, dataManager, context, appContext, metadata, operationMap, privileges,
+            ApiUtils.getUserSession(session).getUserIdAsInt(), skipAllReservedGroup, null, request);
         metadataIndexer.indexMetadataPrivileges(metadata.getUuid(), metadata.getId());
     }
 
@@ -386,7 +383,10 @@ public class MetadataSharingApi {
         AbstractMetadata metadata,
         Map<String, Integer> operationMap,
         List<GroupOperations> privileges,
-        Integer userId, MetadataProcessingReport report, HttpServletRequest request) throws Exception {
+        Integer userId,
+        boolean skipAllReservedGroup,
+        MetadataProcessingReport report,
+        HttpServletRequest request) throws Exception {
         if (privileges != null) {
 
             boolean sharingChanges = false;
@@ -395,6 +395,10 @@ public class MetadataSharingApi {
             boolean allowPublishNonApprovedMd = sm.getValueAsBool(Settings.METADATA_WORKFLOW_ALLOW_PUBLISH_NON_APPROVED_MD);
 
             SharingResponse sharingBefore = getRecordSharingSettings(metadata.getUuid(), request.getSession(), request);
+
+            if (sharing.isClear()) {
+                dataManager.deleteMetadataOper(context, String.valueOf(metadata.getId()), skipAllReservedGroup);
+            }
 
             for (GroupOperations p : privileges) {
                 for (Map.Entry<String, Boolean> o : p.getOperations().entrySet()) {
@@ -435,7 +439,9 @@ public class MetadataSharingApi {
             }
 
             if (sharingChanges) {
-                new RecordPrivilegesChangeEvent(metadata.getId(), userId, ObjectJSONUtils.convertObjectInJsonObject(sharingBefore.getPrivileges(), RecordPrivilegesChangeEvent.FIELD), ObjectJSONUtils.convertObjectInJsonObject(privileges, RecordPrivilegesChangeEvent.FIELD)).publish(appContext);
+                new RecordPrivilegesChangeEvent(metadata.getId(), userId,
+                    ObjectJSONUtils.convertObjectInJsonObject(sharingBefore.getPrivileges(), RecordPrivilegesChangeEvent.FIELD),
+                    ObjectJSONUtils.convertObjectInJsonObject(privileges, RecordPrivilegesChangeEvent.FIELD)).publish(appContext);
             }
         }
     }
@@ -960,7 +966,7 @@ public class MetadataSharingApi {
 
         List<GroupOperations> privileges = sharing.getPrivileges();
         setOperations(sharing, dataManager, context, appContext, metadata, operationMap, privileges,
-            ApiUtils.getUserSession(session).getUserIdAsInt(), null, request);
+            ApiUtils.getUserSession(session).getUserIdAsInt(), true,null, request);
         dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
     }
 
@@ -1004,14 +1010,9 @@ public class MetadataSharingApi {
                     ApiUtils.createServiceContext(request), String.valueOf(metadata.getId()))) {
                     report.addNotEditableMetadataId(metadata.getId());
                 } else {
-                    boolean skip = false;
+                    boolean skipAllReservedGroup = false;
                     if (!isAdmin && accessMan.hasReviewPermission(context, Integer.toString(metadata.getId()))) {
-                        skip = true;
-                    }
-
-                    if (sharing.isClear()) {
-                        dataMan.deleteMetadataOper(context,
-                            String.valueOf(metadata.getId()), skip);
+                        skipAllReservedGroup = true;
                     }
 
                     OperationRepository operationRepository = appContext.getBean(OperationRepository.class);
@@ -1023,7 +1024,7 @@ public class MetadataSharingApi {
 
                     List<GroupOperations> privileges = sharing.getPrivileges();
                     setOperations(sharing, dataMan, context, appContext, metadata, operationMap, privileges,
-                        ApiUtils.getUserSession(session).getUserIdAsInt(), report, request);
+                        ApiUtils.getUserSession(session).getUserIdAsInt(), skipAllReservedGroup, report, request);
                     report.incrementProcessedRecords();
                     listOfUpdatedRecords.add(String.valueOf(metadata.getId()));
                 }


### PR DESCRIPTION
The previous code was deleting the privileges before retrieving the previous value in `setOperations`, sending to the `RecordPrivilegesChangeEvent` a wrong value.

https://github.com/geonetwork/core-geonetwork/blob/489a7dfecb473de1930173f45a97ad59df4956ba/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java#L266-L277


https://github.com/geonetwork/core-geonetwork/blob/489a7dfecb473de1930173f45a97ad59df4956ba/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java#L381-L397