### PR TITLE
Metadata editor - fix rendering of codelists in template fields

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -616,7 +616,7 @@
                         </textarea>
                       </xsl:when>
                       <xsl:when test="$codelist != ''">
-                        <select class="form-control input-sm"
+                        <select class="form-control"
                                 data-gn-field-tooltip="{$schema}|{@tooltip}"
                                 id="{$id}_{@label}">
                           <xsl:if test="$readonly = 'true'">


### PR DESCRIPTION
**Before:**

![before-codelist](https://user-images.githubusercontent.com/1695003/114886940-489b5b00-9e08-11eb-9509-13a0e12e0bcc.png)

**After:**

![after-codelist](https://user-images.githubusercontent.com/1695003/114887084-67015680-9e08-11eb-9cf8-07c4ce0440ee.png)


**To test:**

1. Enable `INSPIRE` in the settings.
2. Create an iso19139 metadata with the default template.
3. Switch to the `INSPIRE` view and find the section `Responsible organization (s)`
