### PR TITLE
Harvester / Add visual summary (totals/graphs)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -110,6 +110,20 @@
         },
         track_total_hits: true
       },
+      harvester: {
+        facets: gnGlobalSettings.gnCfg.mods.admin.facetConfig,
+        source: {
+          includes: [
+            'id',
+            'uuid',
+            'overview.*',
+            'resource*',
+            'isTemplate',
+            'valid'
+          ]
+        },
+        track_total_hits: true
+      },
       directory: {
         facets: {
           'valid': {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -567,7 +567,7 @@
               // scale: {scheme: 'category20b'}
             }
           };
-          if (scope.facet.meta.vega === 'bar') {
+          if ((scope.facet.meta) && (scope.facet.meta.vega === 'bar')) {
             mark = 'bar';
             encoding = {
               y: {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -18,8 +18,7 @@
     <span class="gn-facet-label flex-shrink text-ellipsis">
       {{::ctrl.item.value | facetTranslator: ctrl.facet.key | capitalize}}
     </span>
-    <span class="gn-facet-count flex-no-shrink"
-          data-ng-if="::ctrl.item.count">({{::ctrl.item.count}})</span>
+    <span class="gn-facet-count flex-no-shrink gn-facet-count-{{ctrl.item.count}}">{{::ctrl.item.count}}</span>
   </a>
   <div class="flex-spacer"></div>
   <a href

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -82,7 +82,9 @@
     };
 
     this.getFinalParams = function() {
-      return $scope.finalParams;
+      var p = angular.copy($scope.finalParams, {});
+      p.query_string = JSON.stringify($scope.searchObj.state.filters);
+      return p;
     };
 
     this.getSearchResults = function() {
@@ -283,16 +285,16 @@
         if(angular.isObject(filters)) {
           var query_string = JSON.stringify(filters);
           if (Object.keys(filters).length) {
-            params.query_string = query_string
+            params.query_string = query_string;
           } else {
-            delete params.query_string
+            delete params.query_string;
           }
         } else {
           if (filters != '') {
             params.query_string = filters;
             $scope.searchObj.state.filters = JSON.parse(filters);
           } else {
-            delete params.query_string
+            delete params.query_string;
           }
         }
 

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
@@ -1,10 +1,12 @@
 <div>
   <div class="clearfix">
     <div data-ng-show="searchResults.count > 0">
-      <ng-pluralize count="searchResults.count"
-                    when="{'0 ': ('noRecordFound' | translate),
-              'one': '1 ' +  ('record' | translate),
-              'other': '{} ' +  ('records' | translate)}"/>
+      <strong>
+        <ng-pluralize count="searchResults.count"
+                      when="{'0 ': ('noRecordFound' | translate),
+                'one': '1 ' +  ('record' | translate),
+                'other': '{} ' +  ('records' | translate)}"/>
+      </strong>
     </div>
     <div data-ng-show="options.selection.mode.indexOf('local') === -1">
       <div class="btn-group pull-right"

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
@@ -34,7 +34,9 @@
           data-ng-click="onClick(md)">
         <div data-ng-if="options.mode == 'title'">
           <gn-md-type-widget metadata="md"></gn-md-type-widget>
-          {{md.resourceTitle}}
+          <a href="catalog.search#/metadata/{{md.uuid}}">
+            {{md.resourceTitle}}
+          </a>
         </div>
         <div class="row" data-ng-if="options.mode == 'simple'">
           <div class="col-lg-12"

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -273,7 +273,7 @@ goog.require('gn_alert');
               'meta': {
                 'vega': 'arc'
               }
-            },
+            }
           },
           'aafacetConfig': {
             'cl_hierarchyLevel.key': {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -258,8 +258,24 @@ goog.require('gn_alert');
           'facetTabField': '',
           // Enable vega only if using vega facet type
           // See https://github.com/geonetwork/core-geonetwork/pull/5349
-          'isVegaEnabled': false,
+          'isVegaEnabled': true,
           'facetConfig': {
+            'cl_hierarchyLevel.key': {
+              'terms': {
+                'field': 'cl_hierarchyLevel.key'
+              }
+            },
+            'tag.default': {
+              'terms': {
+                'field': 'tag.default',
+                'size': 10
+              },
+              'meta': {
+                'vega': 'arc'
+              }
+            },
+          },
+          'aafacetConfig': {
             'cl_hierarchyLevel.key': {
               'terms': {
                 'field': 'cl_hierarchyLevel.key'
@@ -726,7 +742,44 @@ goog.require('gn_alert');
         },
         'admin': {
           'enabled': true,
-          'appUrl': '../../{{node}}/{{lang}}/admin.console'
+          'appUrl': '../../{{node}}/{{lang}}/admin.console',
+          'facetConfig': {
+            'availableInServices': {
+              'filters': {
+                //"other_bucket_key": "others",
+                // But does not support to click on it
+                'filters': {
+                  'availableInViewService': {
+                    'query_string': {
+                      'query': '+linkProtocol:/OGC:WMS.*/'
+                    }
+                  },
+                  'availableInDownloadService': {
+                    'query_string': {
+                      'query': '+linkProtocol:/OGC:WFS.*/'
+                    }
+                  }
+                }
+              }
+            },
+            'cl_hierarchyLevel.key': {
+              'terms': {
+                'field': 'cl_hierarchyLevel.key'
+              },
+              'meta': {
+                'vega': 'arc'
+              }
+            },
+            'tag.default': {
+              'terms': {
+                'field': 'tag.default',
+                'size': 10
+              },
+              'meta': {
+                'vega': 'arc'
+              }
+            },
+          }
         },
         'signin': {
           'enabled': true,
@@ -779,6 +832,7 @@ goog.require('gn_alert');
           this.gnCfg.mods.search.scoreConfig = config.mods.search.scoreConfig;
           this.gnCfg.mods.search.facetConfig = config.mods.search.facetConfig;
           this.gnCfg.mods.home.facetConfig = config.mods.home.facetConfig;
+          this.gnCfg.mods.admin.facetConfig = config.mods.admin.facetConfig;
         }
 
         this.gnUrl = gnUrl || '../';
@@ -804,6 +858,7 @@ goog.require('gn_alert');
         copy.mods.home.facetConfig = {};
         copy.mods.search.facetConfig = {};
         copy.mods.search.scoreConfig = {};
+        copy.mods.admin.facetConfig = {};
         copy.mods.map["map-editor"].layers = [];
         return copy;
       },

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -778,7 +778,7 @@ goog.require('gn_alert');
               'meta': {
                 'vega': 'arc'
               }
-            },
+            }
           }
         },
         'signin': {

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -42,18 +42,23 @@
   module.controller('GnHarvestSettingsController', [
     '$scope', '$q', '$http', '$translate', '$injector', '$rootScope',
     'gnSearchManagerService', 'gnUtilityService', '$timeout',
-    'Metadata', 'gnMapsManager',
+    'Metadata', 'gnMapsManager', 'gnGlobalSettings',
     function($scope, $q, $http, $translate, $injector, $rootScope,
              gnSearchManagerService, gnUtilityService, $timeout,
-             Metadata, gnMapsManager) {
+             Metadata, gnMapsManager, gnGlobalSettings) {
 
       $scope.searchObj = {
         internal: true,
-        params: {
+        configId: 'harvester',
+        defaultParams: {
           isTemplate: ['y', 'n', 's', 't'],
           sortBy: 'resourceTitleObject.default.keyword'
         }};
+      $scope.searchObj.params = angular.extend({},
+        $scope.searchObj.params,
+        $scope.searchObj.defaultParams);
 
+      $scope.facetConfig = gnGlobalSettings.gnCfg.mods.admin.facetConfig;
       $scope.harvesterTypes = {};
       $scope.harvesterSelected = null;
       $scope.harvesterUpdated = false;

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -157,5 +157,8 @@
   "commonProtocols": "General protocols:",
   "indexStatusSynchronized": "Records in index/db = <strong>{{indexStatus['index.count']}}/{{indexStatus['db.count']}}</strong>",
   "indexStatusSynchronized-error": "When number of records is not equal in the database and in the index, check first that the catalogue point to the correct index. If yes, try to reindex the catalogue from admin > tools. If there is still a difference, check for indexing errors in the log file and fix the metadata record using the XML view.",
-  "IndexReadOnlyHealthCheck": "Index is in readonly mode"
+  "IndexReadOnlyHealthCheck": "Index is in readonly mode",
+  "summary": "Summary",
+  "metadataRecords": "Metadata records",
+  "results": "Results"
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1226,6 +1226,7 @@ gn-indexing-task-status {
 .text-ellipsis { white-space: nowrap; text-overflow: ellipsis; overflow: hidden; }
 .width-100 { width: 100%; } .width-75 { width: 75%; } .width-50 { width: 50%; }
 .width-25 { width: 25%; } .width-33 { width: 33%; } .width-66 { width: 66%; }
+.height-auto { height: auto !important; max-height: none !important; }
 
 
 html {

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -90,6 +90,15 @@
     }
     .gn-facet-count {
       margin-left: 3px;
+      &:before {
+        content: "(";
+      }
+      &:after {
+        content: ")";
+      }
+      &.gn-facet-count-0 {
+        display: none;
+      }
     }
   }
   .gn-facet-header {

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -307,7 +307,7 @@
               <span data-translate="">summary</span>
             </div>
             <div class="panel-body">
-              <div class="row">
+              <div class="row gn-margin-bottom">
                 <ul class="col-md-4 text-center list-group gn-nomargin-bottom">
                   <li class="list-group-item">
                     <h1><i class="fa fa-file-text-o"></i> {{ searchResults.count }}</h1>
@@ -316,9 +316,10 @@
                     </p>
                   </li>
                 </ul>
-
-
+              </div>
+              <div class="row">
                 <div data-ng-show="searchResults.records.length > 0"
+                     class="gn-harvester-facets"
                      data-es-facets="searchResults.facets"></div>
               </div>
             </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -8,7 +8,7 @@
 
       <div class="panel-body">
         <input id="gn-harvest-select-search"
-               class="form-control"
+               class="form-control gn-margin-bottom"
                data-ng-show="$parent.harvesters.length > 1"
                data-ng-model="harvesterSearch.$"
                data-ng-change="firstPage()"
@@ -21,11 +21,19 @@
              data-ng-class="[h['@id'] === harvesterSelected['@id'] ? 'active' : '', h.error ? 'list-group-item-danger' : '']"
              data-ng-click="selectHarvester(h)"
              title="{{h.error ? ('selectForError' | translate) : (h.info.lastRun.length === 0 ? '' : ('lastRun' | translate) + (h.info.lastRun | gnFromNow))}}">
-            <i data-ng-show="h.options.status === 'active'" class="fa fa-play"/>
-            <i data-ng-show="h.options.status === 'inactive'" class="fa fa-pause"/>
-            <span class="gn-harvester-name"> {{h.site.name}}
-            ({{('harvester-' + h['@type']) | translate}})</span> <span class="badge">{{h.info.result.total}}</span>
-            <i data-ng-show="h.info.running" class="fa fa-spinner fa-spin"/>
+
+            <p>
+              <i data-ng-show="h.options.status === 'active'" class="fa fa-play"/>
+              <i data-ng-show="h.options.status === 'inactive'" class="fa fa-pause"/>
+              <span class="gn-harvester-name"><strong>{{h.site.name}}</strong> ({{('harvester-' + h['@type']) | translate}})</span>
+            </p>
+            <p>
+              <span data-ng-show="h.info.running" class="pull-right">
+                <i class="fa fa-spinner fa-spin fa-2x"/>
+              </span>
+              <span>{{ 'lastRun' | translate }}: {{ h.info.lastRun | gnFromNow }}</span><br>
+              <span>{{ 'harvesterRecords' | translate }}: {{h.info.result.total}}</span>
+            </p>
           </a>
           <span data-gn-pagination-list=""
                 data-items="$parent.harvesters | filter:harvesterSearch | orderBy:'name'"
@@ -57,7 +65,7 @@
         <div id="gn-harvest-select-clone-row" class="btn-group" data-ng-show="$parent.harvesters.length > 0">
           <button id="gn-harvest-select-clone-button"
                   type="button"
-                  class="btn dropdown-toggle"
+                  class="btn btn-default dropdown-toggle"
                   data-toggle="dropdown">
             <span class="fa fa-copy"></span>&nbsp;
             <span data-translate="">cloneHarvester</span>
@@ -76,7 +84,7 @@
 
         <button id="gn-harvest-select-refresh-button"
                 type="button"
-                class="btn"
+                class="btn btn-default"
                 data-ng-show="$parent.harvesters.length > 0"
                 data-ng-click="$parent.refreshHarvester()"
                 title="{{'refreshHarvester' | translate}}">
@@ -84,13 +92,18 @@
         </button>
       </div>
     </div>
-    
+
     <div id="gn-harvest-select-help-button" data-gn-need-help="user-guide/harvesting/index.html"></div>
   </div>
 
 
   <div class="col-lg-8" data-ng-hide="harvesterSelected['@id'] == null">
-    <div id="gn-harvest-settings-panel" class="panel panel-default">
+
+    <tabset id="harvester-tabset" type="pills" justified="false" role="tablist">
+      <tab heading="{{'settings' | translate}}"
+           role="tab"
+           active="true">
+        <div id="gn-harvest-settings-panel" class="panel panel-default gn-margin-top">
       <div class="panel-heading clearfix">
         <span id="gn-harvest-settings-title">
           <span data-ng-hide="harvesterSelected['@id'] == ''" data-translate="">updateHarvester</span>
@@ -160,165 +173,237 @@
         <div id="gn-harvest-settings-selected-row" data-ng-include="getTplForHarvester()"></div>
       </div>
     </div>
-
-    <div id="gn-harvest-history-panel"
-         class="panel panel-default"
-         data-ng-hide="harvesterSelected['@id'] == '' || isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1">
-      <div class="panel-heading">
-        <span id="gn-harvest-history-title">
-          <span data-translate="">harvesterHistory</span>
-          <i data-ng-show="isLoadingHarvesterHistory" class="fa fa-spinner fa-spin"></i>
-        </span>
-        <div id="gn-harvest-history-buttons" class="btn-toolbar">
-          <button id="gn-harvest-history-buttons-delete"
-                  type="button"
-                  class="btn btn-primary pull-right btn-danger"
-                  data-ng-hide="harvesterHistory.length === 0"
-                  data-ng-click="deleteHarvesterHistory()">
-            <span class="fa fa-times"></span>
-            <span data-translate="">deleteHarvesterHistory</span>
-          </button>
-        </div>
-      </div>
-      <div class="panel-body">
-        <div id="gn-harvest-history-alert" class="alert alert-info" data-ng-show="harvesterHistory.length === 0">
-          <strong data-translate="">noHarvesterHistory</strong>
-        </div>
-        <ul id="gn-harvest-history-timeline-row" class="timeline timeline-1-col" data-ng-show="harvesterHistory.length !== 0">
-          <li class="timeline-inverted"
-              data-ng-repeat="h in harvesterHistory">
-            <div class="timeline-badge"
-                 data-ng-class="h.deleted == 'true' ? 'warning' : (h.info[0]['stack'] ? 'danger' : 'success')">
-              <i class="fa"
-                 data-ng-class="h.deleted == 'true' ? 'fa-times' : 'fa-chevron-right'"></i>
+      </tab>
+      <tab heading="{{'harvesterHistory'|translate}}"
+           role="tab">
+        <div id="gn-harvest-history-panel"
+             class="panel panel-default gn-margin-top"
+             data-ng-hide="harvesterSelected['@id'] == '' || isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1">
+          <div class="panel-heading">
+            <span id="gn-harvest-history-title">
+              <span data-translate="">harvesterHistory</span>
+              <i data-ng-show="isLoadingHarvesterHistory" class="fa fa-spinner fa-spin"></i>
+            </span>
+            <div id="gn-harvest-history-buttons" class="btn-toolbar">
+              <button id="gn-harvest-history-buttons-delete"
+                      type="button"
+                      class="btn btn-primary pull-right btn-danger"
+                      data-ng-hide="harvesterHistory.length === 0"
+                      data-ng-click="deleteHarvesterHistory()">
+                <span class="fa fa-times"></span>
+                <span data-translate="">deleteHarvesterHistory</span>
+              </button>
             </div>
-            <div class="timeline-panel">
-              <div class="timeline-heading" data-ng-if="h.info[0]['stack'] !== undefined">
-                <h4 class="timeline-title">
-                  {{h.info[0]['@id']}}
-                </h4>
-                <p>
-                  <small class="text-muted">
-                    <i class="fa fa-clock-o"></i>
-                    {{ h.harvestdate | gnFromNow }}
-                  </small>
-                </p>
-                <div class="timeline-body">
-                  {{h.info[0]['message']}}
-
-                  <pre><span data-ng-repeat="line in h.info[0]['stack']">{{line['@class']}} {{line['@file']}} ({{line['@line']}}) #{{line['@method']}}
-</span></pre>
+          </div>
+          <div class="panel-body">
+            <div id="gn-harvest-history-alert" class="alert alert-info" data-ng-show="harvesterHistory.length === 0">
+              <strong data-translate="">noHarvesterHistory</strong>
+            </div>
+            <ul id="gn-harvest-history-timeline-row" class="timeline timeline-1-col" data-ng-show="harvesterHistory.length !== 0">
+              <li class="timeline-inverted"
+                  data-ng-repeat="h in harvesterHistory">
+                <div class="timeline-badge"
+                     data-ng-class="h.deleted == 'true' ? 'warning' : (h.info[0]['stack'] ? 'danger' : 'success')">
+                  <i class="fa"
+                     data-ng-class="h.deleted == 'true' ? 'fa-times' : 'fa-chevron-right'"></i>
                 </div>
-              </div>
+                <div class="timeline-panel">
+                  <div class="timeline-heading" data-ng-if="h.info[0]['stack'] !== undefined">
+                    <h4 class="timeline-title">
+                      {{h.info[0]['@id']}}
+                    </h4>
+                    <p>
+                      <small class="text-muted">
+                        <i class="fa fa-clock-o"></i>
+                        {{ h.harvestdate | gnFromNow }}
+                      </small>
+                    </p>
+                    <div class="timeline-body">
+                      {{h.info[0]['message']}}
 
-              <div class="timeline-heading" data-ng-if="h.info[0]['stack'] === undefined">
-                <h4 data-ng-show="h.deleted == 'true'">
-                  <strong>{{h.info[0][0]['@recordsRemoved']}}</strong>
-                  <span data-ng-show="h.info[0][0]['@recordsRemoved']" data-translate="">recordsRemoved</span></h4>
-                  <strong>{{h.info[0][0]['@recordsTransfered']}}</strong>
-                  <span data-ng-show="h.info[0][0]['@recordsTransfered']" data-translate="">recordsTransfered</span></h4>
-                <h4 data-ng-show="h.deleted == 'false'" class="timeline-title">
-                  <strong>{{h.info[0].total}}</strong>
-                  <span data-translate="">recordsHarvestedIn</span>
-                  <strong>{{h.elapsedtime}}</strong>
-                  <span data-translate="">seconds</span>
-                </h4>
-                <p>
-                  <small class="text-muted">
-                    <i class="fa fa-clock-o"></i>
-                    {{ h.harvestdate | gnFromNow }}
-                  </small>
-                </p>
-              </div>
-              <div class="timeline-body">
-                <p>
-                <ul>
-                  <li data-ng-repeat="(k, v) in h.info[0]"
-                      data-ng-show="v > 0">
-                    {{k}}: {{v}}
+                      <pre><span data-ng-repeat="line in h.info[0]['stack']">{{line['@class']}} {{line['@file']}} ({{line['@line']}}) #{{line['@method']}}
+    </span></pre>
+                    </div>
+                  </div>
+
+                  <div class="timeline-heading" data-ng-if="h.info[0]['stack'] === undefined">
+                    <h4 data-ng-show="h.deleted == 'true'">
+                      <strong>{{h.info[0][0]['@recordsRemoved']}}</strong>
+                      <span data-ng-show="h.info[0][0]['@recordsRemoved']" data-translate="">recordsRemoved</span></h4>
+                      <strong>{{h.info[0][0]['@recordsTransfered']}}</strong>
+                      <span data-ng-show="h.info[0][0]['@recordsTransfered']" data-translate="">recordsTransfered</span></h4>
+                    <h4 data-ng-show="h.deleted == 'false'" class="timeline-title">
+                      <strong>{{h.info[0].total}}</strong>
+                      <span data-translate="">recordsHarvestedIn</span>
+                      <strong>{{h.elapsedtime}}</strong>
+                      <span data-translate="">seconds</span>
+                    </h4>
+                    <p>
+                      <small class="text-muted">
+                        <i class="fa fa-clock-o"></i>
+                        {{ h.harvestdate | gnFromNow }}
+                      </small>
+                    </p>
+                  </div>
+                  <div class="timeline-body">
+                    <p>
+                    <ul>
+                      <li data-ng-repeat="(k, v) in h.info[0]"
+                          data-ng-show="v > 0">
+                        {{k}}: {{v}}
+                      </li>
+                    </ul>
+                    <!-- in some scenario logfile returns an array of files, take first -->
+                    <a data-ng-show="h.info[0].logfile"
+                       ng-href="admin.harvester.log?file={{ (h.info[0].logfile | asArray)[0] | encodeURIComponent }}" target="_blank"
+                       data-translate="">logFile</a>
+                    </p>
+                  </div>
+                </div>
+              </li>
+            </ul>
+            <ul id="gn-harvest-history-pager-row" class="pager" data-ng-show="harvesterHistory.length !== 0">
+              <li data-ng-class="harvesterHistoryPaging.page == 1 ? 'disabled' : ''"
+                  data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
+                                                                     data-ng-click="historyFirstPage()"
+                                                                     class="ng-scope">«</a></li>
+              <li data-ng-class="harvesterHistoryPaging.page == 1 ? 'disabled' : ''"
+                  data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
+                                                                     data-ng-click="historyPreviousPage()"
+                                                                     class="ng-scope">‹</a></li>
+              <li class="ng-binding">
+                {{harvesterHistoryPaging.page}} / {{harvesterHistoryPaging.pages}} <em data-translate=""
+                                                                                       class="ng-scope">of </em>
+                <ng-pluralize count="harvesterHistoryPaging.total"
+                              when="{'0 ': ('noRecordFound' | translate), 'one': '1 ' + ('record' | translate), 'other': '{} ' + ('records' | translate)}"></ng-pluralize>
+              </li>
+              <li
+                data-ng-class="harvesterHistoryPaging.page == harvesterHistoryPaging.pages ? 'disabled' : ''"
+                data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
+                                                                   data-ng-click="historyNextPage()"
+                                                                   class="ng-scope">›</a></li>
+              <li
+                data-ng-class="harvesterHistoryPaging.page == harvesterHistoryPaging.pages ? 'disabled' : ''"
+                data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
+                                                                   data-ng-click="historyLastPage()"
+                                                                   class="ng-scope">»</a></li>
+            </ul>
+          </div>
+        </div>
+      </tab>
+      <tab heading="{{'results' | translate}}"
+           role="tab">
+        <div id="gn-harvest-records-panel"
+             class="gn-margin-top"
+             data-ng-hide="harvesterSelected['@id'] == '' || isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1"
+             data-ng-search-form=""
+             data-ng-show="searchResults.count != '0'">
+
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <span data-translate="">summary</span>
+            </div>
+            <div class="panel-body">
+              <div class="row">
+                <ul class="col-md-4 text-center list-group gn-nomargin-bottom">
+                  <li class="list-group-item">
+                    <h1><i class="fa fa-file-text-o"></i> {{ searchResults.count }}</h1>
+                    <p data-translate="">
+                      metadataRecords
+                    </p>
                   </li>
                 </ul>
-                <!-- in some scenario logfile returns an array of files, take first -->
-                <a data-ng-show="h.info[0].logfile"
-                   ng-href="admin.harvester.log?file={{ (h.info[0].logfile | asArray)[0] | encodeURIComponent }}" target="_blank"
-                   data-translate="">logFile</a>
-                </p>
+
+                <!-- TODO: loop over configurable list -->
+                <span data-ng-repeat="r in searchResults.facets"
+                      data-ng-if="r.key === 'availableInServices'">
+                  <ul class="col-md-4 text-center list-group gn-nomargin-bottom"
+                      data-ng-repeat="i in r.items">
+                    <li class="list-group-item">
+                      <h1>
+                        <i class="fa fa-download" data-ng-if="i.value === 'availableInDownloadService'"></i>
+                        <i class="fa fa-eye" data-ng-if="i.value === 'availableInViewService'"></i>
+                        {{ i.count }}</h1>
+                      <p>
+                        {{ 'availableInServices-' + i.value | translate }}
+                      </p>
+                    </li>
+                  </ul>
+                </span>
+              </div>
+
+              <div class="row">
+
+                <ul class=" list-group gn-nomargin-bottom height-auto">
+
+                  <li class="col-lg-6 col-md-12 list-group-item gn-margin-top"
+                      data-ng-repeat="f in searchResults.facets"
+                      data-ng-if="f.key === 'cl_hierarchyLevel.key' || f.key === 'tag.default'">
+                    <!-- topic/keyword -->
+                    <div data-ng-if="f.key === 'tag.default'"
+                         data-ng-show="f.items.length > 0">
+                      <h4 data-translate="">facet-tag</h4>
+                      <div gn-facet-vega="f"></div>
+                    </div>
+                    <!-- hierarchy -->
+                    <div data-ng-if="f.key === 'cl_hierarchyLevel.key'"
+                         data-ng-show="f.items.length > 0">
+                      <h4 data-translate="">facet-cl_hierarchyLevel</h4>
+                      <div gn-facet-vega="f" class="maxwidth-100"></div>
+                    </div>
+
+                  </li>
+
+                </ul>
+              </div>
+
+            </div>
+          </div>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <span id="gn-harvest-records-title" data-translate="">harvesterRecords</span>
+            </div>
+
+            <div class="panel-body">
+
+              <div id="gn-harvest-records-buttons" class="gn-margin-bottom">
+                <button id="gn-harvest-records-buttons-assign"
+                        type="button"
+                        class="btn btn-primary btn-warning"
+                        data-ng-disabled="harvesterSelected.info.running === true || deleting.indexOf(harvesterSelected['@id']) > -1"
+                        data-gn-click-and-spin="assignHarvestedRecordToLocalNode()">
+                  <span class="fa fa-database"></span>
+                  <span data-translate=""
+                        data-translate-values="{records: '{{searchResults.count}}'}">assignHarvestedRecordToLocalNode</span>
+                </button>
+
+                <button id="gn-harvest-records-buttons-delete"
+                        type="button"
+                        class="btn btn-warning"
+                        data-gn-click-and-spin="deleteHarvesterRecord(harvesterSelected['@id'])"
+                        data-ng-disabled="harvesterSelected.info.running === true || deleting.indexOf(harvesterSelected['@id']) > -1"
+                        title="{{'deleteHarvesterRecordsHelp' | translate}}">
+                  <span class="fa fa-trash-o"></span>&nbsp;
+                  <span data-translate=""
+                        data-translate-values="{records: '{{searchResults.count}}'}">
+                        deleteHarvesterRecords</span>
+                </button>
+              </div>
+
+              <!-- This information is not relevant for GeoNetwork protocol
+                  which attach records to the source catalogs which has different
+                  UUIDs. TODO -->
+
+              <div data-gn-search-form-results=""
+                   data-gn-search-form-results-mode="title"
+                   data-search-results="searchResults"
+                   data-pagination-info="paginationInfo">
               </div>
             </div>
-          </li>
-        </ul>
-        <ul id="gn-harvest-history-pager-row" class="pager" data-ng-show="harvesterHistory.length !== 0">
-          <li data-ng-class="harvesterHistoryPaging.page == 1 ? 'disabled' : ''"
-              data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
-                                                                 data-ng-click="historyFirstPage()"
-                                                                 class="ng-scope">«</a></li>
-          <li data-ng-class="harvesterHistoryPaging.page == 1 ? 'disabled' : ''"
-              data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
-                                                                 data-ng-click="historyPreviousPage()"
-                                                                 class="ng-scope">‹</a></li>
-          <li class="ng-binding">
-            {{harvesterHistoryPaging.page}} / {{harvesterHistoryPaging.pages}} <em data-translate=""
-                                                                                   class="ng-scope">of </em>
-            <ng-pluralize count="harvesterHistoryPaging.total"
-                          when="{'0 ': ('noRecordFound' | translate), 'one': '1 ' + ('record' | translate), 'other': '{} ' + ('records' | translate)}"></ng-pluralize>
-          </li>
-          <li
-            data-ng-class="harvesterHistoryPaging.page == harvesterHistoryPaging.pages ? 'disabled' : ''"
-            data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
-                                                               data-ng-click="historyNextPage()"
-                                                               class="ng-scope">›</a></li>
-          <li
-            data-ng-class="harvesterHistoryPaging.page == harvesterHistoryPaging.pages ? 'disabled' : ''"
-            data-ng-show="harvesterHistoryPaging.pages > 0"><a href=""
-                                                               data-ng-click="historyLastPage()"
-                                                               class="ng-scope">»</a></li>
-        </ul>
-      </div>
-    </div>
+          </div>
 
-    <div id="gn-harvest-records-panel"
-         class="panel panel-default"
-         data-ng-hide="harvesterSelected['@id'] == '' || isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1"
-         data-ng-search-form=""
-         data-ng-show="searchResults.count != '0'">
-      <div class="panel-heading">
-        <span id="gn-harvest-records-title" data-translate="">harvesterRecords</span>
-        <div id="gn-harvest-records-buttons" class="btn-toolbar pull-right">
-          <button id="gn-harvest-records-buttons-assign"
-                  type="button"
-                  class="btn btn-primary btn-warning"
-                  data-ng-disabled="harvesterSelected.info.running === true || deleting.indexOf(harvesterSelected['@id']) > -1"
-                  data-gn-click-and-spin="assignHarvestedRecordToLocalNode()">
-            <span class="fa fa-database"></span>
-            <span data-translate=""
-                  data-translate-values="{records: '{{searchResults.count}}'}">assignHarvestedRecordToLocalNode</span>
-          </button>
-
-          <button id="gn-harvest-records-buttons-delete"
-                  type="button"
-                  class="btn btn-warning"
-                  data-gn-click-and-spin="deleteHarvesterRecord(harvesterSelected['@id'])"
-                  data-ng-disabled="harvesterSelected.info.running === true || deleting.indexOf(harvesterSelected['@id']) > -1"
-                  title="{{'deleteHarvesterRecordsHelp' | translate}}">
-            <span class="fa fa-trash-o"></span>&nbsp;
-            <span data-translate=""
-                  data-translate-values="{records: '{{searchResults.count}}'}">
-            deleteHarvesterRecords</span>
-          </button>
         </div>
-      </div>
-
-      <div class="panel-body">
-        <!-- This information is not relevant for GeoNetwork protocol
-            which attach records to the source catalogs which has different
-            UUIDs. TODO -->
-
-        <div data-gn-search-form-results=""
-             data-gn-search-form-results-mode="title"
-             data-search-results="searchResults"
-             data-pagination-info="paginationInfo">
-        </div>
-      </div>
-    </div>
+      </tab>
+    </tabset>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -32,7 +32,7 @@
                 <i class="fa fa-spinner fa-spin fa-2x"/>
               </span>
               <span>{{ 'lastRun' | translate }}: {{ h.info.lastRun | gnFromNow }}</span><br>
-              <span>{{ 'harvesterRecords' | translate }}: {{h.info.result.total}}</span>
+              <span data-ng-if="h.info.result.total">{{ 'harvesterRecords' | translate }}: {{h.info.result.total}}</span>
             </p>
           </a>
           <span data-gn-pagination-list=""
@@ -97,7 +97,8 @@
   </div>
 
 
-  <div class="col-lg-8" data-ng-hide="harvesterSelected['@id'] == null">
+  <div class="col-lg-8" data-ng-hide="harvesterSelected['@id'] == null"
+       data-ng-search-form="">
 
     <tabset id="harvester-tabset" type="pills" justified="false" role="tablist">
       <tab heading="{{'settings' | translate}}"
@@ -291,13 +292,15 @@
           </div>
         </div>
       </tab>
-      <tab heading="{{'results' | translate}}"
+      <tab heading="{{ searchResults.count }} {{'metadataRecords' | translate}}"
+           data-ng-hide="harvesterSelected['@id'] == ''
+                          || searchResults.count == '-1'
+                          || isLoadingOneHarvester
+                          || deleting.indexOf(harvesterSelected['@id']) > -1"
+           data-ng-show="searchResults.count > 0"
            role="tab">
         <div id="gn-harvest-records-panel"
-             class="gn-margin-top"
-             data-ng-hide="harvesterSelected['@id'] == '' || isLoadingOneHarvester || deleting.indexOf(harvesterSelected['@id']) > -1"
-             data-ng-search-form=""
-             data-ng-show="searchResults.count != '0'">
+             class="gn-margin-top">
 
           <div class="panel panel-default">
             <div class="panel-heading">
@@ -314,49 +317,10 @@
                   </li>
                 </ul>
 
-                <!-- TODO: loop over configurable list -->
-                <span data-ng-repeat="r in searchResults.facets"
-                      data-ng-if="r.key === 'availableInServices'">
-                  <ul class="col-md-4 text-center list-group gn-nomargin-bottom"
-                      data-ng-repeat="i in r.items">
-                    <li class="list-group-item">
-                      <h1>
-                        <i class="fa fa-download" data-ng-if="i.value === 'availableInDownloadService'"></i>
-                        <i class="fa fa-eye" data-ng-if="i.value === 'availableInViewService'"></i>
-                        {{ i.count }}</h1>
-                      <p>
-                        {{ 'availableInServices-' + i.value | translate }}
-                      </p>
-                    </li>
-                  </ul>
-                </span>
+
+                <div data-ng-show="searchResults.records.length > 0"
+                     data-es-facets="searchResults.facets"></div>
               </div>
-
-              <div class="row">
-
-                <ul class=" list-group gn-nomargin-bottom height-auto">
-
-                  <li class="col-lg-6 col-md-12 list-group-item gn-margin-top"
-                      data-ng-repeat="f in searchResults.facets"
-                      data-ng-if="f.key === 'cl_hierarchyLevel.key' || f.key === 'tag.default'">
-                    <!-- topic/keyword -->
-                    <div data-ng-if="f.key === 'tag.default'"
-                         data-ng-show="f.items.length > 0">
-                      <h4 data-translate="">facet-tag</h4>
-                      <div gn-facet-vega="f"></div>
-                    </div>
-                    <!-- hierarchy -->
-                    <div data-ng-if="f.key === 'cl_hierarchyLevel.key'"
-                         data-ng-show="f.items.length > 0">
-                      <h4 data-translate="">facet-cl_hierarchyLevel</h4>
-                      <div gn-facet-vega="f" class="maxwidth-100"></div>
-                    </div>
-
-                  </li>
-
-                </ul>
-              </div>
-
             </div>
           </div>
           <div class="panel panel-default">
@@ -388,6 +352,12 @@
                         data-translate-values="{records: '{{searchResults.count}}'}">
                         deleteHarvesterRecords</span>
                 </button>
+              </div>
+
+
+              <div data-search-filter-tags
+                   data-dimensions="searchResults.facets"
+                   ng-if="searchResults.facets">
               </div>
 
               <!-- This information is not relevant for GeoNetwork protocol

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -348,6 +348,88 @@ ul.gn-resultview li.list-group-item {
           width: 80%;
         }
       }
+      #gn-harvest-records-panel {
+        .gn-harvester-facets {
+          .gn-facet {
+            opacity: 1;
+            .gn-facet-root-container {
+              .clearfix();
+              .gn-facet-container {
+                width: calc(~"(100% / 3) - 15px");
+                float: left;
+                margin: 5px 15px 5px 0;
+                .gn-facet-item {
+                  a.flex-row {
+                    padding: 10px 15px;
+                    border-radius: @list-group-border-radius;
+                    border: 1px solid @list-group-border;
+                    text-align: center;
+                    flex-direction: column-reverse;
+                    &:hover {
+                      text-decoration: none;
+                    }
+                    .fa {
+                      display: none;
+                    }
+                    .gn-facet-label {
+                      color: #333;
+                      margin-bottom: 10px;
+                    }
+                    .gn-facet-count {
+                      color: #333;
+                      font-weight: 500;
+                      font-size: 36px;
+                      margin: 10px 0 0 0;
+                      &:after {
+                        content: none;
+                      }
+                      &:before {
+                        display: inline-block;
+                        font: normal normal normal 14px/1 FontAwesome;
+                        font-size: inherit;
+                        text-rendering: auto;
+                        -webkit-font-smoothing: antialiased;
+                        margin-right: 10px;
+                        content: "\f0f6";
+                      }
+                    }
+                    .gn-facet-count-0 {
+                      display: block;
+                    }
+                    &.gn-facet-checked {
+                      border-color: @brand-success;
+                    }
+                    &.gn-facet-checked-inverted {
+                      border-color: @brand-danger;
+                    }
+                  }
+                  a[title*="Download"] {
+                    .gn-facet-count {
+                      &:before {
+                        content: "\f019";
+                      }
+                    }
+                  }
+                  a[title*="View"] {
+                    .gn-facet-count {
+                      &:before {
+                        content: "\f06e";
+                      }
+                    }
+                  }
+                  .facet-invert {
+                    right: 18px;
+                    margin-top: 5px;
+                  }
+                }
+              }
+            }
+          }
+        }
+        .search-filter-tags .panel-body {
+          padding-left: 15px;
+        }
+      }
     }
     // settings page
     [data-ng-controller="GnSystemSettingsController"] {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -43,6 +43,19 @@
 .gn-margin-left {
   margin-left: @gn-spacing !important;
 }
+// no margin
+.gn-nomargin-top {
+  margin-top: 0 !important;
+}
+.gn-nomargin-right {
+  margin-right: 0 !important;
+}
+.gn-nomargin-bottom {
+  margin-bottom: 0 !important;
+}
+.gn-nomargin-left {
+  margin-left: 0 !important;
+}
 //border
 .gn-noborder-top {
   border-top-width: 0 !important;
@@ -80,18 +93,18 @@
 .clamp-2 {
   display: -webkit-box !important;
   -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;  
+  -webkit-box-orient: vertical;
   overflow: hidden;
 }
 .clamp-3 {
   display: -webkit-box !important;
   -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;  
+  -webkit-box-orient: vertical;
   overflow: hidden;
 }
 .clamp-6 {
   display: -webkit-box !important;
   -webkit-line-clamp: 6;
-  -webkit-box-orient: vertical;  
+  -webkit-box-orient: vertical;
   overflow: hidden;
-} 
+}

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -108,8 +108,8 @@
 
               <!-- TODOES Link label to icons? -->
               <span class="badge-icon badge-result-topic pull-left">
-                <i class="fa fa-3x gn-icon gn-icon-{{facet.key.toLowerCase().replace('/', '').replace(' ', '')}}"
-                    data-ng-show="homeFacet.key === 'topic.key' || homeFacet.key === 'cl_hierarchyLevel.key'">
+                <i class="fa fa-3x gn-icon gn-icon-{{facet.key.replace('/', '').replace(' ', '')}}"
+                    data-ng-show="homeFacet.key === 'cl_topic.key' || homeFacet.key === 'cl_hierarchyLevel.key'">
                 </i>
               </span>
               <span class="badge-text pull-left">
@@ -153,7 +153,7 @@
                 class="pull-left clearfix"
                 data-ng-href='#/search?query_string={"{{homeFacet.lastKey}}": {"{{facet.key}}": true} }'>
                 <span class="badge-icon pull-left">
-                  <i class="fa fa-3x gn-icon gn-icon-{{facet.key.toLowerCase().replace('/', '').replace(' ', '')}}"
+                  <i class="fa fa-3x gn-icon gn-icon-{{facet.key.replace('/', '').replace(' ', '')}}"
                       data-ng-show="homeFacet.lastKey === 'topic_text' || homeFacet.lastKey === 'cl_hierarchyLevel.key'">
                   </i>
                 </span>

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -219,11 +219,7 @@
       </xsl:otherwise>
     </xsl:choose>
 
-    <xsl:if test="$isVegaEnabled">
-      <script src="{$uiResourcesPath}lib/vega/vega.js"></script>
-    </xsl:if>
-
-    <xsl:if test="$angularApp = 'gn_admin'">
+    <xsl:if test="$isVegaEnabled or $angularApp = ('gn_editor', 'gn_admin')">
       <script src="{$uiResourcesPath}lib/vega/vega.js"></script>
     </xsl:if>
 

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -223,6 +223,10 @@
       <script src="{$uiResourcesPath}lib/vega/vega.js"></script>
     </xsl:if>
 
+    <xsl:if test="$angularApp = 'gn_admin'">
+      <script src="{$uiResourcesPath}lib/vega/vega.js"></script>
+    </xsl:if>
+
     <script src="{$uiResourcesPath}lib/d3_timeseries/d3.min.js?v={$buildNumber}"></script>
     <script src="{$uiResourcesPath}lib/timeline/timeline-zoomable.js?v={$buildNumber}"></script>
     <link rel="stylesheet" href="{$uiResourcesPath}lib/timeline/timeline.css"/>


### PR DESCRIPTION
This PR adds a more visual summary (totals/graphs) to the harvest pages. 

After harvesting the harvest results are displayed more graphically:

![gn-harvester-summary](https://user-images.githubusercontent.com/19608667/116997889-b3400800-acdd-11eb-865f-b77b7b25f86b.png)

Further improvements:
- settings/history/results in tabs
- added extra information in harvester list
- added extra classes to buttons
- Editor board / Fix facet on datestamp