### PR TITLE
Do not show overview images with the exact same URL

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -758,12 +758,28 @@
               s[1] += "?approved=" + (this.draft != 'y');
             }
 
-
-            images.list[insertFn]({url: s[1], label: s[2]});
+            var found = false;
+            var checkForUnique = images.list.filter(function (item) {
+              if (item.url === s[1]) {
+                found = true
+              }
+            });
+            if (!found) {
+              images.list[insertFn]({url: s[1], label: s[2]});
+            }
           }
         } else if (angular.isDefined(this.image)){
           var s = this.image.split('|');
-          images.list.push({url: s[1], label: s[2]});
+
+          var foundImg = false;
+          var checkForUniqueImg = images.list.filter(function (item) {
+            if (item.url === s[1]) {
+              found = true
+            }
+          });
+          if (!found) {
+            images.list.push({url: s[1], label: s[2]});
+          }
         }
         return images;
       },


### PR DESCRIPTION
In some cases metadata records have thumbnails with exact the same url, this PR checks if there are duplicates and adds only one of the same thumbnails to the `overviews` object, so only one of the thumbnails is shown in the detail view.

**Before**
![gn-thumbnail-double](https://user-images.githubusercontent.com/19608667/117645714-31435980-b18b-11eb-88f1-7a19abb18ddd.png)

**After**
![gn-thumbnail-unique](https://user-images.githubusercontent.com/19608667/117645737-356f7700-b18b-11eb-9eda-5602f9830368.png)
