### PR TITLE
Overview / Stored in index and used as dataURL.

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -55,6 +55,7 @@ import java.io.*;
 import java.nio.file.*;
 import java.util.*;
 import javax.annotation.Nullable;
+import javax.resource.NotSupportedException;
 
 public class CMISStore extends AbstractStore {
 
@@ -145,6 +146,11 @@ public class CMISStore extends AbstractStore {
             throw new ResourceNotFoundException(
                 String.format("Error getting metadata resource. '%s' not found for metadata '%s'", resourceId, metadataUuid));
         }
+    }
+
+    @Override
+    public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
+        throw new NotSupportedException("CMISStore does not support getResourceInternal.");
     }
 
     private String getKey(final ServiceContext context, String metadataUuid, int metadataId, MetadataResourceVisibility visibility, String resourceId) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -104,7 +104,7 @@ public class FilesystemStore extends AbstractStore {
         int metadataId = canDownload(context, metadataUuid, visibility, approved);
         checkResourceId(resourceId);
 
-        final Path resourceFile = Lib.resource.getDir(context, visibility.toString(), metadataId).
+        final Path resourceFile = Lib.resource.getDir(visibility.toString(), metadataId).
                 resolve(getFilename(metadataUuid, resourceId));
 
         if (Files.exists(resourceFile)) {
@@ -112,6 +112,27 @@ public class FilesystemStore extends AbstractStore {
         } else {
             throw new ResourceNotFoundException(
                     String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid));
+        }
+    }
+
+
+    @Override
+    public ResourceHolder getResourceInternal(
+        final String metadataUuid,
+        final MetadataResourceVisibility visibility,
+        final String resourceId,
+        Boolean approved) throws Exception {
+        int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+        checkResourceId(resourceId);
+
+        final Path resourceFile = Lib.resource.getDir(visibility.toString(), metadataId).
+            resolve(getFilename(metadataUuid, resourceId));
+
+        if (Files.exists(resourceFile)) {
+            return new ResourceHolderImpl(resourceFile, null);
+        } else {
+            throw new ResourceNotFoundException(
+                String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid));
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -45,6 +45,7 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.resource.NotSupportedException;
 
 /**
  * Decorate a store and record put/get/delete operations in database for reporting statistics.
@@ -85,6 +86,11 @@ public class ResourceLoggerStore extends AbstractStore {
             return holder;
         }
         return null;
+    }
+
+    @Override
+    public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
+        throw new NotSupportedException("ResourceLoggerStore does not support getResourceInternal.");
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.resource.NotSupportedException;
 
 public class S3Store extends AbstractStore {
     @Autowired
@@ -113,6 +114,11 @@ public class S3Store extends AbstractStore {
             throw new ResourceNotFoundException(
                     String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid));
         }
+    }
+
+    @Override
+    public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
+        throw new NotSupportedException("S3Store does not support getResourceInternal.");
     }
 
     private String getKey(String metadataUuid, int metadataId, MetadataResourceVisibility visibility, String resourceId) throws Exception {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -137,6 +137,14 @@ public interface Store {
     ResourceHolder getResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved) throws Exception;
 
     /**
+     * Retrieve a metadata resource path (for internal use eg. indexing)
+     */
+    ResourceHolder getResourceInternal(String metadataUuid,
+                                       final MetadataResourceVisibility visibility,
+                                       String resourceId,
+                                       Boolean approved) throws Exception;
+
+    /**
      * Add a new resource from a file.
      *
      * @param context

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -945,7 +945,7 @@ public class BaseMetadataManager implements IMetadataManager {
                 env.addContent(new Element("parentUuid").setText(parentUuid));
             }
             if (metadataId.isPresent()) {
-                final Path resourceDir = Lib.resource.getDir(context, Params.Access.PRIVATE, metadataId.get());
+                final Path resourceDir = Lib.resource.getDir(Params.Access.PRIVATE, metadataId.get());
                 env.addContent(new Element("datadir").setText(resourceDir.toString()));
             }
 

--- a/core/src/main/java/org/fao/geonet/lib/ResourceLib.java
+++ b/core/src/main/java/org/fao/geonet/lib/ResourceLib.java
@@ -34,8 +34,10 @@ import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.exceptions.OperationNotAllowedEx;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
 import java.util.Set;
@@ -44,17 +46,19 @@ import java.util.Set;
  * Utility class to deal with data and removed directory. Also provide user privileges checking
  * method.
  */
+@Component
 public class ResourceLib {
+
     /**
      * Get metadata public or private data directory
      *
-     * @param access The type of data directory. {@link org.fao.geonet.constants.Params.Access#PUBLIC}
-     *               or {@link org.fao.geonet.constants.Params.Access#PRIVATE}
+     * @param access The type of data directory. {@link Params.Access#PUBLIC}
+     *               or {@link Params.Access#PRIVATE}
      * @param id     The metadata identifier
-     * @return The data directory
+     * @return The metadata directory
      */
-    public Path getDir(ServiceContext context, String access, int id) {
-        Path mdDir = getMetadataDir(context.getBean(GeonetworkDataDirectory.class), id);
+    public Path getDir(String access, int id) {
+        Path mdDir = getMetadataDir(ApplicationContextHolder.get().getBean(GeonetworkDataDirectory.class), id);
         String subDir = (access != null && access.equals(Params.Access.PUBLIC)) ? Params.Access.PUBLIC
             : Params.Access.PRIVATE;
         return mdDir.resolve(subDir);

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -397,9 +397,11 @@
 
 
         <xsl:for-each select="$overviews">
-          <!-- TODO can be multilingual desc and name -->
           <overview type="object">{
             "url": "<xsl:value-of select="normalize-space(.)"/>"
+            <xsl:if test="$isStoringOverviewInIndex">,
+              "data": "<xsl:value-of select="util:buildDataUrl(., 140)"/>"
+            </xsl:if>
             <xsl:if test="count(../../mcc:fileDescription) > 0">,
               "text":
               <xsl:value-of select="gn-fn-index:add-multilingual-field('name', ../../mcc:fileDescription, $allLanguages, true())"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -400,7 +400,11 @@
           <overview type="object">{
             "url": "<xsl:value-of select="normalize-space(.)"/>"
             <xsl:if test="$isStoringOverviewInIndex">,
-              "data": "<xsl:value-of select="util:buildDataUrl(., 140)"/>"
+              <xsl:variable name="data"
+                            select="util:buildDataUrl(., 140)"/>
+              <xsl:if test="$data != ''">,
+                "data": "<xsl:value-of select="$data"/>"
+              </xsl:if>
             </xsl:if>
             <xsl:if test="count(../../mcc:fileDescription) > 0">,
               "text":

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -377,8 +377,12 @@
           <!-- TODO can be multilingual desc and name -->
           <overview type="object">{
             "url": "<xsl:value-of select="normalize-space(.)"/>"
-            <xsl:if test="$isStoringOverviewInIndex">,
-              "data": "<xsl:value-of select="util:buildDataUrl(., 140)"/>"
+            <xsl:if test="$isStoringOverviewInIndex">
+              <xsl:variable name="data"
+                            select="util:buildDataUrl(., 140)"/>
+              <xsl:if test="$data != ''">,
+                "data": "<xsl:value-of select="$data"/>"
+              </xsl:if>
             </xsl:if>
             <xsl:if test="normalize-space(../../gmd:fileDescription) != ''">,
               "text": <xsl:value-of select="gn-fn-index:add-multilingual-field('name', ../../gmd:fileDescription, $allLanguages, true())"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -377,6 +377,9 @@
           <!-- TODO can be multilingual desc and name -->
           <overview type="object">{
             "url": "<xsl:value-of select="normalize-space(.)"/>"
+            <xsl:if test="$isStoringOverviewInIndex">,
+              "data": "<xsl:value-of select="util:buildDataUrl(., 140)"/>"
+            </xsl:if>
             <xsl:if test="normalize-space(../../gmd:fileDescription) != ''">,
               "text": <xsl:value-of select="gn-fn-index:add-multilingual-field('name', ../../gmd:fileDescription, $allLanguages, true())"/>
             </xsl:if>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -40,7 +40,7 @@
              data-ng-class="{'gn-md-no-thumbnail': !md.overview[0]}">
           <img class="gn-img-thumbnail"
                alt="{{md.resourceTitle}}"
-               data-ng-src="{{md.overview[0].url | thumbnailUrlSize}}"
+               data-ng-src="{{md.overview[0].data || (md.overview[0].url | thumbnailUrlSize)}}"
                data-ng-if="md.overview[0]"/>
         </div>
 

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -37,7 +37,7 @@
                   data-ng-if="!md.overview[0].url"></div>
             <img class="gn-img-thumbnail"
                   alt="{{md.title || md.defaultTitle}}"
-                  data-ng-src="{{md.overview[0].url}}?size=250"
+                  data-ng-src="{{md.overview[0].data || (md.overview[0].url | thumbnailUrlSize)}}"
                   data-ng-if="md.overview[0].url"/>
           </div>
         </div>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -49,6 +49,9 @@
   <xsl:variable name="maxFieldLength" select="32000" as="xs:integer"/>
 
 
+  <xsl:variable name="isStoringOverviewInIndex" select="true()"/>
+
+
   <!-- A date, dateTime, Year or Year and Month
   Valid with regards to index date supported types:
   date_optional_time||yyyy-MM-dd||yyyy-MM||yyyy||epoch_millis


### PR DESCRIPTION
When running a search, 30 records are displayed per pages (by default). Most of the users are setting thumbnails in records and this will trigger 30 requests to get thumbnails which can be external images or attachements. In quite some situation, thumbnails are beautiful & quite big.

In https://github.com/geonetwork/core-geonetwork/pull/4593 we added the possibility in the API to reduce image size but this only applies to internal attachements.

To limit the number of requests and the overall download bandwidth on each search result page load, this store a small (140px width) image in the index and use dataUrl to display it. 

![image](https://user-images.githubusercontent.com/1701393/109776245-ac741680-7c02-11eb-8d37-0f0778a09ad0.png)



With this change, a search will be 2 requests (ie. search + related) instead of 32 (search + related + overviews). Search response is a bit bigger but the overall size will be usually smaller.

eg. at EEA using external thumbnails repository

* Before ~32 requests / ~ 15Mo download
![image](https://user-images.githubusercontent.com/1701393/109776313-bb5ac900-7c02-11eb-8244-de98b9ea067f.png)

* After 2 requests / ~ 334Ko download
![image](https://user-images.githubusercontent.com/1701393/109776326-beee5000-7c02-11eb-8308-17b6f10a8961.png)

With this change, browser is also not waiting to complete request calls when user wants to move to next page.