### PR TITLE
Aggregation / Add terms script support

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/LuceneQueryParser.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/LuceneQueryParser.js
@@ -109,10 +109,11 @@
         }
       } else if (angular.isString(node)) {
         query_string += node
-      } else if (node === true) {
-        query_string += indexKey + ':"' + nodeName + '"'
-      } else if (node === false) {
-        query_string += '-' + indexKey + ':"' + nodeName + '"'
+      } else if (node === true || node === false) {
+        var value = nodeName.endsWith('*')
+          ? nodeName.replace(' ', '\\\\ ')
+          : '"' + nodeName + '"';
+        query_string += (node ? '' : '-') + indexKey + ':' + value;
       }
       return query_string
     }

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -103,9 +103,8 @@
             <a class="pull-left clearfix"
               title="{{facet.key}}"
               role="link"
-              data-ng-init="field = (aggResponse.meta && aggResponse.meta.field) || homeFacet.key"
-              data-ng-href='#/search?query_string={"{{field}}": {"{{facet.key}}": true} }'>
-
+              data-ng-init="field = (aggResponse.meta && aggResponse.meta.field) || homeFacet.key; value = aggResponse.meta && aggResponse.meta.wildcard ? (facet.key + '*') : facet.key"
+              data-ng-href='#/search?query_string={"{{field}}": {"{{value}}": true} }'>
               <!-- TODOES Link label to icons? -->
               <span class="badge-icon badge-result-topic pull-left">
                 <i class="fa fa-3x gn-icon gn-icon-{{facet.key.replace('/', '').replace(' ', '')}}"


### PR DESCRIPTION
Elastic provide support of script in aggregation config using painless
language. See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-script

For example, the resource identifier is using a predefined scheme eg. `eurostat_v_4258_100_k_gisco-mreg-2021_i_2021_v01_r01` and user wants to build a facet on the first part of the identifier. The script can extract it and build an aggregation on it. Then the configuration needs to indicate which field has to be used using `meta.field` and if a wildcard mode is required.

```json
'facetConfig': {
  "OrgForResource": {
    "terms" : {
      "script": {
        "inline": "doc['resourceIdentifier.code'].size() == 0 ? 'http' : /_/.split(doc['resourceIdentifier.code'].getValue())[0]"
      },
      "exclude": "http.*",
      "size": 10,
      "order" : { "_key" : "asc" }
    },
    "meta": {
      "field": "resourceIdentifier.code",
      "wildcard": true
    }
  },
```

![image](https://user-images.githubusercontent.com/1701393/121687930-3285e000-cac3-11eb-8866-9c0098e18a35.png)

From the home page the filter is applied

![image](https://user-images.githubusercontent.com/1701393/121688017-4893a080-cac3-11eb-85ec-336b3ce6ef04.png)

(translation API can be used to customize the label)


