### PR TITLE
[5590] Fix for too small privileges popup in Metadata page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -85,12 +85,6 @@
       overflow: auto;
     }
   }
-  // modal dialog (wider for for multilingual)
-  @media (min-width: @screen-sm-min) {
-    .modal-dialog {
-      width: 760px;
-    }
-  }
   form.gn-editor {
     // tabs above editor
     .nav {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -20,7 +20,7 @@
 @navbar-default-link-hover-color: @gray-dark;
 @text-muted: #707070;
 // width of modal dialog
-@modal-md: 700px;
+@modal-md: 760px;
 @navbar-default-color: #333;
 // slightly darker primary color, now color contrast on light gray backgrounds is high enough
 @brand-primary: #3277B3;


### PR DESCRIPTION
Fix for too small privileges popup (some languages have wider labels than others). Fixed by increasing the default Bootstrap width of medium wide `modals`.

Issue: https://github.com/geonetwork/core-geonetwork/issues/5590

**After the fix**
![gn-privileges-popup](https://user-images.githubusercontent.com/19608667/114705016-8c6a6380-9d27-11eb-8814-86a9db08dc36.png)
