### PR TITLE
Formatter / Template field may generate self closing tag and break HT…

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -519,6 +519,7 @@
               </xsl:apply-templates>
             </xsl:for-each>
           </xsl:for-each>
+          &#160;
         </div>
       </xsl:for-each>
     </div>


### PR DESCRIPTION
…ML layout

When this happen the side panel is usually displayed in the main form.


```
Self-closing syntax (“/>”) used on a non-void HTML element. Ignoring the slash and treating as a start tag.
```

Generated:

```html
<div class="entry name gn-field-template">
<h5>Date de création</h5>
<div class="target"/>
</div>
```