### PR TITLE
Editor / Open action improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1068,7 +1068,7 @@ goog.require('gn_alert');
       });
 
       // login url for inline signin form in top toolbar
-      $scope.signInFormAction = '../../signin#' + $location.path();
+      $scope.signInFormAction = '../../signin#' + $location.url();
 
       // when the login input have focus, do not close the dropdown/popup
       $scope.focusLoginPopup = function() {

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -47,8 +47,7 @@
            $location, $window, $timeout,
                gnUtilityService, gnConfig, gnGlobalSettings,
                vcRecaptchaService, $q) {
-          $scope.formAction = '../../signin#' +
-         $location.path();
+          $scope.formAction = '../../signin#' + $location.url();
           $scope.registrationStatus = null;
           $scope.sendPassword = false;
           $scope.password = null;

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -185,7 +185,7 @@
 
               if (!$scope.metadataFound) {
                 $rootScope.$broadcast('StatusUpdated', {
-                  title: $translate.instant('metadataNotFound') || 'metadataNotFound',
+                  title: $translate.instant('metadataNotFound', {id: $routeParams.id}) || 'metadataNotFound',
                   error: $routeParams.id,
                   timeout: 0,
                   type: 'danger'

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -137,6 +137,9 @@
        */
       var duration = 300;
 
+
+
+
       /**
        * Function to call after form load
        * to move view menu to top toolbar
@@ -169,7 +172,9 @@
             $http.post('../api/search/records/_search', {"query": {
                 "bool" : {
                   "must": [
-                    {"term": {"id": $routeParams.id}},
+                    {"multi_match": {
+                        "query": $routeParams.id,
+                        "fields": ['id', 'uuid']}},
                     {"terms": {"draft": ["n", "y", "e"]}},
                     {"terms": {"isTemplate": ["n", "y", "s"]}}
                   ]
@@ -188,9 +193,8 @@
                 return;
               }
 
-              $scope.id = $routeParams.id;
-
               gnCurrentEdit.metadata = new Metadata(r.data.hits.hits[0]);
+              $scope.id = gnCurrentEdit.metadata.id;
               $scope.mdSchema = gnCurrentEdit.metadata.documentStandard;
               gnCurrentEdit.schema = $scope.mdSchema;
               $scope.mdCategories = {values: []};
@@ -244,9 +248,9 @@
                 $scope.layout.hideTopToolBar = true;
 
                 angular.extend(gnCurrentEdit, {
-                  id: $routeParams.id,
-                  formId: '#gn-editor-' + $routeParams.id,
-                  containerId: '#gn-editor-container-' + $routeParams.id,
+                  id: gnCurrentEdit.metadata.id,
+                  formId: '#gn-editor-' + gnCurrentEdit.metadata.id,
+                  containerId: '#gn-editor-container-' + gnCurrentEdit.metadata.id,
                   associatedPanelConfigId: 'default',
                   tab: $location.search()['tab'] || defaultTab,
                   displayAttributes: $location.search()['displayAttributes'] === 'true',
@@ -258,6 +262,7 @@
                   formLoadExtraFn: formLoadExtraFunctions,
                   codelistFilter: '',
                   working: false
+
                 });
 
                 $scope.gnCurrentEdit = gnCurrentEdit;


### PR DESCRIPTION
* Don't lose tab when signin is required. http://localhost:8080/geonetwork/srv/fre/catalog.edit#/metadata/1321?tab=xml should redirect to signin and then redirect to editor in XML (was default view).
* Add possibility to open editor using UUID.