### PR TITLE
Decouple harvester schedule from harvester status

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -638,7 +638,8 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
 
         for (Map.Entry<String, AbstractHarvester> pair : hmHarvesters.entrySet()) {
            AbstractHarvester harvester = pair.getValue();
-           if ( Common.Status.ACTIVE.equals(harvester.getStatus())) {
+           //if ( Common.Status.ACTIVE.equals(harvester.getStatus())) {
+           if (harvester.getParams().isScheduleEnabled()) {
                try {
                    TimeZone triggerTimeZone =  harvester.getTriggerTimezone();
                    String triggerTimeZoneId = defaultTimeZoneId;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
@@ -85,6 +85,7 @@ public abstract class AbstractParams implements Cloneable {
     private String username;
     private String password;
     private String every;
+    private boolean scheduleEnabled;
     private boolean oneRunOnly;
     private HarvestValidationEnum validate;
     private String importXslt;
@@ -187,6 +188,7 @@ public abstract class AbstractParams implements Cloneable {
         setPassword(Util.getParam(account, "password", ""));
 
         setEvery(Util.getParam(opt, "every", "0 0 0 * * ?"));
+        setScheduleEnabled(Util.getParam(opt, "scheduleEnabled", true));
 
         setOneRunOnly(Util.getParam(opt, "oneRunOnly", false));
         setOverrideUuid(
@@ -269,6 +271,7 @@ public abstract class AbstractParams implements Cloneable {
 
         setEvery(Util.getParam(opt, "every", getEvery()));
         setOneRunOnly(Util.getParam(opt, "oneRunOnly", isOneRunOnly()));
+        setScheduleEnabled(Util.getParam(opt, "scheduleEnabled", isScheduleEnabled()));
 
         setOverrideUuid(
                 OverrideUuid.valueOf(
@@ -340,6 +343,8 @@ public abstract class AbstractParams implements Cloneable {
         }
 
         copy.setNodeElement(getNodeElement());
+
+        copy.setScheduleEnabled(isScheduleEnabled());
     }
 
     /**
@@ -630,5 +635,14 @@ public abstract class AbstractParams implements Cloneable {
 
     public void setBatchEdits(String batchEdits) {
         this.batchEdits = batchEdits;
+    }
+
+
+    public boolean isScheduleEnabled() {
+        return scheduleEnabled;
+    }
+
+    public void setScheduleEnabled(boolean scheduleEnabled) {
+        this.scheduleEnabled = scheduleEnabled;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/services/harvesting/Stop.java
+++ b/harvesters/src/main/java/org/fao/geonet/services/harvesting/Stop.java
@@ -53,14 +53,9 @@ public class Stop implements Service {
     //--------------------------------------------------------------------------
 
     public Element exec(Element params, ServiceContext context) throws Exception {
-        String statusParam = org.fao.geonet.Util.getParam(params, "status", Common.Status.INACTIVE.toString());
-        if (statusParam.isEmpty()) {
-            statusParam = Common.Status.INACTIVE.toString();
-        }
-        final Common.Status newStatus = Common.Status.parse(statusParam);
         return Util.exec(params, context, new Util.Job() {
             public OperResult execute(HarvestManager hm, String id) throws Exception {
-                return hm.stop(id, newStatus);
+                return hm.stop(id, Common.Status.INACTIVE);
             }
         });
     }

--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/schedule.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/schedule.html
@@ -5,21 +5,21 @@
     <div id="gn-harvest-settings-selected-schedule-buttons" class="btn-group pull-right" data-toggle="buttons">
       <label id="gn-harvest-settings-selected-schedule-buttons-enable"
              class="btn btn-primary"
-             data-ng-click="harvester.options.status = 'active'"
-             data-ng-class="harvester.options.status === 'active' ? 'active' : ''">
+             data-ng-click="harvester.options.scheduleEnabled = true"
+             data-ng-class="harvester.options.scheduleEnabled === true ? 'active' : ''">
         <input type="radio" name="harvesterStatus"/>
         <strong data-translate="" class="">enable</strong>
       </label>
       <label id="gn-harvest-settings-selected-schedule-buttons-disable"
              class="btn btn-primary"
-             data-ng-class="harvester.options.status === 'active' ? '' : 'active'"
-             data-ng-click="harvester.options.status = 'inactive'">
+             data-ng-class="harvester.options.scheduleEnabled === true ? '' : 'active'"
+             data-ng-click="harvester.options.scheduleEnabled = false">
         <input type="radio" name="harvesterStatus"/>
         <strong data-translate="" class="">disable</strong>
       </label>
     </div>
   </legend>
-  <div id="gn-harvest-settings-selected-schedule-freq-row" data-ng-show="harvester.options.status === 'active'">
+  <div id="gn-harvest-settings-selected-schedule-freq-row" data-ng-show="harvester.options.scheduleEnabled === true">
     <label id="gn-harvest-settings-selected-schedule-freq-label" class="control-label" data-translate="">frequency</label>
     <div class="input-group">
       <input id="gn-harvest-settings-selected-schedule-freq-input" type="text" class="form-control" data-ng-model="harvester.options.every"/>
@@ -45,7 +45,7 @@
     <p ng-show="timeZone" class="help-block" data-translate="" data-translate-values="{ timeZoneTransl: timeZone, zoneOffset: timeZoneOffset}">harvesterTimeZoneHelp</p>
   </div>
 
-  <div id="gn-harvest-settings-selected-schedule-run-row" data-ng-show="harvester.options.status === 'active'">
+  <div id="gn-harvest-settings-selected-schedule-run-row" data-ng-show="harvester.options.scheduleEnabled === true">
     <label class="control-label">
       <input id="gn-harvest-settings-selected-schedule-run-checkbox" type="checkbox" data-ng-model="harvester.options.oneRunOnly"/>&nbsp;
       <span id="gn-harvest-settings-selected-schedule-run-label" data-translate="">oneRunOnly</span>

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -421,11 +421,10 @@
       };
       $scope.stopping = false;
       $scope.stopHarvester = function() {
-        var status = $scope.harvesterSelected.options.status;
         var id = $scope.harvesterSelected['@id'];
         $scope.stopping = true;
         return $http.get('admin.harvester.stop?_content_type=json&id=' +
-            id + '&status=' + status)
+            id)
             .success(function(data) {
               $scope.$parent.loadHarvesters().then(refreshSelectedHarvester);
             }).then(function() {

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
@@ -33,7 +33,8 @@ var gnHarvestercsw = {
         "every" : "0 0 0 ? * *",
         "oneRunOnly" : false,
         "overrideUuid": "SKIP",
-        "status" : "active"
+        "status" : "active",
+        "scheduleEnabled" : "true"
       },
       "ifRecordExistAppendPrivileges": false,
       "privileges" : [ {
@@ -99,6 +100,7 @@ var gnHarvestercsw = {
       + '    <overrideUuid>' + h.options.overrideUuid + '</overrideUuid>'
       + '    <every>' + h.options.every + '</every>'
       + '    <status>' + h.options.status + '</status>'
+      + '    <scheduleEnabled>' + h.options.scheduleEnabled + '</scheduleEnabled>'
       + '  </options>'
       + '  <content>'
       + '    <validate>' + h.content.validate + '</validate>'

--- a/web/src/main/webapp/xsl/xml/harvesting/common.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/common.xsl
@@ -81,6 +81,9 @@
         <status>
           <xsl:value-of select="$opt/status/value"/>
         </status>
+        <scheduleEnabled>
+          <xsl:value-of select="$opt/scheduleEnabled/value" />
+        </scheduleEnabled>
 
         <xsl:apply-templates select="$opt" mode="options"/>
       </options>


### PR DESCRIPTION
For harvesters where the scheduling has been disabled, if you trigger the harvester manually, the scheduling is set to enabled again as the schedule is handle by the harvester status.

This PR adds an isolated property for the schedule to keep it disabled while triggering a manual harvest.


