### PR TITLE
Keep tabs at top.

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -605,3 +605,23 @@ form.gn-editor.gn-indent-bluescale {
 
   }
 }
+
+// keep tabs onscreen
+.nav-tabs {
+  position: fixed;
+  height: 50px;
+  left: 80px;
+  background-color: #f0ffff;
+  z-index: 1;
+}
+
+form.gn-editor div[data-gn-toggle] {
+  position: sticky;
+  width: 80px; height: 80px;
+  top: 80px;
+  z-index: 1;
+}
+
+.gn-editor-sidebar {
+  margin-top: 80px;
+}


### PR DESCRIPTION
This keeps the tabs always within reach no matter how far down the page you scroll. Design feedback appreciated!