### PR TITLE
Copy resource files from working copy to destination folder

### DIFF
--- a/add-schema.sh
+++ b/add-schema.sh
@@ -145,7 +145,7 @@ then
   line=$(grep -n '</dependencies>' services/pom.xml | cut -d: -f1)
   finalLine=$(($line - 1))
 
-  projectGroupId='${project.groupId}'
+  projectGroupId='org.geonetwork-opensource.schemas'
   gnSchemasVersion='${project.version}'
 
   echo "Adding schema ${schema} resources to service/pom.xml"

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -203,10 +203,6 @@ public abstract class AbstractStore implements Store {
         return patchResourceStatus(context, metadataUuid, resourceId, metadataResourceVisibility, true);
     }
 
-    @Override
-    public void copyResources(ServiceContext context, String metadataUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
-
-    }
 
     protected String getFilename(final String metadataUuid, final String resourceId) {
         // It's not always clear when we get a resourceId or a filename

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -238,6 +238,9 @@ public class CMISStore extends AbstractStore {
             }
             try {
                 doc = parentFolder.createDocument(properties, contentStream, VersioningState.MAJOR);
+                if (MapUtils.isNotEmpty(additionalProperties)) {
+                    doc.updateProperties(additionalProperties, true);
+                }
                 // Avoid CMIS API call is info is not enabled.
                 if (Logger.getLogger(Geonet.RESOURCES).isInfoEnabled()) {
                     Log.info(Geonet.RESOURCES,
@@ -398,8 +401,8 @@ public class CMISStore extends AbstractStore {
     }
 
     @Override
-    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
-        final int sourceMetadataId = canDownload(context, sourceUuid, metadataResourceVisibility, false);
+    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility, boolean sourceApproved, boolean targetApproved) throws Exception {
+        final int sourceMetadataId = canEdit(context, sourceUuid, metadataResourceVisibility, sourceApproved);
         final String sourceResourceTypeDir = getMetadataDir(context, sourceMetadataId) + CMISConfiguration.getFolderDelimiter() + metadataResourceVisibility.toString();
         try {
             Folder sourceParentFolder = (Folder) CMISConfiguration.getClient().getObjectByPath(sourceResourceTypeDir);
@@ -409,7 +412,7 @@ public class CMISStore extends AbstractStore {
                 Document sourceDocument = sourceEntry.getValue();
                 if (sourceDocument instanceof Document) {
                     Map<String, Object> sourceProperties = getSecondaryProperties(sourceDocument);
-                    putResource(context, targetUuid, sourceDocument.getName(), sourceDocument.getContentStream().getStream(), null, metadataResourceVisibility, true, sourceProperties);
+                    putResource(context, targetUuid, sourceDocument.getName(), sourceDocument.getContentStream().getStream(), null, metadataResourceVisibility, targetApproved, sourceProperties);
                 }
             }
         } catch (CmisObjectNotFoundException  e) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -34,6 +34,7 @@ import org.apache.chemistry.opencmis.commons.enums.VersioningState;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisConstraintException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisPermissionDeniedException;
+import org.apache.commons.collections.MapUtils;
 import org.apache.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.exception.NotAllowedException;
@@ -163,6 +164,12 @@ public class CMISStore extends AbstractStore {
     public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,
                                         final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility, Boolean approved)
             throws Exception {
+        return putResource(context, metadataUuid, filename, is, changeDate, visibility, approved, null);
+    }
+
+    private MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,
+                                        final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility, Boolean approved, Map<String, Object> additionalProperties)
+        throws Exception {
         final SettingManager settingManager = context.getBean(SettingManager.class);
         final int metadataId = canEdit(context, metadataUuid, approved);
         String key = getKey(context, metadataUuid, metadataId, visibility, filename);
@@ -190,24 +197,28 @@ public class CMISStore extends AbstractStore {
             // If the document is found then we are updating the existing document.
             doc = (Document) CMISConfiguration.getClient().getObjectByPath(key, oc);
             doc.updateProperties(properties, true);
+            if (MapUtils.isNotEmpty(additionalProperties)) {
+                doc.updateProperties(additionalProperties, true);
+            }
+
             doc.setContentStream(contentStream, true, true);
             //           }
             // Avoid CMIS API call is info is not enabled.
             if (Logger.getLogger(Geonet.RESOURCES).isInfoEnabled()) {
                 Log.info(Geonet.RESOURCES,
-                        String.format("Updated metadata resource '%s' for metadata '%s'. Current version '%s'.", key, metadataUuid, doc.getVersionLabel()));
+                    String.format("Updated metadata resource '%s' for metadata '%s'. Current version '%s'.", key, metadataUuid, doc.getVersionLabel()));
             }
         } catch (CmisPermissionDeniedException ex) {
             Log.warning(Geonet.RESOURCES, String.format(
-                    "No permissions to update metadata resource '%s' for metadata '%s' due to constraint violation or lock.", key, metadataUuid));
+                "No permissions to update metadata resource '%s' for metadata '%s' due to constraint violation or lock.", key, metadataUuid));
             throw new NotAllowedException(String.format(
-                    "No permissions to update metadata resource '%s' for metadata '%s' due to constraint violation or lock.", key, metadataUuid));
+                "No permissions to update metadata resource '%s' for metadata '%s' due to constraint violation or lock.", key, metadataUuid));
 
         } catch (CmisConstraintException e) {
             Log.warning(Geonet.RESOURCES, String.format(
-                    "No allowed to modify existing metadata resource '%s' for metadata '%s' due to constraint violation or lock.", key, metadataUuid));
+                "No allowed to modify existing metadata resource '%s' for metadata '%s' due to constraint violation or lock.", key, metadataUuid));
             throw new NotAllowedException(String.format(
-                    "No allowed to modify existing metadata resource '%s' for metadata '%s' due to constraint violation or lock.", key, metadataUuid));
+                "No allowed to modify existing metadata resource '%s' for metadata '%s' due to constraint violation or lock.", key, metadataUuid));
         } catch (CmisObjectNotFoundException e) {
             // If the document is not found then we are adding a new document.
 
@@ -231,18 +242,18 @@ public class CMISStore extends AbstractStore {
                 // Avoid CMIS API call is info is not enabled.
                 if (Logger.getLogger(Geonet.RESOURCES).isInfoEnabled()) {
                     Log.info(Geonet.RESOURCES,
-                            String.format("Added resource metadata resource '%s' for metadata '%s'.", doc.getPaths().get(0), metadataUuid));
+                        String.format("Added resource metadata resource '%s' for metadata '%s'.", doc.getPaths().get(0), metadataUuid));
                 }
             } catch (CmisPermissionDeniedException ex) {
                 Log.warning(Geonet.RESOURCES, String.format(
-                        "No permissions to add metadata resource '%s' for metadata '%s'.", key, metadataUuid));
+                    "No permissions to add metadata resource '%s' for metadata '%s'.", key, metadataUuid));
                 throw new NotAllowedException(String.format(
-                        "No permissions to add metadata resource '%s' for metadata '%s'.", key, metadataUuid));
+                    "No permissions to add metadata resource '%s' for metadata '%s'.", key, metadataUuid));
             }
         }
 
         return createResourceDescription(context, settingManager, metadataUuid, visibility, filename, isLength,
-                doc.getLastModificationDate().getTime(), doc.getVersionLabel(), metadataId, approved);
+            doc.getLastModificationDate().getTime(), doc.getVersionLabel(), metadataId, approved);
     }
 
     @Override
