### PR TITLE
Formatter / Improve rendering of line breaks, hyperlinks and email links

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -585,7 +585,7 @@
     <xsl:variable name="email">
       <xsl:for-each select="*/gmd:contactInfo/
                                       */gmd:address/*/gmd:electronicMailAddress">
-        <xsl:apply-templates mode="render-value"
+        <xsl:apply-templates mode="render-value-no-breaklines"
                              select="."/><xsl:if test="position() != last()">, </xsl:if>
       </xsl:for-each>
     </xsl:variable>
@@ -596,19 +596,19 @@
     <!-- with separator/parentheses as required -->
     <xsl:variable name="displayName">
       <xsl:if test="*/gmd:organisationName">
-        <xsl:apply-templates mode="render-value" select="*/gmd:organisationName"/>
+        <xsl:apply-templates mode="render-value-no-breaklines" select="*/gmd:organisationName"/>
       </xsl:if>
       <xsl:if test="*/gmd:organisationName and */gmd:individualName|*/gmd:positionName"> - </xsl:if>
       <xsl:if test="*/gmd:individualName">
-        <xsl:apply-templates mode="render-value" select="*/gmd:individualName"/>
+        <xsl:apply-templates mode="render-value-no-breaklines" select="*/gmd:individualName"/>
       </xsl:if>
       <xsl:if test="*/gmd:positionName">
         <xsl:choose>
           <xsl:when test="*/gmd:individualName">
-            (<xsl:apply-templates mode="render-value" select="*/gmd:positionName"/>)
+            (<xsl:apply-templates mode="render-value-no-breaklines" select="*/gmd:positionName"/>)
           </xsl:when>
           <xsl:otherwise>
-            <xsl:apply-templates mode="render-value" select="*/gmd:positionName"/>
+            <xsl:apply-templates mode="render-value-no-breaklines" select="*/gmd:positionName"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:if>
@@ -622,7 +622,7 @@
         <div class="gn-contact">
           <strong>
             <xsl:comment select="'email'"/>
-            <xsl:apply-templates mode="render-value"
+            <xsl:apply-templates mode="render-value-no-breaklines"
                                  select="*/gmd:role/*/@codeListValue"/>
           </strong>
           <address>
@@ -643,19 +643,19 @@
                 <div>
                 <i class="fa fa-fw fa-map-marker"><xsl:comment select="'address'"/></i>
                   <xsl:for-each select="gmd:deliveryPoint[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>,
+                    <xsl:apply-templates mode="render-value-no-breaklines" select="."/>,
                   </xsl:for-each>
                   <xsl:for-each select="gmd:city[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>,
+                    <xsl:apply-templates mode="render-value-no-breaklines" select="."/>,
                   </xsl:for-each>
                   <xsl:for-each select="gmd:administrativeArea[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>,
+                    <xsl:apply-templates mode="render-value-no-breaklines" select="."/>,
                   </xsl:for-each>
                   <xsl:for-each select="gmd:postalCode[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>,
+                    <xsl:apply-templates mode="render-value-no-breaklines" select="."/>,
                   </xsl:for-each>
                   <xsl:for-each select="gmd:country[normalize-space(.) != '']">
-                      <xsl:apply-templates mode="render-value" select="."/>
+                    <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                   </xsl:for-each>
                 </div>
               </xsl:for-each>
@@ -663,7 +663,7 @@
             <xsl:for-each select="*/gmd:contactInfo/*">
               <xsl:for-each select="gmd:phone/*/gmd:voice[normalize-space(.) != '']">
                   <xsl:variable name="phoneNumber">
-                    <xsl:apply-templates mode="render-value" select="."/>
+                    <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                   </xsl:variable>
                   <i class="fa fa-fw fa-phone"><xsl:comment select="'phone'"/></i>
                   <a href="tel:{translate($phoneNumber,' ','')}">
@@ -737,11 +737,11 @@
         <xsl:variable name="linkName">
           <xsl:choose>
             <xsl:when test="*/gmd:name[* != '']">
