### PR TITLE
Aggs / Temporal range improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -326,11 +326,11 @@
         scope.signal = null;
 
         scope.vl = null;
-        scope.dateFormat = scope.facet.meta.dateFormat || 'DD-MM-YYYY';
-        scope.vegaDateFormat = scope.facet.meta.vegaDateFormat || '%d-%m-%Y';
+        scope.dateFormat = scope.facet.meta && scope.facet.meta.dateFormat || 'DD-MM-YYYY';
+        scope.vegaDateFormat = scope.facet.meta && scope.facet.meta.vegaDateFormat || '%d-%m-%Y';
         scope.dateRangeConfig = {
-          maxViewMode: scope.facet.meta.dateSelectMode || 'days',
-          minViewMode: scope.facet.meta.dateSelectMode || 'days'
+          maxViewMode: scope.facet.meta && scope.facet.meta.dateSelectMode || 'days',
+          minViewMode: scope.facet.meta && scope.facet.meta.dateSelectMode || 'days'
         };
         scope.initialRange = angular.copy(scope.facet.items);
 
@@ -344,7 +344,7 @@
             return d;
           });
           return [].concat(scope.initialRange, scope.facet.items);
-            }
+        }
         // Assign the specification to a local variable vlSpec.
         var vlSpec = {
           $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
@@ -362,7 +362,7 @@
           },
           vconcat: [{
             mark: {
-              type: scope.facet.meta.mark || 'bar',
+              type: scope.facet.meta && scope.facet.meta.mark || 'bar',
               cornerRadiusEnd: 2
             },
             height: 100,
@@ -455,7 +455,7 @@
 
           scope.vl.view.addEventListener('click',
             function(event, item) {
-            if (item.datum && item.datum.$$hashKey) { // Avoid brush click
+            if (item && item.datum && item.datum.$$hashKey) { // Avoid brush click
               var vlId = item.datum.$$hashKey,
                 rangeItems = scope.vl.view.data('facetValues').filter(
                 function(e, i, a) {
@@ -514,14 +514,26 @@
         }
 
         scope.setRange = function() {
-          scope.signal = scope.range.from === undefined && scope.range.to === undefined
-            ? {}
+          scope.signal = (
+            (scope.range.from === undefined && scope.range.to === undefined)
+            || (scope.range.from === '' && scope.range.to === '')
+            ) ? {}
             : { key: [
               moment(scope.range.from, scope.dateFormat).valueOf(),
               moment(scope.range.to, scope.dateFormat).valueOf()
             ], update: false};
+          if (scope.vl) {
             scope.vl.view.signal('brush', scope.signal);
+          }
         }
+
+        scope.$watch('range.from', scope.setRange);
+        scope.$watch('range.to', scope.setRange);
+
+        scope.$on('resetSelection', function(event, args) {
+          scope.range.from = undefined;
+          scope.range.to = undefined;
+        });
       }
     }
   }])

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-temporalrange.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-temporalrange.html
@@ -8,12 +8,16 @@
        on-change-fn="setRange({from: range.from, to: range.to})"
        date-only-highlight="true">
     <input type="text" class="input-sm form-control"
-           name="start" value="{{::range.from}}"/>
+           data-ng-model="range.from"
+           data-ng-model-options="{debounce: 500}"
+           name="start"/>
     <span class="input-group-addon">
       <icon class="fa fa-fw fa-chevron-right"/>
     </span>
     <input type="text" class="input-sm form-control"
-           name="end" value="{{::range.to}}"/>
+           data-ng-model="range.to"
+           data-ng-model-options="{debounce: 500}"
+           name="end"/>
     <span class="input-group-btn">
       <button class="btn btn-default"
               data-ng-click="filter()"


### PR DESCRIPTION
* Refresh range when manually changing inputs.

![image](https://user-images.githubusercontent.com/1701393/119110001-fa3e3500-ba21-11eb-9f6a-353f0bfc263c.png)


* Reset range when filter directive clear filters 
* Avoid error when config is minimal (ie. with no meta)
eg. 
```
            "dateStamp" : {
              "auto_date_histogram" : {
                "field" : "dateStamp",
                "buckets": 50
              }
            }
```

Also require https://github.com/geonetwork/core-geonetwork/pull/5646 which fix vega lib loading in editor board.