### PR TITLE
Search / Reload page with param does not restore query

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -219,7 +219,8 @@
           state.old.path.indexOf(that.METADATA) === 0
           && state.current.params.query_string;
 
-        if (state.old.path != that.SEARCH &&
+        if (state.old.path != '' &&
+            state.old.path != that.SEARCH &&
             state.old.path != that.HOME &&
             !isFilterFromRecordView &&
             state.current.path == that.SEARCH) {


### PR DESCRIPTION
When loading page with param old path is '' and restoreSearch must not be called as it clear params.

Test:
* Do a search with full text search
* Reload page
* Expected : params are preserved.