### PR TITLE
Remove left sidebar animation in Admin

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -1,20 +1,20 @@
 @import "gn_search_default.less";
 @import "../../../style/gn_admin";
 
-@gn-sidebar-width: 270px;
-@gn-col-main-width: 45px;
+@gn-sidebar-width: 300px;
+@gn-col-main-width: 65px;
 
-@keyframes fadein{
-  0% { opacity:0; }
-  66% { opacity:0; }
-  100% { opacity:1; }
-}
-
-@-webkit-keyframes fadein{
-  0% { opacity:0; }
-  66% { opacity:0; }
-  100% { opacity:1; }
-}
+//@keyframes fadein{
+//  0% { opacity:0; }
+//  66% { opacity:0; }
+//  100% { opacity:1; }
+//}
+//
+//@-webkit-keyframes fadein{
+//  0% { opacity:0; }
+//  66% { opacity:0; }
+//  100% { opacity:1; }
+//}
 
 ul.gn-resultview li.list-group-item {
   margin-bottom: 0;
@@ -133,19 +133,27 @@ ul.gn-resultview li.list-group-item {
         background-color: #fff;
         white-space: nowrap;
         z-index: 10;
-        transition: width 0.5s;
+        padding: 10px;
         .nav-sidebar {
-          span {
-            display: none;
-          }
-        }
-        &:hover {
-          width: calc(~"@{gn-sidebar-width} - @{gn-col-main-width}");
-          .nav-sidebar {
-            span {
-              display: inline-block;
-              -webkit-animation: 0.5s ease 0s normal forwards 1 fadein;
-              animation: 0.5s ease 0s normal forwards 1 fadein;
+          li {
+            a {
+              text-align: center;
+              border-radius: 3px;
+              span {
+                display: none;
+              }
+              &:hover {
+                span {
+                  display: inline-block;
+                  position: absolute;
+                  background-color: #333;
+                  padding: 6px 12px;
+                  color: #fff;
+                  border-radius: 3px;
+                  margin-top: -6px;
+                  margin-left: 18px;
+                }
+              }
             }
           }
         }
@@ -154,6 +162,7 @@ ul.gn-resultview li.list-group-item {
         width: calc(~"100% - @{gn-col-main-width}");
         margin-left: @gn-col-main-width;
         float: left;
+        padding: 10px;
       }
       .sidebar-col-sub-editor {
         width: @gn-sidebar-width;
@@ -161,24 +170,26 @@ ul.gn-resultview li.list-group-item {
       }
       .sidebar-col-full {
         width: @gn-sidebar-width;
-        transition: none;
         .nav-sidebar {
-          span {
-            display: inline-block;
-          }
-        }
-        &:hover {
-          width: @gn-sidebar-width;
-          .nav-sidebar {
-            span {
-              animation: none;
+          li {
+            a {
+              text-align: left;
+              span {
+                display: inline-block;
+                color: #333;
+                padding: 0px 10px;
+              }
+              &:hover {
+                span {
+                  position: relative;
+                  color: #333;
+                  background: none;
+                  padding: 0px 10px;
+                  margin-left: 0;
+                }
+              }
             }
           }
-        }
-      }
-      .nav-sidebar {
-        span {
-          padding-left: 10px;
         }
       }
       h2 {
@@ -189,10 +200,9 @@ ul.gn-resultview li.list-group-item {
       ul {
         li {
           a {
-            padding-left: 15px;
-            border-left: 3px solid #fff;
             color: @gray;
             padding: 10px;
+            border-radius: 3px;
             &:hover {
               color: @gray-dark;
             }
@@ -201,7 +211,6 @@ ul.gn-resultview li.list-group-item {
             a {
               color: @gray-darker;
               background-color: lighten(@brand-primary, 46.7%);
-              border-left-color: @brand-primary;
             }
           }
 


### PR DESCRIPTION
The admin of GeoNetwork has a left sidebar with animation. The animation and fast sequence of opening and closing can distract users. This PR removes the animation and adds tooltips for the labels

**The 'new' style**
![gn-admin-sidebar](https://user-images.githubusercontent.com/19608667/120780804-bcb0d000-c528-11eb-8c9a-522115c9b15a.png)


