### PR TITLE
DOI / Improvements

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/ApplicableSchematron.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ApplicableSchematron.java
@@ -44,7 +44,7 @@ public class ApplicableSchematron {
         return schematron;
     }
 
-    ApplicableSchematron(SchematronRequirement requirement, Schematron schematron) {
+    public ApplicableSchematron(SchematronRequirement requirement, Schematron schematron) {
         this.requirement = requirement;
         this.schematron = schematron;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/SchematronValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchematronValidator.java
@@ -51,7 +51,16 @@ import java.util.List;
 public class SchematronValidator extends AbstractSchematronValidator {
 
     public Element applyCustomSchematronRules(String schema, int metadataId, Element md,
-                                              String lang, List<MetadataValidation> validations) {
+                                              String lang,
+                                              List<MetadataValidation> validations) {
+        return applyCustomSchematronRules(schema, metadataId, md, lang,
+            validations, null);
+    }
+
+    public Element applyCustomSchematronRules(String schema, int metadataId, Element md,
+                                              String lang,
+                                              List<MetadataValidation> validations,
+                                              List<ApplicableSchematron> onlyForSchematronList) {
         SchemaManager schemaManager = ApplicationContextHolder.get().getBean(SchemaManager.class);
 
         MetadataSchema metadataSchema = schemaManager.getSchema(schema);
@@ -59,7 +68,10 @@ public class SchematronValidator extends AbstractSchematronValidator {
 
         Element schemaTronXmlOut = new Element("schematronerrors", Edit.NAMESPACE);
         try {
-            List<ApplicableSchematron> applicableSchematron = getApplicableSchematronList(metadataId, md, metadataSchema);
+            List<ApplicableSchematron> applicableSchematron =
+                onlyForSchematronList == null
+                    ? getApplicableSchematronList(metadataId, md, metadataSchema)
+                    : onlyForSchematronList;
 
             for (ApplicableSchematron applicable : applicableSchematron) {
                 runSchematron(lang, schemaDir, validations, schemaTronXmlOut, metadataId, md, applicable);

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiClient.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiClient.java
@@ -56,6 +56,7 @@ public class DoiClient {
     public static final String DOI_ENTITY = "DOI";
     public static final String ALL_DOI_ENTITY = "All DOI";
     public static final String DOI_METADATA_ENTITY = "DOI metadata";
+
     private String serverUrl;
     private String username;
     private String password;
@@ -355,7 +356,7 @@ public class DoiClient {
      * @param service
      * @return
      */
-    private String createUrl(String service) {
+    public String createUrl(String service) {
         return this.serverUrl +
             (this.serverUrl.endsWith("/") ? "" : "/") +
             service;

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
@@ -58,7 +58,6 @@ public class DoiManager {
     private static final String DOI_REMOVE_XSL_PROCESS = "process/doi-remove.xsl";
     public static final String DATACITE_XSL_CONVERSION_FILE = "formatter/datacite/view.xsl";
     public static final String DOI_PREFIX_PARAMETER = "doiPrefix";
-    public static final String HTTPS_DOI_ORG = "https://doi.org/";
 
     private DoiClient client;
     private String doiPrefix;
@@ -209,14 +208,14 @@ public class DoiManager {
             String currentDoi = schema.queryString(DOI_GET_SAVED_QUERY, xml);
             if (StringUtils.isNotEmpty(currentDoi)) {
                 // Current doi does not match the one going to be inserted. This is odd
-                if (!currentDoi.equals(HTTPS_DOI_ORG + doi)) {
+                if (!currentDoi.equals(client.createUrl("") + doi)) {
                     throw new DoiClientException(String.format(
                         "Record '%s' already contains a DOI '%s' which is not equal " +
                             "to the DOI about to be created (ie. '%s'). " +
                             "Maybe current DOI does not correspond to that record? " +
                             "This may happen when creating a copy of a record having " +
                             "an existing DOI.",
-                        metadata.getUuid(), currentDoi, HTTPS_DOI_ORG + doi));
+                        metadata.getUuid(), currentDoi, client.createUrl("") + doi));
                 }
 
                 throw new DoiClientException(String.format(
@@ -259,8 +258,8 @@ public class DoiManager {
         } catch (Exception e) {
             throw new DoiClientException(String.format(
                 "Record '%s' converted to DataCite format is invalid. Error is: %s. " +
-                    "Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. Check the DataCite format output at " +
-                    "%sapi/records/%s/formatters/datacite?output=xml and " +
+                    "Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. " +
+                    "<a href='%sapi/records/%s/formatters/datacite?output=xml'>Check the DataCite format output</a> and " +
                     "adapt the record content to add missing information.",
                 metadata.getUuid(), e.getMessage(), sm.getNodeURL(), metadata.getUuid()));
         }
@@ -271,9 +270,11 @@ public class DoiManager {
         final String doiResponse = client.retrieveDoi(doi);
         if (doiResponse != null) {
             throw new DoiClientException(String.format(
-                "Record '%s' looks to be already published on DataCite on DOI '%s'. Check DataCite DOI: %s. " +
+                "Record '%s' looks to be already published on DataCite with DOI <a href='%s'>'%s'</a>. DOI on Datacite point to: <a href='%s'>%s</a>. " +
                     "If the DOI is not correct, remove it from the record and ask for a new one.",
-                metadata.getUuid(), doi, doiResponse));
+                metadata.getUuid(),
+                client.createUrl("doi") + "/" + doi,
+                doi, doi, doiResponse));
         }
         // TODO: Could be relevant at some point to return states (draft/findable)
 
@@ -305,20 +306,19 @@ public class DoiManager {
         String landingPage = landingPageTemplate.replace(
                         "{{uuid}}", metadata.getUuid());
         doiInfo.put("doiLandingPage", landingPage);
+        doiInfo.put("doiUrl",
+            client.createUrl("doi") + "/" + doiInfo.get("doi"));
         client.createDoi(doiInfo.get("doi"), landingPage);
 
 
         // Add the DOI in the record
-        Element recordWithDoi = setDOIValue(doiInfo.get("doi"), metadata.getDataInfo().getSchemaId(), metadata.getXmlData(false));
+        Element recordWithDoi = setDOIValue(doiInfo.get("doiUrl"), metadata.getDataInfo().getSchemaId(), metadata.getXmlData(false));
         // Update the published copy
         //--- needed to detach md from the document
 //        md.detach();
 
         dm.updateMetadata(context, metadata.getId() + "", recordWithDoi, false, true, true,
             context.getLanguage(), new ISODate().toString(), true);
-
-        doiInfo.put("doiUrl", HTTPS_DOI_ORG + doiInfo.get("doi"));
-
     }
 
 
@@ -377,7 +377,7 @@ public class DoiManager {
         }
 
         Map<String, Object> params = new HashMap<>(1);
-        params.put("doi", HTTPS_DOI_ORG + doi);
+        params.put("doi", doi);
         return Xml.transform(md, styleSheet, params);
     }
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/schematron-rules-datacite.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/schematron-rules-datacite.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<strings>
+  <datacite.mandatory>Mandatory fields</datacite.mandatory>
+
+  <datacite.identifier.missing>The identifier is missing. The Identifier is a unique
+    string that identifies a resource. This field is mandatory.
+  </datacite.identifier.missing>
+  <datacite.identifier.present>The identifier is: </datacite.identifier.present>
+
+  <datacite.type.missing>The type is missing. Check the metadata section and set the hierarchy level. This field is mandatory.
+  </datacite.type.missing>
+  <datacite.type.present>The resource type is: </datacite.type.present>
+
+  <datacite.title.missing>The title is missing. A name or title by which a
+    resource is known. May be
+    the title of a dataset or the
+    name of a piece of software. This field is mandatory.
+  </datacite.title.missing>
+  <datacite.title.present>The title is:</datacite.title.present>
+
+  <datacite.publicationDate.missing>Publication year is missing. The year when the data was
+    or will be made publicly
+    available. Check publication date in resource identification. This field is mandatory.
+  </datacite.publicationDate.missing>
+  <datacite.publicationDate.present>The publication date is: </datacite.publicationDate.present>
+
+  <datacite.creator.missing>Creator is missing. The main researchers involved
+    in producing the data, or the authors of the publication, in
+    priority order. To supply multiple creators, repeat this
+    property. Check point of contact in resource identification with role 'pointOfContact' or 'custodian'. This field is mandatory.
+  </datacite.creator.missing>
+  <datacite.creator.found> creator(s) found.</datacite.creator.found>
+
+  <datacite.publisher.missing>Publisher is missing. The name of the entity that
+    holds, archives, publishes
+    prints, distributes, releases,
+    issues, or produces the
+    resource. Check distribution section, the publisher is the first distributor contact. This field is mandatory.
+  </datacite.publisher.missing>
+  <datacite.publisher.present>The publisher is: </datacite.publisher.present>
+</strings>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/schematron-rules-datacite.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/schematron-rules-datacite.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<strings>
+  <datacite.mandatory>Mandatory fields</datacite.mandatory>
+
+  <datacite.identifier.missing>The identifier is missing. The Identifier is a unique
+    string that identifies a resource. This field is mandatory.
+  </datacite.identifier.missing>
+  <datacite.identifier.present>The identifier is: </datacite.identifier.present>
+
+  <datacite.type.missing>The type is missing. Check the metadata section and set the hierarchy level. This field is mandatory.
+  </datacite.type.missing>
+  <datacite.type.present>The resource type is: </datacite.type.present>
+
+  <datacite.title.missing>The title is missing. A name or title by which a
+    resource is known. May be
+    the title of a dataset or the
+    name of a piece of software. This field is mandatory.
+  </datacite.title.missing>
+  <datacite.title.present>The title is:</datacite.title.present>
+
+  <datacite.publicationDate.missing>Publication year is missing. The year when the data was
+    or will be made publicly
+    available. Check publication date in resource identification. This field is mandatory.
+  </datacite.publicationDate.missing>
+  <datacite.publicationDate.present>The publication date is: </datacite.publicationDate.present>
+
+  <datacite.creator.missing>Creator is missing. The main researchers involved
+    in producing the data, or the authors of the publication, in
+    priority order. To supply multiple creators, repeat this
+    property. Check point of contact in resource identification with role 'pointOfContact' or 'custodian'. This field is mandatory.
+  </datacite.creator.missing>
+  <datacite.creator.found> creator(s) found.</datacite.creator.found>
+
+  <datacite.publisher.missing>Publisher is missing. The name of the entity that
+    holds, archives, publishes
+    prints, distributes, releases,
+    issues, or produces the
+    resource. Check distribution section, the publisher is the first distributor contact. This field is mandatory.
+  </datacite.publisher.missing>
+  <datacite.publisher.present>The publisher is: </datacite.publisher.present>
+</strings>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/doi-add.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/doi-add.xsl
@@ -4,6 +4,7 @@
                 xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
                 xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                 xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -15,12 +16,21 @@
 
   <xsl:param name="doi"
              select="''"/>
+  <xsl:variable name="doiProtocol"
+                select="'DOI'"/>
+  <xsl:variable name="doiName"
+                select="'Digital Object Identifier (DOI)'"/>
+  <xsl:param name="doiProtocolRegex"
+             select="'(DOI|WWW:LINK-1.0-http--metadata-URL)'"/>
 
   <xsl:variable name="isDoiAlreadySet"
                 select="count(//mdb:identificationInfo/*/mri:citation/*/
                               cit:identifier/*/mcc:code[
                                 contains(*/text(), 'doi.org')
                                 or contains(*/@xlink:href, 'doi.org')]) > 0"/>
+
+<!--  <xsl:variable name="isDoiAlreadySet"-->
+<!--                select="count(//mdb:distributionInfo//mrd:onLine/*[matches(cit:protocol/gco:CharacterString, $doiProtocolRegex)]/cit:linkage/gco:CharacterString[. != '']) > 0"/>-->
 
 
   <xsl:template match="mdb:identificationInfo[1]/*/mri:citation/*[not($isDoiAlreadySet)]"
@@ -63,6 +73,36 @@
                           "/>
     </xsl:copy>
   </xsl:template>
+
+
+  <!--<xsl:template match="mdb:distributionInfo[not($isDoiAlreadySet) and position() = 1]">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <mrd:MD_Distribution>
+        <xsl:apply-templates select="*/@*"/>
+        <xsl:apply-templates select="*/mrd:distributionFormat"/>
+        <xsl:apply-templates select="*/mrd:distributor"/>
+        <xsl:apply-templates select="*/mrd:transferOptions"/>
+        <mrd:transferOptions>
+          <mrd:MD_DigitalTransferOptions>
+            <mrd:onLine>
+              <cit:CI_OnlineResource>
+                <cit:linkage>
+                  <gco:CharacterString><xsl:value-of select="$doi"/></gco:CharacterString>
+                </cit:linkage>
+                <cit:protocol>
+                  <gco:CharacterString><xsl:value-of select="$doiProtocol"/></gco:CharacterString>
+                </cit:protocol>
+                <cit:name>
+                  <gco:CharacterString><xsl:value-of select="$doiName"/></gco:CharacterString>
+                </cit:name>
+              </cit:CI_OnlineResource>
+            </mrd:onLine>
+          </mrd:MD_DigitalTransferOptions>
+        </mrd:transferOptions>
+      </mrd:MD_Distribution>
+    </xsl:copy>
+  </xsl:template>-->
 
   <!-- Do a copy of every nodes and attributes -->
   <xsl:template match="@*|node()">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schematron/schematron-rules-datacite.sch
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schematron/schematron-rules-datacite.sch
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+>
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">Datacite (DOI)</sch:title>
+  <sch:ns prefix="gml" uri="http://www.opengis.net/gml"/>
+  <sch:ns prefix="gmd" uri="http://standards.iso.org/iso/19115/-3/gmd"/>
+  <sch:ns prefix="gmx" uri="http://standards.iso.org/iso/19115/-3/gmx"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="srv" uri="http://standards.iso.org/iso/19115/-3/srv/2.0"/>
+  <sch:ns prefix="mdb" uri="http://standards.iso.org/iso/19115/-3/mdb/2.0"/>
+  <sch:ns prefix="mcc" uri="http://standards.iso.org/iso/19115/-3/mcc/1.0"/>
+  <sch:ns prefix="mri" uri="http://standards.iso.org/iso/19115/-3/mri/1.0"/>
+  <sch:ns prefix="mrs" uri="http://standards.iso.org/iso/19115/-3/mrs/1.0"/>
+  <sch:ns prefix="mrd" uri="http://standards.iso.org/iso/19115/-3/mrd/1.0"/>
+  <sch:ns prefix="mco" uri="http://standards.iso.org/iso/19115/-3/mco/1.0"/>
+  <sch:ns prefix="msr" uri="http://standards.iso.org/iso/19115/-3/msr/2.0"/>
+  <sch:ns prefix="lan" uri="http://standards.iso.org/iso/19115/-3/lan/1.0"/>
+  <sch:ns prefix="gcx" uri="http://standards.iso.org/iso/19115/-3/gcx/1.0"/>
+  <sch:ns prefix="gex" uri="http://standards.iso.org/iso/19115/-3/gex/1.0"/>
+  <sch:ns prefix="dqm" uri="http://standards.iso.org/iso/19157/-2/dqm/1.0"/>
+  <sch:ns prefix="cit" uri="http://standards.iso.org/iso/19115/-3/cit/2.0"/>
+  <sch:ns prefix="mdq" uri="http://standards.iso.org/iso/19157/-2/mdq/1.0"/>
+  <sch:ns prefix="mrl" uri="http://standards.iso.org/iso/19115/-3/mrl/2.0"/>
+  <sch:ns prefix="gco" uri="http://standards.iso.org/iso/19115/-3/gco/1.0"/>
+
+  <sch:pattern>
+    <sch:title>$loc/strings/datacite.mandatory</sch:title>
+    <sch:rule
+      context="//mdb:MD_Metadata|//*[@gco:isoType='mdb:MD_Metadata']">
+
+      <sch:let name="title"
+               value="mdb:identificationInfo/*/mri:citation/*/cit:title"/>
+
+      <sch:assert test="$title != ''">$loc/strings/datacite.title.missing</sch:assert>
+      <sch:report test="$title != ''">
+        <sch:value-of select="$loc/strings/datacite.title.present"/>
+        <sch:value-of select="$title"/>
+      </sch:report>
+
+
+      <sch:let name="identifier"
+               value="string-join(mdb:metadataIdentifier/*/mcc:code/gco:CharacterString, ', ')"/>
+
+      <sch:assert test="$identifier != ''">$loc/strings/datacite.identifier.missing</sch:assert>
+      <sch:report test="$identifier != ''">
+        <sch:value-of select="$loc/strings/datacite.identifier.present"/>
+        "<sch:value-of select="normalize-space($identifier)"/>"
+      </sch:report>
+
+
+      <sch:let name="numberOfCreators"
+               value="count(mdb:identificationInfo/*/mri:pointOfContact/*[cit:role/*/@codeListValue = ('pointOfContact', 'custodian')])"/>
+
+      <sch:assert test="$numberOfCreators > 0">$loc/strings/datacite.creator.missing</sch:assert>
+      <sch:report test="$numberOfCreators > 0">
+        <sch:value-of select="$numberOfCreators"/>
+        <sch:value-of select="$loc/strings/datacite.creator.found"/>
+      </sch:report>
+
+
+      <sch:let name="publisher"
+               value="(mdb:distributionInfo//mrd:distributorContact)[1]//cit:CI_Organisation/cit:name/gco:CharacterString"/>
+
+      <sch:assert test="$publisher != ''">$loc/strings/datacite.publisher.missing</sch:assert>
+      <sch:report test="$publisher != ''">
+        <sch:value-of select="$loc/strings/datacite.publisher.present"/>
+        <sch:value-of select="$publisher"/>
+      </sch:report>
+
+
+      <sch:let name="publicationDate"
+               value="string-join(mdb:identificationInfo/*/mri:citation/*/cit:date/*[cit:dateType/*/@codeListValue = 'publication'], ', ')"/>
+
+      <sch:assert test="$publicationDate != ''">$loc/strings/datacite.publicationDate.missing</sch:assert>
+      <sch:report test="$publicationDate != ''">
+        <sch:value-of select="$loc/strings/datacite.publicationDate.present"/>
+        <sch:value-of select="$publicationDate"/>
+      </sch:report>
+
+      <sch:let name="type"
+               value="string-join(mdb:metadataScope/*/mdb:resourceScope/*/@codeListValue, ', ')"/>
+
+      <sch:assert test="$type != ''">$loc/strings/datacite.type.missing</sch:assert>
+      <sch:report test="$type != ''">
+        <sch:value-of select="$loc/strings/datacite.type.present"/>
+        <sch:value-of select="$type"/>
+      </sch:report>
+
+    </sch:rule>
+  </sch:pattern>
+</sch:schema>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/schematron-rules-datacite.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/schematron-rules-datacite.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<strings>
+  <datacite.mandatory>Mandatory fields</datacite.mandatory>
+
+  <datacite.identifier.missing>The identifier is missing. The Identifier is a unique
+    string that identifies a resource. This field is mandatory.
+  </datacite.identifier.missing>
+  <datacite.identifier.present>The identifier is: </datacite.identifier.present>
+
+  <datacite.type.missing>The type is missing. Check the metadata section and set the hierarchy level. This field is mandatory.
+  </datacite.type.missing>
+  <datacite.type.present>The resource type is: </datacite.type.present>
+
+  <datacite.title.missing>The title is missing. A name or title by which a
+    resource is known. May be
+    the title of a dataset or the
+    name of a piece of software. This field is mandatory.
+  </datacite.title.missing>
+  <datacite.title.present>The title is:</datacite.title.present>
+
+  <datacite.publicationDate.missing>Publication year is missing. The year when the data was
+    or will be made publicly
+    available. Check publication date in resource identification. This field is mandatory.
+  </datacite.publicationDate.missing>
+  <datacite.publicationDate.present>The publication date is: </datacite.publicationDate.present>
+
+  <datacite.creator.missing>Creator is missing. The main researchers involved
+    in producing the data, or the authors of the publication, in
+    priority order. To supply multiple creators, repeat this
+    property. Check point of contact in resource identification with role 'pointOfContact' or 'custodian'. This field is mandatory.
+  </datacite.creator.missing>
+  <datacite.creator.found> creator(s) found.</datacite.creator.found>
+
+  <datacite.publisher.missing>Publisher is missing. The name of the entity that
+    holds, archives, publishes
+    prints, distributes, releases,
+    issues, or produces the
+    resource. Check distribution section, the publisher is the first distributor contact. This field is mandatory.
+  </datacite.publisher.missing>
+  <datacite.publisher.present>The publisher is: </datacite.publisher.present>
+</strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/schematron-rules-datacite.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/schematron-rules-datacite.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<strings>
+  <datacite.mandatory>Mandatory fields</datacite.mandatory>
+
+  <datacite.identifier.missing>The identifier is missing. The Identifier is a unique
+    string that identifies a resource. This field is mandatory.
+  </datacite.identifier.missing>
+  <datacite.identifier.present>The identifier is: </datacite.identifier.present>
+
+  <datacite.type.missing>The type is missing. Check the metadata section and set the hierarchy level. This field is mandatory.
+  </datacite.type.missing>
+  <datacite.type.present>The resource type is: </datacite.type.present>
+
+  <datacite.title.missing>The title is missing. A name or title by which a
+    resource is known. May be
+    the title of a dataset or the
+    name of a piece of software. This field is mandatory.
+  </datacite.title.missing>
+  <datacite.title.present>The title is:</datacite.title.present>
+
+  <datacite.publicationDate.missing>Publication year is missing. The year when the data was
+    or will be made publicly
+    available. Check publication date in resource identification. This field is mandatory.
+  </datacite.publicationDate.missing>
+  <datacite.publicationDate.present>The publication date is: </datacite.publicationDate.present>
+
+  <datacite.creator.missing>Creator is missing. The main researchers involved
+    in producing the data, or the authors of the publication, in
+    priority order. To supply multiple creators, repeat this
+    property. Check point of contact in resource identification with role 'pointOfContact' or 'custodian'. This field is mandatory.
+  </datacite.creator.missing>
+  <datacite.creator.found> creator(s) found.</datacite.creator.found>
+
+  <datacite.publisher.missing>Publisher is missing. The name of the entity that
+    holds, archives, publishes
+    prints, distributes, releases,
+    issues, or produces the
+    resource. Check distribution section, the publisher is the first distributor contact. This field is mandatory.
+  </datacite.publisher.missing>
+  <datacite.publisher.present>The publisher is: </datacite.publisher.present>
+</strings>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/doi-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/doi-add.xsl
@@ -76,7 +76,7 @@
   so it should always exist).
 
   Adding a new transfer option block. 
-  <xsl:template match="gmd:distributionInfo[not($isDoiAlreadSet) and position() = 1]"
+  <xsl:template match="gmd:distributionInfo[not($isDoiAlreadySet) and position() = 1]"
                 priority="2">
     <xsl:copy>
       <xsl:apply-templates select="@*"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/doi-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/doi-add.xsl
@@ -70,26 +70,40 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Insert the DOI after the last onLine element of the first distributionInfo section.
-   This expect to have one onLine element at least.
-  <xsl:template match="gmd:distributionInfo[1]/*/gmd:transferOptions/*/gmd:onLine[
-                              not($isDoiAlreadySet) and
-                              name(following-sibling::*[1]) != 'gmd:onLine']"
+  <!-- Insert the DOI in the first distributionInfo section
+  (a distribution format is mandatory in ISO
+  and a publisher (distributor) is required for a DOI
+  so it should always exist).
+
+  Adding a new transfer option block. 
+  <xsl:template match="gmd:distributionInfo[not($isDoiAlreadSet) and position() = 1]"
                 priority="2">
-    <xsl:copy-of select="."/>
-    <gmd:onLine>
-      <gmd:CI_OnlineResource>
-        <gmd:linkage>
-          <gmd:URL><xsl:value-of select="$doi"/></gmd:URL>
-        </gmd:linkage>
-        <gmd:protocol>
-          <gco:CharacterString><xsl:value-of select="$doiProtocol"/></gco:CharacterString>
-        </gmd:protocol>
-        <gmd:name>
-          <gco:CharacterString><xsl:value-of select="$doiName"/></gco:CharacterString>
-        </gmd:name>
-      </gmd:CI_OnlineResource>
-    </gmd:onLine>
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <gmd:MD_Distribution>
+        <xsl:apply-templates select="*/@*"/>
+        <xsl:apply-templates select="*/gmd:distributionFormat"/>
+        <xsl:apply-templates select="*/gmd:distributor"/>
+        <xsl:apply-templates select="*/gmd:transferOptions"/>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL><xsl:value-of select="$doi"/></gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString><xsl:value-of select="$doiProtocol"/></gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name>
+                  <gco:CharacterString><xsl:value-of select="$doiName"/></gco:CharacterString>
+                </gmd:name>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+      </gmd:MD_Distribution>
+    </xsl:copy>
   </xsl:template>
   -->
 

--- a/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-datacite.sch
+++ b/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-datacite.sch
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+>
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">Datacite (DOI)</sch:title>
+  <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+  <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+
+  <sch:pattern>
+    <sch:title>$loc/strings/datacite.mandatory</sch:title>
+    <sch:rule
+      context="//gmd:MD_Metadata|//*[@gco:isoType='gmd:MD_Metadata']">
+
+      <sch:let name="title"
+               value="gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>
+
+      <sch:assert test="$title != ''">$loc/strings/datacite.title.missing</sch:assert>
+      <sch:report test="$title != ''">
+        <sch:value-of select="$loc/strings/datacite.title.present"/>
+        <sch:value-of select="$title"/>
+      </sch:report>
+
+
+      <sch:let name="identifier"
+               value="gmd:fileIdentifier/gco:CharacterString"/>
+
+      <sch:assert test="$identifier != ''">$loc/strings/datacite.identifier.missing</sch:assert>
+      <sch:report test="$identifier != ''">
+        <sch:value-of select="$loc/strings/datacite.identifier.present"/>
+        "<sch:value-of select="normalize-space($identifier)"/>"
+      </sch:report>
+
+
+      <sch:let name="numberOfCreators"
+               value="count(gmd:identificationInfo/*/gmd:pointOfContact/*[gmd:role/*/@codeListValue = ('pointOfContact', 'custodian')])"/>
+
+      <sch:assert test="$numberOfCreators > 0">$loc/strings/datacite.creator.missing</sch:assert>
+      <sch:report test="$numberOfCreators > 0">
+        <sch:value-of select="$numberOfCreators"/>
+        <sch:value-of select="$loc/strings/datacite.creator.found"/>
+      </sch:report>
+
+
+      <sch:let name="publisher"
+               value="(gmd:distributionInfo//gmd:distributorContact)[1]/*/gmd:organisationName/gco:CharacterString"/>
+
+      <sch:assert test="$publisher != ''">$loc/strings/datacite.publisher.missing</sch:assert>
+      <sch:report test="$publisher != ''">
+        <sch:value-of select="$loc/strings/datacite.publisher.present"/>
+        <sch:value-of select="$publisher"/>
+      </sch:report>
+
+
+      <sch:let name="publicationDate"
+               value="string-join(gmd:identificationInfo/*/gmd:citation/*/gmd:date/*[gmd:dateType/*/@codeListValue = 'publication'], ', ')"/>
+
+      <sch:assert test="$publicationDate != ''">$loc/strings/datacite.publicationDate.missing</sch:assert>
+      <sch:report test="$publicationDate != ''">
+        <sch:value-of select="$loc/strings/datacite.publicationDate.present"/>
+        <sch:value-of select="$publicationDate"/>
+      </sch:report>
+
+      <sch:let name="type"
+               value="string-join(gmd:hierarchyLevel/*/@codeListValue, ', ')"/>
+
+      <sch:assert test="$type != ''">$loc/strings/datacite.type.missing</sch:assert>
+      <sch:report test="$type != ''">
+        <sch:value-of select="$loc/strings/datacite.type.present"/>
+        <sch:value-of select="$type"/>
+      </sch:report>
+
+    </sch:rule>
+  </sch:pattern>
+</sch:schema>

--- a/web-ui/src/main/resources/catalog/components/history/partials/historyStep.html
+++ b/web-ui/src/main/resources/catalog/components/history/partials/historyStep.html
@@ -113,12 +113,12 @@
            data-gn-click-and-spin="closeTask(h)">closeTask</a>
 
         <div data-ng-if="response.doiCreationTask.check"
-             data-ng-class="{'text-danger': response.doiCreationTask.check.status === 400}">
-        {{response.doiCreationTask.check.data.description}}
+             data-ng-class="{'text-danger': response.doiCreationTask.check.status === 400}"
+             data-ng-bind-html="response.doiCreationTask.check.data.description">
         </div>
         <div data-ng-if="response.doiCreationTask.create"
-             data-ng-class="{'text-danger': response.doiCreationTask.create.status === 400}">
-          {{response.doiCreationTask.create.data.description}}
+             data-ng-class="{'text-danger': response.doiCreationTask.create.status === 400}"
+             data-ng-bind-html="response.doiCreationTask.create.data.description">
         </div>
       </div>
     </div>


### PR DESCRIPTION
* Improve insert point when using online resource. Some records may not have gmd:onLine. Insert into first distribution section and add an extra transfert option for the DOI.
* ISO19115-3 / Add example to insert DOI in online resource (default is resource identifier)
* Add hyperlink in validation status response to easily preview the Datacite format
* Avoid hardcoded API - user may be using test env depending on configuration.

![image](https://user-images.githubusercontent.com/1701393/117478174-1a202400-af5f-11eb-9f4e-535339e3ec35.png)

* Add Datacite schematron for easier check (XSD parser error are not that easy to solve by users).

![image](https://user-images.githubusercontent.com/1701393/117772240-3fe74a80-b237-11eb-8712-e2aa9683f167.png)


* Check schematron rules from admin task management (Then XSD parser is used, so user will be able to easily identify which mandatory fields are missing first).

![image](https://user-images.githubusercontent.com/1701393/118508156-36764a80-b72f-11eb-8a9f-8396262fa5ce.png)

