### PR TITLE
Record view / Fix resource identifier display

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -266,7 +266,7 @@
                 <td>
                   <ul>
                     <li data-ng-repeat="i in mdView.current.record.resourceIdentifier">
-                      {{i}}
+                      {{i.code}}
                     </li>
                   </ul>
                 </td>


### PR DESCRIPTION
Use to be text but now is an object (introduced in https://github.com/geonetwork/core-geonetwork/pull/5379/files#diff-936e4fb67d4d170a09c59a025513de797946f33a2e7b19dc5296e35be65ae558R333)