### PR TITLE
Backport add-schema.sh from master and adapt for 3.10.x branch

### DIFF
--- a/add-schema.sh
+++ b/add-schema.sh
@@ -89,29 +89,6 @@ then
 SED_SCRIPT
 fi
 
-
-# Add schema resources in web/pom.xml
-line=$(grep -n "schemas/${schema}/src/main/plugin</directory>" web/pom.xml | cut -d: -f1)
-
-if [ ! $line ]
-then
-  line=$(grep -n 'schemas/iso19139/src/main/plugin</directory>' web/pom.xml | cut -d: -f1)
-  finalLine=$(($line + 3))
-
-  projectBaseDir='${project.basedir}'
-  baseDir='${basedir}'
-
-  echo "Adding schema ${schema} resources to web/pom.xml"
-
-  sed $sedopt -f /dev/stdin web/pom.xml << SED_SCRIPT
-  ${finalLine} a\\
-\                <resource>\\
-\                  <directory>${projectBaseDir}/../schemas/${schema}/src/main/plugin</directory>\\
-\                  <targetPath>${baseDir}/src/main/webapp/WEB-INF/data/config/schema_plugins</targetPath>\\
-\                </resource>
-SED_SCRIPT
-fi
-
 # Add schema resources in service/pom.xml with test scope for unit tests
 line=$(grep -n "<artifactId>schema-${schema}</artifactId>" services/pom.xml | cut -d: -f1)
 

--- a/add-schema.sh
+++ b/add-schema.sh
@@ -7,7 +7,7 @@ function showUsage
   echo -e "Usage: ./`basename $0 $1` schema_name git_schema_repository git_schema_branch"
   echo
   echo -e "Example:"
-  echo -e "\t./`basename $0 $1` iso19115-3 https://github.com/metadata101/iso19115-3 3.4.x"
+  echo -e "\t./`basename $0 $1` iso19139.ca.HNAP https://github.com/metadata101/iso19139.ca.HNAP 3.10.x"
   echo
 }
 
@@ -38,22 +38,31 @@ fi
 # Add submodule
 if [ ! -d "schemas/${schema}" ]; then
   echo "Adding schema from ${gitRepository}, branch  ${gitBranch} to schemas/${schema}"
-  git submodule add -b ${gitBranch} ${gitRepository} schemas/${schema}
+  git submodule add --force -b ${gitBranch} ${gitRepository} schemas/${schema}
 fi
 
 
 # Add schema module in schemas/pom.xml
 line=$(grep -n ${schema} schemas/pom.xml | cut -d: -f1)
 
-if [ ! $line ]
+if [ ! -n "$line" ]
 then
-  line=$(grep -n 'iso19139</module>' schemas/pom.xml | cut -d: -f1)
+  line=$(grep -n '</profiles>' schemas/pom.xml | cut -d: -f1)
+  insertLine=$(($line - 1))
 
   echo "Adding schema ${schema} to schemas/pom.xml"
 
   sed $sedopt -f /dev/stdin schemas/pom.xml << SED_SCRIPT
-  ${line} a\\
-\    <module>${schema}</module>
+  ${insertLine} a\\
+\    <profile>\\
+\      <id>schema-${schema}</id>\\
+\      <activation>\\
+\        <file><exists>${schema}</exists></file>\\
+\      </activation>\\
+\      <modules>\\
+\        <module>${schema}</module>\\
+\      </modules>\\
+\    </profile>
 SED_SCRIPT
 fi
 
@@ -61,46 +70,70 @@ fi
 # Add schema dependency in web/pom.xml
 line=$(grep -n "schema-${schema}" web/pom.xml | cut -d: -f1)
 
-if [ ! $line ]
+if [ ! -n "$line" ]
 then
-  line=$(grep -n 'schema-iso19139</artifactId>' web/pom.xml | cut -d: -f1)
-  insertLine=$(($line + 2))
+  gnSchemasVersion='${project.version}'
+  basedir='${basedir}'
 
-  projectGroupId='${project.groupId}'
-  gnSchemasVersion='${gn.schemas.version}'
+  echo "Adding schema ${schema} dependency to web/pom.xml for schemaCopy"
 
