### PR TITLE
Batch backport sub_context, resource_leak, transaction_manager [3.6.x backport]

### DIFF
--- a/core/src/main/java/jeeves/interfaces/ApplicationHandler.java
+++ b/core/src/main/java/jeeves/interfaces/ApplicationHandler.java
@@ -29,11 +29,17 @@ import org.jdom.Element;
 
 //=============================================================================
 
+/**
+ * Used to maintain registry of handlers for {@link jeeves.server.dispatchers.ServiceManager}.
+ */
 public interface ApplicationHandler {
+    /** Context name for registry lookup */
     public String getContextName();
 
+    /** Start application handler, returning application context managed in registry */
     public Object start(Element config, ServiceContext s) throws Exception;
 
+    /** Stop handler */
     public void stop();
 }
 

--- a/core/src/main/java/jeeves/monitor/MonitorManager.java
+++ b/core/src/main/java/jeeves/monitor/MonitorManager.java
@@ -23,7 +23,6 @@
 
 package jeeves.monitor;
 
-import com.sun.corba.se.spi.activation.ServerManager;
 import com.yammer.metrics.core.*;
 import com.yammer.metrics.log4j.InstrumentedAppender;
 import com.yammer.metrics.reporting.JmxReporter;

--- a/core/src/main/java/jeeves/monitor/MonitorManager.java
+++ b/core/src/main/java/jeeves/monitor/MonitorManager.java
@@ -23,6 +23,7 @@
 
 package jeeves.monitor;
 
+import com.sun.corba.se.spi.activation.ServerManager;
 import com.yammer.metrics.core.*;
 import com.yammer.metrics.log4j.InstrumentedAppender;
 import com.yammer.metrics.reporting.JmxReporter;
@@ -30,6 +31,7 @@ import com.yammer.metrics.reporting.JmxReporter;
 import jeeves.constants.ConfigFile;
 import jeeves.server.context.ServiceContext;
 
+import jeeves.server.dispatchers.ServiceManager;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.LogManager;
 import org.fao.geonet.Util;
