### PR TITLE
CMIS - Add button to go to the main folder.

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -244,6 +244,11 @@ public abstract class AbstractStore implements Store {
             }
 
             @Override
+            public boolean isFolderEnabled() {
+                return false;
+            }
+
+            @Override
             public String toString() {
                 try {
                     return new ObjectMapper().writeValueAsString(this);

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -45,6 +45,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public abstract class AbstractStore implements Store {
     @Override
     public final List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid, final Sort sort,
@@ -221,5 +224,33 @@ public abstract class AbstractStore implements Store {
         if (resourceId.contains("..") || resourceId.startsWith("/") || resourceId.startsWith("file:/")) {
             throw new SecurityException(String.format("Invalid resource identifier '%s'.", resourceId));
         }
+    }
+
+    public ResourceManagementExternalProperties getResourceManagementExternalProperties() {
+        return new ResourceManagementExternalProperties() {
+            @Override
+            public boolean isEnabled() {
+                return false;
+            }
+
+            @Override
+            public String getWindowParameters() {
+                return null;
+            }
+
+            @Override
+            public boolean isModal() {
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                try {
+                    return new ObjectMapper().writeValueAsString(this);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException("Error converting ResourceManagementExternalProperties to json", e);
+                }
+            }
+        };
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -37,6 +37,8 @@ import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.MetadataResource;
+import org.fao.geonet.domain.MetadataResourceContainer;
+import org.fao.geonet.domain.MetadataResourceExternalManagementProperties;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -54,6 +56,9 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class CMISStore extends AbstractStore {
 
@@ -93,8 +98,7 @@ public class CMISStore extends AbstractStore {
                     Path keyPath = new File(cmisFilePath).toPath().getFileName();
                     if (matcher.matches(keyPath)) {
                         final String filename = getFilename(cmisFilePath);
-                        MetadataResource resource = createResourceDescription(context, settingManager, metadataUuid, visibility, filename, object.getContentStreamLength(),
-                                object.getLastModificationDate().getTime(), object.getVersionLabel(), object.getId(), metadataId, approved);
+                        MetadataResource resource = createResourceDescription(context, settingManager, metadataUuid, visibility, filename, object, metadataId, approved);
                         resourceList.add(resource);
                     }
                 }
@@ -110,20 +114,21 @@ public class CMISStore extends AbstractStore {
     }
 
     private MetadataResource createResourceDescription(final ServiceContext context, final SettingManager settingManager, final String metadataUuid,
-                                                       final MetadataResourceVisibility visibility, final String resourceId, long size, Date lastModification, String version,
-                                                       String cmisObjectId, int metadataId, boolean approved) {
+                                                       final MetadataResourceVisibility visibility, final String resourceId,
+                                                       Document document, int metadataId, boolean approved) {
+
         String filename = getFilename(metadataUuid, resourceId);
 
         String versionValue = null;
         if (cmisConfiguration.isVersioningEnabled()) {
-            versionValue = version;
+            versionValue = document.getVersionLabel();
         }
 
-        MetadataResource.ExternalResourceManagementProperties externalResourceManagementProperties =
-            getExternalResourceManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, version, cmisObjectId);
+        MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
+            getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, document.getVersionLabel(), document.getVersionSeriesId(), document.getType());
 
         return new FilesystemStoreResource(metadataUuid, metadataId, filename,
-            settingManager.getNodeURL() + "api/records/", visibility, size, lastModification, versionValue, externalResourceManagementProperties, approved);
+            settingManager.getNodeURL() + "api/records/", visibility, document.getContentStreamLength(), document.getLastModificationDate().getTime(), versionValue, metadataResourceExternalManagementProperties, approved);
     }
 
     private static String getFilename(final String key) {
@@ -140,8 +145,7 @@ public class CMISStore extends AbstractStore {
             final CmisObject object = cmisConfiguration.getClient().getObjectByPath(getKey(context, metadataUuid, metadataId, visibility, resourceId));
             final SettingManager settingManager = context.getBean(SettingManager.class);
             return new ResourceHolderImpl(object, createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId,
-                ((Document) object).getContentStreamLength(),
-                object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), object.getId(), metadataId, approved));
+                (Document) object, metadataId, approved));
         } catch (CmisObjectNotFoundException e) {
             Log.warning(Geonet.RESOURCES, String.format("Error getting metadata resource. '%s' not found for metadata '%s'", resourceId, metadataUuid));
             throw new ResourceNotFoundException(
@@ -165,7 +169,6 @@ public class CMISStore extends AbstractStore {
 
         Map<String, Object> properties = new HashMap<String, Object>();
         setCmisMetadataUUIDPrimary(properties, metadataUuid);
-        int isLength = is.available();
         CmisObject cmisObject;
         try {
             cmisObject = cmisConfiguration.getClient().getObjectByPath(key);
@@ -190,8 +193,8 @@ public class CMISStore extends AbstractStore {
             }
         }
 
-        return createResourceDescription(context, settingManager, metadataUuid, visibility, filename, isLength,
-            doc.getLastModificationDate().getTime(), doc.getVersionLabel(), doc.getId(), metadataId, approved);
+        return createResourceDescription(context, settingManager, metadataUuid, visibility, filename,
+             doc, metadataId, approved);
     }
 
     private void setCmisMetadataUUIDPrimary(Map<String, Object> properties, String metadataUuid) {
@@ -247,8 +250,7 @@ public class CMISStore extends AbstractStore {
                     break;
                 } else {
                     // already the good visibility
-                    return createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId, ((Document) object).getContentStreamLength(),
-                        object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), object.getId(), metadataId, approved);
+                    return createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId, (Document) object, metadataId, approved);
                 }
             } catch (CmisObjectNotFoundException ignored) {
                 // ignored
@@ -282,8 +284,7 @@ public class CMISStore extends AbstractStore {
                         "No permissions to modify metadata resource '%s' for metadata '%s'.", resourceId, metadataUuid));
             }
 
