### PR TITLE
Map / GetFeatureInfo / Don't query background

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
@@ -142,10 +142,11 @@
       }
       this.$scope.$apply(function() {
         var layers = map.getLayers().getArray().filter(function(layer) {
-          return (layer.getSource() instanceof ol.source.ImageWMS ||
+          return layer.background != true
+            && (layer.getSource() instanceof ol.source.ImageWMS ||
               layer.getSource() instanceof ol.source.TileWMS ||
-              layer.getSource() instanceof ol.source.ImageArcGISRest) &&
-              layer.getVisible();
+              layer.getSource() instanceof ol.source.ImageArcGISRest)
+            && layer.getVisible();
         }).reverse();
 
         coordinates = e.coordinate;


### PR DESCRIPTION
It does not really make sense to query the background layers. By default it does nothing because of usage of OSM layer but if the default map is based on one or more WMS/ArcGIS layers then they appear in GFI results.

Exclude all background layers when querying the map.