### PR TITLE
Uniform view for the bounding geometries in the Editor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -1,94 +1,99 @@
-<!-- full width map -->
-<div class="row">
-  <div class="col-md-12" ol-map="ctrl.map"></div>
-</div>
+<div class="gn-drawmap-panel">
+  <!-- full width map -->
+  <div class="row gn-editor-map">
+    <div class="col-md-12 gn-nopadding-right gn-nopadding-left" ol-map="ctrl.map"></div>
+  </div>
 
-<div class="spacer" />
-
-<!-- draw tool & select boxes -->
-<div class="row">
-  <div class="col-xs-12 col-sm-6 col-sm-push-6" ng-if="!ctrl.readOnly">
-    <label class="text-muted control-label" translate>drawOnMap</label>
-    <br />
-    <div gi-btn-group>
-      <div class="btn-group">
-        <div class="btn-group">
-          <button class="btn btn-default btn-warning"
-            gi-btn="active" ng-model="ctrl.drawInteraction.active">
-            <span class="fa fa-pencil"></span>&nbsp;
-            <span translate>Polygon</span>
-          </button>
-          <button class="btn btn-default btn-warning"
-            gi-btn="active" ng-model="ctrl.drawLineInteraction.active">
-            <span class="fa fa-pencil"></span>&nbsp;
-            <span translate>Line</span>
-          </button>
+<!--  <div class="spacer" />-->
+  <div class=" gn-editor-map-toolbar">
+    <!-- draw tool & select boxes -->
+    <div class="row">
+      <div class="col-xs-12 col-sm-6 col-sm-push-6 gn-nopadding-right" ng-if="!ctrl.readOnly">
+        <div class="pull-right">
+          <label class="text-muted control-label" translate>drawOnMap</label>
+          <br />
+          <div gi-btn-group>
+            <div class="btn-group">
+              <div class="btn-group">
+                <button class="btn btn-default"
+                  gi-btn="active" ng-model="ctrl.drawInteraction.active">
+                  <span class="fa fa-pencil"></span>&nbsp;
+                  <span translate>Polygon</span>
+                </button>
+                <button class="btn btn-default"
+                  gi-btn="active" ng-model="ctrl.drawLineInteraction.active">
+                  <span class="fa fa-pencil"></span>&nbsp;
+                  <span translate>Line</span>
+                </button>
+              </div>
+            </div>
+            <button class="btn btn-default"
+              gi-btn="active" ng-model="ctrl.modifyInteraction.active">
+              <span class="fa fa-pencil"></span>&nbsp;
+              <span translate>modifyGeometry</span>
+            </button>
+          </div>
         </div>
       </div>
-      <button class="btn btn-default btn-warning"
-        gi-btn="active" ng-model="ctrl.modifyInteraction.active">
-        <span class="fa fa-pencil"></span>&nbsp;
-        <span translate>modifyGeometry</span>
-      </button>
-    </div>
-  </div>
-  <div class="col-xs-12 col-sm-6 col-sm-pull-6">
-    <label class="text-muted control-label" translate>
-      selectFormatAndProjection</label>
-    <br />
-    <div class="flex-row width-100">
-      <div class="flex-nogrow">
-        <select ng-model="ctrl.currentFormat"
-          ng-options="format for format in ctrl.formats"
-          ng-change="ctrl.handleInputOptionsChange()">
-        </select>
-      </div>
-      <div class="flex-spacer"></div>
-      <div class="flex-shrink">
-        <select ng-model="ctrl.currentProjection"
-          ng-options="proj.code as proj.label for proj in ctrl.projections"
-          ng-change="ctrl.handleInputOptionsChange()">
-        </select>
+      <div class="col-xs-12 col-sm-6 col-sm-pull-6 gn-nopadding-left">
+        <label class="text-muted control-label" translate>
+          selectFormatAndProjection</label>
+        <br />
+        <div class="flex-row width-100">
+          <div class="flex-nogrow">
+            <select ng-model="ctrl.currentFormat"
+              ng-options="format for format in ctrl.formats"
+              ng-change="ctrl.handleInputOptionsChange()">
+            </select>
+          </div>
+          <div class="flex-spacer"></div>
+          <div class="flex-shrink">
+            <select ng-model="ctrl.currentProjection"
+              ng-options="proj.code as proj.label for proj in ctrl.projections"
+              ng-change="ctrl.handleInputOptionsChange()">
+            </select>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</div>
 
-<div class="spacer" />
+    <div class="spacer" />
 
