### PR TITLE
Fix regression on "Compute extents from keywords" button

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-extent-from-geokeywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-extent-from-geokeywords.xsl
@@ -36,7 +36,7 @@
   <xsl:variable name="replaceMode"
                 select="geonet:parseBoolean($replace)"/>
   <xsl:variable name="serviceUrl"
-                select="concat($gurl, '/keywords?pNewSearch=true&amp;pTypeSearch=2&amp;pKeyword=')"/>
+                select="concat(substring($gurl, 1, string-length($gurl)-4), '/api/0.1/registries/vocabularies/search.xml?q=')"/>
 
 
 
@@ -194,7 +194,7 @@
 
       <!-- It should be one but if one keyword is found in more
           thant one thesaurus, then each will be processed.-->
-      <xsl:for-each select="$knode/response/descKeys/keyword">
+      <xsl:for-each select="$knode/response/keyword">
         <xsl:if test="geo">
           <mri:extent>
             <xsl:copy-of select="geonet:make-iso19115-3-extent(geo/west, geo/south, geo/east, geo/north, $word)"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-extent-from-geokeywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-extent-from-geokeywords.xsl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:exslt="http://exslt.org/common"
                 xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
@@ -36,7 +35,7 @@
   <xsl:variable name="replaceMode"
                 select="geonet:parseBoolean($replace)"/>
   <xsl:variable name="serviceUrl"
-                select="concat(substring($gurl, 1, string-length($gurl)-4), '/api/registries/vocabularies/search?_content_type=xml&amp;q=')"/>
+                select="concat(substring($gurl, 1, string-length($gurl)-4), 'api/registries/vocabularies/search?_content_type=xml&amp;q=')"/>
 
 
 
@@ -60,7 +59,6 @@
                       and (not(contains($extentDescription, gco:CharacterString))
                       or not(contains($extentDescription, gmx:Anchor)))
                       and ../mri:type/mri:MD_KeywordTypeCode/@codeListValue='place']"/>
-
     <xsl:if test="$geoKeywords">
       <suggestion process="add-extent-from-geokeywords" id="{generate-id()}" category="keyword" target="extent">
         <name><xsl:value-of select="geonet:i18n($add-extent-loc, 'a', $guiLang)"/><xsl:value-of select="string-join($geoKeywords/gco:CharacterString, ', ')"/>
@@ -90,7 +88,6 @@
   <xsl:template
           match="mdb:identificationInfo/*"
           priority="2">
-
     <xsl:variable name="srv"
                   select="local-name(.)='SV_ServiceIdentification'
             or contains(@gco:isoType, 'SV_ServiceIdentification')"/>
@@ -190,11 +187,10 @@
     <xsl:if test="normalize-space($word)!=''">
       <!-- Get keyword information -->
       <xsl:variable name="keyword" select="document(concat($serviceUrl, encode-for-uri($word)))"/>
-      <xsl:variable name="knode" select="exslt:node-set($keyword)"/>
 
       <!-- It should be one but if one keyword is found in more
           thant one thesaurus, then each will be processed.-->
-      <xsl:for-each select="$knode/response/keyword">
+      <xsl:for-each select="$keyword/response/keyword">
         <xsl:if test="geo">
           <mri:extent>
             <xsl:copy-of select="geonet:make-iso19115-3-extent(geo/west, geo/south, geo/east, geo/north, $word)"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-extent-from-geokeywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-extent-from-geokeywords.xsl
@@ -36,7 +36,7 @@
   <xsl:variable name="replaceMode"
                 select="geonet:parseBoolean($replace)"/>
   <xsl:variable name="serviceUrl"
-                select="concat(substring($gurl, 1, string-length($gurl)-4), '/api/0.1/registries/vocabularies/search.xml?q=')"/>
+                select="concat(substring($gurl, 1, string-length($gurl)-4), '/api/registries/vocabularies/search?_content_type=xml&amp;q=')"/>
 
 
 

--- a/schemas/iso19139/src/main/plugin/iso19139/process/add-extent-from-geokeywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/add-extent-from-geokeywords.xsl
@@ -61,7 +61,7 @@
   <xsl:variable name="replaceMode"
                 select="geonet:parseBoolean($replace)"/>
   <xsl:variable name="serviceUrl"
-                select="concat($gurl, 'keywords?pNewSearch=true&amp;pTypeSearch=2&amp;pKeyword=')"/>
+                select="concat(substring($gurl, 1, string-length($gurl)-4), 'api/registries/vocabularies/search?_content_type=xml&amp;q=')"/>
 
 
   <xsl:template name="list-add-extent-from-geokeywords">
