### PR TITLE
WFS feature harvester / Manage from editor.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -170,6 +170,14 @@
               <br/>
               <strong>{{resource.title | gnLocalized: lang}}</strong><br/>
               {{resource.description | gnLocalized: lang}}
+
+              <div data-ng-if="resource.protocol.match('OGC:WMS') !== null"
+                   data-gn-wfs-filter-facets=""
+                   manager-only="true"
+                   data-wfs-url="{{::resource.lUrl}}"
+                   data-feature-type-name="{{::resource.title | gnLocalized: lang}}"
+                   data-md="gnCurrentEdit.metadata"
+                   data-boot-mode="index"></div>
             </div>
             <div class="col-md-1 text-right">
               <a href=""

--- a/web-ui/src/main/resources/catalog/components/index/partials/datafilterview.html
+++ b/web-ui/src/main/resources/catalog/components/index/partials/datafilterview.html
@@ -1,5 +1,4 @@
 <div class="gn-data-view">
-
   <div>
     <label translate="">filter</label>
     <select class="form-control"
@@ -16,9 +15,9 @@
            class="clearfix"
            data-map="map"></div>
 
-      <div data-gn-wfs-filter-facets="" data-layer="currentLayer" data-boot-mode="index"> </div>
-
+      <div data-gn-wfs-filter-facets=""
+           data-layer="currentLayer"
+           data-boot-mode="index"></div>
     </div>
   </div>
-
 </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -409,6 +409,8 @@
               if (ogcGraticule && ogcGraticule.layer && ogcGraticule.url) {
                 scope.graticuleOgcService = ogcGraticule;
               }
