### PR TITLE
Update Thesaurus keywords to ISO19115-3.2018

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -646,7 +646,7 @@
                 });
               var init = function() {
                 var schema = attrs['schema'] ||
-                    gnCurrentEdit.schema || 'iso19139';
+                    gnCurrentEdit.schema || 'iso19115-3.2018';
                 var config = schema + '|' + attrs['gnSchemaInfo'] + '|||';
 
                 scope.type = attrs['schemaInfoCombo'];

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -125,7 +125,7 @@
               <div data-ng-disabled="!isNew()"
                   data-schema-info-combo="codelist"
                   data-selected-info="thesaurusSelected.dname"
-                  data-gn-schema-info="gmd:MD_KeywordTypeCode"
+                  data-gn-schema-info="mri:MD_KeywordTypeCode"
                   data-init-on-load="true"
                   lang="lang"></div>
             </div>
@@ -328,7 +328,7 @@
             <div
               data-schema-info-combo="codelist"
               data-selected-info="thesaurusImportType"
-              data-gn-schema-info="gmd:MD_KeywordTypeCode"
+              data-gn-schema-info="mri:MD_KeywordTypeCode"
               lang="lang"></div>
             <input type="text" class="hidden" name="dir" data-ng-model="thesaurusImportType"/>
             <ul>
@@ -372,7 +372,7 @@
               <div
                 data-schema-info-combo="codelist"
                 data-selected-info="thesaurusSelected.dname"
-                data-gn-schema-info="gmd:MD_KeywordTypeCode"
+                data-gn-schema-info="mri:MD_KeywordTypeCode"
                 lang="lang"></div>
             </div>
 


### PR DESCRIPTION
This fixes the thesaurus UI to use keywords from ISO19115-3.2018 `mri:MD_KeywordTypeCode` rather than ISO19139 `gmd:MD_KeywordTypeCode`.