-            return createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId, ((Document) object).getContentStreamLength(),
-                    object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), object.getId(), metadataId, approved);
+            return createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId, (Document) object, metadataId, approved);
         } else {
             Log.warning(Geonet.RESOURCES,
                     String.format("Could not update permissions. Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid));
@@ -391,8 +392,28 @@ public class CMISStore extends AbstractStore {
         SettingManager settingManager = context.getBean(SettingManager.class);
         try {
             final CmisObject object = cmisConfiguration.getClient().getObjectByPath(key);
-            return createResourceDescription(context, settingManager, metadataUuid, visibility, filename, ((Document) object).getContentStreamLength(),
-                object.getLastModificationDate().getTime(), ((Document) object).getVersionLabel(), object.getId(), metadataId, approved);
+            return createResourceDescription(context, settingManager, metadataUuid, visibility, filename, (Document)object, metadataId, approved);
+        } catch (CmisObjectNotFoundException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public MetadataResourceContainer getResourceContainerDescription(final ServiceContext context, final String metadataUuid, Boolean approved) throws Exception {
+        int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+
+        final String key = getMetadataDir(context, metadataId);
+
+        SettingManager settingManager = context.getBean(SettingManager.class);
+        try {
+            Folder parentFolder = cmisUtils.getFolderCache(key);;
+
+            MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
+                getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType());
+
+            return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid,
+                settingManager.getNodeURL() + "api/records/", metadataResourceExternalManagementProperties, approved);
+
         } catch (CmisObjectNotFoundException e) {
             return null;
         }
@@ -447,6 +468,7 @@ public class CMISStore extends AbstractStore {
      * get external resource management for the supplied resource.
      * Replace the following
      * {id}  resource id
+     * {type:folder:document} // If the type is folder then type "folder" will be displayed else if document then "document" will be displayed
      * {uuid}  metadatauuid
      * {metadataid}  metadataid
      * {visibility}  visibility
@@ -457,52 +479,59 @@ public class CMISStore extends AbstractStore {
      * {iso3lang}  ISO 639-2/T language
      * <p>
      * Sample Url Alfresco
-     * http://localhost:8080/share/page/document-details?nodeRef=workspace://SpacesStore/{cmisobjectid}
+     * http://localhost:8080/share/page/{type:folder:document}-details?nodeRef=workspace://SpacesStore/{cmisobjectid}
      * Sample Url Open Text
      * http://localhost:8080/livelink/cs?func=ll&objaction=overview&objid={cmisobjectid}&vernum={version}
      */
 
-    private MetadataResource.ExternalResourceManagementProperties getExternalResourceManagementProperties(ServiceContext context,
-                                                    int metadataId,
-                                                    final String metadataUuid,
-                                                    final MetadataResourceVisibility visibility,
-                                                    final String resourceId,
-                                                    String filename,
-                                                    String version,
-                                                    String cmisObjectId
+    private MetadataResourceExternalManagementProperties getMetadataResourceExternalManagementProperties(ServiceContext context,
+                                                                                                         int metadataId,
+                                                                                                         final String metadataUuid,
+                                                                                                         final MetadataResourceVisibility visibility,
+                                                                                                         final String resourceId,
+                                                                                                         String filename,
+                                                                                                         String version,
+                                                                                                         String cmisObjectId,
+                                                                                                         ObjectType type
     ) {
-        String externalResourceManagementUrl = cmisConfiguration.getExternalResourceManagementUrl();
-        if (!StringUtils.isEmpty(externalResourceManagementUrl)) {
+        String metadataResourceExternalManagementPropertiesUrl = cmisConfiguration.getExternalResourceManagementUrl();
+        if (!StringUtils.isEmpty(metadataResourceExternalManagementPropertiesUrl)) {
             // {id}  id
-            if (externalResourceManagementUrl.contains("{id}")) {
-                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{id\\})", resourceId);
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{id}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{id\\})", (resourceId==null?"":resourceId));
             }
-            // {uuid}  metadatauuid
-            if (externalResourceManagementUrl.contains("{uuid}")) {
-                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{uuid\\})", metadataUuid);
-            }
-            // {metadataid}  metadataid
-            if (externalResourceManagementUrl.contains("{metadataid}")) {
-                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{metadataid\\})", String.valueOf(metadataId));
-            }
-            //    {visibility}  visibility
-            if (externalResourceManagementUrl.contains("{visibility}")) {
-                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{visibility\\})", visibility.toString().toLowerCase());
-            }
-            //    {filename}  filename
-            if (externalResourceManagementUrl.contains("{filename}")) {
-                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{filename\\})", filename);
-            }
-            // {version}  version
-            if (externalResourceManagementUrl.contains("{version}")) {
-                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{version\\})", version);
-            }
-            // {cmisobjectid}  cmis object id
-            if (externalResourceManagementUrl.contains("{cmisobjectid}")) {
-                externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{cmisobjectid\\})", cmisObjectId);
+            // {type:folder:document} // If the type is folder then type "folder" will be displayed else if document then "document" will be displayed
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{type:")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("\\{type:([a-zA-Z0-9]*?):([a-zA-Z0-9]*?)\\}",
+                    (type==null?"":(type instanceof Folder?"$1":"$2")));
             }
 
-            if (externalResourceManagementUrl.contains("{lang}") || externalResourceManagementUrl.contains("{ISO3lang}")) {
+            // {uuid}  metadatauuid
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{uuid}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{uuid\\})", (metadataUuid==null?"":metadataUuid));
+            }
+            // {metadataid}  metadataid
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{metadataid}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{metadataid\\})", String.valueOf(metadataId));
+            }
+            //    {visibility}  visibility
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{visibility}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{visibility\\})", (visibility==null?"":visibility.toString().toLowerCase()));
+            }
+            //    {filename}  filename
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{filename}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{filename\\})", (filename==null?"":filename));
+            }
+            // {version}  version
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{version}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{version\\})", (version==null?"":version));
+            }
+            // {cmisobjectid}  cmis object id
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{cmisobjectid}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{cmisobjectid\\})",  (cmisObjectId==null?"":cmisObjectId));
+            }
+
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{lang}") || metadataResourceExternalManagementPropertiesUrl.contains("{ISO3lang}")) {
                 final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
                 String contextLang = context.getLanguage() == null ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
                 String lang;
