### PR TITLE
Use thesaurus multilingual value for thesaurus, if available, to display the title in the metadata editor

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -179,7 +179,12 @@
 
     <xsl:choose>
       <xsl:when test="$thesaurusConfig">
+        <!-- If defined dc:title with xml:lang use it for thesaurus label in the editor -->
+        <xsl:variable name="uiLang2code" select="xslutil:twoCharLangCode($lang, 'en')" />
 
+        <xsl:variable name="thesaurusTitleTranslated" select="$listOfThesaurus/thesaurus[title=$thesaurusTitle]/multilingualTitles/multilingualTitle[lang=$uiLang2code]/title" />
+        <xsl:variable name="thesaurusTitleForEditor" select="if (string($thesaurusTitleTranslated)) then $thesaurusTitleTranslated else $thesaurusTitle" />
+        
         <!-- The thesaurus key may be contained in the MD_Identifier field or
           get it from the list of thesaurus based on its title.
           -->
@@ -261,7 +266,7 @@
         <div data-gn-keyword-selector="{$widgetMode}"
              data-metadata-id="{$metadataId}"
              data-element-ref="{concat('_X', ../gn:element/@ref, '_replace')}"
-             data-thesaurus-title="{if (($isFlatMode and not($thesaurusConfig/@fieldset)) or $thesaurusConfig/@fieldset = 'false') then $thesaurusTitle else ''}"
+             data-thesaurus-title="{if (($isFlatMode and not($thesaurusConfig/@fieldset)) or $thesaurusConfig/@fieldset = 'false') then $thesaurusTitleForEditor else ''}"
              data-thesaurus-key="{$thesaurusKey}"
              data-keywords="{$keywords}"
              data-transformations="{$transformations}"


### PR DESCRIPTION
When defined the thesaurus titles with multilingual values:

```
<dc:title>GEMET - INSPIRE themes, version 1.0</dc:title>
<dc:title xml:lang="en">INSPIRE themes</dc:title>
<dc:title xml:lang="sv">INSPIRE thema</dc:title>
```

The non-multilingual value is used for the thesaurus name element, as usual. With this change, in the metadata editor the thesaurus section is labeled as `INSPIRE themes` in English and `INSPIRE thema` in Swedish, instead of `GEMET - INSPIRE themes, version 1.0`. 

![thesaurus-multilingual-title](https://user-images.githubusercontent.com/1695003/115037221-895da780-9ece-11eb-9bc7-bf76c3c6dfe6.png)


For other UI languages not defined in the thesaurus it is displayed the non-multilingual title `GEMET - INSPIRE themes, version 1.0`.
