### PR TITLE
Use maven major, minor, patch, build, qualifier definition for version

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Version.java
+++ b/common/src/main/java/org/fao/geonet/utils/Version.java
@@ -1,100 +1,165 @@
 package org.fao.geonet.utils;
 
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A parsed version number used to check core-geonetwork and schema plugin compatibility.
+ *
+ * This class is intended to reflect maven version numbering conventions for equality and
+ * comparison. Maven version numbering is quite complicated and improvements will be
+ * required over time.
+ *
+ * @see <a href="https://octopus.com/blog/maven-versioning-explained">Maven versions explained</a>
+ */
 public class Version implements Comparable<Version> {
-    private final int major, minor, micro;
+    private final Integer major;
+    private final Integer minor;
+    private final Integer patch;
+    private final Integer build;
+    private final String qualifer;
+
+    private static final Pattern PATTERN = Pattern.compile("^(\\d*)?[\\.|-]?(\\d*)?[\\.|-]?(\\d*)?[\\.|-]??(\\d*)?[\\.|-]?(\\S*)?$");
 
     /**
-     * Parses a version number removing extra "-*" element and returning an integer.
-     * "2.7.0-SNAPSHOT" is returned as 270.
+     * Parses a version number following maven major, minor, patch definition.
+     *
+     * Use of a qualifier such as SNAPSHOT is considered for comparison order only.
+     *
+     * As an example 2.7.0-SNAPSHOT is returned as major 2, minor 7, patch 0, build null, qualifier SNAPSHOT.
      *
      * @param number The version number to parse
-     * @return The version number as an integer
+     * @return The version number
      */
-    public static Version parseVersionNumber(String number) throws Exception {
-        // Remove extra "-SNAPSHOT" info which may be in version number
-        int dashIdx = number.indexOf("-");
-        if (dashIdx != -1) {
-            number = number.substring(0, number.indexOf("-"));
-        }
-        switch (numDots(number)) {
-            case 0:
-                number += ".0.0";
-                break;
-            case 1:
-                number += ".0";
-                break;
-            default:
-                break;
-        }
+    public static Version parseVersionNumber(String number) {
+        Matcher parsed = PATTERN.matcher(number);
+        if( parsed.find()){
+            String major = parsed.group(1);
+            String minor = parsed.group(2);
+            String patch = parsed.group(3);
+            String build = parsed.group(4);
+            String qualifer = parsed.group(5);
 
-        final String[] parts = number.split("\\.");
-        String major = parts[0];
-        String minor = parts.length > 1 ? parts[1] : "0";
-        String micro = parts.length > 2 ? parts[2] : "0";
-        return new Version(major, minor, micro);
-    }
-
-    public Version(String major, String minor, String micro) {
-        this.major = Integer.parseInt(major);
-        this.minor = Integer.parseInt(minor);
-        this.micro = Integer.parseInt(micro);
+            return new Version(major,minor,patch,build,qualifer);
+        }
+        return new Version(null,null,null,null,number);
     }
 
     public Version() {
         this("0", "0", "0");
     }
 
+    public Version(String major, String minor, String patch) {
+        this(major,minor,patch,null,null);
+    }
+    public Version(String major, String minor, String patch, String build, String qualifier) {
+        this.major = (major != null && !major.isEmpty()) ? Integer.valueOf(major) :  null;
+        this.minor = (minor != null && !minor.isEmpty())? Integer.valueOf(minor) :  null;
+        this.patch = (patch != null && !patch.isEmpty())? Integer.valueOf(patch) :  null;
+        this.build = (build != null && !build.isEmpty())? Integer.valueOf(build) :  null;
+        this.qualifer = (qualifier != null && !qualifier.isEmpty())? qualifier :  null;
+    }
+
+
+    /** Qualifer if present sorts higher than a null*/
+    private static final Comparator<String> qualiferFirst = Comparator
+        .nullsFirst(String::compareTo);
+
+    /** Qualifier placeholder of null sort higher than a default placeholder of 0 */
+    private static final Comparator<Integer> snapshotFirst = Comparator
+        .nullsFirst(Integer::compareTo);
+
+    private static final int placeholder( Integer number, String qualifier){
+        return number != null ? number : "SNAPSHOT".equals(qualifier) ? Integer.MAX_VALUE : 0;
+    }
+
     @Override
     public int compareTo(Version o) {
-        if (major != o.major) {
-            return Integer.compare(major, o.major);
-        }
-        if (minor != o.minor) {
-            return Integer.compare(minor, o.minor);
-        }
-        if (micro != o.micro) {
-            return Integer.compare(micro, o.micro);
-        }
-        return 0;
+        // numbers sort with snapshot (MAX_VALUE), before numbers, before empty (which sorts to zero).
+        int majorCompare = snapshotFirst.compare( placeholder(major,qualifer), placeholder(o.major,o.qualifer));
+        int minorCompare = snapshotFirst.compare( placeholder(minor,qualifer), placeholder(o.minor,o.qualifer));
+        int patchCompare = snapshotFirst.compare( placeholder(patch,qualifer), placeholder(o.patch,o.qualifer));
+        int buildCompare = snapshotFirst.compare( placeholder(build,qualifer), placeholder(o.build,o.qualifer));
+
+        // snapshot qualifier if provided sorts ahead of null
+        int qualiferCompare = qualiferFirst.compare( qualifer, o.qualifer );
+
+        if( major == null && o.major == null)
+            return qualiferCompare;
+        else if ( majorCompare != 0 )
+            return majorCompare;
+
+        if( minor == null && o.minor == null)
+            return qualiferCompare;
+        else if ( minorCompare != 0 )
+            return minorCompare;
+
+        if( patch == null && o.patch == null)
+            return qualiferCompare;
+        else if ( patchCompare != 0 )
+            return patchCompare;
+
+        if( build == null && o.build == null)
+            return qualiferCompare;
+        else if ( buildCompare != 0 )
+            return buildCompare;
+
+        return qualiferCompare;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         Version version = (Version) o;
 
-        if (major != version.major) return false;
-        if (micro != version.micro) return false;
-        if (minor != version.minor) return false;
+        // numbers sort with snapshot (MAX_VALUE), before numbers, before empty (which sorts to zero).
+        int majorCompare = snapshotFirst.compare( placeholder(major,qualifer), placeholder(version.major,version.qualifer));
+        int minorCompare = snapshotFirst.compare( placeholder(minor,qualifer), placeholder(version.minor,version.qualifer));
+        int patchCompare = snapshotFirst.compare( placeholder(patch,qualifer), placeholder(version.patch,version.qualifer));
+        int buildCompare = snapshotFirst.compare( placeholder(build,qualifer), placeholder(version.build,version.qualifer));
+        int qualiferCompare = qualiferFirst.compare( qualifer, version.qualifer );
 
-        return true;
+        return majorCompare == 0 && minorCompare == 0 && patchCompare == 0 && buildCompare == 0 && qualiferCompare == 0;
     }
 
     @Override
     public int hashCode() {
-        int result = major;
-        result = 31 * result + minor;
-        result = 31 * result + micro;
-        return result;
+        int placeholder =  "SNAPSHOT".equals(qualifer) ? Integer.MAX_VALUE : 0;
+
+        // use of placeholder to match hashcode / equals contract
+        return Objects.hash(
+            placeholder(major,qualifer),
+            placeholder(minor,qualifer),
+            placeholder(patch,qualifer),
+            placeholder(build,qualifer),
+            qualifer);
     }
 
     @Override
     public String toString() {
-        return major + "." + minor + "." + micro;
-    }
-
-
-    private static int numDots(String number) {
-        int num = 0;
-
-        for (int i = 0; i < number.length(); i++) {
-            if (number.charAt(i) == '.') {
-                num++;
-            }
+        final StringBuffer sb = new StringBuffer();
+        if( major != null){
+            sb.append(major);
         }
-
-        return num;
+        if( minor != null){
+            sb.append(".").append(minor);
+        }
+        if( patch != null){
+            sb.append(".").append(patch);
+        }
+        if( build != null){
+            sb.append(".").append(build);
+        }
+        if( qualifer != null){
+            if( sb.length() != 0 ){
+                sb.append("-");
+            }
+            sb.append(qualifer);
+        }
+        return sb.toString();
     }
+
 }

--- a/common/src/main/java/org/fao/geonet/utils/Version.java
+++ b/common/src/main/java/org/fao/geonet/utils/Version.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2001-2020 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 package org.fao.geonet.utils;
 
 import java.util.Comparator;
@@ -7,27 +29,71 @@ import java.util.regex.Pattern;
 
 /**
  * A parsed version number used to check core-geonetwork and schema plugin compatibility.
- *
- * This class is intended to reflect maven version numbering conventions for equality and
+ * <p>
+ * This class is intended to reflect Maven version numbering conventions for equality and
  * comparison. Maven version numbering is quite complicated and improvements will be
  * required over time.
  *
  * @see <a href="https://octopus.com/blog/maven-versioning-explained">Maven versions explained</a>
  */
 public class Version implements Comparable<Version> {
+    private static final Pattern PATTERN = Pattern.compile("^(\\d*)?[\\.|-]?(\\d*)?[\\.|-]?(\\d*)?[\\.|-]??(\\d*)?[\\.|-]?(\\S*)?$");
+    /**
+     * Qualifier if present sorts higher than a null.
+     */
+    private static final Comparator<String> qualifierFirst = Comparator.nullsFirst(String::compareTo);
+    /**
+     * Qualifier placeholder of null sort higher than a default placeholder of 0.
+     */
+    private static final Comparator<Integer> snapshotFirst = Comparator.nullsFirst(Integer::compareTo);
     private final Integer major;
     private final Integer minor;
     private final Integer patch;
     private final Integer build;
-    private final String qualifer;
+    private final String qualifier;
 
-    private static final Pattern PATTERN = Pattern.compile("^(\\d*)?[\\.|-]?(\\d*)?[\\.|-]?(\\d*)?[\\.|-]??(\\d*)?[\\.|-]?(\\S*)?$");
+    /**
+     * Build a 0.0.0 version.
+     */
+    public Version() {
+        this("0", "0", "0");
+    }
+
+    /**
+     * Build a version with major, minor and patch, for example 3.10.7.
+     * If any of the parameters can't be parsed as an integer throws a {@link NumberFormatException}.
+     * @param major major version number.
+     * @param minor minor version number.
+     * @param patch patch version number.
+     */
+    public Version(String major, String minor, String patch) {
+        this(major, minor, patch, null, null);
+    }
+
+    /**
+     * Build a version with major, minor and patch, for example 3.10.7.2-SNAPSHOT
+     * If any of the parameters except {@code qualifier} is not null and can't be parsed as
+     * an integer throws a {@link NumberFormatException}.
+     *
+     * @param major major version number.
+     * @param minor minor version number.
+     * @param patch patch version number.
+     * @param build build version number.
+     * @param qualifier the qualifier (part after - character).
+     */
+    public Version(String major, String minor, String patch, String build, String qualifier) {
+        this.major = (major != null && !major.isEmpty()) ? Integer.valueOf(major) : null;
+        this.minor = (minor != null && !minor.isEmpty()) ? Integer.valueOf(minor) : null;
+        this.patch = (patch != null && !patch.isEmpty()) ? Integer.valueOf(patch) : null;
+        this.build = (build != null && !build.isEmpty()) ? Integer.valueOf(build) : null;
+        this.qualifier = (qualifier != null && !qualifier.isEmpty()) ? qualifier : null;
+    }
 
     /**
      * Parses a version number following maven major, minor, patch definition.
-     *
+     * <p>
      * Use of a qualifier such as SNAPSHOT is considered for comparison order only.
-     *
+     * <p>
      * As an example 2.7.0-SNAPSHOT is returned as major 2, minor 7, patch 0, build null, qualifier SNAPSHOT.
      *
      * @param number The version number to parse
@@ -35,131 +101,108 @@ public class Version implements Comparable<Version> {
      */
     public static Version parseVersionNumber(String number) {
         Matcher parsed = PATTERN.matcher(number);
-        if( parsed.find()){
+        if (parsed.find()) {
             String major = parsed.group(1);
             String minor = parsed.group(2);
             String patch = parsed.group(3);
             String build = parsed.group(4);
-            String qualifer = parsed.group(5);
+            String qualifier = parsed.group(5);
 
-            return new Version(major,minor,patch,build,qualifer);
+            return new Version(major, minor, patch, build, qualifier);
         }
-        return new Version(null,null,null,null,number);
+        return new Version(null, null, null, null, number);
     }
 
-    public Version() {
-        this("0", "0", "0");
-    }
-
-    public Version(String major, String minor, String patch) {
-        this(major,minor,patch,null,null);
-    }
-    public Version(String major, String minor, String patch, String build, String qualifier) {
-        this.major = (major != null && !major.isEmpty()) ? Integer.valueOf(major) :  null;
-        this.minor = (minor != null && !minor.isEmpty())? Integer.valueOf(minor) :  null;
-        this.patch = (patch != null && !patch.isEmpty())? Integer.valueOf(patch) :  null;
-        this.build = (build != null && !build.isEmpty())? Integer.valueOf(build) :  null;
-        this.qualifer = (qualifier != null && !qualifier.isEmpty())? qualifier :  null;
-    }
-
-
-    /** Qualifer if present sorts higher than a null*/
-    private static final Comparator<String> qualiferFirst = Comparator
-        .nullsFirst(String::compareTo);
-
-    /** Qualifier placeholder of null sort higher than a default placeholder of 0 */
-    private static final Comparator<Integer> snapshotFirst = Comparator
-        .nullsFirst(Integer::compareTo);
-
-    private static final int placeholder( Integer number, String qualifier){
+    private int placeholder(Integer number, String qualifier) {
         return number != null ? number : "SNAPSHOT".equals(qualifier) ? Integer.MAX_VALUE : 0;
     }
 
     @Override
     public int compareTo(Version o) {
         // numbers sort with snapshot (MAX_VALUE), before numbers, before empty (which sorts to zero).
-        int majorCompare = snapshotFirst.compare( placeholder(major,qualifer), placeholder(o.major,o.qualifer));
-        int minorCompare = snapshotFirst.compare( placeholder(minor,qualifer), placeholder(o.minor,o.qualifer));
-        int patchCompare = snapshotFirst.compare( placeholder(patch,qualifer), placeholder(o.patch,o.qualifer));
-        int buildCompare = snapshotFirst.compare( placeholder(build,qualifer), placeholder(o.build,o.qualifer));
+        int majorCompare = snapshotFirst.compare(placeholder(major, qualifier), placeholder(o.major, o.qualifier));
+        int minorCompare = snapshotFirst.compare(placeholder(minor, qualifier), placeholder(o.minor, o.qualifier));
+        int patchCompare = snapshotFirst.compare(placeholder(patch, qualifier), placeholder(o.patch, o.qualifier));
+        int buildCompare = snapshotFirst.compare(placeholder(build, qualifier), placeholder(o.build, o.qualifier));
 
         // snapshot qualifier if provided sorts ahead of null
-        int qualiferCompare = qualiferFirst.compare( qualifer, o.qualifer );
+        int qualifierCompare = qualifierFirst.compare(qualifier, o.qualifier);
 
-        if( major == null && o.major == null)
-            return qualiferCompare;
-        else if ( majorCompare != 0 )
+        if (major == null && o.major == null) {
+            return qualifierCompare;
+        } else if (majorCompare != 0) {
             return majorCompare;
+        }
 
-        if( minor == null && o.minor == null)
-            return qualiferCompare;
-        else if ( minorCompare != 0 )
+        if (minor == null && o.minor == null) {
+            return qualifierCompare;
+        } else if (minorCompare != 0) {
             return minorCompare;
+        }
 
-        if( patch == null && o.patch == null)
-            return qualiferCompare;
-        else if ( patchCompare != 0 )
+        if (patch == null && o.patch == null) {
+            return qualifierCompare;
+        } else if (patchCompare != 0) {
             return patchCompare;
+        }
 
-        if( build == null && o.build == null)
-            return qualiferCompare;
-        else if ( buildCompare != 0 )
+        if (build == null && o.build == null) {
+            return qualifierCompare;
+        } else if (buildCompare != 0) {
             return buildCompare;
+        }
 
-        return qualiferCompare;
+        return qualifierCompare;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Version version = (Version) o;
 
         // numbers sort with snapshot (MAX_VALUE), before numbers, before empty (which sorts to zero).
-        int majorCompare = snapshotFirst.compare( placeholder(major,qualifer), placeholder(version.major,version.qualifer));
-        int minorCompare = snapshotFirst.compare( placeholder(minor,qualifer), placeholder(version.minor,version.qualifer));
-        int patchCompare = snapshotFirst.compare( placeholder(patch,qualifer), placeholder(version.patch,version.qualifer));
-        int buildCompare = snapshotFirst.compare( placeholder(build,qualifer), placeholder(version.build,version.qualifer));
-        int qualiferCompare = qualiferFirst.compare( qualifer, version.qualifer );
+        int majorCompare = snapshotFirst.compare(placeholder(major, qualifier), placeholder(version.major, version.qualifier));
+        int minorCompare = snapshotFirst.compare(placeholder(minor, qualifier), placeholder(version.minor, version.qualifier));
+        int patchCompare = snapshotFirst.compare(placeholder(patch, qualifier), placeholder(version.patch, version.qualifier));
+        int buildCompare = snapshotFirst.compare(placeholder(build, qualifier), placeholder(version.build, version.qualifier));
+        int qualifierCompare = qualifierFirst.compare(qualifier, version.qualifier);
 
-        return majorCompare == 0 && minorCompare == 0 && patchCompare == 0 && buildCompare == 0 && qualiferCompare == 0;
+        return majorCompare == 0 && minorCompare == 0 && patchCompare == 0 && buildCompare == 0 && qualifierCompare == 0;
     }
 
     @Override
     public int hashCode() {
-        int placeholder =  "SNAPSHOT".equals(qualifer) ? Integer.MAX_VALUE : 0;
-
         // use of placeholder to match hashcode / equals contract
-        return Objects.hash(
-            placeholder(major,qualifer),
-            placeholder(minor,qualifer),
-            placeholder(patch,qualifer),
-            placeholder(build,qualifer),
-            qualifer);
+        return Objects.hash(placeholder(major, qualifier), placeholder(minor, qualifier), placeholder(patch, qualifier),
+                placeholder(build, qualifier), qualifier);
     }
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer();
-        if( major != null){
+        final StringBuilder sb = new StringBuilder();
+        if (major != null) {
             sb.append(major);
         }
-        if( minor != null){
+        if (minor != null) {
             sb.append(".").append(minor);
         }
-        if( patch != null){
+        if (patch != null) {
             sb.append(".").append(patch);
         }
-        if( build != null){
+        if (build != null) {
             sb.append(".").append(build);
         }
-        if( qualifer != null){
-            if( sb.length() != 0 ){
+        if (qualifier != null) {
+            if (sb.length() != 0) {
                 sb.append("-");
             }
-            sb.append(qualifer);
+            sb.append(qualifier);
         }
         return sb.toString();
     }
-
 }

--- a/common/src/main/java/org/fao/geonet/utils/Version.java
+++ b/common/src/main/java/org/fao/geonet/utils/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2020 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -54,6 +54,7 @@ public class Version implements Comparable<Version> {
     /**
      * Build a version with major, minor and patch, for example 3.10.7.
      * If any of the parameters can't be parsed as an integer throws a {@link NumberFormatException}.
+     *
      * @param major major version number.
      * @param minor minor version number.
      * @param patch patch version number.
@@ -67,10 +68,10 @@ public class Version implements Comparable<Version> {
      * If any of the parameters except {@code qualifier} is not null and can't be parsed as
      * an integer throws a {@link NumberFormatException}.
      *
-     * @param major major version number.
-     * @param minor minor version number.
-     * @param patch patch version number.
-     * @param build build version number.
+     * @param major     major version number.
+     * @param minor     minor version number.
+     * @param patch     patch version number.
+     * @param build     build version number.
      * @param qualifier the qualifier (part after - character).
      */
     public Version(String major, String minor, String patch, String build, String qualifier) {
@@ -105,64 +106,82 @@ public class Version implements Comparable<Version> {
         return new Version(null, null, null, null, number);
     }
 
-    private static final int order(Integer number, String qualifier){
+    private static final int order(Integer number, String qualifier) {
         return number != null ? number : order(qualifier);
     }
-    private static final int order(String qualifier){
-        if(qualifier==null) return 0;
-        else if("SNAPSHOT".equalsIgnoreCase(qualifier)) return Integer.MAX_VALUE;
-        else if("RC".equalsIgnoreCase(qualifier)) return -1;
-        else if("0".equalsIgnoreCase(qualifier)) return 0;
-        else if("final".equalsIgnoreCase(qualifier)) return 0;
-        else return -2;
+
+    private static final int order(String qualifier) {
+        if (qualifier == null)
+            return 0;
+        else if ("SNAPSHOT".equalsIgnoreCase(qualifier))
+            return Integer.MAX_VALUE;
+        else if ("RC".equalsIgnoreCase(qualifier))
+            return -1;
+        else if ("0".equalsIgnoreCase(qualifier))
+            return 0;
+        else if ("final".equalsIgnoreCase(qualifier))
+            return 0;
+        else
+            return -2;
     }
 
     @Override
     public int compareTo(Version o) {
         // numbers sort with snapshot (MAX_VALUE), before numbers, before empty (which sorts to zero).
-        int majorCompare = Integer.compare(order(major,qualifier), order(o.major,o.qualifier));
-        int minorCompare = Integer.compare( order(minor,qualifier), order(o.minor,o.qualifier));
-        int patchCompare = Integer.compare( order(patch,qualifier), order(o.patch,o.qualifier));
-        int buildCompare = Integer.compare( order(build,qualifier), order(o.build,o.qualifier));
+        int majorCompare = Integer.compare(order(major, qualifier), order(o.major, o.qualifier));
+        int minorCompare = Integer.compare(order(minor, qualifier), order(o.minor, o.qualifier));
+        int patchCompare = Integer.compare(order(patch, qualifier), order(o.patch, o.qualifier));
+        int buildCompare = Integer.compare(order(build, qualifier), order(o.build, o.qualifier));
 
         // snapshot qualifier if provided sorts ahead of null
-        int qualifierCompare = Integer.compare( order(qualifier), order(o.qualifier) );
+        int qualifierCompare = Integer.compare(order(qualifier), order(o.qualifier));
 
-        if( major == null && o.major == null)  return qualifierCompare;
-        else if ( majorCompare != 0 )  return majorCompare;
+        if (major == null && o.major == null)
+            return qualifierCompare;
+        else if (majorCompare != 0)
+            return majorCompare;
 
-        if( minor == null && o.minor == null) return qualifierCompare;
-        else if ( minorCompare != 0 ) return minorCompare;
+        if (minor == null && o.minor == null)
+            return qualifierCompare;
+        else if (minorCompare != 0)
+            return minorCompare;
 
-        if( patch == null && o.patch == null) return qualifierCompare;
-        else if ( patchCompare != 0 ) return patchCompare;
+        if (patch == null && o.patch == null)
+            return qualifierCompare;
+        else if (patchCompare != 0)
+            return patchCompare;
 
-        if( build == null && o.build == null) return qualifierCompare;
-        else if ( buildCompare != 0 ) return buildCompare;
+        if (build == null && o.build == null)
+            return qualifierCompare;
+        else if (buildCompare != 0)
+            return buildCompare;
 
         return qualifierCompare;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
 
         Version version = (Version) o;
-        return compareTo( version ) == 0;
+        return compareTo(version) == 0;
     }
 
     @Override
     public int hashCode() {
-        int placeholder =  "SNAPSHOT".equals(qualifier) ? Integer.MAX_VALUE : 0;
+        int placeholder = "SNAPSHOT".equals(qualifier) ? Integer.MAX_VALUE : 0;
 
         // use of order to match hashcode / equals contract
-        return Objects.hash(
-            order(major,qualifier),
-            order(minor,qualifier),
-            order(patch,qualifier),
-            order(build,qualifier),
-            order(qualifier));
+        return Objects
+                .hash(order(major, qualifier),
+                        order(minor, qualifier),
+                        order(patch, qualifier),
+                        order(build, qualifier),
+                        order(qualifier)
+                );
     }
 
     @Override

--- a/common/src/test/java/org/fao/geonet/utils/VersionTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/VersionTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2001-2020 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 package org.fao.geonet.utils;
 
 import org.junit.Test;
@@ -9,8 +31,6 @@ import static org.junit.Assert.assertNotEquals;
 public class VersionTest {
 
     final Version V1_SNAPSHOT = new Version("1", null, null, null, "SNAPSHOT");
-    final Version V1_1_1_SNAPSHOT = new Version("1","1","1",null,"SNAPSHOT");
-    final Version V1_1_1 = new Version("1","1","1");
     final Version V1_1 = new Version("1","1",null);
     final Version V1_1_0 = new Version("1","1","0");
     final Version V1 = new Version("1",null,null);

--- a/common/src/test/java/org/fao/geonet/utils/VersionTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2020 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -27,25 +27,26 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
-/** Double check the functionality of Version utility class */
+/**
+ * Double check the functionality of Version utility class
+ */
 public class VersionTest {
 
-    final Version V3_10_SNAPSHOT = new Version("3","10", null, null, "SNAPSHOT");
-    final Version V3_10_5 = new Version("3","10", "5");
-    final Version V3_10_0 = new Version("3","10", null);
+    final Version V3_10_SNAPSHOT = new Version("3", "10", null, null, "SNAPSHOT");
+    final Version V3_10_5 = new Version("3", "10", "5");
+    final Version V3_10_0 = new Version("3", "10", null);
 
     final Version V1_SNAPSHOT = new Version("1", null, null, null, "SNAPSHOT");
-    final Version V1_1_1_SNAPSHOT = new Version("1","1","1",null,"SNAPSHOT");
-    final Version V1_1_1 = new Version("1","1","1");
-    final Version V1_1 = new Version("1","1",null);
-    final Version V1_1_0 = new Version("1","1","0");
-    final Version V1 = new Version("1",null,null);
+    final Version V1_1 = new Version("1", "1", null);
+    final Version V1_1_0 = new Version("1", "1", "0");
+    final Version V1 = new Version("1", null, null);
     final Version V1_0_SNAPSHOT = new Version("1", "0", null, null, "SNAPSHOT");
-    final Version V1_0 = new Version("1","0",null);
-    final Version V1_0_0 = new Version("1","0","0");
-
+    final Version V1_0 = new Version("1", "0", null);
+    final Version V1_0_0 = new Version("1", "0", "0");
 
     @Test
     public void eq() throws Exception {
@@ -65,7 +66,7 @@ public class VersionTest {
         assertNotEquals(V1.hashCode(), V1_SNAPSHOT.hashCode());
     }
 
-    public void string(){
+    public void string() {
         assertEquals("1", V1.toString());
         assertEquals("1.0", V1_0.toString());
         assertEquals("1.0.0", V1_0_0.toString());
@@ -90,68 +91,67 @@ public class VersionTest {
 
     @Test
     public void compareMore() throws Exception {
-        assertCompareVersions( "3.10.0 < 3.10.5");
-        assertCompareVersions( "3.10.6 > 3.10.5");
-        assertCompareVersions( "3.10.6 = 3.10.6-0");
-        assertCompareVersions( "3.10.2 < 3.10-SNAPSHOT");
-        assertCompareVersions( "3.10-RC < 3.10");
-        assertCompareVersions( "3.10-RC < 3.10.0");
-        assertCompareVersions( "3.10 = 3.10.0-0");
+        assertCompareVersions("3.10.0 < 3.10.5");
+        assertCompareVersions("3.10.6 > 3.10.5");
+        assertCompareVersions("3.10.6 = 3.10.6-0");
+        assertCompareVersions("3.10.2 < 3.10-SNAPSHOT");
+        assertCompareVersions("3.10-RC < 3.10");
+        assertCompareVersions("3.10-RC < 3.10.0");
+        assertCompareVersions("3.10 = 3.10.0-0");
     }
 
-    private void assertCompareVersions(String comparison){
-        String split[] = comparison.split(" ");
-        Version a = Version.parseVersionNumber(split[0]);
-        Version b = Version.parseVersionNumber(split[2]);
-        char compare = split[1].charAt(0);
-        switch( a.compareTo(b)){
-            case -1:
-                assertTrue( comparison + " was <", '<' == compare );
-                break;
+    private void assertCompareVersions(String comparison) {
+        String[] split = comparison.split(" ");
+        Version leftSideVersion = Version.parseVersionNumber(split[0]);
+        Version rightSideVersion = Version.parseVersionNumber(split[2]);
+        char operator = split[1].charAt(0);
+        switch (leftSideVersion.compareTo(rightSideVersion)) {
+        case -1:
+            assertEquals(comparison + " was <", '<', operator);
+            break;
 
-            case 0:
-                assertTrue( comparison + " was =", '=' == compare );
-                break;
+        case 0:
+            assertEquals(comparison + " was =", '=', operator);
+            break;
 
-            case 1:
-                assertTrue( comparison + " was >", '>' == compare );
-                break;
+        case 1:
+            assertEquals(comparison + " was >", '>', operator);
+            break;
         }
     }
 
-
     @Test
-    public void parse(){
-        assertEquals(V1,Version.parseVersionNumber("1"));
-        assertEquals(V1_0,Version.parseVersionNumber("1.0"));
-        assertEquals(V1_0_SNAPSHOT,Version.parseVersionNumber("1.0-SNAPSHOT"));
+    public void parse() {
+        assertEquals(V1, Version.parseVersionNumber("1"));
+        assertEquals(V1_0, Version.parseVersionNumber("1.0"));
+        assertEquals(V1_0_SNAPSHOT, Version.parseVersionNumber("1.0-SNAPSHOT"));
 
-        assertEquals(V3_10_0,Version.parseVersionNumber("3.10.0"));
-        assertEquals(V3_10_0,Version.parseVersionNumber("3.10"));
-        assertEquals(V3_10_5,Version.parseVersionNumber("3.10.5"));
-        assertEquals(V3_10_SNAPSHOT,Version.parseVersionNumber("3.10-SNAPSHOT"));
+        assertEquals(V3_10_0, Version.parseVersionNumber("3.10.0"));
+        assertEquals(V3_10_0, Version.parseVersionNumber("3.10"));
+        assertEquals(V3_10_5, Version.parseVersionNumber("3.10.5"));
+        assertEquals(V3_10_SNAPSHOT, Version.parseVersionNumber("3.10-SNAPSHOT"));
     }
 
     @Test
-    public void equivilence(){
+    public void equivalence() {
         Version v1 = Version.parseVersionNumber("3.10.6");
         Version v2 = Version.parseVersionNumber("3.10.6.0");
         Version v3 = Version.parseVersionNumber("3.10.6-0");
         Version v4 = Version.parseVersionNumber("3.10.6.0.0");
         Version v5 = Version.parseVersionNumber("3.10.6.0-0");
         Version v6 = Version.parseVersionNumber("3.10.6-FINAL");
-        List<Version> equivaList = Arrays.asList(v1,v2,v3,v4,v5,v6);
+        List<Version> equivaList = Arrays.asList(v1, v2, v3, v4, v5, v6);
 
-        for( Version v : equivaList){
-            assertEquals( "equals "+v1, v1, v);
-            assertEquals( "equals "+v2, v2, v);
-            assertEquals( "equals "+v3, v3, v);
-            assertEquals( "equals "+v4, v4, v);
-            assertEquals( "equals "+v5, v5, v);
-            assertEquals( "equals "+v6, v6, v);
+        for (Version v : equivaList) {
+            assertEquals("equals " + v1, v1, v);
+            assertEquals("equals " + v2, v2, v);
+            assertEquals("equals " + v3, v3, v);
+            assertEquals("equals " + v4, v4, v);
+            assertEquals("equals " + v5, v5, v);
+            assertEquals("equals " + v6, v6, v);
 
-            assertEquals( "hashcode "+v.hashCode(), v1.hashCode(), v.hashCode() );
-            assertEquals( "= "+v1, 0, v1.compareTo(v));
+            assertEquals("hashcode " + v.hashCode(), v1.hashCode(), v.hashCode());
+            assertEquals("= " + v1, 0, v1.compareTo(v));
         }
     }
 }

--- a/common/src/test/java/org/fao/geonet/utils/VersionTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/VersionTest.java
@@ -24,13 +24,21 @@ package org.fao.geonet.utils;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 /** Double check the functionality of Version utility class */
 public class VersionTest {
 
+    final Version V3_10_SNAPSHOT = new Version("3","10", null, null, "SNAPSHOT");
+    final Version V3_10_5 = new Version("3","10", "5");
+    final Version V3_10_0 = new Version("3","10", null);
+
     final Version V1_SNAPSHOT = new Version("1", null, null, null, "SNAPSHOT");
+    final Version V1_1_1_SNAPSHOT = new Version("1","1","1",null,"SNAPSHOT");
+    final Version V1_1_1 = new Version("1","1","1");
     final Version V1_1 = new Version("1","1",null);
     final Version V1_1_0 = new Version("1","1","0");
     final Version V1 = new Version("1",null,null);
@@ -70,20 +78,80 @@ public class VersionTest {
 
     @Test
     public void compare() throws Exception {
-        assertEquals( "1 = 1", 0, V1.compareTo(V1));
-        assertEquals( "1 = 1.0", 0, V1.compareTo(V1_0));
-        assertEquals( "1 = 1.0.0", 0, V1.compareTo(V1_0_0));
-        assertEquals( "1.1 > 1.0", 1, V1_1.compareTo(V1_0));
+        assertEquals("1 = 1", 0, V1.compareTo(V1));
+        assertEquals("1 = 1.0", 0, V1.compareTo(V1_0));
+        assertEquals("1 = 1.0.0", 0, V1.compareTo(V1_0_0));
+        assertEquals("1.1 > 1.0", 1, V1_1.compareTo(V1_0));
 
-        assertEquals( "1-SNAPSHOT > 1", 1, V1_SNAPSHOT.compareTo(V1));
-        assertEquals( "1-SNAPSHOT > 1.0", 1, V1_SNAPSHOT.compareTo(V1_0));
-        assertEquals( "1-SNAPSHOT > 1.0.0", 1, V1_SNAPSHOT.compareTo(V1_0_0));
+        assertEquals("1-SNAPSHOT > 1", 1, V1_SNAPSHOT.compareTo(V1));
+        assertEquals("1-SNAPSHOT > 1.0", 1, V1_SNAPSHOT.compareTo(V1_0));
+        assertEquals("1-SNAPSHOT > 1.0.0", 1, V1_SNAPSHOT.compareTo(V1_0_0));
     }
+
+    @Test
+    public void compareMore() throws Exception {
+        assertCompareVersions( "3.10.0 < 3.10.5");
+        assertCompareVersions( "3.10.6 > 3.10.5");
+        assertCompareVersions( "3.10.6 = 3.10.6-0");
+        assertCompareVersions( "3.10.2 < 3.10-SNAPSHOT");
+        assertCompareVersions( "3.10-RC < 3.10");
+        assertCompareVersions( "3.10-RC < 3.10.0");
+        assertCompareVersions( "3.10 = 3.10.0-0");
+    }
+
+    private void assertCompareVersions(String comparison){
+        String split[] = comparison.split(" ");
+        Version a = Version.parseVersionNumber(split[0]);
+        Version b = Version.parseVersionNumber(split[2]);
+        char compare = split[1].charAt(0);
+        switch( a.compareTo(b)){
+            case -1:
+                assertTrue( comparison + " was <", '<' == compare );
+                break;
+
+            case 0:
+                assertTrue( comparison + " was =", '=' == compare );
+                break;
+
+            case 1:
+                assertTrue( comparison + " was >", '>' == compare );
+                break;
+        }
+    }
+
 
     @Test
     public void parse(){
         assertEquals(V1,Version.parseVersionNumber("1"));
         assertEquals(V1_0,Version.parseVersionNumber("1.0"));
         assertEquals(V1_0_SNAPSHOT,Version.parseVersionNumber("1.0-SNAPSHOT"));
+
+        assertEquals(V3_10_0,Version.parseVersionNumber("3.10.0"));
+        assertEquals(V3_10_0,Version.parseVersionNumber("3.10"));
+        assertEquals(V3_10_5,Version.parseVersionNumber("3.10.5"));
+        assertEquals(V3_10_SNAPSHOT,Version.parseVersionNumber("3.10-SNAPSHOT"));
+    }
+
+    @Test
+    public void equivilence(){
+        Version v1 = Version.parseVersionNumber("3.10.6");
+        Version v2 = Version.parseVersionNumber("3.10.6.0");
+        Version v3 = Version.parseVersionNumber("3.10.6-0");
+        Version v4 = Version.parseVersionNumber("3.10.6.0.0");
+        Version v5 = Version.parseVersionNumber("3.10.6.0-0");
+        Version v6 = Version.parseVersionNumber("3.10.6-FINAL");
+        List<Version> equivaList = Arrays.asList(v1,v2,v3,v4,v5,v6);
+
+        for( Version v : equivaList){
+            assertEquals( "equals "+v1, v1, v);
+            assertEquals( "equals "+v2, v2, v);
+            assertEquals( "equals "+v3, v3, v);
+            assertEquals( "equals "+v4, v4, v);
+            assertEquals( "equals "+v5, v5, v);
+            assertEquals( "equals "+v6, v6, v);
+
+            assertEquals( "hashcode "+v.hashCode(), v1.hashCode(), v.hashCode() );
+            assertEquals( "= "+v1, 0, v1.compareTo(v));
+        }
     }
 }

--- a/common/src/test/java/org/fao/geonet/utils/VersionTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/VersionTest.java
@@ -1,0 +1,69 @@
+package org.fao.geonet.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/** Double check the functionality of Version utility class */
+public class VersionTest {
+
+    final Version V1_SNAPSHOT = new Version("1", null, null, null, "SNAPSHOT");
+    final Version V1_1_1_SNAPSHOT = new Version("1","1","1",null,"SNAPSHOT");
+    final Version V1_1_1 = new Version("1","1","1");
+    final Version V1_1 = new Version("1","1",null);
+    final Version V1_1_0 = new Version("1","1","0");
+    final Version V1 = new Version("1",null,null);
+    final Version V1_0_SNAPSHOT = new Version("1", "0", null, null, "SNAPSHOT");
+    final Version V1_0 = new Version("1","0",null);
+    final Version V1_0_0 = new Version("1","0","0");
+
+
+    @Test
+    public void eq() throws Exception {
+        assertEquals(V1, V1_0);
+        assertEquals(V1.hashCode(), V1_0.hashCode());
+
+        assertEquals(V1, V1_0_0);
+        assertEquals(V1.hashCode(), V1_0_0.hashCode());
+
+        assertEquals(V1_0, V1_0_0);
+        assertEquals(V1_0.hashCode(), V1_0_0.hashCode());
+
+        assertNotEquals(V1_0, V1_1);
+        assertNotEquals(V1_0.hashCode(), V1_1.hashCode());
+
+        assertNotEquals(V1, V1_SNAPSHOT);
+        assertNotEquals(V1.hashCode(), V1_SNAPSHOT.hashCode());
+    }
+
+    public void string(){
+        assertEquals("1", V1.toString());
+        assertEquals("1.0", V1_0.toString());
+        assertEquals("1.0.0", V1_0_0.toString());
+        assertEquals("1.1.0", V1_1_0.toString());
+
+        assertEquals("1-SNAPSHOT", V1_SNAPSHOT.toString());
+        assertEquals("1.0-SNAPSHOT", V1_0_SNAPSHOT.toString());
+
+    }
+
+    @Test
+    public void compare() throws Exception {
+        assertEquals( "1 = 1", 0, V1.compareTo(V1));
+        assertEquals( "1 = 1.0", 0, V1.compareTo(V1_0));
+        assertEquals( "1 = 1.0.0", 0, V1.compareTo(V1_0_0));
+        assertEquals( "1.1 > 1.0", 1, V1_1.compareTo(V1_0));
+
+        assertEquals( "1-SNAPSHOT > 1", 1, V1_SNAPSHOT.compareTo(V1));
+        assertEquals( "1-SNAPSHOT > 1.0", 1, V1_SNAPSHOT.compareTo(V1_0));
+        assertEquals( "1-SNAPSHOT > 1.0.0", 1, V1_SNAPSHOT.compareTo(V1_0_0));
+    }
+
+    @Test
+    public void parse(){
+        assertEquals(V1,Version.parseVersionNumber("1"));
+        assertEquals(V1_0,Version.parseVersionNumber("1.0"));
+        assertEquals(V1_0_SNAPSHOT,Version.parseVersionNumber("1.0-SNAPSHOT"));
+    }
+}


### PR DESCRIPTION
Uses maven version definition and comparison.

This allows schema plugins to more accurately check for compatibility
(see metadata101/iso19139.ca.HNAP#185 for context).

Backport for 3.10.x is available https://github.com/geonetwork/core-geonetwork/pull/5451