### PR TITLE
Statistics page in the admin without padding/whitespace

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -533,6 +533,10 @@ ul.gn-resultview li.list-group-item {
       }
     }
 
+    // statistics page
+    [data-ng-controller="GnDashboardRenderController"] {
+      margin: -25px -10px -50px -10px;
+    }
   }
 
 }


### PR DESCRIPTION
The admin pages have a padding for the content, the `Content Statistics` page with the Kibana dashboard doesn't need it. This PR removes this padding.

**Before**
![gn-statistics-padding](https://user-images.githubusercontent.com/19608667/120482881-dbd92180-c3b1-11eb-8462-688d552a0265.png)

**After**
![gn-statistics-nopadding](https://user-images.githubusercontent.com/19608667/120482945-ed222e00-c3b1-11eb-99fe-152041d49e1d.png)

