### PR TITLE
Support WAF with authentication

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -518,11 +518,7 @@
       <artifactId>opendap</artifactId>
       <version>2.1</version>
     </dependency>
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>0.2.2</version>
-    </dependency>
+
     <dependency>
       <groupId>org.owasp.esapi</groupId>
       <artifactId>esapi</artifactId>

--- a/harvesters/pom.xml
+++ b/harvesters/pom.xml
@@ -50,6 +50,10 @@
       <artifactId>sardine</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
     </dependency>

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WAFRemoteFile.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WAFRemoteFile.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -23,71 +23,90 @@
 
 package org.fao.geonet.kernel.harvest.harvester.webdav;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.util.Sha1Encoder;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
+import org.jdom.JDOMException;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
-//=============================================================================
-
 class WAFRemoteFile implements RemoteFile {
 
-    private static String outputSchema = "iso19139";
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Constructor
-    //---
-    //---------------------------------------------------------------------------
-    private String path;
+    private static final String OUTPUT_SCHEMA = "iso19139";
+    private final CloseableHttpClient httpClient;
+    private final String path;
     private ISODate changeDate;
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- RemoteFile interface
-    //---
-    //---------------------------------------------------------------------------
-
-    public WAFRemoteFile(String path) {
+    public WAFRemoteFile(String path, CloseableHttpClient httpClient) {
         this.path = path;
+        this.httpClient = httpClient;
     }
 
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- Get Metadata from GetCapabilities file (Service)
-    //---
-    //---------------------------------------------------------------------------
-
+    /**
+     * Get Metadata from GetCapabilities file (Service).
+     *
+     * @param schemaMan
+     * @return
+     * @throws Exception
+     */
     public Element getMetadata(SchemaManager schemaMan) throws Exception {
         String type = WAFRetriever.getFileType(this.path);
-        if (type.equals(WAFRetriever.type_GetCapabilities))
+        if (WAFRetriever.type_GetCapabilities.equals(type)) {
             return getMdFromService(path, schemaMan);
-        else if (type.equals(WAFRetriever.type_xml))
-            return Xml.loadFile(new URL(path));
-        else
+        } else if (WAFRetriever.type_xml.equals(type)) {
+            return getXmlFromUrl(new URL(path));
+        } else {
             return null;
+        }
+    }
+
+    private Element getXmlFromUrl(URL url) throws IOException, JDOMException {
+        HttpGet request = new HttpGet(url.toString());
+        Element result;
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            if (response.getStatusLine().getStatusCode() / 100 == 2) {// 2xx codes (integer division)
+                HttpEntity entity = response.getEntity();
+                try (InputStream responseInputStream = entity.getContent()) {
+                    result = Xml.loadStream(responseInputStream);
+                } finally {
+                    EntityUtils.consumeQuietly(response.getEntity());
+                }
+            } else {
+                EntityUtils.consumeQuietly(response.getEntity());
+                throw new HttpResponseException(response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
+            }
+
+        }
+        return result;
     }
 
     private Element getMdFromService(String url, SchemaManager schemaMan) throws Exception {
-        Element el = null;
+        Element el;
         Path styleSheet = getStyleSheet(url, schemaMan);
         if (styleSheet == null) {
             return null;
         }
-        Element xml = Xml.loadFile(new URL(url));
+
+        Element xml = getXmlFromUrl(new URL(url));
 
         // md5 the full capabilities URL
         String uuid = Sha1Encoder.encodeString(url); // is the service identifier
 
-        Map<String, Object> param = new HashMap<String, Object>();
+        Map<String, Object> param = new HashMap<>();
         param.put("uuid", uuid);
 
         el = Xml.transform(xml, styleSheet, param);
@@ -104,10 +123,10 @@ class WAFRemoteFile implements RemoteFile {
         String serviceType = getServiceType(url);
         if (serviceType == null)
             return null;
-        return schemaMan.getSchemaDir(outputSchema).
-            resolve(Geonet.Path.CONVERT_STYLESHEETS).
-            resolve("OGCWxSGetCapabilitiesto19119").
-            resolve("OGC" + serviceType + "GetCapabilities-to-ISO19119_ISO19139.xsl");
+        return schemaMan.getSchemaDir(OUTPUT_SCHEMA).
+                resolve(Geonet.Path.CONVERT_STYLESHEETS).
+                resolve("OGCWxSGetCapabilitiesto19119").
+                resolve("OGC" + serviceType + "GetCapabilities-to-ISO19119_ISO19139.xsl");
     }
 
     //---------------------------------------------------------------------------
@@ -148,6 +167,7 @@ class WAFRemoteFile implements RemoteFile {
     public ISODate getChangeDate() {
         return changeDate;
     }
+
     public void setChangeDate(String date) {
         try {
             changeDate = new ISODate(ISODate.parseBasicOrFullDateTime(date).getMillis());
@@ -165,4 +185,3 @@ class WAFRemoteFile implements RemoteFile {
 
 }
 
-//=============================================================================

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WAFRetriever.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WAFRetriever.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2012 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -24,50 +24,54 @@
 package org.fao.geonet.kernel.harvest.harvester.webdav;
 
 import jeeves.server.context.ServiceContext;
-
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.params.AuthPolicy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.fao.geonet.Logger;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * This class connects to a remote WAF server and traverse the links gathering the URLs of all
+ * the metadata documents available from the URL passed.
+ */
 class WAFRetriever implements RemoteRetriever {
     public static final String type_GetCapabilities = "GetCapabilities";
-    //--------------------------------------------------------------------------
-    //---
-    //--- RemoteRetriever interface
-    //---
-    //--------------------------------------------------------------------------
     public static final String type_xml = "xml";
-
-    //---------------------------------------------------------------------------
     public static final String type_dir = "directory";
-
-    //---------------------------------------------------------------------------
+    private final List<RemoteFile> files = new ArrayList<>();
+    private final GeonetHttpRequestFactory requestFactory;
+    private final SettingManager settingManager;
     private AtomicBoolean cancelMonitor;
-
-    //---------------------------------------------------------------------------
     private Logger log;
-
-    //---------------------------------------------------------------------------
-    //---
-    //--- check type if url is a xml file or GetCapabilities file
-    //---
-    //---------------------------------------------------------------------------
     private WebDavParams params;
+    private CloseableHttpClient httpClient;
 
-    //---------------------------------------------------------------------------
-    //---
-    //--- Variables
-    //---
-    //---------------------------------------------------------------------------
-    private List<RemoteFile> files = new ArrayList<RemoteFile>();
+    public WAFRetriever(SettingManager settingManager, GeonetHttpRequestFactory requestFactory) {
+        this.settingManager = settingManager;
+        this.requestFactory = requestFactory;
+    }
 
     public static String getFileType(String path) {
         if (path.toUpperCase().contains("REQUEST=GETCAPABILITIES")) {
@@ -85,24 +89,78 @@ class WAFRetriever implements RemoteRetriever {
         this.cancelMonitor = cancelMonitor;
         this.log = log;
         this.params = params;
+
+        String host;
+        try {
+            URL url = new URL(StringUtils.trim(params.url));
+            host = url.getHost();
+        } catch (MalformedURLException e) {
+            log.error("Cannot parse URL " + params.url);
+            log.error(e);
+            throw new IllegalArgumentException("Cannot parse URL " + params.url, e);
+        }
+        HttpClientBuilder clientBuilder = requestFactory.getDefaultHttpClientBuilder().setUserAgent(
+                "GeoNetwork/" + settingManager.getValue(Settings.SYSTEM_PLATFORM_VERSION) + "-" + settingManager
+                        .getValue(Settings.SYSTEM_PLATFORM_SUBVERSION));
+        CredentialsProvider provider = Lib.net.setupProxy(settingManager, clientBuilder, host);
+
+        if (params.isUseAccount() && StringUtils.isNotBlank(params.getUsername())) {
+            String username = params.getUsername();
+            String password = params.getPassword();
+            provider.setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, AuthScope.ANY_REALM, AuthPolicy.BASIC),
+                    new UsernamePasswordCredentials(username, password));
+            provider.setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, AuthScope.ANY_REALM, AuthPolicy.DIGEST),
+                    new UsernamePasswordCredentials(username, password));
+            provider.setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, AuthScope.ANY_REALM, AuthPolicy.SPNEGO),
+                    new UsernamePasswordCredentials(username, password));
+            provider.setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, AuthScope.ANY_REALM, AuthPolicy.KERBEROS),
+                    new UsernamePasswordCredentials(username, password));
+        }
+        clientBuilder.setDefaultCredentialsProvider(provider);
+        this.httpClient = clientBuilder.build();
+
     }
 
     public List<RemoteFile> retrieve() throws Exception {
 
         files.clear();
-        retrieveFiles(params.url);
+        String url = params.url;
+        if (!StringUtils.contains(url, "?") && !StringUtils.endsWith(url, "/")) {
+            url += "/";
+        }
+        retrieveFiles(url);
         return files;
     }
 
     public void destroy() {
-        return;
+        if (this.httpClient != null) {
+            try {
+                this.httpClient.close();
+            } catch (IOException e) {
+                log.warning("Error closing WAF http client");
+                log.error(e);
+            }
+        }
     }
 
-    private void retrieveFiles(String wafurl) throws IOException {
+    private void retrieveFiles(String wafUrl) throws IOException {
 
-        if (log.isDebugEnabled()) log.debug("Scanning resource : " + wafurl);
+        if (log.isDebugEnabled()) {
+            log.debug("Scanning resource : " + wafUrl);
+        }
 
-        Document doc = Jsoup.parse(new URL(wafurl), 3000);
+        Document doc;
+        try (CloseableHttpResponse response = connect(wafUrl)) {
+            if (response.getStatusLine().getStatusCode() / 100 == 2) {
+                try (InputStream responseStream = response.getEntity().getContent()) {
+                    doc = Jsoup.parse(responseStream, null, wafUrl);
+                }
+            } else {
+                throw new HttpResponseException(response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
+            }
+        }
+
+        //Jsoup.parse(new URL(wafUrl), 3000);
         Elements links = doc.select("a[href]");
         for (Element link : links) {
             if (cancelMonitor.get()) {
@@ -112,24 +170,29 @@ class WAFRetriever implements RemoteRetriever {
 
             String url = link.attr("abs:href");
 
-
             String fileType = getFileType(url);
 
-            if (fileType == null) {
-                continue;
-            } else if (fileType.equals(type_dir)) {
+            if (StringUtils.equals(fileType, type_dir)) {
                 if (params.recurse) {
                     // Parent directory or same directory links, ignore
-                    if (!url.contains(wafurl) || url.equals(wafurl)) continue;
+                    if (!url.contains(wafUrl) || url.equals(wafUrl))
+                        continue;
 
                     // Try as a directory
                     retrieveFiles(url);
                 }
+            } else if (StringUtils.equals(fileType, type_xml)) {
+                files.add(new WAFRemoteFile(url, httpClient));
             } else {
-                files.add(new WAFRemoteFile(url));
+                // Skip link
             }
         }
     }
-}
 
-//=============================================================================
+    private CloseableHttpResponse connect(String url) throws IOException {
+        HttpGet get = new HttpGet(url);
+        CloseableHttpResponse response = httpClient.execute(get);
+        return response;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1181,6 +1181,11 @@
         <artifactId>pdfbox</artifactId>
         <version>2.0.19</version>
       </dependency>
+      <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.13.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -507,11 +507,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>0.2.2</version>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>web-ui</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
* Add the ability to harvest a remote WAF server protected with `BASIC` or `DIGEST` authentication.
* User the server's proxy settings if enabled in the Admin Console.
* Update jsoup to `1.13.1` from `0.2.2`
* Add jsoup to managed dependencies in root `pom.xml`
* Remove the dependency from sites where it wasn't used (`web` and `core`)
* Add the dependency to the module where it is required (`harvesters`)

Closes #4050.