### PR TITLE
Fix retrieval of settings during the application startup if the encryptor is not initialised

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
@@ -212,7 +212,7 @@ public class SettingManager {
             if (!se.get().isEncrypted()) {
                 value = se.get().getStoredValue();
             } else {
-                throw new RuntimeException("Encrypted settings can't be accessed before encryptor is initialized");
+                throw new IllegalStateException("Encrypted settings can't be accessed before encryptor is initialized");
             }
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
@@ -38,6 +38,7 @@ import org.fao.geonet.repository.SettingRepository;
 import org.fao.geonet.repository.SortUtils;
 import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.utils.Log;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -86,6 +87,9 @@ public class SettingManager {
 
     @Autowired
     SourceRepository sourceRepository;
+
+    @Autowired
+    StandardPBEStringEncryptor encryptor;
 
     @PostConstruct
     private void init() {
@@ -195,10 +199,27 @@ public class SettingManager {
             Log.error(Geonet.SETTINGS, "  Requested setting with name: " + path + "  not found. Add it to the settings table.");
             return null;
         }
+
         String value = se.get().getValue();
+
+        // This case occurs during the application startup, before the encryptor is initialized:
+        // value is null and storedValue has the correct value in this case.
+        // Affects OpenApiConfig and SettingManager PostConstruct that retrieve settings during the startup,
+        // before the encryptor is initialized.
+        // TODO: Improve EncryptorInitializer. For now it depends on GeonetworkDataDirectory
+        //  that requires to be initialised in GeoNetwork start method.
+        if (!encryptor.isInitialized()) {
+            if (!se.get().isEncrypted()) {
+                value = se.get().getStoredValue();
+            } else {
+                throw new RuntimeException("Encrypted settings can't be accessed before encryptor is initialized");
+            }
+        }
+
         if (value == null && ! nullable) {
             Log.warning(Geonet.SETTINGS, "  Requested setting with name: " + path + " but null value found. Check the settings table.");
         }
+
         return value;
     }
 


### PR DESCRIPTION
Password encryptor is initialised in `GeoNetwork.start` due to a dependency on `GeonetworkDataDirectory`.

Some beans, like `OpenApiConfig` or `SettingManager` `@PostConstruct` retrieve settings before the password encryptor is initialised, causing the value to be `null`. This causes that in Swagger UI the server gets a wrong value (null://null/:null). 

This PR returns in these cases the `storedValue`, that has the correct value. It doesn't solve the case for encrypted settings if would be required  before the password encryptor is initialised (not the case in the current code).

In the long term, initialisation of components should be moved outside of `GeoNetwork.start` to use Spring features, but will require some major refactor on some components.