### PR TITLE
Show label on add resource button when the dialog is opened

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -415,6 +415,7 @@
             type="button"
             class="btn navbar-btn"
             data-ng-class="gnAddLink.$valid && !isUrlOk ? 'btn-warning' : 'btn-success'"
+            ng-disabled="!gnAddLink.$valid"
             data-gn-click-and-spin="addOnlinesrc()">
       <i class="fa gn-icon-onlinesrc"/>
       <i class="icon-external-link"></i>&nbsp;
@@ -423,6 +424,9 @@
       </span>
       <span data-ng-show="gnAddLink.$valid && !isUrlOk">
         {{((isEditing ? 'update' : 'add') + 'LinkAnyway') | translate}}
+      </span>
+      <span data-ng-show="!gnAddLink.$valid">
+        {{((isEditing ? 'update' : 'add') + 'Onlinesrc') | translate}}
       </span>
     </button>
     <div id="gn-addonlinesrc-add-help"


### PR DESCRIPTION
When you want to add an online resource and you open the 'online resource panel' only a button with an icon is shown.

This PR shows a label at the moment the dialog is opened, this button starts disabled, when you start typing the url, the button will be enabled.

![gn-online-resource](https://user-images.githubusercontent.com/19608667/118971932-44ff7480-b970-11eb-8d49-81cb601ddb52.png)
