### PR TITLE
Scroll spy / Editor / Fix empty in editor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/scrollspy/ScrollSpyDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/scrollspy/ScrollSpyDirective.js
@@ -155,7 +155,9 @@
             }
 
             // Spy only first level of fieldsets
-            rootElement.find('> fieldset > legend').each(registerSpy);
+            rootElement
+              .find('> fieldset > legend, > div > fieldset > legend')
+              .each(registerSpy);
             $(window).scroll(function() {
               if (scope.isEnabled) {
                 scope.$apply(function() {


### PR DESCRIPTION
Not sure since when but scroll spy does not work anymore in editor. Probably due to a change in DOM structure.

![image](https://user-images.githubusercontent.com/1701393/121471573-37ae3680-c9c0-11eb-9d06-2c716c9f4191.png)

Tested in editor and settings ok.