### PR TITLE
Indexing / More robust

### DIFF
--- a/common/src/test/java/org/fao/geonet/utils/DateUtilTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/DateUtilTest.java
@@ -53,8 +53,20 @@ public class DateUtilTest {
         zdt = zdt.withZoneSameInstant(ZoneOffset.UTC);
         assertEquals("Testing 2020-11", DateUtil.ISO_OFFSET_DATE_TIME_NANOSECONDS.format(zdt), datetimeInIsoFormat);
 
+        datetimeInIsoFormat = DateUtil.convertToISOZuluDateTime("2012-09-12Z");
+        ld = LocalDate.parse("2012-09-12");
+        zdt = ld.atStartOfDay(ZoneId.systemDefault());
+        zdt = zdt.withZoneSameInstant(ZoneOffset.UTC);
+        assertEquals(DateUtil.ISO_OFFSET_DATE_TIME_NANOSECONDS.format(zdt), datetimeInIsoFormat);
 
+        datetimeInIsoFormat = DateUtil.convertToISOZuluDateTime("2015-10-18T19:59:30.2675269Z");
+        assertEquals("2015-10-18T19:59:30.2675269Z", datetimeInIsoFormat);
 
+        datetimeInIsoFormat = DateUtil.convertToISOZuluDateTime("20170322");
+        ld = LocalDate.parse("2017-03-22");
+        zdt = ld.atStartOfDay(ZoneId.systemDefault());
+        zdt = zdt.withZoneSameInstant(ZoneOffset.UTC);
+        assertEquals(DateUtil.ISO_OFFSET_DATE_TIME_NANOSECONDS.format(zdt), datetimeInIsoFormat);
     }
 
     @Test

--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
@@ -93,8 +93,12 @@
       </harvestedDate>
 
 
-      <!-- For multilingual docs it is good to have a title in the default locale.  In this type of metadata we don't have one but in the general case we do so we need to add it to all -->
-      <resourceTitle><xsl:value-of select="string(dc:title)"/></resourceTitle>
+      <!-- For multilingual docs it is good to have a title in the default locale.
+       In this type of metadata we don't have one but in the general
+       case we do so we need to add it to all -->
+      <xsl:for-each select="dc:title[1]">
+        <resourceTitle><xsl:value-of select="string(.)"/></resourceTitle>
+      </xsl:for-each>
 
       <xsl:for-each select="dc:language">
         <mainLanguage><xsl:value-of select="string(.)"/></mainLanguage>


### PR DESCRIPTION
* Dublin core / Multiple title / Only first one indexed (it will be better managed in DCAT2 plugin providing multilingual support).

* Invalid role value `{{role}}` trying to create an invalid field name.
```
GNIDX-XSL||Invalid element name. Invalid QName {{{role}}OrgForResource} (42)
```

* Multiple phones - only the first one is indexed
```
Error on line 1169 of index.xsl:
  XTTE0790: A sequence of more than one item is not allowed as the first argument of
  gn-fn-index:json-escape() ("02 38 42 24 55", "06 31 14 98 21")
```

* Date parsing - more flexible with support for 20170322, 2015-10-18T19:59:30.2675269Z (nanoseconds)
```
Error parsing ISO DateTimes '20170322'. Error is: Text '20170322' could not be parsed: Unable to obtain ZonedDateTime from TemporalAccessor: {},ISO resolved to 2017-03-22 of type java.time.format.Parsed
```

* Email / JSON character to escape. Only one email per contact is indexed.
```
Parsing invalid JSON node { "organisation":"Direction régionale de l'environnement, de l'aménagement et du logement Centre-Val de Loire", "role":"owner", "email":"###Paramètre "adresse email" dans la fonction "Services INSPIRE"", "website":"", "logo":"", "individual":"", "position":"", "phone":"", "address":"" } for property contactForResource. Error is: Unexpected character ('a' (code 97)): was expecting comma to separate Object entries
 at [Source: (String)"{
```