### PR TITLE
Encrypt passwords stored in the database

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -527,6 +527,10 @@
       <artifactId>aws-java-sdk-s3</artifactId>
       <version>1.11.618</version>
     </dependency>
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -430,7 +430,7 @@ public class JeevesEngine {
 
                 info("--- Handler started ---------------------------------------");
             } catch (Exception e) {
-                Map<String, String> errors = new HashMap<String, String>();
+                Map<String, String> errors = new HashMap<>();
                 String eS = "Raised exception while starting the application. " +
                     "Fix the error and restart.";
                 error(eS);

--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -96,6 +96,7 @@ public final class Geonet {
         public static final String UPDATE_FIXED_INFO = "update-fixed-info.xsl";
         public static final String UPDATE_FIXED_INFO_SUBTEMPLATE = "update-fixed-info-subtemplate.xsl";
         public static final String UPDATE_CHILD_FROM_PARENT_INFO = "update-child-from-parent-info.xsl";
+        public static final String ENCRYPTOR_DIR = "encryptor";
         public static final String EXTRACT_UUID = "extract-uuid.xsl";
         public static final String EXTRACT_TITLES = "extract-titles.xsl";
         public static final String EXTRACT_DEFAULT_LANGUAGE = "extract-default-language.xsl";

--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -444,6 +444,27 @@ public class GeonetworkDataDirectory {
             }
         }
 
+        Path encryptorFolder = configDir.resolve(Geonet.File.ENCRYPTOR_DIR);
+        if (!Files.exists(encryptorFolder)) {
+            Log.info(Geonet.DATA_DIRECTORY, "     - Copying encryptor directory...");
+            try {
+                final Path srcEncryptorDir = getDefaultDataDir(webappDir).resolve("config").resolve(Geonet.File.ENCRYPTOR_DIR);
+                final Path destDir = this.configDir.resolve(Geonet.File.ENCRYPTOR_DIR);
+                // Copy encryptor dir if doesn't exist
+                if (!Files.exists(destDir)) {
+                    IO.copyDirectoryOrFile(srcEncryptorDir, destDir, true);
+                }
+
+            } catch (IOException e) {
+                Log.info(
+                    Geonet.DATA_DIRECTORY,
+                    "      - Error copying encryptor config directory: "
+                        + e.getMessage());
+                throw e;
+            }
+
+        }
+
         final Path locDir = webappDir.resolve("loc");
         if (!Files.exists(locDir)) {
             Files.createDirectories(locDir);

--- a/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java
@@ -216,7 +216,12 @@ public class HarvesterSettingsManager {
      * When adding to a newly created node, path must be 'id:...'.
      */
     public String add(String path, Object name, Object value) {
-        if (name == null)
+        return add(path, name, value, false);
+    }
+
+    public String add(String path, Object name, Object value, boolean encrypted) {
+
+            if (name == null)
             throw new IllegalArgumentException("Name cannot be null");
 
         String sName = makeString(name);
@@ -231,7 +236,8 @@ public class HarvesterSettingsManager {
         if (parent == null)
             return null;
 
-        HarvesterSetting child = new HarvesterSetting().setParent(parent).setName(sName).setValue(sValue);
+        HarvesterSetting child = new HarvesterSetting().setParent(parent)
+            .setName(sName).setValue(sValue).setEncrypted(encrypted);
 
         settingsRepo.save(child);
         return Integer.toString(child.getId());

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -110,7 +110,14 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt-hibernate5</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/domain/src/main/java/org/fao/geonet/domain/MapServer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MapServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -24,12 +24,10 @@
 package org.fao.geonet.domain;
 
 import org.fao.geonet.entitylistener.MapServerEntityListenerManager;
+import org.hibernate.annotations.Type;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.persistence.*;
 
-import java.util.Map;
 
 /**
  * An entity representing mapserver used for publishing records as WMS, WFS, WCS.
@@ -38,6 +36,7 @@ import java.util.Map;
  *
  * @author Francois
  */
+
 @Entity
 @Table(name = "Mapservers")
 @Cacheable
@@ -232,6 +231,7 @@ public class MapServer extends GeonetEntity {
      * @return the password.
      */
     @Column(length = 128)
+    @Type(type="encryptedString")
     public String getPassword() {
         return _password;
     }

--- a/domain/src/main/java/org/fao/geonet/domain/package-info.java
+++ b/domain/src/main/java/org/fao/geonet/domain/package-info.java
@@ -21,10 +21,28 @@
  * Rome - Italy. email: geonetwork@osgeo.org
  */
 
+
 /**
  * Domain objects geonetwork.  These are JPA entities and are configured via javax.persistence
  * annotations.
  *
  * @author Jesse
  */
+@TypeDefs
+    ({
+        @TypeDef(
+            name="encryptedString",
+            typeClass= EncryptedStringType.class,
+            parameters={
+                @Parameter(name="encryptorRegisteredName",
+                    value="STRING_ENCRYPTOR")
+            }
+        )
+    })
+
 package org.fao.geonet.domain;
+
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+import org.jasypt.hibernate5.type.EncryptedStringType;

--- a/domain/src/main/java/org/fao/geonet/entitylistener/HarvesterSettingValueSetter.java
+++ b/domain/src/main/java/org/fao/geonet/entitylistener/HarvesterSettingValueSetter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.entitylistener;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.domain.HarvesterSetting;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+
+/**
+ * Handler for database events to manage encrypt/decrypt of encrypted harvester settings.
+ *
+ */
+public class HarvesterSettingValueSetter implements GeonetworkEntityListener<HarvesterSetting> {
+    @Autowired
+    private StandardPBEStringEncryptor encryptor;
+
+    @Override
+    public Class<HarvesterSetting> getEntityClass() {
+        return HarvesterSetting.class;
+    }
+
+    @Override
+    public void handleEvent(final PersistentEventType type, final HarvesterSetting entity) {
+        if ((type == PersistentEventType.PrePersist) || (type == PersistentEventType.PreUpdate)) {
+            if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getValue())) {
+                entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
+            } else {
+                entity.setStoredValue(entity.getValue());
+            }
+
+        } else if ((type == PersistentEventType.PostLoad) ||  (type == PersistentEventType.PostUpdate)) {
+            if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getStoredValue())) {
+                entity.setValue(this.encryptor.decrypt(entity.getStoredValue()));
+            } else {
+                entity.setValue(entity.getStoredValue());
+            }
+        }
+    }
+}

--- a/domain/src/main/java/org/fao/geonet/entitylistener/SettingValueSetter.java
+++ b/domain/src/main/java/org/fao/geonet/entitylistener/SettingValueSetter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.entitylistener;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.domain.Setting;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Handler for database events to manage encrypt/decrypt of encrypted settings.
+ *
+ */
+public class SettingValueSetter implements GeonetworkEntityListener<Setting> {
+    @Autowired
+    private StandardPBEStringEncryptor encryptor;
+
+    @Override
+    public Class<Setting> getEntityClass() {
+        return Setting.class;
+    }
+
+    @Override
+    public void handleEvent(final PersistentEventType type, final Setting entity) {
+        if ((type == PersistentEventType.PrePersist) || (type == PersistentEventType.PreUpdate)) {
+            if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getValue())) {
+                entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
+            } else {
+                entity.setStoredValue(entity.getValue());
+            }
+
+        } else if ((type == PersistentEventType.PostLoad) ||  (type == PersistentEventType.PostUpdate)) {
+            if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getStoredValue())) {
+                entity.setValue(this.encryptor.decrypt(entity.getStoredValue()));
+            } else {
+                entity.setValue(entity.getStoredValue());
+            }
+        }
+    }
+}

