### PR TITLE
Proxy / Properly unset properties if no proxy used.

### DIFF
--- a/core/src/main/java/org/fao/geonet/lib/NetLib.java
+++ b/core/src/main/java/org/fao/geonet/lib/NetLib.java
@@ -170,10 +170,9 @@ public class NetLib {
                 Log.error(Geonet.GEONETWORK, "Proxy credentials cannot be used");
             }
         } else {
-            Properties props = System.getProperties();
-            props.put("http.proxyHost", "");
-            props.put("http.proxyPort", "");
-            props.put("http.nonProxyHosts", "");
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.nonProxyHosts");
         }
     }
 


### PR DESCRIPTION
A symptom was WFS harvesting was failing with obscure numberFormatException while parsing proxy port. This was only occurring if settings was saved and NetLib called. eg. https://github.com/geotools/geotools/blob/main/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java#L111 expects null and not ""