### PR TITLE
Group / Restore possibility to use group logo / In non debug mode avoid JS error

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -197,9 +197,12 @@
         $scope.fromView = v ? v.substring(1) : v;
       });
 
-      $http.get('../api/groups/' + $scope.gnMdViewObj.current.record.groupOwner,
-        {cache: true}).success(function(data) {
-        $scope.recordGroup = data;
-      });
+      if ($scope.gnMdViewObj.current.record
+        && $scope.gnMdViewObj.current.record.groupOwner) {
+        $http.get('../api/groups/' + $scope.gnMdViewObj.current.record.groupOwner,
+          {cache: true}).success(function(data) {
+          $scope.recordGroup = data;
+        });
+      }
     }]);
 })();


### PR DESCRIPTION
On old record, groupOwner may also be null and current can be null in non debug mode

Related https://github.com/geonetwork/core-geonetwork/pull/5721