### PR TITLE
Keycloak set csrf 3.12.x

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-security/config-security-keycloak.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-keycloak.xml
@@ -118,6 +118,9 @@
 
   <util:list id="keycloakFilterChanFiltersExclusive">
     <ref bean="securityContextPersistenceFilter" />
+    <!-- To disable csrf security (not recommended) comment the following line -->
+		<ref bean="csrfFilter" />
+		<!-- To disable csrf security (not recommended) comment the upper line -->
     <ref bean="logoutFilter" />
     <ref bean="keycloakPreAuthActionsLoginFilter" />
     <ref bean="keycloakAuthenticationProcessingFilter" />
@@ -130,6 +133,9 @@
 
   <util:list id="keycloakFilterChanFiltersLink">
     <ref bean="securityContextPersistenceFilter" />
+    <!-- To disable csrf security (not recommended) comment the following line -->
+		<ref bean="csrfFilter" />
+		<!-- To disable csrf security (not recommended) comment the upper line -->
     <ref bean="logoutFilter" />
     <ref bean="keycloakPreAuthActionsFilter" />
     <ref bean="keycloakAuthenticationProcessingFilter" />


### PR DESCRIPTION
When using Geonetwork integrated with Keycloak, the CSRF token is not set, resulting in security vulnerabilities. 
This adds csrfFilter to lists of filters that missed it. 