### PR TITLE
OpenAPI / Restore missing operations from the doc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1508,7 +1508,7 @@
     <spring.security.version>5.2.5.RELEASE</spring.security.version>
     <spring.jpa.version>2.2.8.RELEASE</spring.jpa.version>
     <springboot.version>2.2.2.RELEASE</springboot.version>
-    <springdoc.version>1.3.9</springdoc.version>
+    <springdoc.version>1.5.9</springdoc.version>
 
     <metrics.version>2.1.1</metrics.version>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH'\:'mm'\:'ssZ</maven.build.timestamp.format>

--- a/services/src/main/java/org/fao/geonet/api/OpenApiController.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiController.java
@@ -26,40 +26,26 @@ import io.swagger.v3.core.util.PathUtils;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.fao.geonet.ApplicationContextHolder;
 import org.springdoc.api.AbstractOpenApiResource;
 import org.springdoc.core.*;
 import org.springdoc.core.customizers.OpenApiCustomiser;
 import org.springdoc.core.customizers.OperationCustomizer;
-import org.springdoc.core.visitor.AbstractRouterFunctionVisitor;
-import org.springdoc.webmvc.api.ActuatorProvider;
-import org.springdoc.webmvc.api.RouterFunctionProvider;
+import org.springdoc.webmvc.core.RouterFunctionProvider;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.MediaType;
-import org.springframework.util.CollectionUtils;
-import org.springframework.web.WebApplicationInitializer;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.context.ContextLoaderListener;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRegistration;
 import javax.servlet.http.HttpServletRequest;
 import java.util.*;
 
