### PR TITLE
MBean registration / Ignore existing

### DIFF
--- a/core/src/main/java/jeeves/server/sources/http/ServletPathFinder.java
+++ b/core/src/main/java/jeeves/server/sources/http/ServletPathFinder.java
@@ -59,6 +59,8 @@ public class ServletPathFinder {
                 baseUrl = resource.substring(resource.indexOf('/', 1), resource.length() - 1);
             } catch (java.net.MalformedURLException e) { // unlikely
                 baseUrl = servletContext.getServletContextName();
+            } catch (NullPointerException e) { // in test using GeonetMockServletContext
+                baseUrl = "/";
             }
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/MetadataIndexerProcessor.java
+++ b/core/src/main/java/org/fao/geonet/kernel/MetadataIndexerProcessor.java
@@ -53,7 +53,7 @@ public abstract class MetadataIndexerProcessor {
         this.dm = dm;
     }
 
-    public abstract void process() throws Exception;
+    public abstract void process(String catalogueId) throws Exception;
 
     protected DataManager getDataManager() {
         return dm;

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -238,7 +238,7 @@ public class BaseMetadataManager implements IMetadataManager {
                 Set<Integer> integerList = toIndex.stream().map(Integer::parseInt).collect(Collectors.toSet());
                 new BatchOpsMetadataReindexer(
                     context.getBean(DataManager.class),
-                    integerList).process(false);
+                    integerList).process(settingManager.getSiteId(), false);
             } else {
                 metadataIndexer.batchIndexInThreadPool(context, toIndex);
             }

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/BatchOpsMetadataReindexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/BatchOpsMetadataReindexer.java
@@ -110,17 +110,19 @@ public class BatchOpsMetadataReindexer extends MetadataIndexerProcessor implemen
         return inError.intValue();
     }
 
