### PR TITLE
Formatter / Multilingual support / Can't define the language anymore

### DIFF
--- a/web/src/main/webapp/xslt/common/utility-tpl.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl.xsl
@@ -71,7 +71,7 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:call-template name="addLineBreaksAndHyperlinksInternal">
-          <xsl:with-param name="txt" select="."/>
+          <xsl:with-param name="txt" select="$txt"/>
         </xsl:call-template>
       </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
Issue introduced in https://github.com/geonetwork/core-geonetwork/pull/5446

An XSL formatter applied to a multilingual record always display all languages.

eg. 
http://localhost:8080/geonetwork/srv/api/records/b07a4589-159b-4c3a-b1e7-dbdad11f7e62/formatters/xsl-view?view=advanced&language=fre MUST display French and fallback to main language