### PR TITLE
Improved visual hierarchy in admin settings and user interface settings

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/mapconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/mapconfig.html
@@ -21,7 +21,7 @@
       data-ng-model="mCfg[key]['extent'][3]"/>
 </div>
 <label class="control-label" translate>mapConfigLayers</label>
-<table class="table table-striped">
+<table class="table table-striped table-bordered">
   <tr data-ng-repeat="layer in mCfg[key]['layers'] track by $index">
   <td style="width: 90%">
     <gn-json-edit height="50" model="layer"></gn-json-edit>
@@ -35,11 +35,12 @@
   </td>
   </tr>
   <tr>
-  <td>
-    <a class="btn btn-link"
-    title="{{'add' | translate}}"
-    data-ng-click="addItem(mCfg[key]['layers'], {type: 'osm'})">
-    <i class="fa fa-plus"/>
+  <td colspan="2">
+    <a class="btn btn-default"
+       title="{{'add' | translate}}"
+       data-ng-click="addItem(mCfg[key]['layers'], {type: 'osm'})">
+      <i class="fa fa-fw fa-plus"/>
+      <span translate="">add</span>
     </a>
   </td>
   </tr>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/projectionSwitcher.html
@@ -1,4 +1,4 @@
-<table class="table table-striped">
+<table class="table table-striped table-bordered">
 	<tr data-ng-repeat="opt in mCfg[key] track by $index"
 		ng-init="parentIndex=$index">
 		<td>
@@ -68,21 +68,29 @@
 			</div>
 			<div class="input-group">
 				<span class="input-group-addon" data-translate="">ui-resolutions</span>
-				<table class="table table-striped">
+				<table class="table table-striped table-bordered">
 					<tr data-ng-repeat="resolution in opt.resolutions track by $index">
-						<td><input type="number" class="form-control"
-							data-ng-model="opt.resolutions[$index]" /></td>
-						<td><a class="btn btn-link text-danger"
-							title="{{'remove' | translate}}"
-							data-ng-click="removeItem(mCfg[key][parentIndex].resolutions, $index)">
+						<td>
+							<input type="number"
+										 class="form-control"
+							       data-ng-model="opt.resolutions[$index]" />
+						</td>
+						<td>
+							<a class="btn btn-link text-danger"
+							   title="{{'remove' | translate}}"
+							   data-ng-click="removeItem(mCfg[key][parentIndex].resolutions, $index)">
 								<i class="fa fa-times text-danger" />
 						</a></td>
 					</tr>
 					<tr>
-						<td colspan="2"><a class="btn btn-link" title="{{'add' | translate}}"
-							data-ng-click="addItem(mCfg[key][$index].resolutions, '')"> <i
-								class="fa fa-plus" />
-						</a></td>
+						<td colspan="2">
+							<a class="btn btn-default"
+								 title="{{'add' | translate}}"
+							   data-ng-click="addItem(mCfg[key][$index].resolutions, '')">
+								<i class="fa fa-fw fa-plus" />
+							  <span translate="add"></span>
+						  </a>
+						</td>
 					</tr>
 				</table>
 			</div>
@@ -97,10 +105,13 @@
 		</a></td>
 	</tr>
 	<tr>
-		<td><a class="btn btn-link" title="{{'add' | translate}}"
-			data-ng-click="addItem(mCfg[key], {'label': '', 'code': 
-				'EPSG:', 'extent': [], worldExtent: [], resolutions: []})">
-					<i class="fa fa-plus" />
-		</a></td>
+		<td colspan="2">
+			<a class="btn btn-default"
+			   title="{{'add' | translate}}"
+			   data-ng-click="addItem(mCfg[key], {'label': '', 'code': 'EPSG:', 'extent': [], worldExtent: [], resolutions: []})">
+				<i class="fa fa-fw fa-plus" />
+				<span translate="add"></span>
+			</a>
+		</td>
 	</tr>
 </table>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -5,11 +5,10 @@
       <input type="checkbox"
              id="{{m}}-checkbox"
              data-ng-model="mCfg.enabled"/>&nbsp;
-      <label class="control-label"
-             for="{{m}}-checkbox">{{('ui-mod-' + m) | translate}}</label>
+      <h2 for="{{m}}-checkbox">{{('ui-mod-' + m) | translate}}</h2>
     </legend>
     <legend data-ng-if="mCfg.enabled === undefined">
-      <label class="control-label">{{('ui-mod-' + m) | translate}}</label>
+      <h2>{{('ui-mod-' + m) | translate}}</h2>
     </legend>
 
     <p class="help-block"
