### PR TITLE
Editor / List formats as protocols.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
@@ -221,36 +221,6 @@
       },
       {
         "group": "onlineDiscover",
-        "label": "onlineDiscoverKML",
-        "copyLabel": "name",
-        "sources": {
-          "filestore": true
-        },
-        "icon": "fa gn-icon-onlinesrc",
-        "process": "onlinesrc-add",
-        "fields": {
-          "url": {},
-          "protocol": {
-            "value": "WWW:LINK",
-            "hidden": true,
-            "isMultilingual": false
-          },
-          "name": {},
-          "desc": {},
-          "function": {
-            "value": "browsing",
-            "hidden": true,
-            "isMultilingual": false
-          },
-          "applicationProfile": {
-            "value": "application/vnd.google-earth.kml+xml",
-            "hidden": true,
-            "isMultilingual": false
-          }
-        }
-      },
-      {
-        "group": "onlineDiscover",
         "label": "onlineDiscoverMap",
         "copyLabel": "name",
         "sources": {
@@ -271,33 +241,6 @@
           "desc": {},
           "function": {
             "value": "browsing",
-            "hidden": true,
-            "isMultilingual": false
-          }
-        }
-      },
-      {
-        "group": "onlineDownload",
-        "label": "onlineDownloadFile",
-        "copyLabel": "name",
-        "sources": {
-          "filestore": true
-        },
-        "icon": "fa gn-icon-onlinesrc",
-        "process": "onlinesrc-add",
-        "fields": {
-          "url": {
-            "isMultilingual": false
-          },
-          "protocol": {
-            "value": "WWW:LINK",
-            "hidden": true,
-            "isMultilingual": false
-          },
-          "name": {},
-          "desc": {},
-          "function": {
-            "value": "download",
             "hidden": true,
             "isMultilingual": false
           }
@@ -326,38 +269,6 @@
           "desc": {},
           "function": {
             "value": "download",
-            "hidden": true,
-            "isMultilingual": false
-          }
-        }
-      },
-      {
-        "group": "onlineDownload",
-        "label": "onlineDownloadKML",
-        "copyLabel": "name",
-        "sources": {
-          "filestore": true
-        },
-        "icon": "fa gn-icon-onlinesrc",
-        "process": "onlinesrc-add",
-        "fields": {
-          "url": {
-            "isMultilingual": false
-          },
-          "protocol": {
-            "value": "WWW:LINK",
-            "hidden": true,
-            "isMultilingual": false
-          },
-          "name": {},
-          "desc": {},
-          "function": {
-            "value": "download",
-            "hidden": true,
-            "isMultilingual": false
-          },
-          "applicationProfile": {
-            "value": "application/vnd.google-earth.kml+xml",
             "hidden": true,
             "isMultilingual": false
           }

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
@@ -305,6 +305,34 @@
       },
       {
         "group": "onlineDownload",
+        "extendWithDataFormats": true,
+        "label": "onlineDownload",
+        "copyLabel": "name",
+        "sources": {
+          "filestore": true
+        },
+        "icon": "fa gn-icon-onlinesrc",
+        "process": "onlinesrc-add",
+        "fields": {
+          "url": {
+            "isMultilingual": false
+          },
+          "protocol": {
+            "value": "WWW:DOWNLOAD:",
+            "hidden": true,
+            "isMultilingual": false
+          },
+          "name": {},
+          "desc": {},
+          "function": {
+            "value": "download",
+            "hidden": true,
+            "isMultilingual": false
+          }
+        }
+      },
+      {
+        "group": "onlineDownload",
         "label": "onlineDownloadKML",
         "copyLabel": "name",
         "sources": {

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl.xsl
@@ -15,9 +15,11 @@
   xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0"
   xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
   xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+  xmlns:gn-fn-index="http://geonetwork-opensource.org/xsl/functions/index"
   xmlns:gn="http://www.fao.org/geonetwork"
   xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
 
+  <xsl:import href="common/index-utils.xsl"/>
   <xsl:include href="utility-tpl-multilingual.xsl"/>
 
   <xsl:template name="get-iso19115-3.2018-is-service">
@@ -28,6 +30,17 @@
   <xsl:template name="get-iso19115-3.2018-title">
     <xsl:value-of select="$metadata/mdb:identificationInfo/*/mri:citation/*/cit:title/gco:CharacterString"/>
   </xsl:template>
+
+  <xsl:template mode="get-formats-as-json" match="mdb:MD_Metadata">
+    [
+    <xsl:for-each select="mdb:distributionInfo/*/mrd:distributionFormat/*/mrd:formatSpecificationCitation/*/cit:title/*/text()">{
+      "value": "WWW:DOWNLOAD:<xsl:value-of select="gn-fn-index:json-escape(.)"/>",
+      "label": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"}
+      <xsl:if test="position() != last()">,</xsl:if>
+    </xsl:for-each>
+    ]
+  </xsl:template>
+
 
   <xsl:template name="get-iso19115-3.2018-extents-as-json">[
    <xsl:for-each select="//mdb:identificationInfo/*/mri:extent

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl.xsl
@@ -22,14 +22,17 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:gmd="http://www.isotc211.org/2005/gmd"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:gn-fn-index="http://geonetwork-opensource.org/xsl/functions/index"
                 xmlns:gn="http://www.fao.org/geonetwork"
                 version="2.0"
                 exclude-result-prefixes="#all">
 
+  <xsl:import href="common/index-utils.xsl"/>
   <xsl:include href="utility-tpl-multilingual.xsl"/>
 
   <xsl:template name="get-iso19139-is-service">
@@ -41,6 +44,15 @@
     <xsl:value-of select="$metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title/gco:CharacterString"/>
   </xsl:template>
 
+  <xsl:template mode="get-formats-as-json" match="gmd:MD_Metadata">
+    [
+    <xsl:for-each select="gmd:distributionInfo/*/gmd:distributionFormat/*/gmd:name/*/text()">{
+      "value": "WWW:DOWNLOAD:<xsl:value-of select="gn-fn-index:json-escape(.)"/>",
+      "label": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"}
+      <xsl:if test="position() != last()">,</xsl:if>
+    </xsl:for-each>
+    ]
+  </xsl:template>
 
   <xsl:template name="get-iso19139-extents-as-json">[
     <xsl:for-each select="//gmd:geographicElement/gmd:EX_GeographicBoundingBox[

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -508,6 +508,7 @@
                 scope.layers = null;
                 scope.mapId = 'gn-thumbnail-maker-map';
                 scope.map = null;
+                scope.dataFormats = null;
 
                 scope.searchObj = {
                   internal: true,
@@ -713,6 +714,8 @@
                       getTypeConfig(linkToEdit) :
                       getType(linkType);
 
+                    scope.dataFormats = gnCurrentEdit.dataFormats;
+
                     if (gnCurrentEdit.mdOtherLanguages) {
                        scope.mdOtherLanguages = gnCurrentEdit.mdOtherLanguages;
                        scope.mdLangs = JSON.parse(scope.mdOtherLanguages);
@@ -834,7 +837,25 @@
                     gnSchemaManagerService.getEditorAssociationPanelConfig(
                       gnCurrentEdit.schema,
                       gnCurrentEdit.associatedPanelConfigId).then(function (r) {
-                      scope.config = r.config;
+                      scope.config = angular.copy(r.config);
+                      scope.config.types = [];
+                      for (var i = 0; i < r.config.types.length; i ++) {
+                        var c = r.config.types[i];
+                        if (c.extendWithDataFormats) {
+                          console.log(scope.gnCurrentEdit.dataFormats);
+                          for (var j = 0; j < scope.gnCurrentEdit.dataFormats.length; j ++) {
+                            var f = scope.gnCurrentEdit.dataFormats[j],
+                              option = angular.copy(c);
+
+                            option.label = f.label;
+                            option.fields.protocol.value = f.value;
+                            scope.config.types.push(option);
+                          }
+                        } else {
+                          scope.config.types.push(c);
+                        }
+                      }
+
 
                       if (withInit) {
                         init();

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -842,12 +842,12 @@
                       for (var i = 0; i < r.config.types.length; i ++) {
                         var c = r.config.types[i];
                         if (c.extendWithDataFormats) {
-                          console.log(scope.gnCurrentEdit.dataFormats);
+                          var labelPrefix = $translate.instant('recordFormatDownload');
                           for (var j = 0; j < scope.gnCurrentEdit.dataFormats.length; j ++) {
                             var f = scope.gnCurrentEdit.dataFormats[j],
                               option = angular.copy(c);
 
-                            option.label = f.label;
+                            option.label = labelPrefix + f.label;
                             option.fields.protocol.value = f.value;
                             scope.config.types.push(option);
                           }
@@ -1140,6 +1140,11 @@
                       // Those parameters are object.
                       scope.params.name = '';
                       scope.params.desc = '';
+                    }
+                    if (scope.params.function === ''
+                      && scope.params.protocol
+                      && scope.params.protocol.indexOf('DOWNLOAD') !== -1) {
+                      scope.params.function = 'download';
                     }
                     scope.loadCurrentLink();
                   }

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -91,7 +91,8 @@
                      name="protocol"
                      data-selected-info="params.protocol"
                      data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.protocol.tooltip}}"
-                     data-gn-schema-info="protocol" lang="lang"></div>
+                     data-gn-schema-info="protocol" lang="lang"
+                     data-extra-options="dataFormats"></div>
               </div>
 
               <div class="col-sm-1 gn-control"></div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -65,6 +65,7 @@
                      data-schema-info-combo="codelist"
                      name="function"
                      data-init-on-load="true"
+                     data-allow-blank="true"
                      data-selected-info="params.function"
                      data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.function.tooltip}}"
                      data-gn-schema-info="function" lang="lang"></div>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -276,6 +276,15 @@
               scope.getTitle = function(link) {
                 return link.title['#text'] || link.title;
               };
+              scope.getBadgeLabel = function(mainType, r) {
+                if (r.protocol && r.protocol.indexOf('WWW:DOWNLOAD:') >= 0) {
+                  return r.protocol.replace('WWW:DOWNLOAD:', '');
+                } else if (mainType.match(/W([MCF]|MT)S.*|ESRI:REST/)) {
+                  return mainType.replace('SERVICE', '');
+                } else {
+                  return '';
+                }
+              };
               scope.hasAction = function(mainType) {
                 var fn = gnRelatedResources.map[mainType].action;
                 // If function name ends with ToMap do not display the action

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -387,6 +387,19 @@
                 } else {
                   return 'WMSSERVICE';
                 }
+              } else if (protocolOrType.match(/download/i)) {
+                var url = $filter('gnLocalized')(resource.url) || resource.url;
+                if (url.match(/zip/i)) {
+                  return 'LINKDOWNLOAD-ZIP';
+                } else if (url.match(/pdf/i)) {
+                  return 'LINKDOWNLOAD-PDF';
+                } else if (url.match(/xml/i)) {
+                  return 'LINKDOWNLOAD-XML';
+                } else if (url.match(/rdf/i)) {
+                  return 'LINKDOWNLOAD-RDF';
+                } else {
+                  return 'LINKDOWNLOAD';
+                }
               } else if (protocolOrType.match(/esri/i)) {
                 return 'ESRI:REST';
               } else if (protocolOrType.match(/wmts/i)) {
@@ -411,19 +424,6 @@
                 return 'KML';
               } else if (protocolOrType.match(/geojson/i)) {
                 return 'GEOJSON';
-              } else if (protocolOrType.match(/download/i)) {
-                var url = $filter('gnLocalized')(resource.url) || resource.url;
-                if (url.match(/zip/i)) {
-                  return 'LINKDOWNLOAD-ZIP';
-                } else if (url.match(/pdf/i)) {
-                  return 'LINKDOWNLOAD-PDF';
-                } else if (url.match(/xml/i)) {
-                  return 'LINKDOWNLOAD-XML';
-                } else if (url.match(/rdf/i)) {
-                  return 'LINKDOWNLOAD-RDF';
-                } else {
-                  return 'LINKDOWNLOAD';
-                }
               } else if (protocolOrType.match(/dataset/i)) {
                 return 'LINKDOWNLOAD';
               } else if (protocolOrType.match(/link/i)) {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -5,27 +5,25 @@
   <div class=""
        data-ng-repeat="(type, items) in relations track by $index"
        data-ng-if="type && type !== 'thumbnails'">
-    <div data-ng-init="mainType = config.getType(r, type);"
+    <div data-ng-init="mainType = config.getType(r, type);
+                       badge = getBadgeLabel(mainType, r);
+                       icon = config.getClassIcon(mainType);"
          class="row list-group-item gn-related-item gn-related-{{type}} gn-relation-type-{{mainType}}"
          data-ng-repeat="r in items track by $index">
-      <div class="col-xs-1 col-sm-1">
-        <!-- OWS have their name overlaid over the globe icon -->
-        <strong data-ng-if="(mainType === 'WMS') || (mainType === 'WMSSERVICE') || (mainType === 'WMTS') ||
-                            (mainType === 'WMTSSERVICE') || (mainType === 'WFS') || (mainType === 'WCS')">
-          <span class="fa-stack fa-1x">
-            <i class="fa fa-globe fa-stack-2x" style="opacity: 0.55;"></i>
-            <span class="fa fa-stack-1x">
-              <strong style="font-size:10px;">{{mainType.replace('SERVICE', '')}}</strong>
-            </span>
-          </span>
-        </strong>
-        <strong data-ng-if="(mainType !== 'WMS') && (mainType !== 'WMSSERVICE') && (mainType !== 'WMTS') &&
-                            (mainType !== 'WMTSSERVICE') && (mainType !== 'WFS') && (mainType !== 'WCS')">
-          <i class="fa"
-             data-ng-class="config.getClassIcon(mainType)"/>&nbsp;
+      <div class="gn-related-icon-col col-xs-2 col-sm-2 text-center">
+        <strong>
+          <div class="clearfix">
+            <i class="fa"
+               data-ng-class="icon"/>
+          </div>
+          <span data-ng-if="badge != ''"
+                class="label label-default"
+                data-ng-class="{
+                  'label-primary': icon === 'fa-download' || icon === 'fa-file-pdf-o',
+                  'label-success': icon === 'fa-globe'}">{{badge}}</span>
         </strong>
       </div>
-      <div data-ng-class="mainType === 'MDFCATS' ? 'col-xs-11' : 'col-xs-8 col-sm-8'">
+      <div data-ng-class="mainType === 'MDFCATS' ? 'col-xs-11' : 'col-xs-7 col-sm-7'">
         <!-- Always display title if available -->
         <h3 data-ng-if="::(r.title | gnLocalized: lang).length">{{::(r.title | gnLocalized: lang)}}</h3>
         <!-- Display description if available -->

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -368,6 +368,14 @@
                'Failed to parse the following extent as JSON: ' +
                value);
              }
+             var dataFormats = [], value = getInputValue('dataformats');
+             try {
+               dataFormats = angular.fromJson(value);
+             } catch (e) {
+               console.warn(
+               'Failed to parse the following dataformats as JSON: ' +
+               value);
+             }
              angular.extend(gnCurrentEdit, {
                isService: getInputValue('isService') == 'true',
                isTemplate: getInputValue('template'),
@@ -389,6 +397,7 @@
                geoPublisherConfig:
                angular.fromJson(getInputValue('geoPublisherConfig')),
                extent: extent,
+               dataFormats: dataFormats,
                isMinor: getInputValue('minor') === 'true',
                layerConfig:
                angular.fromJson(getInputValue('layerConfig')),

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -588,9 +588,9 @@
    * the gnCurrentEdit object or 'iso19139' if not defined.
    */
       .directive('schemaInfoCombo', ['$http', 'gnSchemaManagerService',
-        'gnCurrentEdit',
+        'gnCurrentEdit', '$translate',
         function($http, gnSchemaManagerService,
-                 gnCurrentEdit) {
+                 gnCurrentEdit, $translate) {
           return {
             restrict: 'A',
             replace: true,
@@ -657,9 +657,9 @@
               function appendExtraOptions() {
                 if(baseList && angular.isArray(scope.extraOptions)) {
                   scope.extraOptions.unshift({
-                    value: '', label: 'recordFormats', disabled: true});
+                    value: '', label: $translate.instant('recordFormats'), disabled: true});
                   scope.extraOptions.push({
-                    value: '', label: 'protocols', disabled: true})
+                    value: '', label: $translate.instant('commonProtocols'), disabled: true})
                   scope.infos = scope.extraOptions.concat(baseList);
                 }
               }

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -610,17 +610,28 @@
               var allowBlank = attrs['allowBlank'] == true;
 
               var addBlankValueAndSetDefault = function() {
-                var blank = {label: '', code: ''};
+                var blank = {label: '', code: ''},
+                    isCurrentValueInList = false;
                 if (scope.infos != null && scope.infos.length &&
                     allowBlank) {
                   scope.infos.unshift(blank);
                 }
                 // Search default value
                 angular.forEach(scope.infos, function(h) {
+                  var id = h.code || h.value; // codelist or helper
                   if (h.isDefault === true) {
-                    defaultValue = h.code;
+                    defaultValue = id;
+                  }
+                  if (scope.selectedInfo != ''
+                    && id === scope.selectedInfo) {
+                    isCurrentValueInList = true;
                   }
                 });
+
+                // Add an option if the current value is not in the list
+                if(scope.infos && !isCurrentValueInList) {
+                  scope.infos.push({label: scope.selectedInfo, code: scope.selectedInfo});
+                }
 
                 // If no blank value allowed select default or first
                 // If no value defined, select default or blank one
@@ -653,13 +664,23 @@
                 function(n, o) {
                   appendExtraOptions();
                 });
+              scope.$watch('selectedInfo',
+                function(n, o) {
+                  scope.infos = angular.copy(baseList);
+                  appendExtraOptions();
+                  addBlankValueAndSetDefault();
+                });
 
+              var isLabelSet = false;
               function appendExtraOptions() {
                 if(baseList && angular.isArray(scope.extraOptions)) {
-                  scope.extraOptions.unshift({
-                    value: '', label: $translate.instant('recordFormats'), disabled: true});
-                  scope.extraOptions.push({
-                    value: '', label: $translate.instant('commonProtocols'), disabled: true})
+                  if (!isLabelSet) {
+                    scope.extraOptions.unshift({
+                      value: '', label: $translate.instant('recordFormats'), disabled: true});
+                    scope.extraOptions.push({
+                      value: '', label: $translate.instant('commonProtocols'), disabled: true});
+                    isLabelSet = true;
+                  }
                   scope.infos = scope.extraOptions.concat(baseList);
                 }
               }

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -662,6 +662,7 @@
 
               scope.$watch('extraOptions',
                 function(n, o) {
+                  isLabelSet = false;
                   appendExtraOptions();
                 });
               scope.$watch('selectedInfo',

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -599,11 +599,13 @@
             scope: {
               selectedInfo: '=',
               lang: '=',
+              extraOptions: '=',
               allowBlank: '@',
               infos: '=?schemaInfoComboValues'
             },
             link: function(scope, element, attrs) {
               var initialized = false;
+              var baseList = null;
               var defaultValue;
               var allowBlank = attrs['allowBlank'] == true;
 
@@ -646,6 +648,22 @@
                     init();
                   }
                 });
+
+              scope.$watch('extraOptions',
+                function(n, o) {
+                  appendExtraOptions();
+                });
+
+              function appendExtraOptions() {
+                if(baseList && angular.isArray(scope.extraOptions)) {
+                  scope.extraOptions.unshift({
+                    value: '', label: 'recordFormats', disabled: true});
+                  scope.extraOptions.push({
+                    value: '', label: 'protocols', disabled: true})
+                  scope.infos = scope.extraOptions.concat(baseList);
+                }
+              }
+
               var init = function() {
                 var schema = attrs['schema'] ||
                     gnCurrentEdit.schema || 'iso19139';
@@ -656,6 +674,8 @@
                   gnSchemaManagerService.getCodelist(config, scope.codelistFilter).then(
                       function(data) {
                         scope.infos = angular.copy(data.entry);
+                        baseList = angular.copy(scope.infos);
+                        appendExtraOptions();
                         addBlankValueAndSetDefault();
                       });
                 }
@@ -663,6 +683,8 @@
                   gnSchemaManagerService.getElementInfo(config, scope.codelistFilter).then(
                       function(data) {
                         scope.infos = data.helper ? data.helper.option : null;
+                        baseList = angular.copy(scope.infos);
+                        appendExtraOptions();
                         addBlankValueAndSetDefault();
                       });
                 }

--- a/web-ui/src/main/resources/catalog/components/search/formfields/partials/schemainfocombo.html
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/partials/schemainfocombo.html
@@ -2,6 +2,7 @@
   <option data-ng-repeat="p in infos"
           data-ng-selected="p.value === selectedInfo || p.code === selectedInfo"
           data-ng-hide="p.hideInEditMode == 'true'"
+          data-ng-disabled="p.disabled == true"
           value="{{p.value || p.code}}"
           title="{{p.description}}">{{p.label}}
   </option>

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -151,5 +151,8 @@
   "ui-isVegaEnabled": "Enable interactive graphics facets (using Vega)",
   "ui-exactMatchToggle": "Display exact match toggle",
   "facets.temporalRange.help": "Drag out a brush to select a data range or click on a bar on the lower chart. Click out the selected range to unset. Click the filter button to search.\n\nBlue series: current search, Grey series: all records.",
-  "facets.temporalRange.seriesLegend": "Blue series: current search, Grey series: all records"
+  "facets.temporalRange.seriesLegend": "Blue series: current search, Grey series: all records",
+  "recordFormats": "Distribution formats:",
+  "recordFormatDownload": "Download as ",
+  "commonProtocols": "General protocols:"
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -47,22 +47,11 @@
     margin-top: -1px;
     border-radius: 0;
     padding: 10px 15px 10px 15px;
-    .col-xs-1 {
+    .gn-related-icon-col {
+      padding-left: 0px;
+      padding-right: 0px;
       .fa {
         font-size: 2em;
-      }
-      .fa-stack-1x {
-        font-size: 1em;
-      }
-      .fa-stack {
-        i {
-          opacity: 1 !important;
-        }
-        strong {
-          font-family: arial;
-          display: block;
-          margin-top: 2em;
-        }
       }
     }
     h3 {

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
@@ -21,10 +21,13 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:saxon="http://saxon.sf.net/"
-                xmlns:gn="http://www.fao.org/geonetwork" xmlns:java-xsl-util="java:org.fao.geonet.util.XslUtil"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:saxon="http://saxon.sf.net/"
+                xmlns:gn="http://www.fao.org/geonetwork"
+                xmlns:java-xsl-util="java:org.fao.geonet.util.XslUtil"
                 version="2.0"
                 extension-element-prefixes="saxon" exclude-result-prefixes="#all">
+
 
   <!-- The editor form.
 
@@ -108,7 +111,12 @@
           <xsl:variable name="metadataExtents">
             <saxon:call-template name="{concat('get-', $schema, '-extents-as-json')}"/>
           </xsl:variable>
-          <input type="hidden" id="extent" value="{$metadataExtents}"/>
+          <input type="hidden" id="extent" value="{normalize-space($metadataExtents)}"/>
+
+          <xsl:variable name="metadataFormats">
+            <xsl:apply-templates mode="get-formats-as-json" select="$metadata"/>
+          </xsl:variable>
+          <input type="hidden" id="dataformats" value="{normalize-space($metadataFormats)}"/>
 
           <xsl:call-template name="get-online-source-config">
             <xsl:with-param name="pattern" select="$geopublishMatchingPattern"/>
@@ -160,6 +168,8 @@
     </div>
   </xsl:template>
 
+
+  <xsl:template mode="get-formats-as-json" match="*"/>
 
   <!-- Check if current record has resources which could be
   published in OGC services (eg. onLine resources in ISO19139)


### PR DESCRIPTION
## Adding distribution formats

User populates distribution format eg. ESRI Shapefile and Mapinfo MIF/MID 

![image](https://user-images.githubusercontent.com/1701393/114018887-0903ca80-986e-11eb-8725-20030e55c238.png)


## Add online resources related to one of the distribution format


Then when adding an online source (using the associated resources panel), the list of protocols shows:

* ISO 19139
  * First the list of formats defined in distribution. The value is "WWW:DOWNLOAD:ESRI Shapefile"
  * then the list of protocols defined in the schema configuration

![image](https://user-images.githubusercontent.com/1701393/114018783-e7a2de80-986d-11eb-82e4-ef6be7422b8a.png)


* ISO 19115-3 (which provides a menu to add new online resource)
  *  Access the resource section, contains first as many items as formats declared in distribution section
  * KML protocol choices are removed as they have to be declared as a format to be added as online resource.


![image](https://user-images.githubusercontent.com/1701393/114018399-78c58580-986d-11eb-94c8-c2e89289352e.png)


## Record download access

Record view render format as a badge when defined

![image](https://user-images.githubusercontent.com/1701393/114013870-4d8c6780-9868-11eb-932e-1b59128101b3.png)



## Fixes

* When editing existing online source, don't loose protocol value.


Work done in the context of https://geocat.ch