### PR TITLE
Keep service context independent to address user session null pointer exceptions

### DIFF
--- a/core/src/main/java/jeeves/interfaces/ApplicationHandler.java
+++ b/core/src/main/java/jeeves/interfaces/ApplicationHandler.java
@@ -29,11 +29,17 @@ import org.jdom.Element;
 
 //=============================================================================
 
+/**
+ * Used to maintain registry of handlers for {@link jeeves.server.dispatchers.ServiceManager}.
+ */
 public interface ApplicationHandler {
+    /** Context name for registry lookup */
     public String getContextName();
 
+    /** Start application handler, returning application context managed in registry */
     public Object start(Element config, ServiceContext s) throws Exception;
 
+    /** Stop handler */
     public void stop();
 }
 

--- a/core/src/main/java/jeeves/monitor/MonitorManager.java
+++ b/core/src/main/java/jeeves/monitor/MonitorManager.java
@@ -23,6 +23,7 @@
 
 package jeeves.monitor;
 
+import com.sun.corba.se.spi.activation.ServerManager;
 import com.yammer.metrics.core.*;
 import com.yammer.metrics.log4j.InstrumentedAppender;
 import com.yammer.metrics.reporting.JmxReporter;
@@ -30,6 +31,7 @@ import com.yammer.metrics.reporting.JmxReporter;
 import jeeves.constants.ConfigFile;
 import jeeves.server.context.ServiceContext;
 
+import jeeves.server.dispatchers.ServiceManager;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.LogManager;
 import org.fao.geonet.Util;
