### PR TITLE
Add option for PNG images to mcc:fileType 'Recommended values'

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
@@ -2866,6 +2866,7 @@
       <option value="EPS">EPS</option>
       <option value="GIF">GIF</option>
       <option value="JPEG">JPEG</option>
+      <option value="PNG">PNG</option>
       <option value="PBM">PBM</option>
       <option value="PS">PS</option>
       <option value="TIFF">TIFF</option>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/labels.xml
@@ -4665,6 +4665,7 @@ période de temps couverte par le service.
       <option value="PNG">PNG</option>
       <option value="GIF">GIF</option>
       <option value="JPEG">JPEG</option>
+      <option value="PNG">PNG</option>
       <option value="EPS">EPS</option>
       <option value="PBM">PBM</option>
       <option value="PS">PS</option>


### PR DESCRIPTION
Because PNG is a very common image filetype. Implemented as a minor change to the iso19115-3.2018 localization files.