### PR TITLE
Fix draft metadata manager update method to check if should be applied to the draft metadata or the published metadata.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataManager.java
@@ -133,22 +133,17 @@ public class DraftMetadataManager extends BaseMetadataManager implements IMetada
     public AbstractMetadata update(int id, @Nonnull Updater<? extends AbstractMetadata> updater) {
         AbstractMetadata md = null;
         Log.trace(Geonet.DATA_MANAGER, "AbstractMetadata.update(" + id + ")");
-        try {
-            Log.trace(Geonet.DATA_MANAGER, "Updating metadata table.");
-            md = super.update(id, updater);
-        } catch (ClassCastException t) {
-            // That's fine, maybe we are on the draft side
-        } catch (Throwable e) {
-            Log.error(Geonet.DATA_MANAGER, e.getMessage(), e);
-        }
-        if (md == null) {
+        if (metadataDraftRepository.exists(id)) {
             try {
                 Log.trace(Geonet.DATA_MANAGER, "Updating draft table.");
                 md = metadataDraftRepository.update(id, (Updater<MetadataDraft>) updater);
             } catch (ClassCastException t) {
                 throw new ClassCastException("Unknown AbstractMetadata subtype: " + updater.getClass().getName());
             }
+        } else {
+            md = super.update(id, updater);
         }
+
         return md;
     }
 


### PR DESCRIPTION
It caused an error in the schema upgrade process when applied to the draft metadata. Other code using this method with the draft metadata would get the same issue.