### PR TITLE
Editor improvements related to DCAT support

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -1124,8 +1124,9 @@ public final class Xml {
         Pattern pattern;
         Matcher matcher;
 
-        // Regular expression to see if it starts and ends with the same element
-        final String XML_PATTERN_STR = "<(\\S+?)(.*?)>(.*?)</\\1>";
+        // Regular expression to see if it starts and ends with the same element or
+        // it's a self-closing element.
+        final String XML_PATTERN_STR = "<(\\S+?)(.*?)>(.*?)</\\1>|<(\\S+?)(.*?)/>";
 
         if (inXMLStr != null && inXMLStr.trim().length() > 0) {
             String trimedString = inXMLStr.trim();

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -1128,11 +1128,12 @@ public final class Xml {
         final String XML_PATTERN_STR = "<(\\S+?)(.*?)>(.*?)</\\1>";
 
         if (inXMLStr != null && inXMLStr.trim().length() > 0) {
-            if (inXMLStr.trim().startsWith("<")) {
+            String trimedString = inXMLStr.trim();
+            if (trimedString.startsWith("<")) {
                 pattern = Pattern.compile(XML_PATTERN_STR,
                     Pattern.CASE_INSENSITIVE | Pattern.DOTALL | Pattern.MULTILINE);
 
-                matcher = pattern.matcher(inXMLStr);
+                matcher = pattern.matcher(trimedString);
                 retBool = matcher.matches();
             }
         }

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -659,7 +659,7 @@ public class EditLib {
                             LOGGER_ADD_ELEMENT.error(String.format(
                                 " > adding fragment from XPath in element %s which has no parent. This usually means that the element is not allowed in the XSD. Check this element in the metadata record.",
                                 propEl.getName()
-                                ));
+                            ));
                         } else {
                             int index = parent.indexOf(propEl);
                             parent.addContent(index, child);
@@ -674,9 +674,11 @@ public class EditLib {
                         }
                     }
                 } else if (o instanceof Text) {
-                    propEl.addContent((Content)(new Text(((Text) o).getText())));
+                    propEl.addContent((Content) (new Text(((Text) o).getText())));
                 }
             }