@@ -516,21 +545,49 @@ public class CMISStore extends AbstractStore {
                     iso3Lang = contextLang;
                 }
                 // {lang}  ISO639-1 2 char language
-                if (externalResourceManagementUrl.contains("{lang}")) {
-                    externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{lang\\})", lang);
+                if (metadataResourceExternalManagementPropertiesUrl.contains("{lang}")) {
+                    metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{lang\\})", lang);
                 }
                 // {iso3lang}  ISO 639-2/T language
-                if (externalResourceManagementUrl.contains("{iso3lang}")) {
-                    externalResourceManagementUrl = externalResourceManagementUrl.replaceAll("(\\{iso3lang\\})", iso3Lang);
+                if (metadataResourceExternalManagementPropertiesUrl.contains("{iso3lang}")) {
+                    metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{iso3lang\\})", iso3Lang);
                 }
             }
         }
 
-        MetadataResource.ExternalResourceManagementProperties externalResourceManagementProperties
-                = new MetadataResource.ExternalResourceManagementProperties(externalResourceManagementUrl,
-                cmisConfiguration.getExternalResourceManagementWindowParameters(), cmisConfiguration.isExternalResourceManagementModalEnabled());
+        MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties
+                = new MetadataResourceExternalManagementProperties(cmisObjectId, metadataResourceExternalManagementPropertiesUrl);
 
