### PR TITLE
ES / Update to 7.12 & documentation about security

### DIFF
--- a/es/README.md
+++ b/es/README.md
@@ -83,13 +83,7 @@ As far as Elasticsearch port is not exposed to the web, Elasticsearch index is s
 
 Enable security in `config/elasticsearch.yml`:
 ```
-xpack.ml.enabled: false
 xpack.security.enabled: true
-xpack.security.authc:
-  anonymous:
-    username: anonymous_user
-    roles: kibana_dashboard_only_user
-    authz_exception: true
 ```
 
 Start Elasticsearch.
@@ -120,7 +114,7 @@ Create a role and user for the catalogue access:
 curl -XPOST -u elastic 'localhost:9200/_security/role/gn_admin' \
    -H "Content-Type: application/json" \
    -d '{
-  "indices": [
+  "indices": [ 
     {
       "names": [ "gn*" ],
       "privileges": ["all"]
@@ -145,7 +139,6 @@ curl -XPOST -u elastic 'localhost:9200/_security/user/anonymous' \
   "full_name" : "Anonymous User",
   "roles" : [ "kibana_dashboard_only_user"]
 }'
-
 ```
 
 
@@ -161,8 +154,9 @@ elasticsearch.username: "kibana_system"
 elasticsearch.password: "changeme"
 ```
 
-TODO: Kibana sign in user when authenticated in GeoNetwork ? 
-TODO: Kibana anonymous user can only access public alias
+Future work required:
+* Kibana sign in user when authenticated in GeoNetwork ? 
+* Kibana anonymous user can only access public alias
 
 
 ## Errors

--- a/pom.xml
+++ b/pom.xml
@@ -1444,7 +1444,7 @@
     <jetty.port>8080</jetty.port>
     <jetty.stop.port>8090</jetty.stop.port>
 
-    <es.version>7.11.1</es.version>
+    <es.version>7.12.0</es.version>
     <es.platform>linux-x86_64</es.platform>
     <es.installer.extension>tar.gz</es.installer.extension>
     <es.protocol>http</es.protocol>

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1551,5 +1551,12 @@
         "type": "keyword"
       }
     }
+  },
+  "aliases": {
+    "${es.index.records}-public": {
+      "filter": {
+        "term": { "op0": 1 }
+      }
+    }
   }
 }

--- a/web/src/main/webResources/WEB-INF/data/config/index/records_french.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records_french.json
@@ -1609,5 +1609,12 @@
         "type": "keyword"
       }
     }
+  },
+  "aliases": {
+    "${es.index.records}-public": {
+      "filter": {
+        "term": { "op0": 1 }
+      }
+    }
   }
 }


### PR DESCRIPTION
This pull request propose to optionally setup basic Elasticsearch security (https://www.elastic.co/guide/en/elasticsearch/reference/current/security-minimal-setup.html) in case you need to open access to Elasticsearch for other application or Kibana.

Documentation explains now:
* enable security at Elasticsearch level
* create user and role for GeoNetwork
* configure GeoNetwork user to connect to Elasticsearch
* configure Kibana user to connect to Elasticsearch
* enable anonymous access to Kibana

![image](https://user-images.githubusercontent.com/1701393/116098205-2aa4e480-a6ab-11eb-9eca-10b350612aa9.png)

* create an index alias for only public metadata (TODO: update alias name based on configuration)

![image](https://user-images.githubusercontent.com/1701393/116098356-4d36fd80-a6ab-11eb-82e4-1175cf12e1ac.png)


This also update to 7.12.0.



 