### PR TITLE
Styling and multiple columns for the language list in the `Create Thesaurus Window`

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
@@ -23,9 +23,9 @@
       registryChooseLanguages
     </label>
     <div class="row">
-      <div class="col-md-6">
-        <ul>
-          <li data-ng-repeat="l in languages">
+      <div class="col-md-6 gn-nopadding-left">
+        <ul class="list-group gn-nopadding-right">
+          <li data-ng-repeat="l in languages" class="list-group-item">
             <label><input type="checkbox"
                           name="registryLanguage"
                           data-ng-model="selectedLanguages[l.key]"

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -63,6 +63,20 @@ fieldset.cswCriteriaInfo, ul.list-group {
   max-height: 40em;
   margin-bottom: 51px;
 }
+#gn-upload-thesaurus {
+  ul.list-group {
+    max-height: none;
+    column-count: 3;
+    margin-bottom: 0;
+    margin-top: 10px;
+    li {
+      padding: 6px 15px;
+      -webkit-column-break-inside: avoid;
+      page-break-inside: avoid;
+      break-inside: avoid;
+    }
+  }
+}
 
 fieldset.cswCriteriaInfo, ul.criteria-list-group {
   padding-right: 1em;


### PR DESCRIPTION
This PR improves the styling and adds multiple columns to the language list in the `Create Thesaurus Window`. Before this, the list could be very long and pushing other content out of the view

**The list after the changes:**

![gn-thesaurus-list](https://user-images.githubusercontent.com/19608667/113987022-32146300-984e-11eb-8c42-cf6a1b85a73c.png)
