### PR TITLE
Remove wildcard on URI filter for thesaurus keyword search

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -112,7 +112,7 @@
                 thesaurus: thesaurus,
                 rows: max,
                 q: filter || '',
-                uri: ('*' + filter + '*') || '',
+                uri: filter || '',
                 lang: lang || 'eng'
               };
               if (outputLang) {


### PR DESCRIPTION
I've encountered an issue with the thesaurus picker when using the following media-type thesaurus: https://github.com/metadata101/dcat-ap1.1/blob/master/src/main/plugin/dcat-ap/thesauri/theme/media-type.rdf  

When picking the `application/json` media-type value in the editor and saving it, it would be saved as `application/geo+json` instead.  
This is caused by a pattern matching on the URI which will match in priority the `application/geo+json` over `application/json`. By removing the wildcard on the URI filter, it now works as expected.   

From my tests, I've not encountered any regressions out of this fix but I think this would still be a good idea to make sure there aren't any.