### PR TITLE
Use default language for regions if not available in the UI language

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
@@ -36,6 +36,7 @@ import org.fao.geonet.api.records.extent.MapRenderer;
 import org.fao.geonet.api.regions.model.Category;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.exceptions.LabelNotFoundException;
 import org.fao.geonet.kernel.KeywordBean;
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.kernel.region.RegionsDAO;
@@ -166,9 +167,16 @@ public class RegionsApi {
                     ((ThesaurusBasedRegionsDAO) dao).getRegionTopConcepts(context);
                 if (keywords != null) {
                     for (KeywordBean k : keywords) {
+                        String label = "";
+                        try {
+                            label = k.getPreferredLabel(language);
+                        } catch (LabelNotFoundException ex) {
+                            label = k.getDefaultValue();
+                        }
+
                         Category c = new Category(
                             k.getUriCode(),
-                            k.getPreferredLabel(language)
+                            label
                         );
                         response.add(c);
                     }

--- a/services/src/main/java/org/fao/geonet/api/regions/ThesaurusBasedRegionsDAO.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/ThesaurusBasedRegionsDAO.java
@@ -25,6 +25,7 @@ package org.fao.geonet.api.regions;
 
 import jeeves.JeevesCacheManager;
 import jeeves.server.context.ServiceContext;
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.KeywordBean;
 import org.fao.geonet.kernel.Thesaurus;
 import org.fao.geonet.kernel.ThesaurusManager;
@@ -134,7 +135,7 @@ public class ThesaurusBasedRegionsDAO extends RegionsDAO {
                 public java.util.List<KeywordBean> call() throws Exception {
                     Thesaurus thesaurus = getThesaurus(context);
                     if (thesaurus != null) {
-                        return thesaurus.getTopConcepts(context.getLanguage());
+                        return thesaurus.getTopConcepts(context.getLanguage(), Geonet.DEFAULT_LANGUAGE);
                     } else {
                         return null;
                     }

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -391,7 +391,8 @@
   module.factory('gnRegionService', [
     '$q',
     '$http',
-    function($q, $http) {
+    'gnGlobalSettings',
+    function($q, $http, gnGlobalSettings) {
 
       /**
       * Array of available region type
@@ -423,6 +424,8 @@
           }).success(function(response) {
             var data = response.region;
 
+            var defaultLang =  gnGlobalSettings.gnCfg.langDetector.default;
+
             // Compute default name and add a
             // tokens element which is used for filter
             angular.forEach(data, function(country) {
@@ -430,7 +433,7 @@
               angular.forEach(country.label, function(label) {
                 country.tokens.push(label);
               });
-              country.name = country.label[lang] || country.label[0];
+              country.name = country.label[lang] || country.label[defaultLang];
             });
             defer.resolve(data);
           });


### PR DESCRIPTION
Regions thesaurus is available in English and French, the metadata editor widget to search for regions return empty values if the UI is used in other languages.


![regions-empty-values](https://user-images.githubusercontent.com/1695003/114879114-32d66780-9e01-11eb-9667-a83a0c724ee4.png)

This pull request, uses the values in the default values (English) in these cases:

![region-values](https://user-images.githubusercontent.com/1695003/114879927-e8091f80-9e01-11eb-9c07-fa5e6ce8008b.png)


