### PR TITLE
UI config / Apply filter to main statistics

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1227,10 +1227,14 @@ goog.require('gn_alert');
                 type: 'danger'
               });
             } else {
+              var query = {bool: {must: {query_string: {query: "+isTemplate:n"}}}};
+              if (gnGlobalSettings.gnCfg.mods.search.filters) {
+                query.bool.filter = gnGlobalSettings.gnCfg.mods.search.filters;
+              }
               return $http.post('../api/search/records/_search',
                 {size: 0,
                     track_total_hits: true,
-                    query: {query_string: {query: "+isTemplate:n"}},
+                    query: query,
                     aggs: gnGlobalSettings.gnCfg.mods.home.facetConfig}).
               then(function(r) {
                 $scope.searchInfo = r.data;


### PR DESCRIPTION
Some numbers are displayed on home page and admin home page with the total number of records. If a filter is set in the UI configuration eg.

```json
 'filters': [
            {
              "query_string": {
                "query": "isHarvested:false"
              }
            }
          ],
```
the filter was not applied.


![image](https://user-images.githubusercontent.com/1701393/115241885-9d4d1780-a121-11eb-9790-c1461360c097.png)
