### PR TITLE
Update check for INSPIRE registry valid items to create the RDF file. Fixes #4836

### DIFF
--- a/web/src/main/webapp/xslt/services/thesaurus/registry-to-skos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/registry-to-skos.xsl
@@ -69,7 +69,7 @@
                 select="/documents/*[*:language = 'en']/*:label[@xml:lang = 'en']"/>
 
   <xsl:variable name="statusSuffix"
-                select="'registry/status/valid'"/>
+                select="'/status/valid'"/>
 
   <xsl:variable name="hasBroaderNarrowerLinks"
                 select="count(//*[1]/*:containeditems/*/*:parents) > 0"/>


### PR DESCRIPTION
Seem the 'registry' part is different in some resgistries, like https://registry.gdi-de.org/codelist that uses 'codelist'.

To test: 

1) Add thesaurus from Registry configuring the url https://registry.gdi-de.org/codelist

2) Select English and German

3) Select the following registry item

![registry-item](https://user-images.githubusercontent.com/1695003/113275189-cf1b4d00-92de-11eb-9a5a-d1c27ed78dec.png)

4) The vocabulary has the terms from the https://registry.gdi-de.org/codelist registry

![vocabulary-from-registry](https://user-images.githubusercontent.com/1695003/113275305-eeb27580-92de-11eb-92bf-71f0cd83fd43.png)