### PR TITLE
Aggregation / Tree / Substitute separator even if not translated.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -618,15 +618,18 @@
             //   }
             // },
             if(meta && meta.treeKeySeparator) {
-              name = t.replaceAll(meta.treeKeySeparator, '^');
+              name = t.replaceAll(meta.treeKeySeparator, separator);
             }
 
             if (name.indexOf(separator) === 0) {
               name = name.slice(1);
             }
           }
+        } else {
+          if(meta && meta.treeKeySeparator) {
+            name = name.replaceAll(meta.treeKeySeparator, separator);
+          }
         }
-
 
         var g = name.split(separator);
         createNode(tree, fieldId, g, 0, e);


### PR DESCRIPTION
eg. split a field with "SPW - DGO3 - DEE - DPP" by a separator " - "

```json
'custodianOrgForResource_tree': {
              'terms': {
                'field': 'custodianOrgForResource_tree',
                'include': 'SPW.*',
                'size': 35,
                "order" : { "_key" : "asc" }
              },
              "meta": {
                "treeKeySeparator": " - "
              }
            },
```

![image](https://user-images.githubusercontent.com/1701393/117158591-d5aa5200-adbf-11eb-9621-88e2697a5281.png)
