### PR TITLE
Use long instead of int to retrieve file size in Jeeves ServiceManager

### DIFF
--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -910,7 +910,7 @@ public class ServiceManager {
                 String contentDisposition = binaryFile.getContentDisposition();
                 String contentLength = binaryFile.getContentLength();
 
-                int cl = (contentLength == null) ? -1 : Integer.parseInt(contentLength);
+                long cl = (contentLength == null) ? -1 : Long.parseLong(contentLength);
 
                 // Did we set up a status code for the response?
                 if (context.getStatusCode() != null) {
@@ -933,7 +933,7 @@ public class ServiceManager {
                 String contentDisposition = BLOB.getContentDisposition(response);
                 String contentLength = BLOB.getContentLength(response);
 
-                int cl = (contentLength == null) ? -1 : Integer.parseInt(contentLength);
+                long cl = (contentLength == null) ? -1 : Long.parseLong(contentLength);
 
                 req.beginStream(contentType, cl, contentDisposition, cache);
                 BLOB.write(response, req.getOutputStream());

--- a/core/src/main/java/jeeves/server/local/LocalServiceRequest.java
+++ b/core/src/main/java/jeeves/server/local/LocalServiceRequest.java
@@ -188,7 +188,7 @@ public class LocalServiceRequest extends ServiceRequest {
         beginStream(contentType, -1, null, cache);
     }
 
-    public void beginStream(String contentType, int contentLength,
+    public void beginStream(String contentType, long contentLength,
                             String contentDisposition, boolean cache) {
     }
 

--- a/core/src/main/java/jeeves/server/sources/ServiceRequest.java
+++ b/core/src/main/java/jeeves/server/sources/ServiceRequest.java
@@ -225,7 +225,7 @@ public class ServiceRequest {
      * @param contentDisposition content disposition (inline|attachment|attachment;filename=&quot;filename.jpg&quot;)
      * @param cache true if content can be cached, false to disable caching for dynamic content
      */
-    public void beginStream(String contentType, int contentLength, String contentDisposition ,
+    public void beginStream(String contentType, long contentLength, String contentDisposition ,
                             boolean cache) {
     }
 


### PR DESCRIPTION
Issue found testing https://github.com/geonetwork/core-geonetwork/pull/5526 , although not related to the pull request change, when exporting to MEF format a metadata selection including a file of 3.3 Gb.

The file size should be managed as an `Long`. 

In any case, this code seem only used for `LocalServiceRequest` class, in `ServiceRequest` the method implementation is empty, should be review if `LocalServiceRequest` is used, otherwise to clean up.