@@ -33,8 +32,8 @@
 
       <!-- arrays -->
       <div data-ng-switch-when="hitsperpageValues">
-        <label class="col-sm-4 control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
+        <label class="control-label">{{('ui-' + key) | translate}}</label>
+        <table class="table table-striped table-bordered">
           <tr data-ng-repeat="v in mCfg[key] track by $index">
             <td>
               <input type="number"
@@ -52,10 +51,11 @@
           </tr>
           <tr>
             <td colspan="2">
-              <a class="btn btn-link"
+              <a class="btn btn-default"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], mCfg[key][mCfg[key].length - 1] * 10)">
-                <i class="fa fa-plus"/>
+                <i class="fa fa-fw fa-plus"/>
+                <span translate="">add</span>
               </a>
             </td>
           </tr>
@@ -105,7 +105,7 @@
 
       <div data-ng-switch-when="languages">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
+        <table class="table table-striped table-bordered">
           <tr data-ng-repeat="(iso3, iso2) in mCfg[key] track by $index">
             <td>
               <div class="input-group">
@@ -131,10 +131,11 @@
           </tr>
           <tr>
             <td colspan="2">
-              <a class="btn btn-link"
+              <a class="btn btn-default"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'iso3code': 'iso2code'})">
-                <i class="fa fa-plus"/>
+                <i class="fa fa-fw fa-plus"/>
+                <span translate="">add</span>
               </a>
             </td>
           </tr>
@@ -147,7 +148,7 @@
 
       <div data-ng-switch-when="sortbyValues">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
+        <table class="table table-striped table-bordered">
           <tr data-ng-repeat="opt in mCfg[key] track by $index">
             <td>
               <div class="input-group">
@@ -172,10 +173,11 @@
           </tr>
           <tr>
             <td colspan="2">
-              <a class="btn btn-link"
+              <a class="btn btn-default"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'sortBy': 'fieldName', 'sortOrder': ''})">
-                <i class="fa fa-plus"/>
+                <i class="fa fa-fw fa-plus"/>
+                <span translate="">add</span>
               </a>
             </td>
           </tr>
@@ -199,7 +201,7 @@
 
       <div data-ng-switch-when="resultViewTpls">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
+        <table class="table table-striped table-bordered">
           <tr data-ng-repeat="opt in mCfg[key] track by $index">
             <td>
               <div class="input-group">
@@ -230,10 +232,11 @@
           </tr>
           <tr>
             <td colspan="2">
-              <a class="btn btn-link"
+              <a class="btn btn-default"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'icon': 'fa-fw', 'tplUrl': '', 'tooltip': ''})">
-                <i class="fa fa-plus"/>
+                <i class="fa fa-fw fa-plus"/>
+                <span translate="">add</span>
               </a>
             </td>
           </tr>
@@ -246,7 +249,7 @@
 
       <div data-ng-switch-when="formatter">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
+        <table class="table table-striped table-bordered">
           <tr data-ng-repeat="opt in mCfg[key].list track by $index">
             <td>
               <div class="input-group">
@@ -272,10 +275,11 @@
           </tr>
           <tr>
             <td colspan="2">
-              <a class="btn btn-link"
+              <a class="btn btn-default"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key].list, {'label': '', 'url': ''})">
-                <i class="fa fa-plus"/>
+                <i class="fa fa-fw fa-plus"/>
+                <span translate="">add</span>
               </a>
             </td>
           </tr>
@@ -288,7 +292,7 @@
 
       <div data-ng-switch-when="downloadFormatter">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
+        <table class="table table-striped table-bordered">
           <tr data-ng-repeat="opt in mCfg[key] track by $index">
             <td>
               <div class="input-group">
@@ -314,10 +318,11 @@
           </tr>
           <tr>
             <td colspan="2">
-              <a class="btn btn-link"
+              <a class="btn btn-default"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'label': '', 'url': ''})">
-                <i class="fa fa-plus"/>
+                <i class="fa fa-fw fa-plus"/>
+                <span translate="">add</span>
               </a>
             </td>
           </tr>
@@ -331,7 +336,7 @@
         <h3>{{('ui-' + key) | translate}}</h3>
         <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
           <label class="control-label">{{type}}</label>
-          <table class="table table-striped">
+          <table class="table table-striped table-bordered">
             <tr data-ng-repeat="protocol in value track by $index">
               <td>
                 <input type="text"
@@ -349,10 +354,11 @@
             </tr>
             <tr>
               <td colspan="2">
-                <a class="btn btn-link"
+                <a class="btn btn-default"
                    title="{{'add' | translate}}"
                    data-ng-click="addItem(mCfg[key][type], 'protocol')">
