### PR TITLE
Fix parse of logo upload in groups management when the content type includes the charset encoding

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -589,7 +589,7 @@
         var contentType = req.getResponseHeader('Content-Type');
         var errorText = req.responseText;
         var errorCode = null;
-        if ('application/json' === contentType) {
+        if (contentType && (contentType.indexOf('application/json') == 0)) {
           var parsedError = JSON.parse(req.responseText);
         }
         $rootScope.$broadcast('StatusUpdated', {


### PR DESCRIPTION
If the content type includes the charset, the error was not parsed properly, displaying the following error message:

<img width="539" alt="logo-upload-error-message" src="https://user-images.githubusercontent.com/1695003/109501698-423f6280-7a98-11eb-9baa-126eb8f798a3.png">
