### PR TITLE
Support for non-editable settings

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/Setting.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Setting.java
@@ -51,6 +51,7 @@ public class Setting extends GeonetEntity {
     private SettingDataType dataType = SettingDataType.STRING;
     private int position = 0;
     private char internal = Constants.YN_TRUE;
+    private char editable = Constants.YN_TRUE;
 
     @Id
     @Column(name = "name", nullable = false, length = 255/* mysql cannot accept it any bigger if it is to be the id */)
@@ -135,6 +136,47 @@ public class Setting extends GeonetEntity {
         setInternal_JpaWorkaround(Constants.toYN_EnabledChar(internal));
         return this;
     }
+
+    /**
+     * For backwards compatibility we need the activated column to be either 'n' or 'y'. This is a
+     * workaround to allow this until future versions of JPA that allow different ways of
+     * controlling how types are mapped to the database.
+     */
+    @Column(name = "editable", nullable = false, length = 1, columnDefinition = "char default 'y'")
+    protected char getEditable_JpaWorkaround() {
+        return editable;
+    }
+
+    /**
+     * Set the column value. Constants.YN_ENABLED for true Constants.YN_DISABLED for false.
+     *
+     * @param editableValue the column value. Constants.YN_ENABLED for true Constants.YN_DISABLED
+     *                      for false.
+     */
+    protected void setEditable_JpaWorkaround(char editableValue) {
+        editable = editableValue;
+    }
+
+    /**
+     * Return true if the setting is editable in the administration UI.
+     *
+     * @return true if the setting is editable.
+     */
+    @Transient
+    public boolean isEditable() {
+        return Constants.toBoolean_fromYNChar(getEditable_JpaWorkaround());
+    }
+
+    /**
+     * Set true if the setting is private.
+     *
+     * @param internal true if the setting is private.
+     */
+    public Setting setEditable(boolean editable) {
+        setInternal_JpaWorkaround(Constants.toYN_EnabledChar(editable));
+        return this;
+    }
+
 
     @Override
     public String toString() {

--- a/domain/src/main/java/org/fao/geonet/domain/SettingToObjectSerializer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/SettingToObjectSerializer.java
@@ -45,6 +45,8 @@ public class SettingToObjectSerializer extends JsonSerializer<Setting> {
         jsonGenerator.writeStringField("name", s.getName());
         jsonGenerator.writeStringField("dataType", s.getDataType() == null ? null : s.getDataType().name());
         jsonGenerator.writeNumberField("position", s.getPosition());
+        jsonGenerator.writeBooleanField("internal", s.isInternal());
+        jsonGenerator.writeBooleanField("editable", s.isEditable());
         jsonGenerator.writeFieldName("value");
         writeSettingValue(s, jsonGenerator);
         jsonGenerator.writeEndObject();

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -50,15 +50,15 @@
   module.filter('hideGeoNetworkInternalSettings', function() {
     return function(input) {
       var filtered = [];
-      var internal = ['system/userFeedback/lastNotificationDate'];
       angular.forEach(input, function(el) {
-        if (internal.indexOf(el.name) === -1) {
+        if (el.editable === true) {
           filtered.push(el);
         }
       });
       return filtered;
     }
   });
+
 
   module.filter('orderObjectBy', function() {
     return function(input, attribute) {

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -610,7 +610,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/csw/transactionUpdateCreateXPath', 'true', 2, 1320, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userSelfRegistration/enable', 'false', 2, 1910, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userFeedback/enable', 'false', 2, 1911, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userFeedback/lastNotificationDate', '', 0, 1912, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal, editable) VALUES ('system/userFeedback/lastNotificationDate', '', 0, 1912, 'y', 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/clickablehyperlinks/enable', 'true', 2, 2010, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/localrating/enable', 'advanced', 0, 2110, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/downloadservice/leave', 'false', 0, 2210, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
@@ -2,6 +2,8 @@
 UPDATE Settings SET value='3.11.0' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 
+UPDATE Settings SET editable = 'n' WHERE name = 'system/userFeedback/lastNotificationDate';
+
 -- Increase the length of Validation type (where the schematron file name is stored)
 ALTER TABLE Validation ALTER COLUMN valType TYPE varchar(128);
 


### PR DESCRIPTION
This PR allows to configure settings to prevent to edit them in the settings UI. Currently we have the setting `system/userFeedback/lastNotificationDate` that was hardcoded in the angularjs settings controller.

It can be relevant for GeoNetwork instances provided in a hosted cloud environment, where it's required that the GeoNetwork administrator can't change certain settings like server configuration: host, port or proxy server settings.

Changing the `editable` field of a setting to the value `false` prevent the setting to be displayed in the settings UI. For example for the server host / protocol /port:

![server-settings-non-editable](https://user-images.githubusercontent.com/1695003/113669182-a5ce3880-96b3-11eb-9d26-2d3ac76f0959.png)

Compared to the default configuration:

![server-settings-editable](https://user-images.githubusercontent.com/1695003/113669273-cdbd9c00-96b3-11eb-83ee-c1c5f28901b8.png)
 