### PR TITLE
Add WMS layer - use layer name if the layer title is empty

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -939,7 +939,7 @@
               }
               var layer = this.createOlWMS(map, layerParam, {
                 url: url,
-                label: getCapLayer.Title,
+                label: getCapLayer.Title || getCapLayer.Name,
                 attribution: attribution,
                 attributionUrl: attributionUrl,
                 projection: projCode,


### PR DESCRIPTION
Some services return an empty value in the layer title. Not an expert in WMS, but doesn't seem a good practice as the element is mandatory. In this case it's returned, but empty. See:

http://geodata.rivm.nl/geoserver/wms?request=GetCapabilities&service=WMS&version=1.3.0

```
<Layer queryable="1" opaque="0">
  <Name>gcn:depo_ntot_2013</Name>
  <Title/>
  <Abstract>Grootschalige Depositiekaart NL (2014): stikstof totaal depositie (Ntot) 2013 (berekening 2014)</Abstract>
  <KeywordList>
```

In these cases the layer is displayed in the layer TOC panel but without a

![layer-toc-1](https://user-images.githubusercontent.com/1695003/112979631-24c5ed00-9159-11eb-86d4-ecf928b148a6.png)




Updated to display the layer name in these cases:

![layer-toc-2](https://user-images.githubusercontent.com/1695003/112979701-37d8bd00-9159-11eb-8df7-7b694a2d90e2.png)
 label:
