### PR TITLE
Facet / Temporal range / Fix selection when using custom format eg. YYYY

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -328,13 +328,23 @@
         scope.vl = null;
         scope.dateFormat = scope.facet.meta && scope.facet.meta.dateFormat || 'DD-MM-YYYY';
         scope.vegaDateFormat = scope.facet.meta && scope.facet.meta.vegaDateFormat || '%d-%m-%Y';
+
+        function moment2datePickerFormat(format) {
+          // M > m, D > d, Y > y
+          // https://momentjs.com/docs/#/displaying/
+          // https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#format
+          return format.toLowerCase();
+        }
+
         scope.dateRangeConfig = {
           maxViewMode: scope.facet.meta && scope.facet.meta.dateSelectMode || 'days',
-          minViewMode: scope.facet.meta && scope.facet.meta.dateSelectMode || 'days'
+          minViewMode: scope.facet.meta && scope.facet.meta.dateSelectMode || 'days',
+          format: moment2datePickerFormat(scope.dateFormat)
         };
         scope.initialRange = angular.copy(scope.facet.items);
 
         function buildData() {
+
           angular.forEach(scope.initialRange, function(d) {
             d.type = 'all';
             return d;
@@ -343,7 +353,8 @@
             d.type = 'current';
             return d;
           });
-          return [].concat(scope.initialRange, scope.facet.items);
+          var items = [].concat(scope.initialRange, scope.facet.items);
+          return items;
         }
         // Assign the specification to a local variable vlSpec.
         var vlSpec = {
@@ -366,9 +377,9 @@
               cornerRadiusEnd: 2
             },
             height: 100,
-            selection: {
-              pts: {type: "single"}
-            },
+            // selection: {
+            //   pts: {type: "single"}
+            // },
             encoding: {
               x: {
                 field: 'key',
@@ -459,8 +470,8 @@
               var vlId = item.datum.$$hashKey,
                 rangeItems = scope.vl.view.data('facetValues').filter(
                 function(e, i, a) {
-                  return e.$$hashKey === vlId ||
-                    (a[i - 1] && a[i - 1].$$hashKey === vlId);
+                  return e.type === 'current' && (e.$$hashKey === vlId ||
+                    (a[i - 1] && a[i - 1].$$hashKey === vlId));
                 }, []),
                 selected = item.datum,
                 next = rangeItems[1];
@@ -513,6 +524,11 @@
             });
         }
 
+        scope.reset = function() {
+          scope.range.from = undefined;
+          scope.range.to = undefined;
+        }
+
         scope.setRange = function() {
           scope.signal = (
             (scope.range.from === undefined && scope.range.to === undefined)
@@ -529,11 +545,7 @@
 
         scope.$watch('range.from', scope.setRange);
         scope.$watch('range.to', scope.setRange);
-
-        scope.$on('resetSelection', function(event, args) {
-          scope.range.from = undefined;
-          scope.range.to = undefined;
-        });
+        scope.$on('resetSelection', scope.reset);
       }
     }
   }])

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-temporalrange.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-temporalrange.html
@@ -3,7 +3,6 @@
        title="{{'facets.temporalRange.help' | translate}}"></div>
   <div class="input-daterange input-group input-group-sm"
        gn-bootstrap-datepicker="range"
-       data-date-format="dd-mm-yyyy"
        data-config="dateRangeConfig"
        on-change-fn="setRange({from: range.from, to: range.to})"
        date-only-highlight="true">
@@ -19,6 +18,11 @@
            data-ng-model-options="{debounce: 500}"
            name="end"/>
     <span class="input-group-btn">
+      <button class="btn btn-default"
+              data-ng-click="reset()"
+              title="{{'reset' | translate}}">
+        <icon class="fa fa-fw fa-times"/>
+      </button>
       <button class="btn btn-default"
               data-ng-click="filter()"
               title="{{'apply' | translate}}">


### PR DESCRIPTION
Also add a reset button (also available by double click the lower chart in vega default actions)

```
            'resourceTemporalDateRange': {
              'gnBuildFilterForRange': {
                field: "resourceTemporalDateRange",
                buckets: 2021 - 1990,
                dateFormat: 'YYYY',
                dateSelectMode: 'years',
                vegaDateFormat: '%Y',
                from: 1990,
                to: 2021,
                // buckets: 2021 - 2000,
                // dateFormat: 'YYYY-MM-DD',
                // vegaDateFormat: '%Y-%M-%D',
                // from: 2000,
                // to: 2021,
                // mark: 'area'
              },
              'meta': {
                'vega': 'timeline'
              }
            }
```