### PR TITLE
Fix autocommit error when using a JNDI connection

### DIFF
--- a/web/src/main/java/org/fao/geonet/DatabaseMigration.java
+++ b/web/src/main/java/org/fao/geonet/DatabaseMigration.java
@@ -124,7 +124,8 @@ public class DatabaseMigration implements BeanPostProcessor {
                 return bean;
             }
         } catch (ClassNotFoundException e) {
-            _logger.error(String.format("DB Migration / '%s' is an invalid value for initAfter. Class not found. Error is %s", initAfter, e.getMessage(), e));
+            _logger.error(String.format("DB Migration / '%s' is an invalid value for initAfter. Class not found. Error is %s", initAfter, e.getMessage()));
+            _logger.error(e);
         }
         return bean;
     }
@@ -145,7 +146,9 @@ public class DatabaseMigration implements BeanPostProcessor {
              Statement statement = conn.createStatement()) {
 
             this.foundErrors = doMigration(webappVersion, subVersion, servletContext, path, conn, statement);
-            conn.commit();
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
         } catch (Exception e) {
             _logger.warning("  - Migration: Exception running migration for version: " + webappVersion + " subversion: "
                 + subVersion + ". " + e.getMessage());


### PR DESCRIPTION
Only commit the database migration connection when the connections is not autocommit=true.

When using a JNDI connection the connection obtained from the ((JpaTransactionManager) bean).getDataSource()
has autoCommit set to true and cause this error:
```
java.lang.RuntimeException: org.postgresql.util.PSQLException: Cannot commit when autoCommit is enabled.
     at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.postProcessBeforeInitialization(InitDestroyAnnotationBeanPostProcessor.java:160)
```