### PR TITLE
Fix specification conformance indexing if date is empty. Avoid indexing the conformance if title is empty

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -965,18 +965,22 @@
           </inspireConformResource>
         </xsl:if>
 
-        <specificationConformance type="object">{
-          "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
-          "date": "<xsl:value-of select="*/mdq:result/*/mdq:specification/cit:CI_Citation/cit:date/cit:CI_Date/cit:date/gco:Date" />",
-          <xsl:if test="*/mdq:result/*/mdq:specification/*/cit:title/@xlink:href">
-            "link": "<xsl:value-of select="*/mdq:result/*/mdq:specification/*/cit:title/@xlink:href"/>",
-          </xsl:if>
-          <xsl:if test="*/mdq:result/*/mdq:explanation/*/text() != ''">
-            "explanation": "<xsl:value-of select="gn-fn-index:json-escape((*/mdq:result/*/mdq:explanation/*/text())[1])" />",
-          </xsl:if>
-          "pass": "<xsl:value-of select="$pass" />"
-          }
-        </specificationConformance>
+        <xsl:if test="string($title)">
+          <specificationConformance type="object">{
+            "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
+            <xsl:if test="string(*/mdq:result/*/mdq:specification/cit:CI_Citation/cit:date/cit:CI_Date/cit:date/gco:Date)">
+            "date": "<xsl:value-of select="*/mdq:result/*/mdq:specification/cit:CI_Citation/cit:date/cit:CI_Date/cit:date/gco:Date" />",
+            </xsl:if>
+            <xsl:if test="*/mdq:result/*/mdq:specification/*/cit:title/@xlink:href">
+              "link": "<xsl:value-of select="*/mdq:result/*/mdq:specification/*/cit:title/@xlink:href"/>",
+            </xsl:if>
+            <xsl:if test="*/mdq:result/*/mdq:explanation/*/text() != ''">
+              "explanation": "<xsl:value-of select="gn-fn-index:json-escape((*/mdq:result/*/mdq:explanation/*/text())[1])" />",
+            </xsl:if>
+            "pass": "<xsl:value-of select="$pass" />"
+            }
+          </specificationConformance>
+        </xsl:if>
 
         <xsl:element name="conformTo_{replace(normalize-space($title), '[^a-zA-Z0-9]', '')}">
           <xsl:value-of select="$pass"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -938,18 +938,22 @@
           </inspireConformResource>
         </xsl:if>
 
-        <specificationConformance type="object">{
-          "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
-          "date": "<xsl:value-of select="*/gmd:result/*/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date" />",
-          <xsl:if test="*/gmd:result/*/gmd:specification/*/gmd:title/@xlink:href">
-            "link": "<xsl:value-of select="*/gmd:result/*/gmd:specification/*/gmd:title/@xlink:href"/>",
-          </xsl:if>
-          <xsl:if test="*/gmd:result/*/gmd:explanation/*/text() != ''">
-            "explanation": "<xsl:value-of select="gn-fn-index:json-escape((*/gmd:result/*/gmd:explanation/*/text())[1])" />",
-          </xsl:if>
-          "pass": "<xsl:value-of select="$pass" />"
-          }
-        </specificationConformance>
+        <xsl:if test="string($title)">
+          <specificationConformance type="object">{
+            "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
+            <xsl:if test="string(*/gmd:result/*/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date)">
+              "date": "<xsl:value-of select="*/gmd:result/*/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date" />",
+            </xsl:if>
+            <xsl:if test="*/gmd:result/*/gmd:specification/*/gmd:title/@xlink:href">
+              "link": "<xsl:value-of select="*/gmd:result/*/gmd:specification/*/gmd:title/@xlink:href"/>",
+            </xsl:if>
+            <xsl:if test="*/gmd:result/*/gmd:explanation/*/text() != ''">
+              "explanation": "<xsl:value-of select="gn-fn-index:json-escape((*/gmd:result/*/gmd:explanation/*/text())[1])" />",
+            </xsl:if>
+            "pass": "<xsl:value-of select="$pass" />"
+            }
+          </specificationConformance>
+        </xsl:if>
 
         <xsl:element name="conformTo_{replace(normalize-space($title), '[^a-zA-Z0-9]', '')}">
           <xsl:value-of select="$pass"/>


### PR DESCRIPTION
If specification date it's empty, it was causing an error in the indexing:

```
ERROR [geonetwork.index] - Document with error #4a03a3a9-32e7-4712-a9ee-c2789266794d: ElasticsearchException[Elasticsearch exception [type=mapper_parsing_exception, reason=failed to parse field [specificationConformance.date] of type [date] in document with id '4a03a3a9-32e7-4712-a9ee-c2789266794d'. Preview of field's value: '']]; nested: ElasticsearchException[Elasticsearch exception [type=illegal_argument_exception, reason=cannot parse empty date]];.
```