### PR TITLE
Index temporal extent period, fix multiple temporal extent display inthe metadata detail page. Fixes #5483

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
@@ -358,6 +358,11 @@
                      string="{lower-case(gn-fn-iso19115-3.2018:formatDateTime(.))}"
                      store="true" index="true"/>
             </xsl:for-each>
+
+            <Field name="tempExtentPeriod"
+                   string="{concat(lower-case(gn-fn-iso19115-3.2018:formatDateTime(gml:beginPosition|gml:begin/gml:TimeInstant/gml:timePosition)), '|',
+                                   lower-case(gn-fn-iso19115-3.2018:formatDateTime(gml:endPosition|gml:end/gml:TimeInstant/gml:timePosition)))}"
+                   store="true" index="true"/>
           </xsl:for-each>
         </xsl:for-each>
       </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -291,6 +291,7 @@
           <Field name="geoDescCode" string="{string(.)}" store="true" index="true"/>
         </xsl:for-each>
 
+
         <xsl:for-each select="gmd:temporalElement/
                                   (gmd:EX_TemporalExtent|gmd:EX_SpatialTemporalExtent)/gmd:extent">
           <xsl:for-each select="gml:TimePeriod|gml320:TimePeriod">
@@ -309,6 +310,8 @@
             <Field name="tempExtentBegin" string="{lower-case(substring-before($times,'|'))}"
                    store="true" index="true"/>
             <Field name="tempExtentEnd" string="{lower-case(substring-after($times,'|'))}"
+                   store="true" index="true"/>
+            <Field name="tempExtentPeriod" string="{lower-case($times)}"
                    store="true" index="true"/>
           </xsl:for-each>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/language-default.xsl
@@ -262,30 +262,31 @@
           <Field name="extentDesc" string="{string(.)}" store="true" index="true"/>
         </xsl:for-each>
 
-        <xsl:for-each select="gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent|
-          gmd:temporalElement/gmd:EX_SpatialTemporalExtent/gmd:extent">
-          <xsl:for-each select="gml:TimePeriod/gml:beginPosition|gml320:TimePeriod/gml320:beginPosition">
-            <Field name="tempExtentBegin" string="{string(.)}" store="true" index="true"/>
-          </xsl:for-each>
+        <xsl:for-each select="gmd:temporalElement/
+                                  (gmd:EX_TemporalExtent|gmd:EX_SpatialTemporalExtent)/gmd:extent">
+          <xsl:for-each select="gml:TimePeriod|gml320:TimePeriod">
 
-          <xsl:for-each select="gml:TimePeriod/gml:endPosition|gml320:TimePeriod/gml320:endPosition">
-            <Field name="tempExtentEnd" string="{string(.)}" store="true" index="true"/>
-          </xsl:for-each>
+            <xsl:variable name="times">
+              <xsl:call-template name="newGmlTime">
+                <xsl:with-param name="begin"
+                                select="gml:beginPosition|gml:begin/gml:TimeInstant/gml:timePosition|
+                                        gml320:beginPosition|gml320:begin/gml320:TimeInstant/gml320:timePosition"/>
+                <xsl:with-param name="end"
+                                select="gml:endPosition|gml:end/gml:TimeInstant/gml:timePosition|
+                                        gml320:endPosition|gml320:end/gml320:TimeInstant/gml320:timePosition"/>
+              </xsl:call-template>
+            </xsl:variable>
 
