### PR TITLE
Locale loader: fix to load translation files using the format relativepath|type

### DIFF
--- a/web-ui/src/main/resources/catalog/js/GnLocale.js
+++ b/web-ui/src/main/resources/catalog/js/GnLocale.js
@@ -96,7 +96,28 @@
         var allPromises = [];
 
         angular.forEach(options.locales, function(value, index) {
-          var langUrl = value.startsWith('../') ?
+          /* Check value for:
+              1) Relative url to the translation file: use that url.
+                  Configured with:
+
+                  module.config(['$LOCALES', function($LOCALES) {
+                    $LOCALES.push('../../catalog/locales/en-data.json');
+                  }]);
+
+              2) Relative url with locate type (usually loaded from a custom view):
+                  use buildUrl to create the url. Configured with:
+
+                  module.config(['$LOCALES', function($LOCALES) {
+                    $LOCALES.push('../../catalog/views/myview/locales/|core'');
+                  }]);
+
+              3) Non relative url, usually for language packs:
+                  use buildUrl to create the url.
+
+                  /../api/i18n/packages/search
+
+          */
+          var langUrl = (value.startsWith('../') && (value.indexOf("|") == -1)) ?
                           value :
                           buildUrl(options.prefix, options.key,
               value, options.suffix);


### PR DESCRIPTION
Update locale loader to support relative url with locate type as in previous 3.x versions. This is useful for custom views that provide their own locales.

```
 module.config(['$LOCALES', function($LOCALES) {
   $LOCALES.push('../../catalog/views/myview/locales/|core'');
 }]);
```

To check about using the translation packs, but for now the translation packs configuration is packaged in the services jar, requiring a custom build to change it.

https://github.com/geonetwork/core-geonetwork/blob/dd0ff029a1ae5d240d72dbe025fa7db453818491/services/src/main/resources/config-spring-geonetwork.xml#L167