### PR TITLE
Updated schematron name on error messages so that it does not overlap.

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -875,7 +875,6 @@ input.ng-invalid {
     margin-top: 2px;
   }
   .label {
-    line-height: 2;
     font-size: 11px;
   }
   .no-data a {

--- a/web/src/main/webapp/xslt/common/utility-tpl-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl-metadata.xsl
@@ -221,13 +221,11 @@
               <xsl:otherwise>
                 <li class="list-group-item text-danger">
                   <div class="row">
-                    <div class="col-xs-10">
+                    <div>
+                       <div class="pull-right label label-danger">
+                           <xsl:value-of select="@type"/>
+                       </div>
                       <xsl:value-of select="."/>
-                    </div>
-                    <div class="col-xs-2">
-                      <span class="pull-right label label-danger">
-                        <xsl:value-of select="@type"/>
-                      </span>
                     </div>
                   </div>
                 </li>


### PR DESCRIPTION
Fix for #5520

Before

![image](https://user-images.githubusercontent.com/1868233/111618404-1bd13500-87c3-11eb-8505-c4908a291c02.png)

After

![image](https://user-images.githubusercontent.com/1868233/111618316-fe03d000-87c2-11eb-87c1-0a4f8d97ac15.png)

See #5520 for other screenshots of the issue.

This fix will better accommodate cases where the schematron name is long.