+        } else if (newValue.getName().equals(SpecialUpdateTags.DELETE)) {
+            // Ignore the node
         } else if (newValue.getName().equals(propEl.getName()) &&
             newValue.getNamespace().equals(propEl.getNamespace())) {
             // If the target element has the same name as the element to add
@@ -814,6 +816,7 @@ public class EditLib {
             // when adding the fragment child nodes or suggestion may also be added.
             // In this case, the snippet only has to be inserted
             currentNode.removeContent();
+
             doAddFragmentFromXpath(metadataSchema, value.getNodeValue(), currentNode);
         } else {
             if (isAttribute) {

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -88,6 +88,7 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.output.DOMOutputter;
 import org.locationtech.jts.geom.*;
+import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.operation.valid.IsValidOp;
 import org.locationtech.jts.precision.GeometryPrecisionReducer;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -640,6 +641,29 @@ public final class XslUtil {
         }
 
         return results.toString();
+    }
+
+    public static String wktGeomToBbox(Object geometryAsXmlString) throws Exception {
+        String ret = "";
+        try {
+            Element geometryElement = Xml.loadString((String) geometryAsXmlString, false);
+            if (geometryElement != null) {
+                String wktString = (String) geometryElement.getValue();
+                if (wktString != null && wktString.length() > 0) {
+                    WKTReader reader = new WKTReader();
+                    Geometry geometry = reader.read(wktString);
+                    if (geometry != null) {
+                        final Envelope envelope = geometry.getEnvelopeInternal();
+                        return
+                            String.format("%f|%f|%f|%f",
+                                envelope.getMinX(), envelope.getMinY(),
+                                envelope.getMaxX(), envelope.getMaxY());
+                    }
+                }
+            }
+        } catch (Throwable e) {
+        }
+        return ret;
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -643,22 +643,19 @@ public final class XslUtil {
         return results.toString();
     }
 
-    public static String wktGeomToBbox(Object geometryAsXmlString) throws Exception {
+    public static String wktGeomToBbox(Object WKT) throws Exception {
         String ret = "";
         try {
-            Element geometryElement = Xml.loadString((String) geometryAsXmlString, false);
-            if (geometryElement != null) {
-                String wktString = (String) geometryElement.getValue();
-                if (wktString != null && wktString.length() > 0) {
-                    WKTReader reader = new WKTReader();
-                    Geometry geometry = reader.read(wktString);
-                    if (geometry != null) {
-                        final Envelope envelope = geometry.getEnvelopeInternal();
-                        return
-                            String.format("%f|%f|%f|%f",
-                                envelope.getMinX(), envelope.getMinY(),
-                                envelope.getMaxX(), envelope.getMaxY());
-                    }
+            String wktString = (String) WKT;
+            if (wktString != null && wktString.length() > 0) {
+                WKTReader reader = new WKTReader();
+                Geometry geometry = reader.read(wktString);
+                if (geometry != null) {
+                    final Envelope envelope = geometry.getEnvelopeInternal();
+                    return
+                        String.format("%f|%f|%f|%f",
+                            envelope.getMinX(), envelope.getMinY(),
+                            envelope.getMaxX(), envelope.getMaxY());
                 }
             }
         } catch (Throwable e) {

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1262,6 +1262,30 @@ public final class XslUtil {
         return res;
     }
 
+    public static String getKeywordValueByUri(String uri, String thesaurusId, String langCode) {
+        if (StringUtils.isEmpty(thesaurusId)) {
+            return "";
+        }
+
+        try {
+            ApplicationContext applicationContext = ApplicationContextHolder.get();
+            ThesaurusManager thesaurusManager = applicationContext.getBean(ThesaurusManager.class);
+
+            thesaurusId = thesaurusId.replaceAll("geonetwork.thesaurus.", "");
+            Thesaurus thesaurus = thesaurusManager.getThesaurusByName(thesaurusId);
+
+            if (thesaurus != null) {
+                KeywordBean keywordBean = thesaurus.getKeyword(uri, langCode);
+                if (keywordBean != null) {
+                    return keywordBean.getPreferredLabel(langCode);
+                }
+            }
+            return "";
+        } catch (Exception ex) {
+        }
+        return "";
+    }
+
 
     public static String getKeywordUri(String keyword, String thesaurusId, String langCode) {
         if (StringUtils.isEmpty(thesaurusId)) {

--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -755,6 +755,7 @@ For overview, a simple manager can be used or the general one:
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="text"/>
         <xs:element ref="directive"/>
+        <xs:element ref="section"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -187,6 +187,10 @@
     <for name="mri:descriptiveKeywords" addDirective="data-gn-thesaurus-selector">
       <directiveAttributes
               data-transformation="to-iso19115-3.2018-keyword"/>
+      <directiveAttributes data-include="xpath::string-join(*
+                                          //mri:thesaurusName//cit:identifier/*/
+                                            mcc:code/gcx:Anchor/
+                                              concat('-', substring-after(text()[. != ''], 'geonetwork.thesaurus.')), ',')"/>
     </for>
   </fields>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
@@ -123,6 +123,7 @@
     <xsl:copy-of select="gn-fn-index:add-field('Org', $org)"/>
 
     <any><xsl:value-of select="$title"/></any>
+    <any><xsl:value-of select="$org"/></any>
     <any><xsl:value-of select="$name"/></any>
     <any><xsl:value-of select="$mail"/></any>
     <xsl:for-each

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -277,7 +277,7 @@
 
       Exclude all thesaurus already used in the metadata:
       -->
-      <directiveAttributes data-include="xpath::string-join(gmd:MD_Metadata/gmd:identificationInfo
+      <directiveAttributes data-include="xpath::string-join(*
                                           //gmd:thesaurusName/*/gmd:identifier/*/
                                             gmd:code/gmx:Anchor/
                                               concat('-', substring-after(text()[. != ''], 'geonetwork.thesaurus.')), ',')"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -60,7 +60,7 @@
     <!--Add all Thesaurus as first block of keywords-->
     <xsl:if test="name(preceding-sibling::*[1]) != name()">
       <xsl:call-template name="addAllThesaurus">
-        <xsl:with-param name="ref" select="../gn:element/@ref"/>
+        <xsl:with-param name="ref" select="concat('_X', ../gn:element/@ref, '_', replace(name(), ':', 'COLON'))"/>
       </xsl:call-template>
     </xsl:if>
 
@@ -290,9 +290,11 @@
 
   <xsl:template name="addAllThesaurus">
     <xsl:param name="ref"/>
+    <xsl:param name="xpath" select="''" required="no"/>
+    <xsl:param name="keywordList" select="''" required="no"/>
+    <xsl:param name="transformation" select="'to-iso19139-keyword'" required="no"/>
+
     <xsl:if test="java:getSettingValue('system/metadata/allThesaurus') = 'true'">
-
-
       <xsl:variable name="thesaurusConfig"
                     as="element()?"
                     select="$thesaurusList/thesaurus[@key='external.none.allThesaurus']"/>
@@ -307,13 +309,15 @@
       <div
               data-gn-keyword-selector="tagsinput"
               data-metadata-id=""
-              data-element-ref="_X{$ref}_gmdCOLONdescriptiveKeywords"
+              data-element-ref="{$ref}"
+              data-element-xpath="{$xpath}"
               data-thesaurus-title="{{{{'selectKeyword' | translate}}}}"
               data-thesaurus-key="external.none.allThesaurus"
-              data-keywords=""
+              data-keywords="{$keywordList}"
               data-transformations="{$transformations}"
-              data-current-transformation="to-iso19139-keyword"
-              data-max-tags="" data-lang="{$metadataOtherLanguagesAsJson}"
+              data-current-transformation="{$transformation}"
+              data-max-tags=""
+              data-lang="{$metadataOtherLanguagesAsJson}"
               data-textgroup-only="false"
               class="">
       </div>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -74,7 +74,7 @@
 
     <xsl:if test="$name = 'gmd:descriptiveKeywords' and count(../gmd:descriptiveKeywords) = 0">
       <xsl:call-template name="addAllThesaurus">
-        <xsl:with-param name="ref" select="../gn:element/@ref"/>
+        <xsl:with-param name="ref" select="concat('_X', ../gn:element/@ref, '_', replace('gmd:descriptiveKeywords', ':', 'COLON'))"/>
       </xsl:call-template>
     </xsl:if>
 

--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -310,6 +310,9 @@
                      // Initialize tooltip when description returned
                      var html = '';
 
+                     // Add description to the body html
+                     html += '<p>' + info.description + '</p>';
+
                      // TODO: externalize in a template.
                      if (angular.isArray(info.help)) {
                        angular.forEach(info.help, function(helpText) {
@@ -327,9 +330,6 @@
                      if (iconMode) {
                        closeTooltips();
                      }
-
-                     // Add description to the body html
-                     html += '<p>' + info.description + '</p>';
 
                      // Right same width as field
                      // For legend, popover is right

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/partials/directoryentryselector.html
@@ -1,5 +1,7 @@
 <span data-ng-search-form="">
-  <div class="input-group width-100">
+  <!-- Form input mode -->
+  <div class="input-group width-100"
+       data-ng-hide="insertAsTags">
     <div class="input-group-btn">
       <span data-ng-show="templateAddAction"
             data-ng-transclude=""></span>
@@ -46,12 +48,12 @@
 
                     <div class="btn btn-default btn-sm pull-right"
                          data-ng-if="insertAsXlink && !hasDynamicVariable"
-                         data-ng-click="addEntry(r, undefined, true)">
+                         data-ng-click="addEntry(r, undefined, true, true)">
             <i class="fa fa-link"></i>
           </div>
           <div class="btn btn-default btn-sm pull-right"
                data-ng-if="insertAsText && !hasDynamicVariable"
-               data-ng-click="addEntry(r)">
+               data-ng-click="addEntry(r, undefined, false, true)">
             <i class="fa fa-plus"></i>
           </div>
 
@@ -66,7 +68,7 @@
             <div gn-popover-content>
               <ul>
                 <li data-ng-repeat="role in roles" data-ng-hide="role['@hideInEditMode']">
-                  <a href="" data-ng-click="addEntry(r, role.code, true)" title="{{role.description}}">
+                  <a href="" data-ng-click="addEntry(r, role.code, true, true)" title="{{role.description}}">
                     {{role.label}}
                   </a>
                 </li>
@@ -87,7 +89,7 @@
               <ul>
                 <li data-ng-repeat="role in roles"
                     data-ng-hide="role['@hideInEditMode']">
-                  <a href="" data-ng-click="addEntry(r, role.code)"
+                  <a href="" data-ng-click="addEntry(r, role.code, false, true)"
                       title="{{role.description}}">
                     {{role.label}}
                   </a>
@@ -108,10 +110,24 @@
       </button>
     </div>
 
-      <!-- The contact to insert once received -->
-    <div data-ng-if="snippet">
+      <!-- The contact to insert once received.
+       When using tagsinput mode, empty snippet means remove element. -->
+    <div data-ng-if="snippet && !insertAsTags">
       <input name="{{snippetRef}}" type="hidden" value="{{snippet}}"/>
     </div>
   </div>
 
+  <!-- Keyword like input mode -->
+  <div data-ng-show="insertAsTags"
+       data-ng-class="maxTags && selected.length == maxTags ? 'gn-maxtags' : ''">
+    <input type="text"
+           id="tagsinput_{{elementRef}}{{elementName.replace(':', '')}}"
+           class="form-control"></input>
+
+    <div data-ng-if="insertAsTags">
+      <input name="{{snippetRef}}_xml"
+             type="hidden" value="<gn_replace_all>{{snippet}}</gn_replace_all>"/>
+      <input name="{{snippetRef}}" type="hidden" value="{{elementXpath}}"/>
+    </div>
+  </div>
 </span>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1260,7 +1260,7 @@
                     ['url', 'name'].forEach(function(pName) {
                       setParameterValue(pName, o[pName]);
                     });
-                    scope.params.protocol = 'WWW:DOWNLOAD-1.0-http--download';
+                    scope.params.protocol = scope.params.protocol || 'WWW:DOWNLOAD';
                   }
                 };
 

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -663,8 +663,8 @@
            /**
            * Build a field name for an XML field
            */
-           buildXMLFieldName: function(elementRef, elementName) {
-             var t = ['_X', elementRef,
+           buildXMLFieldName: function(elementRef, elementName, prefix) {
+             var t = [(prefix || '_X'), elementRef,
                '_', elementName.replace(':', 'COLON')];
              return t.join('');
            }

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -215,6 +215,7 @@
            scope: {
              elementRef: '@',
              elementXpath: '@',
+             wrapper: '@',
              thesaurusKey: '@',
              keywords: '@',
              transformations: '@',
@@ -544,7 +545,7 @@
                gnThesaurusService
                 .getXML(scope.thesaurusKey,
                getKeywordIds(), scope.currentTransformation, scope.langs,
-                   scope.textgroupOnly,scope.langConversion).then(
+                   scope.textgroupOnly, scope.langConversion, scope.wrapper).then(
                function(data) {
                  scope.snippet = data;
                });

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -214,6 +214,7 @@
            transclude: true,
            scope: {
              elementRef: '@',
+             elementXpath: '@',
              thesaurusKey: '@',
              keywords: '@',
              transformations: '@',
@@ -238,6 +239,16 @@
              scope.results = null;
              scope.snippet = null;
              scope.isInitialized = false;
+
+             var id = '#tagsinput_' + scope.elementRef;
+
+             // If XPath mode, then 2 parameters are sent
+             // _Pref_elementName for the path
+             // _Pref_elementName_xml for the snippet
+             if (scope.elementXpath != '') {
+               scope.elementRefXpath = scope.elementRef;
+             }
+
              scope.elementRefBackup = scope.elementRef;
              scope.invalidKeywordMatch = false;
              scope.selected = [];
@@ -375,7 +386,6 @@
 
              // Init typeahead and tag input
              var initTagsInput = function() {
-               var id = '#tagsinput_' + scope.elementRef;
                $timeout(function() {
                  try {
                    $(id).tagsinput({

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -289,7 +289,9 @@
                * eg. to-iso19139-keyword for default form.
                */
               getXML: function(thesaurus,
-                  keywordUris, transformation, lang, textgroupOnly,langConversion) {
+                               keywordUris, transformation,
+                               lang, textgroupOnly, langConversion,
+                               wrapper) {
                 // http://localhost:8080/geonetwork/srv/eng/
                 // xml.keyword.get?thesaurus=external.place.regions&id=&
                 // multiple=false&transformation=to-iso19139-keyword&
@@ -305,6 +307,9 @@
                 }
                 if (lang) {
                   params.lang = lang;
+                }
+                if (wrapper) {
+                  params.wrapper = wrapper;
                 }
                 if (textgroupOnly) {
                   params.textgroupOnly = textgroupOnly;

--- a/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
@@ -48,7 +48,8 @@
 
     <!-- The thesaurus snippet to insert once received -->
     <div>
-      <input name="{{elementRef}}" type="hidden" value="{{snippet}}"/>
+      <input name="{{elementRef}}{{elementXpath != '' ? '_xml' : ''}}" type="hidden" value="{{snippet}}"/>
+      <input name="{{elementRefXpath}}" type="hidden" value="{{elementXpath}}"/>
     </div>
   </span>
 </div>

--- a/web-ui/src/main/resources/catalog/lib/bootstrap.ext/typeahead.js/typeahead.bundle.js
+++ b/web-ui/src/main/resources/catalog/lib/bootstrap.ext/typeahead.js/typeahead.bundle.js
@@ -359,7 +359,10 @@
         _.mixin(Transport.prototype, {
             _fingerprint: function fingerprint(o) {
                 o = o || {};
-                return o.url + o.type + $.param(o.data || {});
+                // Avoid Uncaught TypeError: String.prototype.indexOf called on null or undefined
+                // When using POST with JSON Body.
+                return o.url + o.type
+                  + (o.data && o.data.indexOf('{') ===0 ? o.data : $.param(o.data || {}));
             },
             _get: function(o, cb) {
                 var that = this, fingerprint, jqXhr;

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
@@ -75,17 +75,17 @@
     <xsl:variable name="hasSidePanel"
                   select="exists($viewConfig/sidePanel) and $isTemplate != 's' and $isTemplate != 't'"/>
     <div id="gn-editor-container-{$metadataId}">
-      <div class="col-md-{if ($hasSidePanel) then '8' else '12'}">
+      <form id="gn-editor-{$metadataId}"
+            name="gnEditor" accept-charset="UTF-8" method="POST"
+            novalidate="" class="form-horizontal gn-editor gn-tab-{$tab} {if ($hasViewClass) then concat('gn-editor-config-css ', $viewConfig/@class) else ''}" role="form"
+            data-spy="scroll" data-target="#gn-editor-{$metadataId}-spy"
+            autocomplete="off">
+
+        <div class="col-md-{if ($hasSidePanel) then '8' else '12'}">
 
         <!--
               The main editor form.
         -->
-        <form id="gn-editor-{$metadataId}"
-              name="gnEditor" accept-charset="UTF-8" method="POST"
-              novalidate="" class="form-horizontal gn-editor gn-tab-{$tab} {if ($hasViewClass) then concat('gn-editor-config-css ', $viewConfig/@class) else ''}" role="form"
-              data-spy="scroll" data-target="#gn-editor-{$metadataId}-spy"
-              autocomplete="off">
-
           <input type="hidden" id="schema" value="{$schema}"/>
           <input type="hidden" id="template" name="template" value="{$isTemplate}"/>
           <input type="hidden" id="isService" name="type" value="{$isService}"/>
@@ -155,16 +155,18 @@
               </saxon:call-template>
             </xsl:otherwise>
           </xsl:choose>
-        </form>
-      </div>
-      <xsl:if test="$hasSidePanel">
-        <div class="col-md-4 gn-editor-sidebar">
-          <div class="gn-editor-tools-container">
-            <xsl:apply-templates mode="form-builder"
-                                 select="$viewConfig/sidePanel/*"/>
-          </div>
         </div>
-      </xsl:if>
+        <xsl:if test="$hasSidePanel">
+          <div class="col-md-4 gn-editor-sidebar">
+            <div class="gn-editor-tools-container">
+              <xsl:apply-templates mode="form-builder"
+                                   select="$viewConfig/sidePanel/*">
+                <xsl:with-param name="base" select="$metadata"/>
+              </xsl:apply-templates>
+            </div>
+          </div>
+        </xsl:if>
+      </form>
     </div>
   </xsl:template>
 

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -989,9 +989,11 @@
                       <xsl:choose>
                         <xsl:when test="starts-with(., 'xpath::')">
                           <xsl:variable name="xpath" select="substring-after(., 'xpath::')"/>
+
+
                           <xsl:attribute name="{name(.)}">
                             <saxon:call-template name="{concat('evaluate-', $schema)}">
-                              <xsl:with-param name="base" select="$metadata"/>
+                              <xsl:with-param name="base" select="$metadata//*[gn:element/@ref = $parentEditInfo/@ref]"/>
                               <xsl:with-param name="in"
                                               select="concat('/../', $xpath)"/>
                             </saxon:call-template>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1457,6 +1457,7 @@
   -->
   <xsl:template mode="render-for-field-for-attribute" match="@*">
     <xsl:param name="ref"/>
+    <xsl:param name="class" select="''"/>
 
     <xsl:variable name="attributeName" select="name()"/>
     <xsl:variable name="attributeValue" select="."/>
@@ -1476,12 +1477,13 @@
     <xsl:variable name="fieldName"
                   select="concat('_', $ref, '_', replace($attributeName, ':', 'COLON'))"/>
 
-    <div class="form-group gn-attr-{replace($attributeName, ':', '_')}" id="gn-attr-{$fieldName}">
+
+    <div class="form-group {$class} gn-attr-{replace($attributeName, ':', '_')}" id="gn-attr-{$fieldName}">
       <label class="col-sm-4">
         <xsl:if test="$attributeName = 'xlink:href'">
           <i class="fa fa-link fa-fw"/>
         </xsl:if>
-        <xsl:value-of select="gn-fn-metadata:getLabel($schema, $attributeName, $labels, name(..), '', '')/label"/>
+        <xsl:value-of select="gn-fn-metadata:getLabel($schema, $attributeName, $labels, name(..), '', gn-fn-metadata:getXPath(.))/label"/>
       </label>
       <div class="col-sm-7">
         <xsl:variable name="isDivLevelDirective"

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1479,7 +1479,7 @@
         <xsl:if test="$attributeName = 'xlink:href'">
           <i class="fa fa-link fa-fw"/>
         </xsl:if>
-        <xsl:value-of select="gn-fn-metadata:getLabel($schema, $attributeName, $labels)/label"/>
+        <xsl:value-of select="gn-fn-metadata:getLabel($schema, $attributeName, $labels, name(..), '', '')/label"/>
       </label>
       <div class="col-sm-7">
         <xsl:variable name="isDivLevelDirective"


### PR DESCRIPTION
## Editor config

* Side panel can now contain sections

![image](https://user-images.githubusercontent.com/1701393/116511192-59e36d80-a8c6-11eb-8b1c-61560b725b75.png)



## Keywords

* Add possibility to use the virtual all thesaurus to populate simple keyword structure 
* Add xpath mode to gnKeywordSelector directive

![image](https://user-images.githubusercontent.com/1701393/115525901-d0adb480-a28f-11eb-85b7-414eed5abaf0.png)

* Fix XML API edits (trim XML snippet, detect self closing tags, ignore gn_delete tag)

![image](https://user-images.githubusercontent.com/1701393/116407613-3a9b0080-a832-11eb-9eb3-69c18b4ee2e2.png)

## Subtemplates

* Add a new taginput mode to be able to populate contact like keywords

![image](https://user-images.githubusercontent.com/1701393/116585396-a5266c00-a918-11eb-9fa3-06adba56d10c.png)

To enable it use the following configuration.

```xml
 <for name="dct:creator" addDirective="data-gn-directory-entry-selector">
      <directiveAttributes
        data-template-type="contact"
        data-element-xpath="./dcat:Dataset/dct:creator"
        data-max-tags="1"
        data-insert-modes="tags"
        data-values="xpath::string-join(.//dct:creator/@xlink:href, '◿')"
        data-default-role="creator"
        data-transformation="contact-from-iso19139-to-foaf-agent"/>
    </for>
```

In this mode, encoding is made using XLinks (so turn XLink resolution on in the admin > settings).

This mode does not work (yet?) for ISO records where the role has to be set. But the configuration would look like that:
```xml
    <for name="gmd:pointOfContact" addDirective="data-gn-directory-entry-selector">
      <directiveAttributes
        data-template-type="contact"
        data-insert-modes="tags"
        data-element-xpath="gmd:identificationInfo/*/gmd:pointOfContact"
        data-values="xpath::string-join(*/gmd:pointOfContact/@xlink:href, '◿')"
        data-default-role="pointOfContact"
        data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
    </for>
```


## Geometry 

* Add possibility to define a wrapper element (currently only ISO19139 can use the polygon directive)
* Add utility to parse WKT to simple extent string


## Label

* Attributes may have context element for more contextual label (eg. use for rdf:resource or rdf:about in DCAT)
