### PR TITLE
Fix for the panel arrow in the collapsed state in the Editor

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -175,6 +175,9 @@
         font-size: 16px;
         margin-top: 0px;
       }
+      legend.collapsed[data-gn-slide-toggle]:before {
+        content: "\f105";
+      }
       table {
         .col-sm-2, .col-sm-9 {
           padding-right: 0;


### PR DESCRIPTION
In the editor the arrow of the panels is always the same, when it's collapsed or not.

This PR fixes it, the arrow is different now when the panel is collapsed.

**Before**
![gn-arrow-before](https://user-images.githubusercontent.com/19608667/117276953-aea35d00-ae5f-11eb-9fbf-33a5f1b491c9.png)

**After**
![gn-arrow-after](https://user-images.githubusercontent.com/19608667/117276974-b4993e00-ae5f-11eb-9a81-9c21e732f1af.png)
