### PR TITLE
ISO19139 / Mapping / Codelist may have multiple values

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
@@ -904,7 +904,7 @@
     <xsl:param name="codeListValue"/>
     <!-- The correct codeList Location goes here -->
     <xsl:variable name="codeListLocation" select="'http://standards.iso.org/iso/19139/resources/gmxCodelists.xml'"/>
-    <xsl:if test="$codeListValue">
+    <xsl:for-each select="$codeListValue">
       <xsl:element name="{$elementName}">
         <xsl:element name="{$codeListName}">
           <xsl:attribute name="codeList">
@@ -914,14 +914,14 @@
           </xsl:attribute>
           <xsl:attribute name="codeListValue">
             <!-- the anyValidURI value is used for testing with paths -->
-            <xsl:value-of select="$codeListValue"/>
+            <xsl:value-of select="current()"/>
             <!-- commented out for testing -->
             <!--<xsl:value-of select="$codeListValue"/>-->
           </xsl:attribute>
-          <xsl:value-of select="$codeListValue"/>
+          <xsl:value-of select="current()"/>
         </xsl:element>
       </xsl:element>
-    </xsl:if>
+    </xsl:for-each>
   </xsl:template>
 
   <xsl:template name="writeCharacterStringElement">


### PR DESCRIPTION
Current mapping may produce invalid ISO19139 record


```xml
         <mri:status>
            <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode"
                                 codeListValue="obsolete"/>
         </mri:status>
         <mri:status>
            <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode"
                                 codeListValue="superseded"/>
         </mri:status>
```

produce 19139 with `obsolete superseded` instead of 2 gmd:status element

```xml
      <gmd:status>
        <gmd:MD_ProgressCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ProgressCode"
                                                 codeListValue="obsolete superseded">obsolete superseded</gmd:MD_ProgressCode>
      </gmd:status>
```