### PR TITLE
ISO19115-3 / Associated resource / Adding URL with a # truncate begin…

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/onlinesrc-add.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/onlinesrc-add.xsl
@@ -163,7 +163,6 @@
     
     <!-- Add online source from URL -->
     <xsl:if test="$url">
-
       <!-- If a name is provided loop on all languages -->
       <xsl:choose>
         <xsl:when test="contains($name, ',')">
@@ -171,7 +170,7 @@
             <mrd:onLine>
               <cit:CI_OnlineResource>
                 <cit:linkage>
-                  <xsl:copy-of select="gn-fn-iso19115-3.2018:fillTextElement($url, $mainLang, $useOnlyPTFreeText)"/>
+                  <xsl:copy-of select="gn-fn-iso19115-3.2018:fillTextElement($url, '◿', '◿', $mainLang, $useOnlyPTFreeText)"/>
                 </cit:linkage>
 
                 <xsl:if test="$protocol != ''">
@@ -217,7 +216,7 @@
           <mrd:onLine>
             <cit:CI_OnlineResource>
               <cit:linkage>
-                <xsl:copy-of select="gn-fn-iso19115-3.2018:fillTextElement($url, $mainLang, $useOnlyPTFreeText)"/>
+                <xsl:copy-of select="gn-fn-iso19115-3.2018:fillTextElement($url, '◿', '◿', $mainLang, $useOnlyPTFreeText)"/>
               </cit:linkage>
 
               <xsl:if test="$protocol != ''">


### PR DESCRIPTION
…ning of URL

URL containing `#` was considered multilingual token like name and description are handled.
Multilingual URL are not supported (yet).

Test: Add web link to `http://lemonde.fr#dada` and the link added was only `dada`