@@ -420,6 +431,50 @@ public class CMISStore extends AbstractStore {
         } catch (CmisObjectNotFoundException e) {
             return null;
         }
+    }
+
+    @Override
+    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
+        final int sourceMetadataId = canDownload(context, sourceUuid, metadataResourceVisibility, false);
+        final String sourceResourceTypeDir = getMetadataDir(context, sourceMetadataId) + CMISConfiguration.getFolderDelimiter() + metadataResourceVisibility.toString();
+        try {
+            Folder sourceParentFolder = (Folder) CMISConfiguration.getClient().getObjectByPath(sourceResourceTypeDir);
+
+            Map<String, Document> sourceDocumentMap = getCmisObjectMap(sourceParentFolder, null);
+            for (Map.Entry<String, Document> sourceEntry : sourceDocumentMap.entrySet()) {
+                Document sourceDocument = sourceEntry.getValue();
+                if (sourceDocument instanceof Document) {
+                    Map<String, Object> sourceProperties = getSecondaryProperties(sourceDocument);
+                    putResource(context, targetUuid, sourceDocument.getName(), sourceDocument.getContentStream().getStream(), null, metadataResourceVisibility, true, sourceProperties);
+
+                }
+            }
+        } catch (CmisObjectNotFoundException  e) {
+            Log.warning("Cannot find folder object from CMIS ... Abort copping resources from "+sourceResourceTypeDir, e);
+        }
+
+
+    }
+
+    private Map<String, Object> getSecondaryProperties(Document document) {
+        String secondaryPropertyId=null;
+        for (Property<?> property:document.getProperties()) {
+            if(property.getId().equals(PropertyIds.SECONDARY_OBJECT_TYPE_IDS)) {
+                secondaryPropertyId = property.getValueAsString();
+                break;
+            }
+        }
+
+        Map<String, Object> properties = null;
+        if (!StringUtils.isEmpty(secondaryPropertyId)) {
+            properties = new HashMap<>();
+            for (Property<?> property:document.getProperties()) {
+                if (property.getId().contains(secondaryPropertyId) && property.getValue()!=null) {
+                    properties.put(property.getId(), property.getValue());
+                }
+            }
+        }
+        return properties;
     }
 
     private String getMetadataDir(ServiceContext context, final int metadataId) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -234,6 +234,11 @@ public class FilesystemStore extends AbstractStore {
     }
 
     @Override
