### PR TITLE
Editor / Keywords from all thesaurus / XPath mode

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -1128,11 +1128,12 @@ public final class Xml {
         final String XML_PATTERN_STR = "<(\\S+?)(.*?)>(.*?)</\\1>";
 
         if (inXMLStr != null && inXMLStr.trim().length() > 0) {
-            if (inXMLStr.trim().startsWith("<")) {
+            String trimedString = inXMLStr.trim();
+            if (trimedString.startsWith("<")) {
                 pattern = Pattern.compile(XML_PATTERN_STR,
                     Pattern.CASE_INSENSITIVE | Pattern.DOTALL | Pattern.MULTILINE);
 
-                matcher = pattern.matcher(inXMLStr);
+                matcher = pattern.matcher(trimedString);
                 retBool = matcher.matches();
             }
         }

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -88,6 +88,7 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.output.DOMOutputter;
 import org.locationtech.jts.geom.*;
+import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.operation.valid.IsValidOp;
 import org.locationtech.jts.precision.GeometryPrecisionReducer;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -640,6 +641,29 @@ public final class XslUtil {
         }
 
         return results.toString();
+    }
+
+    public static String wktGeomToBbox(Object geometryAsXmlString) throws Exception {
+        String ret = "";
+        try {
+            Element geometryElement = Xml.loadString((String) geometryAsXmlString, false);
+            if (geometryElement != null) {
+                String wktString = (String) geometryElement.getValue();
+                if (wktString != null && wktString.length() > 0) {
+                    WKTReader reader = new WKTReader();
+                    Geometry geometry = reader.read(wktString);
+                    if (geometry != null) {
+                        final Envelope envelope = geometry.getEnvelopeInternal();
+                        return
+                            String.format("%f|%f|%f|%f",
+                                envelope.getMinX(), envelope.getMinY(),
+                                envelope.getMaxX(), envelope.getMaxY());
+                    }
+                }
+            }
+        } catch (Throwable e) {
+        }
+        return ret;
     }
 
     /**

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -60,7 +60,7 @@
     <!--Add all Thesaurus as first block of keywords-->
     <xsl:if test="name(preceding-sibling::*[1]) != name()">
       <xsl:call-template name="addAllThesaurus">
-        <xsl:with-param name="ref" select="../gn:element/@ref"/>
+        <xsl:with-param name="ref" select="concat('_X', ../gn:element/@ref, '_', replace(name(), ':', 'COLON'))"/>
       </xsl:call-template>
     </xsl:if>
 
@@ -290,9 +290,11 @@
 
   <xsl:template name="addAllThesaurus">
     <xsl:param name="ref"/>
+    <xsl:param name="xpath" select="''" required="no"/>
+    <xsl:param name="keywordList" select="''" required="no"/>
+    <xsl:param name="transformation" select="'to-iso19139-keyword'" required="no"/>
+
     <xsl:if test="java:getSettingValue('system/metadata/allThesaurus') = 'true'">
-
-
       <xsl:variable name="thesaurusConfig"
                     as="element()?"
                     select="$thesaurusList/thesaurus[@key='external.none.allThesaurus']"/>
@@ -307,13 +309,15 @@
       <div
               data-gn-keyword-selector="tagsinput"
               data-metadata-id=""
-              data-element-ref="_X{$ref}_gmdCOLONdescriptiveKeywords"
+              data-element-ref="{$ref}"
+              data-element-xpath="{$xpath}"
               data-thesaurus-title="{{{{'selectKeyword' | translate}}}}"
               data-thesaurus-key="external.none.allThesaurus"
-              data-keywords=""
+              data-keywords="{$keywordList}"
               data-transformations="{$transformations}"
-              data-current-transformation="to-iso19139-keyword"
-              data-max-tags="" data-lang="{$metadataOtherLanguagesAsJson}"
+              data-current-transformation="{$transformation}"
+              data-max-tags=""
+              data-lang="{$metadataOtherLanguagesAsJson}"
               data-textgroup-only="false"
               class="">
       </div>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -74,7 +74,7 @@
 
     <xsl:if test="$name = 'gmd:descriptiveKeywords' and count(../gmd:descriptiveKeywords) = 0">
       <xsl:call-template name="addAllThesaurus">
-        <xsl:with-param name="ref" select="../gn:element/@ref"/>
+        <xsl:with-param name="ref" select="concat('_X', ../gn:element/@ref, '_', replace('gmd:descriptiveKeywords', ':', 'COLON'))"/>
       </xsl:call-template>
     </xsl:if>
 

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -215,6 +215,7 @@
            scope: {
              elementRef: '@',
              elementXpath: '@',
+             wrapper: '@',
              thesaurusKey: '@',
              keywords: '@',
              transformations: '@',
@@ -544,7 +545,7 @@
                gnThesaurusService
                 .getXML(scope.thesaurusKey,
                getKeywordIds(), scope.currentTransformation, scope.langs,
-                   scope.textgroupOnly,scope.langConversion).then(
+                   scope.textgroupOnly, scope.langConversion, scope.wrapper).then(
                function(data) {
                  scope.snippet = data;
                });

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -214,6 +214,7 @@
            transclude: true,
            scope: {
              elementRef: '@',
+             elementXpath: '@',
              thesaurusKey: '@',
              keywords: '@',
              transformations: '@',
@@ -238,6 +239,16 @@
              scope.results = null;
              scope.snippet = null;
              scope.isInitialized = false;
+
+             var id = '#tagsinput_' + scope.elementRef;
+
+             // If XPath mode, then 2 parameters are sent
+             // _Pref_elementName for the path
+             // _Pref_elementName_xml for the snippet
+             if (scope.elementXpath != '') {
+               scope.elementRefXpath = scope.elementRef;
+             }
+
              scope.elementRefBackup = scope.elementRef;
              scope.invalidKeywordMatch = false;
              scope.selected = [];
@@ -375,7 +386,6 @@
 
              // Init typeahead and tag input
              var initTagsInput = function() {
-               var id = '#tagsinput_' + scope.elementRef;
                $timeout(function() {
                  try {
                    $(id).tagsinput({

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -289,7 +289,9 @@
                * eg. to-iso19139-keyword for default form.
                */
               getXML: function(thesaurus,
-                  keywordUris, transformation, lang, textgroupOnly,langConversion) {
+                               keywordUris, transformation,
+                               lang, textgroupOnly, langConversion,
+                               wrapper) {
                 // http://localhost:8080/geonetwork/srv/eng/
                 // xml.keyword.get?thesaurus=external.place.regions&id=&
                 // multiple=false&transformation=to-iso19139-keyword&
@@ -305,6 +307,9 @@
                 }
                 if (lang) {
                   params.lang = lang;
+                }
+                if (wrapper) {
+                  params.wrapper = wrapper;
                 }
                 if (textgroupOnly) {
                   params.textgroupOnly = textgroupOnly;

--- a/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
@@ -48,7 +48,8 @@
 
     <!-- The thesaurus snippet to insert once received -->
     <div>
-      <input name="{{elementRef}}" type="hidden" value="{{snippet}}"/>
+      <input name="{{elementRef}}{{elementXpath != '' ? '_xml' : ''}}" type="hidden" value="{{snippet}}"/>
+      <input name="{{elementRefXpath}}" type="hidden" value="{{elementXpath}}"/>
     </div>
   </span>
 </div>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1479,7 +1479,7 @@
         <xsl:if test="$attributeName = 'xlink:href'">
           <i class="fa fa-link fa-fw"/>
         </xsl:if>
-        <xsl:value-of select="gn-fn-metadata:getLabel($schema, $attributeName, $labels)/label"/>
+        <xsl:value-of select="gn-fn-metadata:getLabel($schema, $attributeName, $labels, name(..), '', '')/label"/>
       </label>
       <div class="col-sm-7">
         <xsl:variable name="isDivLevelDirective"


### PR DESCRIPTION
Add possibility to configure an editor to populate all keywords in a record whatever the thesaurus. This mainly target DCAT where we want to keep the editor interface as simple as possible.