### PR TITLE
Add a new directive for combining add online resource fields

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/FieldsModule.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsModule.js
@@ -42,6 +42,7 @@
   goog.require('gn_anchor_switcher_directive')
   goog.require('gn_field_upload_directive');
   goog.require('gn_multientry_combiner');
+  goog.require('gn_multientry_combiner_onlineresourcesdescription');
 
 
   angular.module('gn_fields', [
@@ -62,6 +63,7 @@
     'gn_bounding',
     'gn_anchor_switcher_directive',
     'gn_field_upload_directive',
-    'gn_multientry_combiner'
+    'gn_multientry_combiner',
+    'gn_multientry_combiner_onlineresourcesdescription'
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/MultiEntryCombinerOnlineResourcesDescription.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/MultiEntryCombinerOnlineResourcesDescription.js
@@ -1,0 +1,454 @@
+/*
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+
+
+/*
+ * This directive allows for a single metadata-field to be broken up into multiple fields on the add online resource
+ * dialog.
+ *
+ *  This is best to see as an example - the "Government of Canada" OrganisationName editor.
+ *
+ *  In the metadata schema, this is just a string.
+ *
+ *  However, it is to be formatted like;
+ *    "Government of Canada; Organization of Public Services and Procurement Canada; Defence and Marine Procurement"
+ *
+ *   The first bit "Government of Canada" is HARD CODED
+ *   The second bit "Canadian Environmental Assessment Agency" is a Thesaurus Keyword Picker
+ *   The third bit "Defence and Marine Procurement" is a free text field
+ *
+ *   This makes it easier for a user to enter the information correctly.
+ *
+ *   This is multi-lingual.
+ *
+ *   The configuration (see example, below) defines;
+ *
+ *    a) how the fields are joined together ("; " in this example) -- combiner
+ *    b) root_id of the field in the metadata.
+ *    d) values -- actual Metadata record values (one per language)
+ *    e) configuration - this defines how the edit fields are shown to the user
+ *        a) type - what type is this?  (fixedValue, thesaurus, freeText)
+ *        b) heading - helper text to show ABOVE the field
+ *        c) other configuration information
+ *
+ *
+ * 1. fixedValue
+ *     This represents something that the user cannot edit - "Government of Canada" in our example.
+ *           + values is a dictionary from language-name to value
+ *
+ * 2. thesaurus
+ *      This represents a Thesaurus KeyWord Picker.
+ *           + thesaurus is the name of the thesaurus
+ *
+ * 3. freeText
+ *      This represents a field the user can type into.
+ *        + it doesn't have any specific configuration
+ *
+ *
+ *
+ *    This directive also handles the multi-lingual aspects (and puts in nav-pills like the normal multi-lingual directive).
+ */
+
+/*
+ *
+ * SAMPLE CONFIGURATION - AS USED BY HNAP
+ *
+ * {
+ *   "combiner":"; ",
+ *   "fieldName":"desc",
+ *   "defaultLang":"eng",
+ *   "values":
+ *       {
+ *
+ *         "eng":"Government of Canada; Organization of Public Services and Procurement Canada; Defence and Marine Procurement" ,
+ *         "fra":"Gouvernement du Canada; Organisation de Services publics et Approvisionnement Canada; Approvisionnement maritime et de défense"
+ *       },
+ *
+ *   "config":
+ *   [
+ *       {
+ *         "type": "fixedValue",
+ *         "heading": {
+ *             "eng": "",
+ *             "fra": ""
+ *         },
+ *         "values": {
+ *           "eng": "Government of Canada",
+ *           "fra": "Gouvernement du Canada"
+ *         }
+ *       },
+ *       {
+ *         "type": "thesaurus",
+ *         "heading": {
+ *           "eng": "Government of Canada Organization",
+ *           "fra": "Organisation du Gouvernement du Canada"
+ *         },
+ *         "thesaurus": "external.theme.EC_Government_Titles"
+ *       },
+ *       {
+ *         "type": "freeText",
+ *         "heading": {
+ *           "eng": "Branch/Sector/Division",
+ *           "fra": "Branche/Secteur/Division"
+ *         }
+ *       }
+ *   ]
+ * }
+ */
+
+/*
+ * Typical usage in the schema config/associated-panel/default.json (for desc field)
+ *
+ *
+ *
+ *   {
+ *      "config": {
+ *        "display": "radio",
+ *        "types": [{
+ *          "label": "addOnlinesrc",
+ *          "sources": {
+ *            "filestore": true
+ *          },
+ *          "icon": "fa gn-icon-onlinesrc",
+ *          "process": "onlinesrc-add",
+ *          "fields": {
+ *            "protocol": {
+ *              "value": "WWW:LINK-1.0-http--link",
+ *              "isMultilingual": false,
+ *              "required": true,
+ *              "tooltip": "gmd:protocol"
+ *            },
+ *            "url": {
+ *              "isMultilingual": false,
+ *              "required": true,
+ *              "tooltip": "gmd:URL"
+ *            },
+ *            "name": {"tooltip": "gmd:name"},
+ *            "desc": {
+ *              "tooltip": "gmd:description",
+ *              "directive": "gn-multientry-combiner-online-resources-description",
+ *              "directiveConfig": {
+ *                "valueElementId": "multicombinervalue",
+ *                "fieldName": "desc",
+ *                "combiner":"; ",
+ *                "config":
+ *                [
+ *                  {
+ *                    "type": "thesaurus",
+ *                    "heading": {
+ *                      "eng": "Content type",
+ *                      "fra": "Content type"
+ *                    },
+ *                    "thesaurus": "external.theme.GC_Resource_ContentTypes"
+ *                  },
+ *                  {
+ *                    "type": "thesaurus",
+ *                    "heading": {
+ *                      "eng": "Format",
+ *                      "fra": "Format"
+ *                    },
+ *                    "thesaurus": "external.theme.GC_Resource_Formats"
+ *                  },
+ *                  {
+ *                    "type": "thesaurus",
+ *                    "heading": {
+ *                      "eng": "Language",
+ *                      "fra": "Language"
+ *                    },
+ *                    "thesaurus": "external.theme.GC_Resource_Languages"
+ *                  }
+ *                ]
+ *              }
+ *            },
+ *            "function": {
+ *              "isMultilingual": false,
+ *              "tooltip": "gmd:function"
+ *            },
+ *            "applicationProfile": {
+ *              "isMultilingual": false,
+ *              "tooltip": "gmd:applicationProfile"
+ *            }
+ *          }
+ *        }, {
+ *          "label": "addThumbnail",
+ *          "sources": {
+ *            "filestore": true,
+ *            "thumbnailMaker": true
+ *          },
+ *          "icon": "fa gn-icon-thumbnail",
+ *          "fileStoreFilter": "*.{jpg,JPG,jpeg,JPEG,png,PNG,gif,GIF}",
+ *          "process": "thumbnail-add",
+ *          "fields": {
+ *            "url": {
+ *              "param": "thumbnail_url",
+ *              "isMultilingual": false,
+ *              "required": true
+ *            },
+ *            "name": {"param": "thumbnail_desc"}
+ *          }
+ *        }],
+ *        "multilingualFields": ["name", "desc"]
+ *      }
+ *    }
+*/
+
+(function() {
+  goog.provide('gn_multientry_combiner_onlineresourcesdescription');
+
+  var module = angular.module('gn_multientry_combiner_onlineresourcesdescription',
+    ['pascalprecht.translate']);
+
+  module
+    .directive('gnMultientryCombinerOnlineResourcesDescription',
+      ['gnCurrentEdit','gnGlobalSettings', 'gnLangs', '$log',
+        function(gnCurrentEdit,gnGlobalSettings, gnLangs, $log) {
+          return {
+            restrict: 'A',
+            transclude: true,
+            replace: true,
+            templateUrl: '../../catalog/components/edit/multientrycombiner/partials/multientrycombiner_onlineresourcesdescription.html',
+            scope: {
+              configuration: '@gnMultientryCombinerOnlineResourcesDescription'
+            },
+            link: function (scope, element, attrs) {
+              scope.config = JSON.parse(scope.configuration);
+
+              if (angular.isUndefined(scope.config.fieldName) || scope.config.fieldName === '') {
+                $log.error("MultiEntryCombinerOnlineResourceDescription: The fieldName configuration option is mandatory" );
+                throw "The fieldName configuration option is mandatory";
+              }
+              var emptyLangs = {};
+              _.each(_.keys(gnCurrentEdit.allLanguages.code2iso), function (code) {
+                var lang = code.replace("#", "");
+                emptyLangs[lang] = "";
+              });
+              scope.config.values = angular.extend({}, scope.$parent.params[scope.config.fieldName], emptyLangs);
+
+
+              // helper function - fix up values
+              // if its a fixed values, but the user hasn't put anything in, put the fixed value in the correct location
+              var fix_values = function() {
+                //first, make sure missing items are ''
+                var nExpectedNumber = scope.config.config.length;
+                scope.individualValues = _.mapObject(scope.individualValues, function(val, key) {
+                  val.length = nExpectedNumber; //extend array
+                  //set any undefined to ''
+                  val = _.map(val, function(v) {
+                    if (v === undefined)
+                      return '';
+                    return v.trim();//remove leading/trailing spaces
+                  });
+                  //put in any fixedValue
+                  for (var idx =0; idx < nExpectedNumber; idx++) {
+                    var meta = scope.config.config[idx];
+                    if (meta.type === 'fixedValue') {  // fixed values are always the same
+                      val[idx] = meta.values[key];
+                    } else {  // default values -- put in if its not set (only do this at start)
+                      if ( (val[idx] === '') && (meta.defaultValues) && (meta.defaultValues[key]) ) {
+                        val[idx] = meta.defaultValues[key];
+                      }
+                    }
+                  }
+                  return val;
+                } );
+              }
+
+              scope.currentLang = gnCurrentEdit.mdLanguage;
+              //get the current UI lang
+              // will be "eng" or "fra"
+
+              scope.initCurrentLang = function() {
+                var detectedLang = gnCurrentEdit.allLanguages.iso2code[gnLangs.detectLang(
+                    gnGlobalSettings.gnCfg.langDetector,
+                    gnGlobalSettings
+                )];
+
+                if (angular.isUndefined(detectedLang)) {
+                  $log.warn("The current UI language is not present in the metadata document: " +
+                      gnLangs.detectLang(gnGlobalSettings.gnCfg.langDetector, gnGlobalSettings) + ". Defaulting to " + scope.currentLang)
+                  scope.currentUILang = scope.currentLang;
+                } else {
+                  scope.currentUILang = detectedLang.replace("#", "");
+                }
+              };
+
+              scope.showFieldsAfterDomRendered = function () {
+                //runs after dom renders!
+                // hide all language-based inputs except the current language
+                setTimeout(function () {
+                  if (scope.$parent.isMdMultilingual) {
+                    var inputs = scope.element.find("input[lang='" + scope.currentLang + "']");
+                    if (inputs.length === 0) {
+                      inputs = scope.element.find("input[lang='" + gnCurrentEdit.allLanguages.iso2code[scope.currentLang].substring(1) + "']")
+                    }
+                    _.each(inputs, function (input) {
+                      $(input).removeClass("hidden");
+                    });
+                  } else {
+                    var inputs = scope.element.find("input");
+                    _.each(inputs, function (input) {
+                      $(input).removeClass("hidden");
+                    });
+                  }
+                }, 0);
+              };
+
+              scope.initCurrentValues = function() {
+                scope.currentLang = gnCurrentEdit.mdLanguage;
+                scope.initCurrentLang();
+                var parentParam = scope.$parent.params[scope.config.fieldName];
+                if (angular.isObject(parentParam)) {
+                  // multilingual
+                  scope.config.values = angular.extend({}, scope.$parent.params[scope.config.fieldName], emptyLangs);
+                  scope.individualValues = _.mapObject(scope.$parent.params[scope.config.fieldName], function(val, key){
+                    return val.split(scope.combinerSimple); // split on simple one, then we will "fix up" trailing spaces
+                  });
+                } else {
+                  // single language
+                  scope.individualValues = {};
+                  _.mapObject(emptyLangs, function (val, key) {
+                    scope.individualValues[key] = parentParam.split(scope.combinerSimple);
+                  });
+                }
+                fix_values();
+                scope.showFieldsAfterDomRendered();
+
+                //lang list [{lang:'eng',isolang:'eng'},{lang:'fra',isolang:'fre'}]
+                scope.langs = _.map(_.keys(scope.config.values), function(l){
+                  return {'lang': l, 'isolang': gnCurrentEdit.allLanguages.code2iso['#' + l]};
+                } );
+                if (scope.langs.length === 0) {
+                  scope.langs = {'lang': scope.currentLang, 'isolang': gnCurrentEdit.allLanguages.code2iso['#' + scope.currentLang]};
+                }
+              };
+
+              scope.initCurrentLang();
+
+              scope.element = element;
+              //we need to do this because GN trims a trailing "; ", which causes problems
+              scope.combinerSimple = scope.config.combiner.trim(); //"; " -> ";"
+
+              scope.$on('onlineSrcDialogInited', function(event, args) {
+                scope.initCurrentValues();
+                scope.$broadcast('resetValue', {reset: "true"});
+
+              });
+
+              scope.$on('onlineSrcDialogHidden', function(evt, msg) {
+                // nothing to do
+              })
+              //values that the user has actually selected
+              scope.initCurrentValues();
+
+
+
+              //because the type-ahead control makes a lot of changes to the DOM, hiding the non-active language
+              // is a bit more complicated that you would expect.
+              //what we do is find the <input> for the language, and then find its <span> parent.
+              // We then control the visibility of that span.
+              scope.$watch('currentLang', function(newValue, oldValue) {
+                if (scope.$parent.isMdMultilingual) {
+                  //hide all inputs
+                  var inputs = scope.element.find("input[lang]"); // all lang inputs
+                  _.each(inputs, function (input) {
+                    $(input).addClass("hidden");
+                  });
+
+                  //show language-appropriate inputs
+                  if (newValue) {
+                    var inputs = scope.element.find("input[lang='" + newValue + "']");
+                    if (inputs.length === 0) {
+                      inputs = scope.element.find("input[lang='" + gnCurrentEdit.allLanguages.iso2code[newValue].substring(1) + "']")
+                    }
+                    _.each(inputs, function (input) {
+                      $(input).removeClass("hidden");
+                    });
+                  }
+                } else {
+                  var inputs = scope.element.find("input");
+                  _.each(inputs, function (input) {
+                    $(input).removeClass("hidden");
+                  });
+                }
+              });
+
+
+              //deep watch a model change
+              scope.$watch('individualValues', function(newval, oldval){
+                //build the master values...
+                _.each(_.keys(scope.config.values), function(lang){
+                  //values for this lang
+                  //filter out blank values -- or you'll get stuff like "org; ;" or "; abc;"
+                  var vs = scope.individualValues[lang].slice();
+                  while (vs[vs.length - 1] === '') {  // remove trailing ones only
+                    vs.pop();
+                  }
+                  var v = vs.join(scope.config.combiner); // use full value
+                  scope.config.values[lang] = v;
+
+
+                  if (scope.$parent.isMdMultilingual) {
+                    //scope.$parent.params.desc[lang] = v;
+                    scope.$parent.params[scope.config.fieldName][lang] = v;
+                  } else {
+                    //scope.$parent.params.desc = v;
+                    scope.$parent.params[scope.config.fieldName] = v;
+                  }
+                });
+              }, true);
+
+              //nav pill clicked - change language
+              scope.changeLang = function(newLang) {
+                scope.currentLang = newLang;
+              };
+
+              scope.$watch("config.values", function(newVal, oldVal, localScope) {
+                var tempArray = [];
+                var inputValue = '';
+                if (angular.isDefined(newVal)) {
+                 if (angular.isObject(newVal)) {
+                   _.mapObject(newVal, function(value, lang) {
+                     var item = lang + "#" + value;
+                     tempArray.push(item);
+                   });
+                   inputValue = tempArray.join("|");
+                 } else {
+                   inputValue = newVal;
+                 }
+                } else {
+                  $log.info("config.values newValue is undefined");
+                }
+                scope.hiddenFieldValue = inputValue;
+              }, true);
+
+              scope.$on('$destroy', function() {
+                $log.debug("destroy multientrycombiner");
+              });
+
+            } //link
+          }
+        }//fn
+      ]);
+
+})();

--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner_onlineresourcesdescription.html
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner_onlineresourcesdescription.html
@@ -1,0 +1,48 @@
+<div class="combiner">
+  <div data-ng-transclude=""/>
+<!--  <input type="hidden" data-ng-attr-id="{{config.valueElementId}}" data-ng-value="hiddenFieldValue" />-->
+
+  <div style="padding-left: 15px; padding-right: 15px">
+    <div class="form-group" ng-repeat="c in config.config" ng-if="c.type !== 'fixedValue'">
+      <div class="config">
+        <div ng-if="c.heading[currentUILang] != ''">
+          <label for="field_{{$index}}" class=" ">{{c.heading[currentUILang]}}</label>
+        </div>
+        <div class="thesaurus">
+          <div ng-if="c.type === 'thesaurus'">
+            <input class="form-control hidden"
+                   data-gn-keyword-picker=""
+                   data-thesaurus-key="{{c.thesaurus}}"
+                   data-faux-multilingual="true"
+                   data-focus-to-input="false"
+                   lang="{{lang}}"
+                   type="text"
+                   ng-model="$parent.individualValues[lang][$parent.$index]"
+                   ng-repeat="(lang, langValues) in individualValues"
+                   reset-value="{{$parent.individualValues[lang][$parent.$index]}}"/>
+
+          </div>
+        </div>
+
+        <div ng-if="c.type == 'freeText'">
+          <input class="form-control hidden"
+                 lang="{{lang}}"
+                 type="text"
+                 ng-model="$parent.$parent.individualValues[lang][$parent.$index]"
+                 ng-repeat="(lang, langValues) in individualValues"/>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+
+  <div class="gn-multilingual-field" ng-if="langs.length > 1">
+    <ul class="nav nav-pills">
+      <li ng-repeat="langinfo in langs" data-ng-class="{'active': langinfo.lang === currentLang}">
+        <a ng-click="changeLang(langinfo.lang)">{{langinfo.isolang|translate}}</a>
+      </li>
+    </ul>
+  </div>
+
+</div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -345,6 +345,9 @@
               post: function(scope, element, attrs) {
                 scope.clearFormOnProtocolChange = !(attrs.clearFormOnProtocolChange == "false"); //default to true (old behavior)
                 scope.popupid = attrs['gnPopupid'];
+                $(scope.popupid).on('hidden.bs.modal', function(){
+                  scope.$broadcast('onlineSrcDialogHidden', {"popupid": scope.popupid});
+                });
 
                 scope.config = null;
                 scope.linkType = null;
@@ -673,6 +676,7 @@
                       scope.params.desc= '';
                       initMultilingualFields();
                     }
+                    scope.$broadcast('onlineSrcDialogInited', {"popupid": scope.popupid});
                   };
                   function loadConfigAndInit(withInit) {
                     gnSchemaManagerService.getEditorAssociationPanelConfig(

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -232,35 +232,41 @@
                      for="gn-addonlinesrc-description-single-textarea"
                      class="col-sm-2 control-label"
                      data-translate="">description</label>
-              <div id="gn-addonlinesrc-description-single-row"
-                   class="col-sm-9"
-                   data-ng-if="!isFieldMultilingual('desc')">
-              <textarea rows="3"
-                        id="gn-addonlinesrc-description-single-textarea"
-                        data-gn-autogrow=""
-                        data-ng-required="params.linkType.fields.desc.required"
-                        data-ng-model="params.desc"
-                        class="form-control input-sm"
-                        placeholder="description"
-                        data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
-                        name="description"/>
+              <div class="col-sm-9" data-ng-if="!params.linkType.fields.desc.directive">
+                <div id="gn-addonlinesrc-description-single-row"
+                     data-ng-if="!isFieldMultilingual('desc')">
+                  <textarea rows="3"
+                          id="gn-addonlinesrc-description-single-textarea"
+                          data-gn-autogrow=""
+                          data-ng-required="params.linkType.fields.desc.required"
+                          data-ng-model="params.desc"
+                          class="form-control input-sm"
+                          placeholder="description"
+                          data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
+                          name="description"/>
+                </div>
+                <div id="gn-addonlinesrc-description-multilingual-row"
+                     data-ng-if="isFieldMultilingual('desc')"
+                     gn-multilingual-field="{{mdOtherLanguages}}"
+                     data-main-language="{{mdLang}}"
+                     expanded="false">
+                  <textarea data-ng-repeat="(key, val) in mdLangs"
+                          id="gn-addonlinesrc-description-multilingual-{{val}}"
+                          rows="3"
+                          lang="{{val}}"
+                          data-ng-required="params.linkType.fields.applicationProfile.required"
+                          data-ng-model="params.desc[val]"
+                          class="form-control input-sm"
+                          placeholder="description"
+                          data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
+                          name="description"/>
+                </div>
               </div>
-              <div id="gn-addonlinesrc-description-multilingual-row"
-                   class="col-sm-9"
-                   data-ng-if="isFieldMultilingual('desc')"
-                   gn-multilingual-field="{{mdOtherLanguages}}"
-                   data-main-language="{{mdLang}}"
-                   expanded="false">
-              <textarea data-ng-repeat="(key, val) in mdLangs"
-                        id="gn-addonlinesrc-description-multilingual-{{val}}"
-                        rows="3"
-                        lang="{{val}}"
-                        data-ng-required="params.linkType.fields.applicationProfile.required"
-                        data-ng-model="params.desc[val]"
-                        class="form-control input-sm"
-                        placeholder="description"
-                        data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
-                        name="description"/>
+              <div data-ng-if="params.linkType.fields.desc.directive === 'gn-multientry-combiner-online-resources-description'">
+                <div data-gn-multientry-combiner-online-resources-description="{{params.linkType.fields.desc.directiveConfig}}"
+                  class="col-sm-12 col-xs-12 gn-value nopadding-in-table"
+                    data-label="description" data-ng-required="params.linkType.fields.desc.required" >
+                </div>
               </div>
 
               <div class="col-sm-1 gn-control"></div>

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -568,13 +568,33 @@
       return {
         restrict: 'A',
         scope: {
-             fauxMultilingual: '@fauxMultilingual' // we are doing our own multi-lingual support
+          fauxMultilingual: '@fauxMultilingual', // we are doing our own multi-lingual support
+          resetValue: "@?" //value to set when we receive the `resetValue` event.
         },
         link: function(scope, element, attrs) {
+          // customId is a property used to identify the input elements created by this instance of
+          // the ThesaurusDirective. We can use it later in the resetValue event handler to retrieve
+          // only these autocomplete inputs in case the DOM structure doesn't fit with what is expected.
+          scope.customId = Date.now();
+          element.attr('customId', scope.customId);
+
           scope.thesaurusKey = attrs.thesaurusKey || '';
           scope.orderById = attrs.orderById || 'false';
           scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
           scope.fauxMultilingual = scope.fauxMultilingual==="true"; //default false
+
+
+          // respond to a parent asking me to reset
+          scope.$on('resetValue', function (event, data) {
+
+            setTimeout(function () {
+              element.parent().parent().find('input.tt-input[customId="' + scope.customId + '"]').each(function (index, item) {
+                var itemJQ = $(item);
+                itemJQ.typeahead('val', angular.isDefined(scope.resetValue) ? scope.resetValue : '');
+                itemJQ.triggerHandler('input'); //tell angular about value change
+              });
+            });
+          });
 
 
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -433,6 +433,29 @@
     .gn-attribution();
   }
 }
+#gn-addonlinesrc-description-row {
+  .form-control {
+    background: #fff !important;
+  }
+  .tt-menu {
+    top: auto !important;
+    width: calc(~"100% - 30px");
+    margin-left: 15px;
+  }
+  .twitter-typeahead .tt-menu {
+    width: 100%;
+    margin-left: 0;
+  }
+  .tt-menu + .twitter-typeahead {
+    display: none !important;
+  }
+  .tt-suggestion {
+    &:hover {
+      cursor: pointer;
+      background-color: @dropdown-link-hover-bg;
+    }
+  }
+}
 
 // alternative style for the editor form
 // Class to put label above fields


### PR DESCRIPTION
Add a new `gnMultientryCombinerOnlineResourcesDescription` for use in the add online resource
panel. It allows to show one original field as multiple fields, combining the values of
these ones back into the original one when the resource is added.
Check the comments in about the usage.

This directive allows for a single metadata-field to be broken up into multiple fields on the add online resource dialog.

 In the metadata schema, this is just a string.
 However, it is to be formatted like;
   `"Government of Canada; Organization of Public Services and Procurement Canada; Defence and Marine Procurement"`

 The first bit `"Government of Canada"` is HARD CODED
 The second bit `"Canadian Environmental Assessment Agency"` is a Thesaurus Keyword Picker
 The third bit "Defence and Marine Procurement" is a free text field
 his makes it easier for a user to enter the information correctly.
 
This can be multi-lingual.

The configuration (see example, below) defines;

a) `combiner`: how the fields are joined together (`"; "` in this example)
b) `fieldName`: name of the original field in the dialog.
d) `values`: actual Metadata record values (one per language)
e) `configuration` - this defines how the edit fields are shown to the user
  a) `type` - what type is this?  (`fixedValue`, `thesaurus`, `freeText`)
  b) `heading` - helper text to show ABOVE the field
  c) other configuration information
       1. `fixedValue`
          This represents something that the user cannot edit - "Government of Canada" in our example. 
                + values is a dictionary from language-name to value
       2. `thesaurus`
           This represents a Thesaurus KeyWord Picker.
               + thesaurus is the name of the thesaurus
      3. `freeText`
           This represents a field the user can type into.
               + it doesn't have any specific configuration

 This directive also handles the multi-lingual aspects (and puts in nav-pills like the normal multi-lingual directive).

 SAMPLE CONFIGURATION - AS USED BY HNAP