-                  <i class="fa fa-plus"/>
+                  <i class="fa fa-fw fa-plus"/>
+                  <span translate="">add</span>
                 </a>
               </td>
             </tr>
@@ -372,8 +378,7 @@
           <input type="checkbox"
                  id="{{key + type}}-checkbox"
                  data-ng-model="mCfg[key][type]"/>&nbsp;
-          <label class="control-label"
-                 for="{{key + type}}-checkbox">{{('ui-' + type) | translate}}</label>
+          <label for="{{key + type}}-checkbox">{{('ui-' + type) | translate}}</label>
 
           <p class="help-block"
              data-ng-show="(('ui-' + key + type + '-help') | translate) != ('ui-' + key + type + '-help')">
@@ -404,7 +409,7 @@
         <h3>{{('ui-' + key) | translate}}</h3>
         <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
           <label class="control-label">{{type}}</label>
-          <table class="table table-striped">
+          <table class="table table-striped table-bordered">
             <tr data-ng-repeat="s in value track by $index">
               <td>
                 <div class="input-group">
@@ -430,10 +435,11 @@
             </tr>
             <tr>
               <td colspan="2">
-                <a class="btn btn-link"
+                <a class="btn btn-default"
                    title="{{'add' | translate}}"
                    data-ng-click="addItem(mCfg[key][type], {'name': 'Service label', 'url': 'http://'})">
-                  <i class="fa fa-plus"/>
+                  <i class="fa fa-fw fa-plus"/>
+                  <span translate="">add</span>
                 </a>
               </td>
             </tr>
@@ -448,7 +454,7 @@
 
       <div data-ng-switch-when="projectionList">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped">
+        <table class="table table-striped table-bordered">
           <tr data-ng-repeat="opt in mCfg[key] track by $index">
             <td>
               <div class="input-group">
@@ -474,10 +480,11 @@
           </tr>
           <tr>
             <td colspan="2">
-              <a class="btn btn-link"
+              <a class="btn btn-default"
                  title="{{'add' | translate}}"
                  data-ng-click="addItem(mCfg[key], {'label': '', 'code': 'EPSG:'})">
-                <i class="fa fa-plus"/>
+                <i class="fa fa-fw fa-plus"/>
+                <span translate="">add</span>
               </a>
             </td>
           </tr>
@@ -631,22 +638,22 @@
       </div>
 
       <div data-ng-switch-when="disabledTools">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
+        <h3>{{('ui-' + key) | translate}}</h3>
+        <p class="help-block"
+          data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
         <div data-ng-repeat="(t, value) in mCfg[key]">
           <div>
             <input type="checkbox"
                  id="{{key}}-{{t}}-checkbox"
                  data-ng-model="mCfg[key][t]"
                  ng-true-value="false" ng-false-value="true"/>&nbsp;
-            <label class="control-label"
-                   for="{{key}}-{{t}}-checkbox">
+            <label for="{{key}}-{{t}}-checkbox">
               {{(t + 'Tool') | translate}}
             </label>
           </div>
         </div>
-        <p class="help-block"
-          data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
+        
       </div>
 
       <div data-ng-switch-when="defaultSearchString">
@@ -696,7 +703,7 @@
       <div data-ng-switch-when="grid">
         <h3>{{('ui-' + key) | translate}}</h3>
         <label class="control-label" translate>gridConfigRelatedTypes</label>
-        <table class="table table-striped">
+        <table class="table table-striped table-bordered">
           <tr data-ng-repeat="relatedType in mCfg[key]['related'] track by $index">
             <td>
               <input type="text" class="form-control" ng-model="mCfg[key]['related'][$index]" />
@@ -709,8 +716,9 @@
           </tr>
           <tr>
             <td colspan="2">
-              <a class="btn btn-link" title="{{'add' | translate}}" data-ng-click="addItem(mCfg[key]['related'], '')">
-                <i class="fa fa-plus"/>
+              <a class="btn btn-default" title="{{'add' | translate}}" data-ng-click="addItem(mCfg[key]['related'], '')">
+                <i class="fa fa-fw fa-plus"/>
+                <span translate="">add</span>
               </a>
             </td>
           </tr>
@@ -1022,8 +1030,9 @@
       </div>
     </div>
   </fieldset>
-  <br/>
-  <span data-translate="">ui-advancedConfig</span>
+
+
+  <h2 data-translate="" class="gn-margin-bottom">ui-advancedConfig</h2>
 
   <gn-json-edit model="jsonConfig"></gn-json-edit>
   <textarea name="{{id}}" id="uiconfig" class="hidden">{{jsonConfig}}</textarea>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -50,7 +50,7 @@
            data-watch="sectionsLevel1"
            data-all-depth="true"/>
       <div class="panel-heading">
