### PR TITLE
Update ZipUtil.java to use tempFile configuration to avoid memory issue

### DIFF
--- a/common/src/main/java/org/fao/geonet/ZipUtil.java
+++ b/common/src/main/java/org/fao/geonet/ZipUtil.java
@@ -32,6 +32,8 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.file.*;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Zip or unzip files
@@ -101,7 +103,11 @@ public class ZipUtil {
     public static FileSystem createZipFs(Path path) throws IOException, URISyntaxException {
         Files.deleteIfExists(path);
 
+        Map<String, Object> env = new HashMap<>();
+        env.put("create", String.valueOf(true));
+        env.put("useTempFile", Boolean.TRUE);
+
         URI uri = new URI("jar:" + path.toUri());
-        return FileSystems.newFileSystem(uri, Collections.singletonMap("create", String.valueOf(true)));
+        return FileSystems.newFileSystem(uri, env);
     }
 }

--- a/common/src/main/java/org/fao/geonet/utils/BinaryFile.java
+++ b/common/src/main/java/org/fao/geonet/utils/BinaryFile.java
@@ -279,16 +279,21 @@ public final class BinaryFile {
 
     private String readInputMinimum(Path path) {
 
+        FileInputStream inputStream = null;
+        Scanner sc = null;
+
         try {
-            FileInputStream inputStream = new FileInputStream(path.toFile());
-            Scanner sc = new Scanner(inputStream, Constants.CHARSET.toString());
+            inputStream = new FileInputStream(path.toFile());
+            sc = new Scanner(inputStream, Constants.CHARSET.toString());
             String line = sc.nextLine();
-            sc.close();
-            inputStream.close();
+
             return line;
         } catch (IOException e) {
             Log.error("geonetwork", "Error reading file: " + path);
             return null;
+        } finally {
+            IOUtils.closeQuietly(sc);
+            IOUtils.closeQuietly(inputStream);
         }
     }
 

--- a/common/src/main/java/org/fao/geonet/utils/BinaryFile.java
+++ b/common/src/main/java/org/fao/geonet/utils/BinaryFile.java
@@ -283,6 +283,8 @@ public final class BinaryFile {
             FileInputStream inputStream = new FileInputStream(path.toFile());
             Scanner sc = new Scanner(inputStream, Constants.CHARSET.toString());
             String line = sc.nextLine();
+            sc.close();
+            inputStream.close();
             return line;
         } catch (IOException e) {
             Log.error("geonetwork", "Error reading file: " + path);


### PR DESCRIPTION
@juanluisrp @jodygarnett 

This is related to https://github.com/geonetwork/core-geonetwork/issues/5479 that we discussed about memory issue. So the workaround is to have tempFile enabled. I tested from my local and works as expected.


