### PR TITLE
Avoid loading Recaptcha API by angular-recaptcha if Recaptcha is disabled in the settings

### DIFF
--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -86,9 +86,23 @@
     </xsl:if>
 
 
-    <xsl:if test="$isRecaptchaEnabled and $service = 'new.account'">
-      <script src="https://www.google.com/recaptcha/api.js"></script>
-    </xsl:if>
+    <!-- Load recaptcha api if recaptcha is enabled:
+          - in the new account service.
+          - in the search application if metadaat user feedback is enabled
+    -->
+    <xsl:choose>
+      <xsl:when test="$isRecaptchaEnabled and ($service = 'new.account' or ($angularApp = 'gn_search' and $metadataUserFeedbackEnabled))">
+        <script src="https://www.google.com/recaptcha/api.js"></script>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- Add dummy object to prevent angularjs-recaptcha to load recaptcha api.js file in other cases.
+             If angularjs-recaptcha doesn't find the grecaptcha object with the function render, request the api.js file
+             adding some extra cookies that can cause issues with EU directive.
+        -->
+        <script>var grecaptcha = {render: function() {}};
+        </script>
+      </xsl:otherwise>
+    </xsl:choose>
 
     <xsl:choose>
       <xsl:when test="$isDebugMode">

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -148,4 +148,7 @@
                 select="'^WWW:DOWNLOAD.*|^FILE:GEO|FILE:RASTER|^DB:POSTGIS'"/>
   <xsl:variable name="layerMatchingPattern"
                 select="'^OGC:WMS.*'"/>
+
+
+  <xsl:variable name="metadataUserFeedbackEnabled" select="$envSystem/localrating/enable = 'advanced'" />
 </xsl:stylesheet>


### PR DESCRIPTION
`angularjs-recaptcha` loads the recaptcha api.js file if detects it's not loaded already.

If the recaptcha feature is disabled in the settings this is not desirable as does not fit with cookie statements.

This pull request adds a dummy object that `angularjs-recaptcha` checks to decide if the recaptcha api.js file should be loaded, to prevent the file from loading when the function is disabled in settings.