-              <xsl:apply-templates mode="render-value"
+              <xsl:apply-templates mode="render-value-no-breaklines"
                                    select="*/gmd:name"/>
             </xsl:when>
             <xsl:when test="*/gmd:description[* != '']">
-              <xsl:apply-templates mode="render-value"
+              <xsl:apply-templates mode="render-value-no-breaklines"
                                    select="*/gmd:description"/>
             </xsl:when>
             <xsl:otherwise>
@@ -755,9 +755,9 @@
           </span>
         </a>
         <xsl:if test="*/gmd:protocol[normalize-space(gco:CharacterString|gmx:Anchor) != '']">
-        (<span><xsl:comment select="name()"/>
-          <xsl:apply-templates mode="render-value"
-                   select="*/gmd:protocol"/>
+          (<span><xsl:comment select="name()"/>
+          <xsl:apply-templates mode="render-value-no-breaklines"
+                               select="*/gmd:protocol"/>
         </span>)</xsl:if>
         <xsl:if test="*/gmd:description[normalize-space(gco:CharacterString|gmx:Anchor) != '' and * != $linkName]">
           <p><xsl:comment select="name()"/>
@@ -783,20 +783,20 @@
       <dd>
 
         <xsl:if test="*/gmd:codeSpace">
-          <xsl:apply-templates mode="render-value"
+          <xsl:apply-templates mode="render-value-no-breaklines"
                                select="*/gmd:codeSpace"/>
           /
         </xsl:if>
-        <xsl:apply-templates mode="render-value"
+        <xsl:apply-templates mode="render-value-no-breaklines"
                              select="*/gmd:code"/>
         <xsl:if test="*/gmd:version">
           /
-          <xsl:apply-templates mode="render-value"
+          <xsl:apply-templates mode="render-value-no-breaklines"
                                select="*/gmd:version"/>
         </xsl:if>
         <xsl:if test="*/gmd:authority">
           <p><xsl:comment select="name()"/>
-            <xsl:apply-templates mode="render-field"
+            <xsl:apply-templates mode="render-value-no-breaklines"
                                  select="*/gmd:authority"/>
           </p>
         </xsl:if>
@@ -882,9 +882,9 @@
           <xsl:for-each select="parent::node()/gmd:distributionFormat">
             <xsl:if test="*/gmd:name[. != '']">
               <li>
-                <xsl:apply-templates mode="render-value"
+                <xsl:apply-templates mode="render-value-no-breaklines"
                                     select="*/gmd:name"/>
-                (<xsl:apply-templates mode="render-value"
+                (<xsl:apply-templates mode="render-value-no-breaklines"
                                       select="*/gmd:version"/>)
                 <p><xsl:comment select="name()"/>
                   <xsl:apply-templates mode="render-field"
@@ -1023,6 +1023,32 @@
       </xsl:call-template>
      </span>
   </xsl:template>
+
+  <xsl:template mode="render-value-no-breaklines"
+                match="*[gco:CharacterString]">
+
+    <xsl:variable name="txtNonNormalized">
+      <xsl:apply-templates mode="localised" select=".">
+        <xsl:with-param name="langId" select="$langId"/>
+      </xsl:apply-templates>
+    </xsl:variable>
+
+    <xsl:variable name="txt" select="normalize-space($txtNonNormalized)" />
+    <span>
+      <xsl:choose>
+        <xsl:when test="name() = 'gmd:parentIdentifier'">
+          <a href="{$nodeUrl}api/records/{./gco:CharacterString}">
+            <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
+            <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
+          </a>
+        </xsl:when>
+
+      </xsl:choose><xsl:comment select="name()"/>
+      <xsl:value-of select="$txt" />
+    </span>
+  </xsl:template>
+
+
 
   <xsl:template mode="render-value"
                 match="*[gmx:Anchor|gmd:URL]">

--- a/web/src/main/webapp/xslt/common/utility-tpl.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl.xsl
@@ -22,7 +22,6 @@
   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:util="java:org.fao.geonet.util.XslUtil"
                 version="2.0">
 
   <xsl:template name="replaceString">
@@ -48,169 +47,6 @@
   </xsl:template>
 
 
-  <!--											-->
-  <!-- Adds hyperlinks to a word and adds <br/> if word is longer than max length.	-->
-  <!--											-->
-  <xsl:template name="addHyperlinksAndLineBreaksToSingleWord">
-    <xsl:param name="word"/>
-
-    <!-- if word contains ), remove remainder from processing here  -->
-    <!-- this is to cope with texts containing "(http://blah.org)," -->
-    <!-- (the part from the ')' is not part of the hyperlink)       -->
-    <xsl:variable name="word-to-use">
-      <xsl:choose>
-        <xsl:when test="contains($word, ')')">
-          <xsl:value-of select="substring-before($word, ')')"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of  select="$word"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-
-    <xsl:choose>
-      <!-- http links -->
-      <xsl:when test="substring($word-to-use, 0, 8) = 'http://'">
-        <a>
-          <xsl:attribute name="href">
-            <xsl:value-of select="$word-to-use"/>
-          </xsl:attribute>
-          <xsl:value-of select="$word-to-use"/>
-        </a>
-      </xsl:when>
-      <!-- https links -->
-      <xsl:when test="substring($word-to-use, 0, 9) = 'https://'">
-        <a>
-          <xsl:attribute name="href">
-            <xsl:value-of select="$word-to-use"/>
-          </xsl:attribute>
-          <xsl:value-of select="$word-to-use"/>
-        </a>
-      </xsl:when>
-      <!-- ftp links -->
-      <xsl:when test="substring($word-to-use, 0, 7) = 'ftp://'">
-        <a>
-          <xsl:attribute name="href">
-            <xsl:value-of select="$word-to-use"/>
-          </xsl:attribute>
-          <xsl:value-of select="$word-to-use"/>
-        </a>
-      </xsl:when>
-      <!-- mailto links -->
-      <xsl:when test="contains($word-to-use, '@')">
-        <a>
-          <xsl:attribute name="href">
-            <xsl:text>mailto:</xsl:text><xsl:value-of select="$word-to-use"/>
-          </xsl:attribute>
-          <xsl:value-of select="$word-to-use"/>
-        </a>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="$word-to-use"/>
-      </xsl:otherwise>
-    </xsl:choose>
-
-    <xsl:if test="contains($word, ')')">
-      <xsl:text>)</xsl:text><xsl:value-of select="substring-after($word, ')')"/>
-    </xsl:if>
-
-  </xsl:template>
-
-  <!--									-->
-  <!-- Just as substring-before, but matching the delimiter only if	-->
-  <!-- it occurs after position. 						-->
-  <!--									-->
-  <xsl:template name="substring-before-from">
-    <xsl:param name="start-position"/>
-    <xsl:param name="delimiter"/>
-    <xsl:param name="string"/>
-
-    <xsl:variable name="string-before-position" select="substring($string, 1, $start-position - 1)"/>
-    <xsl:variable name="string-after-position" select="substring($string, $start-position)"/>
-    <xsl:variable name="first-word-after-position" select="substring-before($string-after-position, $delimiter)"/>
-
-    <xsl:choose>
-      <xsl:when test="$first-word-after-position">
-        <xsl:value-of select="concat($string-before-position, $first-word-after-position)"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="$string"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
-
-  <!--										-->
-  <!-- Template to add HTML hyperlinks if your text contains them; also breaks 	-->
-  <!-- long words that might otherwise run outside your containing <div>.		-->
-  <!--										-->
-  <!-- Divide-and-conquer (DVC) version to avoid stack overflow for long texts 	-->
-  <!--										-->
-  <xsl:template name="addHyperlinksAndLineBreaks">
-    <xsl:param name="txt"/>
-
-    <xsl:choose>
-      <xsl:when test="util:getSettingValue('system/clickablehyperlinks/enable') = 'true'">
-
-        <xsl:variable name="nTxt" select="normalize-space($txt)"/>
-
-        <xsl:variable name="first-word" select="substring-before($nTxt,' ')"/>
-        <xsl:variable name="rest" select="substring-after($nTxt,' ')"/>
-
-        <xsl:choose>
-          <!-- there is more than 1 word -->
-          <xsl:when test="$first-word">
-            <!-- handle first word -->
-            <xsl:variable name="first-word-with-space-appended" select="concat($first-word,' ')"/>
-
-            <xsl:call-template name="addHyperlinksAndLineBreaksToSingleWord">
-              <xsl:with-param name="word" select="$first-word-with-space-appended"/>
-            </xsl:call-template>
-
-            <!-- halve the rest, breaking at space -->
-            <xsl:variable name="half-length" select="floor(string-length($rest) div 2)"/>
-
-            <xsl:variable name="first-half">
-              <xsl:call-template name="substring-before-from">
-                <xsl:with-param name="start-position" select="$half-length"/>
-                <xsl:with-param name="delimiter" select="' '"/>
-                <xsl:with-param name="string" select="$rest"/>
-              </xsl:call-template>
-            </xsl:variable>
-
-            <xsl:variable name="second-half" select="substring($rest, string-length($first-half) + 1)"/>
-
-            <!-- recursively handle the first half of the rest of the words -->
-            <xsl:call-template name="addHyperlinksAndLineBreaks">
-              <xsl:with-param name="txt" select="$first-half"/>
-            </xsl:call-template>
-
-            <!-- recursively handle the second half of the rest of the words -->
-            <xsl:call-template name="addHyperlinksAndLineBreaks">
-              <xsl:with-param name="txt" select="$second-half"/>
-            </xsl:call-template>
-
-          </xsl:when>
-          <!-- there is exactly 1 word -->
-          <xsl:when test="$txt">
-            <!-- handle the word -->
-            <xsl:variable name="word-with-space-appended" select="concat($txt,' ')"/>
-            <xsl:call-template name="addHyperlinksAndLineBreaksToSingleWord">
-              <xsl:with-param name="word" select="$word-with-space-appended"/>
-            </xsl:call-template>
-          </xsl:when>
-        </xsl:choose>
-
-
-
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:copy-of select="$txt"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
-
   <!--
         Translates CR-LF sequences into HTML newlines <p/>
         and process current line and next line to add hyperlinks.
