### PR TITLE
feat(WPS) when min/max dates are specified, limit datepicker values a…

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -943,8 +943,6 @@
           date: '=gnBootstrapDatepicker',
           dates: '=dateAvailable',
           config: '=config',
-          dateMin: '=dateMin',
-          dateMax: '=dateMax',
           onChangeFn: '&?'
         },
         link: function(scope, element, attrs) {
@@ -959,10 +957,10 @@
           // });
 
           var init = function() {
-            if (scope.dateMin || scope.dateMax) {
+            if (scope.config.dateMin || scope.config.dateMax) {
               limits = {
-                min: new Date(scope.dateMin),
-                max: new Date(scope.dateMax)
+                min: new Date(scope.config.dateMin),
+                max: new Date(scope.config.dateMax)
               };
             }
             // if dates is specified it overrides the min/max params
@@ -1031,7 +1029,7 @@
               });
             }
             // only display available dates if either min or max is specified
-            if (angular.isDefined(scope.dateMin) || angular.isDefined(scope.dateMax)) {
+            if (angular.isDefined(scope.config.dateMin) || angular.isDefined(scope.config.dateMax)) {
               angular.extend(datepickConfig, {
                 startDate: limits.min,
                 endDate: limits.max

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -943,6 +943,8 @@
           date: '=gnBootstrapDatepicker',
           dates: '=dateAvailable',
           config: '=config',
+          dateMin: '=dateMin',
+          dateMax: '=dateMax',
           onChangeFn: '&?'
         },
         link: function(scope, element, attrs) {
@@ -957,6 +959,13 @@
           // });
 
           var init = function() {
+            if (scope.dateMin || scope.dateMax) {
+              limits = {
+                min: new Date(scope.dateMin),
+                max: new Date(scope.dateMax)
+              };
+            }
+            // if dates is specified it overrides the min/max params
             if (scope.dates) {
               // Time epoch
               if (angular.isArray(scope.dates) &&
@@ -1009,6 +1018,7 @@
               language: gnLangs.getIso2Lang(gnLangs.getCurrent())
             }, scope.config);
 
+            // apply range and limits if defined
             if (angular.isDefined(scope.dates)) {
               angular.extend(datepickConfig, {
                 beforeShowDay: function(dt, a, b) {
@@ -1016,6 +1026,13 @@
                   return highlight ? (isEnable ? 'gn-date-hl' : undefined) :
                       isEnable;
                 },
+                startDate: limits.min,
+                endDate: limits.max
+              });
+            }
+            // only display available dates if either min or max is specified
+            if (angular.isDefined(scope.dateMin) || angular.isDefined(scope.dateMax)) {
+              angular.extend(datepickConfig, {
                 startDate: limits.min,
                 endDate: limits.max
               });

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -182,7 +182,16 @@
             scope.checkOutput = function (outputs) {
               return outputs.filter(function(o) {
                 return o.reference.mimeType !== 'application/x-ogc-wms';
-              })
+              });
+            };
+            scope.getDateBounds = function(input, isMin) {
+              if (!input ) {
+                return;
+              }
+              else if (isMin) {
+                return input.literalData.allowedValues.valueOrRange[0].minimumValue.value;
+              }
+              return input.literalData.allowedValues.valueOrRange[0].maximumValue.value;
             };
 
             // get values from wfs filters

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -67,6 +67,8 @@
                 <div ng-repeat="field in getInputsByName(input.identifier.value)"
                      class="input-daterange input-group input-group-sm"
                      gn-bootstrap-datepicker="pickerValues"
+                     date-min="getDateBounds(input, true)"
+                     date-max="getDateBounds(input, false)"
                      data-date-format="dd-mm-yyyy">
                   <input ng-model="field.value" type="text" ng-blur="onBlur($event)" class="input-sm form-control"/>
                   <span class="input-group-addon" translate>date</span>

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -67,8 +67,7 @@
                 <div ng-repeat="field in getInputsByName(input.identifier.value)"
                      class="input-daterange input-group input-group-sm"
                      gn-bootstrap-datepicker="pickerValues"
-                     date-min="getDateBounds(input, true)"
-                     date-max="getDateBounds(input, false)"
+                     config="{dateMin: getDateBounds(input, true), dateMax: getDateBounds(input, false)}"
                      data-date-format="dd-mm-yyyy">
                   <input ng-model="field.value" type="text" ng-blur="onBlur($event)" class="input-sm form-control"/>
                   <span class="input-group-addon" translate>date</span>


### PR DESCRIPTION
DateTime WPS input paramater can have a min and a max value.
This PR will limit the datepicker range to either min, max or both
```
        <LiteralData>
          <ows:DataType ows:reference="urn:ogc:def:dataType:OGC:1.1:dateTime">dateTime</ows:DataType>
          <ows:AllowedValues>
            <ows:Range ows:rangeClosure="closed">
              <ows:MinimumValue>0001-01-01T00:00:00</ows:MinimumValue>
              <ows:MaximumValue>9999-12-31T23:59:59</ows:MaximumValue>
            </ows:Range>
          </ows:AllowedValues>
        </LiteralData>

```