### PR TITLE
Directory / Import entries from shape / Add charset parameters

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
@@ -579,11 +579,11 @@ public class DirectoryApi {
             boolean lenient,
         @Parameter(
             description = "Attribute table charset",
-            defaultValue = "",
             required = false
         )
         @RequestParam(
-            required = false
+            required = false,
+            defaultValue = ""
         )
             String charset,
         @Parameter(

--- a/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/DirectoryApi.java
@@ -54,6 +54,7 @@ import org.geotools.data.DataStoreFinder;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.Query;
 import org.geotools.data.collection.ListFeatureCollection;
+import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.feature.FeatureIterator;
@@ -94,6 +95,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -576,6 +578,15 @@ public class DirectoryApi {
         )
             boolean lenient,
         @Parameter(
+            description = "Attribute table charset",
+            defaultValue = "",
+            required = false
+        )
+        @RequestParam(
+            required = false
+        )
+            String charset,
+        @Parameter(
             description = "Create only bounding box for each spatial objects.",
             required = false)
         @RequestParam(
@@ -631,7 +642,7 @@ public class DirectoryApi {
 
         for (File shapeFile : shapeFiles) {
 
-            SimpleFeatureCollection collection = shapeFileToFeatureCollection(shapeFile);
+            SimpleFeatureCollection collection = shapeFileToFeatureCollection(shapeFile, charset);
 
             try (FeatureIterator<SimpleFeature> features = collection.features()) {
 
@@ -790,10 +801,13 @@ public class DirectoryApi {
         return StringUtils.isNotEmpty(featureDescriptionValue) ? featureDescriptionValue : "";
     }
 
-    private SimpleFeatureCollection shapeFileToFeatureCollection(File shapefile) throws IOException {
+    private SimpleFeatureCollection shapeFileToFeatureCollection(File shapefile, String charset) throws IOException {
         Map<String, Object> map = new HashMap<>();
         map.put("url", shapefile.toURI().toURL());
         DataStore dataStore = DataStoreFinder.getDataStore(map);
+        if (dataStore instanceof ShapefileDataStore && StringUtils.isNotEmpty(charset)) {
+            ((ShapefileDataStore)dataStore).setCharset(Charset.forName(charset));
+        }
         String typeName = dataStore.getTypeNames()[0];
         SimpleFeatureSource source = dataStore.getFeatureSource(typeName);
         Query query = new Query(typeName, Filter.INCLUDE);


### PR DESCRIPTION
.cgp file does not sound to be used when reading Shapefile. Add an option to set charset.


eg. to load shapefile
```
curl \
  -H "Cookie: $COOKIE" \
  -H "X-XSRF-TOKEN: $TOKEN" \
  -H 'Content-Type: multipart/form-data' \
  -H 'Accept: application/json' \
  -F file=@g1g21.zip \
  -X POST "$CATALOG/srv/api/registries/actions/entries/import/spatial?uuidAttribute=GMDNR&uuidPattern=geocatch-subtpl-extent-hoheitsgebiet-%7B%7Buuid%7D%7D&descriptionAttribute=GMDNAME&geomProjectionTo=EPSG%3A4326&lenient=true&onlyBoundingBox=false&process=build-extent-subtemplate&schema=iso19139&uuidProcessing=OVERWRITE&charset=UTF-8"

```