@@ -241,7 +241,7 @@
       <xsl:variable name="keyword" select="document(concat($serviceUrl, encode-for-uri($word)))"/>
       <!-- It should be one but if one keyword is found in more
           thant one thesaurus, then each will be processed.-->
-      <xsl:for-each select="$keyword/response/descKeys/keyword">
+      <xsl:for-each select="$keyword/response/keyword">
         <xsl:if test="geo">
           <xsl:choose>
             <xsl:when test="$srv">

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -330,7 +330,7 @@ public class KeywordsApi {
         nickname = "searchKeywordsXml",
         notes = "")
     @RequestMapping(
-        path = "/search.xml",
+        path = {"/search", "/search.xml"},
         method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_XML_VALUE,

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -308,7 +308,135 @@ public class KeywordsApi {
         return searcher.getResults();
     }
 
-
+    /**
+     * Search keywords.
+     *
+     * @param q the q
+     * @param lang the lang
+     * @param rows the rows
+     * @param start the start
+     * @param targetLangs the target langs
+     * @param thesaurus the thesaurus
+     * @param type the type
+     * @param uri the uri
+     * @param sort the sort
+     * @param request the request
+     * @param httpSession the http session
+     * @return the list
+     * @throws Exception the exception
+     */
+    @ApiOperation(
+        value = "Search keywords (XML)",
+        nickname = "searchKeywordsXml",
+        notes = "")
+    @RequestMapping(
+        path = "/search.xml",
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.APPLICATION_XML_VALUE,
+        })
+    @ResponseStatus(
+        value = HttpStatus.OK)
+    @ResponseBody
+    public Element searchKeywordsXML(
+        @ApiParam(
+            value = "Query",
+            required = false
+        )
+        @RequestParam(
+            required = false
+        )
+            String q,
+        @ApiParam(
+            value = "Query in that language",
+            required = false
+        )
+        @RequestParam(
+            value = "lang",
+            defaultValue = "eng"
+        )
+            String lang,
+        @ApiParam(
+            value = "Number of rows",
+            required = false
+        )
+        @RequestParam(
+            required = false,
+            defaultValue = "1000"
+        )
+            int rows,
+        @ApiParam(
+            value = "Start from",
+            required = false
+        )
+        @RequestParam(
+            defaultValue = "0",
+            required = false
+        )
+            int start,
+        @ApiParam(
+            value = "Return keyword information in one or more languages",
+            required = false
+        )
+        @RequestParam(
+            value = XmlParams.pLang,
+            required = false
+        )
+            List<String> targetLangs,
+        @ApiParam(
+            value = "Thesaurus identifier",
+            required = false
+        )
+        @RequestParam(
+            required = false
+        )
+            String[] thesaurus,
+        //        @ApiParam(
+        //            value = "?",
+        //            required = false
+        //        )
+        //        @RequestParam(
+        //            required = false
+        //        )
+        //            String thesauriDomainName,
+        @ApiParam(
+            value = "Type of search",
+            required = false
+        )
+        @RequestParam(
+            defaultValue = "CONTAINS"
+        )
+            KeywordSearchType type,
+        @ApiParam(
+            value = "URI query",
+            required = false
+        )
+        @RequestParam(
+            required = false
+        )
+            String uri,
+        @ApiParam(
+            value = "Sort by",
+            required = false
+        )
+        @RequestParam(
+            required = false,
+            defaultValue = "DESC"
+        )
+            String sort,
+        @ApiIgnore
+            HttpServletRequest request,
+        @ApiIgnore
+        @ApiParam(hidden = true)
+            HttpSession httpSession
+    ) throws Exception {
+        List<KeywordBean> keywords = searchKeywords(q, lang, rows, start, targetLangs, thesaurus, type, uri, sort, request, httpSession);
+        Element root = new Element("response");
+        for (KeywordBean kw : keywords) {
+            root.addContent(kw.toElement("eng")); // FIXME: Localize
+        }
+        return root;
+    }
 
     /** The mapper. */
     @Autowired

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -102,6 +102,8 @@ import springfox.documentation.annotations.ApiIgnore;
 
 import net.sf.json.JSON;
 
