### PR TITLE
Proxy / Add proxy for microservices.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1429,6 +1429,9 @@
      when watchlist notifier is triggered (Default 4AM) -->
     <savedselection.watchlist.frequency>0 0 4 * * ?</savedselection.watchlist.frequency>
 
+    <microservices.url></microservices.url>
+    <!--<microservices.url>http://localhost:9901</microservices.url>-->
+
     <!-- Proxy security configuration:
     * NONE: allow all.
     * DB_LINK_CHECK:

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -372,6 +372,32 @@
   </servlet-mapping>
 
 
+  <servlet>
+    <servlet-name>MicroServicesProxy</servlet-name>
+    <servlet-class>org.fao.geonet.proxy.URITemplateProxyServlet</servlet-class>
+    <init-param>
+      <param-name>targetUri</param-name>
+      <param-value>${microservices.url}</param-value>
+    </init-param>
+    <init-param>
+      <param-name>forwardHost</param-name>
+      <param-value>true</param-value>
+    </init-param>
+    <init-param>
+      <param-name>forwardHostPrefixPath</param-name>
+      <param-value>/api</param-value>
+    </init-param>
+    <init-param>
+      <param-name>log</param-name>
+      <param-value>false</param-value>
+    </init-param>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>MicroServicesProxy</servlet-name>
+    <url-pattern>/api/*</url-pattern>
+  </servlet-mapping>
+
+
   <!--Direct proxy to ES server.
   One specific proxy for features
   which are requested by client apps. Redirect

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -41,6 +41,7 @@
         <sec:filter-chain pattern="/jolokia/**" filters="securityContextPersistenceFilter, authenticatedUserFilter"/>
         <sec:filter-chain pattern="/dashboards/**" filters="securityContextPersistenceFilter, basicAuthenticationFilter, authenticatedUserFilter"/>
         <sec:filter-chain pattern="/doc/**" filters=""/>
+        <sec:filter-chain pattern="/api/**" filters=""/>
         <!-- wroAPI is protected for admin only
         This is causing issue on node-change-warning page.
         <sec:filter-chain pattern="/static/wroAPI" filters=""/>-->

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-mapping.xml
@@ -36,9 +36,14 @@
     <property name="securityMetadataSource">
       <sec:filter-security-metadata-source use-expressions="true" request-matcher="regex">
         <sec:intercept-url pattern="/metadata/.*" access="permitAll"/>
-        <!-- Secure proxy URL if needed eg. restrict to some host only. -->
-        <sec:intercept-url pattern="/proxy\?url=.*" access="permitAll"/>
+
+        <sec:intercept-url pattern="/api/.*" access="permitAll"/>
+
+        <!-- Secure proxy URL if needed using proxy.securityMode
+        or restrict to some host only. -->
         <!--<sec:intercept-url pattern="/proxy\?url=.*(www.brgm.fr|www.ifremer.fr).*" access="permitAll"/>-->
+        <sec:intercept-url pattern="/proxy\?url=.*" access="permitAll"/>
+
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/" access="permitAll"/>
         <sec:intercept-url pattern="/[a-zA-Z0-9_\-]+/metadata/.*" access="permitAll"/>


### PR DESCRIPTION
In order to expose one or more microservice (See https://github.com/geonetwork/geonetwork-microservices) behing GeoNetwork, a proxy is set to redirect all calls made to `/api' to the microservices.

eg. with OGC API Records

![image](https://user-images.githubusercontent.com/1701393/115013494-6a045180-9eb1-11eb-9c4b-a0ca9821caa4.png)


Configuration for microservices in order to use the GeoNetwork URL in response of `servletRequest.getRequestURL()`, `X-Forwarded-*` headers are set:
```
server.forward-headers-strategy: FRAMEWORK
gn.baseurl: http://localhost:8080/geonetwork/api
```

In the long run, we will have to define a strategy to move part of the API calls to the microservice gateway (and/or the other way around).