@@ -227,149 +63,104 @@
         <xsl:for-each select="$txt/div">
           <xsl:copy>
             <xsl:copy-of select="@*"/>
-            <xsl:call-template name="addLineBreaksAndHyperlinks">
+            <xsl:call-template name="addLineBreaksAndHyperlinksInternal">
               <xsl:with-param name="txt" select="."/>
             </xsl:call-template>
           </xsl:copy>
         </xsl:for-each>
       </xsl:when>
       <xsl:otherwise>
-
-        <xsl:choose>
-          <xsl:when test="util:getSettingValue('system/clickablehyperlinks/enable') = 'true'">
-            <xsl:choose>
-              <xsl:when test="contains($txt,'&#13;&#10;')">
-                <p>
-                  <xsl:choose>
-                    <xsl:when test="contains($txt,'&#13;&#10;')">
-                      <xsl:call-template name="addLineBreaksAndHyperlinks">
-                        <xsl:with-param name="txt" select="substring-before($txt,'&#13;&#10;')"/>
-                      </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:call-template name="addHyperlinksAndLineBreaks">
-                        <xsl:with-param name="txt" select="substring-before($txt,'&#13;&#10;')"/>
-                      </xsl:call-template>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </p>
-                <p>
-                  <xsl:choose>
-                    <xsl:when test="contains($txt,'&#13;&#10;')">
-                      <xsl:call-template name="addLineBreaksAndHyperlinks">
-                        <xsl:with-param name="txt" select="substring-after($txt,'&#13;&#10;')"/>
-                      </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:call-template name="addHyperlinksAndLineBreaks">
-                        <xsl:with-param name="txt" select="substring-after($txt,'&#13;&#10;')"/>
-                      </xsl:call-template>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </p>
-              </xsl:when>
-              <xsl:when test="contains($txt,'&#13;')">
-                <p>
-                  <xsl:choose>
-                    <xsl:when test="contains($txt,'&#13;')">
-                      <xsl:call-template name="addLineBreaksAndHyperlinks">
-                        <xsl:with-param name="txt" select="substring-before($txt,'&#13;')"/>
-                      </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:call-template name="addHyperlinksAndLineBreaks">
-                        <xsl:with-param name="txt" select="substring-before($txt,'&#13;')"/>
-                      </xsl:call-template>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </p>
-                <p>
-                  <xsl:choose>
-                    <xsl:when test="contains($txt,'&#13;')">
-                      <xsl:call-template name="addLineBreaksAndHyperlinks">
-                        <xsl:with-param name="txt" select="substring-after($txt,'&#13;')"/>
-                      </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:call-template name="addHyperlinksAndLineBreaks">
-                        <xsl:with-param name="txt" select="substring-after($txt,'&#13;')"/>
-                      </xsl:call-template>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </p>
-              </xsl:when>
-              <xsl:when test="contains($txt,'&#10;')">
-                <p>
-                  <xsl:choose>
-                    <xsl:when test="contains($txt,'&#10;')">
-                      <xsl:call-template name="addLineBreaksAndHyperlinks">
-                        <xsl:with-param name="txt" select="substring-before($txt,'&#10;')"/>
-                      </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:call-template name="addHyperlinksAndLineBreaks">
-                        <xsl:with-param name="txt" select="substring-before($txt,'&#10;')"/>
-                      </xsl:call-template>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </p>
-                <p>
-                  <xsl:choose>
-                    <xsl:when test="contains($txt,'&#10;')">
-                      <xsl:call-template name="addLineBreaksAndHyperlinks">
-                        <xsl:with-param name="txt" select="substring-after($txt,'&#10;')"/>
-                      </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:call-template name="addHyperlinksAndLineBreaks">
-                        <xsl:with-param name="txt" select="substring-after($txt,'&#10;')"/>
-                      </xsl:call-template>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </p>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:call-template name="addHyperlinksAndLineBreaks">
-                  <xsl:with-param name="txt"  select="$txt"/>
-                </xsl:call-template>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:choose>
-              <xsl:when test="contains($txt,'&#13;&#10;')">
-                <p>
-                  <xsl:value-of select="substring-before($txt,'&#13;&#10;')"/>
-                </p><p>
-                <xsl:call-template name="addLineBreaksAndHyperlinks">
-                  <xsl:with-param name="txt"  select="substring-after($txt,'&#13;&#10;')"/>
-                </xsl:call-template>
-              </p>
-              </xsl:when>
-              <xsl:when test="contains($txt,'&#13;')">
-                <p><xsl:value-of select="substring-before($txt,'&#13;')"/>
-                </p><p>
-                <xsl:call-template name="addLineBreaksAndHyperlinks">
-                  <xsl:with-param name="txt"  select="substring-after($txt,'&#13;')"/>
-                </xsl:call-template>
-              </p>
-              </xsl:when>
-              <xsl:when test="contains($txt,'&#10;')">
-                <p><xsl:value-of select="substring-before($txt,'&#10;')"/>
-                </p><p>
-                <xsl:call-template name="addLineBreaksAndHyperlinks">
-                  <xsl:with-param name="txt"  select="substring-after($txt,'&#10;')"/>
-                </xsl:call-template>
-              </p>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="$txt"/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:otherwise>
-        </xsl:choose>
+        <xsl:call-template name="addLineBreaksAndHyperlinksInternal">
+          <xsl:with-param name="txt" select="."/>
+        </xsl:call-template>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template name="addLineBreaksAndHyperlinksInternal">
+    <xsl:param name="txt" select="string(.)" />
+
+    <xsl:variable name="txtWithBr">
+      <xsl:analyze-string select="$txt"
+                          regex="[\r\n]{{2}}">
+        <!-- Code the breakline with the char ◿, to be matched later (regular expression with ^ seem doesn't match multiple chars)
+             so can't use string that is unlikely to happen like BRBRBR for this and replaced later by <br/>.
+
+             The use of the char ◿ is arbitrary, selected as a very unlikely char to happen in the metadata.
+        -->
+        <xsl:matching-substring>
+          ◿<xsl:value-of select="."/>
+        </xsl:matching-substring>
+        <xsl:non-matching-substring>
+          <xsl:value-of select="."/>
+        </xsl:non-matching-substring>
+      </xsl:analyze-string>
+    </xsl:variable>
+
+    <!-- See previous comment about the usage of the char ◿ -->
+    <xsl:analyze-string select="$txtWithBr"
+                        regex="[^\n\r◿]+">
+      <!-- Surround text without breaklines inside a p element -->
+      <xsl:matching-substring>
+        <xsl:if test="string(normalize-space(.))">
+        <p>
+          <xsl:call-template name="hyperlink">
+            <xsl:with-param name="string" select="." />
+          </xsl:call-template>
+        </p>
+        </xsl:if>
+      </xsl:matching-substring>
+      <xsl:non-matching-substring>
+        <xsl:if test="string(normalize-space(.))">
+          <xsl:call-template name="hyperlink">
+            <xsl:with-param name="string" select="." />
+          </xsl:call-template>
+        </xsl:if>
+      </xsl:non-matching-substring>
+    </xsl:analyze-string>
+  </xsl:template>
+
+
+  <xsl:template name="hyperlink">
+    <xsl:param name="string" select="." />
+    <xsl:analyze-string select="$string"
+                        regex="(http|https|ftp)://[^\s]+">
+      <xsl:matching-substring>
+        <a href="{.}">
+          <xsl:value-of select="." />
+        </a>
+      </xsl:matching-substring>
+      <xsl:non-matching-substring>
+        <xsl:call-template name="hyperlink-mailaddress">
+          <xsl:with-param name="string" select="." />
+        </xsl:call-template>
+      </xsl:non-matching-substring>
+    </xsl:analyze-string>
+  </xsl:template>
+
+  <xsl:template name="hyperlink-mailaddress">
+    <xsl:param name="string" select="." />
+    <xsl:analyze-string select="$string"
+                        regex="([\w\.]+)@([a-zA-Z_]+?\.[a-zA-Z]{{2,3}})">
+      <xsl:matching-substring>
+        <a href="mailto:{.}">
+          <xsl:value-of select="." />
+        </a>
+      </xsl:matching-substring>
+      <xsl:non-matching-substring>
+
+        <!-- See previous comment about the usage of the char ◿ -->
+        <xsl:analyze-string select="$string"
+                            regex="◿">
+          <xsl:matching-substring>
+            <br/>
+            <xsl:value-of select="replace(., '◿', '')"/>
+          </xsl:matching-substring>
+          <xsl:non-matching-substring>
+            <xsl:value-of select="."/>
+          </xsl:non-matching-substring>
+        </xsl:analyze-string>
+      </xsl:non-matching-substring>
+    </xsl:analyze-string>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
* Replace recursive xslt templates to add breaklines and hyperlinks in metadata detail page (full view), to use pattern matching to avoid stack overflow for texts with many breaklines

* Update templates to manage breaklines to preserve all the breaklines

https://github.com/geonetwork/core-geonetwork/pull/5446

Co-authored-by: Jose García <josegar74@gmail.com>

Co-authored-by: Francois Prunayre <fx.prunayre@gmail.com>