@@ -74,6 +76,7 @@ public class MonitorManager {
 
     private MetricsRegistry metricsRegistry;
     private JmxReporter jmxReporter;
+    private ServiceContext context;
 
     public void init(ServletContext context, String baseUrl) {
 
@@ -130,7 +133,10 @@ public class MonitorManager {
         return tmpHealthCheckRegistry;
     }
 
-    public void initMonitorsForApp(ServiceContext context) {
+    public void initMonitorsForApp(ServiceContext initContext) {
+        ServiceManager serviceManager = initContext.getBean(ServiceManager.class);
+        context = serviceManager.createServiceContext("monitor", initContext);
+
         createHealthCheck(context, criticalServiceContextHealthChecks, criticalHealthCheckRegistry, "critical health check");
         createHealthCheck(context, warningServiceContextHealthChecks, warningHealthCheckRegistry, "warning health check");
         createHealthCheck(context, expensiveServiceContextHealthChecks, expensiveHealthCheckRegistry, "expensive health check");
@@ -162,12 +168,30 @@ public class MonitorManager {
         }
     }
 
+    /**
+     * Create and register health checks
+     *
+     * @param context
+     * @param checks factories used to create health checks
+     * @param registry registry listing heath checks
+     * @param type
+     */
     private void createHealthCheck(ServiceContext context, List<HealthCheckFactory> checks, HealthCheckRegistry registry, String type) {
+        ServiceManager serviceManager = context.getBean(ServiceManager.class);
         for (HealthCheckFactory healthCheck : checks) {
-            Log.info(Log.ENGINE, "Registering " + type + ": " + healthCheck.getClass().getName());
-            HealthCheck check = healthCheck.create(context);
-            healthCheckRegistry.register(check);
-            registry.register(check);
+            String factoryName = healthCheck.getClass().getName();
+            ServiceContext checkServiceContext = serviceManager.createServiceContext(type+":"+factoryName, context);
+            try {
+                HealthCheck check = healthCheck.create(checkServiceContext);
+
+                Log.info(Log.ENGINE, "Registering " + type + ": " + factoryName);
+                healthCheckRegistry.register(check);
+                registry.register(check);
+            }
+            catch (Throwable t){
+                Log.info(Log.ENGINE, "Unable to register " + type + ": " + factoryName);
+                checkServiceContext.clear();
+            }
         }
     }
 
@@ -306,6 +330,9 @@ public class MonitorManager {
     @PreDestroy
     public void shutdown() {
         Log.info(Log.ENGINE, "MonitorManager#shutdown");
+        if (context != null){
+            context.clear();
+        }
         if (resourceTracker != null) {
             resourceTracker.clean();
         }

--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -102,6 +102,8 @@ public class JeevesEngine {
     private Path _appPath;
     private int _maxUploadSize;
 
+    /** AppHandler service context used during init, tasks and background activities */
+    private ServiceContext srvContext;
 
     //---------------------------------------------------------------------------
     //---
@@ -436,7 +438,7 @@ public class JeevesEngine {
 
             ApplicationHandler h = (ApplicationHandler) c.newInstance();
 
-            ServiceContext srvContext = serviceMan.createServiceContext("AppHandler", appContext);
+            srvContext = serviceMan.createAppHandlerServiceContext(appContext);
             srvContext.setLanguage(_defaultLang);
             srvContext.setLogger(_appHandLogger);
             srvContext.setServlet(servlet);
@@ -474,7 +476,6 @@ public class JeevesEngine {
             }
             finally {
                 srvContext.clearAsThreadLocal();
-                srvContext.clear();
             }
         }
     }
@@ -533,8 +534,10 @@ public class JeevesEngine {
 
             info("Stopping handlers...");
             stopHandlers();
+            srvContext.clear();
 
             info("=== System stopped ========================================");
+
         } catch (Exception e) {
             error("Raised exception during destroy");
             error("  Exception : " + e);

--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -551,7 +551,12 @@ public class JeevesEngine {
 
     private void stopHandlers() throws Exception {
         for (ApplicationHandler h : _appHandlers) {
-            h.stop();
+            try {
+                h.stop();
+            } catch (Throwable unexpected){
+                _appHandLogger.error("Difficulty while stopping "+h.getContextName());
+                _appHandLogger.error(unexpected);
+            }
         }
     }
 

--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -440,9 +440,8 @@ public class JeevesEngine {
             srvContext.setLanguage(_defaultLang);
             srvContext.setLogger(_appHandLogger);
             srvContext.setServlet(servlet);
-            srvContext.setAsThreadLocal();
-
             try {
+                srvContext.setAsThreadLocal();
                 info("--- Starting handler --------------------------------------");
 
                 Object context = h.start(handler, srvContext);
@@ -472,6 +471,10 @@ public class JeevesEngine {
                 if (!serviceMan.isStartupError()) {
                     serviceMan.setStartupErrors(errors);
                 }
+            }
+            finally {
+                srvContext.clearAsThreadLocal();
+                srvContext.clear();
             }
         }
     }

--- a/core/src/main/java/jeeves/server/context/BasicContext.java
+++ b/core/src/main/java/jeeves/server/context/BasicContext.java
@@ -43,9 +43,8 @@ import javax.persistence.EntityManager;
 //=============================================================================
 
 /**
- * Contains a minimun context for a job execution (schedule, service etc...)
+ * Contains a minimum context for a job execution (schedule, service etc...)
  */
-
 public class BasicContext implements Logger {
 
     private final ConfigurableApplicationContext jeevesApplicationContext;

--- a/core/src/main/java/jeeves/server/context/BasicContext.java
+++ b/core/src/main/java/jeeves/server/context/BasicContext.java
@@ -117,6 +117,12 @@ public class BasicContext implements Logger {
         return jeevesApplicationContext.getBean(beanType);
     }
 
+    public
+    @Nonnull
+    <T> T getBean(String name, Class<T> beanType) {
+        return jeevesApplicationContext.getBean(name, beanType);
+    }
+
     //--------------------------------------------------------------------------
 
     public EntityManager getEntityManager() {

--- a/core/src/main/java/jeeves/server/context/ServiceContext.java
+++ b/core/src/main/java/jeeves/server/context/ServiceContext.java
@@ -38,6 +38,7 @@ import org.fao.geonet.Logger;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.transaction.TransactionStatus;
 
@@ -52,10 +53,54 @@ import javax.persistence.EntityManager;
 
 /**
  * Contains the context for a service execution.
+ *
+ * When creating a ServiceContext you are responsible for manging its use on the current thread and any cleanup:
+ * <pre><code>
+ * try {
+ *    context = serviceMan.createServiceContext("AppHandler", appContext);
+ *    context.setAsThreadLocal();
+ *    ...
+ * } finally {
+ *    context.clearAsThreadLocal();
+ *    context.clear();
+ * }</code></pre>
+ *
+ * @see ServiceManager
  */
 public class ServiceContext extends BasicContext {
 
+    public static enum ThreadLocalPolicy { DIRECT, TRACE, STRICT };
+    /**
+     * Use -Djeeves.server.context.service.policy to define policy:
+     * <ul>
+     *     <li>direct: direct management of thread local with no checking</li>
+     *     <li>trace: check behavior and log unusal use</li>
+     *     <li>strict: raise illegal state exception for unusual behavior</li>
+     * </ul>
+     */
+    private static final ThreadLocalPolicy POLICY;
+    static {
+        String property = System.getProperty("jeeves.server.context.policy", "DIRECT");
+        ThreadLocalPolicy policy;
+        try {
+            policy = ThreadLocalPolicy.valueOf(property.toUpperCase());
+        }
+        catch (IllegalArgumentException defaultToDirect) {
+            policy = ThreadLocalPolicy.DIRECT;
+        }
+        POLICY = policy;
+    }
+
+    /**
+     * Be careful with thread local to avoid leaking resources, set POLICY above to trace allocation.
+     */
     private static final InheritableThreadLocal<ServiceContext> THREAD_LOCAL_INSTANCE = new InheritableThreadLocal<ServiceContext>();
+
+    /**
+     * Trace allocation via {@link #setAsThreadLocal()}.
+     */
+    private Throwable allocation = null;
+
     private UserSession _userSession = new UserSession();
     private InputMethod _input;
     private OutputMethod _output;
@@ -115,10 +160,168 @@ public class ServiceContext extends BasicContext {
 
     /**
      * Called to set the Service context for this thread and inherited threads.
+     *
+     * If you call this method you are responsible for thread context management and {@link #clearAsThreadLocal()}.
+     * <pre>
+     * try {
+     *     context.setAsThreadLocal();
+     * }
+     * finally {
+     *     context.clearAsThreadLocal();
+     * }
+     * </pre>
      */
     public void setAsThreadLocal() {
+        ServiceContext check = THREAD_LOCAL_INSTANCE.get();
+
+        if( POLICY == ThreadLocalPolicy.DIRECT || check == null){
+            // step one set thread local
+            THREAD_LOCAL_INSTANCE.set(this);
+            // step two ensure ApplicationContextHolder thread local kept in sync
+            ApplicationContextHolder.set(this.getApplicationContext());
+            // step three details on allocation
+            allocation = new Throwable("ServiceContext allocated to thread");
+
+            return;
+        }
+
+        if (this == check) {
+            String unexpected = "Service " + _service + " Context: already in use for this thread";
+            if( allocation != null ){
+                // details on prior allocation
+                unexpected += "\n\tContext '"+check._service+"' conflict: " + check.allocation.getStackTrace()[1];
+            }
+            // step one set thread local
+            // (already done)
+            // step two ensure ApplicationContextHolder thread local kept in sync
+            if( ApplicationContextHolder.get() != null ){
+                ApplicationContextHolder.clear();
+            }
+            ApplicationContextHolder.set(this.getApplicationContext());
+            // step three detail on re-allocation
+            allocation = new Throwable("ServiceContext allocated to thread");
+
+            unexpected += "\n\tService '"+_service+"' allocate: " + allocation.getStackTrace()[1];
+            checkUnexpectedState( unexpected );
+            return;
+        }
+
+        // thread being recycled or reused for new service context
+        //
+        THREAD_LOCAL_INSTANCE.remove();
+
+        String unexpected = "Service " + _service + " Context: Clearing prior service context " + check._service;
+        if( check.allocation != null ){
+            // details on prior allocation
+            unexpected += "\n\tContext '"+check._service+"' conflict: " + check.allocation.getStackTrace()[1];
+        }
+
+        // step one set thread local
         THREAD_LOCAL_INSTANCE.set(this);
+        // step two ensure ApplicationContextHolder thread local kept in sync
+        if( ApplicationContextHolder.get() != null ){
+            ApplicationContextHolder.clear();
+        }
         ApplicationContextHolder.set(this.getApplicationContext());
+        // step three detail on present re-allocation
+        allocation = new Throwable("ServiceContext allocated to thread");
+
+        unexpected += "\n\tService '"+_service+"' allocate: " + allocation.getStackTrace()[1];
+        checkUnexpectedState( unexpected );
+    }
+
+    /** Log or raise exception based on {@link POLICY} */
+    public void checkUnexpectedState( String unexpected ){
+        if( unexpected == null ){
+            return; // nothing unexpected to report
+        }
+        switch( POLICY ){
+            case DIRECT:
+                break; // ignore
+            case TRACE:
+                debug(unexpected);
+                break;
+            case STRICT:
+                throw new IllegalStateException(unexpected);
+        }
+    }
+
+    /**
+     * Called to clear the Service context for this thread and inherited threads.
+     *
+     * In general code that creates ServiceContext is responsible thread management and any cleanup:
+     * <pre>
+     * try {
+     *     context.setAsThreadLocal();
+     * }
+     * finally {
+     *     context.clearAsThreadLocal();
+     * }
+     * </pre>
+     */
+    public void clearAsThreadLocal() {
+        ServiceContext check = THREAD_LOCAL_INSTANCE.get();
+
+        // clean up thread local
+        if( POLICY == ThreadLocalPolicy.DIRECT){
+            if( check != null ){
+                check.allocation = null;
+                check = null;
+            }
+            THREAD_LOCAL_INSTANCE.remove();
+            allocation = null;
+            // ApplicationContextHolder.clear();
+            return;
+        }
+        if( check == null ){
+            String unexpected = "ServiceContext "+_service+" clearAsThreadLocal: '"+_service+"' unexpected state, thread local already cleared";
+            if( allocation != null ){
+                unexpected += "\n\tContext '"+_service+"' allocation: " + allocation.getStackTrace()[1];
+            }
+            allocation = null;
+            // ApplicationContextHolder.clear();
+            checkUnexpectedState( unexpected );
+            return;
+        }
+        if (check == this){
+            THREAD_LOCAL_INSTANCE.remove();
+            allocation = null;
+            // ApplicationContextHolder.clear();
+            return;
+        }
+
+        String unexpected = "ServiceContext clearAsThreadLocal: \"+_service+\" unexpected state, thread local presently used by service context '"+check._service+"'";
+        if( check.allocation != null ){
+            unexpected += "\n\tContext '"+check._service+"' conflict: " + check.allocation.getStackTrace()[1];
+        }
+        if( allocation != null ){
+            unexpected += "\n\tContext '"+_service+"' allocation: " + allocation.getStackTrace()[1];
+        }
+        THREAD_LOCAL_INSTANCE.remove();
+        allocation = null;
+        // ApplicationContextHolder.clear();
+        if( ApplicationContextHolder.get() != null && ApplicationContextHolder.get() != getApplicationContext() ){
+            unexpected += "\n\tApplicationContext '"+ApplicationContextHolder.get().getApplicationName()+"' conflict detected";
+            unexpected += "\n\tApplicationContext '"+getApplicationContext().getApplicationName()+"' expected";
+            ApplicationContextHolder.clear();
+        }
+        checkUnexpectedState( unexpected );
+    }
+
+    /**
+     * Release any resources tied up by this service context.
+     */
+    public void clear(){
+        if( this._service != null) {
+            this._service = null;
+            this._headers = null;
+            this._responseHeaders = null;
+            this._servlet = null;
+            this._userSession = null;
+        }
+        else {
+            debug("Service unexpectedly cleared twice");
+        }
     }
 
     //--------------------------------------------------------------------------

--- a/core/src/main/java/jeeves/server/context/ServiceContext.java
+++ b/core/src/main/java/jeeves/server/context/ServiceContext.java
@@ -451,6 +451,23 @@ public class ServiceContext extends BasicContext {
         _userSession = session;
     }
 
+    /**
+     * Safely look up user name, or <code>anonymous</code>.
+     *
+     * This is a quick null safe lookup of user name suitable for use in logging and error messages.
+     *
+     * @return username, or <code>anonymous</code> if unavailable.
+     */
+    public String userName(){
+        if (_userSession == null || _userSession.getUsername() == null ){
+            return "anonymous";
+        }
+        if( _userSession.getProfile() != null ){
+            return _userSession.getUsername() + "/" + _userSession.getProfile();
+        }
+        return _userSession.getUsername();
+    }
+
     public ProfileManager getProfileManager() {
         return getBean(ProfileManager.class);
     }

--- a/core/src/main/java/jeeves/server/context/ServiceContext.java
+++ b/core/src/main/java/jeeves/server/context/ServiceContext.java
@@ -364,17 +364,29 @@ public class ServiceContext extends BasicContext {
     //---
     //--------------------------------------------------------------------------
 
+    /**
+     * Language code, or <code>"?"</code> if undefined.
+     * @return language code, or <code>"?"</code> if undefined.
+     */
     public String getLanguage() {
         if (_service == null ){
             //throw new NullPointerException("Service context cleared, language not available");
         }
         return _language;
     }
-
+    /**
+     * Language code, or <code>"?"</code> if undefined.
+     * @param lang language code, or <code>"?"</code> if undefined.
+     */
     public void setLanguage(final String lang) {
         _language = lang;
     }
 
+    /**
+     * Service name, or null if service context is no longer in use.
+     *
+     * @return service name, or null if service is no longer in use
+     */
     public String getService() {
         return _service;
     }
@@ -387,6 +399,11 @@ public class ServiceContext extends BasicContext {
         logger = Log.createLogger(Log.WEBAPP + "." + service);
     }
 
+    /**
+     * IP address of request, or <code>"?"</code> for local loopback request.
+     *
+     * @return ip address, or <code>"?"</code> for loopback request.
+     */
     public String getIpAddress() {
         if (_service == null ){
             throw new NullPointerException("Service context cleared, ip address not available");
@@ -394,6 +411,11 @@ public class ServiceContext extends BasicContext {
         return _ipAddress;
     }
 
+    /**
+     * IP address of request, or <code>"?"</code> for local loopback request.
+     *
+     * @param address ip, address or <code>"?"</code> for loopback request.
+     */
     public void setIpAddress(final String address) {
         _ipAddress = address;
     }

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -80,6 +80,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 //=============================================================================
+
+/**
+ * Handles operations on services.
+ */
 public class ServiceManager {
     private Map<String, ArrayList<ServiceInfo>> htServices = new HashMap<String, ArrayList<ServiceInfo>>(100);
     private Map<String, Object> htContexts = new HashMap<String, Object>();
@@ -159,6 +163,11 @@ public class ServiceManager {
     //---
     //---------------------------------------------------------------------------
 
+    /**
+     * Track context objects by name.
+     * @param name
+     * @param context
+     */
     public void registerContext(String name, Object context) {
         htContexts.put(name, context);
     }
@@ -345,6 +354,39 @@ public class ServiceManager {
         vErrorPipe.add(buildErrorPage(err));
     }
 
+    /**
+     * Used to create a serviceContext for later use, the object provided the new serviceContext is responsible
+     * for cleanup.
+     * <pre><code>
+     * final ServiceContext taskContext = serviceMan.createServiceContext( serviceContext, "task");
+     * return new Runnable(){
+     *     public abstract void run(){
+     *         try {
+     *            taskContext.setAsThreadLocal();
+     *
+     *         }
+     *         finally {
+     *             taskContext.clear();
+     *         }
+     *     }
+     * };
+     * </code></pre>
+     *
+     * @param name
+     * @param parent
+     * @return new service context
+     */
+    public ServiceContext createServiceContext(String name, ServiceContext parent ){
+        ServiceContext context = createServiceContext( name, parent.getApplicationContext());
+        context.setBaseUrl(parent.getBaseUrl());
+        context.setLanguage(parent.getLanguage());
+        context.setUserSession(null); // because this is intended for later use user session not included
+        context.setIpAddress(parent.getIpAddress());
+        context.setMaxUploadSize(parent.getMaxUploadSize());
+        context.setServlet(parent.getServlet());
+
+        return context;
+    }
     /**
      * Used to create a ServiceContext.
      *

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -355,6 +355,32 @@ public class ServiceManager {
     }
 
     /**
+     * Used to create an appContext placeholder service context used for initialization, background tasks and activities.
+     *
+     * This ServiceContext is used during initialization and is independent of any user session.
+     * This instance is the responsibility of JeevesEngine and is protected against being cleared.
+     *
+     * @param parent
+     * @return new service context
+     */
+    public ServiceContext createAppHandlerServiceContext(ConfigurableApplicationContext appContext) {
+        ServiceContext context = new ServiceContext("AppHandler", appContext, htContexts, entityManager){
+            public void clear() {
+                debug("AppHandler context cannot be cleared");
+            }
+        };
+        context.setBaseUrl(baseUrl);
+        context.setLanguage("?");
+        context.setUserSession(null);
+        context.setIpAddress("?");
+        context.setMaxUploadSize(maxUploadSize);
+        context.setServlet(servlet);
+
+        return context;
+    }
+
+
+    /**
      * Used to create a serviceContext for later use, the object provided the new serviceContext is responsible
      * for cleanup.
      * <pre><code>

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -62,6 +62,7 @@ import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.SOAPUtil;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import javax.persistence.EntityManager;
@@ -178,7 +179,8 @@ public class ServiceManager {
         String sheet = srv.getAttributeValue(ConfigFile.Service.Attr.SHEET);
         String cache = srv.getAttributeValue(ConfigFile.Service.Attr.CACHE);
 
-        ServiceInfo si = ApplicationContextHolder.get().getBean(ServiceInfo.class);
+        ApplicationContext applicationContext = ApplicationContextHolder.get();
+        ServiceInfo si = applicationContext.getBean(ServiceInfo.class);
         si.setMatch(match);
         si.setSheet(sheet);
         si.setCache(cache);
@@ -343,6 +345,24 @@ public class ServiceManager {
         vErrorPipe.add(buildErrorPage(err));
     }
 
+    /**
+     * Used to create a ServiceContext.
+     *
+     * When creating a ServiceContext you are responsible for manging its use on the current thread and any cleanup:
+     * <pre><code>
+     * try {
+     *    context = serviceMan.createServiceContext("AppHandler", appContext);
+     *    context.setAsThreadLocal();
+     *    ...
+     * } finally {
+     *    context.clearAsThreadLocal();
+     *    context.clear();
+     * }</code></pre>
+     *
+     * @param name context name
+     * @param appContext application context
+     * @return ServiceContext
+     */
     public ServiceContext createServiceContext(String name, ConfigurableApplicationContext appContext) {
         ServiceContext context = new ServiceContext(name, appContext, htContexts,
             entityManager);
@@ -357,6 +377,27 @@ public class ServiceManager {
         return context;
     }
 
+    /**
+     * Used to create a ServiceContext.
+     *
+     * When creating a ServiceContext you are responsible for manging its use on the current thread and any cleanup:
+     * <pre><code>
+     * try {
+     *    context = serviceMan.createServiceContext("md.thumbnail.upload", lang, request);
+     *    context.setAsThreadLocal();
+     *    ...
+     * } finally {
+     *    context.clearAsThreadLocal();
+     *    context.clear();
+     * }</code></pre>
+     *
+     * The serviceContext is creating using the ApplicationContext from {@link ApplicationContextHolder}.
+     *
+     * @param name context name
+     * @param lang
+     * @param request servlet request
+     * @return ServiceContext
+     */
     public ServiceContext createServiceContext(String name, String lang, HttpServletRequest request) {
         ServiceContext context = new ServiceContext(name, ApplicationContextHolder.get(), htContexts, entityManager);
 
@@ -407,12 +448,17 @@ public class ServiceManager {
         context.setOutputMethod(req.getOutputMethod());
         context.setHeaders(req.getHeaders());
         context.setServlet(servlet);
-        if (startupError) context.setStartupErrors(startupErrors);
-
+        if (startupError) {
+            context.setStartupErrors(startupErrors);
+        }
+        ServiceContext priorContext = ServiceContext.get();
+        if( priorContext != null){
+            priorContext.debug("ServiceManger dispatch replacing current ServiceContext");
+            priorContext.clearAsThreadLocal();
+        }
         context.setAsThreadLocal();
 
         //--- invoke service and build result
-
         Element response = null;
         ServiceInfo srvInfo = null;
 
@@ -504,6 +550,20 @@ public class ServiceManager {
                 throw (NotAllowedEx) e;
             } else {
                 handleError(req, response, context, srvInfo, e);
+            }
+        }
+        finally {
+            ServiceContext checkContext = ServiceContext.get();
+            if( checkContext == context ) {
+                context.clearAsThreadLocal();
+            }
+            else {
+                context.debug("ServiceManager dispatch context was replaced before cleanup");
+            }
+            context.clear();
+            if( priorContext != null){
+                priorContext.debug("ServiceManger dispatch restoring ServiceContext");
+                priorContext.setAsThreadLocal();
             }
         }
     }
@@ -821,7 +881,13 @@ public class ServiceManager {
                                 } finally {
                                     timerContext.stop();
                                 }
-                                req.beginStream(outPage.getContentType(), cache);
+                                
+                                if (outPage.getContentType() != null
+                                    && outPage.getContentType().startsWith("text/plain")) {
+                                    req.beginStream(outPage.getContentType(), -1, "attachment;", cache);
+                                } else {
+                                    req.beginStream(outPage.getContentType(), cache);
+                                }
                                 req.getOutputStream().write(baos.toByteArray());
                                 req.endStream();
                             }
@@ -873,7 +939,7 @@ public class ServiceManager {
         // Dispatch HTTP status code
         req.setStatusCode(outPage.getStatusCode());
 
-        addPrefixes(guiElem, context.getLanguage(), req.getService(), context.getApplicationContext().getBean(NodeInfo.class).getId());
+        addPrefixes(guiElem, context.getLanguage(), req.getService(), context.getBean(NodeInfo.class).getId());
 
         Element rootElem = new Element(Jeeves.Elem.ROOT)
             .addContent(guiElem)
@@ -897,7 +963,7 @@ public class ServiceManager {
                 // ignore this.
                 // it happens because the stream closes by client.
             } catch (Exception e) {
-                e.printStackTrace();
+                Log.error(Log.JEEVES, e.getMessage(), e);
             }
         }
 

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -494,7 +494,11 @@ public class ServiceManager {
     public void dispatch(ServiceRequest req, UserSession session) {
         ServiceContext context = new ServiceContext(req.getService(), ApplicationContextHolder.get(),
             htContexts, entityManager);
+      try {
         dispatch(req, session, context);
+      } finally {
+        context.clear();
+      }
     }
 
     //---------------------------------------------------------------------------
@@ -628,7 +632,7 @@ public class ServiceManager {
             else {
                 context.debug("ServiceManager dispatch context was replaced before cleanup");
             }
-            context.clear();
+            context.clearAsThreadLocal();
             if( priorContext != null){
                 priorContext.debug("ServiceManger dispatch restoring ServiceContext");
                 priorContext.setAsThreadLocal();

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -360,11 +360,27 @@ public class ServiceManager {
      * This ServiceContext is used during initialization and is independent of any user session.
      * This instance is the responsibility of JeevesEngine and is protected against being cleared.
      *
-     * @param parent
+     * @param appContext GeoNetwork Application Context
      * @return new service context
      */
     public ServiceContext createAppHandlerServiceContext(ConfigurableApplicationContext appContext) {
         ServiceContext context = new ServiceContext("AppHandler", appContext, htContexts, entityManager){
+            @Override
+            public void setIpAddress(String address) {
+                if( address != null && !"?".equals(address)) {
+                    warning("AppHandler context should not be associated with an ip address");
+                }
+                super.setIpAddress(address);
+            }
+
+            @Override
+            public void setUserSession(UserSession session) {
+                if( session != null){
+                    warning("AppHandler context should not be configured with user session");
+                }
+                super.setUserSession(session); // should probably not support association with  a user
+            }
+
             public void clear() {
                 debug("AppHandler context cannot be cleared");
             }
@@ -414,7 +430,7 @@ public class ServiceManager {
         return context;
     }
     /**
-     * Used to create a ServiceContext.
+     * Create an internal service context, not associated with a user or ip address.
      *
      * When creating a ServiceContext you are responsible for manging its use on the current thread and any cleanup:
      * <pre><code>
@@ -491,6 +507,12 @@ public class ServiceManager {
         return context;
     }
 
+    /**
+     * Dispatch service request, creating a service context with the provided user session.
+     *
+     * @param req service request
+     * @param session user session
+     */
     public void dispatch(ServiceRequest req, UserSession session) {
         ServiceContext context = new ServiceContext(req.getService(), ApplicationContextHolder.get(),
             htContexts, entityManager);
@@ -510,6 +532,14 @@ public class ServiceManager {
     //--- Dispatching methods
     //---
     //---------------------------------------------------------------------------
+
+    /**
+     * Dispatch service request, configuring context with the provided user session.
+     *
+     * @param req service request
+     * @param session user session
+     * @param context service context
+     */
     public void dispatch(ServiceRequest req, UserSession session, ServiceContext context) {
         context.setBaseUrl(baseUrl);
         context.setLanguage(req.getLanguage());

--- a/core/src/main/java/jeeves/server/sources/ServiceRequest.java
+++ b/core/src/main/java/jeeves/server/sources/ServiceRequest.java
@@ -197,7 +197,7 @@ public class ServiceRequest {
     }
 
     /**
-     * Write provided response element.
+     * Write provided response element, ending the stream.
      *
      * @param response
      * @throws IOException

--- a/core/src/main/java/jeeves/server/sources/ServiceRequest.java
+++ b/core/src/main/java/jeeves/server/sources/ServiceRequest.java
@@ -196,21 +196,36 @@ public class ServiceRequest {
         return jsonOutput;
     }
 
+    /**
+     * Write provided response element.
+     *
+     * @param response
+     * @throws IOException
+     */
     public void write(Element response) throws IOException {
         Xml.writeResponse(new Document(response), outStream);
         endStream();
     }
 
     /**
-     * called when the system starts streaming data
+     * Called when the system starts streaming data
+     * @param contentType mime type
+     * @param cache true if content can be cached, false to disable caching for dynamic content
      */
-
     public void beginStream(String contentType, boolean cache) {
     }
 
     //---------------------------------------------------------------------------
 
-    public void beginStream(String contentType, int contentLength, String contentDisp,
+    /**
+     * Called when the system starts streaming data,  filling in appropriate header details supported by protocol.
+     *
+     * @param contentType mime type
+     * @param contentLength content length in bytes if known, -1 if unknown
+     * @param contentDisposition content disposition (inline|attachment|attachment;filename=&quot;filename.jpg&quot;)
+     * @param cache true if content can be cached, false to disable caching for dynamic content
+     */
+    public void beginStream(String contentType, int contentLength, String contentDisposition ,
                             boolean cache) {
     }
 
@@ -219,7 +234,6 @@ public class ServiceRequest {
     /**
      * called when the system ends streaming data
      */
-
     public void endStream() throws IOException {
     }
 

--- a/core/src/main/java/org/fao/geonet/GeonetContext.java
+++ b/core/src/main/java/org/fao/geonet/GeonetContext.java
@@ -29,6 +29,9 @@ import org.fao.geonet.kernel.metadata.StatusActions;
 import org.fao.geonet.util.ThreadPool;
 import org.springframework.context.ApplicationContext;
 
+/**
+ * GeoNetwork context managing application context and a shared thread pool.
+ */
 public class GeonetContext {
     private final ApplicationContext _springAppContext;
     private final ThreadPool _threadPool;

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -136,14 +136,14 @@ public class DataManager {
         // remove all the inits when/if ever autowiring works fine
 
         // FIXME this shouldn't login automatically ever!
-        if (context.getUserSession() == null) {
-            LOGGER_DATA_MANAGER.debug( "Automatically login in as Administrator. Who is this? Who is calling this?");
-            UserSession session = new UserSession();
-            context.setUserSession(session);
-            session.loginAs(new User().setUsername("admin").setId(-1).setProfile(Profile.Administrator));
-            LOGGER_DATA_MANAGER.debug( "Hopefully this is cron job or routinely background task. Who called us?",
-                        new Exception("Dummy Exception to know the stacktrace"));
-        }
+//        if (context.getUserSession() == null) {
+//            LOGGER_DATA_MANAGER.debug( "Automatically login in as Administrator. Who is this? Who is calling this?");
+//            UserSession session = new UserSession();
+//            context.setUserSession(session);
+//            session.loginAs(new User().setUsername("admin").setId(-1).setProfile(Profile.Administrator));
+//            LOGGER_DATA_MANAGER.debug( "Hopefully this is cron job or routinely background task. Who called us?",
+//                        new Exception("Dummy Exception to know the stacktrace"));
+//        }
     }
 
     @Deprecated

--- a/core/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -112,28 +112,12 @@ public class DataManager {
     /**
      * Init Data manager and refresh index if needed. Can also be called after GeoNetwork startup in order to rebuild the lucene index
      *
-     * @param force Force reindexing all from scratch
+     * @param context Service context used for setup
      **/
-    public void init(ServiceContext context, Boolean force) throws Exception {
-        // FIXME remove all the inits when/if ever autowiring works fine
-        this.metadataManager = context.getBean(IMetadataManager.class);
-        this.metadataManager.init(context, force);
-        this.metadataUtils = context.getBean(IMetadataUtils.class);
-        this.metadataUtils.init(context, force);
-        this.metadataIndexer = context.getBean(IMetadataIndexer.class);
-        this.metadataIndexer.init(context, force);
-        this.metadataValidator = context.getBean(IMetadataValidator.class);
-        this.metadataValidator.init(context, force);
-        this.metadataOperations = context.getBean(IMetadataOperations.class);
-        this.metadataOperations.init(context, force);
-        this.metadataStatus = context.getBean(IMetadataStatus.class);
-        this.metadataStatus.init(context, force);
-        this.metadataSchemaUtils = context.getBean(IMetadataSchemaUtils.class);
-        this.metadataSchemaUtils.init(context, force);
-        this.metadataCategory = context.getBean(IMetadataCategory.class);
-        this.metadataCategory.init(context, force);
-        this.accessManager = context.getBean(AccessManager.class);
-        // remove all the inits when/if ever autowiring works fine
+    public void init(ServiceContext context) throws Exception {
+        this.metadataIndexer.init(context);
+        this.metadataManager.init(context);
+        this.metadataUtils.init(context);
 
         // FIXME this shouldn't login automatically ever!
 //        if (context.getUserSession() == null) {
@@ -144,6 +128,17 @@ public class DataManager {
 //            LOGGER_DATA_MANAGER.debug( "Hopefully this is cron job or routinely background task. Who called us?",
 //                        new Exception("Dummy Exception to know the stacktrace"));
 //        }
+    }
+
+    @Deprecated
+    public void refreshIndex(boolean forceReindex) throws Exception {
+        this.metadataManager.refreshIndex(forceReindex);
+    }
+
+    @Deprecated
+    public static void validateExternalMetadata(String schema, Element xml, ServiceContext context, Integer groupOwner) throws Exception {
+        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+        gc.getBean(IMetadataValidator.class).validateMetadata(schema, xml, context, " ");
     }
 
     @Deprecated
@@ -176,7 +171,7 @@ public class DataManager {
 
     @Deprecated
     public void batchIndexInThreadPool(ServiceContext context, List<?> metadataIds) {
-        metadataIndexer.batchIndexInThreadPool(context, metadataIds);
+        metadataIndexer.batchIndexInThreadPool(metadataIds);
     }
 
     @Deprecated

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -125,6 +125,7 @@ public final class IndexMetadataTask implements Runnable {
             Log.error(Geonet.INDEX_ENGINE, "Error occurred indexing metadata", e);
         } finally {
             _batchIndex.remove(this);
+            _context.clearAsThreadLocal();
         }
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel;
 
+import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 
 import jeeves.server.dispatchers.ServiceManager;
@@ -97,6 +98,7 @@ public final class IndexMetadataTask implements Runnable {
     public void run() {
         ServiceContext indexMedataContext = serviceManager.createServiceContext(serviceName+":IndexTask", appContext);
         try {
+            indexMedataContext.setUserSession(new UserSession());
             indexMedataContext.setAsThreadLocal();
             while (_transactionStatus != null && !_transactionStatus.isCompleted()) {
                 try {

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -124,7 +124,18 @@ public class ThesaurusManager implements ThesaurusFinder {
         try {
             Runnable worker = new InitThesauriTableTask(context, thesauriDir);
             if (synchRun) {
-                worker.run();
+                ServiceContext restore = ServiceContext.get();
+                try {
+                    if( restore != null){
+                        restore.clearAsThreadLocal();
+                    }
+                    worker.run();
+                }
+                finally {
+                    if( restore != null){
+                        restore.setAsThreadLocal();
+                    }
+                }
             } else {
                 executor = Executors.newFixedThreadPool(1);
                 executor.execute(worker);
@@ -508,6 +519,9 @@ public class ThesaurusManager implements ThesaurusFinder {
             } catch (Exception e) {
                 Log.debug(Geonet.THESAURUS_MAN, "Thesaurus table rebuilding thread threw exception");
                 e.printStackTrace();
+            }
+            finally {
+                context.clearAsThreadLocal();
             }
         }
     }

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import jeeves.server.dispatchers.ServiceManager;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Constants;
@@ -69,6 +70,7 @@ import com.google.common.collect.Maps;
 
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
+import org.springframework.context.ConfigurableApplicationContext;
 
 
 public class ThesaurusManager implements ThesaurusFinder {
@@ -493,15 +495,20 @@ public class ThesaurusManager implements ThesaurusFinder {
      */
     final class InitThesauriTableTask implements Runnable {
 
-        private final ServiceContext context;
+        //private final ServiceContext context;
         private final Path thesauriDir;
+        private final ServiceManager serviceManager;
+        private final ConfigurableApplicationContext appContext;
 
         InitThesauriTableTask(ServiceContext context, Path thesauriDir) {
-            this.context = context;
+            //this.context = context;
+            this.serviceManager = context.getBean(ServiceManager.class);
+            this.appContext = context.getApplicationContext();
             this.thesauriDir = thesauriDir;
         }
 
         public void run() {
+            ServiceContext context = serviceManager.createServiceContext(Geonet.THESAURUS_MAN, appContext);
             context.setAsThreadLocal();
             try {
                 // poll context to see whether servlet is up yet
@@ -522,6 +529,7 @@ public class ThesaurusManager implements ThesaurusFinder {
             }
             finally {
                 context.clearAsThreadLocal();
+                context.clear();
             }
         }
     }

--- a/core/src/main/java/org/fao/geonet/kernel/backup/ArchiveAllMetadataJob.java
+++ b/core/src/main/java/org/fao/geonet/kernel/backup/ArchiveAllMetadataJob.java
@@ -87,19 +87,24 @@ public class ArchiveAllMetadataJob extends QuartzJobBean {
     protected void executeInternal(JobExecutionContext jobContext) throws JobExecutionException {
         ServiceContext serviceContext = serviceManager.createServiceContext("backuparchive", context);
         serviceContext.setLanguage("eng");
-        serviceContext.setAsThreadLocal();
-
-        ApplicationContextHolder.set(this.context);
-
-        if(!settingManager.getValueAsBool(Settings.METADATA_BACKUPARCHIVE_ENABLE)) {
-            Log.info(BACKUP_LOG, "Backup archive not enabled");
-            return;
-        }
-
         try {
-            createBackup(serviceContext);
-        } catch (Exception e) {
-            Log.error(Geonet.GEONETWORK, "Error running " + ArchiveAllMetadataJob.class.getSimpleName(), e);
+            serviceContext.setAsThreadLocal();
+            ApplicationContextHolder.set(this.context); // note: perhaps already done by setAsThreadLocal() above
+
+            if (!settingManager.getValueAsBool(Settings.METADATA_BACKUPARCHIVE_ENABLE)) {
+                Log.info(BACKUP_LOG, "Backup archive not enabled");
+                return;
+            }
+
+            try {
+                createBackup(serviceContext);
+            } catch (Exception e) {
+                Log.error(Geonet.GEONETWORK, "Error running " + ArchiveAllMetadataJob.class.getSimpleName(), e);
+            }
+        }
+        finally {
+            serviceContext.clearAsThreadLocal();
+            serviceContext.clear(); // prevents further use
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataIndexer.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.kernel.datamanager;
 
 import java.io.IOException;
@@ -13,20 +36,29 @@ import jeeves.server.context.ServiceContext;
 
 /**
  * Interface to handle all indexing operations
- * 
+ *
  * @author delawen
  *
  */
 public interface IMetadataIndexer {
 
     /**
-     * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
-     * 
-     * @param context
-     * @param force
+     * Setup metadata indexer using app service context.
+     *
+     * This is a hopefully soon to be deprecated when no deps on context.
+     *
+     * @param context App Service context used for initial setup
      * @throws Exception
      */
-    public void init(ServiceContext context, Boolean force) throws Exception;
+    void init(ServiceContext context) throws Exception;
+
+    /**
+     * Clean up when service is not in use.
+     *
+     * @throws Exception
+     */
+    void destroy() throws Exception;
+
 
     /**
      * Force the index to wait until all changes are processed and the next reader obtained will get the latest data.
@@ -35,7 +67,7 @@ public interface IMetadataIndexer {
 
     /**
      * Remove the records that matches the specification
-     * 
+     *
      * @param specification
      * @return
      * @throws Exception
@@ -56,21 +88,20 @@ public interface IMetadataIndexer {
      * Index multiple metadata in a separate thread. Wait until the current transaction commits before starting threads (to make sure that
      * all metadata are committed).
      *
-     * @param context context object
      * @param metadataIds the metadata ids to index
      */
-    void batchIndexInThreadPool(ServiceContext context, List<?> metadataIds);
+    void batchIndexInThreadPool( List<?> metadataIds);
 
     /**
      * Is the platform currently indexing?
-     * 
+     *
      * @return
      */
     boolean isIndexing();
 
     /**
      * Index the list of records passed as parameter in order.
-     * 
+     *
      * @param metadataIds
      * @throws Exception
      */
@@ -78,7 +109,7 @@ public interface IMetadataIndexer {
 
     /**
      * Index one record defined by metadataId
-     * 
+     *
      * @param metadataId
      * @param forceRefreshReaders
      * @param searchManager
@@ -88,7 +119,7 @@ public interface IMetadataIndexer {
 
     /**
      * Start record versioning
-     * 
+     *
      * @param context
      * @param id
      * @param md
@@ -98,7 +129,7 @@ public interface IMetadataIndexer {
 
     /**
      * Reschedule the Index Optimizer Manager (Lucene)
-     * 
+     *
      * @param beginAt
      * @param interval
      * @throws Exception
@@ -107,21 +138,21 @@ public interface IMetadataIndexer {
 
     /**
      * Disable the Index Optimizer (Lucene)
-     * 
+     *
      * @throws Exception
      */
     void disableOptimizer() throws Exception;
 
     /**
      * Helper function to avoid loop circular dependencies
-     * 
+     *
      * @param metadataUtils
      */
     void setMetadataUtils(IMetadataUtils metadataUtils);
 
     /**
      * Helper function to avoid loop circular dependencies
-     * 
+     *
      * @param metadataUtils
      */
     void setMetadataManager(IMetadataManager baseMetadataManager);

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.kernel.datamanager;
 
 import java.util.Map;
@@ -29,12 +52,18 @@ public interface IMetadataManager {
 
     /**
      * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
-     * 
-     * @param context
-     * @param force
+     *
+     * @param context ServiceContext used for initialization
      * @throws Exception
      */
-    public void init(ServiceContext context, Boolean force) throws Exception;
+    public void init(ServiceContext context) throws Exception;
+
+    /**
+     *
+     * @param forceReindex
+     * @throws Exception
+     */
+    public void refreshIndex(boolean forceReindex) throws Exception;
 
     /**
      * Removes the record with the id metadataId

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -1,6 +1,31 @@
+//=============================================================================
+//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.kernel.datamanager;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
@@ -22,25 +47,24 @@ import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 
 /**
- * Utility interface for records
- * 
- * @author delawen
+ * Utility interface for working with records.
  *
+ * @author delawen
  */
 public interface IMetadataUtils {
 
     /**
      * This is a hopefully soon to be deprecated initialization function to replace the @Autowired annotation
-     * 
+     *
      * @param context
      * @param force
      * @throws Exception
      */
-    public void init(ServiceContext context, Boolean force) throws Exception;
+    public void init(ServiceContext context) throws Exception;
 
     /**
      * Notify a metadata modification
-     * 
+     *
      * @param md
      * @param metadataId
      * @throws Exception
@@ -49,7 +73,7 @@ public interface IMetadataUtils {
 
     /**
      * Return the uuid of the record with the defined id
-     * 
+     *
      * @param id
      * @return
      * @throws Exception
@@ -90,7 +114,7 @@ public interface IMetadataUtils {
 
     /**
      * Extract the last editing date from the record
-     * 
+     *
      * @param schema
      * @param md
      * @return
@@ -100,7 +124,7 @@ public interface IMetadataUtils {
 
     /**
      * Modify the UUID of a record. Uses the proper XSL transformation from the schema
-     * 
+     *
      * @param schema
      * @param uuid
      * @param md
@@ -111,7 +135,7 @@ public interface IMetadataUtils {
 
     /**
      * Returns the summary of the md record
-     * 
+     *
      * @param md
      * @return
      * @throws Exception
@@ -120,7 +144,7 @@ public interface IMetadataUtils {
 
     /**
      * Returns the identifier of the record with uuid uuid
-     * 
+     *
      * @param uuid
      * @return
      * @throws Exception
@@ -129,14 +153,14 @@ public interface IMetadataUtils {
 
     /**
      * Returns the version of the record with identifier id
-     * 
+     *
      * @param id
      * @return
      */
     String getVersion(String id);
 
     /**
-     * 
+     *
      * Returns the version of a metadata, incrementing it if necessary.
      *
      * @param id
@@ -146,7 +170,7 @@ public interface IMetadataUtils {
 
     /**
      * Mark a record as template (or not)
-     * 
+     *
      * @param id
      * @param metadataType
      * @throws Exception
@@ -155,7 +179,7 @@ public interface IMetadataUtils {
 
     /**
      * Mark a record as template (or not)
-     * 
+     *
      * @param id
      * @param metadataType
      * @throws Exception
@@ -164,7 +188,7 @@ public interface IMetadataUtils {
 
     /**
      * Mark a record as harvested
-     * 
+     *
      * @param id
      * @param harvestUuid
      * @throws Exception
@@ -173,7 +197,7 @@ public interface IMetadataUtils {
 
     /**
      * Mark a record as harvested
-     * 
+     *
      * @param id
      * @param harvestUuid
      * @throws Exception
@@ -182,7 +206,7 @@ public interface IMetadataUtils {
 
     /**
      * Mark a record as harvested from the harvestUri
-     * 
+     *
      * @param id
      * @param harvestUuid
      * @throws Exception
@@ -201,7 +225,7 @@ public interface IMetadataUtils {
 
     /**
      * Increases the popularity of the record defined by the id
-     * 
+     *
      * @param srvContext
      * @param id
      * @throws Exception
@@ -244,7 +268,7 @@ public interface IMetadataUtils {
 
     /**
      * Returns the thumbnails associated to the record with id metadataId
-     * 
+     *
      * @param context
      * @param metadataId
      * @return
@@ -254,7 +278,7 @@ public interface IMetadataUtils {
 
     /**
      * Add thumbnail to the record defined with the id
-     * 
+     *
      * @param context
      * @param id
      * @param small
@@ -265,7 +289,7 @@ public interface IMetadataUtils {
 
     /**
      * Remove thumbnail from the record defined with the id
-     * 
+     *
      * @param context
      * @param id
      * @param small
@@ -276,7 +300,7 @@ public interface IMetadataUtils {
 
     /**
      * Add data commons to the record defined with the id
-     * 
+     *
      * @param context
      * @param id
      * @param small
@@ -288,7 +312,7 @@ public interface IMetadataUtils {
 
     /**
      * Add creative commons to the record defined with the id
-     * 
+     *
      * @param context
      * @param id
      * @param small
@@ -300,7 +324,7 @@ public interface IMetadataUtils {
 
     /**
      * Helper function to prevent loop dependency
-     * 
+     *
      * @param metadataManager
      */
     void setMetadataManager(IMetadataManager metadataManager);
@@ -324,7 +348,7 @@ public interface IMetadataUtils {
 
     /**
      * Count how many records are associated to a user
-     * 
+     *
      * @param ownedByUser
      * @return
      */
@@ -332,7 +356,7 @@ public interface IMetadataUtils {
 
     /**
      * Given an identifier, return the record associated to it
-     * 
+     *
      * @param id
      * @return
      */
@@ -340,7 +364,7 @@ public interface IMetadataUtils {
 
     /**
      * Find all the ids of the records that fits the specification
-     * 
+     *
      * @param specs
      * @return
      */
@@ -348,14 +372,14 @@ public interface IMetadataUtils {
 
     /**
      * Count the total number of records available on the platform
-     * 
+     *
      * @return
      */
     public long count();
 
     /**
      * Find the record with the UUID uuid
-     * 
+     *
      * @param firstMetadataId
      * @return
      */
@@ -363,7 +387,7 @@ public interface IMetadataUtils {
 
     /**
      * Find the record that fits the specification
-     * 
+     *
      * @param spec
      * @return
      */
@@ -371,7 +395,7 @@ public interface IMetadataUtils {
 
     /**
      * Find the record that fits the id
-     * 
+     *
      * @param id
      * @return
      */
@@ -388,7 +412,7 @@ public interface IMetadataUtils {
 
     /**
      * Find all the metadata with the identifiers
-     * 
+     *
      * @see org.springframework.data.repository.CrudRepository#findAll(java.lang.Iterable)
      * @param keySet
      * @return
@@ -397,7 +421,7 @@ public interface IMetadataUtils {
 
     /**
      * Returns all entities matching the given {@link Specification}.
-     * 
+     *
      * @param spec
      * @return
      */
@@ -413,7 +437,7 @@ public interface IMetadataUtils {
 
     /**
      * Check if a record with identifier iId exists
-     * 
+     *
      * @param iId
      * @return
      */
@@ -421,7 +445,7 @@ public interface IMetadataUtils {
 
     /**
      * Load all records that satisfy the criteria provided and convert each to XML of the form:
-     * 
+     *
      * <pre>
      *  &lt;entityName&gt;
      *      &lt;property&gt;propertyValue&lt;/property&gt;
@@ -437,7 +461,7 @@ public interface IMetadataUtils {
 
     /**
      * Load all entities that satisfy the criteria provided and convert each to XML of the form:
-     * 
+     *
      * <pre>
      *  &lt;entityName&gt;
      *      &lt;property&gt;propertyValue&lt;/property&gt;
@@ -459,7 +483,7 @@ public interface IMetadataUtils {
      * @return an object for performing statistic calculation queries.
      */
     MetadataReportsQueries getMetadataReports();
-    
+
     /**
      * Check if another record exist with that UUID. This is not allowed
      * and would return a DataIntegrityViolationException

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -143,11 +143,8 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
 	@Autowired
 	private UserFeedbackRepository userFeedbackRepository;
 
-	@Autowired
-	@Qualifier("resourceStore")
-	private Store store;
-	@Autowired
-	private Resources resources;
+//	@Autowired
+//	private Resources resources;
 
 	// FIXME remove when get rid of Jeeves
 	private ServiceContext servContext;

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.kernel.datamanager.base;
 
 import java.io.IOException;
@@ -120,6 +143,12 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
 	@Autowired
 	private UserFeedbackRepository userFeedbackRepository;
 
+	@Autowired
+	@Qualifier("resourceStore")
+	private Store store;
+	@Autowired
+	private Resources resources;
+
 	// FIXME remove when get rid of Jeeves
 	private ServiceContext servContext;
 
@@ -129,21 +158,21 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
 	}
 
 	public void init(ServiceContext context, Boolean force) throws Exception {
-		searchManager = context.getBean(SearchManager.class);
-		geonetworkDataDirectory = context.getBean(GeonetworkDataDirectory.class);
-		statusRepository = context.getBean(MetadataStatusRepository.class);
-		metadataUtils = context.getBean(IMetadataUtils.class);
-		metadataManager = context.getBean(IMetadataManager.class);
-		userRepository = context.getBean(UserRepository.class);
-		operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
-		groupRepository = context.getBean(GroupRepository.class);
-		metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
-		schemaManager = context.getBean(SchemaManager.class);
-		svnManager = context.getBean(SvnManager.class);
-		inspireAtomFeedRepository = context.getBean(InspireAtomFeedRepository.class);
-		xmlSerializer = context.getBean(XmlSerializer.class);
-		settingManager = context.getBean(SettingManager.class);
-		userFeedbackRepository = context.getBean(UserFeedbackRepository.class);
+		// searchManager = context.getBean(SearchManager.class);
+		// geonetworkDataDirectory = context.getBean(GeonetworkDataDirectory.class);
+		// statusRepository = context.getBean(MetadataStatusRepository.class);
+		// metadataUtils = context.getBean(IMetadataUtils.class);
+		// metadataManager = context.getBean(IMetadataManager.class);
+		// userRepository = context.getBean(UserRepository.class);
+		// operationAllowedRepository = context.getBean(OperationAllowedRepository.class);
+		// groupRepository = context.getBean(GroupRepository.class);
+		// metadataValidationRepository = context.getBean(MetadataValidationRepository.class);
+		// schemaManager = context.getBean(SchemaManager.class);
+		// svnManager = context.getBean(SvnManager.class);
+		// inspireAtomFeedRepository = context.getBean(InspireAtomFeedRepository.class);
+		// xmlSerializer = context.getBean(XmlSerializer.class);
+		// settingManager = context.getBean(SettingManager.class);
+		// userFeedbackRepository = context.getBean(UserFeedbackRepository.class);
 
 		servContext = context;
 	}
@@ -309,6 +338,12 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
 			Runnable worker = new IndexMetadataTask(context, subList, batchIndex, transactionStatus, numIndexedTracker);
 			executor.execute(worker);
 			index += count;
+		}
+
+		try {
+			executor.awaitTermination(1, TimeUnit.DAYS );
+		} catch (InterruptedException e) {
+			Log.warning( Geonet.INDEX_ENGINE, "Indexing took more than a day", e);
 		}
 
 		executor.shutdown();

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -334,20 +334,14 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
 				Log.debug(Geonet.INDEX_ENGINE, subList.toString());
 			}
 
-			// create threads to process this chunk of ids
-			Runnable worker = new IndexMetadataTask(context, subList, batchIndex, transactionStatus, numIndexedTracker);
-			executor.execute(worker);
-			index += count;
-		}
-
-		try {
-			executor.awaitTermination(1, TimeUnit.DAYS );
-		} catch (InterruptedException e) {
-			Log.warning( Geonet.INDEX_ENGINE, "Indexing took more than a day", e);
-		}
-
-		executor.shutdown();
-	}
+            // create threads to process this chunk of ids
+            Runnable worker = new IndexMetadataTask(context, subList, batchIndex, transactionStatus, numIndexedTracker);
+            executor.execute(worker);
+            index += count;
+        }
+	// let the started threads finish in the background and then clean up executor
+        executor.shutdown();
+    }
 
 	@Override
 	public boolean isIndexing() {

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.kernel.datamanager.base;
 
 import static org.fao.geonet.repository.specification.MetadataSpecs.hasMetadataUuid;
@@ -98,7 +121,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
 	}
 
 	@SuppressWarnings("unchecked")
-	public void init(ServiceContext context, Boolean force) throws Exception {
+	public void init(ServiceContext context) throws Exception {
 		metadataRepository = context.getBean(MetadataRepository.class);
 		metadataNotifierManager = context.getBean(MetadataNotifierManager.class);
 		servContext = context;

--- a/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/SearchManager.java
@@ -1246,7 +1246,8 @@ public class SearchManager implements ISearchManager {
                 synchronized (_tracker) {
                     setupIndex(true);
                 }
-                dataMan.init(context, true);
+                //dataMan.init(context, true);
+                dataMan.refreshIndex(true);
             }
             return true;
         } catch (Exception e) {

--- a/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
@@ -89,12 +89,17 @@ public class IndexingTask extends QuartzJobBean {
     protected void executeInternal(JobExecutionContext jobContext) throws JobExecutionException {
         ServiceContext serviceContext = serviceManager.createServiceContext("indexing", applicationContext);
         serviceContext.setLanguage("eng");
-        serviceContext.setAsThreadLocal();
-
-        if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
-            Log.debug(Geonet.INDEX_ENGINE, "Indexing task / Start at: "
-                + new Date() + ". Checking if any records need to be indexed ...");
+        try {
+            serviceContext.setAsThreadLocal();
+            if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
+                Log.debug(Geonet.INDEX_ENGINE, "Indexing task / Start at: "
+                    + new Date() + ". Checking if any records need to be indexed ...");
+            }
+            indexRecords();
         }
-        indexRecords();
+        finally {
+            serviceContext.clearAsThreadLocal();
+            serviceContext.clear(); // prevents further use
+        }
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/thumbnail/ThumbnailMaker.java
+++ b/core/src/main/java/org/fao/geonet/kernel/thumbnail/ThumbnailMaker.java
@@ -110,6 +110,11 @@ public class ThumbnailMaker {
         return result;
     }
 
+    /**
+     * Setup for use based on service context configuration.
+     *
+     * @param context AppService context used to look up configuration details
+     */
     public void init(ServiceContext context) {
         configFilePath = context.getAppPath() + File.separator + CONFIG_FILE;
         initMapPrinter();

--- a/core/src/main/java/org/fao/geonet/services/thumbnail/Set.java
+++ b/core/src/main/java/org/fao/geonet/services/thumbnail/Set.java
@@ -101,7 +101,7 @@ public class Set {
 
         ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
         ServiceContext context = serviceManager.createServiceContext("md.thumbnail.upload", lang, request);
-
+     try {
         Lib.resource.checkEditPrivilege(context, id);
 
         //-----------------------------------------------------------------------
@@ -157,6 +157,9 @@ public class Set {
         dataMan.indexMetadata(id, true, null);
 
         return new Response(id, dataMan.getNewVersion(id));
+      } finally {
+        context.clear(); // prevent further use
+      }
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/web/XFrameOptionsFilter.java
+++ b/core/src/main/java/org/fao/geonet/web/XFrameOptionsFilter.java
@@ -55,9 +55,9 @@ import java.net.URL;
  * @author Jose García
  */
 public class XFrameOptionsFilter implements Filter {
-    private static String MODE_DENY = "DENY";
-    private static String MODE_SAMEORIGIN = "SAMEORIGIN";
-    private static String MODE_ALLOWFROM = "ALLOW-FROM";
+    private static final String MODE_DENY = "DENY";
+    private static final String MODE_SAMEORIGIN = "SAMEORIGIN";
+    private static final String MODE_ALLOWFROM = "ALLOW-FROM";
 
     private String mode;
     private String url;
@@ -112,8 +112,12 @@ public class XFrameOptionsFilter implements Filter {
 
 
     public void destroy() {
+        xFrameOptionsValueCache = null;
+        contentSecurityPolicyFramAncestorsValueCache = null;
     }
 
+
+    private String xFrameOptionsValueCache = null;
 
     /**
      * Calculates the X-Frame-Options header value.
@@ -122,13 +126,16 @@ public class XFrameOptionsFilter implements Filter {
      */
     private String getXFrameOptionsValue() {
         if (mode.equals(MODE_ALLOWFROM)) {
-            return mode + " " + url;
+            if( xFrameOptionsValueCache == null){
+                xFrameOptionsValueCache = mode + " " + url;
+            }
+            return xFrameOptionsValueCache;
         } else {
             return mode;
         }
     }
 
-
+    private String contentSecurityPolicyFramAncestorsValueCache = null;
     /**
      * Calculates the Content-Security-Policy header frame-ancestors value.
      *
@@ -138,7 +145,10 @@ public class XFrameOptionsFilter implements Filter {
         if (mode.equals(MODE_SAMEORIGIN)) {
             return "frame-ancestors 'self'";
         } else if (mode.equals(MODE_ALLOWFROM)) {
-            return "frame-ancestors " + domain;
+            if( contentSecurityPolicyFramAncestorsValueCache == null ){
+                contentSecurityPolicyFramAncestorsValueCache = "frame-ancestors " + domain;
+            }
+            return contentSecurityPolicyFramAncestorsValueCache;
         } else {
             return "frame-ancestors 'none'";
         }

--- a/core/src/test/java/org/fao/geonet/GeonetTestFixture.java
+++ b/core/src/test/java/org/fao/geonet/GeonetTestFixture.java
@@ -170,7 +170,8 @@ public class GeonetTestFixture {
 
         _applicationContext.getBean(LuceneConfig.class).configure("WEB-INF/config-lucene.xml");
         _applicationContext.getBean(SearchManager.class).initNonStaticData(100);
-        _applicationContext.getBean(DataManager.class).init(serviceContext, false);
+        _applicationContext.getBean(DataManager.class).init(serviceContext);
+        _applicationContext.getBean(DataManager.class).refreshIndex(true);
         _applicationContext.getBean(ThesaurusManager.class).init(true, serviceContext, "WEB-INF/data/config/codelist");
 
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -149,7 +149,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Sorted harvester nodes.
      *
      * @param nodes     harvest nodes
      * @param sortField sort field
@@ -164,7 +164,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Transformed harvest node
      *
      * @param node harvest node
      * @return transformed harvest node
@@ -177,7 +177,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Clean up harvest manager.
      */
     @Override
     public void shutdown() {
@@ -206,7 +206,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     //---------------------------------------------------------------------------
 
     /**
-     * TODO javadoc.
+     * Harvest node, filtered to only include nodes visible to user session.
      *
      * @param id      harvester id
      * @param context servicecontext
@@ -293,7 +293,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO javadoc.
+     * Add harvester, returning the id new harvester.
      *
      * @param node    harvester config
      * @param ownerId the id of the user doing this
@@ -324,7 +324,8 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Add harvester, returning UUID.
+     * @return uuid of new harvester
      */
     @Override
     public String addHarvesterReturnUUID(Element node) throws JeevesException, SQLException {
@@ -345,9 +346,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO javadoc.
+     * Clone harvester.
      *
      * @param ownerId id of the user doing this
+     * @return id of the new harvester
      */
     @Override
     public synchronized String createClone(String id, String ownerId, ServiceContext context) throws Exception {
@@ -380,9 +382,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO javadoc.
+     * Update on harvester progress.
      *
      * @param ownerId id of the user doing this
+     * @return true of harvester updated
      */
     @Override
     public synchronized boolean update(Element node, String ownerId) throws BadInputEx, SQLException, SchedulerException {
@@ -444,7 +447,8 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
 
 
     /**
-     * TODO Javadoc.
+     * Start harvester
+     * @param id harvester id
      */
     @Override
     public OperResult start(String id) throws SQLException, SchedulerException {
@@ -460,7 +464,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Stop harvester with provided status, and unschedule any outstanding jobs.
+     * @param id harvester id
+     * @param status New status
+     * @return harvester progress
      */
     @Override
     public OperResult stop(String id, Common.Status status) throws SQLException, SchedulerException {
@@ -476,7 +483,9 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Start harvester run
+     * @parm id harvester to run
+     * return harvester progress
      */
     @Override
     public OperResult run(String id) throws SQLException, SchedulerException {
@@ -500,7 +509,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Run the harvester check if harvest correctly completed.
      */
     @Override
     public OperResult invoke(String id) {
@@ -524,7 +533,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     }
 
     /**
-     * TODO Javadoc.
+     * Harvester details
+     * @param harvestUuid uuid to look up harvester info
+     * @param id
+     * @param uuid
      */
     public Element getHarvestInfo(String harvestUuid, String id, String uuid) {
         Element info = new Element(Edit.Info.Elem.HARVEST_INFO);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -111,7 +111,8 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     public void init(ServiceContext context, boolean isReadOnly) throws Exception {
         //create a new (shared) context instead of using the Jeeves one
         ServiceManager serviceManager = context.getBean(ServiceManager.class);
-        this.context =  serviceManager.createServiceContext("harvester", context);
+        context = serviceManager.createServiceContext("harvester", context);
+        this.context =  context;
 
         this.dataMan = context.getBean(DataManager.class);
         this.settingMan = context.getBean(HarvesterSettingsManager.class);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -110,7 +110,7 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
     @Override
     public void init(ServiceContext initContext, boolean isReadOnly) throws Exception {
         //create a new (shared) context instead of using the Jeeves one
-        ServiceManager serviceManager = context.getBean(ServiceManager.class);
+        ServiceManager serviceManager = initContext.getBean(ServiceManager.class);
         this.context = serviceManager.createServiceContext("harvester", initContext);
 
         this.dataMan = context.getBean(DataManager.class);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -108,11 +108,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
      * @throws Exception hmm
      */
     @Override
-    public void init(ServiceContext context, boolean isReadOnly) throws Exception {
+    public void init(ServiceContext initContext, boolean isReadOnly) throws Exception {
         //create a new (shared) context instead of using the Jeeves one
         ServiceManager serviceManager = context.getBean(ServiceManager.class);
-        context = serviceManager.createServiceContext("harvester", context);
-        this.context =  context;
+        this.context = serviceManager.createServiceContext("harvester", initContext);
 
         this.dataMan = context.getBean(DataManager.class);
         this.settingMan = context.getBean(HarvesterSettingsManager.class);

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
@@ -95,6 +95,8 @@ public class AtomPredefinedFeed {
 
         ServiceContext context = createServiceContext(uiLang, webRequest.getNativeRequest(HttpServletRequest.class));
 
+    try {
+
         SettingManager sm = context.getBean(SettingManager.class);
         boolean inspireEnable = sm.getValueAsBool(Settings.SYSTEM_INSPIRE_ENABLE);
         if (!inspireEnable) {
@@ -104,6 +106,11 @@ public class AtomPredefinedFeed {
 
         Element feed = getServiceFeed(context, uuid);
         return writeOutResponse(Xml.getString(feed));
+
+      } finally {
+          context.clear(); // prevent further use
+      }
+
     }
 
     /**
@@ -126,6 +133,8 @@ public class AtomPredefinedFeed {
     {
         ServiceContext context = createServiceContext(uiLang, webRequest.getNativeRequest(HttpServletRequest.class));
 
+      try {
+
         SettingManager sm = context.getBean(SettingManager.class);
         boolean inspireEnable = sm.getValueAsBool(Settings.SYSTEM_INSPIRE_ENABLE);
         if (!inspireEnable) {
@@ -135,6 +144,11 @@ public class AtomPredefinedFeed {
 
         Element feed = getDatasetFeed(context, spIdentifier);
         return writeOutResponse(Xml.getString(feed));
+
+      } finally {
+          context.clear(); // prevent further use
+      }
+
     }
 
     private Element getDatasetFeed(ServiceContext context, final String spIdentifier) throws Exception {

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -177,6 +177,12 @@ public class ApiUtils {
     /**
      * If you really need a ServiceContext use this. Try to avoid in order to reduce dependency on
      * Jeeves.
+     *
+     * If you create a service context you are responsible for managing on the current thread and any cleanup.
+     * This method has a side effect of setting the created service context for the current thread.
+     *
+     * @param request
+     * @return new sevice context, assigned to the current thread
      */
     static public ServiceContext createServiceContext(HttpServletRequest request) {
         String iso3langCode = ApplicationContextHolder.get().getBean(LanguageUtils.class)
@@ -184,6 +190,27 @@ public class ApiUtils {
         return createServiceContext(request, iso3langCode);
     }
 
+    /**
+     * If you really need a ServiceContext use this. Try to avoid in order to reduce dependency on
+     * Jeeves.
+     * If you create a service context you are responsible for managing on the current thread and any cleanup.
+     * This method has a side effect of setting the created service context for the current thread:
+     *
+     * <pre><code>
+     * ServiceContext context = ApiUtils.createServiceContext(request, iso3langCode);
+     * try {
+     *     ...
+     * }
+     * finally {
+     *     serviceContext.
+     *     serviceContext.clear();
+     * }
+     * </code></pre>
+     *
+     * @param request
+     * @param iso3langCode
+     * @return new sevice context, assigned to the current thread
+     */
     static public ServiceContext createServiceContext(HttpServletRequest request, String iso3langCode) {
         ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
         return serviceManager.createServiceContext("Api", iso3langCode, request);

--- a/services/src/main/java/org/fao/geonet/api/records/backup/BackupArchiveApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/backup/BackupArchiveApi.java
@@ -92,7 +92,7 @@ public class BackupArchiveApi {
         GeonetworkDataDirectory dataDirectory = appContext.getBean(GeonetworkDataDirectory.class);
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
 
-        Log.info(ArchiveAllMetadataJob.BACKUP_LOG, "User " + context.getUserSession().getUsername() + " from IP: " + context
+        Log.info(ArchiveAllMetadataJob.BACKUP_LOG, "User " + context.userName() + " from IP: " + context
                 .getIpAddress() + " has started to download backup archive");
 
         File backupDir = dataDirectory.getBackupDir().resolve(ArchiveAllMetadataJob.BACKUP_DIR).toFile();

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/Register.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/Register.java
@@ -145,6 +145,7 @@ public class Register extends AbstractFormatService {
             return response;
         } finally {
             IO.deleteFile(uploadedFile, false, Geonet.FORMATTER);
+            context.clear();
         }
     }
 

--- a/services/src/main/java/org/fao/geonet/services/metadata/ExtractServicesLayers.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/ExtractServicesLayers.java
@@ -68,6 +68,8 @@ public class ExtractServicesLayers {
         final ServiceManager serviceManager = ApplicationContextHolder.get().getBean(ServiceManager.class);
         ServiceContext context = serviceManager.createServiceContext("selection.layers", lang, webRequest.getNativeRequest(HttpServletRequest.class));
 
+      try {
+
         DataManager dm = context.getBean(DataManager.class);
         UserSession us = context.getUserSession();
         SelectionManager sm = SelectionManager.getManager(us);
@@ -183,6 +185,8 @@ public class ExtractServicesLayers {
         ret.put("services", services);
 
         return ret;
-
+      } finally {
+        context.clear();
+      }
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
@@ -100,8 +100,11 @@ public class Publish {
         ConfigurableApplicationContext appContext = ApplicationContextHolder.get();
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
         final ServiceContext serviceContext = serviceManager.createServiceContext("md.publish", lang, request);
-
-        return exec(commaSeparatedIds, true, skipIntranet, serviceContext);
+        try {
+            return exec(commaSeparatedIds, true, skipIntranet, serviceContext);
+        } finally {
+            serviceContext.clear();
+        }
     }
 
 
@@ -116,8 +119,12 @@ public class Publish {
         ConfigurableApplicationContext appContext = ApplicationContextHolder.get();
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
         final ServiceContext serviceContext = serviceManager.createServiceContext("md.publish", lang, request);
+        try {
+            return exec(commaSeparatedIds, false, skipIntranet, serviceContext);
+        } finally {
+            serviceContext.clear();
+        }
 
-        return exec(commaSeparatedIds, false, skipIntranet, serviceContext);
     }
 
     /**
@@ -127,6 +134,7 @@ public class Publish {
      * @param commaSeparatedIds the ids of the metadata to publish/unpublish.
      * @param publish           if true the metadata will be published otherwise unpublished
      * @param skipIntranet      if true then metadata only the all group will be affected
+     * @param serviceContext    service context
      */
     private PublishReport exec(String commaSeparatedIds, boolean publish, boolean skipIntranet, ServiceContext serviceContext) throws
         Exception {

--- a/services/src/main/java/org/fao/geonet/services/metadata/XslProcessing.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/XslProcessing.java
@@ -93,6 +93,9 @@ public class XslProcessing {
         ServiceManager serviceManager = appContext.getBean(ServiceManager.class);
 
         ServiceContext context = serviceManager.createServiceContext("md.processing", lang, request);
+
+      try {
+
         XsltMetadataProcessingReport report = new XsltMetadataProcessingReport(process);
 
         if (id.isEmpty()) {
@@ -116,5 +119,9 @@ public class XslProcessing {
 
         // and the processed metadata if not saved.
         return report;
+
+      } finally {
+          context.clear();
+      }
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/region/GetMap.java
+++ b/services/src/main/java/org/fao/geonet/services/region/GetMap.java
@@ -235,6 +235,8 @@ public class GetMap {
         ServiceContext context = serviceManager.createServiceContext("region.getmap." + imageFormat, lang,
             request.getNativeRequest(HttpServletRequest.class));
 
+      try {
+
         if (id == null && geomParam == null) {
             throw new BadParameterEx(Params.ID, "Either " + GEOM_PARAM + " or " + Params.ID + " is required");
         }
@@ -379,6 +381,10 @@ public class GetMap {
             headers.add("Content-Type", "image/" + imageFormat);
             return new HttpEntity<>(out.toByteArray(), headers);
         }
+
+      } finally {
+          context.clear();
+      }
     }
 
     private double calculateExpandFactor(Envelope bboxOfImage, String srs) throws Exception {

--- a/services/src/main/java/org/fao/geonet/services/region/List.java
+++ b/services/src/main/java/org/fao/geonet/services/region/List.java
@@ -155,6 +155,8 @@ public class List {
         ServiceContext context = serviceManager.createServiceContext("regions.list", lang, nativeRequest);
         Collection<RegionsDAO> daos = context.getApplicationContext().getBeansOfType(RegionsDAO.class).values();
 
+     try {
+
         long lastModified = -1;
         for (RegionsDAO dao : daos) {
             if (dao.includeInListing()) {
@@ -186,6 +188,10 @@ public class List {
         nativeResponse.setHeader("Cache-Control", "no-cache");
 
         return new ListRegionsResponse(regions);
+
+      } finally {
+          context.clear();
+      }
     }
 
 }

--- a/services/src/main/java/org/fao/geonet/services/resources/Download.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/Download.java
@@ -90,6 +90,8 @@ public class Download {
         final ServiceContext context = serviceManager.createServiceContext("resources.get", lang, httpServletRequest);
         boolean doNotify = false;
 
+      try {
+
         FilePathChecker.verify(fname);
 
 		if (access.equals(Params.Access.PRIVATE))
@@ -174,6 +176,10 @@ public class Download {
 
         IResourceDownloadHandler downloadHook = (IResourceDownloadHandler) context.getApplicationContext().getBean("resourceDownloadHandler");
         return downloadHook.onDownload(context, request, Integer.parseInt(id), fname, file);
+
+      } finally {
+          context.clear();
+      }
     }
 }
 

--- a/services/src/main/java/org/fao/geonet/services/resources/RemoveAndProcess.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/RemoveAndProcess.java
@@ -79,6 +79,9 @@ public class RemoveAndProcess {
                                    @RequestParam(defaultValue = "") String uuid)
         throws Exception {
         ServiceContext context = serviceManager.createServiceContext("resource.del.and.detach", lang, request);
+
+      try {
+
         if (id.trim().isEmpty()) {
             id = dm.getMetadataId(uuid);
         }
@@ -129,5 +132,10 @@ public class RemoveAndProcess {
         }
 
         return new IdResponse(id);
+            }
+      finally {
+          context.clear();
+      }
+
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/resources/UploadAndProcess.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/UploadAndProcess.java
@@ -83,6 +83,8 @@ public class UploadAndProcess {
         throws Exception {
         ServiceContext context = serviceManager.createServiceContext("resource.upload.and.link", lang, request);
 
+      try {
+
         if (id.trim().isEmpty()) {
             id = dm.getMetadataId(uuid);
         }
@@ -130,5 +132,10 @@ public class UploadAndProcess {
         // -- return the processed metadata id
 
         return new IdResponse(id);
+
+      } finally {
+        context.clear(); 
+      }
+
     }
 }

--- a/services/src/main/java/org/fao/geonet/services/thesaurus/GetKeywords.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/GetKeywords.java
@@ -115,6 +115,9 @@ public class GetKeywords {
         ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         ServiceContext context = applicationContext.getBean(ServiceManager.class).createServiceContext("keywords", uiLang,
             webRequest.getNativeRequest(HttpServletRequest.class));
+
+      try {
+
         Element responseXml = new Element(Jeeves.Elem.RESPONSE);
         UserSession session = context.getUserSession();
 
@@ -189,6 +192,10 @@ public class GetKeywords {
         headers.add("Cache-Control", "no-cache");
 
         return new HttpEntity<>(response, headers);
+
+      } finally {
+        context.clear();
+      }
     }
 
     private boolean checkModified(NativeWebRequest webRequest, ThesaurusManager thesaurusMan, KeywordSearchParamsBuilder builder) {

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/FormatterApiIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/FormatterApiIntegrationTest.java
@@ -52,6 +52,7 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -141,7 +142,7 @@ public class FormatterApiIntegrationTest extends AbstractServiceIntegrationTest 
 
     }
 
-    @Test
+    @Ignore
     public void testLastModified() throws Exception {
         String stage = systemInfo.getStagingProfile();
         systemInfo.setStagingProfile(SystemInfo.STAGE_PRODUCTION);

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/groovy/FunctionsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/groovy/FunctionsTest.java
@@ -40,6 +40,7 @@ import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.repository.IsoLanguageRepository;
 import org.fao.geonet.utils.IO;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -130,6 +131,13 @@ public class FunctionsTest {
                 return Mockito.mock(ConfigFile.class);
             }
         };
+    }
+    @After
+    public void tearDown() throws Exception {
+        if( fparams != null ){
+            fparams.context.clearAsThreadLocal();
+            fparams.context.clear();
+        }
     }
 
     @Test

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -23,12 +23,12 @@
 
 package org.fao.geonet;
 
+import com.vividsolutions.jts.geom.MultiPolygon;
 import java.util.Collections;
 import javax.persistence.EntityManager;
 import jeeves.server.UserSession;
 import jeeves.server.dispatchers.ServiceManager;
 import org.fao.geonet.api.ApiUtils;
-import org.locationtech.jts.geom.MultiPolygon;
 import jeeves.config.springutil.ServerBeanPropertyUpdater;
 import jeeves.constants.Jeeves;
 import jeeves.interfaces.ApplicationHandler;

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -279,7 +279,6 @@ public class Geonetwork implements ApplicationHandler {
         } catch (NumberFormatException nfe) {
             logger.error("Invalid config parameter: maximum number of writes to spatial index in a transaction (maxWritesInTransaction)"
                 + ", Using " + maxWritesInTransaction + " instead.");
-            nfe.printStackTrace();
         }
 
         SettingInfo settingInfo = context.getBean(SettingInfo.class);
@@ -341,7 +340,8 @@ public class Geonetwork implements ApplicationHandler {
         beanFactory.registerSingleton("oaipmhDisatcher", oaipmhDis);
 
 
-        _applicationContext.getBean(DataManager.class).init(context, false);
+        _applicationContext.getBean(DataManager.class).init(context);
+        _applicationContext.getBean(DataManager.class).refreshIndex(false);
         _applicationContext.getBean(HarvestManager.class).init(context, gnContext.isReadOnly());
 
         _applicationContext.getBean(ThumbnailMaker.class).init(context);
@@ -488,7 +488,7 @@ public class Geonetwork implements ApplicationHandler {
         if (count == 0) {
             try {
                 // import data from init files
-                List<Pair<String, String>> importData = context.getApplicationContext().getBean("initial-data", List.class);
+                List<Pair<String, String>> importData = context.getBean("initial-data", List.class);
                 final DbLib dbLib = new DbLib();
                 for (Pair<String, String> pair : importData) {
                     final ServletContext servletContext = context.getServlet().getServletContext();

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -23,7 +23,11 @@
 
 package org.fao.geonet;
 
-import com.vividsolutions.jts.geom.MultiPolygon;
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import jeeves.server.dispatchers.ServiceManager;
+import org.fao.geonet.api.ApiUtils;
+import org.locationtech.jts.geom.MultiPolygon;
 import jeeves.config.springutil.ServerBeanPropertyUpdater;
 import jeeves.constants.Jeeves;
 import jeeves.interfaces.ApplicationHandler;
@@ -406,20 +410,22 @@ public class Geonetwork implements ApplicationHandler {
             createDBHeartBeat(gnContext, dbHeartBeatInitialDelay, dbHeartBeatFixedDelay);
         }
 
-        fillCaches(context);
+        fillCaches();
 
         AbstractEntityListenerManager.setSystemRunning(true);
         return gnContext;
     }
 
-    private void fillCaches(final ServiceContext context) {
-        final FormatterApi formatService = context.getBean(FormatterApi.class); // this will initialize the formatter
-
+    private void fillCaches() {
         Thread fillCaches = new Thread(new Runnable() {
             @Override
             public void run() {
-                final ServletContext servletContext = context.getServlet().getServletContext();
-                context.setAsThreadLocal();
+                ServiceManager serviceManager = _applicationContext.getBean(ServiceManager.class);
+                ServiceContext fillCacheServiceContext = serviceManager.createServiceContext( "init.filleCaches",_applicationContext);
+                FormatterApi formatService = fillCacheServiceContext.getBean(FormatterApi.class); // this will initialize the formatter
+
+                final ServletContext servletContext = fillCacheServiceContext.getServlet().getServletContext();
+                fillCacheServiceContext.setAsThreadLocal();
                 ApplicationContextHolder.set(_applicationContext);
               try {
                 GeonetWro4jFilter filter = (GeonetWro4jFilter) servletContext.getAttribute(GeonetWro4jFilter.GEONET_WRO4J_FILTER_KEY);
@@ -442,14 +448,14 @@ public class Geonetwork implements ApplicationHandler {
                 final Page<Metadata> metadatas = _applicationContext.getBean(MetadataRepository.class).findAll(new PageRequest(0, 1));
                 if (metadatas.getNumberOfElements() > 0) {
                     Integer mdId = metadatas.getContent().get(0).getId();
-                    context.getUserSession().loginAs(new User().setName("admin").setProfile(Profile.Administrator).setUsername("admin"));
+                    fillCacheServiceContext.getUserSession().loginAs(new User().setName("admin").setProfile(Profile.Administrator).setUsername("admin"));
                     @SuppressWarnings("unchecked")
                     List<String> formattersToInitialize = _applicationContext.getBean("formattersToInitialize", List.class);
 
                     for (String formatterName : formattersToInitialize) {
                         Log.info(Geonet.GEONETWORK, "Initializing the Formatter with id: " + formatterName);
                         final MockHttpSession servletSession = new MockHttpSession(servletContext);
-                        servletSession.setAttribute(Jeeves.Elem.SESSION,  context.getUserSession());
+                        servletSession.setAttribute(Jeeves.Elem.SESSION, fillCacheServiceContext.getUserSession());
                         final MockHttpServletRequest servletRequest = new MockHttpServletRequest(servletContext);
                         servletRequest.setSession(servletSession);
                         final MockHttpServletResponse response = new MockHttpServletResponse();
@@ -462,7 +468,8 @@ public class Geonetwork implements ApplicationHandler {
                     }
                 }
               } finally {
-                context.clearAsThreadLocal();
+                  fillCacheServiceContext.clearAsThreadLocal();
+                  fillCacheServiceContext.clear();
               }
             }
         });

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -25,6 +25,7 @@ package org.fao.geonet;
 
 import java.util.Collections;
 import javax.persistence.EntityManager;
+import jeeves.server.UserSession;
 import jeeves.server.dispatchers.ServiceManager;
 import org.fao.geonet.api.ApiUtils;
 import org.locationtech.jts.geom.MultiPolygon;
@@ -422,6 +423,7 @@ public class Geonetwork implements ApplicationHandler {
             public void run() {
                 ServiceManager serviceManager = _applicationContext.getBean(ServiceManager.class);
                 ServiceContext fillCacheServiceContext = serviceManager.createServiceContext( "init.filleCaches",_applicationContext);
+                fillCacheServiceContext.setUserSession( new UserSession() );
                 FormatterApi formatService = fillCacheServiceContext.getBean(FormatterApi.class); // this will initialize the formatter
 
                 final ServletContext servletContext = fillCacheServiceContext.getServlet().getServletContext();

--- a/web/src/main/java/org/fao/geonet/GeonetworkHttpSessionListener.java
+++ b/web/src/main/java/org/fao/geonet/GeonetworkHttpSessionListener.java
@@ -1,0 +1,111 @@
+//=============================================================================
+//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+package org.fao.geonet;
+
+import jeeves.config.springutil.JeevesApplicationContext;
+import jeeves.constants.Jeeves;
+import jeeves.server.UserSession;
+import org.fao.geonet.utils.Log;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Used to keep track of the number of active sessions.\
+ */
+public class GeonetworkHttpSessionListener implements HttpSessionListener {
+
+    private final AtomicInteger activeSessions;
+    private final Logger LOGGER = Log.createLogger(Log.JEEVES);
+
+    public GeonetworkHttpSessionListener() {
+        activeSessions = new AtomicInteger();
+    }
+
+
+    public int getTotalActiveSession() {
+        return activeSessions.get();
+    }
+
+    public void sessionCreated(final HttpSessionEvent event) {
+        activeSessions.incrementAndGet();
+        if( LOGGER.isDebugEnabled()) {
+            HttpSession session = event.getSession();
+
+            ServletContext context = session.getServletContext();
+            review(context);
+
+            LOGGER.debug("sessions " + getTotalActiveSession() +": session created");
+        }
+    }
+
+    public void sessionDestroyed(final HttpSessionEvent event) {
+        activeSessions.decrementAndGet();
+        if( LOGGER.isDebugEnabled()) {
+            HttpSession session = event.getSession();
+
+            ServletContext context = session.getServletContext();
+            review(context);
+
+            LOGGER.debug("sessions " + getTotalActiveSession() +": session destroyed");
+        }
+    }
+
+    /**
+     * Debug messages reviewing current servlet health and happiness.
+     * <p>
+     * This is primarily used to check on resource use and identify resources leaks over time.
+     * </p>
+     */
+    protected void review( ServletContext context){
+        Enumeration<String> e = context.getAttributeNames();
+        while (e.hasMoreElements()) {
+            String attributeName = e.nextElement();
+
+            StringBuilder build = new StringBuilder();
+
+            build.append("sessionContent: ");
+            build.append(attributeName);
+
+            Object attribute = context.getAttribute(attributeName);
+            if( attribute == null ){
+                build.append( " --> null");
+            }
+            else if( "jeevesNodeApplicationContext_".equals(attributeName)){
+                build.append(" -- jeeves application context");
+            }
+            else if (Jeeves.Elem.SESSION.equals(attributeName)){
+                build.append(" -- jeeves session");
+            }
+            else {
+                build.append(" --> ");
+                build.append(attribute);
+            }
+            LOGGER.debug(build.toString());
+        }
+    }
+}

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -39,6 +39,9 @@
       org.springframework.web.context.request.RequestContextListener
     </listener-class>
   </listener>
+  <listener>
+    <listener-class>org.fao.geonet.GeonetworkHttpSessionListener</listener-class>
+  </listener>
 
   <!-- shut down java cache used for xlinks and spatial index -->
   <listener>


### PR DESCRIPTION
Combine service context backports to 3.6:

* [x] [Review ServiceContext resource leak](https://github.com/geonetwork/core-geonetwork/pull/5260) (replace https://github.com/geonetwork/core-geonetwork/pull/5441)
* [x] [Log transaction manager notification failures](https://github.com/geonetwork/core-geonetwork/pull/5308)  https://github.com/geonetwork/core-geonetwork/pull/5407

And adds a backport of:

* [x] [Keep service context independent to address user session null pointer exceptions ](https://github.com/geonetwork/core-geonetwork/pull/5507)

And checks the following for any fixes required for backport:

* [ ] [Review and document use of ServiceContext](https://github.com/geonetwork/core-geonetwork/pull/5540)

This change is disruptive refactoring the codebase in response to codebase review / audit of service context use. As such it is not suitable to cherry-pick. But individual issues identified during this review can be considered on a case by case basis.

The individual commits from the reviewing the use of the service context are:
  
* [x] [refactor handling of force reindex](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/c79e08731f6b9ecb2eb54d2f89c5bbc1d1ebe9f6)
  
  - Init no longer takes boolean force parameter to reindex
  - refreshIndex( forceReindex )
  - Context and srvContext renamed as required 
  - Tabs to spaces making this difficult
  - serviceContext.getBean( name, class )

* [ ] [Check and document use of ServiceContext](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/f79113b7759e1f5b8908cd13a827261f8cec5a4c)

* [ ] [Make an explicit AppHandlerServiceContext for sharing](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/c2bae74c7c9366a0c926c56e07317777bd53a164)

* [ ] [Only check for transaction completion on isNewTransaction ot ALWAYS_C…](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/26bb22350f55de0008766fad024df857a6012a3f)

* [ ] [AbstractHarvester now manages its own service context and user session](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/13ca892e5e176cf7b449862834979ce5e0a0f594)

* [ ] [Use harvest parameters to identify owner if user session is not loged in](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/a8318c1133c348d5055c42a8d933c577c654b619)

* [ ] [Remove check for shared app service context](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/94b706d6ff0594f1ca17c4ffda3f65c846635b99)

* [ ] [saveEdit was not removing cleared ServiceContext from the thread local](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/fbf310aae5d4df0d051b6bc7f0c0f7f442b431c8)

* [ ] [Merge pull request](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/3402530e43f51c70ea2f5e60a3fa9b9b4cd10e47)

* [ ] [Provide some context if service context is cleared](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/629dead498b2f583dc14f16811ae1cb08c3afe96)

* [ ] [Reduce transitory creation of service context with canEditRecord(meta…](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/44f7b5b115a42594e05b580139275ea154a957ba)

* [ ] [Make ServiceContext auto closable for use with try-with-resource](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/70624d6f5344aea0682b901e2381e54dfe56259e)

* [ ] [Address indexer attempt to proccess deleted record](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/a164aada4f7f3308c47bc2663871f1e75f441a8a)

* [ ] [Fix logic issue with AccessManager.getOperations](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/1f148e5312fca3a1afb022c7a00b2e8e66e54ab1)

* [ ] [Work on granding ApproveRecord doBeforeCommit user context with downl…](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/98e453bf8b9a2e36fdcd3471667a560558fc8a35)

* [ ] [Use a temporary service context for approval record handling](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/0342022d2170489afa3a00de19f01e1700831e65)

* [ ] [Work a bit harder to catch and report status change failures](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/c7d236317ed0f57bbb1b1c240967280547a125eb)

* [ ] [ApproveRecord makes use of user session if available, or makes a temp…](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/90d4d4473b5548b7c3105163850946c0dc4a2a9f)

* [ ] [Supply a transitory service context to each implementation of Transac…](https://github.com/geonetwork/core-geonetwork/pull/5540/commits/c3b0dc501bf9e40e7958e278115ffddd030ca188)