### PR TITLE
Fix issue with localized exception where with* functions were returning LocalizedException instead of the class

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/exception/FeatureNotEnabledException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/FeatureNotEnabledException.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet.api.exception;
 
+import java.util.Locale;
+
 import org.fao.geonet.exceptions.LocalizedException;
 
 public class FeatureNotEnabledException extends LocalizedException {
@@ -45,5 +47,35 @@ public class FeatureNotEnabledException extends LocalizedException {
 
     protected String getResourceBundleBeanQualifier() {
         return "apiMessages";
+    }
+
+    @Override
+    public FeatureNotEnabledException withMessageKey(String messageKey) {
+        super.withMessageKey(messageKey);
+        return this;
+    }
+
+    @Override
+    public FeatureNotEnabledException withMessageKey(String messageKey, Object[] messageKeyArgs) {
+        super.withMessageKey(messageKey, messageKeyArgs);
+        return this;
+    }
+
+    @Override
+    public FeatureNotEnabledException withDescriptionKey(String descriptionKey) {
+        super.withDescriptionKey(descriptionKey);
+        return this;
+    }
+
+    @Override
+    public FeatureNotEnabledException withDescriptionKey(String descriptionKey, Object[] descriptionKeyArgs) {
+        super.withDescriptionKey(descriptionKey, descriptionKeyArgs);
+        return this;
+    }
+
+    @Override
+    public FeatureNotEnabledException withLocale(Locale locale) {
+        super.withLocale(locale);
+        return this;
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/exception/ForbiddenException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/ForbiddenException.java
@@ -48,4 +48,34 @@ public class ForbiddenException extends LocalizedRuntimeException {
     protected String getResourceBundleBeanQualifier() {
         return "apiMessages";
     }
+
+    @Override
+    public ForbiddenException withMessageKey(String messageKey) {
+        super.withMessageKey(messageKey);
+        return this;
+    }
+
+    @Override
+    public ForbiddenException withMessageKey(String messageKey, Object[] messageKeyArgs) {
+        super.withMessageKey(messageKey, messageKeyArgs);
+        return this;
+    }
+
+    @Override
+    public ForbiddenException withDescriptionKey(String descriptionKey) {
+        super.withDescriptionKey(descriptionKey);
+        return this;
+    }
+
+    @Override
+    public ForbiddenException withDescriptionKey(String descriptionKey, Object[] descriptionKeyArgs) {
+        super.withDescriptionKey(descriptionKey, descriptionKeyArgs);
+        return this;
+    }
+
+    @Override
+    public ForbiddenException withLocale(Locale locale) {
+        super.withLocale(locale);
+        return this;
+    }
 }

--- a/core/src/main/java/org/fao/geonet/api/exception/GeoPublisherException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/GeoPublisherException.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet.api.exception;
 
+import java.util.Locale;
+
 import org.fao.geonet.exceptions.LocalizedException;
 
 public class GeoPublisherException extends LocalizedException {
@@ -45,5 +47,35 @@ public class GeoPublisherException extends LocalizedException {
 
     protected String getResourceBundleBeanQualifier() {
         return "apiMessages";
+    }
+
+    @Override
+    public GeoPublisherException withMessageKey(String messageKey) {
+        super.withMessageKey(messageKey);
+        return this;
+    }
+
+    @Override
+    public GeoPublisherException withMessageKey(String messageKey, Object[] messageKeyArgs) {
+        super.withMessageKey(messageKey, messageKeyArgs);
+        return this;
+    }
+
+    @Override
+    public GeoPublisherException withDescriptionKey(String descriptionKey) {
+        super.withDescriptionKey(descriptionKey);
+        return this;
+    }
+
+    @Override
+    public GeoPublisherException withDescriptionKey(String descriptionKey, Object[] descriptionKeyArgs) {
+        super.withDescriptionKey(descriptionKey, descriptionKeyArgs);
+        return this;
+    }
+
+    @Override
+    public GeoPublisherException withLocale(Locale locale) {
+        super.withLocale(locale);
+        return this;
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/exception/NoResultsFoundException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/NoResultsFoundException.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet.api.exception;
 
+import java.util.Locale;
+
 import org.fao.geonet.exceptions.LocalizedException;
 
 public class NoResultsFoundException extends LocalizedException {
@@ -45,5 +47,35 @@ public class NoResultsFoundException extends LocalizedException {
 
     protected String getResourceBundleBeanQualifier() {
         return "apiMessages";
+    }
+
+    @Override
+    public NoResultsFoundException withMessageKey(String messageKey) {
+        super.withMessageKey(messageKey);
+        return this;
+    }
+
+    @Override
+    public NoResultsFoundException withMessageKey(String messageKey, Object[] messageKeyArgs) {
+        super.withMessageKey(messageKey, messageKeyArgs);
+        return this;
+    }
+
+    @Override
+    public NoResultsFoundException withDescriptionKey(String descriptionKey) {
+        super.withDescriptionKey(descriptionKey);
+        return this;
+    }
+
+    @Override
+    public NoResultsFoundException withDescriptionKey(String descriptionKey, Object[] descriptionKeyArgs) {
+        super.withDescriptionKey(descriptionKey, descriptionKeyArgs);
+        return this;
+    }
+
+    @Override
+    public NoResultsFoundException withLocale(Locale locale) {
+        super.withLocale(locale);
+        return this;
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/exception/NotAllowedException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/NotAllowedException.java
@@ -23,6 +23,8 @@
 package org.fao.geonet.api.exception;
 
 
+import java.util.Locale;
+
 import org.fao.geonet.exceptions.LocalizedRuntimeException;
 
 public class NotAllowedException extends LocalizedRuntimeException {
@@ -100,5 +102,35 @@ public class NotAllowedException extends LocalizedRuntimeException {
 
     protected String getResourceBundleBeanQualifier() {
         return "apiMessages";
+    }
+
+    @Override
+    public NotAllowedException withMessageKey(String messageKey) {
+        super.withMessageKey(messageKey);
+        return this;
+    }
+
+    @Override
+    public NotAllowedException withMessageKey(String messageKey, Object[] messageKeyArgs) {
+        super.withMessageKey(messageKey, messageKeyArgs);
+        return this;
+    }
+
+    @Override
+    public NotAllowedException withDescriptionKey(String descriptionKey) {
+        super.withDescriptionKey(descriptionKey);
+        return this;
+    }
+
+    @Override
+    public NotAllowedException withDescriptionKey(String descriptionKey, Object[] descriptionKeyArgs) {
+        super.withDescriptionKey(descriptionKey, descriptionKeyArgs);
+        return this;
+    }
+
+    @Override
+    public NotAllowedException withLocale(Locale locale) {
+        super.withLocale(locale);
+        return this;
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/exception/ResourceAlreadyExistException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/ResourceAlreadyExistException.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet.api.exception;
 
+import java.util.Locale;
+
 import org.fao.geonet.exceptions.LocalizedException;
 
 public class ResourceAlreadyExistException extends LocalizedException {
@@ -45,5 +47,35 @@ public class ResourceAlreadyExistException extends LocalizedException {
 
     protected String getResourceBundleBeanQualifier() {
         return "apiMessages";
+    }
+
+    @Override
+    public ResourceAlreadyExistException withMessageKey(String messageKey) {
+        super.withMessageKey(messageKey);
+        return this;
+    }
+
+    @Override
+    public ResourceAlreadyExistException withMessageKey(String messageKey, Object[] messageKeyArgs) {
+        super.withMessageKey(messageKey, messageKeyArgs);
+        return this;
+    }
+
+    @Override
+    public ResourceAlreadyExistException withDescriptionKey(String descriptionKey) {
+        super.withDescriptionKey(descriptionKey);
+        return this;
+    }
+
+    @Override
+    public ResourceAlreadyExistException withDescriptionKey(String descriptionKey, Object[] descriptionKeyArgs) {
+        super.withDescriptionKey(descriptionKey, descriptionKeyArgs);
+        return this;
+    }
+
+    @Override
+    public ResourceAlreadyExistException withLocale(Locale locale) {
+        super.withLocale(locale);
+        return this;
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/exception/ResourceNotFoundException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/ResourceNotFoundException.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet.api.exception;
 
+import java.util.Locale;
+
 import org.fao.geonet.exceptions.LocalizedException;
 
 public class ResourceNotFoundException extends LocalizedException {
@@ -44,5 +46,35 @@ public class ResourceNotFoundException extends LocalizedException {
 
     protected String getResourceBundleBeanQualifier() {
         return "apiMessages";
+    }
+
+    @Override
+    public ResourceNotFoundException withMessageKey(String messageKey) {
+        super.withMessageKey(messageKey);
+        return this;
+    }
+
+    @Override
+    public ResourceNotFoundException withMessageKey(String messageKey, Object[] messageKeyArgs) {
+        super.withMessageKey(messageKey, messageKeyArgs);
+        return this;
+    }
+
+    @Override
+    public ResourceNotFoundException withDescriptionKey(String descriptionKey) {
+        super.withDescriptionKey(descriptionKey);
+        return this;
+    }
+
+    @Override
+    public ResourceNotFoundException withDescriptionKey(String descriptionKey, Object[] descriptionKeyArgs) {
+        super.withDescriptionKey(descriptionKey, descriptionKeyArgs);
+        return this;
+    }
+
+    @Override
+    public ResourceNotFoundException withLocale(Locale locale) {
+        super.withLocale(locale);
+        return this;
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/exception/WebApplicationException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/WebApplicationException.java
@@ -23,6 +23,8 @@
 package org.fao.geonet.api.exception;
 
 
+import java.util.Locale;
+
 import org.fao.geonet.exceptions.LocalizedRuntimeException;
 
 public class WebApplicationException extends LocalizedRuntimeException {
@@ -100,5 +102,35 @@ public class WebApplicationException extends LocalizedRuntimeException {
 
     protected String getResourceBundleBeanQualifier() {
         return "apiMessages";
+    }
+
+    @Override
+    public WebApplicationException withMessageKey(String messageKey) {
+        super.withMessageKey(messageKey);
+        return this;
+    }
+
+    @Override
+    public WebApplicationException withMessageKey(String messageKey, Object[] messageKeyArgs) {
+        super.withMessageKey(messageKey, messageKeyArgs);
+        return this;
+    }
+
+    @Override
+    public WebApplicationException withDescriptionKey(String descriptionKey) {
+        super.withDescriptionKey(descriptionKey);
+        return this;
+    }
+
+    @Override
+    public WebApplicationException withDescriptionKey(String descriptionKey, Object[] descriptionKeyArgs) {
+        super.withDescriptionKey(descriptionKey, descriptionKeyArgs);
+        return this;
+    }
+
+    @Override
+    public WebApplicationException withLocale(Locale locale) {
+        super.withLocale(locale);
+        return this;
     }
 }

--- a/core/src/main/java/org/fao/geonet/exceptions/LocalizedException.java
+++ b/core/src/main/java/org/fao/geonet/exceptions/LocalizedException.java
@@ -57,6 +57,10 @@ public abstract class LocalizedException extends Exception implements ILocalized
         super(message, cause, enableSuppression, writableStackTrace);
     }
 
+    // Note that the following could not be a generic abstract class using generic type -i.e<T extends LocalizedException>
+    // As generic class is not allowed to extend the Throwable class directly or indirectly.
+    // https://docs.oracle.com/javase/specs/jls/se6/html/classes.html#303584
+    // So each child class needs to have it's own version.
     public LocalizedException withMessageKey(String messageKey) {
         return withMessageKey(messageKey, null);
     }
@@ -148,4 +152,5 @@ public abstract class LocalizedException extends Exception implements ILocalized
     public void setDescriptionKeyArgs(Object[] descriptionKeyArgs) {
         this.descriptionKeyArgs = descriptionKeyArgs;
     }
+
 }

--- a/core/src/main/java/org/fao/geonet/exceptions/LocalizedRuntimeException.java
+++ b/core/src/main/java/org/fao/geonet/exceptions/LocalizedRuntimeException.java
@@ -57,6 +57,10 @@ public abstract class LocalizedRuntimeException extends RuntimeException impleme
         super(message, cause, enableSuppression, writableStackTrace);
     }
 
+    // Note that the following could not be a generic abstract class using generic type -i.e<T extends LocalizedException>
+    // As generic class is not allowed to extend the Throwable class directly or indirectly.
+    // https://docs.oracle.com/javase/specs/jls/se6/html/classes.html#303584
+    // So each child class needs to have it's own version.
     public LocalizedRuntimeException withMessageKey(String messageKey) {
         return withMessageKey(messageKey, null);
     }


### PR DESCRIPTION
Fix issue with localized exception where with* functions were returning LocalizedException instead of the class. i.e. ResourceNotFoundException

Fix issue from #5323

The following

https://github.com/geonetwork/core-geonetwork/blob/a2ada8b830d0bdb937e1846432376267d41cd402/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java#L111-L113

Is throwing an LocalizedException exception instead of a ResourceNotFoundException but since the function throws a generic Exception, the issue was not initially caught.

This fix correct the issue so that the with* functions return the proper exception such as ResourceNotFoundException in the example above.


An attempt was made to use generic class in the abstract class such as the following

`public <T extends LocalizedException> T withMessageKey(String messageKey) `

However I could not get that to work due to generic classes not being allowed in the throwable class.

https://docs.oracle.com/javase/specs/jls/se6/html/classes.html#303584

So each exception needs to have the extra functions if they wish to support that option.

Alternatively they could be removed and the code that want to throw the error would have to do something similar to the following.

```
ResourceNotFoundException resourceNotFoundException =  new new ResourceNotFoundException(String.format("Metadata with UUID '%s' not found.", metadataUuid)) ;
resourceNotFoundException.setMessageKey("exception.resourceNotFound.metadata") ;
resourceNotFoundException.setDescriptionKey("exception.resourceNotFound.metadata.description", new String[]{ metadataUuid }); 
throw resourceNotFoundException;
```
But I think the other is cleaner.
