### PR TITLE
Remove buttons from the toolbar in the contribute dashboard

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -140,7 +140,7 @@ div[gn-transfer-ownership] * .list-group {
     }
   }
   .gn-editor-board {
-    padding-top: 120px;
+    padding-top: 135px;
   }
   .gn-editor-container, .gn-batch-editor, #gn-directory-container,
   #gn-new-metadata-container, #gn-import-container {

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -7,13 +7,12 @@
           data-runSearch="true"
           data-wait-for-user="true" >
 
-        <div class="gn-sub-bar">
+        <div class="gn-sub-bar col-md-8 col-md-offset-2">
           <form class="form-horizontal"
                 role="form">
             <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div class="row gn-top-search">
-              <div class="col-xs-12 col-sm-6 col-md-6 col-lg-5">
-                <div class="input-group gn-form-any">
+              <div class="input-group gn-form-any">
                   <span class="input-group-addon">
                     <label>
                       <input type="checkbox" title="{{'onlyMyRecord' | translate}}" data-ng-model="onlyMyRecord.is">
@@ -49,27 +48,6 @@
                     </button>
                   </div>
                 </div>
-              </div>
-              <div class="col-xs-12 col-sm-6 col-md-6 col-lg-7 text-right">
-                <a href="#/create" class="btn btn-primary btn-truncate" title="{{'addRecord' | translate}}">
-                  <i class="fa fa-fw fa-plus"/><span class=" hidden-sm" data-translate="">addRecord</span>
-                </a>
-                <a href="#/import" class="btn btn-default btn-truncate" title="{{'ImportRecord' | translate}}">
-                  <i class="fa fa-fw fa-upload"/><span class="hidden-xs hidden-sm" data-translate="">ImportRecord</span>
-                </a>
-                <a href="#/directory" class="btn btn-default btn-truncate" title="{{'directoryManager' | translate}}"
-                  ng-if="user.isEditorOrMore()">
-                  <i class="fa fa-fw fa-bookmark"/><span class="hidden-xs hidden-sm hidden-md btn-truncate-lg" data-translate="">directoryManager</span>
-                </a>
-                <a href="#/batchedit" class="btn btn-default btn-truncate" title="{{'batchEditing' | translate}}"
-                  ng-if="user.isEditorOrMore()">
-                  <i class="fa fa-fw fa-pencil"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
-                </a>
-                <a href="#/accessManager" class="btn btn-default" title="{{'accessManager' | translate}}"
-                  ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
-                  <i class="fa fa-fw fa-lock"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
-                </a>
-              </div>
             </div>
           </form>
         </div>


### PR DESCRIPTION
There are a lot of buttons in the second toolbar on the contribute dashboard page (righthand side of the search box). On smaller screens these buttons can be displayed on multiple lines and labels are hidden. This can be a problem, because the subbar is then displayed over the table with records.

This PR removes these buttons because they are the same as in the main toolbar (see screenshot)

However, this solution may be not for everyone, if you have ideas how to solve the issue, please add a comment.

**Screenshot of no buttons**
![gn-contribute-subbar](https://user-images.githubusercontent.com/19608667/117296987-f8973d80-ae75-11eb-8a7c-707cec9eb5ee.png)
