### PR TITLE
Add isoLang (i.e. en, fr) into a link.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1330,8 +1330,9 @@
           var link = attrs.gnActiveTbItem, href,
               isCurrentService = false;
 
-          // Replace lang in link
+          // Replace lang in link (three character language code i.e. eng, fre)
           link = link.replace('{{lang}}', gnLangs.getCurrent());
+          // Replace standard ISO lang in link (two character language code i.e. en, fr)
           link = link.replace('{{isoLang}}', gnLangs.getIso2Lang(gnLangs.getCurrent()));
           link = link.replace('{{node}}', gnConfig.env.node);
 

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1091,7 +1091,7 @@
               });
             }
           };
-          
+
           init();
 
           // model -> view
@@ -1332,6 +1332,7 @@
 
           // Replace lang in link
           link = link.replace('{{lang}}', gnLangs.getCurrent());
+          link = link.replace('{{isoLang}}', gnLangs.getIso2Lang(gnLangs.getCurrent()));
           link = link.replace('{{node}}', gnConfig.env.node);
 
           // Insert debug mode between service and route

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1163,6 +1163,7 @@
     "ui-languages-help": "Define the list of languages in the language selector",
     "ui-mod-home": "Home page",
     "ui-appUrl": "Application URL",
+    "ui-appUrl-help": "URL of the home page. Can contain the following variables between 2 opening and closing '{': <ul><li><strong>node</strong> for the current portal</li><li><strong>lang</strong> for 3 letters language code</li><li> <strong>isoLang</strong> for 2 letters language code.</li></ul>",
     "ui-advancedSearchTemplate": "Template for advanced search form",
     "ui-advancedSearchTemplate-help": "Allows the customization of the advanced search form with a custom template.",
     "ui-mod-search": "Search application",


### PR DESCRIPTION
Current lang variable in redirecting url consists of three characters (i.e. eng, fre) which is not integrated well with other system. isoLang variable is added to retrieve such language code (i.e. en, fr).