-    public void process(boolean runInCurrentThread) throws Exception {
-        wrapAsyncProcess(runInCurrentThread);
+    public void process(String catalogueId, boolean runInCurrentThread) throws Exception {
+        wrapAsyncProcess(catalogueId, runInCurrentThread);
         allCompleted.get();
     }
 
-    public void process() throws Exception {
-        process(false);
+    public void process(String catalogueId) throws Exception {
+        process(catalogueId, false);
     }
 
-    public String wrapAsyncProcess(boolean runInCurrentThread) throws Exception {
-        probeName = new ObjectName(String.format("geonetwork:name=indexing-task,idx=%s", this.hashCode()));
+    public String wrapAsyncProcess(String catalogueId, boolean runInCurrentThread) throws Exception {
+        probeName = new ObjectName(String.format(
+            "geonetwork-%s:name=indexing-task,idx=%s",
+            catalogueId, this.hashCode()));
         exporter.registerManagedResource(this, probeName);
         return processAsync(runInCurrentThread);
     }

--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -221,6 +221,7 @@
 
   <bean id="exporter" class="org.springframework.jmx.export.MBeanExporter" lazy-init="false">
     <property name="namingStrategy" ref="namingStrategy"/>
+    <property name="registrationPolicy" value="IGNORE_EXISTING"/>
   </bean>
   <bean id="namingStrategy"
         class="org.springframework.jmx.export.naming.KeyNamingStrategy">

--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -223,6 +223,7 @@
     <property name="namingStrategy" ref="namingStrategy"/>
     <property name="registrationPolicy" value="IGNORE_EXISTING"/>
   </bean>
+
   <bean id="namingStrategy"
         class="org.springframework.jmx.export.naming.KeyNamingStrategy">
     <property name="mappings">

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -601,7 +601,7 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
         }
 
         @Override
-        public void process() throws Exception {
+        public void process(String catalogueId) throws Exception {
             doHarvest(logger);
         }
     }
@@ -673,7 +673,7 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
                         logger.info("Started harvesting from node : " + nodeName);
                         HarvestWithIndexProcessor h = new HarvestWithIndexProcessor(dataMan, logger);
                         // todo check (was: processwithfastindexing)
-                        h.process();
+                        h.process(settingManager.getSiteId());
                         logger.info("Ended harvesting from node : " + nodeName);
 
                         if (getParams().isOneRunOnly()) {

--- a/services/src/main/java/org/fao/geonet/api/links/EmptySlot.java
+++ b/services/src/main/java/org/fao/geonet/api/links/EmptySlot.java
@@ -11,9 +11,11 @@ public class EmptySlot implements SelfNaming {
 
     private ObjectName objectName;
 
-    public EmptySlot(int i) {
+    public EmptySlot(String catalogueId, int i) {
         try {
-            objectName = new ObjectName(String.format("geonetwork:name=url-check,idx=empty-slot-%d", i));
+            objectName = new ObjectName(String.format(
+                "geonetwork-%s:name=url-check,idx=empty-slot-%d",
+                catalogueId, i));
         } catch (MalformedObjectNameException e) {
             e.printStackTrace();
         }

--- a/services/src/main/java/org/fao/geonet/api/links/LinksApi.java
+++ b/services/src/main/java/org/fao/geonet/api/links/LinksApi.java
@@ -45,6 +45,7 @@ import org.fao.geonet.exceptions.OperationNotAllowedEx;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.url.UrlAnalyzer;
 import org.fao.geonet.repository.LinkRepository;
 import org.fao.geonet.repository.MetadataRepository;
@@ -105,13 +106,15 @@ public class LinksApi {
     MBeanExporter mBeanExporter;
     @Autowired
     AccessManager accessManager;
+    @Autowired
+    SettingManager settingManager;
 
     private ArrayDeque<SelfNaming> mAnalyseProcesses = new ArrayDeque<>(NUMBER_OF_SUBSEQUENT_PROCESS_MBEAN_TO_KEEP);
 
     @PostConstruct
     public void iniMBeansSlidingWindowWithEmptySlot() {
         for (int i = 0; i < NUMBER_OF_SUBSEQUENT_PROCESS_MBEAN_TO_KEEP; i++) {
-            EmptySlot emptySlot = new EmptySlot(i);
+            EmptySlot emptySlot = new EmptySlot(settingManager.getSiteId(), i);
             mAnalyseProcesses.addFirst(emptySlot);
             try {
                 mBeanExporter.registerManagedResource(emptySlot, emptySlot.getObjectName());
@@ -364,7 +367,11 @@ public class LinksApi {
     }
 
     private MAnalyseProcess getRegistredMAnalyseProcess() {
-        MAnalyseProcess mAnalyseProcess = new MAnalyseProcess(linkRepository, metadataRepository, urlAnalyser, appContext);
+        MAnalyseProcess mAnalyseProcess = new MAnalyseProcess(
+            settingManager.getSiteId(),
+            linkRepository,
+            metadataRepository,
+            urlAnalyser, appContext);
         mBeanExporter.registerManagedResource(mAnalyseProcess, mAnalyseProcess.getObjectName());
         try {
             mBeanExporter.unregisterManagedResource(mAnalyseProcesses.removeLast().getObjectName());

--- a/services/src/main/java/org/fao/geonet/api/links/MAnalyseProcess.java
+++ b/services/src/main/java/org/fao/geonet/api/links/MAnalyseProcess.java
@@ -46,13 +46,17 @@ public class MAnalyseProcess implements SelfNaming {
     private long testLinkDate = Long.MAX_VALUE;
 
 
-    public MAnalyseProcess(LinkRepository linkRepository, MetadataRepository metadataRepository, UrlAnalyzer urlAnalyser, ApplicationContext appContext) {
+    public MAnalyseProcess(String catalogueId,
+                           LinkRepository linkRepository,
+                           MetadataRepository metadataRepository,
+                           UrlAnalyzer urlAnalyser,
+                           ApplicationContext appContext) {
         this.linkRepository = linkRepository;
         this.metadataRepository = metadataRepository;
         this.urlAnalyser = urlAnalyser;
         this.appContext = appContext;
         try {
-            this.probeName = new ObjectName(String.format("geonetwork:name=url-check,idx=%s", this.hashCode()));
+            this.probeName = new ObjectName(String.format("geonetwork-%s:name=url-check,idx=%s", catalogueId, this.hashCode()));
         } catch (MalformedObjectNameException e) {
             e.printStackTrace();
         }

--- a/services/src/main/java/org/fao/geonet/api/processing/EmptySlotBatch.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/EmptySlotBatch.java
@@ -13,7 +13,7 @@ public class EmptySlotBatch implements SelfNaming {
 
     public EmptySlotBatch(String name, int i) {
         try {
-            objectName = new ObjectName(String.format("geonetwork:name=%s,idx=empty-slot-%d", name, i));
+            objectName = new ObjectName(String.format("geonetwork-%s:idx=empty-slot-%d", name, i));
         } catch (MalformedObjectNameException e) {
             e.printStackTrace();
         }

--- a/services/src/main/java/org/fao/geonet/api/processing/MInspireEtfValidateProcess.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/MInspireEtfValidateProcess.java
@@ -60,14 +60,18 @@ public class MInspireEtfValidateProcess implements SelfNaming {
     private long analyseMdDate = Long.MAX_VALUE;
 
 
-    public MInspireEtfValidateProcess(String URL,
-                                      ServiceContext serviceContext, ApplicationContext appContext) {
+    public MInspireEtfValidateProcess(String catalogueId,
+                                      String URL,
+                                      ServiceContext serviceContext,
+                                      ApplicationContext appContext) {
         this.URL = URL;
         this.serviceContext = serviceContext;
         this.appContext = appContext;
 
         try {
-            this.probeName = new ObjectName(String.format("geonetwork:name=batch-etf-inspire,idx=%s", this.hashCode()));
+            this.probeName = new ObjectName(String.format(
+                "geonetwork-%s:name=batch-etf-inspire,idx=%s",
+                catalogueId, this.hashCode()));
         } catch (MalformedObjectNameException e) {
             e.printStackTrace();
         }

--- a/services/src/main/java/org/fao/geonet/api/processing/MetadataSearchAndReplace.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/MetadataSearchAndReplace.java
@@ -78,7 +78,7 @@ public class MetadataSearchAndReplace extends MetadataIndexerProcessor {
     }
 
     @Override
-    public void process() throws Exception {
+    public void process(String catalogueId) throws Exception {
         GeonetContext gc = (GeonetContext) context
             .getHandlerContext(Geonet.CONTEXT_NAME);
         DataManager dm = gc.getBean(DataManager.class);

--- a/services/src/main/java/org/fao/geonet/api/processing/ProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ProcessApi.java
@@ -35,6 +35,7 @@ import org.fao.geonet.api.processing.report.MetadataReplacementProcessingReport;
 import org.fao.geonet.api.processing.report.ProcessingReport;
 import org.fao.geonet.api.processing.report.registry.IProcessingReportRegistry;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -63,6 +64,9 @@ public class ProcessApi {
 
     @Autowired
     DataManager dataMan;
+
+    @Autowired
+    SettingManager settingManager;
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Get current process reports",
@@ -184,7 +188,7 @@ public class ProcessApi {
                 isTesting, isCaseInsensitive, vacuumMode,
                 allParams,
                 ApiUtils.createServiceContext(request), records, report);
-            m.process();
+            m.process(settingManager.getSiteId());
         } catch (Exception e) {
             throw e;
         } finally {

--- a/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ValidateApi.java
@@ -207,7 +207,7 @@ public class ValidateApi {
 
             // index records
             BatchOpsMetadataReindexer r = new BatchOpsMetadataReindexer(dataMan, report.getMetadata());
-            r.process(true);
+            r.process(settingManager.getSiteId(), true);
         } catch (Exception e) {
             throw e;
         } finally {
@@ -278,7 +278,7 @@ public class ValidateApi {
 
             // index records
             BatchOpsMetadataReindexer r = new BatchOpsMetadataReindexer(dataMan, report.getMetadata());
-            r.process(true);
+            r.process(settingManager.getSiteId(), true);
         } catch (Exception e) {
             throw e;
         } finally {
@@ -344,7 +344,7 @@ public class ValidateApi {
     private MInspireEtfValidateProcess getRegistredMInspireEtfValidateProcess(ServiceContext serviceContext) {
         String URL = settingManager.getValue(Settings.SYSTEM_INSPIRE_REMOTE_VALIDATION_URL);
 
-        MInspireEtfValidateProcess mAnalyseProcess = new MInspireEtfValidateProcess(URL, serviceContext, appContext);
+        MInspireEtfValidateProcess mAnalyseProcess = new MInspireEtfValidateProcess(settingManager.getSiteId(), URL, serviceContext, appContext);
         mBeanExporter.registerManagedResource(mAnalyseProcess, mAnalyseProcess.getObjectName());
         try {
             mBeanExporter.unregisterManagedResource(mAnalyseProcesses.removeLast().getObjectName());

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
@@ -41,6 +41,7 @@ import org.fao.geonet.events.history.RecordProcessingChangeEvent;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.MetadataIndexerProcessor;
 import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
@@ -93,6 +94,9 @@ public class XslProcessApi {
 
     @Autowired
     SchemaManager schemaMan;
+
+    @Autowired
+    SettingManager settingManager;
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Preview process result applied to one or more records",
@@ -299,7 +303,7 @@ public class XslProcessApi {
                 ApiUtils.createServiceContext(request),
                 dataMan, records, process, httpSession, siteURL,
                 xslProcessingReport, request, index, updateDateStamp, userSession.getUserIdAsInt());
-            m.process();
+            m.process(settingManager.getSiteId());
 
         } catch (Exception exception) {
             xslProcessingReport.addError(exception);
@@ -346,7 +350,7 @@ public class XslProcessApi {
         }
 
         @Override
-        public void process() throws Exception {
+        public void process(String catalogueId) throws Exception {
             DataManager dataMan = context.getBean(DataManager.class);
             ApplicationContext appContext = ApplicationContextHolder.get();
             for (String uuid : this.records) {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataIndexApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataIndexApi.java
@@ -37,6 +37,7 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.SelectionManager;
 import org.fao.geonet.kernel.search.index.BatchOpsMetadataReindexer;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -61,6 +62,9 @@ public class MetadataIndexApi {
 
     @Autowired
     DataManager dataManager;
+
+    @Autowired
+    SettingManager settingManager;
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Index a set of records",
@@ -123,7 +127,8 @@ public class MetadataIndexApi {
             }
         }
         index = ids.size();
-        new BatchOpsMetadataReindexer(dataManager, ids).process(false);
+        new BatchOpsMetadataReindexer(dataManager, ids)
+            .process(settingManager.getSiteId(), false);
 
         JSONObject res = new JSONObject();
         res.put("success", true);

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
@@ -307,7 +307,7 @@ public class DirectoryApi {
         if (save) {
             dataManager.flush();
             BatchOpsMetadataReindexer r = new BatchOpsMetadataReindexer(dataManager, listOfEntriesInternalId);
-            r.process();
+            r.process(settingManager.getSiteId());
             report.close();
             return new ResponseEntity<>(report, HttpStatus.CREATED);
         } else {
@@ -496,7 +496,7 @@ public class DirectoryApi {
             dataManager.flush();
             BatchOpsMetadataReindexer r =
                 new BatchOpsMetadataReindexer(dataManager, listOfRecordInternalId);
-            r.process();
+            r.process(settingManager.getSiteId());
             report.close();
             return new ResponseEntity<>(report, HttpStatus.CREATED);
         } else {
@@ -714,7 +714,7 @@ public class DirectoryApi {
             ));
 
             BatchOpsMetadataReindexer r = new BatchOpsMetadataReindexer(dataManager, listOfRecordInternalId);
-            r.process();
+            r.process(settingManager.getSiteId());
 
             errors.forEach((k, v) ->
                 report.addError(v)

--- a/services/src/test/java/org/fao/geonet/services/metadata/BatchOpsMetadatReindexerTest.java
+++ b/services/src/test/java/org/fao/geonet/services/metadata/BatchOpsMetadatReindexerTest.java
@@ -39,7 +39,7 @@ public class BatchOpsMetadatReindexerTest {
         Set<Integer> toIndex = createMetadataToIndex();
 
         BatchOpsMetadataReindexer toTest = new BatchOpsMetadataReindexer(mockDataMan, toIndex);
-        toTest.process(false);
+        toTest.process("siteId", false);
 
         ArgumentCaptor<String> metadataIdCaptor = captureIndexationLaunched(mockDataMan);
         assertEquals("1-2-3-4", metadataIdCaptor.getAllValues().stream().collect(Collectors.joining("-")));
@@ -56,7 +56,7 @@ public class BatchOpsMetadatReindexerTest {
         Set<Integer> toIndex = createMetadataToIndex();
 
         BatchOpsMetadataReindexer toTest = new BatchOpsMetadataReindexer(mockDataMan, toIndex);
-        toTest.process(false);
+        toTest.process("siteId", false);
 
         ArgumentCaptor<String> metadataIdCaptor = captureIndexationLaunched(mockDataMan);
         assertEquals("1-2-3-4", metadataIdCaptor.getAllValues().stream().sorted().collect(Collectors.joining("-")));
@@ -72,7 +72,7 @@ public class BatchOpsMetadatReindexerTest {
         Set<Integer> toIndex = createMetadataToIndex();
 
         BatchOpsMetadataReindexer toTest = new BatchOpsMetadataReindexer(mockDataMan, toIndex);
-        toTest.process(true);
+        toTest.process("siteId", true);
 
         ArgumentCaptor<String> metadataIdCaptor = captureIndexationLaunched(mockDataMan);
         assertEquals("1-2-3-4", metadataIdCaptor.getAllValues().stream().sorted().collect(Collectors.joining("-")));
@@ -93,7 +93,7 @@ public class BatchOpsMetadatReindexerTest {
         assertEquals(0, toTest.getProcessed());
         assertEquals(4, toTest.getToProcessCount());
 
-        toTest.wrapAsyncProcess(false);
+        toTest.wrapAsyncProcess("siteId", false);
 
         latch.countDown();
         Thread.sleep(500);
@@ -118,7 +118,7 @@ public class BatchOpsMetadatReindexerTest {
 
         assertEquals(0, toTest.getProcessed());
         assertEquals(4, toTest.getToProcessCount());
-        toTest.wrapAsyncProcess(false);
+        toTest.wrapAsyncProcess("siteId",false);
 
         latch.countDown();
         Thread.sleep(500);
@@ -143,7 +143,7 @@ public class BatchOpsMetadatReindexerTest {
             @Override
             public void run() {
                 try {
-                    toTest.wrapAsyncProcess(true);
+                    toTest.wrapAsyncProcess("siteId",true);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/web-ui/src/main/resources/catalog/components/admin/batch/BatchTaskDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/batch/BatchTaskDirective.js
@@ -112,8 +112,8 @@
    * <gn-batch-tasks-container />
    */
   module.directive('gnBatchTasksContainer', [
-    '$http',
-    function ($http) {
+    '$http', 'gnConfig',
+    function ($http, gnConfig) {
       return {
         restrict: 'E',
         scope: {
@@ -133,7 +133,9 @@
             var me = this;
 
             this.refresh = function () {
-              $http.get('../../jolokia/read/geonetwork:name=' + $scope.task + ',idx=*')
+              $http.get('../../jolokia/read/'
+                + 'geonetwork-' + gnConfig['system.site.siteId']
+                + ':name=' + $scope.task + ',idx=*')
                 .then(function successCallback(result) {
                   me.tasks.length = 0;
 

--- a/web-ui/src/main/resources/catalog/components/admin/index/IndexingTaskDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/index/IndexingTaskDirective.js
@@ -111,8 +111,8 @@
    * <gn-indexing-tasks-container />
    */
   module.directive('gnIndexingTasksContainer', [
-    '$http',
-    function ($http) {
+    '$http', 'gnConfig',
+    function ($http, gnConfig) {
       return {
         restrict: 'E',
         scope: {},
@@ -128,7 +128,9 @@
             var me = this;
 
             this.refresh = function () {
-              $http.get('../../jolokia/read/geonetwork:name=indexing-task,idx=*')
+              $http.get('../../jolokia/read/'
+                + 'geonetwork-' + gnConfig['system.site.siteId']
+                + ':name=indexing-task,idx=*')
                 .then(function (result) {
                   //console.log(result);
                   me.tasks.length = 0;

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardRecordLinkController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardRecordLinkController.js
@@ -187,7 +187,8 @@
   var ICON = ['fa-question', 'fa-question', 'fa-spinner fa-spin', 'fa-check', 'fa-exclamation-triangle'];
   var CLASS = ['', '', '', 'success', 'warning'];
 
-  module.directive('gnDashboardRecordLinksProcessesContainer', ['$http', function($http) {
+  module.directive('gnDashboardRecordLinksProcessesContainer', ['$http', 'gnConfig',
+    function($http, gnConfig) {
     return {
       restrict: 'E',
       scope: {},
@@ -219,7 +220,9 @@
         };
 
         this.refresh = function() {
-          $http.get('../../jolokia/read/geonetwork:name=url-check,idx=*').then(function(result) {
+          $http.get('../../jolokia/read/'
+            + 'geonetwork-' + gnConfig['system.site.siteId']
+            + ':name=url-check,idx=*').then(function(result) {
 
             if (!result.data || !result.data.value) { return; }
 
@@ -256,7 +259,7 @@
                 });
               }
             });
-            setTimeout(me.refresh, 1000);
+            setTimeout(me.refresh, 5000);
           });
         };
 

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -42,10 +42,10 @@
   module.controller('GnHarvestSettingsController', [
     '$scope', '$q', '$http', '$translate', '$injector', '$rootScope',
     'gnSearchManagerService', 'gnUtilityService', '$timeout',
-    'Metadata', 'gnMapsManager', 'gnGlobalSettings',
+    'Metadata', 'gnMapsManager', 'gnGlobalSettings', 'gnConfig',
     function($scope, $q, $http, $translate, $injector, $rootScope,
              gnSearchManagerService, gnUtilityService, $timeout,
-             Metadata, gnMapsManager, gnGlobalSettings) {
+             Metadata, gnMapsManager, gnGlobalSettings, gnConfig) {
 
       $scope.searchObj = {
         internal: true,
@@ -385,7 +385,7 @@
       };
       $scope.assignHarvestedRecordToLocalNode = function() {
         $http.post('../api/harvesters/' + $scope.harvesterSelected.site.uuid +
-                   '/assign?source=' + $scope.info['system/site/siteId'])
+                   '/assign?source=' + gnConfig['system.site.siteId'])
             .success(function(data) {
               $scope.harvesterSelected = {};
               $scope.harvesterUpdated = false;

--- a/workers/camelPeriodicProducer/pom.xml
+++ b/workers/camelPeriodicProducer/pom.xml
@@ -57,5 +57,13 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/workers/camelPeriodicProducer/pom.xml
+++ b/workers/camelPeriodicProducer/pom.xml
@@ -58,8 +58,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.quartz-scheduler</groupId>
-      <artifactId>quartz</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>gn-core</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.quartz-scheduler</groupId>

--- a/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerFactory.java
+++ b/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerFactory.java
@@ -27,10 +27,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.quartz2.QuartzComponent;
 import org.apache.camel.component.quartz2.QuartzEndpoint;
 import org.apache.camel.model.RouteDefinition;
+import org.fao.geonet.harvester.wfsfeatures.worker.WFSHarvesterRouteBuilder;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
 import org.quartz.TriggerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.jmx.support.RegistrationPolicy;
 
 import javax.annotation.PostConstruct;
 
@@ -42,9 +47,15 @@ public class MessageProducerFactory {
     @Autowired
     protected QuartzComponent quartzComponent;
 
+    private static Logger LOGGER = LoggerFactory.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
+
     @PostConstruct
     public void init() throws Exception {
-        quartzComponent.start();
+        try {
+            quartzComponent.start();
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+        }
     }
 
     public void registerAndStart(MessageProducer messageProducer) throws Exception {

--- a/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerService.java
+++ b/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerService.java
@@ -87,7 +87,7 @@ public class MessageProducerService implements ApplicationListener<ServerStartup
                     try {
                         messageProducerFactory.registerAndStart(buildWfsHarvesterParameterMessageProducer(messageProducerEntity));
                     } catch (Exception e) {
-                        LOGGER.error("failed to initialise persisted quartz wfs harvester command messages producer, id: ({}).", messageProducerEntity.getId());
+                        LOGGER.error("Failed to initialise persisted quartz wfs harvester command messages producer, id: ({}).", messageProducerEntity.getId());
                     }
                 });
             isConfigured = true;

--- a/workers/camelPeriodicProducer/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/camelPeriodicProducer/src/main/resources/config-spring-geonetwork.xml
@@ -28,8 +28,21 @@
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
 
+  <bean id="schedulerFactory"
+        class="org.quartz.impl.StdSchedulerFactory">
+    <constructor-arg name="props">
+      <props>
+        <prop key="org.quartz.scheduler.instanceName">geonetwork-harvest-wfs</prop>
+        <prop key="org.quartz.threadPool.threadCount">2</prop>
+      </props>
+    </constructor-arg>
+  </bean>
+
+  <bean class="org.apache.camel.component.quartz2.QuartzComponent">
+    <property name="schedulerFactory" ref="schedulerFactory"/>
+  </bean>
+
   <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerFactory"/>
-  <bean class="org.apache.camel.component.quartz2.QuartzComponent"/>
   <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerService"/>"
 
 </beans>

--- a/workers/camelPeriodicProducer/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/camelPeriodicProducer/src/main/resources/config-spring-geonetwork.xml
@@ -43,6 +43,6 @@
   </bean>
 
   <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerFactory"/>
-  <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerService"/>"
+  <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerService"/>
 
 </beans>

--- a/workers/camelPeriodicProducer/src/test/java/org/fao/geonet/camelPeriodicProducer/MessageProducerControllerTest.java
+++ b/workers/camelPeriodicProducer/src/test/java/org/fao/geonet/camelPeriodicProducer/MessageProducerControllerTest.java
@@ -52,7 +52,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"/camel-test-config.xml", "/domain-repository-test-context.xml"})
+@ContextConfiguration(locations = {
+    "/camel-test-config.xml",
+    "/domain-repository-test-context.xml",
+    "/config-spring-geonetwork.xml"
+})
 public class MessageProducerControllerTest {
     private static final String EVERY_SECOND = "* * * ? * * *";
 
@@ -73,12 +77,12 @@ public class MessageProducerControllerTest {
 
     private QuartzComponent quartzComponent;
 
-    private MessageProducerFactory messageProducerFactory;
+    @Autowired
+    MessageProducerFactory messageProducerFactory;
 
     @Before
     public void init() throws Exception {
         testCamelNetwork.getContext().start();
-        messageProducerFactory = new MessageProducerFactory();
         messageProducerFactory.routeBuilder = testCamelNetwork;
         quartzComponent = new QuartzComponent(testCamelNetwork.getContext());
         messageProducerFactory.quartzComponent = quartzComponent;
@@ -99,7 +103,7 @@ public class MessageProducerControllerTest {
 
         List<MessageProducerEntity> persisted = toTest.msgProducerRepository.findAll();
         assertEquals(1, persisted.size());
-        assertEquals(testCamelNetwork.getWfsHarvesterParamConsumer().getFromURI(), "quartz2://" + persisted.get(0).getId());
+        assertEquals(testCamelNetwork.getWfsHarvesterParamConsumer().getFromURI(), "quartz2://null-" + persisted.get(0).getId());
 
         toTest.delete(persisted.get(0).getId());
         testCamelNetwork.getWfsHarvesterParamConsumer().reset();
@@ -131,7 +135,7 @@ public class MessageProducerControllerTest {
         assertEquals("url-mod", persistedWfsHarvesterParam.getUrl());
         assertEquals("typeName-mod", persistedWfsHarvesterParam.getTypeName());
         assertEquals(1, toTest.msgProducerRepository.findAll().size());
-        assertEquals(testCamelNetwork.getWfsHarvesterParamConsumer().getFromURI(), "quartz2://" + persisted.getId());
+        assertEquals(testCamelNetwork.getWfsHarvesterParamConsumer().getFromURI(), "quartz2://null-" + persisted.getId());
 
         toTest.delete(persisted.getId());
     }

--- a/workers/camelPeriodicProducer/src/test/java/org/fao/geonet/camelPeriodicProducer/MessageProducerTest.java
+++ b/workers/camelPeriodicProducer/src/test/java/org/fao/geonet/camelPeriodicProducer/MessageProducerTest.java
@@ -26,7 +26,6 @@ package org.fao.geonet.camelPeriodicProducer;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.quartz2.QuartzComponent;
 import org.apache.camel.component.quartz2.QuartzEndpoint;
-import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.junit.Before;
 import org.junit.Test;

--- a/workers/camelPeriodicProducer/src/test/java/org/fao/geonet/camelPeriodicProducer/MessageProducerTest.java
+++ b/workers/camelPeriodicProducer/src/test/java/org/fao/geonet/camelPeriodicProducer/MessageProducerTest.java
@@ -26,12 +26,15 @@ package org.fao.geonet.camelPeriodicProducer;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.quartz2.QuartzComponent;
 import org.apache.camel.component.quartz2.QuartzEndpoint;
+import org.fao.geonet.AbstractCoreIntegrationTest;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.quartz.CronTrigger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.Serializable;
@@ -49,8 +52,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"/camel-test-config.xml"})
-public class MessageProducerTest {
+@ContextConfiguration(locations = {
+    "/camel-test-config.xml",
+    "/domain-repository-test-context.xml",
+    "/config-spring-geonetwork.xml"
+})
+public class MessageProducerTest extends AbstractJUnit4SpringContextTests {
 
     private static final String EVERY_SIX_SECOND = "/6 * * ? * * *";
     private static final String EVERY_THREE_SECOND = "/3 * * ? * * *";
@@ -60,7 +67,13 @@ public class MessageProducerTest {
     @Autowired
     private TestCamelNetwork testCamelNetwork;
 
-    private  QuartzComponent quartzComponent;
+    @Autowired
+    private SettingManager settingManager;
+
+    @Autowired
+    MessageProducerFactory toTest;
+
+    private QuartzComponent quartzComponent;
 
     @Before
     public void init() throws Exception {
@@ -71,7 +84,6 @@ public class MessageProducerTest {
     @Test
     public void registerAndStart() throws Exception {
         testCamelNetwork.getContext().start();
-        MessageProducerFactory toTest = new MessageProducerFactory();
         toTest.routeBuilder = testCamelNetwork;
         toTest.quartzComponent = quartzComponent;
 
@@ -127,7 +139,6 @@ public class MessageProducerTest {
     @Test
     public void registerAndStartWithoutCronExpression() throws Exception {
         testCamelNetwork.getContext().start();
-        MessageProducerFactory toTest = new MessageProducerFactory();
         toTest.routeBuilder = testCamelNetwork;
         toTest.quartzComponent = quartzComponent;
 
@@ -140,7 +151,8 @@ public class MessageProducerTest {
         toTest.registerAndStart(messageProducer);
 
         QuartzEndpoint endpoint = (QuartzEndpoint) toTest.routeBuilder.getContext().getEndpoints().stream()
-            .filter(x -> x.getEndpointKey().compareTo("quartz2://" + messageProducer.getId()) == 0).findFirst().get();
+            .filter(x -> x.getEndpointKey().compareTo(
+                "quartz2://" + settingManager.getSiteId() + "-" + messageProducer.getId()) == 0).findFirst().get();
 
         CronTrigger trigger = (CronTrigger) quartzComponent.getScheduler().getTrigger(endpoint.getTriggerKey());
         assertEquals(NEVER, trigger.getCronExpression());
@@ -155,7 +167,7 @@ public class MessageProducerTest {
     }
 
 
-    private class TestMessage  implements Serializable {
+    private class TestMessage implements Serializable {
 
         private String content;
 

--- a/workers/camelPeriodicProducer/src/test/java/org/fao/geonet/camelPeriodicProducer/TestCamelNetwork.java
+++ b/workers/camelPeriodicProducer/src/test/java/org/fao/geonet/camelPeriodicProducer/TestCamelNetwork.java
@@ -31,8 +31,7 @@ public class TestCamelNetwork extends RouteBuilder {
     private MessageProducerControllerTest.MessageConsumer wfsHarvesterParamConsumer;
 
 
-    public TestCamelNetwork()
-    {
+    public TestCamelNetwork() {
         messageConsumer = new MessageProducerTest.MessageConsumer("direct:consumer");
         wfsHarvesterParamConsumer = new MessageProducerControllerTest.MessageConsumer("direct:wfsHravesterParamConsumer");
     }
@@ -49,14 +48,14 @@ public class TestCamelNetwork extends RouteBuilder {
     public void configure() throws Exception {
 
         from(messageConsumer.getUri())
-                .id("test_route_id")
-                .setProperty("configuration", simple("${body}"))
-                .bean(messageConsumer, "consume");
+            .id("test_route_id")
+            .setProperty("configuration", simple("${body}"))
+            .bean(messageConsumer, "consume");
 
         from(wfsHarvesterParamConsumer.getUri())
-                .id("test_route_id_for_wfs_harvester_param")
-                .setProperty("configuration", simple("${body.parameters}"))
-                .bean(wfsHarvesterParamConsumer, "consume");
+            .id("test_route_id_for_wfs_harvester_param")
+            .setProperty("configuration", simple("${body.parameters}"))
+            .bean(wfsHarvesterParamConsumer, "consume");
 
     }
 }

--- a/workers/camelPeriodicProducer/src/test/resources/domain-repository-test-context.xml
+++ b/workers/camelPeriodicProducer/src/test/resources/domain-repository-test-context.xml
@@ -89,4 +89,9 @@
   <bean id="savedQuery" class="org.fao.geonet.api.records.MetadataSavedQueryApi"/>
   <bean id="schemaManager" class="org.fao.geonet.kernel.SchemaManager"/>
 
+  <bean id="servletContext" class="org.fao.geonet.GeonetMockServletContext"/>
+  <bean id="strongEncryptor"
+        class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor" />
+  <bean id="settingsManager" class="org.fao.geonet.kernel.setting.SettingManager"/>
+
 </beans>


### PR DESCRIPTION
When running multiple GeoNetwork on same Jetty, the following error will happen on startup
```
2021-05-04 14:30:51,431 ERROR [jeeves] - JeevesContextLoaderListener:
Error creating bean with name 'org.fao.geonet.camelPeriodicProducer.MessageProducerFactory#0': 
Invocation of init method failed; nested exception is org.quartz.SchedulerException: 
Unable to register scheduler with MBeanServer. [See nested exception: javax.management.InstanceAlreadyExistsException:
 quartz:type=QuartzScheduler,name=DefaultQuartzScheduler-harvest-wfs,instance=NON_CLUSTERED]
```
and one of the web app will not be available.

Using IGNORE_EXISTING registration policy seems to solve the issue but is maybe not the perfect fix ?

It looks like progress status are mixed up between apps. So maybe some progress indicator ids should contain webapp name or node uuid ?


![image](https://user-images.githubusercontent.com/1701393/117456397-6c097f80-af48-11eb-801d-78ced5be69bb.png)


@cmangeat any experience on this ?