-  echo "Adding schema ${schema} dependency to web/pom.xml"
-
+  line=$(grep -n '<!-- add schema_plugins -->' web/pom.xml | cut -d: -f1 | tail -1)
+  insertLine=$(($line))
   sed $sedopt -f /dev/stdin web/pom.xml << SED_SCRIPT
   ${insertLine} a\\
-\    <dependency>\\
-\      <groupId>${projectGroupId}</groupId>\\
-\      <artifactId>schema-${schema}</artifactId>\\
-\      <version>${gnSchemasVersion}</version>\\
-\    </dependency>
+\        <dependency>\\
+\          <groupId>org.geonetwork-opensource.schemas</groupId>\\
+\          <artifactId>schema-${schema}</artifactId>\\
+\          <version>${gnSchemasVersion}</version>\\
+\        </dependency>
 SED_SCRIPT
-fi
 
+  echo "Adding schema ${schema} dependency to web/pom.xml for schemaUnpack"
 
-# Add schema resources in web/pom.xml
-line=$(grep -n "schemas/${schema}/src/main/plugin</directory>" web/pom.xml | cut -d: -f1)
-
-if [ ! $line ]
-then
-  line=$(grep -n 'schemas/iso19139/src/main/plugin</directory>' web/pom.xml | cut -d: -f1)
-  finalLine=$(($line + 3))
-
-  projectBaseDir='${project.basedir}'
-  baseDir='${basedir}'
-
-  echo "Adding schema ${schema} resources to web/pom.xml"
-
+  line=$(grep -n '</profiles>' web/pom.xml | cut -d: -f1)
+  insertLine=$(($line - 1))
   sed $sedopt -f /dev/stdin web/pom.xml << SED_SCRIPT
-  ${finalLine} a\\
-\                <resource>\\
-\                  <directory>${projectBaseDir}/../schemas/${schema}/src/main/plugin</directory>\\
-\                  <targetPath>${baseDir}/src/main/webapp/WEB-INF/data/config/schema_plugins</targetPath>\\
-\                </resource>
+  ${insertLine} a\\
+\    <profile>\\
+\      <id>schema-${schema}</id>\\
+\      <activation>\\
+\        <property><name>schemasCopy</name><value>!true</value></property>\\
+\        <file><exists>../schemas/${schema}</exists></file>\\
+\      </activation>\\
+\      <dependencies>\\
+\        <dependency>\\
+\          <groupId>org.geonetwork-opensource.schemas</groupId>\\
+\          <artifactId>schema-${schema}</artifactId>\\
+\          <version>${gnSchemasVersion}</version>\\
+\        </dependency>\\
+\      </dependencies>\\
+\      <build>\\
+\        <plugins>\\
+\          <plugin>\\
+\            <groupId>org.apache.maven.plugins</groupId>\\
+\            <artifactId>maven-dependency-plugin</artifactId>\\
+\            <executions>\\
+\              <execution>\\
+\                <id>${schema}-resources</id>\\
+\                <phase>process-resources</phase>\\
+\                <goals><goal>unpack</goal></goals>\\
+\                <configuration>\\
+\                  <artifactItems>\\
+\                    <artifactItem>\\
+\                      <groupId>org.geonetwork-opensource.schemas</groupId>\\
+\                      <artifactId>schema-${schema}</artifactId>\\
+\                      <type>zip</type>\\
+\                      <overWrite>false</overWrite>\\
+\                      <outputDirectory>\$\{schema-plugins.dir\}</outputDirectory>\\
+\                    </artifactItem>\\
+\                  </artifactItems>\\
+\                </configuration>\\
+\              </execution>\\
+\            </executions>\\
+\          </plugin>\\
+\        </plugins>\\
+\      </build>\\
+\    </profile>
 SED_SCRIPT
 fi
 
@@ -112,15 +145,14 @@ then
   line=$(grep -n '</dependencies>' services/pom.xml | cut -d: -f1)
   finalLine=$(($line - 1))
 
-  projectGroupId='${project.groupId}'
-  gnSchemasVersion='${gn.schemas.version}'
+  gnSchemasVersion='${project.version}'
 
   echo "Adding schema ${schema} resources to service/pom.xml"
 
   sed $sedopt -f /dev/stdin services/pom.xml << SED_SCRIPT
   ${finalLine} a\\
 \    <dependency>\\
