### PR TITLE
Min width to avoid table data wrapping.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -16,7 +16,7 @@
           {{r.id.split('/').splice(2).join('/') | decodeURIComponent}}
         </a>
       </td>
-      <td style="min-width:50px" data-ng-if="r.version.length > 0">
+      <td class="text-nowrap" data-ng-if="r.version.length > 0">
           {{r.version}}
       </td>
       <td data-ng-if="r.externalResourceManagementProperties.url.length > 0">

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -16,7 +16,7 @@
           {{r.id.split('/').splice(2).join('/') | decodeURIComponent}}
         </a>
       </td>
-      <td data-ng-if="r.version.length > 0">
+      <td style="min-width:50px" data-ng-if="r.version.length > 0">
           {{r.version}}
       </td>
       <td data-ng-if="r.externalResourceManagementProperties.url.length > 0">


### PR DESCRIPTION
The issue is version number wraps in the table because there is no min width for this entry. So when version number is a decimal number like 11.01. It wraps around.

![image](https://user-images.githubusercontent.com/74916635/107570466-8933e980-6bb7-11eb-8da4-bcf254a5530f.png)


The solution is to specify this field to be 50px minimum.