### PR TITLE
fix xpath to match only the main citation title, not other titles

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -109,7 +109,7 @@
         <Field name="_defaultTitle" string="{string($_defaultTitle)}" store="true" index="true"/>
       </xsl:if>
       <xsl:variable name="title"
-                    select="/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:identificationInfo/./gmd:citation/./gmd:title/./gmd:LocalisedCharacterString[@locale=$poundLangId]"/>
+                    select="/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:identificationInfo/./gmd:citation//gmd:title//gmd:LocalisedCharacterString[@locale=$poundLangId]"/>
 
       <!-- not tokenized title for sorting -->
       <xsl:choose>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -109,7 +109,7 @@
         <Field name="_defaultTitle" string="{string($_defaultTitle)}" store="true" index="true"/>
       </xsl:if>
       <xsl:variable name="title"
-                    select="/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:identificationInfo//gmd:citation//gmd:title//gmd:LocalisedCharacterString[@locale=$poundLangId]"/>
+                    select="/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:identificationInfo/./gmd:citation/./gmd:title/./gmd:LocalisedCharacterString[@locale=$poundLangId]"/>
 
       <!-- not tokenized title for sorting -->
       <xsl:choose>


### PR DESCRIPTION
when multilingual records contains multiple citations, "A sequence of more than one item is not allowed as the first argument of normalize-space()" was thrown. This fixes that. Which causes title element not to be indexed and displayed empty in search results.