```json
 {
   "combiner":"; ",
   "fieldName":"desc",
   "defaultLang":"eng",
   "values":
       {
         "eng":"Government of Canada; Organization of Public Services and Procurement Canada; Defence and Marine Procurement" ,
         "fra":"Gouvernement du Canada; Organisation de Services publics et Approvisionnement Canada; Approvisionnement maritime et de défense"
       },

   "config":
   [
       {
         "type": "fixedValue",
         "heading": {
             "eng": "",
             "fra": ""
         },
         "values": {
           "eng": "Government of Canada",
           "fra": "Gouvernement du Canada"
         }
       },
       {
         "type": "thesaurus",
         "heading": {
           "eng": "Government of Canada Organization",
           "fra": "Organisation du Gouvernement du Canada"
         },
         "thesaurus": "external.theme.EC_Government_Titles"
       },
       {
         "type": "freeText",
         "heading": {
           "eng": "Branch/Sector/Division",
           "fra": "Branche/Secteur/Division"
         }
       }
   ]
 }
 ```


Typical usage in the schema config/associated-panel/default.json (for desc field)
```json
{
  "config": {
    "display": "radio",
    "types": [{
      "label": "addOnlinesrc",
      "sources": {
        "filestore": true
      },
      "icon": "fa gn-icon-onlinesrc",
      "process": "onlinesrc-add",
      "fields": {
        "protocol": {
          "value": "WWW:LINK-1.0-http--link",
          "isMultilingual": false,
          "required": true,
          "tooltip": "gmd:protocol"
        },
        "url": {
          "isMultilingual": false,
          "required": true,
          "tooltip": "gmd:URL"
        },
        "name": {"tooltip": "gmd:name"},
        "desc": {
          "tooltip": "gmd:description",
          "directive": "gn-multientry-combiner-online-resources-description",
          "directiveConfig": {
            "valueElementId": "multicombinervalue",
            "fieldName": "desc",
            "combiner":"; ",
            "config":
            [
              {
                "type": "thesaurus",
                "heading": {
                  "eng": "Content type",
                  "fra": "Content type"
                },
                "thesaurus": "external.theme.GC_Resource_ContentTypes"
              },
              {
                "type": "thesaurus",
                "heading": {
                  "eng": "Format",
                  "fra": "Format"
                },
                "thesaurus": "external.theme.GC_Resource_Formats"
              },
              {
                "type": "thesaurus",
                "heading": {
                  "eng": "Language",
                  "fra": "Language"
                },
                "thesaurus": "external.theme.GC_Resource_Languages"
              }
            ]
          }
        },
        "function": {
          "isMultilingual": false,
          "tooltip": "gmd:function"
        },
        "applicationProfile": {
          "isMultilingual": false,
          "tooltip": "gmd:applicationProfile"
        }
      }
    }, {
      "label": "addThumbnail",
      "sources": {
        "filestore": true,
        "thumbnailMaker": true
      },
      "icon": "fa gn-icon-thumbnail",
      "fileStoreFilter": "*.{jpg,JPG,jpeg,JPEG,png,PNG,gif,GIF}",
      "process": "thumbnail-add",
      "fields": {
        "url": {
          "param": "thumbnail_url",
          "isMultilingual": false,
          "required": true
        },
        "name": {"param": "thumbnail_desc"}
      }
    }],
    "multilingualFields": ["name", "desc"]
  }
}
```

![image](https://user-images.githubusercontent.com/826920/113059500-d132be00-91af-11eb-85a0-9417543f3d49.png)


Check https://github.com/metadata101/iso19139.ca.HNAP/issues/95 for more info.


