### PR TITLE
Fix for missing icons for the topics on the homepage

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -108,8 +108,8 @@
 
               <!-- TODOES Link label to icons? -->
               <span class="badge-icon badge-result-topic pull-left">
-                <i class="fa fa-3x gn-icon gn-icon-{{facet.key.toLowerCase().replace('/', '').replace(' ', '')}}"
-                    data-ng-show="homeFacet.key === 'topic.key' || homeFacet.key === 'cl_hierarchyLevel.key'">
+                <i class="fa fa-3x gn-icon gn-icon-{{facet.key.replace('/', '').replace(' ', '')}}"
+                    data-ng-show="homeFacet.key === 'cl_topic.key' || homeFacet.key === 'cl_hierarchyLevel.key'">
                 </i>
               </span>
               <span class="badge-text pull-left">
@@ -153,7 +153,7 @@
                 class="pull-left clearfix"
                 data-ng-href='#/search?query_string={"{{homeFacet.lastKey}}": {"{{facet.key}}": true} }'>
                 <span class="badge-icon pull-left">
-                  <i class="fa fa-3x gn-icon gn-icon-{{facet.key.toLowerCase().replace('/', '').replace(' ', '')}}"
+                  <i class="fa fa-3x gn-icon gn-icon-{{facet.key.replace('/', '').replace(' ', '')}}"
                       data-ng-show="homeFacet.lastKey === 'topic_text' || homeFacet.lastKey === 'cl_hierarchyLevel.key'">
                   </i>
                 </span>


### PR DESCRIPTION
The homepage was missing icons for the topics, this PR fixes this.

**The missing icons**
![gn-missing-icons](https://user-images.githubusercontent.com/19608667/116524371-99668580-a8d7-11eb-80f3-b6543a05ce89.png)

Fixes:
- removed to `toLowerCase` on icon class names
- changed check on a key name