### PR TITLE
Fix issue using custom UUIDs

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -436,7 +436,7 @@ public class MetadataInsertDeleteApi {
         // User assigned uuid: check if already exists
         String metadataUuid = null;
 
-        if (generateUuid && !StringUtils.isEmpty(targetUuid)) {
+        if (!generateUuid && !StringUtils.isEmpty(targetUuid)) {
             // Check if the UUID exists
             try {
                 ApiUtils.getRecord(targetUuid);


### PR DESCRIPTION
We were having problems setting custom UUIDs on new metadata records using the URN templates feature. This one character fix is enough to correct this regression.