--- a/domain/src/main/java/org/fao/geonet/repository/HarvesterSettingRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/HarvesterSettingRepository.java
@@ -63,7 +63,7 @@ public interface HarvesterSettingRepository extends GeonetRepository<HarvesterSe
      * @param value the setting value.
      * @return All settings with the given name and value.
      */
-    List<HarvesterSetting> findAllByNameAndValue(@Nonnull String name, @Nonnull String value);
+    List<HarvesterSetting> findAllByNameAndStoredValue(@Nonnull String name, @Nonnull String value);
 
     /**
      * Find the settings with the given name and value. Null is returned if not found.
@@ -73,5 +73,5 @@ public interface HarvesterSettingRepository extends GeonetRepository<HarvesterSe
      * @return The setting with the given name and value.
      */
     @Nullable
-    HarvesterSetting findOneByNameAndValue(@Nonnull String name, @Nonnull String value);
+    HarvesterSetting findOneByNameAndStoredValue(@Nonnull String name, @Nonnull String value);
 }

--- a/domain/src/main/resources/config-spring-geonetwork.xml
+++ b/domain/src/main/resources/config-spring-geonetwork.xml
@@ -38,6 +38,12 @@
   <bean id="userNodeIdSetter"
         class="org.fao.geonet.entitylistener.UserNodeIdSetter"/>
 
