### PR TITLE
Fix encoding issue in field upload directive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/fieldupload/FieldUploadDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/fieldupload/FieldUploadDirective.js
@@ -78,6 +78,7 @@
             var elementNs = scope.elementName.split(':')[0];
             var elementXlinkNs = 'xlink';
 
+            // Use underscore _.escape to encode html entities in the xml snippet
             scope.xmlSnippet = '<' + scope.elementName +
               ' xmlns:' +
               elementNs + '="' +
@@ -90,8 +91,8 @@
               '" xmlns:' + anchorElementNs + '="' +
               gnSchemaManagerService.findNamespaceUri(anchorElementNs,
                 gnCurrentEdit.schema) + '">' +
-              '<' + anchorElement + ' xlink:href="' + scope.linkHref + '">' +
-              scope.value + '</' + anchorElement + '>' +
+              '<' + anchorElement + ' xlink:href="' + _.escape(scope.linkHref) + '">' +
+              _.escape(scope.value) + '</' + anchorElement + '>' +
               '</' + scope.elementName + '>';
           };
 


### PR DESCRIPTION
When using the character `&` in the directive text fields, it was not encoded when added to the xml snippet that is created for the metadata element, causing an error. 