### PR TITLE
Harvester / Localfile / Disable script option.

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -231,19 +231,23 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult, L
     }
 
     private void runBeforeScript() throws IOException, InterruptedException {
-		if (StringUtils.isEmpty(params.beforeScript)) {
+        if (StringUtils.isEmpty(params.beforeScript)) {
 			return;
 		}
-		log.info("Running the before script: " + params.beforeScript);
-        List<String> args = new ArrayList<String>(Arrays.asList(params.beforeScript.split(" ")));
-        Process process = new ProcessBuilder(args).
-				redirectError(ProcessBuilder.Redirect.INHERIT).
-				redirectOutput(ProcessBuilder.Redirect.INHERIT).
-				start();
-		int result = process.waitFor();
-		if ( result != 0 ) {
-			log.warning("The beforeScript failed with exit value=" + Integer.toString(result));
-			throw new RuntimeException("The beforeScript returned an error: " + Integer.toString(result));
-		}
+
+        throw new InterruptedException("Script option is currently disabled.");
+        // TODO: Script MUST be limited to well known ones added by a
+        // catalog admin in the data directory. To be improved
+        //		log.info("Running the before script: " + params.beforeScript);
+        //        List<String> args = new ArrayList<String>(Arrays.asList(params.beforeScript.split(" ")));
+        //        Process process = new ProcessBuilder(args).
+        //				redirectError(ProcessBuilder.Redirect.INHERIT).
+        //				redirectOutput(ProcessBuilder.Redirect.INHERIT).
+        //				start();
+        //		int result = process.waitFor();
+        //		if ( result != 0 ) {
+        //			log.warning("The beforeScript failed with exit value=" + Integer.toString(result));
+        //			throw new RuntimeException("The beforeScript returned an error: " + Integer.toString(result));
+        //		}
 	}
 }


### PR DESCRIPTION
Script option can be unsecured and needs improvement to limit to scripts that have been checked by catalog admin.

![image](https://user-images.githubusercontent.com/1701393/117106916-fe5f2700-ad80-11eb-8659-b46be92779d6.png)

@cmangeat not sure if you have resource to improve that (as it is used in geocat.ch) and limit it to scripts that are defined in the data directory only ? We will turn it off for now in coming release.