-        return externalResourceManagementProperties;
+        return metadataResourceExternalManagementProperties;
+    }
+
+    public ResourceManagementExternalProperties getResourceManagementExternalProperties() {
+        return new ResourceManagementExternalProperties() {
+            @Override
+            public boolean isEnabled() {
+                // Return true if we have an external management url
+                return !StringUtils.isEmpty(cmisConfiguration.getExternalResourceManagementUrl());
+            }
+
+            @Override
+            public String getWindowParameters() {
+                return cmisConfiguration.getExternalResourceManagementWindowParameters();
+            }
+
+            @Override
+            public boolean isModal() {
+                return cmisConfiguration.isExternalResourceManagementModalEnabled();
+            }
+
+            @Override
+            public String toString() {
+                try {
+                    return new ObjectMapper().writeValueAsString(this);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException("Error converting ResourceManagementExternalProperties to json", e);
+                }
+            }
+        };
     }
 
     private static class ResourceHolderImpl implements ResourceHolder {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -406,8 +406,11 @@ public class CMISStore extends AbstractStore {
 
         SettingManager settingManager = context.getBean(SettingManager.class);
         try {
-            Folder parentFolder = cmisUtils.getFolderCache(key);;
-
+            String folderRoot = cmisConfiguration.getExternalResourceManagementFolderRoot();
+            if (folderRoot == null) {
+                folderRoot = "";
+            }
+            Folder parentFolder = cmisUtils.getFolderCache(key + folderRoot);
             MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
                 getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType());
 
@@ -577,6 +580,11 @@ public class CMISStore extends AbstractStore {
             @Override
             public boolean isModal() {
                 return cmisConfiguration.isExternalResourceManagementModalEnabled();
+            }
+
+            @Override
+            public boolean isFolderEnabled() {
+                return isEnabled() && cmisConfiguration.isExternalResourceManagementFolderEnabled();
             }
 
             @Override

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -30,6 +30,7 @@ import org.fao.geonet.api.exception.ResourceAlreadyExistException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.MetadataResource;
+import org.fao.geonet.domain.MetadataResourceContainer;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -143,6 +144,24 @@ public class FilesystemStore extends AbstractStore {
         }
         return new FilesystemStoreResource(metadataUuid, metadataId, filePath.getFileName().toString(), settingManager.getNodeURL() + "api/records/",
                                            visibility, fileSize, new Date(Files.getLastModifiedTime(filePath).toMillis()), approved);
+    }
+
+    @Override
+    public MetadataResourceContainer getResourceContainerDescription(ServiceContext context, String metadataUuid, Boolean approved) throws Exception {
+
+        int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+        final Path metadataDir = Lib.resource.getMetadataDir(getDataDirectory(context), metadataId);
+        if (!Files.exists(metadataDir)) {
+            try {
+                Files.createDirectories(metadataDir);
+            } catch (Exception e) {
+                throw new IOException(
+                    String.format("Can't create folder '%s' for metadata '%d'.", metadataDir, metadataId));
+            }
+        }
+
+        SettingManager settingManager = context.getBean(SettingManager.class);
+        return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid, settingManager.getNodeURL() + "api/records/", approved);
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResource.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResource.java
@@ -28,6 +28,7 @@ package org.fao.geonet.api.records.attachments;
 
 import com.google.common.net.UrlEscapers;
 import org.fao.geonet.domain.MetadataResource;
+import org.fao.geonet.domain.MetadataResourceExternalManagementProperties;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 
 import java.util.Date;
@@ -46,7 +47,7 @@ public class FilesystemStoreResource implements MetadataResource {
     private final String metadataUuid;
     private final String filename;
     private final String version;
-    private final ExternalResourceManagementProperties externalResourceManagementProperties;
+    private final MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties;
     private final boolean approved;
 
     public FilesystemStoreResource(String metadataUuid,
@@ -57,7 +58,7 @@ public class FilesystemStoreResource implements MetadataResource {
                                    long size,
                                    Date lastModification,
                                    String version,
-                                   ExternalResourceManagementProperties externalResourceManagementProperties,
+                                   MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties,
                                    boolean approved) {
         this.metadataUuid = metadataUuid;
         this.metadataId = metadataId;
@@ -68,7 +69,7 @@ public class FilesystemStoreResource implements MetadataResource {
         this.size = size;
         this.lastModification = lastModification;
         this.version=version;
-        this.externalResourceManagementProperties = externalResourceManagementProperties;
+        this.metadataResourceExternalManagementProperties = metadataResourceExternalManagementProperties;
     }
 
     public FilesystemStoreResource(String metadataUuid,
@@ -134,8 +135,8 @@ public class FilesystemStoreResource implements MetadataResource {
     }
 
     @Override
-    public ExternalResourceManagementProperties getExternalResourceManagementProperties() {
-        return externalResourceManagementProperties;
+    public MetadataResourceExternalManagementProperties getMetadataResourceExternalManagementProperties() {
+        return metadataResourceExternalManagementProperties;
     }
 
 
@@ -151,7 +152,9 @@ public class FilesystemStoreResource implements MetadataResource {
         sb.append("Last modification: ").append(lastModification).append("\n");
         sb.append("Approved: ").append(approved).append("\n");
         sb.append("Version: ").append(version).append("\n");
-        sb.append("ExternalResourceManagementProperties.url: ").append(externalResourceManagementProperties.getUrl()).append("\n");
+        sb.append("metadataResourceExternalManagementProperties.url: ").append(
+            (metadataResourceExternalManagementProperties==null?"":metadataResourceExternalManagementProperties .getUrl())
+        ).append("\n");
         return sb.toString();
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResourceContainer.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResourceContainer.java
@@ -1,0 +1,110 @@
+/*
+ * =============================================================================
+ * ===	Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * ===	and United Nations Environment Programme (UNEP)
+ * ===
+ * ===	This program is free software; you can redistribute it and/or modify
+ * ===	it under the terms of the GNU General Public License as published by
+ * ===	the Free Software Foundation; either version 2 of the License, or (at
+ * ===	your option) any later version.
+ * ===
+ * ===	This program is distributed in the hope that it will be useful, but
+ * ===	WITHOUT ANY WARRANTY; without even the implied warranty of
+ * ===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * ===	General Public License for more details.
+ * ===
+ * ===	You should have received a copy of the GNU General Public License
+ * ===	along with this program; if not, write to the Free Software
+ * ===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ * ===
+ * ===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * ===	Rome - Italy. email: geonetwork@osgeo.org
+ * ==============================================================================
+ */
+
+package org.fao.geonet.api.records.attachments;
+
+
+import org.fao.geonet.domain.MetadataResourceContainer;
+import org.fao.geonet.domain.MetadataResourceExternalManagementProperties;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.UrlEscapers;
+
+public class FilesystemStoreResourceContainer implements MetadataResourceContainer {
+    private final String url;
+    private final int metadataId;
+    private final String metadataUuid;
+    private final String containerName;
+    private final MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties;
+    private final boolean approved;
+
+    public FilesystemStoreResourceContainer(String metadataUuid,
+                                            int metadataId,
+                                            String containerName,
+                                            String baseUrl,
+                                            MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties,
+                                            boolean approved) {
+        this.metadataUuid = metadataUuid;
+        this.metadataId = metadataId;
+        this.approved=approved;
+        this.containerName = containerName;
+        this.url = baseUrl + getId();
+        this.metadataResourceExternalManagementProperties = metadataResourceExternalManagementProperties;
+    }
+
+    public FilesystemStoreResourceContainer(String metadataUuid,
+                                            int metadataId,
+                                            String containerName,
+                                            String baseUrl,
+                                            boolean approved) {
+        this(metadataUuid, metadataId, containerName, baseUrl, null, approved);
+    }
+
+    @Override
+    public String getId() {
+        return UrlEscapers.urlFragmentEscaper().escape(metadataUuid) +
+                "/attachments/";
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public String getContainterName() {
+        return containerName;
+    }
+
+    @Override
+    public boolean isApproved() {
+        return approved;
+    }
+
+    @Override
+    public int getMetadataId() {
+        return metadataId;
+    }
+
+    @Override
+    public String getMetadataUuid() {
+        return metadataUuid;
+    }
+
+    @Override
+    public MetadataResourceExternalManagementProperties getMetadataResourceExternalManagementProperties() {
+        return metadataResourceExternalManagementProperties;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return new ObjectMapper().writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting FilesystemStoreResourceContainer to json", e);
+        }
+    }
+}

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -32,6 +32,7 @@ import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.MetadataFileDownload;
 import org.fao.geonet.domain.MetadataFileUpload;
 import org.fao.geonet.domain.MetadataResource;
+import org.fao.geonet.domain.MetadataResourceContainer;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataFileDownloadRepository;
@@ -148,6 +149,14 @@ public class ResourceLoggerStore extends AbstractStore {
             throws Exception {
         if (decoratedStore != null) {
             return decoratedStore.getResourceDescription(context, metadataUuid, visibility, filename, approved);
+        }
+        return null;
+    }
+
+    @Override
+    public MetadataResourceContainer getResourceContainerDescription(ServiceContext context, String metadataUuid, Boolean approved) throws Exception {
+        if (decoratedStore != null) {
+            return decoratedStore.getResourceContainerDescription(context, metadataUuid, approved);
         }
         return null;
     }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -33,9 +33,9 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import jeeves.server.context.ServiceContext;
-import org.apache.commons.io.FilenameUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.domain.MetadataResource;
+import org.fao.geonet.domain.MetadataResourceContainer;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.resources.S3Credentials;
@@ -235,6 +235,15 @@ public class S3Store extends AbstractStore {
         } catch (AmazonServiceException e) {
             return null;
         }
+    }
+
+    @Override
+    public MetadataResourceContainer getResourceContainerDescription(ServiceContext context, String metadataUuid, Boolean approved) throws Exception {
+
+        int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+
+        SettingManager settingManager = context.getBean(SettingManager.class);
+        return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid, settingManager.getNodeURL() + "api/records/", approved);
     }
 
     private String getMetadataDir(final int metadataId) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -352,5 +352,11 @@ public interface Store {
          * @return boolean to indicate is the external management window should be modal or not.
          */
         boolean isModal();
+
+        /**
+         * Get the folder settings for the resource management window.
+         * @return boolean to indicate is the external management window should be enabled or not for folders.
+         */
+        boolean isFolderEnabled();
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -27,6 +27,7 @@ package org.fao.geonet.api.records.attachments;
 
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.domain.MetadataResource;
+import org.fao.geonet.domain.MetadataResourceContainer;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -37,6 +38,9 @@ import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A store allows user to upload resources (eg. files) to a metadata record and retrieve them.
@@ -315,8 +319,38 @@ public interface Store {
     MetadataResource getResourceDescription(final ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility,
                                             String filename, Boolean approved) throws Exception;
 
+    /**
+     * Get the resource container description.
+     * @param context
+     * @param metadataUuid The metadata UUID
+     * @return The container description or null if the metadata uuid does doesn't exist
+     */
+    MetadataResourceContainer getResourceContainerDescription(final ServiceContext context, final String metadataUuid, Boolean approved) throws Exception;
+
     interface ResourceHolder extends Closeable {
         Path getPath();
         MetadataResource getMetadata();
+    }
+
+    ResourceManagementExternalProperties getResourceManagementExternalProperties();
+
+    interface ResourceManagementExternalProperties {
+        /**
+         * Get the modal setting for the resource management window.
+         * @return boolean to indicate is the external management window should be modal or not.
+         */
+        boolean isEnabled();
+
+        /**
+         * Get the resource management windows parameters based on configuration for the store
+         * @return the javascript windows open parameters. i.e."toolbar=0,width=600,height=600"
+         */
+        String getWindowParameters();
+
+        /**
+         * Get the modal setting for the resource management window.
+         * @return boolean to indicate is the external management window should be modal or not.
+         */
+        boolean isModal();
     }
 }

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -66,6 +66,7 @@ public class CMISConfiguration {
 
     private final String CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS = "toolbar=0,width=600,height=600";
     private final Boolean CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED = true;
+    private final Boolean CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED = true;
     private final Boolean CMIS_DEFAULT_VERSIONING_ENABLED = false;
 
     private String servicesBaseUrl;
@@ -79,9 +80,12 @@ public class CMISConfiguration {
     /**
      * Url used for managing enhanced resource properties related to the metadata.
      */
-    private String externalResourceManagementUrl = System.getenv("CMIS_EXTERNAL_RESOURCE_MANAGEMENT_URL");
-    private String externalResourceManagementWindowParameters = System.getenv("CMIS_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS");
-    private Boolean externalResourceManagementModalEnabled = BooleanUtils.toBooleanObject(System.getenv("CMIS_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED"));
+    private String externalResourceManagementUrl;
+    private String externalResourceManagementWindowParameters;
+    private Boolean externalResourceManagementModalEnabled;
+    private Boolean externalResourceManagementFolderEnabled;
+    private String externalResourceManagementFolderRoot;
+
     /*
      * Enable option to add versioning in the link to the resource.
      */
@@ -209,6 +213,36 @@ public class CMISConfiguration {
 
     public void setExternalResourceManagementModalEnabled(String externalResourceManagementModalEnabled) {
         this.externalResourceManagementModalEnabled = BooleanUtils.toBooleanObject(externalResourceManagementModalEnabled);;
+    }
+
+    public Boolean isExternalResourceManagementFolderEnabled() {
+        if (externalResourceManagementFolderEnabled == null) {
+            return CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED;
+        } else {
+            return externalResourceManagementFolderEnabled;
+        }
+    }
+
+    public void setExternalResourceManagementFolderEnabled(Boolean externalResourceManagementFolderEnabled) {
+        this.externalResourceManagementFolderEnabled = externalResourceManagementFolderEnabled;
+    }
+
+    public String getExternalResourceManagementFolderRoot() {
+        return this.externalResourceManagementFolderRoot;
+    }
+
+    public void setExternalResourceManagementFolderRoot(String externalResourceManagementFolderRoot) {
+        String folderRoot = externalResourceManagementFolderRoot;
+        if (folderRoot != null) {
+            if (!folderRoot.startsWith(getFolderDelimiter())) {
+                folderRoot = getFolderDelimiter() + folderRoot;
+            }
+            if (folderRoot.endsWith(getFolderDelimiter())) {
+                folderRoot = folderRoot.substring(0, folderRoot.length() - 1);
+            }
+        }
+
+        this.externalResourceManagementFolderRoot=folderRoot;
     }
 
     @Nonnull
@@ -572,4 +606,5 @@ public class CMISConfiguration {
             return serviceUrl;
         }
     }
+
 }

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -27,6 +27,9 @@ package org.fao.geonet.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+
+import org.fao.geonet.api.records.attachments.Store;
+import org.fao.geonet.domain.MetadataResourceContainer;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.MultiPolygon;
 import jeeves.component.ProfileManager;
@@ -83,6 +86,7 @@ import org.opengis.referencing.operation.MathTransform;
 import org.owasp.esapi.errors.EncodingException;
 import org.owasp.esapi.reference.DefaultEncoder;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.w3c.dom.Node;
@@ -390,6 +394,36 @@ public final class XslUtil {
         }
         // If we cannot find SecurityProviderConfiguration then default to empty string.
         return "";
+    }
+
+    /**
+     * get external manager url for resource.
+     *
+     * @param metadataUuid uuid of the record
+     * @param approved is metadata approved
+     * @return url to access the resource. Or null if not supported
+     */
+    public static MetadataResourceContainer getResourceContainerDescription(String metadataUuid, Boolean approved) throws Exception {
+        Store store = BeanFactoryAnnotationUtils.qualifiedBeanOfType(ApplicationContextHolder.get().getBeanFactory(), Store.class, "filesystemStore");
+
+        if (store != null && store.getResourceManagementExternalProperties() != null && store.getResourceManagementExternalProperties().isEnabled()) {
+            ServiceContext context = ServiceContext.get();
+            return store.getResourceContainerDescription(context, metadataUuid, approved);
+        }
+        return null;
+    }
+
+    /**
+     * get resource management external properties.
+     *
+     * @return the windows parameters to be used.
+     */
+    public static Store.ResourceManagementExternalProperties getResourceManagementExternalProperties() {
+        Store store = BeanFactoryAnnotationUtils.qualifiedBeanOfType(ApplicationContextHolder.get().getBeanFactory(), Store.class, "filesystemStore");
+        if (store != null) {
+            return store.getResourceManagementExternalProperties();
+        }
+        return null;
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+import org.fao.geonet.api.records.attachments.FilesystemStoreResourceContainer;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.domain.MetadataResourceContainer;
 import org.locationtech.jts.geom.Envelope;
@@ -406,11 +407,16 @@ public final class XslUtil {
     public static MetadataResourceContainer getResourceContainerDescription(String metadataUuid, Boolean approved) throws Exception {
         Store store = BeanFactoryAnnotationUtils.qualifiedBeanOfType(ApplicationContextHolder.get().getBeanFactory(), Store.class, "filesystemStore");
 
-        if (store != null && store.getResourceManagementExternalProperties() != null) {
-            ServiceContext context = ServiceContext.get();
-            return store.getResourceContainerDescription(context, metadataUuid, approved);
+        if (store != null) {
+            if (store.getResourceManagementExternalProperties() != null && store.getResourceManagementExternalProperties().isFolderEnabled()) {
+                ServiceContext context = ServiceContext.get();
+                return store.getResourceContainerDescription(ServiceContext.get(), metadataUuid, approved);
+            } else {
+                // Return an empty object which should not be used because the folder is not enabled.
+                return new FilesystemStoreResourceContainer(metadataUuid, -1, null, null, null, approved);
+            }
         }
-        Log.error(Geonet.RESOURCES,"Could not locate a Store bean in getResourceContainerDescription");
+        Log.error(Geonet.RESOURCES, "Could not locate a Store bean in getResourceContainerDescription");
         return null;
     }
 

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -406,10 +406,11 @@ public final class XslUtil {
     public static MetadataResourceContainer getResourceContainerDescription(String metadataUuid, Boolean approved) throws Exception {
         Store store = BeanFactoryAnnotationUtils.qualifiedBeanOfType(ApplicationContextHolder.get().getBeanFactory(), Store.class, "filesystemStore");
 
-        if (store != null && store.getResourceManagementExternalProperties() != null && store.getResourceManagementExternalProperties().isEnabled()) {
+        if (store != null && store.getResourceManagementExternalProperties() != null) {
             ServiceContext context = ServiceContext.get();
             return store.getResourceContainerDescription(context, metadataUuid, approved);
         }
+        Log.error(Geonet.RESOURCES,"Could not locate a Store bean in getResourceContainerDescription");
         return null;
     }
 
@@ -423,6 +424,7 @@ public final class XslUtil {
         if (store != null) {
             return store.getResourceManagementExternalProperties();
         }
+        Log.error(Geonet.RESOURCES,"Could not locate a Store bean in getResourceManagementExternalProperties");
         return null;
     }
 

--- a/core/src/main/resources/config-store/config-cmis-overrides.properties
+++ b/core/src/main/resources/config-store/config-cmis-overrides.properties
@@ -7,8 +7,10 @@ cmis.repository.id=${CMIS_REPOSITORY_ID:#{null}}
 cmis.repository.name=${CMIS_REPOSITORY_NAME:#{null}}
 
 cmis.external.resource.management.url=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_URL:#{null}}
-cmis.external.resource.management.window.parameters=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETER:#{null}}
+cmis.external.resource.management.window.parameters=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS:#{null}}
 cmis.external.resource.management.modal.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED:#{null}}
+cmis.external.resource.management.folder.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED:#{null}}
+cmis.external.resource.management.folder.root=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ROOT:#{null}}
 
 
 cmis.versioning.enabled=${CMIS_VERSIONING_ENABLED:#{null}}

--- a/core/src/main/resources/config-store/config-cmis-overrides.properties
+++ b/core/src/main/resources/config-store/config-cmis-overrides.properties
@@ -12,7 +12,7 @@ cmis.external.resource.management.modal.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEM
 
 
 cmis.versioning.enabled=${CMIS_VERSIONING_ENABLED:#{null}}
-cmis.versioning.state=${CMIS_VERSIONING_STATE:#{null}}
+cmis.versioning.state=#{'${CMIS_VERSIONING_STATE:MAJOR}'.toUpperCase()}
 cmis.versioning.major.on.update=${CMIS_VERSIONING_MAJOR_ON_UPDATE:#{null}}
 
 cmis.metadata.uuid.property.name=${CMIS_METADATA_UUID_PROPERTY_NAME:#{null}}

--- a/core/src/main/resources/config-store/config-cmis.xml
+++ b/core/src/main/resources/config-store/config-cmis.xml
@@ -78,6 +78,8 @@
        CMIS_EXTERNAL_RESOURCE_MANAGEMENT_URL=http://localhost:8080/share/page/{type:folder:document}-details?nodeRef=workspace://SpacesStore/{cmisobjectid}
        CMIS_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS=toolbar=0,width=600,height=600
        CMIS_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED=true
+       CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED=true
+       CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ROOT=/public
        CMIS_VERSIONING_ENABLED=true
        CMIS_VERSIONING_STATE=MAJOR
        CMIS_VERSIONING_MAJOR_ON_UPDATE=false
@@ -95,7 +97,8 @@
         <property name="externalResourceManagementUrl" value="${cmis.external.resource.management.url}"/>
         <property name="externalResourceManagementWindowParameters" value="${cmis.external.resource.management.window.parameters}"/>
         <property name="externalResourceManagementModalEnabled" value="${cmis.external.resource.management.modal.enabled}"/>
-
+        <property name="externalResourceManagementFolderEnabled" value="${cmis.external.resource.management.folder.enabled}"/>
+        <property name="externalResourceManagementFolderRoot" value="${cmis.external.resource.management.folder.root}"/>
 
         <property name="versioningEnabled" value="${cmis.versioning.enabled}"/>
         <property name="versioningState" value="${cmis.versioning.state}"/>

--- a/core/src/main/resources/config-store/config-cmis.xml
+++ b/core/src/main/resources/config-store/config-cmis.xml
@@ -48,7 +48,7 @@
 <!--      &lt;!&ndash;property name="bindingType" value="atompub"/>-->
 <!--      <property name="atompubUrl" value="/api/-default-/public/cmis/versions/1.1/atom"/&ndash;&gt;-->
 <!--      &lt;!&ndash;property name="bindingType" value="webservices"/>-->
-<!--      <property name="externalResourceManagementUrl" value="http://localhost:8080/share/page/document-details?nodeRef=workspace://SpacesStore/{cmisobjectid}"/>-->
+<!--      <property name="externalResourceManagementUrl" value="http://localhost:8080/share/page/{type:folder:document}-details?nodeRef=workspace://SpacesStore/{cmisobjectid}"/>-->
 <!--      <property name="externalResourceManagementWindowParameters" value="toolbar=0,width=600,height=600"/>-->
 <!--      <property name="externalResourceManagementModalEnabled" value="true"/>-->
 <!--    </bean>-->
@@ -75,7 +75,7 @@
        CMIS_BASE_REPOSITORY_PATH=geonetwork
        CMIS_BINDING_TYPE=browser
        CMIS_BROWSER_URL=/api/-default-/public/cmis/versions/1.1/browser
-       CMIS_EXTERNAL_RESOURCE_MANAGEMENT_URL=http://localhost:8080/share/page/document-details?nodeRef=workspace://SpacesStore/{cmisobjectid}
+       CMIS_EXTERNAL_RESOURCE_MANAGEMENT_URL=http://localhost:8080/share/page/{type:folder:document}-details?nodeRef=workspace://SpacesStore/{cmisobjectid}
        CMIS_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS=toolbar=0,width=600,height=600
        CMIS_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED=true
        CMIS_VERSIONING_ENABLED=true

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataResourceContainer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataResourceContainer.java
@@ -25,37 +25,25 @@
 
 package org.fao.geonet.domain;
 
-import java.util.Date;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
-/**
- * Created by francois on 31/12/15.
- */
-@XmlRootElement(name = "resource")
+@XmlRootElement(name = "resourceContainer")
 @XmlAccessorType(XmlAccessType.FIELD)
-public interface MetadataResource {
+public interface MetadataResourceContainer {
 
     String getId();
 
     String getUrl();
 
-    MetadataResourceVisibility getVisibility();
-
-    long getSize();
-
-    Date getLastModification();
-
-    String getFilename();
+    String getContainterName();
 
     boolean isApproved();
 
     int getMetadataId();
 
     String getMetadataUuid();
-
-    String getVersion();
 
     MetadataResourceExternalManagementProperties getMetadataResourceExternalManagementProperties();
 }

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataResourceExternalManagementProperties.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataResourceExternalManagementProperties.java
@@ -25,37 +25,28 @@
 
 package org.fao.geonet.domain;
 
-import java.util.Date;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
-/**
- * Created by francois on 31/12/15.
- */
-@XmlRootElement(name = "resource")
+@XmlRootElement(name = "metadataResourceExternalManagementProperties")
 @XmlAccessorType(XmlAccessType.FIELD)
-public interface MetadataResource {
+public class MetadataResourceExternalManagementProperties {
+        private final String id;
+        private final String url;
 
-    String getId();
+        public MetadataResourceExternalManagementProperties(String id, String url) {
+            this.id = id;
+            this.url = url;
+        }
 
-    String getUrl();
+        public String getUrl() {
+            return url;
+        }
 
-    MetadataResourceVisibility getVisibility();
+        public String getId() {
+            return id;
+        }
+    }
 
-    long getSize();
 
-    Date getLastModification();
-
-    String getFilename();
-
-    boolean isApproved();
-
-    int getMetadataId();
-
-    String getMetadataUuid();
-
-    String getVersion();
-
-    MetadataResourceExternalManagementProperties getMetadataResourceExternalManagementProperties();
-}

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -49,12 +49,13 @@
     'gnCurrentEdit',
     '$q',
     '$http',
+    '$window',
     '$rootScope',
     '$translate',
     '$filter',
     'Metadata',
     function(gnBatchProcessing, gnHttp, gnEditor, gnCurrentEdit,
-             $q, $http, $rootScope, $translate, $filter, Metadata) {
+             $q, $http, $window, $rootScope, $translate, $filter, Metadata) {
 
       var reload = false;
       var openCb = {};
@@ -285,6 +286,50 @@
           } else {
             console.warn('No callback functions available for \'' + type +
                 '\'. Check the type value.');
+          }
+        },
+
+        /**
+         * @ngdoc method
+         * @methodOf gn_onlinesrc.service:gnOnlinesrc
+         * @name gnOnlinesrc#openExternalResourceManagement
+         *
+         * @description
+         * Open open external resource management popup
+         * function (from the directive).
+         *
+         * @param {r} MetadataResource
+         * @param {$window} window object
+         */
+        openExternalResourceManagement: function(r, $window) {
+          try {
+            var url = r.metadataResourceExternalManagementProperties.url;
+          } catch (e) {
+            console.log("external management url not defined")
+            return
+          }
+
+          var modal = gnCurrentEdit.resourceManagementExternalProperties.modal;
+          var externalManagementWindowsParameters = gnCurrentEdit.resourceManagementExternalProperties.windowParameters;
+
+          var win = window.open(url, "_blank", externalManagementWindowsParameters)
+
+          if (modal) {
+            var ZIndex = $('.modal').css("z-index");
+            $('.modal').css("z-index", 0);
+            var timer = setInterval(function () {
+              if (win.closed) {
+                clearInterval(timer);
+                $('.modal').css("z-index", ZIndex);
+                $rootScope.$broadcast('gnFileStoreUploadDone');
+              } else {
+                // whenever user comes back to the browser window give them focus on the popup.
+                // This will simulat a modal
+                if (document.hasFocus()) {
+                  win.focus()
+                }
+              }
+            }, 250);
           }
         },
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -299,8 +299,14 @@
       <div id="gn-addonlinesrc-file-panel"
            class="panel panel-default"
            data-ng-show="params.linkType.sources.filestore">
-        <div class="panel-heading"
-             data-translate>fileStore
+        <div class="panel-heading">
+          <span data-translate>fileStore</span>
+          <a class="btn btn-link btn-xs pull-right"
+             title="{{'externalResourceManagement' | translate}}"
+             data-ng-click="onlinesrcService.openExternalResourceManagement(gnCurrentEdit.resourceContainerDescription)"
+             data-ng-if="gnCurrentEdit.resourceManagementExternalProperties.enabled && gnCurrentEdit.resourceContainerDescription.url.length > 0">
+            <i class="fa fa-folder-open"></i>
+          </a>
         </div>
         <div class="panel-body">
           <div id="gn-addonlinesrc-file-input"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -304,7 +304,7 @@
           <a class="btn btn-link btn-xs pull-right"
              title="{{'externalResourceManagement' | translate}}"
              data-ng-click="onlinesrcService.openExternalResourceManagement(gnCurrentEdit.resourceContainerDescription)"
-             data-ng-if="gnCurrentEdit.resourceManagementExternalProperties.enabled && gnCurrentEdit.resourceContainerDescription.url.length > 0">
+             data-ng-if="gnCurrentEdit.resourceManagementExternalProperties.folderEnabled && gnCurrentEdit.resourceContainerDescription.url.length > 0">
             <i class="fa fa-folder-open"></i>
           </a>
         </div>

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -33,10 +33,11 @@
       .directive('gnFileStore', [
         'gnFileStoreService',
         'gnOnlinesrc',
+        'gnCurrentEdit',
         '$translate',
         '$rootScope',
         '$parse',
-        function(gnfilestoreService, gnOnlinesrc, $translate, $rootScope, $parse) {
+        function(gnfilestoreService, gnOnlinesrc, gnCurrentEdit, $translate, $rootScope, $parse) {
           return {
             restrict: 'A',
             templateUrl: '../../catalog/components/filestore/' +
@@ -54,26 +55,8 @@
                   angular.isUndefined(attrs['defaultStatus']) ?
                   'public' : attrs['defaultStatus'];
               scope.onlinesrcService = gnOnlinesrc;
+              scope.gnCurrentEdit = gnCurrentEdit;
 
-              scope.openExternalResourceManagement = function(r, $window) {
-                var win = window.open(r.externalResourceManagementProperties.url, "_blank", r.externalResourceManagementProperties.windowParameters)
-                if (r.externalResourceManagementProperties.modal) {
-                  var ZIndex = $('.modal').css("z-index");
-                  $('.modal').css("z-index", 0);
-                  var timer = setInterval(function () {
-                    if (win.closed) {
-                      clearInterval(timer);
-                      $('.modal').css("z-index", ZIndex);
-                    } else {
-                      // whenever user comes back to the browser window give them focus on the popup.
-                      // This will simulat a modal
-                      if (document.hasFocus()) {
-                        win.focus()
-                      }
-                    }
-                  }, 250);
-                }
-              };
               scope.setResource = function(r) {
                 scope.selectCallback({ selected: r });
               };

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -19,10 +19,10 @@
       <td data-ng-if="r.version.length > 0">
           {{r.version}}
       </td>
-      <td data-ng-if="r.externalResourceManagementProperties.url.length > 0">
-        <a class="btn btn-link"
+      <td data-ng-if="gnCurrentEdit.resourceManagementExternalProperties.enabled && r.metadataResourceExternalManagementProperties.url.length > 0">
+      <a class="btn btn-link"
            title="{{'externalResourceManagement' | translate}}"
-           data-ng-click="openExternalResourceManagement(r)">
+           data-ng-click="onlinesrcService.openExternalResourceManagement(r)">
           <i class="fa fa-file-text"></i>
         </a>
       </td>

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -388,6 +388,10 @@
                tab: getInputValue('currTab'),
                geoPublisherConfig:
                angular.fromJson(getInputValue('geoPublisherConfig')),
+               resourceContainerDescription:
+                 angular.fromJson(getInputValue('resourceContainerDescription')),
+               resourceManagementExternalProperties:
+                 angular.fromJson(getInputValue('resourceManagementExternalProperties')),
                extent: extent,
                isMinor: getInputValue('minor') === 'true',
                layerConfig:

--- a/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
@@ -24,6 +24,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:gn="http://www.fao.org/geonetwork"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:saxon="http://saxon.sf.net/"
                 version="2.0" extension-element-prefixes="saxon"
 >
@@ -116,6 +117,12 @@
   <xsl:variable name="isFlatMode"
                 select="if (/root/request/flat) then /root/request/flat = 'true'
     else $tabConfig/@mode = 'flat'"/>
+
+  <xsl:variable name="resourceContainerDescription"
+                select="util:getResourceContainerDescription($metadataInfo/uuid, ($metadataInfo/draft != 'y'))"/>
+
+  <xsl:variable name="resourceManagementExternalProperties"
+                select="util:getResourceManagementExternalProperties()"/>
 
   <xsl:variable name="isDisplayingAttributes"
                 select="if (/root/request/displayAttributes)

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
@@ -91,6 +91,8 @@
           <input type="hidden" id="title" value="{$metadataTitle}"/>
           <input type="hidden" id="language" value="{$metadataLanguage}"/>
           <input type="hidden" id="otherLanguages" value="{$metadataOtherLanguagesAsJson}"/>
+          <input type="hidden" id="resourceContainerDescription" value="{$resourceContainerDescription}"/>
+          <input type="hidden" id="resourceManagementExternalProperties" value="{$resourceManagementExternalProperties}"/>
           <input type="hidden" id="version" name="version" value="{$metadata/gn:info/version}"/>
           <input type="hidden" id="currTab" name="currTab" value="{$tab}"/>
           <input type="hidden" id="displayAttributes" name="displayAttributes"


### PR DESCRIPTION
CMIS - Add logic for displaying a button to go to the main folder.

![image](https://user-images.githubusercontent.com/1868233/108921261-76d09b80-760c-11eb-91ab-9f8bd713e8bf.png)

This will allow the user to go directly to the storage folder related to the related CMIS application and use management feature of the application to upload files, properties.
In some cases if attempting to upload a 100MB data file via a slow or unreliable internet, it could be difficult.  By going to the management tool main folder, a user could use the features of that tool i.e. resume uploads,   performing bulk uploads, and some application can connect to tools such as dropbox or ms onedrive

For Alfresco, this would go to the folder page. 

The resource management url would change to use {type:folder:document} in the url - like the following.

`CMIS_EXTERNAL_RESOURCE_MANAGEMENT_URL=http://localhost:8080/share/page/{type:folder:document}-details?nodeRef=workspace://SpacesStore/{cmisobjectid}`

![image](https://user-images.githubusercontent.com/1868233/108923410-2444ae80-760f-11eb-9153-818dbb523bac.png)


Also fixed a couple other minor bugs in the process.