-\      <groupId>${projectGroupId}</groupId>\\
+\      <groupId>org.geonetwork-opensource.schemas</groupId>\\
 \      <artifactId>schema-${schema}</artifactId>\\
 \      <version>${gnSchemasVersion}</version>\\
 \      <scope>test</scope>\\

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -57,4 +57,8 @@
     <gn.project.version>3.10-SNAPSHOT</gn.project.version>
   </properties>
 
+  <!-- used by add-schema.sh -->
+  <profiles>
+  </profiles>
+
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -751,6 +751,35 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-schemas-ant</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+                <!-- Copy all the src/main/plugin folders in schemas to the webapp folder
+                in order to be loaded by the application when running mvn jetty:run.
+                -->
+              <target description="copy from schemas to schema_plugins folder">
+                <copy todir="src/main/webapp/WEB-INF/data/config/schema_plugins" preservelastmodified="true">
+                  <fileset dir="${basedir}/../schemas/">
+                    <include name="**/src/main/plugin/**"/>
+                  </fileset>
+                  <regexpmapper handledirsep="yes"
+                    from="^[-_\.a-zA-Z0-9]+/src/main/plugin/(.*)"
+                      to="\1" />
+                </copy>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
@@ -777,7 +806,7 @@
             </configuration>
           </execution>
           <execution>
-            <id>copy-schemas</id>
+            <id>copy-docs</id>
             <phase>process-resources</phase>
             <goals>
               <goal>copy-resources</goal>
@@ -787,34 +816,6 @@
               <overwrite>true</overwrite>
               <outputDirectory>${build.webapp.resources}</outputDirectory>
               <resources>
-                <!-- Copy the schema folder to the webapp folder source directory
-                in order to be loaded by the application when running mvn jetty:run.
-                -->
-                <resource>
-                  <directory>${project.basedir}/../schemas/iso19139/src/main/plugin</directory>
-                  <targetPath>${basedir}/src/main/webapp/WEB-INF/data/config/schema_plugins
-                  </targetPath>
-                </resource>
-                <resource>
-                  <directory>${project.basedir}/../schemas/iso19110/src/main/plugin</directory>
-                  <targetPath>${basedir}/src/main/webapp/WEB-INF/data/config/schema_plugins
-                  </targetPath>
-                </resource>
-                <resource>
-                  <directory>${project.basedir}/../schemas/dublin-core/src/main/plugin</directory>
-                  <targetPath>${basedir}/src/main/webapp/WEB-INF/data/config/schema_plugins
-                  </targetPath>
-                </resource>
-                <resource>
-                  <directory>${project.basedir}/../schemas/csw-record/src/main/plugin</directory>
-                  <targetPath>${basedir}/src/main/webapp/WEB-INF/data/config/schema_plugins
-                  </targetPath>
-                </resource>
-                <resource>
-                  <directory>${project.basedir}/../schemas/iso19115-3.2018/src/main/plugin</directory>
-                  <targetPath>${basedir}/src/main/webapp/WEB-INF/data/config/schema_plugins
-                  </targetPath>
-                </resource>
                 <!-- Copy the documentation in the webapp. -->
                 <resource>
                   <directory>${project.basedir}/../docs/manuals/target/doc</directory>


### PR DESCRIPTION
Note use of ``--force`` to allow reuse of previously added remote locations (see "Reactivating" in the sample output below).

Sample run:

```
% ./add-schema.sh iso19139.ca.HNAP https://github.com/metadata101/iso19139.ca.HNAP 3.10.x
```
```
Adding schema from https://github.com/metadata101/iso19139.ca.HNAP, branch  3.10.x to schemas/iso19139.ca.HNAP
Reactivating local git directory for submodule 'schemas/iso19139.ca.HNAP'.
Adding schema iso19139.ca.HNAP to schemas/pom.xml
Adding schema iso19139.ca.HNAP dependency to web/pom.xml for schemaCopy
Adding schema iso19139.ca.HNAP dependency to web/pom.xml for schemaUnpack
Adding schema iso19139.ca.HNAP resources to service/pom.xml
```