### PR TITLE
Fix for the layout of the `gn-status` field in the editor

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -331,6 +331,7 @@
     }
     // field in field
     .gn-field {
+      float: none;
       label {
         font-size: 12px;
         &:after {


### PR DESCRIPTION
Fix for https://github.com/geonetwork/core-geonetwork/pull/5469#discussion_r597593522

Fix for the `gn-status` field in the editor that was inheriting a class that messed up the layout

After the fix
![gn-editor-field-fix](https://user-images.githubusercontent.com/19608667/111782364-3980c600-88b9-11eb-8b42-98d178cc5f36.png)
