### PR TITLE
CSW / GetCapabilities / Avoid exception in log due to GetDomain

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/component/csw/GetCapabilities.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/GetCapabilities.java
@@ -167,7 +167,7 @@ public class GetCapabilities extends AbstractOperation implements CatalogService
             String cswServiceSpecificContraint = request.getChildText(Geonet.Elem.FILTER);
 
             if (!isFromRecord) {
-                setKeywords(capabilities, context);
+                // TODOES: setKeywords(capabilities, context);
             }
             setOperationsParameters(capabilities);
 


### PR DESCRIPTION
In GeoNetwork GetCapabilities document, keyword list was populated based on the GetDomain operation results. It is currently not yet supported in v4. So an exception like
```
2021-02-11 01:08:53,042 ERROR [geonetwork.csw] - Error getting domain value for specified PropertyName : org.apache.commons.lang.NotImplementedException: CSW GetDomain operation not implemented in ES
```
was raised.



The recommended approach to configure CSW is to use service metadata record (see https://geonetwork-opensource.org/manuals/4.0.x/en/administrator-guide/configuring-the-catalog/csw-configuration.html#service-metadata-record).