### PR TITLE
Replace Secondary properties from target to source when replacing source. (during replacing working copy to main version)

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -44,6 +44,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public abstract class AbstractStore implements Store {
     @Override
@@ -153,26 +154,26 @@ public abstract class AbstractStore implements Store {
     @Override
     public final MetadataResource putResource(final ServiceContext context, final String metadataUuid, final MultipartFile file,
             final MetadataResourceVisibility visibility) throws Exception {
-        return putResource(context, metadataUuid, file.getOriginalFilename(), file.getInputStream(), null, visibility, true);
+        return putResource(context, metadataUuid, file.getOriginalFilename(), file.getInputStream(), null, visibility, true, null);
     }
 
     @Override
     public final MetadataResource putResource(final ServiceContext context, final String metadataUuid, final MultipartFile file,
             final MetadataResourceVisibility visibility, Boolean approved) throws Exception {
-        return putResource(context, metadataUuid, file.getOriginalFilename(), file.getInputStream(), null, visibility, approved);
+        return putResource(context, metadataUuid, file.getOriginalFilename(), file.getInputStream(), null, visibility, approved, null);
     }
 
     @Override
     public final MetadataResource putResource(final ServiceContext context, final String metadataUuid, final Path file,
             final MetadataResourceVisibility visibility) throws Exception {
-        return putResource(context, metadataUuid, file, visibility, true);
+        return putResource(context, metadataUuid, file, visibility, true, null);
     }
 
     @Override
     public final MetadataResource putResource(final ServiceContext context, final String metadataUuid, final Path file,
-            final MetadataResourceVisibility visibility, Boolean approved) throws Exception {
+            final MetadataResourceVisibility visibility, Boolean approved, Map<String, Object> secondaryProperties) throws Exception {
         final InputStream is = new BufferedInputStream(Files.newInputStream(file));
-        return putResource(context, metadataUuid, file.getFileName().toString(), is, null, visibility, approved);
+        return putResource(context, metadataUuid, file.getFileName().toString(), is, null, visibility, approved, secondaryProperties);
     }
 
     @Override
@@ -184,7 +185,7 @@ public abstract class AbstractStore implements Store {
     @Override
     public final MetadataResource putResource(ServiceContext context, String metadataUuid, URL fileUrl,
             MetadataResourceVisibility visibility, Boolean approved) throws Exception {
-        return putResource(context, metadataUuid, getFilenameFromUrl(fileUrl), fileUrl.openStream(), null, visibility, approved);
+        return putResource(context, metadataUuid, getFilenameFromUrl(fileUrl), fileUrl.openStream(), null, visibility, approved, null);
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -47,6 +47,7 @@ import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -87,7 +88,7 @@ public class FilesystemStore extends AbstractStore {
                 MetadataResource resource = new FilesystemStoreResource(metadataUuid, metadataId, path.getFileName().toString(),
                                                                         settingManager.getNodeURL() + "api/records/", visibility,
                                                                         Files.size(path),
-                                                                        new Date(Files.getLastModifiedTime(path).toMillis()), approved);
+                                                                        new Date(Files.getLastModifiedTime(path).toMillis()), approved, null);
                 resourceList.add(resource);
             }
         } catch (IOException ignored) {
@@ -161,13 +162,13 @@ public class FilesystemStore extends AbstractStore {
             Log.error(Geonet.RESOURCES, e.getMessage(), e);
         }
         return new FilesystemStoreResource(metadataUuid, metadataId, filePath.getFileName().toString(), settingManager.getNodeURL() + "api/records/",
-                                           visibility, fileSize, new Date(Files.getLastModifiedTime(filePath).toMillis()), approved);
+                                           visibility, fileSize, new Date(Files.getLastModifiedTime(filePath).toMillis()), approved, null);
     }
 
     @Override
     public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,
                                         final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility,
-                                        Boolean approved) throws Exception {
+                                        Boolean approved, Map<String, Object> secondaryProperties) throws Exception {
         int metadataId = canEdit(context, metadataUuid, approved);
         Path filePath = getPath(context, metadataId, visibility, filename, approved);
         Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResource.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResource.java
@@ -31,6 +31,7 @@ import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 
 import java.util.Date;
+import java.util.Map;
 
 /**
  * Metadata resource stored in the file system.
@@ -48,6 +49,7 @@ public class FilesystemStoreResource implements MetadataResource {
     private final String version;
     private final ExternalResourceManagementProperties externalResourceManagementProperties;
     private final boolean approved;
+    private Map<String, Object> secondaryProperties;
 
     public FilesystemStoreResource(String metadataUuid,
                                    int metadataId,
@@ -58,7 +60,8 @@ public class FilesystemStoreResource implements MetadataResource {
                                    Date lastModification,
                                    String version,
                                    ExternalResourceManagementProperties externalResourceManagementProperties,
-                                   boolean approved) {
+                                   boolean approved,
+                                   Map<String, Object> secondaryProperties) {
         this.metadataUuid = metadataUuid;
         this.metadataId = metadataId;
         this.approved=approved;
@@ -69,6 +72,7 @@ public class FilesystemStoreResource implements MetadataResource {
         this.lastModification = lastModification;
         this.version=version;
         this.externalResourceManagementProperties = externalResourceManagementProperties;
+        this.secondaryProperties=secondaryProperties;
     }
 
     public FilesystemStoreResource(String metadataUuid,
@@ -78,8 +82,9 @@ public class FilesystemStoreResource implements MetadataResource {
                                    MetadataResourceVisibility metadataResourceVisibility,
                                    long size,
                                    Date lastModification,
-                                   boolean approved) {
-        this(metadataUuid, metadataId, filename, baseUrl, metadataResourceVisibility, size, lastModification, null, null, approved);
+                                   boolean approved,
+                                   Map<String, Object> secondaryProperties) {
+        this(metadataUuid, metadataId, filename, baseUrl, metadataResourceVisibility, size, lastModification, null, null, approved, secondaryProperties);
     }
 
     @Override
@@ -136,6 +141,11 @@ public class FilesystemStoreResource implements MetadataResource {
     @Override
     public ExternalResourceManagementProperties getExternalResourceManagementProperties() {
         return externalResourceManagementProperties;
+    }
+
+    @Override
+    public Map<String, Object> getSecondaryProperties() {
+        return secondaryProperties;
     }
 
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -44,6 +44,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.resource.NotSupportedException;
 
@@ -96,10 +97,11 @@ public class ResourceLoggerStore extends AbstractStore {
     @Override
     public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,
                                         final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility,
-                                        Boolean approved) throws Exception {
+                                        Boolean approved,
+                                        Map<String, Object> secondaryProperties) throws Exception {
         if (decoratedStore != null) {
             final MetadataResource resource = decoratedStore
-                    .putResource(context, metadataUuid, filename, is, changeDate, visibility, approved);
+                    .putResource(context, metadataUuid, filename, is, changeDate, visibility, approved, secondaryProperties);
             if (resource != null) {
                 storePutRequest(context, metadataUuid, resource.getId(), resource.getSize(), approved);
             }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -48,6 +48,7 @@ import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.resource.NotSupportedException;
 
@@ -90,7 +91,7 @@ public class S3Store extends AbstractStore {
     private MetadataResource createResourceDescription(final SettingManager settingManager, final String metadataUuid,
             final MetadataResourceVisibility visibility, final String resourceId, long size, Date lastModification, int metadataId, boolean approved) {
         return new FilesystemStoreResource(metadataUuid, metadataId, getFilename(metadataUuid, resourceId),
-                                           settingManager.getNodeURL() + "api/records/", visibility, size, lastModification, approved);
+                                           settingManager.getNodeURL() + "api/records/", visibility, size, lastModification, approved, null);
     }
 
     private static String getFilename(final String key) {
@@ -129,7 +130,7 @@ public class S3Store extends AbstractStore {
 
     @Override
     public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,
-            final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility, Boolean approved)
+            final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility, Boolean approved, Map<String, Object> secondaryProperties)
             throws Exception {
         final SettingManager settingManager = context.getBean(SettingManager.class);
         final int metadataId = canEdit(context, metadataUuid, approved);

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -180,11 +181,12 @@ public interface Store {
      * @param changeDate                 The optional change date
      * @param metadataResourceVisibility The type of sharing policy {@link MetadataResourceVisibility}
      * @param approved   Put the approved version or not
+     * @param secondaryProperties The secondary type properties as part of the resource
      * @return The resource description
      */
     MetadataResource putResource(ServiceContext context, String metadataUuid, String filename, InputStream is,
                                  @Nullable Date changeDate,
-                                 MetadataResourceVisibility metadataResourceVisibility, Boolean approved)
+                                 MetadataResourceVisibility metadataResourceVisibility, Boolean approved, Map<String, Object> secondaryProperties)
         throws Exception;
 
     /**
@@ -196,9 +198,10 @@ public interface Store {
      * @param filePath                   The resource local filepath
      * @param metadataResourceVisibility The type of sharing policy {@link MetadataResourceVisibility}
      * @param approved   Return the approved version or not
+     * @param secondaryProperties The secondary type properties as part of the resource (optional)
      * @return The resource description
      */