-          <xsl:for-each select="gml:TimePeriod/gml:begin/gml:TimeInstant/gml:timePosition|gml320:TimePeriod/gml320:begin/gml320:TimeInstant/gml320:timePosition">
-            <Field name="tempExtentBegin" string="{string(.)}" store="true" index="true"/>
-          </xsl:for-each>
-
-          <xsl:for-each select="gml:TimePeriod/gml:end/gml:TimeInstant/gml:timePosition|gml320:TimePeriod/gml320:end/gml320:TimeInstant/gml320:timePosition">
-            <Field name="tempExtentEnd" string="{string(.)}" store="true" index="true"/>
-          </xsl:for-each>
-
-          <xsl:for-each select="gml:TimeInstant/gml:timePosition|gml320:TimeInstant/gml320:timePosition">
-            <Field name="tempExtentBegin" string="{string(.)}" store="true" index="true"/>
-            <Field name="tempExtentEnd" string="{string(.)}" store="true" index="true"/>
+            <Field name="tempExtentBegin" string="{lower-case(substring-before($times,'|'))}"
+                   store="true" index="true"/>
+            <Field name="tempExtentEnd" string="{lower-case(substring-after($times,'|'))}"
+                   store="true" index="true"/>
+            <Field name="tempExtentPeriod" string="{lower-case($times)}"
+                   store="true" index="true"/>
           </xsl:for-each>
 
         </xsl:for-each>
+
       </xsl:for-each>
 
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -567,7 +567,7 @@
         'denominator', 'resolution', 'geoDesc', 'geoBox', 'inspirethemewithac',
         'status', 'status_text', 'crs', 'identifier', 'responsibleParty',
         'mdLanguage', 'datasetLang', 'type', 'link', 'crsDetails',
-        'creationDate', 'publicationDate', 'revisionDate', 'spatialRepresentationType_text'];
+        'creationDate', 'publicationDate', 'revisionDate', 'spatialRepresentationType_text', 'tempExtentPeriod'];
       var listOfJsonFields = ['keywordGroup', 'crsDetails', 'featureTypes'];
       // See below; probably not necessary
       var record = this;

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -542,8 +542,7 @@
                   data-ng-if="mdView.current.record.creationDate ||
                               mdView.current.record.publicationDate ||
                               mdView.current.record.revisionDate ||
-                              mdView.current.record.tempExtentBegin ||
-                              mdView.current.record.tempExtentEnd">
+                              mdView.current.record.tempExtentPeriod">
             <h2>
               <i class="fa fa-fw fa-clock-o"></i>
               <span data-translate="">tempExtent</span>
@@ -569,13 +568,14 @@
                   data-format="YYYY-MM-DD"/>
             </dl>
             <dl
-              data-ng-show="mdView.current.record.tempExtentBegin ||
-                                mdView.current.record.tempExtentEnd">
+              data-ng-show="mdView.current.record.tempExtentPeriod.length > 0">
               <dt data-translate>tempExtentBegin</dt>
-              <dd>
-                <span data-gn-humanize-time="{{mdView.current.record.tempExtentBegin}}"/>
+              <dd data-ng-repeat="period in mdView.current.record.tempExtentPeriod track by $index">
+                <span data-gn-humanize-time="{{period.split('|')[0]}}"
+                      data-format="YYYY-MM-DD"/>
                 &nbsp;<i class="fa fa-fw fa-forward"></i>
-                <span data-gn-humanize-time="{{mdView.current.record.tempExtentEnd}}"/>
+                <span data-gn-humanize-time="{{period.split('|')[1]}}"
+                      data-format="YYYY-MM-DD"/>
               </dd>
             </dl>
             </p>

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -175,6 +175,7 @@
       <field name="serviceType" tagName="serviceType"/>
       <field name="tempExtentBegin" tagName="tempExtentBegin"/>
       <field name="tempExtentEnd" tagName="tempExtentEnd"/>
+      <field name="tempExtentPeriod" tagName="tempExtentPeriod"/>
       <field name="geoBox" tagName="geoBox"/>
       <field name="boundingPolygon" tagName="boundingPolygon"/>
       <field name="extentDesc" tagName="geoDesc"/>


### PR DESCRIPTION
Implemented option 2 described in #5483, with the changes the metadata detail page displays all the temporal extents defined:

![multiple-temporal-extents](https://user-images.githubusercontent.com/1695003/110756065-fdf75380-8249-11eb-9da9-5bd433738471.png)
