### PR TITLE
Search / Add all title's translations in the default search

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -145,7 +145,7 @@ goog.require('gn_alert');
           // Full text on all fields
           // 'queryBase': '${any}',
           // Full text but more boost on title match
-          'queryBase': 'any:(${any}) resourceTitleObject.default:(${any})^2',
+          'queryBase': 'any:(${any}) resourceTitleObject.\\*:(${any})^2',
           'exactMatchToggle': true,
           // Score query may depend on where we are in the app?
           'scoreConfig': {


### PR DESCRIPTION
Fixes https://github.com/geonetwork/core-geonetwork/issues/5660

Solve use case: search with a word in the non default lang title return no result

Then the question is what to do next eg. index translation in any field, choose language to search on depending on UI ...