### PR TITLE
Add `register` and `lost password` option to accessible login menu

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -569,6 +569,13 @@ goog.require('gn_alert');
       $scope.isExternalViewerEnabled = gnExternalViewer.isEnabled();
       $scope.externalViewerUrl = gnExternalViewer.getBaseUrl();
 
+      $scope.isSelfRegisterPossible = function() {
+        return gnConfig['system.userSelfRegistration.enable'];
+      };
+
+      $scope.isHostDefined = function () {
+        return gnConfig['system.feedback.mailServer.hostIsDefined'];
+      };
 
       $scope.layout = {
         hideTopToolBar: false

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -96,6 +96,13 @@
            $scope.sendPassword = value;
            $('#username').focus();
           };
+
+         var showForgotPassword = gnUtilityService.getUrlParameter('showforgotpassword');
+
+         if ((showForgotPassword) && (showForgotPassword === 'true')) {
+           $scope.setSendPassword(true);
+         }
+
          /**
           * Register user. An email will be sent to the new
           * user and another to the catalog admin if a profile

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -234,7 +234,7 @@ a {
   @media (max-width: @screen-md-max) {
     margin-top: -6px;
   }
-  @media (max-width: @screen-xs-max) {  
+  @media (max-width: @screen-xs-max) {
     margin-top: 0;
   }
 }
@@ -1002,6 +1002,21 @@ gn-md-type-widget, gn-md-type-inspire-validation-widget {
       font-weight: 500;
     }
   }
+  &.accessible-dropdown {
+    .dropdown-menu {
+      li:not(.divider) {
+        padding: 3px 15px;
+        a:not(.btn) {
+          padding: 8px 15px !important;
+          margin-left: -15px;
+          margin-right: -15px;
+        }
+      }
+      .navbar-form {
+        padding: 0;
+      }
+    }
+  }
 }
 // styles for login popup in the navbar
 .signin-dropdown {
@@ -1016,7 +1031,19 @@ gn-md-type-widget, gn-md-type-inspire-validation-widget {
     }
   }
 }
-
+.accessible-dropdown {
+  .signin-dropdown {
+    .dropdown-menu {
+      .navbar-form {
+        .input-group {
+          .form-control {
+            min-width: 200px;
+          }
+        }
+      }
+    }
+  }
+}
 
 // map
 .gn-drawmap-panel {

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
@@ -27,7 +27,7 @@
   <div id="navbar" class="navbar-accessible navbar-collapse collapse">
     <ul class="nav navbar-nav gn-menu-xs" role="menu">
       <li class="clearfix hidden-xs" data-ng-if="gnCfg.mods.home.enabled">
-        <a class="pull-left gn-logo-link" 
+        <a class="pull-left gn-logo-link"
            data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
           <img class="gn-logo"
                data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}"
@@ -148,7 +148,7 @@
 
     <div class="navbar-right">
       <ul data-ng-if="gnCfg.mods.signin.enabled"
-          class="nav navbar-nav username-dropdown">
+          class="nav navbar-nav username-dropdown accessible-dropdown">
         <!-- logged in -->
         <li class="dropdown" data-ng-show="authenticated">
           <a title="{{'userDetails' | translate}}"
@@ -214,11 +214,11 @@
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu" role="menu">
-            <li role="menuitem">
-              <form name="gnSigninForm" class="navbar-form flex-row"
-                action="{{signInFormAction}}" method="post" role="form">
-                <input type="hidden" name="_csrf" value="{{csrf}}"/>
-                <div class="form-group form-group-sm">
+            <form name="gnSigninForm" class="navbar-form"
+                  action="{{signInFormAction}}" method="post" role="form">
+              <input type="hidden" name="_csrf" value="{{csrf}}"/>
+              <li role="menuitem">
+                <div class="form-group">
                   <div class="input-group">
                     <span class="input-group-addon">
                       <span class="fa fa-fw fa-user"></span>
@@ -234,8 +234,9 @@
                           required=""/>
                   </div>
                 </div>
-                <div class="flex-spacer hidden-xs"></div>
-                <div class="form-group form-group-sm">
+              </li>
+              <li role="menuitem">
+                <div class="form-group">
                   <div class="input-group">
                     <span class="input-group-addon">
                       <span class="fa fa-fw fa-lock"></span>
@@ -251,16 +252,55 @@
                           required=""/>
                   </div>
                 </div>
-                <div class="flex-spacer hidden-xs"></div>
-
-                <input type="hidden" name="redirectUrl" value="{{redirectUrlAfterSign}}"/>
-
-                <button type="submit" class="btn btn-primary btn-sm pull-right"
+              </li>
+              <input type="hidden" name="redirectUrl" value="{{redirectUrlAfterSign}}"/>
+              <li role="menuitem">
+                <button type="submit" class="btn btn-primary btn-block"
                         aria-label="{{'signIn' | translate}}"
                         data-ng-disabled="!gnSigninForm.$valid">
                   <span class="fa fa-sign-in"></span>
+                  <span translate="">signIn</span>
                 </button>
-              </form>
+              </li>
+            </form>
+            <!-- register -->
+            <li role="separator" class="divider hidden-xs" data-ng-show="isSelfRegisterPossible()"></li>
+            <li role="menuitem" data-ng-show="isSelfRegisterPossible()">
+              <b data-translate="">needAnAccount</b>
+              <p data-translate="">needAnAccountInfo</p>
+              <a class="btn btn-default" href="new.account" data-translate="">createAnAccount</a>
+            </li>
+            <li role="separator" class="divider hidden-xs" data-ng-show="isHostDefined()"></li>
+            <li data-ng-show="isHostDefined()">
+              <!-- forgot password -->
+              <b data-translate="">forgetDetails</b>
+<!--                <span data-ng-show="sendPassword === false">-->
+              <span>
+                <p data-translate="">forgetDetailsInfo</p>
+                <button type="submit" class="btn btn-default btn-block" data-ng-click="setSendPassword(true)">
+                  <span data-translate="">recoverPassword</span>
+                </button>
+              </span>
+
+              <div data-ng-show="sendPassword === true">
+                <form class="form-horizontal" id="userinfo" name="gnUserinfo">
+                  <input type="hidden" name="_csrf" value="{{csrf}}"/>
+                  <div class="form-group">
+                    <label data-translate="">username</label>
+                    <input type="text" name="username" id="username"
+                           aria-label="{{'username' | translate}}"
+                           data-ng-model="usernameToRemind"
+                           data-ng-required="" class="form-control"/>
+                  </div>
+                  <button type="submit"
+                          class="btn btn-default btn-block"
+                          data-ng-disabled="usernameToRemind == ''"
+                          data-ng-click="remindMyPassword('#userinfo')">
+                    <i class="fa fa-question-sign"/>
+                    <span data-translate="">sendPasswordLinkToMyEmail</span>
+                  </button>
+                </form>
+              </div>
             </li>
           </ul>
         </li>

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
@@ -271,36 +271,13 @@
               <a class="btn btn-default" href="new.account" data-translate="">createAnAccount</a>
             </li>
             <li role="separator" class="divider hidden-xs" data-ng-show="isHostDefined()"></li>
-            <li data-ng-show="isHostDefined()">
+            <li data-ng-show="isHostDefined()" class="gn-margin-bottom">
               <!-- forgot password -->
               <b data-translate="">forgetDetails</b>
-<!--                <span data-ng-show="sendPassword === false">-->
               <span>
                 <p data-translate="">forgetDetailsInfo</p>
-                <button type="submit" class="btn btn-default btn-block" data-ng-click="setSendPassword(true)">
-                  <span data-translate="">recoverPassword</span>
-                </button>
+                <a class="btn btn-default btn-block" href="catalog.signin?showforgotpassword=true" data-translate="">recoverPassword</a>
               </span>
-
-              <div data-ng-show="sendPassword === true">
-                <form class="form-horizontal" id="userinfo" name="gnUserinfo">
-                  <input type="hidden" name="_csrf" value="{{csrf}}"/>
-                  <div class="form-group">
-                    <label data-translate="">username</label>
-                    <input type="text" name="username" id="username"
-                           aria-label="{{'username' | translate}}"
-                           data-ng-model="usernameToRemind"
-                           data-ng-required="" class="form-control"/>
-                  </div>
-                  <button type="submit"
-                          class="btn btn-default btn-block"
-                          data-ng-disabled="usernameToRemind == ''"
-                          data-ng-click="remindMyPassword('#userinfo')">
-                    <i class="fa fa-question-sign"/>
-                    <span data-translate="">sendPasswordLinkToMyEmail</span>
-                  </button>
-                </form>
-              </div>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
The changes to the accessibility of the menu do prevent to click on the login option to go to the login page. Not going to the login page also prevents a user from registering or asking for a new password.

This PR adds the options to the login menu (when activated in the settings):
- register: open the register page
- forgot password: go to login page and open the 'lost password' panel

**The 'new' login popup**
![gn-add-options-to-login-popup](https://user-images.githubusercontent.com/19608667/113986244-53288400-984d-11eb-8211-6ae46b650369.png)
