### PR TITLE
Add support to retrieve online resource protocol from a vocabulary in the metadata editor online resources panel

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -86,7 +86,9 @@
               </label>
               <div class="col-sm-9">
                 <input type="text" data-ng-if="(params.linkType.fields.protocol.thesaurus != undefined) && (params.linkType.fields.protocol.thesaurus != '')"
-                       data-ng-model="params.protocol"
+                       data-ng-model="params.protocol" class="form-control"
+                       name="protocol"
+                       data-ng-required="params.linkType.fields.protocol.required"
                        data-init-on-load="true"
                        data-gn-keyword-picker=""
                        data-thesaurus-key="{{params.linkType.fields.protocol.thesaurus}}"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -85,7 +85,15 @@
                 <span data-translate="">protocol</span>
               </label>
               <div class="col-sm-9">
-                <div id="gn-addonlinesrc-protocol-list"
+                <input type="text" data-ng-if="(params.linkType.fields.protocol.thesaurus != undefined) && (params.linkType.fields.protocol.thesaurus != '')"
+                       data-ng-model="params.protocol"
+                       data-init-on-load="true"
+                       data-gn-keyword-picker=""
+                       data-thesaurus-key="{{params.linkType.fields.protocol.thesaurus}}"
+                       data-order-by-id="true"
+                       lang="lang" />
+
+                <div id="gn-addonlinesrc-protocol-list" data-ng-if="(params.linkType.fields.protocol.thesaurus == undefined) || (params.linkType.fields.protocol.thesaurus == '')"
                      data-schema-info-combo="element"
                      data-init-on-load="true"
                      name="protocol"


### PR DESCRIPTION
To enable the values from the thesaurus, configure in https://github.com/geonetwork/core-geonetwork/blob/master/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json, the key `thesaurus` with the thesaurus identifier:

```
"fields": {
        "protocol": {
          "value": "",
          "isMultilingual": false,
          "required": true,
          "tooltip": "gmd:protocol",
          "thesaurus": "external.theme.httpinspireeceuropaeumetadatacodelistProtocolValue-ProtocolValue"
        },
```

![protocol-from-thesaurus](https://user-images.githubusercontent.com/1695003/113731594-324f1a00-96f9-11eb-829b-31806bc86b13.png)