+    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
+        //TODO:
+    }
+
+    @Override
     public MetadataResource patchResourceStatus(ServiceContext context, String metadataUuid, String resourceId,
 
                                                 MetadataResourceVisibility visibility, Boolean approved) throws Exception {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -234,12 +234,12 @@ public class FilesystemStore extends AbstractStore {
     }
 
     @Override
-    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
+    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility, boolean sourceApproved, boolean targetApproved) throws Exception {
         for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
-            final List<MetadataResource> resources = getResources(context, sourceUuid, visibility, null, false);
+            final List<MetadataResource> resources = getResources(context, sourceUuid, visibility, null, sourceApproved);
             for (MetadataResource resource: resources) {
-                try (Store.ResourceHolder holder = getResource(context, targetUuid, visibility, resource.getFilename(), true)) {
-                    putResource(context, targetUuid, holder.getPath(), visibility, true);
+                try (Store.ResourceHolder holder = getResource(context, targetUuid, visibility, resource.getFilename(), targetApproved)) {
+                    putResource(context, targetUuid, holder.getPath(), visibility, targetApproved);
                 }
             }
         }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -235,7 +235,14 @@ public class FilesystemStore extends AbstractStore {
 
     @Override
     public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
-        //TODO:
+        for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
+            final List<MetadataResource> resources = getResources(context, sourceUuid, visibility, null, false);
+            for (MetadataResource resource: resources) {
+                try (Store.ResourceHolder holder = getResource(context, targetUuid, visibility, resource.getFilename(), true)) {
+                    putResource(context, targetUuid, holder.getPath(), visibility, true);
+                }
+            }
+        }
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -149,6 +149,14 @@ public class ResourceLoggerStore extends AbstractStore {
     }
 
     @Override
+    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
+        if (decoratedStore != null) {
+            decoratedStore.copyResources(context, sourceUuid, targetUuid, metadataResourceVisibility);
+        }
+
+    }
+
+    @Override
     public MetadataResource getResourceDescription(final ServiceContext context, final String metadataUuid,
                                                    final MetadataResourceVisibility visibility, final String filename, Boolean approved)
             throws Exception {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -149,9 +149,9 @@ public class ResourceLoggerStore extends AbstractStore {
     }
 
     @Override
-    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
+    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility, boolean sourceApproved, boolean targetApproved) throws Exception {
         if (decoratedStore != null) {
-            decoratedStore.copyResources(context, sourceUuid, targetUuid, metadataResourceVisibility);
+            decoratedStore.copyResources(context, sourceUuid, targetUuid, metadataResourceVisibility, sourceApproved, targetApproved);
         }
 
     }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -220,7 +220,14 @@ public class S3Store extends AbstractStore {
 
     @Override
     public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
-        //TODO:
+        for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
+            final List<MetadataResource> resources = getResources(context, sourceUuid, visibility, null, false);
+            for (MetadataResource resource: resources) {
+                try (Store.ResourceHolder holder = getResource(context, targetUuid, visibility, resource.getFilename(), true)) {
+                    putResource(context, targetUuid, holder.getPath(), visibility, true);
+                }
+            }
+        }
     }
 
     private boolean tryDelResource(final String metadataUuid, final int metadataId, final MetadataResourceVisibility visibility,

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -218,6 +218,11 @@ public class S3Store extends AbstractStore {
         return String.format("Unable to remove resource '%s'.", resourceId);
     }
 
+    @Override
+    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
+        //TODO:
+    }
+
     private boolean tryDelResource(final String metadataUuid, final int metadataId, final MetadataResourceVisibility visibility,
             final String resourceId) throws Exception {
         final String key = getKey(metadataUuid, metadataId, visibility, resourceId);

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -219,12 +219,12 @@ public class S3Store extends AbstractStore {
     }
 
     @Override
-    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception {
+    public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility, boolean sourceApproved, boolean targetApproved) throws Exception {
         for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
-            final List<MetadataResource> resources = getResources(context, sourceUuid, visibility, null, false);
+            final List<MetadataResource> resources = getResources(context, sourceUuid, visibility, null, sourceApproved);
             for (MetadataResource resource: resources) {
-                try (Store.ResourceHolder holder = getResource(context, targetUuid, visibility, resource.getFilename(), true)) {
-                    putResource(context, targetUuid, holder.getPath(), visibility, true);
+                try (Store.ResourceHolder holder = getResource(context, targetUuid, visibility, resource.getFilename(), targetApproved)) {
+                    putResource(context, targetUuid, holder.getPath(), visibility, targetApproved);
                 }
             }
         }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -313,6 +313,18 @@ public interface Store {
                        String resourceId, Boolean approved) throws Exception;
 
     /**
+     * Copy all resources from none approved (draft working copy) to approved folder.
+     *
+     *
+     * @param context
+     * @param sourceUuid               The metadata UUID
+     * @param targetUuid               The metadata UUID
+     * @param metadataResourceVisibility The type of sharing policy {@link MetadataResourceVisibility}
+     *
+     */
+    void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception;
+
+    /**
      * Get the resource description.
      * @param context
      * @param metadataUuid The metadata UUID

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -319,10 +319,12 @@ public interface Store {
      * @param context
      * @param sourceUuid               The source metadata UUID
      * @param targetUuid               The target metadata UUID
+     * @param sourceApproved           The source approved flag
+     * @param targetApproved           The target approved flag
      * @param metadataResourceVisibility The type of sharing policy {@link MetadataResourceVisibility}
      *
      */
-    void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception;
+    void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility, boolean sourceApproved, boolean targetApproved) throws Exception;
 
     /**
      * Get the resource description.

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -317,11 +317,12 @@ public interface Store {
      *
      *
      * @param context
-     * @param metadataUuid               The metadata UUID
+     * @param sourceUuid               The source metadata UUID
+     * @param targetUuid               The target metadata UUID
      * @param metadataResourceVisibility The type of sharing policy {@link MetadataResourceVisibility}
      *
      */
-    void copyResources(ServiceContext context, String metadataUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception;
+    void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility) throws Exception;
 
     /**
      * Get the resource description.

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
@@ -133,22 +133,8 @@ public abstract class StoreUtils {
             List<MetadataResource> targetAddResources = exceptMetadataResource(sourceResources, targetResources);
             List<MetadataResource> targetUpdateResources = exceptMetadataResource(targetResources, targetDeleteResources);
 
-            // Add new records
-//            for (MetadataResource resource: targetAddResources) {
-//                try (Store.ResourceHolder holder = store.getResource(context, sourceUuid, visibility, resource.getFilename(), sourceApproved)) {
-//                    store.putResource(context, targetUuid, holder.getPath(), visibility, targetApproved);
-//                }
-//            }
-
-            // update new records
-
-//            for (MetadataResource resource: targetUpdateResources) {
-//                try (Store.ResourceHolder holder = store.getResource(context, sourceUuid, visibility, resource.getFilename(), sourceApproved)) {
-//                    store.putResource(context, targetUuid, holder.getPath(), visibility, targetApproved);
-//                }
-//            }
-
-            store.copyResources(context, sourceUuid, visibility);
+            // copy all resources from source to target
+            store.copyResources(context, sourceUuid, targetUuid, visibility);
 
             // delete old records
             for (MetadataResource resource: targetDeleteResources) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
@@ -68,12 +68,8 @@ public abstract class StoreUtils {
     public static void copyDataDir(ServiceContext context, String oldUuid, String newUuid, boolean newApproved) throws Exception {
         final Store store = context.getBean("resourceStore", Store.class);
         for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
-            final List<MetadataResource> resources = store.getResources(context, oldUuid, visibility, null, true);
-            for (MetadataResource resource: resources) {
-                try (Store.ResourceHolder holder = store.getResource(context, oldUuid, visibility, resource.getFilename(), true)) {
-                    store.putResource(context, newUuid, holder.getPath(), visibility, newApproved);
-                }
-            }
+            boolean oldApproved = true;
+            store.copyResources(context, oldUuid, newUuid, visibility, oldApproved, newApproved);
         }
     }
 
@@ -130,11 +126,9 @@ public abstract class StoreUtils {
 
             // In order to sync the 2 folders, we need to identify the records to be added, deleted and updated.
             List<MetadataResource> targetDeleteResources  = exceptMetadataResource(targetResources, sourceResources);
-            List<MetadataResource> targetAddResources = exceptMetadataResource(sourceResources, targetResources);
-            List<MetadataResource> targetUpdateResources = exceptMetadataResource(targetResources, targetDeleteResources);
 
             // copy all resources from source to target
-            store.copyResources(context, sourceUuid, targetUuid, visibility);
+            store.copyResources(context, sourceUuid, targetUuid, visibility, sourceApproved, targetApproved);
 
             // delete old records
             for (MetadataResource resource: targetDeleteResources) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
@@ -133,20 +133,8 @@ public abstract class StoreUtils {
             List<MetadataResource> targetAddResources = exceptMetadataResource(sourceResources, targetResources);
             List<MetadataResource> targetUpdateResources = exceptMetadataResource(targetResources, targetDeleteResources);
 
-            // Add new records
-            for (MetadataResource resource: targetAddResources) {
-                try (Store.ResourceHolder holder = store.getResource(context, sourceUuid, visibility, resource.getFilename(), sourceApproved)) {
-                    store.putResource(context, targetUuid, holder.getPath(), visibility, targetApproved);
-                }
-            }
-
-            // update new records
-
-            for (MetadataResource resource: targetUpdateResources) {
-                try (Store.ResourceHolder holder = store.getResource(context, sourceUuid, visibility, resource.getFilename(), sourceApproved)) {
-                    store.putResource(context, targetUuid, holder.getPath(), visibility, targetApproved);
-                }
-            }
+            // copy all resources from source to target
+            store.copyResources(context, sourceUuid, targetUuid, visibility);
 
             // delete old records
             for (MetadataResource resource: targetDeleteResources) {


### PR DESCRIPTION
The issue is secondary properties are not copied from draft to approved metadata online resources.

And these properties gets lost. This rule should apply not just CMIS but all related store type. My code change intension is to fix the CMIS. So I did some rough work to S3Store and FilesystemStore just simply copy past the code from StoreUtils.copyDataDir

Please feel free to point out issues.