-        <span data-translate="">settings</span>
+        <h1 data-translate="">settings</h1>
 
         <div data-gn-need-help="administrator-guide/configuring-the-catalog/system-configuration.html"
              class="pull-right"></div>
@@ -60,11 +60,11 @@
           <div id="gn-settings-spy-target">
           <fieldset data-ng-repeat="(key, section1) in sectionsLevel1 | orderObjectBy:'position'"
                     id="gn-settings-spy-target-{{section1.name}}">
-            <legend>{{section1.name | translate}}</legend>
+            <legend><h2>{{section1.name | translate}}</h2></legend>
             <fieldset data-ng-repeat="section2 in section1.children | orderObjectBy:'position'"
                       id="{{section2.name.replace('/', '-')}}"
                       data-ng-show="section2.name">
-              <legend>{{section2.name | translate}}
+              <legend><h3>{{section2.name | translate}}</h3>
 
                 <div data-ng-if="::section2.name === 'system/inspire'"
                      data-gn-need-help="administrator-guide/configuring-the-catalog/inspire-configuration.html"

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
@@ -52,7 +52,7 @@
       <div class="panel panel-default"
            data-ng-show="uiConfiguration">
         <div class="panel-heading">
-          <span data-translate="">ui</span>
+          <h1 data-translate="">ui</h1>
 
           <div data-gn-need-help="administrator-guide/configuring-the-catalog/user-interface-configuration.html"
                class="pull-right"></div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -52,6 +52,12 @@ ul.gn-resultview li.list-group-item {
     background-color: #fff;
     top: 0;
     z-index: 100;
+    padding-left: 0;
+    // navbar in admin always 100%
+    .container, .container-fluid {
+      width: auto;
+      padding: 0;
+    }
     .navbar-collapse {
       background: #fff;
     }
@@ -296,6 +302,9 @@ ul.gn-resultview li.list-group-item {
         }
         .navbar-right {
           margin-right: 0;
+          .btn {
+            float: none;
+          }
           @media (max-width: @screen-xs-max) {
             .form-control, .btn {
               margin: 10px 0;
@@ -345,11 +354,51 @@ ul.gn-resultview li.list-group-item {
       #gn-settings {
         margin-top: 15px;
       }
+      h1 {
+        font-size: 18px;
+        margin-bottom: 15px;
+        margin-top: 0;
+      }
+      .panel-heading h1 {
+        font-size: 18px;
+        margin: 0;
+        display: inline-block;
+      }
+      h2 {
+        font-size: 17px;
+        margin: 0;
+        border: none;
+      }
+      h3 {
+        font-size: 16px;
+        text-decoration: underline;
+        font-weight: 400;
+      }
+      legend {
+        font-size: 16px;
+        h2 {
+          display: inline-block;
+        }
+        h3 {
+          font-size: 16px;
+          text-decoration: none;
+          margin: 0;
+          display: inline-block;
+        }
+        .btn {
+          margin: 0;
+        }
+      }
       fieldset, [data-ng-show="uiConfiguration"] {
-        h1 {
-          font-size: 24px;
-          margin-bottom: 15px;
-          margin-top: 0;
+        label {
+          padding-top: 7px;
+          font-weight: normal;
+          &.control-label {
+            font-weight: 500;
+          }
+        }
+        .ace_editor {
+          border: 1px solid @panel-default-border;
         }
         fieldset {
           padding: 10px;
@@ -366,6 +415,12 @@ ul.gn-resultview li.list-group-item {
             font-size: 14px;
             border-top-left-radius: @gn-border-radius;
             border-top-right-radius: @gn-border-radius;
+            h1, h2, h3 {
+              display: inline-block;
+            }
+            h2 {
+              font-weight: 400;
+            }
             label {
               padding-top: 0;
               font-size: 14px;
@@ -378,6 +433,11 @@ ul.gn-resultview li.list-group-item {
               margin-bottom: 5px;
             }
           }
+        }
+      }
+      .input-group {
+        .table {
+          margin-bottom: 0;
         }
       }
     }


### PR DESCRIPTION
Improved visual hierarchy in admin settings and user interface settings
Improvements:
- use of `<h1>`, `<h2>` and `<h3>`
- use larger font for headings higher in the hierarchy
- add label after `add` icon and make it a button
- add borders around tables and editors

![gn-admin-hierarchy](https://user-images.githubusercontent.com/19608667/110798463-7d048000-827a-11eb-8f5a-d9d23bb51195.png)