+  <bean id="settingValueSetter"
+        class="org.fao.geonet.entitylistener.SettingValueSetter"/>
+
+  <bean id="harvesterSettingValueSetter"
+        class="org.fao.geonet.entitylistener.HarvesterSettingValueSetter"/>
+
   <bean id="entityManagerFactory"
         class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
     <property name="dataSource" ref="jdbcDataSource"/>

--- a/domain/src/test/java/org/fao/geonet/repository/HarvesterSettingRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/HarvesterSettingRepositoryTest.java
@@ -47,7 +47,7 @@ public class HarvesterSettingRepositoryTest extends AbstractSpringDataTest {
 
     public static HarvesterSetting newSetting(AtomicInteger inc) {
         int id = inc.incrementAndGet();
-        return new HarvesterSetting().setName("name " + id).setValue("value " + id);
+        return new HarvesterSetting().setName("name " + id).setStoredValue("value " + id);
     }
 
     @Test

--- a/domain/src/test/java/org/fao/geonet/repository/MapServerTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/MapServerTest.java
@@ -25,6 +25,9 @@ package org.fao.geonet.repository;
 
 
 import org.fao.geonet.domain.MapServer;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.hibernate5.encryptor.HibernatePBEEncryptorRegistry;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +49,17 @@ public class MapServerTest extends AbstractSpringDataTest {
     EntityManager _entityManager;
 
     private AtomicInteger _nextId = new AtomicInteger();
+
+    @BeforeClass
+    public static void init() {
+        StandardPBEStringEncryptor strongEncryptor = new StandardPBEStringEncryptor();
+        strongEncryptor.setPassword("testpassword");
+
+        HibernatePBEEncryptorRegistry registry =
+            HibernatePBEEncryptorRegistry.getInstance();
+        registry.registerPBEStringEncryptor("STRING_ENCRYPTOR", strongEncryptor);
+    }
+
 
     public static MapServer newMapServer(AtomicInteger nextId) {
         int id = nextId.incrementAndGet();

--- a/domain/src/test/resources/domain-repository-test-context.xml
+++ b/domain/src/test/resources/domain-repository-test-context.xml
@@ -80,4 +80,13 @@
     <entry key="hibernate.enable_lazy_load_no_trans" value="true"/>
   </util:map>
 
+  <bean id="strongEncryptor"
+        class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor">
+    <property name="algorithm">
+      <value>PBEWithMD5AndDES</value>
+    </property>
+    <property name="password">
+      <value>jasypt</value>
+    </property>
+  </bean>
 </beans>

--- a/domain/src/test/resources/issue1876-context.xml
+++ b/domain/src/test/resources/issue1876-context.xml
@@ -81,4 +81,14 @@
 	<bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
 		<property name="entityManagerFactory" ref="entityManagerFactory" />
 	</bean>
+
+  <bean id="strongEncryptor"
+        class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor">
+    <property name="algorithm">
+      <value>PBEWithMD5AndDES</value>
+    </property>
+    <property name="password">
+      <value>jasypt</value>
+    </property>
+  </bean>
 </beans>

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -946,7 +946,7 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
         String useAccId = harvesterSettingsManager.add(ID_PREFIX + siteId, "useAccount", params.isUseAccount());
 
         harvesterSettingsManager.add(ID_PREFIX + useAccId, "username", params.getUsername());
-        harvesterSettingsManager.add(ID_PREFIX + useAccId, "password", params.getPassword());
+        harvesterSettingsManager.add(ID_PREFIX + useAccId, "password", params.getPassword(), true);
 
         //--- setup options node ---------------------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -1119,6 +1119,16 @@
         <artifactId>pdfbox</artifactId>
         <version>2.0.19</version>
       </dependency>
+      <dependency>
+        <groupId>org.jasypt</groupId>
+        <artifactId>jasypt</artifactId>
+        <version>${jasypt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jasypt</groupId>
+        <artifactId>jasypt-hibernate5</artifactId>
+        <version>${jasypt.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -1476,7 +1486,6 @@
      request the list of hosts (but JPA cache db queries). -->
     <cors.allowedHosts>*</cors.allowedHosts>
 
-
     <jetty.version>9.4.27.v20200227</jetty.version>
     <jetty.file>jetty-distribution-${jetty.version}</jetty.file>
     <jetty.download>https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/${jetty.file}.tar.gz</jetty.download>
@@ -1511,6 +1520,7 @@
     <xbean.version>3.18</xbean.version>
     <jolokia.version>1.6.0</jolokia.version>
     <httpcomponents.version>4.5.9</httpcomponents.version>
+    <jasypt.version>1.9.3</jasypt.version>
 
     <skipIT>true</skipIT> <!-- disable integration tests by default, use the "it" profile to run them which enables them -->
   </properties>

--- a/services/src/test/java/org/fao/geonet/api/mapservers/MapServersApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/mapservers/MapServersApiTest.java
@@ -29,8 +29,11 @@ import org.fao.geonet.api.JsonFieldNamingStrategy;
 import org.fao.geonet.domain.MapServer;
 import org.fao.geonet.repository.MapServerRepository;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.hibernate5.encryptor.HibernatePBEEncryptorRegistry;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -66,6 +69,16 @@ public class MapServersApiTest extends AbstractServiceIntegrationTest {
     @Before
     public void setUp() {
         createTestData();
+    }
+
+    @BeforeClass
+    public static void init() {
+        StandardPBEStringEncryptor strongEncryptor = new StandardPBEStringEncryptor();
+        strongEncryptor.setPassword("testpassword");
+
+        HibernatePBEEncryptorRegistry registry =
+            HibernatePBEEncryptorRegistry.getInstance();
+        registry.registerPBEStringEncryptor("STRING_ENCRYPTOR", strongEncryptor);
     }
 
     @Test

--- a/services/src/test/resources/services-repository-test-context.xml
+++ b/services/src/test/resources/services-repository-test-context.xml
@@ -62,4 +62,13 @@
         class="org.fao.geonet.api.records.formatters.cache.NoCachingStore">
   </bean>
 
+  <bean id="strongEncryptor"
+        class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor">
+    <property name="algorithm">
+      <value>PBEWithMD5AndDES</value>
+    </property>
+    <property name="password">
+      <value>jasypt</value>
+    </property>
+  </bean>
 </beans>

--- a/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
+++ b/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
@@ -1,0 +1,192 @@
+//=============================================================================
+//===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.utils.Log;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.hibernate5.encryptor.HibernatePBEEncryptorRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EncryptorInitializer {
+    private final static String LOG_MODULE = Geonet.GEONETWORK + ".encryptor";
+
+    @Autowired
+    StandardPBEStringEncryptor encryptor;
+
+    @Autowired
+    DataSource dataSource;
+
+    public void init(GeonetworkDataDirectory dataDirectory) throws Exception {
+        String securityPropsPath = dataDirectory.getConfigDir().resolve("encryptor")
+            .resolve("encryptor.properties").toString();
+
+        PropertiesConfiguration conf = new PropertiesConfiguration(securityPropsPath);
+        String encryptorAlgorithm = (String) conf.getProperty("encryptor.algorithm");
+        String encryptorPassword = (String) conf.getProperty("encryptor.password");
+
+        boolean updateDatabase = false;
+
+        // Creates a random encryptor password if the password has the value 'default'
+        if (StringUtils.isEmpty(encryptorPassword)) {
+            Log.info(LOG_MODULE, "Generating a random password for the database password encryptor");
+            encryptorPassword = RandomStringUtils.randomAlphanumeric(10);
+
+            conf.setProperty("encryptor.password", encryptorPassword);
+            conf.save();
+
+            updateDatabase = true;
+        }
+
+        Log.info(LOG_MODULE, "Password database encryptor initialized - Keep the file " + securityPropsPath +
+            " safe and make a backup. When upgrading to a newer version of GeoNetwork the file must be restored, " +
+            "otherwise GeoNetwork will not be able to decrypt passwords already stored in the database.");
+
+        encryptor.setAlgorithm(encryptorAlgorithm);
+        encryptor.setPassword(encryptorPassword);
+
+        /**
+         * Updates the database rows with passwords. Uses SQL updates to avoid interfere with the Hibernate TypeDef
+         * to encrypt database fields. For example in {@link org.fao.geonet.domain.MapServer}.
+         *
+         * Can't be done in a database upgrade as when the {@link javax.sql.DataSource} and
+         * {@link org.springframework.orm.jpa.JpaTransactionManager} beans are initialized the data directory bean is
+         * not yet ready.
+         *
+         * Adding a migration upgrade that depends on this bean to be initialized doesn't work as the database version
+         * has been already updated in the previous upgrades.
+         */
+        if (updateDatabase) {
+            Log.info(LOG_MODULE, "Password database encryptor - encrypting passwords stored in the database");
+            updateDb();
+        }
+
+        // Register encryptor in HibernatePBEEncryptorRegistry class
+        HibernatePBEEncryptorRegistry registry =
+            HibernatePBEEncryptorRegistry.getInstance();
+        registry.registerPBEStringEncryptor("STRING_ENCRYPTOR", encryptor);
+
+    }
+
+    private void updateDb() throws SQLException {
+
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            final String encryptedSettings = "SELECT name, value FROM Settings WHERE encrypted = 'y'";
+
+            ResultSet settingsResultSet = statement.executeQuery(encryptedSettings);
+            int numberOfSettings = 0;
+            Map<String, String> updates = new HashMap<String, String>();
+
+            try {
+                while (settingsResultSet.next()) {
+                    String name = settingsResultSet.getString(1);
+                    String value = settingsResultSet.getString(2);
+                    if (StringUtils.isNotEmpty(value)) {
+                        value = encryptor.encrypt(value);
+                        updates.put(name, value);
+                        numberOfSettings++;
+                    }
+                }
+                Log.debug(LOG_MODULE, "  Number of settings of type password to update: " + numberOfSettings);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            } finally {
+                settingsResultSet.close();
+            }
+
+            for(String key : updates.keySet()) {
+                statement.execute("UPDATE Settings SET value='" + updates.get(key) + "' WHERE name='" + key + "'");
+            }
+
+            final String encryptedHarvesterSettings = "SELECT name, value FROM HarvesterSettings WHERE name = 'password'";
+            ResultSet harvesterSettingsResultSet = statement.executeQuery(encryptedHarvesterSettings);
+            int numberOfHarvesterSettings = 0;
+            updates = new HashMap<String, String>();
+            try {
+                while (harvesterSettingsResultSet.next()) {
+                    String name = harvesterSettingsResultSet.getString(1);
+                    String value = harvesterSettingsResultSet.getString(2);
+                    if (StringUtils.isNotEmpty(value)) {
+                        value = encryptor.encrypt(value);
+                        updates.put(name, value);
+
+                        numberOfHarvesterSettings++;
+                    }
+                }
+
+                Log.debug(LOG_MODULE, "  Number of harvester settings of type password to update: " + numberOfHarvesterSettings);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            } finally {
+                harvesterSettingsResultSet.close();
+            }
+
+            for(String key : updates.keySet()) {
+                statement.execute("UPDATE HarvesterSettings SET value='" + updates.get(key) + "' WHERE name='" + key + "'");
+            }
+
+
+            final String encryptedMapServerPasswords = "SELECT id, password FROM Mapservers";
+            ResultSet mapServerResultSet = statement.executeQuery(encryptedMapServerPasswords);
+            int numberOfMapServers = 0;
+            Map<Integer, String> updatesMapServers = new HashMap<Integer, String>();
+            try {
+                while (mapServerResultSet.next()) {
+                    Integer id = mapServerResultSet.getInt(1);
+                    String password = mapServerResultSet.getString(2);
+                    if (StringUtils.isNotEmpty(password)) {
+                        password = encryptor.encrypt(password);
+                        updatesMapServers.put(id, password);
+                        numberOfMapServers++;
+                    }
+                }
+
+                Log.debug(LOG_MODULE, "  Number of map server passwords to update: " + numberOfMapServers);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            } finally {
+                harvesterSettingsResultSet.close();
+            }
+
+            for(Integer key : updatesMapServers.keySet()) {
+                statement.execute("UPDATE Mapservers SET password='" + updatesMapServers.get(key) + "' WHERE id='" + key + "'");
+            }
+
+            connection.commit();
+        }
+    }
+}

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -149,6 +149,8 @@ public class Geonetwork implements ApplicationHandler {
         final GeonetworkDataDirectory dataDirectory = _applicationContext.getBean(GeonetworkDataDirectory.class);
         dataDirectory.init(webappName, appPath, handlerConfig, context.getServlet());
 
+
+
         // Get config handler properties
         String systemDataDir = handlerConfig.getMandatoryValue(Geonet.Config.SYSTEM_DATA_DIR);
         String thesauriDir = handlerConfig.getMandatoryValue(Geonet.Config.CODELIST_DIR);
@@ -156,6 +158,11 @@ public class Geonetwork implements ApplicationHandler {
         logger.info("Data directory: " + systemDataDir);
 
         setProps(appPath, handlerConfig);
+
+        // Initialize password encryptor
+        logger.info("Initializing database password encryptor");
+        final EncryptorInitializer encryptorInitializer = _applicationContext.getBean(EncryptorInitializer.class);
+        encryptorInitializer.init(dataDirectory);
 
         importDatabaseData(context);
 

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -172,4 +172,10 @@
     <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>
     <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>
 -->
+
+  <bean id="strongEncryptor"
+        class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor" />
+
+  <bean id="encryptorInitialiser"
+        class="org.fao.geonet.EncryptorInitializer" />
 </beans>

--- a/web/src/main/webapp/WEB-INF/classes/log4j-dev.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j-dev.xml
@@ -30,6 +30,9 @@
     <appender-ref ref="consoleAppender"/>
     <appender-ref ref="fileAppender"/>
   </logger>
+  <logger name="geonetwork.encryptor">
+    <level value="DEBUG"/>
+  </logger>
   <logger name="geonetwork.databasemigration">
     <level value="DEBUG"/>
   </logger>

--- a/web/src/main/webapp/WEB-INF/classes/log4j-index.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j-index.xml
@@ -30,6 +30,9 @@
     <appender-ref ref="consoleAppender"/>
     <appender-ref ref="fileAppender"/>
   </logger>
+  <logger name="geonetwork.encryptor">
+    <level value="INFO"/>
+  </logger>
   <logger name="geonetwork.search" additivity="false">
     <level value="WARN"/>
   </logger>

--- a/web/src/main/webapp/WEB-INF/classes/log4j-search.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j-search.xml
@@ -30,6 +30,9 @@
     <appender-ref ref="consoleAppender"/>
     <appender-ref ref="fileAppender"/>
   </logger>
+  <logger name="geonetwork.encryptor">
+    <level value="INFO"/>
+  </logger>
   <logger name="geonetwork.search" additivity="true">
     <level value="DEBUG"/>
   </logger>

--- a/web/src/main/webapp/WEB-INF/classes/log4j.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j.xml
@@ -30,6 +30,9 @@
     <appender-ref ref="consoleAppender"/>
     <appender-ref ref="fileAppender"/>
   </logger>
+  <logger name="geonetwork.encryptor">
+    <level value="INFO"/>
+  </logger>
   <logger name="geonetwork.resources">
     <level value="ERROR"/>
   </logger>

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -591,14 +591,14 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/host', NULL, 0, 520, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/port', NULL, 1, 530, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/username', NULL, 0, 540, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/password', NULL, 0, 550, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/proxy/password', NULL, 0, 550, 'y', 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/ignorehostlist', NULL, 0, 560, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/cors/allowedHosts', '*', 0, 561, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/email', 'root@localhost', 0, 610, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/host', '', 0, 630, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/port', '25', 1, 640, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/username', '', 0, 642, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/password', '', 0, 643, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/feedback/mailServer/password', '', 0, 643, 'y', 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/ssl', 'false', 2, 641, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/tls', 'false', 2, 644, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/feedback/mailServer/ignoreSslCertificateErrors', 'false', 2, 645, 'y');
@@ -696,7 +696,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doienabled', 'false', 2, 100191, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doiurl', '', 0, 100192, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doiusername', '', 0, 100193, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipassword', '', 0, 100194, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/publication/doi/doipassword', '', 0, 100194, 'y', 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doikey', '', 0, 110095, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doilandingpagetemplate', 'http://localhost:8080/geonetwork/srv/resources/records/{{uuid}}', 0, 100195, 'n');
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v404/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v404/migrate-default.sql
@@ -1,2 +1,7 @@
 UPDATE Settings SET value='4.0.4' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
+
+-- ALTER TABLE Settings ADD COLUMN encrypted VARCHAR(1) DEFAULT 'n';
+UPDATE Settings SET encrypted='y' WHERE name='system/proxy/password';
+UPDATE Settings SET encrypted='y' WHERE name='system/feedback/mailServer/password';
+UPDATE Settings SET encrypted='y' WHERE name='system/publication/doi/doipassword';

--- a/web/src/main/webapp/WEB-INF/data/config/encryptor/encryptor.properties
+++ b/web/src/main/webapp/WEB-INF/data/config/encryptor/encryptor.properties
@@ -1,0 +1,3 @@
+# Password encripter configuration
+encryptor.algorithm = PBEWithMD5AndDES
+encryptor.password =


### PR DESCRIPTION
Allows to encrypt the passwords used for mail, proxy, harvesters and map servers that are stored in the database.

When the passwords are retrieved from the database are unencrypted, the code using them requires no changes.

For the encryption/decryption of the passwords is used the library jasypt.

The configuration for the encrypter is stored in the file `WEB-INF/data/config/encryptor/encryptor.properties`:

```
# Password encryptor for passwords stored in database
encryptor.algorithm=PBEWithMD5AndDES
encryptor.password=
```

When GeoNetwork starts up, if `encryptor.password` has an empty value it's generated a random key that replaces the value default and the database rows that stored passwords are encrypted.

```
2021-03-08 13:41:11,640 INFO  [geonetwork.encryptor] - Generating a random password for the database password encryptor
2021-03-08 13:41:21,011 INFO  [geonetwork.encryptor] - Password database encryptor initialized - Keep the file /PATH/data/config/encryptor/encryptor.properties safe and make a backup. When upgrading to a newer version of GeoNetwork the file must be restored, otherwise GeoNetwork will not be able to decrypt passwords already stored in the database.
```

It's important to indicate that if GeoNetwork is migrated to a newer version, the encryptor configuration file `encryptor.properties` should be copied to the new installation, otherwise will not be possible to decrypt the existing passwords stored in the database.