### PR TITLE
point as bounding-polygon

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
@@ -276,7 +276,7 @@
       <xsl:with-param name="subTreeSnippet">
 
         <xsl:variable name="geometry">
-          <xsl:apply-templates select="gex:polygon/gml:MultiSurface|gex:polygon/gml:LineString"
+          <xsl:apply-templates select="gex:polygon/gml:MultiSurface|gex:polygon/gml:LineString|gex:polygon/gml:Point"
                                mode="gn-element-cleaner"/>
         </xsl:variable>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -285,6 +285,7 @@
   <!-- Add required gml attributes if missing -->
   <xsl:template match="gml:Polygon[not(@gml:id) and not(@srsName)]|
                        gml:MultiSurface[not(@gml:id) and not(@srsName)]|
+                       gml:Point[not(@gml:id) and not(@srsName)]|
                        gml:LineString[not(@gml:id) and not(@srsName)]">
     <xsl:copy>
       <xsl:attribute name="gml:id">

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-gml.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-gml.xsl
@@ -52,8 +52,8 @@
           -->
     <xsl:for-each select="gmd:polygon/(gml:*|gml320:*)[
                             local-name() != 'MultiCurve' and
-                            count(*) > 0 and
-                            .//(gml:posList|gml320:posList) != '']">
+                            count(*) > 0 and (
+                            .//(gml:posList|gml320:posList) != '' or .//(gml:pos|gml320:pos) != '')]">
       <xsl:copy-of copy-namespaces="no" select="."/>
     </xsl:for-each>
   </xsl:template>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields.xsl
@@ -285,8 +285,8 @@
       <xsl:with-param name="subTreeSnippet">
 
         <xsl:variable name="geometry">
-          <xsl:apply-templates select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:LineString|
-                                       gmd:polygon/gml320:MultiSurface|gmd:polygon/gml320:LineString"
+          <xsl:apply-templates select="gmd:polygon/gml:MultiSurface|gmd:polygon/gml:LineString|gmd:polygon/gml:Point|
+                                       gmd:polygon/gml320:MultiSurface|gmd:polygon/gml320:LineString|gmd:polygon/gml320:Point"
                                mode="gn-element-cleaner"/>
         </xsl:variable>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -296,9 +296,11 @@
   <xsl:template match="gml:Polygon[not(@gml:id) or not(@srsName)]|
                        gml:MultiSurface[not(@gml:id) or not(@srsName)]|
                        gml:LineString[not(@gml:id) or not(@srsName)]|
+                       gml:Point[not(@gml:id) or not(@srsName)]|
                        gml320:Polygon[not(@gml320:id) or not(@srsName)]|
                        gml320:MultiSurface[not(@gml:id) or not(@srsName)]|
-                       gml320:LineString[not(@gml:id) or not(@srsName)]">
+                       gml320:LineString[not(@gml:id) or not(@srsName)]|
+                       gml320:Point[not(@gml320:id) or not(@srsName)]">
     <xsl:element name="gml:{local-name()}"
                  namespace="{if($isUsing2005Schema)
                              then 'http://www.opengis.net/gml'

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -8,27 +8,26 @@
 <!-- draw tool & select boxes -->
 <div class="row">
   <div class="col-xs-12 col-sm-6 col-sm-push-6" ng-if="!ctrl.readOnly">
-    <label class="text-muted control-label" translate>drawOnMap</label>
-    <br />
-    <div gi-btn-group>
-      <div class="btn-group">
-        <div class="btn-group">
-          <button class="btn btn-default btn-warning"
-            gi-btn="active" ng-model="ctrl.drawInteraction.active">
-            <span class="fa fa-pencil"></span>&nbsp;
-            <span translate>Polygon</span>
-          </button>
-          <button class="btn btn-default btn-warning"
-            gi-btn="active" ng-model="ctrl.drawLineInteraction.active">
-            <span class="fa fa-pencil"></span>&nbsp;
-            <span translate>Line</span>
-          </button>
-        </div>
-      </div>
-      <button class="btn btn-default btn-warning"
-        gi-btn="active" ng-model="ctrl.modifyInteraction.active">
+    <div class="pull-right">
+      <label class="text-muted control-label" translate>drawOnMap</label>
+      <br />
+      <button class="btn btn-default btn-warning pull-left gn-margin-right"
+              ng-click="ctrl.setActiveDrawInteraction('MultiPolygon')"
+              ng-class="{'active': ctrl.activeDrawType === 'MultiPolygon'}">
         <span class="fa fa-pencil"></span>&nbsp;
-        <span translate>modifyGeometry</span>
+        <span translate>Polygon</span>
+      </button>
+      <button class="btn btn-default btn-warning pull-left gn-margin-right"
+              ng-click="ctrl.setActiveDrawInteraction('LineString')"
+              ng-class="{'active': ctrl.activeDrawType === 'LineString'}">
+        <span class="fa fa-pencil"></span>&nbsp;
+        <span translate>Line</span>
+      </button>
+      <button class="btn btn-default btn-warning pull-left"
+              ng-click="ctrl.setActiveDrawInteraction('Point')"
+              ng-class="{'active': ctrl.activeDrawType === 'Point'}">
+        <span class="fa fa-pencil"></span>&nbsp;
+        <span translate>Point</span>
       </button>
     </div>
   </div>
@@ -39,15 +38,15 @@
     <div class="flex-row width-100">
       <div class="flex-nogrow">
         <select ng-model="ctrl.currentFormat"
-          ng-options="format for format in ctrl.formats"
-          ng-change="ctrl.handleInputOptionsChange()">
+                ng-options="format for format in ctrl.formats"
+                ng-change="ctrl.handleInputOptionsChange()">
         </select>
       </div>
       <div class="flex-spacer"></div>
       <div class="flex-shrink">
         <select ng-model="ctrl.currentProjection"
-          ng-options="proj.code as proj.label for proj in ctrl.projections"
-          ng-change="ctrl.handleInputOptionsChange()">
+                ng-options="proj.code as proj.label for proj in ctrl.projections"
+                ng-change="ctrl.handleInputOptionsChange()">
         </select>
       </div>
     </div>
@@ -56,7 +55,7 @@
 
 <div class="spacer" />
 
-<div ng-if="ctrl.dataOlProjection == null" class="alert alert-danger"
+<div ng-if="ctrl.polygonXml && ctrl.dataOlProjection == null" class="alert alert-danger"
      data-translate=""
      data-translate-values="{srsName:'{{ctrl.dataProjection}}'}">
   badGmlProjectionCode
@@ -66,24 +65,24 @@
 <div class="row">
   <div class="col-md-12">
     <div class="has-feedback"
-      ng-class="{ 'has-success': ctrl.fromTextInput && !ctrl.parseError, 'has-error': ctrl.parseError }">
+         ng-class="{ 'has-success': ctrl.fromTextInput && !ctrl.parseError, 'has-error': ctrl.parseError }">
       <label class="text-muted control-label" translate>inputGeometryText</label>
       <textarea class="form-control" rows="4" ng-model="ctrl.inputGeometry"
-        ng-model-options="{ debounce: 300 }"
-        placeholder="{{'inputGeometryText' | translate}}"
-        ng-change="ctrl.handleInputChange()"
-        ng-readonly="ctrl.readOnly"/>
+                ng-model-options="{ debounce: 300 }"
+                placeholder="{{'inputGeometryText' | translate}}"
+                ng-change="ctrl.handleInputChange()"
+                ng-readonly="ctrl.readOnly"/>
       <small class="text-danger"
-        ng-show="ctrl.fromTextInput && ctrl.parseError">
+             ng-show="ctrl.fromTextInput && ctrl.parseError">
         {{ 'inputGeometryIsInvalid' | translate}} {{ctrl.parseError}}</small>
       <small class="text-success"
-        ng-show="ctrl.fromTextInput && !ctrl.parseError" translate>
+             ng-show="ctrl.fromTextInput && !ctrl.parseError" translate>
         inputGeometryIsValid</small>
       <small class="text-muted"
-        ng-show="!ctrl.fromTextInput && !ctrl.readOnly" translate>
+             ng-show="!ctrl.fromTextInput && !ctrl.readOnly" translate>
         inputGeometryHint</small>
       <small class="text-muted"
-        ng-show="ctrl.readOnly" translate>
+             ng-show="ctrl.readOnly" translate>
         inputGeometryReadOnlyHint</small>
     </div>
   </div>
@@ -91,4 +90,4 @@
 
 <!-- final output in GML -->
 <input name="{{ctrl.identifier}}"
-  type="hidden" value="{{ctrl.outputPolygonXml}}"/>
+       type="hidden" value="{{ctrl.outputPolygonXml}}"/>

--- a/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/geometry/GeometryService.js
@@ -176,11 +176,17 @@
           format: 'gml'
         }, options);
 
