### PR TITLE
Index documentStandard field (metadata standard) in Java code and remove the old schema field name, not used anymore.

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -627,7 +627,7 @@ public final class Geonet {
         public static final String HASXLINKS = "_hasxlinks";
         public static final String XLINK = "_xlink";
         public static final String ROOT = "_root";
-        public static final String SCHEMA = "schema";
+        public static final String SCHEMA = "documentStandard";
         public static final String DATABASE_CREATE_DATE = "createDate";
         public static final String DATABASE_CHANGE_DATE = "changeDate";
         public static final String SOURCE = "_source";

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -168,7 +168,6 @@
     <!-- Create a first document representing the main record. -->
     <doc>
       <xsl:copy-of select="gn-fn-index:add-field('docType', 'metadata')"/>
-      <xsl:copy-of select="gn-fn-index:add-field('documentStandard', 'iso19115-3.2018')"/>
       <!-- Index the metadata document as XML -->
       <document>
         <!--<xsl:value-of select="saxon:serialize(., 'default-serialize-mode')"/>-->

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -143,7 +143,6 @@
     <doc>
 
       <xsl:copy-of select="gn-fn-index:add-field('docType', 'metadata')"/>
-      <xsl:copy-of select="gn-fn-index:add-field('documentStandard', 'iso19139')"/>
 
       <!-- Index the metadata document as XML -->
       <document>

--- a/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
@@ -95,7 +95,7 @@
                         "aggs": {
                           "schema": {
                             "terms": {
-                              "field": "schema.keyword",
+                              "field": "documentStandard",
                               "size": 10
                             }
                           }

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -191,7 +191,7 @@
               $scope.id = $routeParams.id;
 
               gnCurrentEdit.metadata = new Metadata(r.data.hits.hits[0]);
-              $scope.mdSchema = gnCurrentEdit.metadata.schema;
+              $scope.mdSchema = gnCurrentEdit.metadata.documentStandard;
               gnCurrentEdit.schema = $scope.mdSchema;
               $scope.mdCategories = {values: []};
               var categories = gnCurrentEdit.metadata.cat;


### PR DESCRIPTION
Currently the document standard indexing, used to relate a metadata record with a metadata schema, it's indexed in this template. Example for `iso19139`, see at the end of the snippet:

https://github.com/geonetwork/core-geonetwork/blob/7818588893f5e36581913a40cad73a2bf4906889/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl#L96-L146

Custom schemas based on `iso19139` must define this full template, even for a the single change of the document standard, making maintenance of the file more difficult to keep in synch the changes with `iso19139`.

With this change, the indexing is done in Java code (as was done for the old `schema` field, to work with any schema without having to explicitly specify the field in the indexing xsl of each schema.