### PR TITLE
Stream attachments to the browser without loading them in memory

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * ===	Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * ===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
  * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * ===	and United Nations Environment Programme (UNEP)
  * ===
@@ -25,9 +25,15 @@
 
 package org.fao.geonet.api.records.attachments;
 
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -38,13 +44,11 @@ import org.fao.geonet.domain.MetadataResourceVisibilityConverter;
 import org.fao.geonet.events.history.AttachmentAddedEvent;
 import org.fao.geonet.events.history.AttachmentDeletedEvent;
 import org.springframework.context.ApplicationContext;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -57,14 +61,15 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import springfox.documentation.annotations.ApiIgnore;
 
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-
-import javax.annotation.PostConstruct;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Metadata resource related operations.
@@ -95,7 +100,7 @@ public class AttachmentsApi {
     public static String getFileContentType(Path file) throws IOException {
         String contentType = Files.probeContentType(file);
         if (contentType == null) {
-            String ext = com.google.common.io.Files.getFileExtension(file.getFileName().toString()).toLowerCase();
+            String ext = FilenameUtils.getExtension(file.getFileName().toString()).toLowerCase();
             switch (ext) {
             case "png":
             case "gif":
@@ -142,7 +147,10 @@ public class AttachmentsApi {
         return null;
     }
 
-    @ApiOperation(value = "List all metadata attachments", notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/associating-resources/using-filestore.html'>More info</a>", nickname = "getAllMetadataResources")
+    @ApiOperation(
+            value = "List all metadata attachments",
+            notes = "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/associating-resources/using-filestore.html'>More info</a>",
+            nickname = "getAllMetadataResources")
     @RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(value = HttpStatus.OK)
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Return the record attachments."),
@@ -159,7 +167,9 @@ public class AttachmentsApi {
         return list;
     }
 
-    @ApiOperation(value = "Delete all uploaded metadata resources", nickname = "deleteAllMetadataResources")
+    @ApiOperation(
+            value = "Delete all uploaded metadata resources",
+            nickname = "deleteAllMetadataResources")
     @RequestMapping(method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasRole('Editor')")
     @ApiResponses(value = { @ApiResponse(code = 204, message = "Attachment added."),
@@ -176,12 +186,13 @@ public class AttachmentsApi {
         if (metadataIdString != null) {
             long metadataId = Long.parseLong(metadataIdString);
             UserSession userSession = ApiUtils.getUserSession(request.getSession());
-            new AttachmentDeletedEvent(metadataId, userSession.getUserIdAsInt(), "All attachments")
-                    .publish(ApplicationContextHolder.get());
+            new AttachmentDeletedEvent(metadataId, userSession.getUserIdAsInt(), "All attachments").publish(ApplicationContextHolder.get());
         }
     }
 
-    @ApiOperation(value = "Create a new resource for a given metadata", nickname = "putResourceFromFile")
+    @ApiOperation(
+            value = "Create a new resource for a given metadata",
+            nickname = "putResourceFromFile")
     @PreAuthorize("hasRole('Editor')")
     @RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(value = HttpStatus.CREATED)
@@ -208,7 +219,10 @@ public class AttachmentsApi {
         return resource;
     }
 
-    @ApiOperation(value = "Create a new resource from a URL for a given metadata", nickname = "putResourcesFromURL", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation(
+            value = "Create a new resource from a URL for a given metadata",
+            nickname = "putResourcesFromURL",
+            produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasRole('Editor')")
     @RequestMapping(method = RequestMethod.PUT)
     @ResponseStatus(value = HttpStatus.CREATED)
@@ -220,7 +234,7 @@ public class AttachmentsApi {
             @ApiParam(value = "The sharing policy", example = "public") @RequestParam(required = false, defaultValue = "public") MetadataResourceVisibility visibility,
             @ApiParam(value = "The URL to load in the store") @RequestParam("url") URL url,
             @ApiParam(value = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "false") Boolean approved,
-           @ApiIgnore HttpServletRequest request) throws Exception {
+            @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
         MetadataResource resource = store.putResource(context, metadataUuid, url, visibility, approved);
 
@@ -228,41 +242,42 @@ public class AttachmentsApi {
         if (metadataIdString != null && url != null) {
             long metadataId = Long.parseLong(metadataIdString);
             UserSession userSession = ApiUtils.getUserSession(request.getSession());
-            new AttachmentAddedEvent(metadataId, userSession.getUserIdAsInt(), url.toString())
-                    .publish(ApplicationContextHolder.get());
+            new AttachmentAddedEvent(metadataId, userSession.getUserIdAsInt(), url.toString()).publish(ApplicationContextHolder.get());
         }
 
         return resource;
     }
 
-    @ApiOperation(value = "Get a metadata resource", nickname = "getResource")
+    @ApiOperation(
+            value = "Get a metadata resource",
+            nickname = "getResource")
     // @PreAuthorize("permitAll")
     @RequestMapping(value = "/{resourceId:.+}", method = RequestMethod.GET)
-    @ResponseStatus(value = HttpStatus.OK)
     @ApiResponses(value = { @ApiResponse(code = 201, message = "Record attachment."),
-            @ApiResponse(code = 403, message = "Operation not allowed. "
-                    + "User needs to be able to download the resource.") })
-    @ResponseBody
-    public HttpEntity<byte[]> getResource(
+            @ApiResponse(code = 403, message = "Operation not allowed. " + "User needs to be able to download the resource.") })
+    public void getResource(
             @ApiParam(value = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
             @ApiParam(value = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
             @ApiParam(value = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "true") Boolean approved,
-            @ApiIgnore HttpServletRequest request) throws Exception {
+            @ApiIgnore HttpServletRequest request, @ApiIgnore HttpServletResponse response) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
         try (Store.ResourceHolder file = store.getResource(context, metadataUuid, resourceId, approved)) {
 
             ApiUtils.canViewRecord(metadataUuid, request);
 
-            MultiValueMap<String, String> headers = new HttpHeaders();
-            headers.add("Content-Disposition", "inline; filename=\"" + file.getMetadata().getFilename() + "\"");
-            headers.add("Cache-Control", "no-cache");
-            headers.add("Content-Type", getFileContentType(file.getPath()));
-
-            return new HttpEntity<>(Files.readAllBytes(file.getPath()), headers);
+            response.addHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + file.getMetadata().getFilename() + "\"");
+            response.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
+            response.setContentType(getFileContentType(file.getPath()));
+            response.setContentLengthLong(Files.size(file.getPath()));
+            response.setStatus(HttpStatus.OK.value());
+            ServletOutputStream outputStream = response.getOutputStream();
+            FileUtils.copyFile(file.getPath().toFile(), outputStream);
         }
     }
 
-    @ApiOperation(value = "Update the metadata resource visibility", nickname = "patchMetadataResourceVisibility")
+    @ApiOperation(
+            value = "Update the metadata resource visibility",
+            nickname = "patchMetadataResourceVisibility")
     @PreAuthorize("hasRole('Editor')")
     @ApiResponses(value = { @ApiResponse(code = 201, message = "Attachment visibility updated."),
             @ApiResponse(code = 403, message = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT) })
@@ -279,7 +294,9 @@ public class AttachmentsApi {
         return store.patchResourceStatus(context, metadataUuid, resourceId, visibility, approved);
     }
 
-    @ApiOperation(value = "Delete a metadata resource", nickname = "deleteMetadataResource")
+    @ApiOperation(
+            value = "Delete a metadata resource",
+            nickname = "deleteMetadataResource")
     @PreAuthorize("hasRole('Editor')")
     @RequestMapping(value = "/{resourceId:.+}", method = RequestMethod.DELETE)
     @ApiResponses(value = { @ApiResponse(code = 204, message = "Attachment visibility removed."),
@@ -289,7 +306,7 @@ public class AttachmentsApi {
             @ApiParam(value = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
             @ApiParam(value = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
             @ApiParam(value = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "false") Boolean approved,
-           @ApiIgnore HttpServletRequest request) throws Exception {
+            @ApiIgnore HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
         store.delResource(context, metadataUuid, resourceId, approved);
 
@@ -297,8 +314,7 @@ public class AttachmentsApi {
         if (metadataIdString != null) {
             long metadataId = Long.parseLong(metadataIdString);
             UserSession userSession = ApiUtils.getUserSession(request.getSession());
-            new AttachmentDeletedEvent(metadataId, userSession.getUserIdAsInt(), resourceId)
-                    .publish(ApplicationContextHolder.get());
+            new AttachmentDeletedEvent(metadataId, userSession.getUserIdAsInt(), resourceId).publish(ApplicationContextHolder.get());
         }
     }
 }


### PR DESCRIPTION
Send the attachment content to the client directly without loading the full file in memory first. Also send the `Content-Length` header.

Fixes #5449.