### PR TITLE
Fix map height when there is no footer

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -932,6 +932,7 @@ goog.require('gn_alert');
       $scope.showGNName = gnGlobalSettings.gnCfg.mods.header.showGNName;
       $scope.isHeaderFixed = gnGlobalSettings.gnCfg.mods.header.isHeaderFixed;
       $scope.isLogoInHeader = gnGlobalSettings.gnCfg.mods.header.isLogoInHeader;
+      $scope.isFooterEnabled = gnGlobalSettings.gnCfg.mods.footer.enabled;
 
       // If gnLangs current already set by config, do not use URL
       $scope.langs = gnGlobalSettings.gnCfg.mods.header.languages;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -22,6 +22,9 @@
   bottom: 0px;
   left: 0px;
   right: 0px;
+  [ol-map] {
+    height: calc(~"100vh - @{gn-menubar-height} - @{gn-bottombar-height} - 2px");
+  }
   .ol-attribution {
     .gn-attribution();
     bottom: 1em;
@@ -112,6 +115,16 @@
   }
 }
 
+.gn-hide-footer {
+  [gn-main-viewer] {
+    [ol-map] {
+      height: calc(~"100vh - @{gn-menubar-height} - 1px");
+    }
+    .control-tools {
+      bottom: 1em;
+    }
+  }
+}
 // minimap on search results
 .gn-search-map {
   [ol-map] {
@@ -139,7 +152,11 @@
     text-transform: uppercase;
   }
 }
-
+.gn-hide-footer {
+  .gn-toggle {
+    bottom: 20px;
+  }
+}
 
 gn-wps-process-form {
   .panel-body {

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -67,7 +67,7 @@
       loading site information, check user login state
       and a facet search to get main site information.
       -->
-      <body data-ng-controller="GnCatController" data-ng-class="[isHeaderFixed ? 'gn-header-fixed' : 'gn-header-relative', isLogoInHeader ? 'gn-logo-in-header' : 'gn-logo-in-navbar']">
+      <body data-ng-controller="GnCatController" data-ng-class="[isHeaderFixed ? 'gn-header-fixed' : 'gn-header-relative', isLogoInHeader ? 'gn-logo-in-header' : 'gn-logo-in-navbar', isFooterEnabled ? 'gn-show-footer' : 'gn-hide-footer']">
 
         <div data-gn-alert-manager=""></div>
 


### PR DESCRIPTION
In GeoNetwork the height of the map is calculated assuming the footer is always present. However, in the admin it's possible to disable the footer. This results in the map having whitespace at the bottom

This PR adds a setting and styling for the map height when there is no footer.

**Before**
![gn-map-no-footer](https://user-images.githubusercontent.com/19608667/118936148-9138bd80-b94c-11eb-93f4-b85c4a5dcea8.png)

**After**
![gn-map-footer](https://user-images.githubusercontent.com/19608667/118936014-6ea6a480-b94c-11eb-88db-b823b6a6c388.png)