-    MetadataResource putResource(ServiceContext context, String metadataUuid, Path filePath, MetadataResourceVisibility metadataResourceVisibility, Boolean approved) throws Exception;
+    MetadataResource putResource(ServiceContext context, String metadataUuid, Path filePath, MetadataResourceVisibility metadataResourceVisibility, Boolean approved, Map<String, Object> secondaryProperties) throws Exception;
 
     /**
      * Add a new resource from a local file path.

--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -563,7 +563,7 @@ public class Importer {
         final IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
         final String metadataUuid = metadataUtils.getMetadataUuid(id);
         assert metadataUuid != null;
-        store.putResource(context, metadataUuid, file, is, new ISODate(changeDate).toDate(), access, true);
+        store.putResource(context, metadataUuid, file, is, new ISODate(changeDate).toDate(), access, true, null);
     }
 
     /**

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataResource.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataResource.java
@@ -27,6 +27,7 @@ package org.fao.geonet.domain;
 
 
 import java.util.Date;
+import java.util.Map;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -88,4 +89,6 @@ public interface MetadataResource {
     String getVersion();
 
     ExternalResourceManagementProperties getExternalResourceManagementProperties();
+
+    Map<String, Object> getSecondaryProperties();
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -436,7 +436,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
                     final Store store = context.getBean("resourceStore", Store.class);
                     final IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
                     final String metadataUuid = metadataUtils.getMetadataUuid(id[index]);
-                    store.putResource(context, metadataUuid, file, is, new ISODate(changeDate).toDate(), visibility, true);
+                    store.putResource(context, metadataUuid, file, is, new ISODate(changeDate).toDate(), visibility, true, null);
                 }
 
                 public void handleFeatureCat(Element md, int index)
@@ -902,7 +902,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
                 log.debug("  - Adding remote " + metadataUuid + "  file with name:" + file);
             }
 
-            store.putResource(context, metadataUuid, file, is, remIsoDate.toDate(), visibility, true);
+            store.putResource(context, metadataUuid, file, is, remIsoDate.toDate(), visibility, true, null);
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("  - Nothing to do in dir " + metadataUuid + " for file with name:" + file);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -669,7 +669,7 @@ public class MetadataInsertDeleteApi {
         // Save the context if no context-url provided
         if (StringUtils.isEmpty(url)) {
             store.putResource(context, metadataUuid, filename, IOUtils.toInputStream(Xml.getString(wmcDoc)), null,
-                MetadataResourceVisibility.PUBLIC, true);
+                MetadataResourceVisibility.PUBLIC, true, null);
 
             // Update the MD
             Map<String, Object> onlineSrcParams = new HashMap<String, Object>();
@@ -687,7 +687,7 @@ public class MetadataInsertDeleteApi {
 
         if (StringUtils.isNotEmpty(overview) && StringUtils.isNotEmpty(overviewFilename)) {
             store.putResource(context, metadataUuid, overviewFilename, new ByteArrayInputStream(Base64.decodeBase64(overview)), null,
-                MetadataResourceVisibility.PUBLIC, true);
+                MetadataResourceVisibility.PUBLIC, true, null);
 
             // Update the MD
             Map<String, Object> onlineSrcParams = new HashMap<String, Object>();

--- a/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceUploadHandler.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceUploadHandler.java
@@ -61,7 +61,7 @@ public class DefaultResourceUploadHandler implements IResourceUploadHandler {
             throw new Exception("File upload unsuccessful because "
                 + fileName + " already exists and overwrite was not permitted");
         }
-        store.putResource(context, uuid, fileName, is, null, visibility, true);
+        store.putResource(context, uuid, fileName, is, null, visibility, true, null);
     }
 
 


### PR DESCRIPTION
The secondary type properties are needed when working copy merged back to the main version. However they were not part of the replace file process. This change is to add such properties to the interface.

![image](https://user-images.githubusercontent.com/74916635/116086588-f6f79980-a66d-11eb-8686-53f2472a202a.png)
