### PR TITLE
Admin / Harvester / No harvester in list after error

### DIFF
--- a/common/src/main/java/org/fao/geonet/exceptions/JeevesException.java
+++ b/common/src/main/java/org/fao/geonet/exceptions/JeevesException.java
@@ -26,6 +26,8 @@ package org.fao.geonet.exceptions;
 import org.fao.geonet.Constants;
 import org.jdom.Element;
 
+import static org.fao.geonet.utils.Xml.XML10_ILLEGAL_CHAR_PATTERN;
+
 //=============================================================================
 
 @SuppressWarnings("serial")
@@ -74,7 +76,8 @@ public abstract class JeevesException extends RuntimeException {
         }
 
         Element error = new Element(Constants.ERROR)
-            .addContent(new Element("message").setText(msg))
+            .addContent(new Element("message").setText(
+                msg.replaceAll(XML10_ILLEGAL_CHAR_PATTERN, "")))
             .addContent(new Element("class").setText(cls))
             .addContent(getStackTrace(t, 10));
 

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -128,6 +128,14 @@ public final class Xml {
     public static final Namespace xsiNS = Namespace.getNamespace("xsi", XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI);
     public static final NioPathAwareEntityResolver PATH_RESOLVER = new NioPathAwareEntityResolver();
 
+    // http://www.w3.org/TR/REC-xml/#charsets
+    public static final String XML10_ILLEGAL_CHAR_PATTERN = "[^"
+        + "\u0009\r\n"
+        + "\u0020-\uD7FF"
+        + "\uE000-\uFFFD"
+        + "\ud800\udc00-\udbff\udfff"
+        + "]";
+
     //--------------------------------------------------------------------------
 
     /**


### PR DESCRIPTION
Some harvester may fail and return an error. The error is stored in the
history table and returned in the harvester list API call.

It may happen that the error contains invalid XML characters and then
completely broke the harvester admin not listing anything.

```
2021-02-18 14:02:24,963 INFO  [jeeves.request] - HTML Request (from 134.246.214.106) : /geonetwork/srv/fre/admin.harvester.list
2021-02-18 14:02:24,963 DEBUG [jeeves.request] - Method       : GET
2021-02-18 14:02:24,963 DEBUG [jeeves.request] - Content type : null
2021-02-18 14:02:24,963 DEBUG [jeeves.request] - Accept       : text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
2021-02-18 14:02:24,963 DEBUG [jeeves.request] - Session id is 013927AA667B4CE950187698C0F4FE98
2021-02-18 14:02:25,005 ERROR [jeeves.service] - Exception when executing service
2021-02-18 14:02:25,005 ERROR [jeeves.service] -  (C) Exc : org.jdom.IllegalDataException: The data "Response: '�       �]�r����@�ڔ]Y7�$7�,y���Hڣ��jɱA �:�G*���˓��M$e[�jW�{fz��_���臻���`�%�9����`S�f�\�{?_����ѯ��ׇ�FSb�`��^�{@L�&��qǽ���,6
�>�kǲ�ú����&��?Sv�Z��MF
x�QRҋ�zmϐ�/�kX	�TE��Ǿ��X66���coWn$͝A���[q`9��4���1�K�����NO.}Y��� ��%�N,y$�����dݺ��f�ܟ"oy�s�V0���Y=e�k�Z��w�y�mZtI]�I{�3���
�1����
O��F��W�xE<O�N���
���
�1��o��� �c�������N�7��` |�]k����u����.Y���߶t�<־)��i��Q-Ӄy>�s�Y��
	�#��e~t�
9�1O��l��)&��3b��B�sg�L�g0ݙt*�=2�H�N�X�%��'����))+�[lN7�~�vm��3HA/ڥ�޹�ѱn�|���Z�Lۡ�6�ԓ�%fΰ�Ď�̙K���-���
�^Z&.���`}b԰X��$�)"F4�I
���=b!�y_d-���cwrs�X��Чu:C'����"�b;�����4�7�PM���^����Ko�)���M<|籰��DAC����#u���~����n�ȶ����9��pyt�ˇã1�	C+�u��	�$��+./ʈ��r�����xT��.���fmsQb̰ٶA���"�Z����%ܟ`�y�ki���5�f����m.̍9,,ka�>F��|^��~
��c00����Z�gu��Hlyd^������l꓍k�"v�׌�uJ�M��͢^�[�u6Z$�3]E��Ë�5�����3�z�{7�`���ڲ�в����f�\j3�K9��[;���
����7����:G�	��C���N�ݴ����u��������Π�PS����>�}8}���������OU�^��ei#6'�(ɒ��<l��4�g��S�!Hk�ώ�RK��狓	5�q����
���+��
(a|c]熅l���`=X`�����sa���\F
/J��N��<W�&Lg"/aI�t�M�4bK����򍘿��k
x�� �T����Y9��/׶m9�� s��(�V�����"Όc�XcL�R1��ͦ*�U����\�\2�6������{tB�^<vU	 �� ��~�2;Pc�c�9s���=c;�'H���܃~?I�..'�~ ���\H�*+Hǁ�VUӄ
�$�j�t�R-
Ъd���1�j�����Z��(�J-�&���Z�^���5zk�"���?Ps��v�[�K����&�����R��-!�rb��gx��Un 3���~�a�J�
������ө�@xM�?`��d��Q�����I�$0U	S�AlR�(�ƀ>ǽ@�=fE̻q/P�uW����/bCw��1��� p��� ���R��+��Z�x�M�$}z���2{Qj7J1�����
NDNz�Y,�J������v�ݸ\�ө�@QiHw�jwk�p{r�D�4�-N�4��l�`�d����9=[y.N� �� ��������^J��M�Ҵ�Źؗ4U�#$K}ĉCm����3�eS�M5_z�F֝�=��-��8���v*����9�d'3�&��O��nn����j�[2�� &]b�Xz�߹�gs��@8��E���8ws�k�W����������_�w�1,�o�!p�E������8Qp65��N��1<�d�dɶ�X6��q�+D�p��ez��8�r�%�0UƂ���,
�4V&ѣ�������ʋ�_������_�%s�ep4p��~� �զ���^�>��2���q%�+p�M�)�#W|�&���@Ӥ��^DAj�$~0��ɪ[��&�	2�Y�������*�I� �2�C^{�h�W_~�ˉQ^Uq̉��8X2]K�b~�P��|O&B·h*)j��֗tA�3q
��2���)R��.�Ҩ��~ʹF���h�� �Fawl��w;w7�Z=&UQ�iyp$i�Dd)A"R�D��H8�w��HG$�<'���~�0n�2��+��
 {
$fF���&L�Qԯ,�	�	��2ִ�Jk<�+rt��f^��� ��0�:Ǻ�O�܃�yK G}��Z�@l�����Zf=��g ,u����k�J���$%��Gmqy��R?���p������[%����lA1�*�Al�4!�U�Z��*���T +����LR�S��R�&!�/�g�ú(ϕ�n'k
`��V�Ƚ�[s%$yCY`�6(��6�%1�]"z�l(��hrC�uU�� e�?��� ,�s��������ء���F�]"����H`�J:�<e�ց�J�t�4°s��N���)��ҕ���y�Ub�]z}z~j�nآ.��nRNv�n�z\�X�K����+�r�廫Sȳ
��0C���M��f3uA�+SW�I�.'��$H��Jۅd��a���TV�@�)�>�
~TEz�s��㓩�z�\>����T,�CO�J�KM�EL��	�\� �SI���T��ԇ����P��S�}Nº���P�]��_�q�7U���u�"8�C�.��t;���nWz��2�n�ڹS}U����_�Q��O�g��+�.��B�{��x��ES[������ɪ������c���AU�%=��}���1~f9�c�����eos���29�O���g�K�g$|*�wο�t����"R�����<�K��]�|�K��
k�N��$��{\�0_þ�'ޠ�S�84� |0�8#��	��0�L�r}�3��=�*�V�����O�����[{�?����]<쟞������]
��M���zEU�V���3y ��k`Qj��@o^��$��IMa�~�v�Y�g%�O�
����@�k�k�W�:�x�{�q\^���w�3��v��;��|��W�_��Ġ5:.is�mNK:�����|����Ey����D���1w�����Cm��#�^��}�p��:��Vw������`�����~eQ[P���~��¢-��;o꼩ʛ�0��xl��%��51g��c�+�aB�JH}�m����P��o�C������@_�d9��U���M7d�/u��
�w� H�l�nYL����BG���=�)���U�^_��o1�i�ibe�@&�Cy������NTAr[}N�ɫa����+� �r6�%�v.�V�3S�AtZ�����
����	w����u�
�����B_�����{��$�;�}�<W����[������%�} �h��wx�1�@��e6k�f�)HV���a�PD\E�D��"���WA��Av�������\i����%~��3����vN��R3���;���P�s��x�����K��hS�:W؏+D�ڟ+,-��	�d�3��bi�3Зu1b�k�����%�)r��q�K��3\���M��=���1r�W�:��O�&���t)��VQkw�ܬV��'[
��7�n���ㄭ�1%���/����|)L�35��(��[��$���ϑ+�Qq�Q����s	�
�� �U�� W�*BW�{j{����+��#Ӈx�g���>��͐6=2'���4�́k��#Ҋ1��Y �v��	�+@�]b����T7կF,q���C�O�Xn�Xk��)�>z������]I�J�;�|'�?��~��D&q�c�j�:�r5H#�����U�[�B�P��^��9ߦ}h�2F�2cd�)�e�ɋ���[v'/�  �� 8k��{�  ' (from URI https://ows.emodnet-bathymetry.eu/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities)" is not legal for a JDOM character content: 0x1f is not a legal XML character.
2021-02-18 14:02:25,005 ERROR [jeeves] - Error occurred within a transaction
org.jdom.IllegalDataException: The data "Response: '�       �]�r����@�ڔ]Y7�$7�,y���Hڣ��jɱA �:�G*���˓��M$e[�jW�{fz��_���臻���`�%�9����`S�f�\�{?_����ѯ��ׇ�FSb�`��^�{@L�&��qǽ���,6
�>�kǲ�ú����&��?Sv�Z��MF
x�QRҋ�zmϐ�/�kX	�TE��Ǿ��X66���coWn$͝A���[q`9��4���1�K�����NO.}Y��� ��%�N,y$�����dݺ��f�ܟ"oy�s�V0���Y=e�k�Z��w�y�mZtI]�I{�3���
�1����
O��F��W�xE<O�N���
���
�1��o��� �c�������N�7��` |�]k����u����.Y���߶t�<־)��i��Q-Ӄy>�s�Y��
	�#��e~t�
9�1O��l��)&��3b��B�sg�L�g0ݙt*�=2�H�N�X�%��'����))+�[lN7�~�vm��3HA/ڥ�޹�ѱn�|���Z�Lۡ�6�ԓ�%fΰ�Ď�̙K���-���
�^Z&.���`}b԰X��$�)"F4�I
���=b!�y_d-���cwrs�X��Чu:C'����"�b;�����4�7�PM���^����Ko�)���M<|籰��DAC����#u���~����n�ȶ����9��pyt�ˇã1�	C+�u��	�$��+./ʈ��r�����xT��.���fmsQb̰ٶA���"�Z����%ܟ`�y�ki���5�f����m.̍9,,ka�>F��|^��~
��c00����Z�gu��Hlyd^������l꓍k�"v�׌�uJ�M��͢^�[�u6Z$�3]E��Ë�5�����3�z�{7�`���ڲ�в����f�\j3�K9��[;���
����7����:G�	��C���N�ݴ����u��������Π�PS����>�}8}���������OU�^��ei#6'�(ɒ��<l��4�g��S�!Hk�ώ�RK��狓	5�q����
���+��
(a|c]熅l���`=X`�����sa���\F
/J��N��<W�&Lg"/aI�t�M�4bK����򍘿��k
x�� �T����Y9��/׶m9�� s��(�V�����"Όc�XcL�R1��ͦ*�U����\�\2�6������{tB�^<vU	 �� ��~�2;Pc�c�9s���=c;�'H���܃~?I�..'�~ ���\H�*+Hǁ�VUӄ
�$�j�t�R-
Ъd���1�j�����Z��(�J-�&���Z�^���5zk�"���?Ps��v�[�K����&�����R��-!�rb��gx��Un 3���~�a�J�
������ө�@xM�?`��d��Q�����I�$0U	S�AlR�(�ƀ>ǽ@�=fE̻q/P�uW����/bCw��1��� p��� ���R��+��Z�x�M�$}z���2{Qj7J1�����
NDNz�Y,�J������v�ݸ\�ө�@QiHw�jwk�p{r�D�4�-N�4��l�`�d����9=[y.N� �� ��������^J��M�Ҵ�Źؗ4U�#$K}ĉCm����3�eS�M5_z�F֝�=��-��8���v*����9�d'3�&��O��nn����j�[2�� &]b�Xz�߹�gs��@8��E���8ws�k�W����������_�w�1,�o�!p�E������8Qp65��N��1<�d�dɶ�X6��q�+D�p��ez��8�r�%�0UƂ���,
�4V&ѣ�������ʋ�_������_�%s�ep4p��~� �զ���^�>��2���q%�+p�M�)�#W|�&���@Ӥ��^DAj�$~0��ɪ[��&�	2�Y�������*�I� �2�C^{�h�W_~�ˉQ^Uq̉��8X2]K�b~�P��|O&B·h*)j��֗tA�3q
��2���)R��.�Ҩ��~ʹF���h�� �Fawl��w;w7�Z=&UQ�iyp$i�Dd)A"R�D��H8�w��HG$�<'���~�0n�2��+��
 {
$fF���&L�Qԯ,�	�	��2ִ�Jk<�+rt��f^��� ��0�:Ǻ�O�܃�yK G}��Z�@l�����Zf=��g ,u����k�J���$%��Gmqy��R?���p������[%����lA1�*�Al�4!�U�Z��*���T +����LR�S��R�&!�/�g�ú(ϕ�n'k
`��V�Ƚ�[s%$yCY`�6(��6�%1�]"z�l(��hrC�uU�� e�?��� ,�s��������ء���F�]"����H`�J:�<e�ց�J�t�4°s��N���)��ҕ���y�Ub�]z}z~j�nآ.��nRNv�n�z\�X�K����+�r�廫Sȳ
��0C���M��f3uA�+SW�I�.'��$H��Jۅd��a���TV�@�)�>�
~TEz�s��㓩�z�\>����T,�CO�J�KM�EL��	�\� �SI���T��ԇ����P��S�}Nº���P�]��_�q�7U���u�"8�C�.��t;���nWz��2�n�ڹS}U����_�Q��O�g��+�.��B�{��x��ES[������ɪ������c���AU�%=��}���1~f9�c�����eos���29�O���g�K�g$|*�wο�t����"R�����<�K��]�|�K��
k�N��$��{\�0_þ�'ޠ�S�84� |0�8#��	��0�L�r}�3��=�*�V�����O�����[{�?����]<쟞������]
��M���zEU�V���3y ��k`Qj��@o^��$��IMa�~�v�Y�g%�O�
����@�k�k�W�:�x�{�q\^���w�3��v��;��|��W�_��Ġ5:.is�mNK:�����|����Ey����D���1w�����Cm��#�^��}�p��:��Vw������`�����~eQ[P���~��¢-��;o꼩ʛ�0��xl��%��51g��c�+�aB�JH}�m����P��o�C������@_�d9��U���M7d�/u��
�w� H�l�nYL����BG���=�)���U�^_��o1�i�ibe�@&�Cy������NTAr[}N�ɫa����+� �r6�%�v.�V�3S�AtZ�����
����	w����u�
�����B_�����{��$�;�}�<W����[������%�} �h��wx�1�@��e6k�f�)HV���a�PD\E�D��"���WA��Av�������\i����%~��3����vN��R3���;���P�s��x�����K��hS�:W؏+D�ڟ+,-��	�d�3��bi�3Зu1b�k�����%�)r��q�K��3\���M��=���1r�W�:��O�&���t)��VQkw�ܬV��'[
��7�n���ㄭ�1%���/����|)L�35��(��[��$���ϑ+�Qq�Q����s	�
�� �U�� W�*BW�{j{����+��#Ӈx�g���>��͐6=2'���4�́k��#Ҋ1��Y �v��	�+@�]b����T7կF,q���C�O�Xn�Xk��)�>z������]I�J�;�|'�?��~��D&q�c�j�:�r5H#�����U�[�B�P��^��9ߦ}h�2F�2cd�)�e�ɋ���[v'/�  �� 8k��{�  ' (from URI https://ows.emodnet-bathymetry.eu/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities)" is not legal for a JDOM character content: 0x1f is not a legal XML character.
	at org.jdom.Text.setText(Text.java:188)
	at org.jdom.Text.<init>(Text.java:99)
	at org.jdom.Element.setText(Element.java:653)
	at org.fao.geonet.exceptions.JeevesException.toElement(JeevesException.java:77)
	at org.fao.geonet.kernel.harvest.harvester.AbstractHarvester.addInfo(AbstractHarvester.java:536)
	at org.fao.geonet.kernel.harvest.HarvestManagerImpl.addInfo(HarvestManagerImpl.java:547)

```

Escape invalid XML character from message to avoid that situation.