-<div ng-if="ctrl.dataOlProjection == null" class="alert alert-danger"
-     data-translate=""
-     data-translate-values="{srsName:'{{ctrl.dataProjection}}'}">
-  badGmlProjectionCode
-</div>
-
-<!-- input geometry field -->
-<div class="row">
-  <div class="col-md-12">
-    <div class="has-feedback"
-      ng-class="{ 'has-success': ctrl.fromTextInput && !ctrl.parseError, 'has-error': ctrl.parseError }">
-      <label class="text-muted control-label" translate>inputGeometryText</label>
-      <textarea class="form-control" rows="4" ng-model="ctrl.inputGeometry"
-        ng-model-options="{ debounce: 300 }"
-        placeholder="{{'inputGeometryText' | translate}}"
-        ng-change="ctrl.handleInputChange()"
-        ng-readonly="ctrl.readOnly"/>
-      <small class="text-danger"
-        ng-show="ctrl.fromTextInput && ctrl.parseError">
-        {{ 'inputGeometryIsInvalid' | translate}} {{ctrl.parseError}}</small>
-      <small class="text-success"
-        ng-show="ctrl.fromTextInput && !ctrl.parseError" translate>
-        inputGeometryIsValid</small>
-      <small class="text-muted"
-        ng-show="!ctrl.fromTextInput && !ctrl.readOnly" translate>
-        inputGeometryHint</small>
-      <small class="text-muted"
-        ng-show="ctrl.readOnly" translate>
-        inputGeometryReadOnlyHint</small>
+    <div ng-if="ctrl.dataOlProjection == null" class="alert alert-danger"
+         data-translate=""
+         data-translate-values="{srsName:'{{ctrl.dataProjection}}'}">
+      badGmlProjectionCode
     </div>
-  </div>
-</div>
 
-<!-- final output in GML -->
-<input name="{{ctrl.identifier}}"
-  type="hidden" value="{{ctrl.outputPolygonXml}}"/>
+    <!-- input geometry field -->
+    <div class="row">
+      <div class="col-md-12 gn-nopadding-left gn-nopadding-right">
+        <div class="has-feedback"
+          ng-class="{ 'has-success': ctrl.fromTextInput && !ctrl.parseError, 'has-error': ctrl.parseError }">
+          <label class="text-muted control-label" translate>inputGeometryText</label>
+          <textarea class="form-control" rows="4" ng-model="ctrl.inputGeometry"
+            ng-model-options="{ debounce: 300 }"
+            placeholder="{{'inputGeometryText' | translate}}"
+            ng-change="ctrl.handleInputChange()"
+            ng-readonly="ctrl.readOnly"/>
+          <small class="text-danger"
+            ng-show="ctrl.fromTextInput && ctrl.parseError">
+            {{ 'inputGeometryIsInvalid' | translate}} {{ctrl.parseError}}</small>
+          <small class="text-success"
+            ng-show="ctrl.fromTextInput && !ctrl.parseError" translate>
+            inputGeometryIsValid</small>
+          <small class="text-muted"
+            ng-show="!ctrl.fromTextInput && !ctrl.readOnly" translate>
+            inputGeometryHint</small>
+          <small class="text-muted"
+            ng-show="ctrl.readOnly" translate>
+            inputGeometryReadOnlyHint</small>
+        </div>
+      </div>
+    </div>
+
+    <!-- final output in GML -->
+    <input name="{{ctrl.identifier}}"
+      type="hidden" value="{{ctrl.outputPolygonXml}}"/>
+</div>
+</div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -404,8 +404,8 @@
     padding: 0 15px 15px 15px;
     position: relative;
     margin-top: 0;
-    border-radius: 0;
     [ol-map] {
+      border-radius: 0;
       .ol-attribution {
         .gn-attribution();
       }
@@ -417,6 +417,11 @@
     border: 1px solid @panel-default-border;
     background-color: @panel-default-heading-bg;
     border-bottom: 0;
+  }
+  .gn-editor-map + .gn-editor-map-toolbar {
+    margin: -15px 15px 0 15px;
+    border-top: 0;
+    border-bottom: 1px solid @panel-default-border;
   }
 }
 // online resource panel


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/5399

I don't know if that PR has to go first (thought it was already merged)

This PR creates a uniform view for the 'draw geometry' maps in the editor.

**The view after the changes**
![gn-editor-bounding](https://user-images.githubusercontent.com/19608667/115002657-4dfab300-9ea5-11eb-9500-0db9864bc519.png)

**It now has the same look as the 'draw box' map**
![gn-editor-drawbox](https://user-images.githubusercontent.com/19608667/115002781-6cf94500-9ea5-11eb-826d-efa7f859d3d1.png)