@@ -91,18 +77,19 @@ public class OpenApiController extends AbstractOpenApiResource {
     private final Optional<RouterFunctionProvider> routerFunctionProvider;
 
     @Autowired
-    public OpenApiController(OpenAPIBuilder openAPIBuilder, AbstractRequestBuilder requestBuilder,
-                           GenericResponseBuilder responseBuilder, OperationBuilder operationParser,
-                           RequestMappingInfoHandlerMapping requestMappingHandlerMapping,
-                           Optional<ActuatorProvider> servletContextProvider,
-                           Optional<List<OperationCustomizer>> operationCustomizers,
-                           Optional<List<OpenApiCustomiser>> openApiCustomisers,
-                           SpringDocConfigProperties springDocConfigProperties,
-                           Optional<SecurityOAuth2Provider> springSecurityOAuth2Provider,
-                           Optional<RouterFunctionProvider> routerFunctionProvider) {
-        super(DEFAULT_GROUP_NAME, openAPIBuilder, requestBuilder, responseBuilder, operationParser, operationCustomizers, openApiCustomisers, springDocConfigProperties);
-
-//        springDocConfigProperties.setPathsToMatch(Arrays.asList(new String[]{"api/**"}));
+    public OpenApiController(ObjectFactory<OpenAPIService> openAPIBuilderObjectFactory,
+                             AbstractRequestService requestBuilder,
+                             GenericResponseService responseBuilder,
+                             OperationService operationParser,
+                             RequestMappingInfoHandlerMapping requestMappingHandlerMapping,
+                             Optional<ActuatorProvider> servletContextProvider,
+                             Optional<List<OperationCustomizer>> operationCustomizers,
+                             Optional<List<OpenApiCustomiser>> openApiCustomisers,
+                             SpringDocConfigProperties springDocConfigProperties,
+                             Optional<ActuatorProvider> actuatorProvider,
+                             Optional<SecurityOAuth2Provider> springSecurityOAuth2Provider,
+                             Optional<RouterFunctionProvider> routerFunctionProvider) {
+        super(DEFAULT_GROUP_NAME, openAPIBuilderObjectFactory, requestBuilder, responseBuilder, operationParser, operationCustomizers, openApiCustomisers, springDocConfigProperties, actuatorProvider);
         springDocConfigProperties.setPathsToExclude(Arrays.asList(new String[]{"/0.1/**"}));
         springDocConfigProperties.setPackagesToScan(Arrays.asList(new String[]{
             "org.fao.geonet.api",
@@ -138,7 +125,6 @@ public class OpenApiController extends AbstractOpenApiResource {
 
         if (servletContextProvider.isPresent()) {
             map = servletContextProvider.get().getMethods();
-            this.openAPIBuilder.addTag(new HashSet<>(map.values()), servletContextProvider.get().getTag());
             calculatePath(restControllers, map, servletContextProvider);
         }
         if (this.springSecurityOAuth2Provider.isPresent()) {
@@ -151,7 +137,9 @@ public class OpenApiController extends AbstractOpenApiResource {
         }
     }
 
-    protected void calculatePath(Map<String, Object> restControllers, Map<RequestMappingInfo, HandlerMethod> map, Optional<ActuatorProvider> actuatorProvider) {
+    protected void calculatePath(Map<String, Object> restControllers,
+                                 Map<RequestMappingInfo, HandlerMethod> map,
+                                 Optional<ActuatorProvider> actuatorProvider) {
         for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : map.entrySet()) {
             RequestMappingInfo requestMappingInfo = entry.getKey();
             HandlerMethod handlerMethod = entry.getValue();
@@ -161,36 +149,36 @@ public class OpenApiController extends AbstractOpenApiResource {
             for (String pattern : patterns) {
                 String operationPath = PathUtils.parsePath(pattern, regexMap)
                     .replace("/{portal}/api", "");
-                if (((actuatorProvider.isPresent() && actuatorProvider.get().isRestController(operationPath))
+                if (((actuatorProvider.isPresent() && actuatorProvider.get().isRestController(operationPath, handlerMethod.getClass()))
                     || isRestController(restControllers, handlerMethod, operationPath))
                     && isPackageToScan(handlerMethod.getBeanType().getPackage())
                     && isPathToMatch(operationPath)) {
                     Set<RequestMethod> requestMethods = requestMappingInfo.getMethodsCondition().getMethods();
+
                     // default allowed requestmethods
                     if (requestMethods.isEmpty())
                         requestMethods = this.getDefaultAllowedHttpMethods();
                     calculatePath(handlerMethod, operationPath, requestMethods);
+//                } else {
+//                    System.out.println("API path ignored: " + operationPath);
                 }
             }
         }
-//        routerFunctionProvider.ifPresent(routerFunctions -> routerFunctions.getWebMvcRouterFunctionPaths()
-//            .ifPresent(routerBeans -> routerBeans.forEach(this::getRouterFunctionPaths)));
     }
 
-    protected boolean isRestController(Map<String, Object> restControllers, HandlerMethod handlerMethod,
+    protected boolean isRestController(Map<String, Object> restControllers,
+                                       HandlerMethod handlerMethod,
                                        String operationPath) {
-        ResponseBody responseBodyAnnotation = AnnotationUtils.findAnnotation(handlerMethod.getBeanType(), ResponseBody.class);
-        if (responseBodyAnnotation == null)
-            responseBodyAnnotation = AnnotationUtils.findAnnotation(handlerMethod.getMethod(), ResponseBody.class);
-
-        return (responseBodyAnnotation != null && restControllers.containsKey(handlerMethod.getBean().toString()) || isAdditionalRestController(handlerMethod.getBeanType()))
+        return (restControllers.containsKey(handlerMethod.getBean().toString())
+                || isAdditionalRestController(handlerMethod.getBeanType()))
             && operationPath.startsWith(DEFAULT_PATH_SEPARATOR)
-            && (springDocConfigProperties.isModelAndViewAllowed() || !ModelAndView.class.isAssignableFrom(handlerMethod.getMethod().getReturnType()));
+            && (springDocConfigProperties.isModelAndViewAllowed()
+                || !ModelAndView.class.isAssignableFrom(handlerMethod.getMethod().getReturnType()));
     }
 
     protected void calculateServerUrl(HttpServletRequest request, String apiDocsUrl) {
         String requestUrl = decode(request.getRequestURL().toString());
         String calculatedUrl = requestUrl.substring(0, requestUrl.length() - apiDocsUrl.length());
-        openAPIBuilder.setServerBaseUrl(calculatedUrl);
+        this.openAPIService.setServerBaseUrl(calculatedUrl);
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/languages/LanguagesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/languages/LanguagesApi.java
@@ -28,20 +28,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.context.ServiceContext;
-import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.domain.Language;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.lib.DbLib;
-import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.LanguageRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -58,7 +55,7 @@ import java.util.List;
 })
 @Tag(name = "languages",
     description = "Languages operations")
-@Controller("languages")
+@RestController
 public class LanguagesApi {
 
     @Autowired
@@ -66,6 +63,7 @@ public class LanguagesApi {
 
     @Autowired
     private GeonetworkDataDirectory dataDirectory;
+
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Get languages",

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/WFSHarvesterApi.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/WFSHarvesterApi.java
@@ -39,7 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -48,7 +47,7 @@ import java.util.HashMap;
 /**
  * Created by fgravin on 10/29/15.
  */
-@Controller
+@RestController
 @RequestMapping(value = {
         "/{portal}/api/workers/data/wfs/actions"
 })
@@ -82,7 +81,6 @@ public class WFSHarvesterApi {
 
     @Operation(summary = "Delete a WFS feature type")
     @RequestMapping(
-//    @RequestMapping(value = "/{serviceUrl:.*}/{typeName:.*}",
         consumes = MediaType.ALL_VALUE,
         produces = MediaType.ALL_VALUE,
         method = RequestMethod.DELETE)


### PR DESCRIPTION
Was mainly related to isRestController checking for non null ResponseBody and also some controllers not listed in https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-common/src/main/java/org/springdoc/core/OpenAPIService.java#L216-L218 (not sure why).


Related 
* https://github.com/geonetwork/core-geonetwork/pull/5631
* https://github.com/geonetwork/core-geonetwork/issues/5432

@ianwallen I took some time to have a look to the missing API methods. It should be better now.
Maybe you can check this PR when you've a moment, thanks?

It fixes missing GET|DELETE /records/uuid and missing /languages/*