+import static org.fao.geonet.constants.Params.CONTENT_TYPE;
+
 
 /**
  * The Class KeywordsApi.
@@ -167,12 +169,13 @@ public class KeywordsApi {
         path = "/search",
         method = RequestMethod.GET,
         produces = {
-            MediaType.APPLICATION_JSON_VALUE
+            MediaType.APPLICATION_JSON_VALUE,
+            MediaType.APPLICATION_XML_VALUE
         })
     @ResponseStatus(
         value = HttpStatus.OK)
     @ResponseBody
-    public List<KeywordBean> searchKeywords(
+    public Object searchKeywords(
         @ApiParam(
             value = "Query",
             required = false
@@ -264,7 +267,9 @@ public class KeywordsApi {
             @ApiParam(hidden = true)
         HttpSession httpSession
     )
-        throws Exception {ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
+        throws Exception {
+
+        ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
         UserSession session = ApiUtils.getUserSession(httpSession);
 
@@ -303,139 +308,17 @@ public class KeywordsApi {
         session.setProperty(Geonet.Session.SEARCH_KEYWORDS_RESULT,
             searcher);
 
+        List<KeywordBean> keywords = searcher.getResults();
 
-        // get the results
-        return searcher.getResults();
-    }
-
-    /**
-     * Search keywords.
-     *
-     * @param q the q
-     * @param lang the lang
-     * @param rows the rows
-     * @param start the start
-     * @param targetLangs the target langs
-     * @param thesaurus the thesaurus
-     * @param type the type
-     * @param uri the uri
-     * @param sort the sort
-     * @param request the request
-     * @param httpSession the http session
-     * @return the list
-     * @throws Exception the exception
-     */
-    @ApiOperation(
-        value = "Search keywords (XML)",
-        nickname = "searchKeywordsXml",
-        notes = "")
-    @RequestMapping(
-        path = "/search",
-        method = RequestMethod.GET,
-        produces = {
-            MediaType.APPLICATION_XML_VALUE,
-        })
-    @ResponseStatus(
-        value = HttpStatus.OK)
-    @ResponseBody
-    public Element searchKeywordsXML(
-        @ApiParam(
-            value = "Query",
-            required = false
-        )
-        @RequestParam(
-            required = false
-        )
-            String q,
-        @ApiParam(
-            value = "Query in that language",
-            required = false
-        )
-        @RequestParam(
-            value = "lang",
-            defaultValue = "eng"
-        )
-            String lang,
-        @ApiParam(
-            value = "Number of rows",
-            required = false
-        )
-        @RequestParam(
-            required = false,
-            defaultValue = "1000"
-        )
-            int rows,
-        @ApiParam(
-            value = "Start from",
-            required = false
-        )
-        @RequestParam(
-            defaultValue = "0",
-            required = false
-        )
-            int start,
-        @ApiParam(
-            value = "Return keyword information in one or more languages",
-            required = false
-        )
-        @RequestParam(
-            value = XmlParams.pLang,
-            required = false
-        )
-            List<String> targetLangs,
-        @ApiParam(
-            value = "Thesaurus identifier",
-            required = false
-        )
-        @RequestParam(
-            required = false
-        )
-            String[] thesaurus,
-        //        @ApiParam(
-        //            value = "?",
-        //            required = false
-        //        )
-        //        @RequestParam(
-        //            required = false
-        //        )
-        //            String thesauriDomainName,
-        @ApiParam(
-            value = "Type of search",
-            required = false
-        )
-        @RequestParam(
-            defaultValue = "CONTAINS"
-        )
-            KeywordSearchType type,
-        @ApiParam(
-            value = "URI query",
-            required = false
-        )
-        @RequestParam(
-            required = false
-        )
-            String uri,
-        @ApiParam(
-            value = "Sort by",
-            required = false
-        )
-        @RequestParam(
-            required = false,
-            defaultValue = "DESC"
-        )
-            String sort,
-        @ApiIgnore
-            HttpServletRequest request,
-        @ApiIgnore
-        @ApiParam(hidden = true)
-            HttpSession httpSession
-    ) throws Exception {
-        List<KeywordBean> keywords = searchKeywords(q, lang, rows, start, targetLangs, thesaurus, type, uri, sort, request, httpSession);
-        Element root = new Element("response");
-        for (KeywordBean kw : keywords) {
-            root.addContent(kw.toElement("eng")); // FIXME: Localize
+        if ("xml".equals(request.getParameter(CONTENT_TYPE))) {
+            Element root = new Element("response");
+            for (KeywordBean kw : keywords) {
+                root.addContent(kw.toElement("eng")); // FIXME: Localize
+            }
+            return root;
+        } else {
+            return keywords;
         }
-        return root;
     }
 
     /** The mapper. */

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -330,7 +330,7 @@ public class KeywordsApi {
         nickname = "searchKeywordsXml",
         notes = "")
     @RequestMapping(
-        path = {"/search", "/search.xml"},
+        path = "/search",
         method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_XML_VALUE,


### PR DESCRIPTION
The XSLT powering this button from the geonetwork editor called out to the geonetwork API. This API being called has switched to responding with JSON which XSLT doesn't understand.

This pull request restores a working XML endpoint for it to call. Content negotiation was attempted, but we found this doesn't work with the relevant XSLT processor.