+
+              initFromLocation();
             },
             post: function postLink(scope, iElement, iAttrs, controller) {
               //TODO: find another solution to render the map

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -1,4 +1,5 @@
-<form name="wfsFilterForm">
+<form name="wfsFilterForm"
+      ng-if="isFeatureTypeAvailable !== false">
   <input type="hidden" name="_csrf" value="{{csrf}}"/>
 
   <!--WFS not available alert-->

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -18,14 +18,68 @@
 
   <div>
 
-    <!--Facet count-->
-    <div data-ng-if="isFeaturesIndexed" class="count text-center"
-         data-ng-if="showCount">
-      {{count | number}}&nbsp;/&nbsp;{{countTotal | number}}&nbsp;<span translate="">features</span>
+    <!--admin buttons-->
+    <div class="btn-group dropup wfs-filter-group">
+      <!--Facet count-->
+      <div class="btn btn-default btn-xs disabled"
+           data-ng-if="isFeaturesIndexed" class="count text-center"
+           data-ng-if="showCount">
+        {{count | number}}&nbsp;/&nbsp;{{countTotal | number}}&nbsp;<span translate="">features</span>
+      </div>
+
+      <button class="btn btn-default btn-xs"
+              data-ng-if="!managerOnly && isFeaturesIndexed"
+              title="{{::'Table' | translate}}"
+              ng-click="showTable()">
+        <i class="fa fa-table"></i>
+      </button>
+      <button class="btn btn-default btn-xs"
+              ng-class="{ disabled: !filtersChanged }"
+              data-ng-if="!managerOnly && isFeaturesIndexed"
+              title="{{::'applyFilter' | translate}}"
+              data-gn-click-and-spin="filterWMS()"
+              data-gn-click-and-spin-stay-disabled="true">
+        <i class="fa fa-filter"></i>
+      </button>
+      <button class="btn btn-default btn-xs"
+              title="{{::'refresh' | translate}}"
+              data-ng-click="initIndexRequest()">
+        <i class="fa fa-refresh"></i>
+      </button>
+      <button data-ng-if="user.canEditRecord(md) || md.isHarvested == 'true'"
+              type="button"
+              class="btn btn-default btn-xs dropdown-toggle"
+              data-toggle="dropdown"
+              aria-haspopup="true" aria-expanded="false">
+        <i class="fa fa-cog"></i>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenu1"
+          data-ng-if="user.canEditRecord(md) || md.isHarvested == 'true'">
+        <li>
+          <a href="" data-ng-click="indexWFSFeatures('1.1.0')">
+            <i class="fa fa-cloud-download"></i>&nbsp;
+            <span data-translate="">reindexWFSFeatures</span>
+          </a>
+        </li>
+        <li>
+          <a href="" data-ng-click="dropFeatures()">
+            <i class="fa fa-eraser"></i>&nbsp;
+            <span data-translate="">removeFeatures</span>
+          </a>
+        </li>
+      </ul>
+      <a data-ng-if="managerOnly"
+         title="{{'addToMap' | translate}}"
+         data-ng-href="catalog.search#/map?add={{mapAddCmd | encodeURIComponent}}"
+         class="btn btn-default btn-xs">
+        <i class="fa fa-globe"></i>
+      </a>
     </div>
 
+
     <!--Facet fields-->
-    <div data-ng-if="isFeaturesIndexed"
+    <div data-ng-if="!managerOnly && isFeaturesIndexed"
          class="gn-facet"
          data-ng-repeat="field in fields track by field.name">
       <h5 gn-collapsible="field.expanded">
@@ -77,7 +131,7 @@
     </div>
     <!--Geometry Field-->
     <div class="gn-facet"
-         ng-if="isFeaturesIndexed && indexObject.geomField">
+         ng-if="!managerOnly && isFeaturesIndexed && indexObject.geomField">
       <h5 gn-collapsible="indexObject.geomField.expanded">
         <span class="fa fa-arrow-circle-right"
               data-ng-class="{'fa-rotate-90': indexObject.geomField.expanded, 'gn-field-empty': !isFilterActive('geometry')}"></span>
@@ -92,57 +146,9 @@
       </div>
     </div>
 
-    <!--admin buttons-->
-    <div class="btn-group dropup wfs-filter-group">
-      <button class="btn btn-default btn-xs" ng-class="{ disabled: !filtersChanged }"
-              data-gn-click-and-spin="filterWMS()"
-              data-gn-click-and-spin-stay-disabled="true">
-        <i class="fa fa-filter"></i>&nbsp;
-        <span data-translate="">applyFilter</span>
-      </button>
-      <button class="btn btn-default btn-xs"
-              title="{{'refresh' | translate}}"
-              data-ng-click="initIndexRequest()">
-        <i class="fa fa-refresh"></i>
-      </button>
-      <button data-ng-if="user.canEditRecord(md) || md.isHarvested == 'true'"
-              type="button" class="btn btn-default btn-xs dropdown-toggle"
-              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <i class="fa fa-cog"></i>
-        <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu" aria-labelledby="dropdownMenu1"
-          data-ng-if="user.canEditRecord(md) || md.isHarvested == 'true'">
-        <li>
-          <a href="" data-ng-click="indexWFSFeatures('1.1.0')">
-            <i class="fa fa-pie-chart"></i>&nbsp;
-            <span data-translate="">reindexWFSFeatures</span>
-          </a>
-        </li>
-        <li>
-          <a href="" data-ng-click="initIndexRequest()">
-            <i class="fa fa-refresh"></i>&nbsp;
-            <span data-translate="">refresh</span>
-          </a>
-        </li>
-        <li>
-          <a href="" data-ng-click="dropFeatures()">
-            <i class="fa fa-times"></i>&nbsp;
-            <span data-translate="">removeFeatures</span>
-          </a>
-        </li>
-      </ul>
-      <button class="btn btn-default btn-xs"
-              data-ng-if="isFeaturesIndexed"
-              ng-click="showTable()">
-        <i class="fa fa-table"></i>&nbsp;
-        <span data-translate="">Table</span>
-      </button>
-    </div>
-
-    <hr>
-    <button data-gn-click-and-spin="resetFacets(false).then(filterWMS)"
-            class="btn btn-primary gn-reset-facets">
+    <button data-ng-if="!managerOnly && isFeaturesIndexed"
+            data-gn-click-and-spin="resetFacets(false).then(filterWMS)"
+            class="btn btn-primary btn-xs gn-reset-facets">
       <span translate>reset</span>
     </button>
 


### PR DESCRIPTION
Give more visibility to the WFS feature harvester. From the editor, user can trigger WFS feature indexing. Once complete, they can preview the layer on the map. If the feature type is not found, the widget is not displayed.

![image](https://user-images.githubusercontent.com/1701393/121665012-60116000-caa8-11eb-8955-361d532365d3.png)

The same directive is used in the map viewer:

![image](https://user-images.githubusercontent.com/1701393/121665023-6273ba00-caa8-11eb-8d19-350f153b428f.png)
