### PR TITLE
Fix time offset when CatalogUiTimezone is Browser

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/datepicker/DatePickerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/datepicker/DatePickerDirective.js
@@ -79,11 +79,16 @@
                scope.dateInput = dateTime.format(format);
              };
 
-             var getTimeZoneOffset = function(date) {
-               return moment.tz(date).format('ZZ')
+             var userTimezone =  moment.tz.guess();
+
+             var getTimeZoneOffset = function(timeZone) {
+               var actualTz = timeZone;
+               if (timeZone !== null && timeZone.trim().toLowerCase() === "browser") {
+                 actualTz = userTimezone;
+               }
+               return moment.tz(actualTz).format('ZZ')
                  .replace(/([+-]?[0-9]{2})([0-9]{2})/, '$1:$2')
              }
-             var userTimezone =  moment.tz.guess();
 
              scope.timezoneNames = [
                {name: $translate.instant('NoTimezone'), offset: ''},


### PR DESCRIPTION
When `gnGlobalSettings.gnCfg.mods.global.timezone` is set to Browser GN was launching
an warning about the timezone not being found:
```
Moment Timezone has no data for Browser. See http://momentjs.com/timezone/docs/#/data-loading/.
``` 

This commit fixes this message and sets properly the time offset suggested in the date picker timezone 
selector when the value for `gnGlobalSettings.gnCfg.mods.global.timezone` is `Browser`.

Before (in a browser in Europe/Madrid timezone):
![image](https://user-images.githubusercontent.com/826920/112650177-6b5ed300-8e4b-11eb-8fbb-62b2fbf9f571.png)

After:
![image](https://user-images.githubusercontent.com/826920/112650640-e2946700-8e4b-11eb-833e-489452c59651.png)


