### PR TITLE
Use display catalogue name in the header setting to display/hide the catalogue name in small devices

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -6,6 +6,7 @@
            data-ng-src="{{gnUrl}}../images/logos/{{info['node/id'] || info['system/site/siteId']}}.png?random{{info['system/site/lastUpdate']}}"/>
     </a>
     <a class="hidden-sm hidden-md hidden-lg btn btn-link pull-left"
+       data-ng-if="gnCfg.mods.header.showGNName"
        data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
       <span class="gn-name"
             data-ng-class="authenticated && user.isEditorOrMore() ? 'gn-truncate' : ''"
@@ -27,7 +28,7 @@
   <div id="navbar" class="navbar-collapse collapse">
     <ul class="nav navbar-nav gn-menu-xs" role="menu">
       <li class="clearfix hidden-xs" data-ng-if="gnCfg.mods.home.enabled">
-        <a class="pull-left gn-logo-link" 
+        <a class="pull-left gn-logo-link"
            data-gn-active-tb-item="{{gnCfg.mods.home.appUrl}}">
           <img class="gn-logo"
                data-ng-hide="{{gnCfg.mods.header.isLogoInHeader}}"


### PR DESCRIPTION

![cataloguename-setting](https://user-images.githubusercontent.com/1695003/116849942-00de4700-abf0-11eb-8656-a6e1028fac97.png)


**Before:**

![cataloguename-before](https://user-images.githubusercontent.com/1695003/116849611-59611480-abef-11eb-9832-a6b3da75b4a1.png)

**After:**

![cataloguename-after](https://user-images.githubusercontent.com/1695003/116849770-a2b16400-abef-11eb-8a20-af9e4b219bfe.png)