### PR TITLE
Encode metadata title and decode in the translate function.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/GnLocale.js
+++ b/web-ui/src/main/resources/catalog/js/GnLocale.js
@@ -142,8 +142,8 @@
       );
 
       $translateProvider.preferredLanguage(gnGlobalSettings.iso3lang);
-      // $translateProvider.useSanitizeValueStrategy('escape');
-      $translateProvider.useSanitizeValueStrategy('escape', 'sanitizeParameters');
+      $translateProvider.useSanitizeValueStrategy('escape');
+      // $translateProvider.useSanitizeValueStrategy('sanitizeParameters');
 
       moment.locale(gnGlobalSettings.lang);
     }]);

--- a/web-ui/src/main/resources/catalog/js/GnLocale.js
+++ b/web-ui/src/main/resources/catalog/js/GnLocale.js
@@ -143,7 +143,7 @@
 
       $translateProvider.preferredLanguage(gnGlobalSettings.iso3lang);
       // $translateProvider.useSanitizeValueStrategy('escape');
-      $translateProvider.useSanitizeValueStrategy('sanitizeParameters');
+      $translateProvider.useSanitizeValueStrategy('escape', 'sanitizeParameters');
 
       moment.locale(gnGlobalSettings.lang);
     }]);

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -538,13 +538,11 @@
         if ($location.search()['justcreated']) {
           // Remove newly created record
           var md = gnCurrentEdit.metadata;
-          var encodedTitle = encodeURI(md.title);
-          var encodedDefaultTitle = encodeURI(md.defaultTitle);
           gnMetadataActions.deleteMd(md).
               then(function(data) {
                 $rootScope.$broadcast('StatusUpdated', {
-                  title: decodeURI($translate.instant('metadataRemoved',
-                  {title: encodedTitle || encodedDefaultTitle})),
+                  title: $translate.instant('metadataRemoved',
+                  {title: md.title || md.defaultTitle}),
                   timeout: 2
                 });
                 closeEditor();

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -538,11 +538,13 @@
         if ($location.search()['justcreated']) {
           // Remove newly created record
           var md = gnCurrentEdit.metadata;
+          var encodedTitle = encodeURI(md.title);
+          var encodedDefaultTitle = encodeURI(md.defaultTitle);
           gnMetadataActions.deleteMd(md).
               then(function(data) {
                 $rootScope.$broadcast('StatusUpdated', {
-                  title: $translate.instant('metadataRemoved',
-                  {title: md.title || md.defaultTitle}),
+                  title: decodeURI($translate.instant('metadataRemoved',
+                  {title: encodedTitle || encodedDefaultTitle})),
                   timeout: 2
                 });
                 closeEditor();


### PR DESCRIPTION
For some reason, part of the pop up box for the metadata title is not decoded in editor when cancelling a newly added metadata.

![image](https://user-images.githubusercontent.com/74916635/107697228-f5c6eb00-6c80-11eb-934c-19de93ef7f82.png)

I found the work around is to force decode all metadata title that includes not just accent character, but also white space and etc. The decoded and encoded string looks like :
![image](https://user-images.githubusercontent.com/74916635/107697359-23139900-6c81-11eb-98b9-098822e5912e.png)

So as result, the popup will look like:
![image](https://user-images.githubusercontent.com/74916635/107697513-56562800-6c81-11eb-8745-afdaf19e85a3.png)