+        var outputValue = '';
+        var inputGeom = feature.getGeometry();
+        if (!inputGeom) {
+          return outputValue;
+        }
+
         // clone & transform geom
-        var outputGeom = feature.getGeometry().clone().transform(
-            map.getView().getProjection(),
-            options.crs || LONLAT_WGS84
-            );
+        var outputGeom = inputGeom.clone().transform(
+          map.getView().getProjection(),
+          options.crs || LONLAT_WGS84
+        );
         var outputFeature = new ol.Feature({
           geometry: outputGeom
         });
@@ -190,7 +196,6 @@
 
         var formatLabel = options.format.toLowerCase();
         var format;
-        var outputValue;
         switch (formatLabel) {
           case 'json':
           case 'geojson':
@@ -359,11 +364,14 @@
         // Get dimensions from GML
         var dim = gmlString.match(new RegExp('srsDimension=\"([^"]*)\"'));
         // If srsDimension > 2 OR geometry is already 2D, return unmodified geometry
-        if ((dim && dim.length === 2 && dim[1] >= 3) || 
-            (geom.layout === 'XY' && geom.stride === 2)) 
-              return geom;            
-        // Drop Z (and M)
-        geom.setCoordinates(geom.getCoordinates(), 'XY');
+        if ((dim && dim.length === 2 && dim[1] >= 3) ||
+          (geom.layout === 'XY' && geom.stride === 2))
+          return geom;
+        var coords = geom.getCoordinates();
+        // Drop Z (and M):
+        // For polygons and lines, the stride setting 'XY' takes care of dropping the Z and M.
+        // For point features, this does not work (OL bug?), so we slice the coordinate array explicitly!
+        geom.setCoordinates(geom.getType() === 'Point' ? coords.slice(0, 2) : coords, 'XY');
         return geom;
       }
 


### PR DESCRIPTION
this brings in some features from 3.10 to use a point as boundingpolygon, resolves #4811 for gn4
this manages the schema and ui part, aspects of #5396 may be required to get the full feature supported