### PR TITLE
Add statusIds list to MetadataWorkflowApi.getStatusByType API

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/MetadataStatusRepositoryCustom.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataStatusRepositoryCustom.java
@@ -59,6 +59,7 @@ public interface MetadataStatusRepositoryCustom {
                                       List<StatusValueType> types,
                                       List<Integer> authorIds, List<Integer> ownerIds,
                                       List<Integer> recordIds,
+                                      List<String> statusIds,
                                       String dateFrom, String dateTo,
                                       @Nullable Pageable pageable);
 }

--- a/domain/src/main/java/org/fao/geonet/repository/MetadataStatusRepositoryImpl.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataStatusRepositoryImpl.java
@@ -37,6 +37,7 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.MetadataStatus;
 import org.fao.geonet.domain.MetadataStatus_;
@@ -104,6 +105,7 @@ public class MetadataStatusRepositoryImpl implements MetadataStatusRepositoryCus
                                              List<Integer> ownerIds,
                                              List<Integer> authorIds,
                                              List<Integer> recordIds,
+                                             List<String> statusIds,
                                              String dateFrom, String dateTo,
                                              @Nullable Pageable pageable) {
         final CriteriaBuilder cb = _entityManager.getCriteriaBuilder();
@@ -124,6 +126,7 @@ public class MetadataStatusRepositoryImpl implements MetadataStatusRepositoryCus
         Predicate authorPredicate = null;
         Predicate ownerPredicate = null;
         Predicate recordPredicate = null;
+        Predicate statusIdPredicate = null;
         if (ids != null) {
             final Path<Integer> idPath = metadataStatusRoot.get(MetadataStatus_.id);
             idPredicate = idPath.in(ids);
@@ -153,6 +156,10 @@ public class MetadataStatusRepositoryImpl implements MetadataStatusRepositoryCus
             recordPredicate = recordIdPath.in(recordIds);
         }
 
+        if (CollectionUtils.isNotEmpty(statusIds)) {
+            statusIdPredicate = statusIdPath.in(statusIds);
+        }
+
         Predicate whereClause = cb.and(statusIdJoin);
         if (idPredicate != null) {
             whereClause.getExpressions().add(idPredicate);
@@ -171,6 +178,9 @@ public class MetadataStatusRepositoryImpl implements MetadataStatusRepositoryCus
         }
         if (recordPredicate != null) {
             whereClause.getExpressions().add(recordPredicate);
+        }
+        if (statusIdPredicate != null) {
+            whereClause.getExpressions().add(statusIdPredicate);
         }
 
 

--- a/domain/src/main/java/org/fao/geonet/repository/MetadataStatusRepositoryImpl.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataStatusRepositoryImpl.java
@@ -38,6 +38,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.MetadataStatus;
 import org.fao.geonet.domain.MetadataStatus_;
@@ -127,31 +128,31 @@ public class MetadataStatusRepositoryImpl implements MetadataStatusRepositoryCus
         Predicate ownerPredicate = null;
         Predicate recordPredicate = null;
         Predicate statusIdPredicate = null;
-        if (ids != null) {
+        if (CollectionUtils.isNotEmpty(ids)) {
             final Path<Integer> idPath = metadataStatusRoot.get(MetadataStatus_.id);
             idPredicate = idPath.in(ids);
         }
 
-        if (uuids != null) {
+        if (CollectionUtils.isNotEmpty(uuids)) {
             final Path<String> uuidPath = metadataStatusRoot.get(MetadataStatus_.uuid);
             uuidPredicate = uuidPath.in(uuids);
         }
 
-        if (types != null) {
+        if (CollectionUtils.isNotEmpty(types)) {
             Predicate typePredicate = statusTypePath.in(types);
             typeFilter = cb.and(statusIdJoin, typePredicate);
         }
 
-        if (authorIds != null) {
+        if (CollectionUtils.isNotEmpty(authorIds)) {
             final Path<Integer> authorIdPath = metadataStatusRoot.get(MetadataStatus_.userId);
             authorPredicate = authorIdPath.in(authorIds);
         }
-        if (ownerIds != null) {
+        if (CollectionUtils.isNotEmpty(ownerIds)) {
             final Path<Integer> ownerIdPath = metadataStatusRoot.get(MetadataStatus_.owner);
             ownerPredicate = ownerIdPath.in(ownerIds);
         }
 
-        if (recordIds != null) {
+        if (CollectionUtils.isNotEmpty(recordIds)) {
             final Path<Integer> recordIdPath = metadataStatusRoot.get(MetadataStatus_.metadataId);
             recordPredicate = recordIdPath.in(recordIds);
         }
@@ -184,10 +185,10 @@ public class MetadataStatusRepositoryImpl implements MetadataStatusRepositoryCus
         }
 
 
-        if (dateFrom != null) {
+        if (StringUtils.isNotBlank(dateFrom)) {
             whereClause.getExpressions().add(cb.greaterThanOrEqualTo(statusIdDatePath, new ISODate(dateFrom)));
         }
-        if (dateTo != null) {
+        if (StringUtils.isNotBlank(dateTo)) {
             whereClause.getExpressions().add(cb.lessThanOrEqualTo(statusIdDatePath, new ISODate(dateTo)));
         }
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -33,6 +33,7 @@ import java.util.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
@@ -390,6 +391,7 @@ public class MetadataWorkflowApi {
             @ApiParam(value = "End date", required = false) @RequestParam(required = false) String dateTo,
             @ApiParam(value = "From page", required = false) @RequestParam(required = false, defaultValue = "0") Integer from,
             @ApiParam(value = "Number of records to return", required = false) @RequestParam(required = false, defaultValue = "100") Integer size,
+            @ApiParam(value = "One or more status id. Default is all.", required = false) @RequestParam(required = false) List<String> statusIds,
             HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
 
@@ -402,14 +404,16 @@ public class MetadataWorkflowApi {
                 (type != null && type.length > 0) ||
                 (author != null && author.length > 0) ||
                 (owner != null && owner.length > 0) ||
-                (record != null && record.length > 0)) {
+                (record != null && record.length > 0)||
+                CollectionUtils.isNotEmpty(statusIds)) {
             metadataStatuses = metadataStatusRepository.searchStatus(
                     id != null && id.length > 0 ? Arrays.asList(id) : null,
                     uuid != null && uuid.length > 0 ? Arrays.asList(uuid) : null,
                     type != null && type.length > 0 ? Arrays.asList(type) : null,
                     author != null && author.length > 0 ? Arrays.asList(author) : null,
                     owner != null && owner.length > 0 ? Arrays.asList(owner) : null,
-                    record != null && record.length > 0 ? Arrays.asList(record) : null, dateFrom, dateTo, pageRequest);
+                    record != null && record.length > 0 ? Arrays.asList(record) : null,
+                    statusIds, dateFrom, dateTo, pageRequest);
         } else {
             metadataStatuses = metadataStatusRepository.findAll(pageRequest).getContent();
         }

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -26,7 +26,6 @@ package org.fao.geonet.api.records;
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
-import static org.springframework.data.jpa.domain.Specifications.where;
 
 import java.util.*;
 
@@ -63,7 +62,6 @@ import org.fao.geonet.kernel.search.LuceneSearcher;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.*;
-import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
@@ -73,7 +71,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -380,40 +377,39 @@ public class MetadataWorkflowApi {
     @ResponseStatus(value = HttpStatus.OK)
     @ResponseBody
     public List<MetadataStatusResponse> getStatusByType(
-            @ApiParam(value = "One or more types to retrieve (ie. worflow, event, task). Default is all.", required = false) @RequestParam(required = false) StatusValueType[] type,
-            @ApiParam(value = "All event details including XML changes. Responses are bigger. Default is false", required = false) @RequestParam(required = false) boolean details,
-            @ApiParam(value = "One or more event author. Default is all.", required = false) @RequestParam(required = false) Integer[] author,
-            @ApiParam(value = "One or more event owners. Default is all.", required = false) @RequestParam(required = false) Integer[] owner,
-            @ApiParam(value = "One or more record identifier. Default is all.", required = false) @RequestParam(required = false) Integer[] id,
-            @ApiParam(value = "One or more metadata record identifier. Default is all.", required = false) @RequestParam(required = false) Integer[] record,
-            @ApiParam(value = "One or more metadata uuid. Default is all.", required = false) @RequestParam(required = false) String[] uuid,
-            @ApiParam(value = "Start date", required = false) @RequestParam(required = false) String dateFrom,
-            @ApiParam(value = "End date", required = false) @RequestParam(required = false) String dateTo,
-            @ApiParam(value = "From page", required = false) @RequestParam(required = false, defaultValue = "0") Integer from,
-            @ApiParam(value = "Number of records to return", required = false) @RequestParam(required = false, defaultValue = "100") Integer size,
-            @ApiParam(value = "One or more status id. Default is all.", required = false) @RequestParam(required = false) List<String> statusIds,
-            HttpServletRequest request) throws Exception {
+        @ApiParam(value = "One or more types to retrieve (ie. worflow, event, task). Default is all.", required = false) @RequestParam(required = false) List<StatusValueType> type,
+        @ApiParam(value = "All event details including XML changes. Responses are bigger. Default is false", required = false) @RequestParam(required = false) boolean details,
+        @ApiParam(value = "Sort Order (ie. DESC or ASC). Default is none.", required = false) @RequestParam(required = false) Sort.Direction sortOrder,
+        @ApiParam(value = "One or more event author. Default is all.", required = false) @RequestParam(required = false) List<Integer> author,
+        @ApiParam(value = "One or more event owners. Default is all.", required = false) @RequestParam(required = false) List<Integer> owner,
+        @ApiParam(value = "One or more record identifier. Default is all.", required = false) @RequestParam(required = false) List<Integer> id,
+        @ApiParam(value = "One or more metadata record identifier. Default is all.", required = false) @RequestParam(required = false) List<Integer> record,
+        @ApiParam(value = "One or more metadata uuid. Default is all.", required = false) @RequestParam(required = false) List<String> uuid,
+        @ApiParam(value = "One or more status id. Default is all.", required = false) @RequestParam(required = false) List<String> statusIds,
+        @ApiParam(value = "Start date", required = false) @RequestParam(required = false) String dateFrom,
+        @ApiParam(value = "End date", required = false) @RequestParam(required = false) String dateTo,
+        @ApiParam(value = "From page", required = false) @RequestParam(required = false, defaultValue = "0") Integer from,
+        @ApiParam(value = "Number of records to return", required = false) @RequestParam(required = false, defaultValue = "100") Integer size,
+        HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
 
-        Sort sortByStatusChangeDate = SortUtils.createSort(Sort.Direction.DESC, MetadataStatus_.changeDate).and(SortUtils.createSort(Sort.Direction.DESC, MetadataStatus_.id));
-        final PageRequest pageRequest = new PageRequest(from, size, sortByStatusChangeDate);
+        PageRequest pageRequest = null;
+        if (sortOrder !=null) {
+            Sort sortByStatusChangeDate = SortUtils.createSort(sortOrder, MetadataStatus_.changeDate).and(SortUtils.createSort(sortOrder, MetadataStatus_.id));
+            pageRequest = new PageRequest(from, size, sortByStatusChangeDate);
+        }
 
         List<MetadataStatus> metadataStatuses;
-        if ((id != null && id.length > 0) ||
-                (uuid != null && uuid.length > 0) ||
-                (type != null && type.length > 0) ||
-                (author != null && author.length > 0) ||
-                (owner != null && owner.length > 0) ||
-                (record != null && record.length > 0)||
-                CollectionUtils.isNotEmpty(statusIds)) {
+        if (CollectionUtils.isNotEmpty(id) ||
+            CollectionUtils.isNotEmpty(uuid) ||
+            CollectionUtils.isNotEmpty(type) ||
+            CollectionUtils.isNotEmpty(author) ||
+            CollectionUtils.isNotEmpty(owner) ||
+            CollectionUtils.isNotEmpty(record) ||
+            CollectionUtils.isNotEmpty(statusIds)) {
             metadataStatuses = metadataStatusRepository.searchStatus(
-                    id != null && id.length > 0 ? Arrays.asList(id) : null,
-                    uuid != null && uuid.length > 0 ? Arrays.asList(uuid) : null,
-                    type != null && type.length > 0 ? Arrays.asList(type) : null,
-                    author != null && author.length > 0 ? Arrays.asList(author) : null,
-                    owner != null && owner.length > 0 ? Arrays.asList(owner) : null,
-                    record != null && record.length > 0 ? Arrays.asList(record) : null,
-                    statusIds, dateFrom, dateTo, pageRequest);
+                id, uuid, type, author, owner, record, statusIds,
+                dateFrom, dateTo, pageRequest);
         } else {
             metadataStatuses = metadataStatusRepository.findAll(pageRequest).getContent();
         }

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -47,11 +47,6 @@
     <constructor-arg index="1" ref="defaultLanguage"/>
   </bean>
 
-  <bean name="statusActionFactory"
-        class="org.fao.geonet.kernel.metadata.StatusActionsFactory">
-    <constructor-arg name="className" value="org.fao.geonet.kernel.metadata.DefaultStatusActions"/>
-  </bean>
-
   <!--
    Configure here what the publish/unpublish action does.
    By default, it set view, download and dynamic operation

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -47,6 +47,11 @@
     <constructor-arg index="1" ref="defaultLanguage"/>
   </bean>
 
+  <bean name="statusActionFactory"
+        class="org.fao.geonet.kernel.metadata.StatusActionsFactory">
+    <constructor-arg name="className" value="org.fao.geonet.kernel.metadata.DefaultStatusActions"/>
+  </bean>
+
   <!--
    Configure here what the publish/unpublish action does.
    By default, it set view, download and dynamic operation

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataWorkflowApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataWorkflowApiTest.java
@@ -111,9 +111,6 @@ public class MetadataWorkflowApiTest  extends AbstractServiceIntegrationTest {
 
     @Test
     public void testGetStatusByType() throws Exception {
-        StatusActionsFactory statusActionFactory = Mockito.mock(StatusActionsFactory.class);
-        Mockito.when(wac.getBean(StatusActionsFactory.class)).thenReturn(statusActionFactory);
-
         MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
         MockHttpSession mockHttpSession = loginAsAdmin();
 

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataWorkflowApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataWorkflowApiTest.java
@@ -1,0 +1,77 @@
+package org.fao.geonet.api.records;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataStatus;
+import org.fao.geonet.domain.StatusValue;
+import org.fao.geonet.repository.MetadataStatusRepository;
+import org.fao.geonet.repository.StatusValueRepository;
+import org.fao.geonet.repository.StatusValueRepositoryTest;
+import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+public class MetadataWorkflowApiTest  extends AbstractServiceIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext wac;
+    @Autowired
+    MetadataStatusRepository metadataStatusRepo;
+    @Autowired
+    StatusValueRepository statusValueRepo;
+
+    private String uuid;
+
+
+    @Before
+    public void setUp() throws Exception {
+        createTestData();
+    }
+
+    private void createTestData() {
+        this.uuid = UUID.randomUUID().toString();
+
+        MetadataStatus metadataStatus = new MetadataStatus();
+        metadataStatus.setMetadataId(111);
+        metadataStatus.setChangeDate(new ISODate());
+        metadataStatus.setUserId(1);
+        metadataStatus.setChangeMessage("change message test");
+        metadataStatus.setOwner(1);
+        metadataStatus.setUuid(uuid);
+
+        Random random = new Random();
+        AtomicInteger inc = new AtomicInteger(random.nextInt(16));
+        final StatusValue statusValue = statusValueRepo.save(StatusValueRepositoryTest.newStatusValue(inc));
+        metadataStatus.setStatusValue(statusValue);
+        metadataStatusRepo.save(metadataStatus);
+    }
+
+    @Test
+    public void testGetStatusByType() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAsAdmin();
+
+        mockMvc.perform(get("/srv/api/records/status/search?type=&uuid="+uuid+"&from=0&size=100")
+            .accept(MediaType.parseMediaType("application/json"))
+            .session(mockHttpSession))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
+            .andExpect(jsonPath("$.[0].uuid").value(uuid));
+
+    }
+
+}

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataWorkflowApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataWorkflowApiTest.java
@@ -1,27 +1,41 @@
 package org.fao.geonet.api.records;
 
+import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GCO;
+import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GMD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.MetadataStatus;
-import org.fao.geonet.domain.StatusValue;
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.domain.*;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.UpdateDatestamp;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.metadata.StatusActionsFactory;
 import org.fao.geonet.repository.MetadataStatusRepository;
+import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.repository.StatusValueRepository;
 import org.fao.geonet.repository.StatusValueRepositoryTest;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -34,19 +48,54 @@ public class MetadataWorkflowApiTest  extends AbstractServiceIntegrationTest {
     @Autowired
     StatusValueRepository statusValueRepo;
 
+
+    @Autowired
+    private DataManager dataManager;
+    @Autowired
+    private SourceRepository sourceRepository;
+    @Autowired
+    private SchemaManager schemaManager;
+
     private String uuid;
+    private ServiceContext context;
 
 
     @Before
     public void setUp() throws Exception {
+        this.context = createServiceContext();
         createTestData();
     }
 
-    private void createTestData() {
+    private void createTestData() throws Exception {
         this.uuid = UUID.randomUUID().toString();
 
+        loginAsAdmin(context);
+
+        final Element sampleMetadataXml = getSampleMetadataXml();
+        this.uuid = UUID.randomUUID().toString();
+        Xml.selectElement(sampleMetadataXml, "gmd:fileIdentifier/gco:CharacterString", Arrays.asList(GMD, GCO)).setText(this.uuid);
+
+        String source = sourceRepository.findAll().get(0).getUuid();
+        String schema = schemaManager.autodetectSchema(sampleMetadataXml);
+        final Metadata metadata = (Metadata) new Metadata()
+            .setDataAndFixCR(sampleMetadataXml)
+            .setUuid(uuid);
+        metadata.getDataInfo()
+            .setRoot(sampleMetadataXml.getQualifiedName())
+            .setSchemaId(schema)
+            .setType(MetadataType.METADATA)
+            .setPopularity(1000);
+        metadata.getSourceInfo()
+            .setOwner(1)
+            .setSourceId(source);
+        metadata.getHarvestInfo()
+            .setHarvested(false);
+
+        int id = dataManager.insertMetadata(context, metadata, sampleMetadataXml, false, true, false, UpdateDatestamp.NO,
+            false, false).getId();
+
         MetadataStatus metadataStatus = new MetadataStatus();
-        metadataStatus.setMetadataId(111);
+        metadataStatus.setMetadataId(id);
         metadataStatus.setChangeDate(new ISODate());
         metadataStatus.setUserId(1);
         metadataStatus.setChangeMessage("change message test");
@@ -62,12 +111,16 @@ public class MetadataWorkflowApiTest  extends AbstractServiceIntegrationTest {
 
     @Test
     public void testGetStatusByType() throws Exception {
+        StatusActionsFactory statusActionFactory = Mockito.mock(StatusActionsFactory.class);
+        Mockito.when(wac.getBean(StatusActionsFactory.class)).thenReturn(statusActionFactory);
+
         MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
         MockHttpSession mockHttpSession = loginAsAdmin();
 
         mockMvc.perform(get("/srv/api/records/status/search?type=&uuid="+uuid+"&from=0&size=100")
             .accept(MediaType.parseMediaType("application/json"))
             .session(mockHttpSession))
+            .andDo(MockMvcResultHandlers.print())
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andExpect(jsonPath("$.[0].uuid").value(uuid));

--- a/services/src/test/resources/services-web-test-context.xml
+++ b/services/src/test/resources/services-web-test-context.xml
@@ -24,6 +24,11 @@
     </property>
   </bean>
 
+  <bean name="statusActionFactory"
+        class="org.fao.geonet.kernel.metadata.StatusActionsFactory">
+    <constructor-arg name="className" value="org.fao.geonet.kernel.metadata.DefaultStatusActions"/>
+  </bean>
+
   <mvc:annotation-driven content-negotiation-manager="cnManager">
     <mvc:message-converters>
       <bean class = "org.springframework.http.converter.StringHttpMessageConverter">

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -59,11 +59,6 @@
     <property name="defaultNode" value="true"/>
   </bean>
 
-  <bean name="statusActionFactory"
-        class="org.fao.geonet.kernel.metadata.StatusActionsFactory">
-    <constructor-arg name="className" value="org.fao.geonet.kernel.metadata.DefaultStatusActions"/>
-  </bean>
-
 
   <bean id="scheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
     <property name="applicationContextSchedulerContextKey" value="applicationContext"/>
@@ -195,7 +190,7 @@
     <bean class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataIndexer"/>
     <bean class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataManager"/>
     <bean class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataUtils"/>
-  
+
   <!-- In order to get non-draft metadata  uncomment the definitions below,
     or make them available in an external override file -->
 <!--
@@ -203,5 +198,5 @@
     <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>
     <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>
 -->
-  
+
 </beans>

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -59,6 +59,11 @@
     <property name="defaultNode" value="true"/>
   </bean>
 
+  <bean name="statusActionFactory"
+        class="org.fao.geonet.kernel.metadata.StatusActionsFactory">
+    <constructor-arg name="className" value="org.fao.geonet.kernel.metadata.DefaultStatusActions"/>
+  </bean>
+
 
   <bean id="scheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
     <property name="applicationContextSchedulerContextKey" value="applicationContext"/>


### PR DESCRIPTION
This is the API information:

![image](https://user-images.githubusercontent.com/74916635/106493688-774f9980-6487-11eb-892e-e7ecb22ffb23.png)


Add status Id list into the API. So the RESTful interface will pass this list into search query. This list can be left empty or with some invalid number, or mix with valid and invalid status Id.

![image](https://user-images.githubusercontent.com/74916635/106493350-07411380-6487-11eb-9d2f-8ac39c472e19.png)


The result will only returns good status Ids and ignore invalid ids and emptiness.

Here is the information to test:

curl -X GET "http://localhost:8080/geonetwork/srv/api/0.1/records/status/search?type=event&details=true&uuid=86a9d0b0-fcce-48ed-a124-68061d7b7553&from=0&size=100&statusIds=50&statusIds=51&statusIds=100" -H "accept: application/json" -H "X-XSRF-TOKEN: b172b8fc-4798-4a73-8402-752a35132872"

This is the url of my localhost. So you will need type=event&details=true&uuid=<YOUR_LOCAL_VALID_UUID>. Then put statusId list in. The valid value can be found here https://github.com/geonetwork/core-geonetwork/blob/9c7ffc7b4c4c799437258b7020c9036de51b0d91/domain/src/main/java/org/fao/geonet/domain/StatusValue.java#L226-L240