@@ -74,6 +76,7 @@ public class MonitorManager {
 
     private MetricsRegistry metricsRegistry;
     private JmxReporter jmxReporter;
+    private ServiceContext context;
 
     public void init(ServletContext context, String baseUrl) {
 
@@ -130,7 +133,10 @@ public class MonitorManager {
         return tmpHealthCheckRegistry;
     }
 
-    public void initMonitorsForApp(ServiceContext context) {
+    public void initMonitorsForApp(ServiceContext initContext) {
+        ServiceManager serviceManager = initContext.getBean(ServiceManager.class);
+        context = serviceManager.createServiceContext("monitor", initContext);
+
         createHealthCheck(context, criticalServiceContextHealthChecks, criticalHealthCheckRegistry, "critical health check");
         createHealthCheck(context, warningServiceContextHealthChecks, warningHealthCheckRegistry, "warning health check");
         createHealthCheck(context, expensiveServiceContextHealthChecks, expensiveHealthCheckRegistry, "expensive health check");
@@ -162,12 +168,30 @@ public class MonitorManager {
         }
     }
 
+    /**
+     * Create and register health checks
+     *
+     * @param context
+     * @param checks factories used to create health checks
+     * @param registry registry listing heath checks
+     * @param type
+     */
     private void createHealthCheck(ServiceContext context, List<HealthCheckFactory> checks, HealthCheckRegistry registry, String type) {
+        ServiceManager serviceManager = context.getBean(ServiceManager.class);
         for (HealthCheckFactory healthCheck : checks) {
-            Log.info(Log.ENGINE, "Registering " + type + ": " + healthCheck.getClass().getName());
-            HealthCheck check = healthCheck.create(context);
-            healthCheckRegistry.register(check);
-            registry.register(check);
+            String factoryName = healthCheck.getClass().getName();
+            ServiceContext checkServiceContext = serviceManager.createServiceContext(type+":"+factoryName, context);
+            try {
+                HealthCheck check = healthCheck.create(checkServiceContext);
+
+                Log.info(Log.ENGINE, "Registering " + type + ": " + factoryName);
+                healthCheckRegistry.register(check);
+                registry.register(check);
+            }
+            catch (Throwable t){
+                Log.info(Log.ENGINE, "Unable to register " + type + ": " + factoryName);
+                checkServiceContext.clear();
+            }
         }
     }
 
@@ -306,6 +330,9 @@ public class MonitorManager {
     @PreDestroy
     public void shutdown() {
         Log.info(Log.ENGINE, "MonitorManager#shutdown");
+        if (context != null){
+            context.clear();
+        }
         if (resourceTracker != null) {
             resourceTracker.clean();
         }

--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -102,6 +102,8 @@ public class JeevesEngine {
     private Path _appPath;
     private int _maxUploadSize;
 
+    /** AppHandler service context used during init, tasks and background activities */
+    private ServiceContext srvContext;
 
     //---------------------------------------------------------------------------
     //---
@@ -435,7 +437,7 @@ public class JeevesEngine {
 
             ApplicationHandler h = (ApplicationHandler) c.newInstance();
 
-            ServiceContext srvContext = serviceMan.createServiceContext("AppHandler", appContext);
+            srvContext = serviceMan.createAppHandlerServiceContext(appContext);
             srvContext.setLanguage(_defaultLang);
             srvContext.setLogger(_appHandLogger);
             srvContext.setServlet(servlet);
@@ -474,7 +476,6 @@ public class JeevesEngine {
             }
             finally {
                 srvContext.clearAsThreadLocal();
-                srvContext.clear();
             }
         }
     }
@@ -533,8 +534,10 @@ public class JeevesEngine {
 
             info("Stopping handlers...");
             stopHandlers();
+            srvContext.clear();
 
             info("=== System stopped ========================================");
+
         } catch (Exception e) {
             error("Raised exception during destroy");
             error("  Exception : " + e);

--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -551,7 +551,12 @@ public class JeevesEngine {
 
     private void stopHandlers() throws Exception {
         for (ApplicationHandler h : _appHandlers) {
-            h.stop();
+            try {
+                h.stop();
+            } catch (Throwable unexpected){
+                _appHandLogger.error("Difficulty while stopping "+h.getContextName());
+                _appHandLogger.error(unexpected);
+            }
         }
     }
 

--- a/core/src/main/java/jeeves/server/context/ServiceContext.java
+++ b/core/src/main/java/jeeves/server/context/ServiceContext.java
@@ -451,6 +451,23 @@ public class ServiceContext extends BasicContext {
         _userSession = session;
     }
 
+    /**
+     * Safely look up user name, or <code>anonymous</code>.
+     *
+     * This is a quick null safe lookup of user name suitable for use in logging and error messages.
+     *
+     * @return username, or <code>anonymous</code> if unavailable.
+     */
+    public String userName(){
+        if (_userSession == null || _userSession.getUsername() == null ){
+            return "anonymous";
+        }
+        if( _userSession.getProfile() != null ){
+            return _userSession.getUsername() + "/" + _userSession.getProfile();
+        }
+        return _userSession.getUsername();
+    }
+
     public ProfileManager getProfileManager() {
         return getBean(ProfileManager.class);
     }

--- a/core/src/main/java/jeeves/server/context/ServiceContext.java
+++ b/core/src/main/java/jeeves/server/context/ServiceContext.java
@@ -364,17 +364,29 @@ public class ServiceContext extends BasicContext {
     //---
     //--------------------------------------------------------------------------
 
+    /**
+     * Language code, or <code>"?"</code> if undefined.
+     * @return language code, or <code>"?"</code> if undefined.
+     */
     public String getLanguage() {
         if (_service == null ){
             //throw new NullPointerException("Service context cleared, language not available");
         }
         return _language;
     }
-
+    /**
+     * Language code, or <code>"?"</code> if undefined.
+     * @param lang language code, or <code>"?"</code> if undefined.
+     */
     public void setLanguage(final String lang) {
         _language = lang;
     }
 
+    /**
+     * Service name, or null if service context is no longer in use.
+     *
+     * @return service name, or null if service is no longer in use
+     */
     public String getService() {
         return _service;
     }
@@ -387,6 +399,11 @@ public class ServiceContext extends BasicContext {
         logger = Log.createLogger(Log.WEBAPP + "." + service);
     }
 
+    /**
+     * IP address of request, or <code>"?"</code> for local loopback request.
+     *
+     * @return ip address, or <code>"?"</code> for loopback request.
+     */
     public String getIpAddress() {
         if (_service == null ){
             throw new NullPointerException("Service context cleared, ip address not available");
@@ -394,6 +411,11 @@ public class ServiceContext extends BasicContext {
         return _ipAddress;
     }
 
+    /**
+     * IP address of request, or <code>"?"</code> for local loopback request.
+     *
+     * @param address ip, address or <code>"?"</code> for loopback request.
+     */
     public void setIpAddress(final String address) {
         _ipAddress = address;
     }

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -353,6 +353,32 @@ public class ServiceManager {
     }
 
     /**
+     * Used to create an appContext placeholder service context used for initialization, background tasks and activities.
+     *
+     * This ServiceContext is used during initialization and is independent of any user session.
+     * This instance is the responsibility of JeevesEngine and is protected against being cleared.
+     *
+     * @param parent
+     * @return new service context
+     */
+    public ServiceContext createAppHandlerServiceContext(ConfigurableApplicationContext appContext) {
+        ServiceContext context = new ServiceContext("AppHandler", appContext, htContexts, entityManager){
+            public void clear() {
+                debug("AppHandler context cannot be cleared");
+            }
+        };
+        context.setBaseUrl(baseUrl);
+        context.setLanguage("?");
+        context.setUserSession(null);
+        context.setIpAddress("?");
+        context.setMaxUploadSize(maxUploadSize);
+        context.setServlet(servlet);
+
+        return context;
+    }
+
+
+    /**
      * Used to create a serviceContext for later use, the object provided the new serviceContext is responsible
      * for cleanup.
      * <pre><code>

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -492,7 +492,11 @@ public class ServiceManager {
     public void dispatch(ServiceRequest req, UserSession session) {
         ServiceContext context = new ServiceContext(req.getService(), ApplicationContextHolder.get(),
             htContexts, entityManager);
+      try {
         dispatch(req, session, context);
+      } finally {
+        context.clear();
+      }
     }
 
     //---------------------------------------------------------------------------
@@ -626,7 +630,7 @@ public class ServiceManager {
             else {
                 context.debug("ServiceManager dispatch context was replaced before cleanup");
             }
-            context.clear();
+            context.clearAsThreadLocal();
             if( priorContext != null){
                 priorContext.debug("ServiceManger dispatch restoring ServiceContext");
                 priorContext.setAsThreadLocal();

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -79,6 +79,10 @@ import java.util.*;
 import java.util.Map.Entry;
 
 //=============================================================================
+
+/**
+ * Handles operations on services.
+ */
 public class ServiceManager {
     private Map<String, ArrayList<ServiceInfo>> htServices = new HashMap<String, ArrayList<ServiceInfo>>(100);
     private Map<String, Object> htContexts = new HashMap<String, Object>();
@@ -158,6 +162,11 @@ public class ServiceManager {
     //---
     //---------------------------------------------------------------------------
 
+    /**
+     * Track context objects by name.
+     * @param name
+     * @param context
+     */
     public void registerContext(String name, Object context) {
         htContexts.put(name, context);
     }
@@ -343,6 +352,39 @@ public class ServiceManager {
         vErrorPipe.add(buildErrorPage(err));
     }
 
+    /**
+     * Used to create a serviceContext for later use, the object provided the new serviceContext is responsible
+     * for cleanup.
+     * <pre><code>
+     * final ServiceContext taskContext = serviceMan.createServiceContext( serviceContext, "task");
+     * return new Runnable(){
+     *     public abstract void run(){
+     *         try {
+     *            taskContext.setAsThreadLocal();
+     *
+     *         }
+     *         finally {
+     *             taskContext.clear();
+     *         }
+     *     }
+     * };
+     * </code></pre>
+     *
+     * @param name
+     * @param parent
+     * @return new service context
+     */
+    public ServiceContext createServiceContext(String name, ServiceContext parent ){
+        ServiceContext context = createServiceContext( name, parent.getApplicationContext());
+        context.setBaseUrl(parent.getBaseUrl());
+        context.setLanguage(parent.getLanguage());
+        context.setUserSession(null); // because this is intended for later use user session not included
+        context.setIpAddress(parent.getIpAddress());
+        context.setMaxUploadSize(parent.getMaxUploadSize());
+        context.setServlet(parent.getServlet());
+
+        return context;
+    }
     /**
      * Used to create a ServiceContext.
      *

--- a/core/src/main/java/org/fao/geonet/GeonetContext.java
+++ b/core/src/main/java/org/fao/geonet/GeonetContext.java
@@ -29,6 +29,9 @@ import org.fao.geonet.kernel.metadata.StatusActions;
 import org.fao.geonet.util.ThreadPool;
 import org.springframework.context.ApplicationContext;
 
+/**
+ * GeoNetwork context managing application context and a shared thread pool.
+ */
 public class GeonetContext {
     private final ApplicationContext _springAppContext;
     private final ThreadPool _threadPool;

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -125,10 +125,7 @@ public abstract class AbstractStore implements Store {
         boolean canEdit = getAccessManager(context).canEdit(context, String.valueOf(metadataId));
         if ((visibility == null && !canEdit) || (visibility == MetadataResourceVisibility.PRIVATE && !canEdit)) {
             throw new SecurityException(String.format("User '%s' does not have privileges to access '%s' resources for metadata '%s'.",
-                                                      context.getUserSession() != null ?
-                                                              context.getUserSession().getUsername() + "/" + context.getUserSession()
-                                                                      .getProfile() :
-                                                              "anonymous", visibility == null ? "any" : visibility, metadataUuid));
+                                                      context.userName(), visibility == null ? "any" : visibility, metadataUuid));
         }
         return metadataId;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -117,14 +117,14 @@ public class DataManager {
         this.metadataUtils.init(context, force);
 
         // FIXME this shouldn't login automatically ever!
-        if (context.getUserSession() == null) {
-            LOGGER_DATA_MANAGER.debug( "Automatically login in as Administrator. Who is this? Who is calling this?");
-            UserSession session = new UserSession();
-            context.setUserSession(session);
-            session.loginAs(new User().setUsername("admin").setId(-1).setProfile(Profile.Administrator));
-            LOGGER_DATA_MANAGER.debug( "Hopefully this is cron job or routinely background task. Who called us?",
-                        new Exception("Dummy Exception to know the stacktrace"));
-        }
+//        if (context.getUserSession() == null) {
+//            LOGGER_DATA_MANAGER.debug( "Automatically login in as Administrator. Who is this? Who is calling this?");
+//            UserSession session = new UserSession();
+//            context.setUserSession(session);
+//            session.loginAs(new User().setUsername("admin").setId(-1).setProfile(Profile.Administrator));
+//            LOGGER_DATA_MANAGER.debug( "Hopefully this is cron job or routinely background task. Who called us?",
+//                        new Exception("Dummy Exception to know the stacktrace"));
+//        }
     }
 
     @Deprecated

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel;
 
+import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 
 import jeeves.server.dispatchers.ServiceManager;
@@ -97,6 +98,7 @@ public final class IndexMetadataTask implements Runnable {
     public void run() {
         ServiceContext indexMedataContext = serviceManager.createServiceContext(serviceName+":IndexTask", appContext);
         try {
+            indexMedataContext.setUserSession(new UserSession());
             indexMedataContext.setAsThreadLocal();
             while (_transactionStatus != null && !_transactionStatus.isCompleted()) {
                 try {

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import jeeves.server.dispatchers.ServiceManager;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Constants;
@@ -69,6 +70,7 @@ import com.google.common.collect.Maps;
 
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
+import org.springframework.context.ConfigurableApplicationContext;
 
 
 public class ThesaurusManager implements ThesaurusFinder {
@@ -537,15 +539,20 @@ public class ThesaurusManager implements ThesaurusFinder {
      */
     final class InitThesauriTableTask implements Runnable {
 
-        private final ServiceContext context;
+        //private final ServiceContext context;
         private final Path thesauriDir;
+        private final ServiceManager serviceManager;
+        private final ConfigurableApplicationContext appContext;
 
         InitThesauriTableTask(ServiceContext context, Path thesauriDir) {
-            this.context = context;
+            //this.context = context;
+            this.serviceManager = context.getBean(ServiceManager.class);
+            this.appContext = context.getApplicationContext();
             this.thesauriDir = thesauriDir;
         }
 
         public void run() {
+            ServiceContext context = serviceManager.createServiceContext(Geonet.THESAURUS_MAN, appContext);
             context.setAsThreadLocal();
             try {
                 // poll context to see whether servlet is up yet
@@ -565,6 +572,7 @@ public class ThesaurusManager implements ThesaurusFinder {
             }
             finally {
                 context.clearAsThreadLocal();
+                context.clear();
             }
         }
     }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -339,12 +339,7 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
             executor.execute(worker);
             index += count;
         }
-
-        try {
-            executor.awaitTermination(1, TimeUnit.DAYS );
-        } catch (InterruptedException e) {
-            Log.warning( Geonet.INDEX_ENGINE, "Indexing took more than a day", e);
-        }
+        // let the started threads finish in the background and then clean up executor
         executor.shutdown();
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -149,7 +149,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Sorted harvester nodes.
      *
      * @param nodes     harvest nodes
      * @param sortField sort field
@@ -164,7 +164,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Transformed harvest node
      *
      * @param node harvest node
      * @return transformed harvest node
@@ -177,7 +177,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Clean up harvest manager.
      */
     @Override
     public void shutdown() {
@@ -206,7 +206,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     //---------------------------------------------------------------------------
 
     /**
-     * TODO javadoc.
+     * Harvest node, filtered to only include nodes visible to user session.
      *
      * @param id      harvester id
      * @param context servicecontext
@@ -293,7 +293,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO javadoc.
+     * Add harvester, returning the id new harvester.
      *
      * @param node    harvester config
      * @param ownerId the id of the user doing this
@@ -324,7 +324,8 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Add harvester, returning UUID.
+     * @return uuid of new harvester
      */
     @Override
     public String addHarvesterReturnUUID(Element node) throws JeevesException, SQLException {
@@ -345,9 +346,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO javadoc.
+     * Clone harvester.
      *
      * @param ownerId id of the user doing this
+     * @return id of the new harvester
      */
     @Override
     public synchronized String createClone(String id, String ownerId, ServiceContext context) throws Exception {
@@ -380,9 +382,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO javadoc.
+     * Update on harvester progress.
      *
      * @param ownerId id of the user doing this
+     * @return true of harvester updated
      */
     @Override
     public synchronized boolean update(Element node, String ownerId) throws BadInputEx, SQLException, SchedulerException {
@@ -444,7 +447,8 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
 
 
     /**
-     * TODO Javadoc.
+     * Start harvester
+     * @param id harvester id
      */
     @Override
     public OperResult start(String id) throws SQLException, SchedulerException {
@@ -460,7 +464,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Stop harvester with provided status, and unschedule any outstanding jobs.
+     * @param id harvester id
+     * @param status New status
+     * @return harvester progress
      */
     @Override
     public OperResult stop(String id, Common.Status status) throws SQLException, SchedulerException {
@@ -476,7 +483,9 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Start harvester run
+     * @parm id harvester to run
+     * return harvester progress
      */
     @Override
     public OperResult run(String id) throws SQLException, SchedulerException {
@@ -500,7 +509,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Run the harvester check if harvest correctly completed.
      */
     @Override
     public OperResult invoke(String id) {
@@ -524,7 +533,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Harvester details
+     * @param harvestUuid uuid to look up harvester info
+     * @param id
+     * @param uuid
      */
     public Element getHarvestInfo(String harvestUuid, String id, String uuid) {
         Element info = new Element(Edit.Info.Elem.HARVEST_INFO);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -110,7 +110,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     @Override
     public void init(ServiceContext initContext, boolean isReadOnly) throws Exception {
         //create a new (shared) context instead of using the Jeeves one
-        ServiceManager serviceManager = context.getBean(ServiceManager.class);
+        ServiceManager serviceManager = initContext.getBean(ServiceManager.class);
         this.context = serviceManager.createServiceContext("harvester", initContext);
 
         this.dataMan = context.getBean(DataManager.class);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -108,11 +108,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
      * @throws Exception hmm
      */
     @Override
-    public void init(ServiceContext context, boolean isReadOnly) throws Exception {
+    public void init(ServiceContext initContext, boolean isReadOnly) throws Exception {
         //create a new (shared) context instead of using the Jeeves one
         ServiceManager serviceManager = context.getBean(ServiceManager.class);
-        context = serviceManager.createServiceContext("harvester", context);
-        this.context =  context;
+        this.context = serviceManager.createServiceContext("harvester", initContext);
 
         this.dataMan = context.getBean(DataManager.class);
         this.settingMan = context.getBean(HarvesterSettingsManager.class);

--- a/services/src/main/java/org/fao/geonet/api/records/backup/BackupArchiveApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/backup/BackupArchiveApi.java
@@ -92,7 +92,7 @@ public class BackupArchiveApi {
         GeonetworkDataDirectory dataDirectory = appContext.getBean(GeonetworkDataDirectory.class);
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
 
-        Log.info(ArchiveAllMetadataJob.BACKUP_LOG, "User " + context.getUserSession().getUsername() + " from IP: " + context
+        Log.info(ArchiveAllMetadataJob.BACKUP_LOG, "User " + context.userName() + " from IP: " + context
                 .getIpAddress() + " has started to download backup archive");
 
         File backupDir = dataDirectory.getBackupDir().resolve(ArchiveAllMetadataJob.BACKUP_DIR).toFile();

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/groovy/FunctionsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/groovy/FunctionsTest.java
@@ -40,6 +40,7 @@ import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.repository.IsoLanguageRepository;
 import org.fao.geonet.utils.IO;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -130,6 +131,13 @@ public class FunctionsTest {
                 return Mockito.mock(ConfigFile.class);
             }
         };
+    }
+    @After
+    public void tearDown() throws Exception {
+        if( fparams != null ){
+            fparams.context.clearAsThreadLocal();
+            fparams.context.clear();
+        }
     }
 
     @Test

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -25,6 +25,7 @@ package org.fao.geonet;
 
 import java.util.Collections;
 import javax.persistence.EntityManager;
+import jeeves.server.UserSession;
 import jeeves.server.dispatchers.ServiceManager;
 import org.fao.geonet.api.ApiUtils;
 import org.locationtech.jts.geom.MultiPolygon;
@@ -425,6 +426,7 @@ public class Geonetwork implements ApplicationHandler {
             public void run() {
                 ServiceManager serviceManager = _applicationContext.getBean(ServiceManager.class);
                 ServiceContext fillCacheServiceContext = serviceManager.createServiceContext( "init.filleCaches",_applicationContext);
+                fillCacheServiceContext.setUserSession( new UserSession() );
                 FormatterApi formatService = fillCacheServiceContext.getBean(FormatterApi.class); // this will initialize the formatter
 
                 final ServletContext servletContext = fillCacheServiceContext.getServlet().getServletContext();

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -23,6 +23,10 @@
 
 package org.fao.geonet;
 
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import jeeves.server.dispatchers.ServiceManager;
+import org.fao.geonet.api.ApiUtils;
 import org.locationtech.jts.geom.MultiPolygon;
 import jeeves.config.springutil.ServerBeanPropertyUpdater;
 import jeeves.constants.Jeeves;
@@ -406,7 +410,7 @@ public class Geonetwork implements ApplicationHandler {
             createDBHeartBeat(gnContext, dbHeartBeatInitialDelay, dbHeartBeatFixedDelay);
         }
 
-        fillCaches(context);
+        fillCaches();
 
         AbstractEntityListenerManager.setSystemRunning(true);
 
@@ -415,14 +419,16 @@ public class Geonetwork implements ApplicationHandler {
         return gnContext;
     }
 
-    private void fillCaches(final ServiceContext context) {
-        final FormatterApi formatService = context.getBean(FormatterApi.class); // this will initialize the formatter
-
+    private void fillCaches() {
         Thread fillCaches = new Thread(new Runnable() {
             @Override
             public void run() {
-                final ServletContext servletContext = context.getServlet().getServletContext();
-                context.setAsThreadLocal();
+                ServiceManager serviceManager = _applicationContext.getBean(ServiceManager.class);
+                ServiceContext fillCacheServiceContext = serviceManager.createServiceContext( "init.filleCaches",_applicationContext);
+                FormatterApi formatService = fillCacheServiceContext.getBean(FormatterApi.class); // this will initialize the formatter
+
+                final ServletContext servletContext = fillCacheServiceContext.getServlet().getServletContext();
+                fillCacheServiceContext.setAsThreadLocal();
                 ApplicationContextHolder.set(_applicationContext);
               try {
                 GeonetWro4jFilter filter = (GeonetWro4jFilter) servletContext.getAttribute(GeonetWro4jFilter.GEONET_WRO4J_FILTER_KEY);
@@ -445,14 +451,14 @@ public class Geonetwork implements ApplicationHandler {
                 final Page<Metadata> metadatas = _applicationContext.getBean(MetadataRepository.class).findAll(new PageRequest(0, 1));
                 if (metadatas.getNumberOfElements() > 0) {
                     Integer mdId = metadatas.getContent().get(0).getId();
-                    context.getUserSession().loginAs(new User().setName("admin").setProfile(Profile.Administrator).setUsername("admin"));
+                    fillCacheServiceContext.getUserSession().loginAs(new User().setName("admin").setProfile(Profile.Administrator).setUsername("admin"));
                     @SuppressWarnings("unchecked")
                     List<String> formattersToInitialize = _applicationContext.getBean("formattersToInitialize", List.class);
 
                     for (String formatterName : formattersToInitialize) {
                         Log.info(Geonet.GEONETWORK, "Initializing the Formatter with id: " + formatterName);
                         final MockHttpSession servletSession = new MockHttpSession(servletContext);
-                        servletSession.setAttribute(Jeeves.Elem.SESSION, context.getUserSession());
+                        servletSession.setAttribute(Jeeves.Elem.SESSION, fillCacheServiceContext.getUserSession());
                         final MockHttpServletRequest servletRequest = new MockHttpServletRequest(servletContext);
                         servletRequest.setSession(servletSession);
                         final MockHttpServletResponse response = new MockHttpServletResponse();
@@ -465,7 +471,8 @@ public class Geonetwork implements ApplicationHandler {
                     }
                 }
               } finally {
-                context.clearAsThreadLocal();
+                  fillCacheServiceContext.clearAsThreadLocal();
+                  fillCacheServiceContext.clear();
               }
             }
         });


### PR DESCRIPTION
This pull request is working on addressing issues reported by previous service context PR, which now cleans up service context, and logs some messages when service context is handled in an unexpected way.

* Carefully treating the AppHandler service context created by Jeeves for use during init. This AppHandler service context is now cleaned up during Jeeves shutdown (so it is still available for initialization tasks that have been started in separate threads). I have placed some warnings if this shared AppHandler service context is configured by any of the tasks (as this would result in side effects for other tasks).

* Monitor now maintains a service context for use by the health checks. Previously these were using the Jeeves AppHandler service context

* We noticed during testing that indexing api was waiting to complete and no longer providing feedback

As usual I am gradually adding javadocs to these core abstractions based on how they are used. Reviewers are asked to directly edit this pull request if they have clarifications or corrections!