### PR TITLE
Fix escaped "+" in keyword identifier

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -403,8 +403,6 @@ public class KeywordsApi {
 
         Element descKeys;
 
-        uri = URLDecoder.decode(uri, "UTF-8");
-
         if (uri == null) {
             descKeys = new Element("descKeys");
         } else {


### PR DESCRIPTION
If a keyword contains a "+" sign, it will be escaped as a space character.

Related: https://github.com/geonetwork/core-geonetwork/pull/5477