### PR TITLE
Metadata import - catch update metadata resources link exception with metadata templates and avoid stopping the import process

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -346,7 +346,11 @@ public class Importer {
                     // In GeoNetwork 3.x, links to resources changed:
                     // * thumbnails contains full URL instead of file name only
                     // * API mode change old URL structure.
-                    MetadataResourceDatabaseMigration.updateMetadataResourcesLink(metadata, null, sm);
+                    try {
+                        MetadataResourceDatabaseMigration.updateMetadataResourcesLink(metadata, null, sm);
+                    } catch (UnsupportedOperationException ex) {
+                        // Ignore, this is triggered when importing templates with empty gmd:fileIdentifier, should not fail.
+                    }
                 }
 
                 if (validate) {


### PR DESCRIPTION
Test case:

1) Backup a catalogue with templates using http://localhost:8080/geonetwork/doc/api/index.html#/records/trigger

2) Download the catalogue backup http://localhost:8080/geonetwork/doc/api/index.html#/records/downloadBackup

3) Import the catalogue backup in other instance --> An error `Metadata is not supported. UUID is not defined.` is reported

This is caused in https://github.com/geonetwork/core-geonetwork/blob/54b3ac3411b40c3da5c9de438fbe6ea37b1d2471/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java#L163-L165 when importing templates, as usually the `gmd:fileIdentifier` is empty for templates.

Updated the code in the import process to catch the exception and ignore it, as it's not really an error, otherwise the import process stops and the rest of the records in the MEF file are skipped.
