### PR TITLE
funding links for github repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: [osgeo]
+custom: ['https://github.com/geonetwork/core-geonetwork/wiki','https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=LDTWEL3XKUVU8&source=url']


### PR DESCRIPTION
This provides some funding links for the GitHub repository:

- GitHub sponsors via osgeo organization
- Link to wiki where we have a heading on financial support
- PayPal

See https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository for details and background.