### PR TITLE
Add a TOC to the UI settings page and fix the top toolbar

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -1,353 +1,54 @@
 <div>
   <p class="help-block" data-translate="">ui/config-help</p>
-  <fieldset data-ng-repeat="(m, mCfg) in jsonConfig.mods">
-    <legend data-ng-if="mCfg.enabled !== undefined">
-      <input type="checkbox"
-             id="{{m}}-checkbox"
-             data-ng-model="mCfg.enabled"/>&nbsp;
-      <h2><label for="{{m}}-checkbox">{{('ui-mod-' + m) | translate}}</label></h2>
-    </legend>
-    <legend data-ng-if="mCfg.enabled === undefined">
-      <h2>{{('ui-mod-' + m) | translate}}</h2>
-    </legend>
-
-    <p class="help-block"
-       data-ng-show="(('ui-mod-' + m + '-help') | translate) != ('ui-mod-' + m + '-help')">
-      {{('ui-' + m + '-help') | translate}} </p>
-
-    <div class="col-sm-12 form-group"
-         data-ng-if="mCfg.enabled === undefined || mCfg.enabled === true"
-         data-ng-repeat="(key, value) in mCfg"
-         data-ng-switch="key">
-
-      <!-- DEPRECATED SETTINGS (hidden) -->
-      <div data-ng-switch-when="enabled"></div>
-      <div data-ng-switch-when="context"></div>
-      <div data-ng-switch-when="layer"></div>
-      <div data-ng-switch-when="searchMapLayers"></div>
-      <div data-ng-switch-when="viewerMapLayers"></div>
-      <div data-ng-switch-when="mapExtent"></div>
-      <div data-ng-switch-when="mapBackgroundLayer"></div>
-
-
-      <!-- arrays -->
-      <div data-ng-switch-when="hitsperpageValues">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped table-bordered">
-          <tr data-ng-repeat="v in mCfg[key] track by $index">
-            <td>
-              <input type="number"
-                     class="form-control"
-                     id="{{key}}-{{$index}}"
-                     data-ng-model="mCfg[key][$index]"/>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <a class="btn btn-default"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], mCfg[key][mCfg[key].length - 1] * 10)">
-                <i class="fa fa-fw fa-plus"/>
-                <span translate="">add</span>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
+  <tabset id="settings-tabset" type="pills" justified="false" role="tablist">
+    <tab heading="{{('ui-mod-' + m) | translate}}"
+         id="setting_{{m}}"
+         role="tab"
+         data-ng-repeat="(m, mCfg) in jsonConfig.mods">
+      <div data-ng-if="mCfg.enabled !== undefined">
+        <input type="checkbox"
+               id="{{m}}-checkbox"
+               data-ng-model="mCfg.enabled"/>&nbsp;
+        <h2><label for="{{m}}-checkbox">{{('ui-mod-' + m) | translate}}</label></h2>
+      </div>
+      <div data-ng-if="mCfg.enabled === undefined">
+        <h2>{{('ui-mod-' + m) | translate}}</h2>
       </div>
 
+      <p class="help-block"
+         data-ng-show="(('ui-mod-' + m + '-help') | translate) != ('ui-mod-' + m + '-help')">
+        {{('ui-' + m + '-help') | translate}} </p>
 
-      <div data-ng-switch-when="scoreConfig">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
-           translate>
-          ui-scoreConfig-help</p>
-      </div>
+      <div class="col-sm-12 form-group"
+           data-ng-if="mCfg.enabled === undefined || mCfg.enabled === true"
+           data-ng-repeat="(key, value) in mCfg"
+           data-ng-switch="key">
 
-      <div data-ng-switch-when="autocompleteConfig">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
-           translate>
-          ui-autocompleteConfig-help</p>
-      </div>
-
-      <div data-ng-switch-when="moreLikeThisConfig">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
-           translate>
-          ui-moreLikeThisConfig-help</p>
-      </div>
-
-      <div data-ng-switch-when="facetConfig">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
-           translate>
-          ui-facetConfig-help</p>
-      </div>
+        <!-- DEPRECATED SETTINGS (hidden) -->
+        <div data-ng-switch-when="enabled"></div>
+        <div data-ng-switch-when="context"></div>
+        <div data-ng-switch-when="layer"></div>
+        <div data-ng-switch-when="searchMapLayers"></div>
+        <div data-ng-switch-when="viewerMapLayers"></div>
+        <div data-ng-switch-when="mapExtent"></div>
+        <div data-ng-switch-when="mapBackgroundLayer"></div>
 
 
-      <div data-ng-switch-when="languages">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped table-bordered">
-          <tr data-ng-repeat="(iso3, iso2) in mCfg[key] track by $index">
-            <td>
-              <div class="input-group">
-                <input type="text"
-                       class="form-control"
-                       id="{{iso3}}-{{$index}}"
-                       data-ng-change="updateKey(mCfg[key], iso3, $index)"
-                       data-ng-model="iso3"/>
-                <span class="input-group-addon">=</span>
-                <input type="text"
-                       class="form-control"
-                       id="{{iso2}}-{{$index}}"
-                       data-ng-model="mCfg[key][iso3]"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], iso3)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <a class="btn btn-default"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], {'iso3code': 'iso2code'})">
-                <i class="fa fa-fw fa-plus"/>
-                <span translate="">add</span>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-
-      <div data-ng-switch-when="sortbyValues">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped table-bordered">
-          <tr data-ng-repeat="opt in mCfg[key] track by $index">
-            <td>
-              <div class="input-group">
-                <input type="text"
-                       class="form-control"
-                       id="ui-sortBy-{{$index}}"
-                       data-ng-model="opt.sortBy"/>
-                <span class="input-group-addon"> order </span>
-                <select class="form-control"
-                        id="ui-sortOrder-{{$index}}"
-                        data-ng-options="o for o in sortOrderChoices"
-                        data-ng-model="opt.sortOrder"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <a class="btn btn-default"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], {'sortBy': 'fieldName', 'sortOrder': ''})">
-                <i class="fa fa-fw fa-plus"/>
-                <span translate="">add</span>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-
-
-      <div data-ng-switch-when="filters">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
-           translate>
-          ui-filters-help</p>
-      </div>
-
-
-      <div data-ng-switch-when="resultViewTpls">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped table-bordered">
-          <tr data-ng-repeat="opt in mCfg[key] track by $index">
-            <td>
-              <div class="input-group">
-                <span class="input-group-addon">Icon </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-tplIcon-{{$index}}"
-                       data-ng-model="opt.icon"/>
-                <span class="input-group-addon">Template URL </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-tplURL-{{$index}}"
-                       data-ng-model="opt.tplUrl"/>
-                <span class="input-group-addon">Tooltip </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-tplTooltip-{{$index}}"
-                       data-ng-model="opt.tooltip"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <a class="btn btn-default"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], {'icon': 'fa-fw', 'tplUrl': '', 'tooltip': ''})">
-                <i class="fa fa-fw fa-plus"/>
-                <span translate="">add</span>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-
-      <div data-ng-switch-when="formatter">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped table-bordered">
-          <tr data-ng-repeat="opt in mCfg[key].list track by $index">
-            <td>
-              <div class="input-group">
-                <span class="input-group-addon">Label </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-formatterLabel-{{$index}}"
-                       data-ng-model="opt.label"/>
-                <span class="input-group-addon">URL </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-formatterURL-{{$index}}"
-                       data-ng-model="opt.url"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key].list, $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <a class="btn btn-default"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key].list, {'label': '', 'url': ''})">
-                <i class="fa fa-fw fa-plus"/>
-                <span translate="">add</span>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-
-      <div data-ng-switch-when="downloadFormatter">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped table-bordered">
-          <tr data-ng-repeat="opt in mCfg[key] track by $index">
-            <td>
-              <div class="input-group">
-                <span class="input-group-addon">Label </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-formatterLabel-{{$index}}"
-                       data-ng-model="opt.label"/>
-                <span class="input-group-addon">URL </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-formatterURL-{{$index}}"
-                       data-ng-model="opt.url"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <a class="btn btn-default"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], {'label': '', 'url': ''})">
-                <i class="fa fa-fw fa-plus"/>
-                <span translate="">add</span>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <div data-ng-switch-when="linkTypes">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
-          <label class="control-label">{{type}}</label>
+        <!-- arrays -->
+        <div data-ng-switch-when="hitsperpageValues">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
           <table class="table table-striped table-bordered">
-            <tr data-ng-repeat="protocol in value track by $index">
+            <tr data-ng-repeat="v in mCfg[key] track by $index">
               <td>
-                <input type="text"
+                <input type="number"
                        class="form-control"
-                       id="ui-protocol-{{$index}}"
-                       data-ng-model="mCfg[key][type][$index]"/>
+                       id="{{key}}-{{$index}}"
+                       data-ng-model="mCfg[key][$index]"/>
               </td>
               <td>
                 <a class="btn btn-link text-danger"
                    title="{{'remove' | translate}}"
-                   data-ng-click="removeItem(mCfg[key][type], $index)">
+                   data-ng-click="removeItem(mCfg[key], $index)">
                   <i class="fa fa-times text-danger"/>
                 </a>
               </td>
@@ -356,79 +57,78 @@
               <td colspan="2">
                 <a class="btn btn-default"
                    title="{{'add' | translate}}"
-                   data-ng-click="addItem(mCfg[key][type], 'protocol')">
+                   data-ng-click="addItem(mCfg[key], mCfg[key][mCfg[key].length - 1] * 10)">
                   <i class="fa fa-fw fa-plus"/>
                   <span translate="">add</span>
                 </a>
               </td>
             </tr>
           </table>
-        </div>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-
-      <!-- user custom searches -->
-      <div data-ng-switch-when="usersearches">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
-
-          <input type="checkbox"
-                 id="{{key + type}}-checkbox"
-                 data-ng-model="mCfg[key][type]"/>&nbsp;
-          <label for="{{key + type}}-checkbox">{{('ui-' + type) | translate}}</label>
-
           <p class="help-block"
-             data-ng-show="(('ui-' + key + type + '-help') | translate) != ('ui-' + key + type + '-help')">
-            {{('ui-' + key + type + '-help') | translate}} </p>
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
         </div>
-      </div>
 
-      <div data-ng-switch-when="savedSelection">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
 
-          <input type="checkbox"
-                 id="{{key + type}}-checkbox"
-                 data-ng-model="mCfg[key][type]"/>&nbsp;
-          <label class="control-label"
-                 for="{{key + type}}-checkbox">{{('ui-' + type) | translate}}</label>
-
+        <div data-ng-switch-when="scoreConfig">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
           <p class="help-block"
-             data-ng-show="(('ui-' + key + type + '-help') | translate) != ('ui-' + key + type + '-help')">
-            {{('ui-' + key + type + '-help') | translate}} </p>
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
+             translate>
+            ui-scoreConfig-help</p>
         </div>
-      </div>
+
+        <div data-ng-switch-when="autocompleteConfig">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
+             translate>
+            ui-autocompleteConfig-help</p>
+        </div>
+
+        <div data-ng-switch-when="moreLikeThisConfig">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
+             translate>
+            ui-moreLikeThisConfig-help</p>
+        </div>
+
+        <div data-ng-switch-when="facetConfig">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
+             translate>
+            ui-facetConfig-help</p>
+        </div>
 
 
-
-
-      <div data-ng-switch-when="listOfServices">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
-          <label class="control-label">{{type}}</label>
+        <div data-ng-switch-when="languages">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
           <table class="table table-striped table-bordered">
-            <tr data-ng-repeat="s in value track by $index">
+            <tr data-ng-repeat="(iso3, iso2) in mCfg[key] track by $index">
               <td>
                 <div class="input-group">
-                  <span class="input-group-addon">Label </span>
                   <input type="text"
                          class="form-control"
-                         id="ui-service{{type}}-{{$index}}"
-                         data-ng-model="s.name"/>
-                  <span class="input-group-addon">URL </span>
+                         id="{{iso3}}-{{$index}}"
+                         data-ng-change="updateKey(mCfg[key], iso3, $index)"
+                         data-ng-model="iso3"/>
+                  <span class="input-group-addon">=</span>
                   <input type="text"
                          class="form-control"
-                         id="ui-serviceUrl{{type}}-{{$index}}"
-                         data-ng-model="s.url"/>
+                         id="{{iso2}}-{{$index}}"
+                         data-ng-model="mCfg[key][iso3]"/>
                 </div>
               </td>
               <td>
                 <a class="btn btn-link text-danger"
                    title="{{'remove' | translate}}"
-                   data-ng-click="removeItem(mCfg[key][type], $index)">
+                   data-ng-click="removeItem(mCfg[key], iso3)">
                   <i class="fa fa-times text-danger"/>
                 </a>
               </td>
@@ -437,371 +137,763 @@
               <td colspan="2">
                 <a class="btn btn-default"
                    title="{{'add' | translate}}"
-                   data-ng-click="addItem(mCfg[key][type], {'name': 'Service label', 'url': 'http://'})">
+                   data-ng-click="addItem(mCfg[key], {'iso3code': 'iso2code'})">
                   <i class="fa fa-fw fa-plus"/>
                   <span translate="">add</span>
                 </a>
               </td>
             </tr>
           </table>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
         </div>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
 
 
-
-      <div data-ng-switch-when="projectionList">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <table class="table table-striped table-bordered">
-          <tr data-ng-repeat="opt in mCfg[key] track by $index">
-            <td>
-              <div class="input-group">
-                <span class="input-group-addon">Label </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionLabel-{{$index}}"
-                       data-ng-model="opt.label"/>
-                <span class="input-group-addon">Code </span>
-                <input type="text"
-                       class="form-control"
-                       id="ui-projectionCode-{{$index}}"
-                       data-ng-model="opt.code"/>
-              </div>
-            </td>
-            <td>
-              <a class="btn btn-link text-danger"
-                 title="{{'remove' | translate}}"
-                 data-ng-click="removeItem(mCfg[key], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <a class="btn btn-default"
-                 title="{{'add' | translate}}"
-                 data-ng-click="addItem(mCfg[key], {'label': '', 'code': 'EPSG:'})">
-                <i class="fa fa-fw fa-plus"/>
-                <span translate="">add</span>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <!-- Projection Switcher -->
-      <div data-ng-switch-when="switcherProjectionList">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-          <div ng-include="'../../catalog/components/admin/uiconfig/partials/projectionSwitcher.html'">
+        <div data-ng-switch-when="sortbyValues">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <table class="table table-striped table-bordered">
+            <tr data-ng-repeat="opt in mCfg[key] track by $index">
+              <td>
+                <div class="input-group">
+                  <input type="text"
+                         class="form-control"
+                         id="ui-sortBy-{{$index}}"
+                         data-ng-model="opt.sortBy"/>
+                  <span class="input-group-addon"> order </span>
+                  <select class="form-control"
+                          id="ui-sortOrder-{{$index}}"
+                          data-ng-options="o for o in sortOrderChoices"
+                          data-ng-model="opt.sortOrder"/>
+                </div>
+              </td>
+              <td>
+                <a class="btn btn-link text-danger"
+                   title="{{'remove' | translate}}"
+                   data-ng-click="removeItem(mCfg[key], $index)">
+                  <i class="fa fa-times text-danger"/>
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <a class="btn btn-default"
+                   title="{{'add' | translate}}"
+                   data-ng-click="addItem(mCfg[key], {'sortBy': 'fieldName', 'sortOrder': ''})">
+                  <i class="fa fa-fw fa-plus"/>
+                  <span translate="">add</span>
+                </a>
+              </td>
+            </tr>
+          </table>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
         </div>
-      </div>
-
-      <div data-ng-switch-when="timezone">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <input type="text"
-               class="form-control"
-               placeholder="Australia/Hobart"
-               data-gn-timezone-selector=""
-               data-element-timezone="{{value}}"
-               data-ng-model="mCfg[key]"/>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
 
 
-      <!-- numbers -->
-      <div data-ng-switch-when="paginationInfo">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <input type="number"
-               class="form-control"
-               data-ng-model="value.hitsPerPage"/>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+
+        <div data-ng-switch-when="filters">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
+             translate>
+            ui-filters-help</p>
+        </div>
 
 
-      <!-- boolean -->
-      <div data-ng-switch-when="is3DModeAllowed">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+        <div data-ng-switch-when="resultViewTpls">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <table class="table table-striped table-bordered">
+            <tr data-ng-repeat="opt in mCfg[key] track by $index">
+              <td>
+                <div class="input-group">
+                  <span class="input-group-addon">Icon </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-tplIcon-{{$index}}"
+                         data-ng-model="opt.icon"/>
+                  <span class="input-group-addon">Template URL </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-tplURL-{{$index}}"
+                         data-ng-model="opt.tplUrl"/>
+                  <span class="input-group-addon">Tooltip </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-tplTooltip-{{$index}}"
+                         data-ng-model="opt.tooltip"/>
+                </div>
+              </td>
+              <td>
+                <a class="btn btn-link text-danger"
+                   title="{{'remove' | translate}}"
+                   data-ng-click="removeItem(mCfg[key], $index)">
+                  <i class="fa fa-times text-danger"/>
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <a class="btn btn-default"
+                   title="{{'add' | translate}}"
+                   data-ng-click="addItem(mCfg[key], {'icon': 'fa-fw', 'tplUrl': '', 'tooltip': ''})">
+                  <i class="fa fa-fw fa-plus"/>
+                  <span translate="">add</span>
+                </a>
+              </td>
+            </tr>
+          </table>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
 
-      <div data-ng-switch-when="isVegaEnabled">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+        <div data-ng-switch-when="formatter">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <table class="table table-striped table-bordered">
+            <tr data-ng-repeat="opt in mCfg[key].list track by $index">
+              <td>
+                <div class="input-group">
+                  <span class="input-group-addon">Label </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-formatterLabel-{{$index}}"
+                         data-ng-model="opt.label"/>
+                  <span class="input-group-addon">URL </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-formatterURL-{{$index}}"
+                         data-ng-model="opt.url"/>
+                </div>
+              </td>
+              <td>
+                <a class="btn btn-link text-danger"
+                   title="{{'remove' | translate}}"
+                   data-ng-click="removeItem(mCfg[key].list, $index)">
+                  <i class="fa fa-times text-danger"/>
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <a class="btn btn-default"
+                   title="{{'add' | translate}}"
+                   data-ng-click="addItem(mCfg[key].list, {'label': '', 'url': ''})">
+                  <i class="fa fa-fw fa-plus"/>
+                  <span translate="">add</span>
+                </a>
+              </td>
+            </tr>
+          </table>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
 
-      <div data-ng-switch-when="exactMatchToggle">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+        <div data-ng-switch-when="downloadFormatter">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <table class="table table-striped table-bordered">
+            <tr data-ng-repeat="opt in mCfg[key] track by $index">
+              <td>
+                <div class="input-group">
+                  <span class="input-group-addon">Label </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-formatterLabel-{{$index}}"
+                         data-ng-model="opt.label"/>
+                  <span class="input-group-addon">URL </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-formatterURL-{{$index}}"
+                         data-ng-model="opt.url"/>
+                </div>
+              </td>
+              <td>
+                <a class="btn btn-link text-danger"
+                   title="{{'remove' | translate}}"
+                   data-ng-click="removeItem(mCfg[key], $index)">
+                  <i class="fa fa-times text-danger"/>
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <a class="btn btn-default"
+                   title="{{'add' | translate}}"
+                   data-ng-click="addItem(mCfg[key], {'label': '', 'url': ''})">
+                  <i class="fa fa-fw fa-plus"/>
+                  <span translate="">add</span>
+                </a>
+              </td>
+            </tr>
+          </table>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+        <div data-ng-switch-when="linkTypes">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
+            <label class="control-label">{{type}}</label>
+            <table class="table table-striped table-bordered">
+              <tr data-ng-repeat="protocol in value track by $index">
+                <td>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-protocol-{{$index}}"
+                         data-ng-model="mCfg[key][type][$index]"/>
+                </td>
+                <td>
+                  <a class="btn btn-link text-danger"
+                     title="{{'remove' | translate}}"
+                     data-ng-click="removeItem(mCfg[key][type], $index)">
+                    <i class="fa fa-times text-danger"/>
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <a class="btn btn-default"
+                     title="{{'add' | translate}}"
+                     data-ng-click="addItem(mCfg[key][type], 'protocol')">
+                    <i class="fa fa-fw fa-plus"/>
+                    <span translate="">add</span>
+                  </a>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-      <div data-ng-switch-when="isSaveMapInCatalogAllowed">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+        <!-- user custom searches -->
+        <div data-ng-switch-when="usersearches">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
 
-      <div data-ng-switch-when="isExportMapAsImageEnabled">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <div data-ng-switch-when="useOSM">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <div data-ng-switch-when="isUserRecordsOnly">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-      <div data-ng-switch-when="isFilterTagsDisplayed">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-      <div data-ng-switch-when="isFilterTagsDisplayedInSearch">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <div data-ng-switch-when="disabledTools">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <p class="help-block"
-          data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-        <div data-ng-repeat="(t, value) in mCfg[key]">
-          <div>
             <input type="checkbox"
-                 id="{{key}}-{{t}}-checkbox"
-                 data-ng-model="mCfg[key][t]"
-                 ng-true-value="false" ng-false-value="true"/>&nbsp;
-            <label for="{{key}}-{{t}}-checkbox">
-              {{(t + 'Tool') | translate}}
-            </label>
+                   id="{{key + type}}-checkbox"
+                   data-ng-model="mCfg[key][type]"/>&nbsp;
+            <label for="{{key + type}}-checkbox">{{('ui-' + type) | translate}}</label>
+
+            <p class="help-block"
+               data-ng-show="(('ui-' + key + type + '-help') | translate) != ('ui-' + key + type + '-help')">
+              {{('ui-' + key + type + '-help') | translate}} </p>
           </div>
         </div>
 
-      </div>
+        <div data-ng-switch-when="savedSelection">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
 
-      <div data-ng-switch-when="defaultSearchString">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <div>
-          <input type="text"
-               class="form-control"
-               data-ng-model="mCfg[key]"/>&nbsp;<p class="help-block"
-               data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            <input type="checkbox"
+                   id="{{key + type}}-checkbox"
+                   data-ng-model="mCfg[key][type]"/>&nbsp;
+            <label class="control-label"
+                   for="{{key + type}}-checkbox">{{('ui-' + type) | translate}}</label>
+
+            <p class="help-block"
+               data-ng-show="(('ui-' + key + type + '-help') | translate) != ('ui-' + key + type + '-help')">
+              {{('ui-' + key + type + '-help') | translate}} </p>
+          </div>
+        </div>
+
+
+
+
+        <div data-ng-switch-when="listOfServices">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <div data-ng-repeat="(type, value) in mCfg[key] track by $index">
+            <label class="control-label">{{type}}</label>
+            <table class="table table-striped table-bordered">
+              <tr data-ng-repeat="s in value track by $index">
+                <td>
+                  <div class="input-group">
+                    <span class="input-group-addon">Label </span>
+                    <input type="text"
+                           class="form-control"
+                           id="ui-service{{type}}-{{$index}}"
+                           data-ng-model="s.name"/>
+                    <span class="input-group-addon">URL </span>
+                    <input type="text"
+                           class="form-control"
+                           id="ui-serviceUrl{{type}}-{{$index}}"
+                           data-ng-model="s.url"/>
+                  </div>
+                </td>
+                <td>
+                  <a class="btn btn-link text-danger"
+                     title="{{'remove' | translate}}"
+                     data-ng-click="removeItem(mCfg[key][type], $index)">
+                    <i class="fa fa-times text-danger"/>
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <a class="btn btn-default"
+                     title="{{'add' | translate}}"
+                     data-ng-click="addItem(mCfg[key][type], {'name': 'Service label', 'url': 'http://'})">
+                    <i class="fa fa-fw fa-plus"/>
+                    <span translate="">add</span>
+                  </a>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
             {{('ui-' + key + '-help') | translate}} </p>
         </div>
-      </div>
 
-      <div data-ng-switch-when="graticuleOgcService">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <div class="input-group">
-          <span class="input-group-addon">Type </span>
-          <input type="text"
-                 class="form-control"
-                 data-ng-model="mCfg[key].type"/>
-          <span class="input-group-addon">Layer </span>
-          <input type="text"
-                 class="form-control"
-                 data-ng-model="mCfg[key].layer"/>
-          <span class="input-group-addon">Url </span>
-          <input type="text"
-                 class="form-control"
-                 data-ng-model="mCfg[key].url"/>
+
+
+        <div data-ng-switch-when="projectionList">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <table class="table table-striped table-bordered">
+            <tr data-ng-repeat="opt in mCfg[key] track by $index">
+              <td>
+                <div class="input-group">
+                  <span class="input-group-addon">Label </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-projectionLabel-{{$index}}"
+                         data-ng-model="opt.label"/>
+                  <span class="input-group-addon">Code </span>
+                  <input type="text"
+                         class="form-control"
+                         id="ui-projectionCode-{{$index}}"
+                         data-ng-model="opt.code"/>
+                </div>
+              </td>
+              <td>
+                <a class="btn btn-link text-danger"
+                   title="{{'remove' | translate}}"
+                   data-ng-click="removeItem(mCfg[key], $index)">
+                  <i class="fa fa-times text-danger"/>
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <a class="btn btn-default"
+                   title="{{'add' | translate}}"
+                   data-ng-click="addItem(mCfg[key], {'label': '', 'code': 'EPSG:'})">
+                  <i class="fa fa-fw fa-plus"/>
+                  <span translate="">add</span>
+                </a>
+              </td>
+            </tr>
+          </table>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
         </div>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
 
-      <div data-ng-switch-when="autoFitOnLayer">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+        <!-- Projection Switcher -->
+        <div data-ng-switch-when="switcherProjectionList">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+            <div ng-include="'../../catalog/components/admin/uiconfig/partials/projectionSwitcher.html'">
+          </div>
+        </div>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+        <div data-ng-switch-when="timezone">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <input type="text"
+                 class="form-control"
+                 placeholder="Australia/Hobart"
+                 data-gn-timezone-selector=""
+                 data-element-timezone="{{value}}"
+                 data-ng-model="mCfg[key]"/>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-      <div data-ng-switch-when="grid">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <label class="control-label" translate>gridConfigRelatedTypes</label>
-        <table class="table table-striped table-bordered">
-          <tr data-ng-repeat="relatedType in mCfg[key]['related'] track by $index">
-            <td>
-              <input type="text" class="form-control" ng-model="mCfg[key]['related'][$index]" />
-            </td>
-            <td>
-              <a class="btn btn-link text-danger" title="{{'remove' | translate}}" data-ng-click="removeItem(mCfg[key]['related'], $index)">
-                <i class="fa fa-times text-danger"/>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <a class="btn btn-default" title="{{'add' | translate}}" data-ng-click="addItem(mCfg[key]['related'], '')">
-                <i class="fa fa-fw fa-plus"/>
-                <span translate="">add</span>
-              </a>
-            </td>
-          </tr>
-        </table>
-        <p class="help-block">{{ 'gridConfigRelatedTypes-help' | translate }}</p>
-        <p class="help-block"
+
+        <!-- numbers -->
+        <div data-ng-switch-when="paginationInfo">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <input type="number"
+                 class="form-control"
+                 data-ng-model="value.hitsPerPage"/>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+
+        <!-- boolean -->
+        <div data-ng-switch-when="is3DModeAllowed">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="isVegaEnabled">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="exactMatchToggle">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="isSaveMapInCatalogAllowed">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="isExportMapAsImageEnabled">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="useOSM">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="isUserRecordsOnly">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+        <div data-ng-switch-when="isFilterTagsDisplayed">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+        <div data-ng-switch-when="isFilterTagsDisplayedInSearch">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="disabledTools">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <p class="help-block"
             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+            {{('ui-' + key + '-help') | translate}} </p>
+          <div data-ng-repeat="(t, value) in mCfg[key]">
+            <div>
+              <input type="checkbox"
+                   id="{{key}}-{{t}}-checkbox"
+                   data-ng-model="mCfg[key][t]"
+                   ng-true-value="false" ng-false-value="true"/>&nbsp;
+              <label for="{{key}}-{{t}}-checkbox">
+                {{(t + 'Tool') | translate}}
+              </label>
+            </div>
+          </div>
 
-      <div data-ng-switch-when="showSocialBarInFooter">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+        </div>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+        <div data-ng-switch-when="defaultSearchString">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <div>
+            <input type="text"
+                 class="form-control"
+                 data-ng-model="mCfg[key]"/>&nbsp;<p class="help-block"
+                 data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+              {{('ui-' + key + '-help') | translate}} </p>
+          </div>
+        </div>
 
-      <div data-ng-switch-when="isSocialbarEnabled">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+        <div data-ng-switch-when="graticuleOgcService">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+          <div class="input-group">
+            <span class="input-group-addon">Type </span>
+            <input type="text"
+                   class="form-control"
+                   data-ng-model="mCfg[key].type"/>
+            <span class="input-group-addon">Layer </span>
+            <input type="text"
+                   class="form-control"
+                   data-ng-model="mCfg[key].layer"/>
+            <span class="input-group-addon">Url </span>
+            <input type="text"
+                   class="form-control"
+                   data-ng-model="mCfg[key].url"/>
+          </div>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+        <div data-ng-switch-when="autoFitOnLayer">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
 
-      <div data-ng-switch-when="isLogoInHeader">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-           {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+        <div data-ng-switch-when="grid">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <label class="control-label" translate>gridConfigRelatedTypes</label>
+          <table class="table table-striped table-bordered">
+            <tr data-ng-repeat="relatedType in mCfg[key]['related'] track by $index">
+              <td>
+                <input type="text" class="form-control" ng-model="mCfg[key]['related'][$index]" />
+              </td>
+              <td>
+                <a class="btn btn-link text-danger" title="{{'remove' | translate}}" data-ng-click="removeItem(mCfg[key]['related'], $index)">
+                  <i class="fa fa-times text-danger"/>
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <a class="btn btn-default" title="{{'add' | translate}}" data-ng-click="addItem(mCfg[key]['related'], '')">
+                  <i class="fa fa-fw fa-plus"/>
+                  <span translate="">add</span>
+                </a>
+              </td>
+            </tr>
+          </table>
+          <p class="help-block">{{ 'gridConfigRelatedTypes-help' | translate }}</p>
+          <p class="help-block"
+              data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-      <div data-ng-switch-when="isHeaderFixed">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+        <div data-ng-switch-when="showSocialBarInFooter">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-           {{('ui-' + key + '-help') | translate}} </p>
-      </div>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
 
-      <div data-ng-switch-when="logoInHeaderPosition">
+        <div data-ng-switch-when="isSocialbarEnabled">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="isLogoInHeader">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+             {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="isHeaderFixed">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+             {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="logoInHeaderPosition">
+            <label class="control-label">{{('ui-' + key) | translate}}</label>
+
+            <div class="checkbox">
+              <label>
+                <input type="radio" data-ng-model="mCfg[key]"
+                       value="left"/>
+                <i class="fa fa-fw fa-align-left"></i>&nbsp;
+                <span data-translate="">left</span>
+              </label>
+            </div>
+            <div class="checkbox">
+              <label>
+                <input type="radio" data-ng-model="mCfg[key]"
+                       value="center"/>
+                <i class="fa fa-fw fa-align-center"></i>&nbsp;
+                <span data-translate="">center</span>
+              </label>
+            </div>
+            <div class="checkbox">
+              <label>
+                <input type="radio" data-ng-model="mCfg[key]"
+                       value="right"/>
+                <i class="fa fa-fw fa-align-right"></i>&nbsp;
+                <span data-translate="">right</span>
+              </label>
+            </div>
+
+            <p class="help-block"
+               data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+              {{('ui-' + key + '-help') | translate}} </p>
+          </div>
+
+        <!-- map configs -->
+        <div data-ng-switch-when="map-viewer">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+          <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
+          </div>
+        </div>
+        <div data-ng-switch-when="map-search">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+          <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
+          </div>
+        </div>
+        <div data-ng-switch-when="map-editor">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+          <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
+          </div>
+        </div>
+
+        <div data-ng-switch-when="createPageTpl">
           <label class="control-label">{{('ui-' + key) | translate}}</label>
 
           <div class="checkbox">
             <label>
               <input type="radio" data-ng-model="mCfg[key]"
-                     value="left"/>
-              <i class="fa fa-fw fa-align-left"></i>&nbsp;
-              <span data-translate="">left</span>
+                     value="../../catalog/templates/editor/new-metadata-horizontal.html"/>
+              <i class="fa fa-align-center fa-rotate-90"></i>&nbsp;
+              <span data-translate="">ui-createPageTpl-horizontal</span>
             </label>
           </div>
           <div class="checkbox">
             <label>
               <input type="radio" data-ng-model="mCfg[key]"
-                     value="center"/>
-              <i class="fa fa-fw fa-align-center"></i>&nbsp;
-              <span data-translate="">center</span>
+                     value="../../catalog/templates/editor/new-metadata-vertical.html"/>
+              <i class="fa fa-align-center"></i>&nbsp;
+              <span data-translate="">ui-createPageTpl-vertical</span>
             </label>
           </div>
           <div class="checkbox">
             <label>
               <input type="radio" data-ng-model="mCfg[key]"
-                     value="right"/>
-              <i class="fa fa-fw fa-align-right"></i>&nbsp;
-              <span data-translate="">right</span>
+                     value=""/>
+              <span data-translate="">ui-createPageTpl-other</span>
+
+              <input type="text"
+                     class="form-control"
+                     data-ng-model="mCfg[key]"/>
+            </label>
+          </div>
+
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="editorIndentType">
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
+
+          <div class="checkbox">
+            <label>
+              <input type="radio" data-ng-model="mCfg[key]"
+                     value="gn-indent-default"/>
+              <i class="fa fa-fw fa-align-justify"></i>&nbsp;
+              <span data-translate="">ui-editorIndentType-default</span>
+            </label>
+          </div>
+          <div class="checkbox">
+            <label>
+              <input type="radio" data-ng-model="mCfg[key]"
+                     value="gn-indent-colored"/>
+              <i class="fa fa-fw fa-indent"></i>&nbsp;
+              <span data-translate="">ui-editorIndentType-colored</span>
             </label>
           </div>
 
@@ -810,241 +902,155 @@
             {{('ui-' + key + '-help') | translate}} </p>
         </div>
 
-      <!-- map configs -->
-      <div data-ng-switch-when="map-viewer">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-        <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
-        </div>
-      </div>
-      <div data-ng-switch-when="map-search">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-        <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
-        </div>
-      </div>
-      <div data-ng-switch-when="map-editor">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-        <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
-        </div>
-      </div>
-
-      <div data-ng-switch-when="createPageTpl">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-
-        <div class="checkbox">
-          <label>
-            <input type="radio" data-ng-model="mCfg[key]"
-                   value="../../catalog/templates/editor/new-metadata-horizontal.html"/>
-            <i class="fa fa-align-center fa-rotate-90"></i>&nbsp;
-            <span data-translate="">ui-createPageTpl-horizontal</span>
-          </label>
-        </div>
-        <div class="checkbox">
-          <label>
-            <input type="radio" data-ng-model="mCfg[key]"
-                   value="../../catalog/templates/editor/new-metadata-vertical.html"/>
-            <i class="fa fa-align-center"></i>&nbsp;
-            <span data-translate="">ui-createPageTpl-vertical</span>
-          </label>
-        </div>
-        <div class="checkbox">
-          <label>
-            <input type="radio" data-ng-model="mCfg[key]"
-                   value=""/>
-            <span data-translate="">ui-createPageTpl-other</span>
-
+        <div data-ng-switch-when="externalViewer">
+          <h3>{{('ui-' + key) | translate}}</h3>
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+          <div>
+            <input type="checkbox"
+                  id="ui-externalViewer-enabled"
+                  data-ng-model="mCfg[key]['enabled']"/>&nbsp;
+            <label class="control-label"
+                    for="ui-externalViewer-enabled" translate>
+              ui-externalViewer-enabled
+            </label>
+            <p class="help-block" translate>
+               ui-externalViewer-enabled-help</p>
+          </div>
+          <div ng-show="mCfg[key]['enabled']">
+            <label class="control-label" translate>
+              ui-externalViewer-baseUrl
+            </label>
             <input type="text"
                    class="form-control"
-                   data-ng-model="mCfg[key]"/>
-          </label>
+                   data-ng-model="mCfg[key]['baseUrl']"/>
+            <p class="help-block" translate>
+               ui-externalViewer-baseUrl-help</p>
+          </div>
+          <div ng-show="mCfg[key]['enabled']">
+            <label class="control-label" translate>
+              ui-externalViewer-urlTemplate
+            </label>
+            <input type="text"
+                   class="form-control"
+                   data-ng-model="mCfg[key]['urlTemplate']"/>
+            <p class="help-block" translate>
+               ui-externalViewer-urlTemplate-help</p>
+          </div>
+          <div ng-show="mCfg[key]['enabled']">
+            <input type="checkbox"
+                  id="ui-externalViewer-openNewWindow"
+                  data-ng-model="mCfg[key]['openNewWindow']"/>&nbsp;
+            <label class="control-label"
+                    for="ui-externalViewer-openNewWindow" translate>
+              ui-externalViewer-openNewWindow
+            </label>
+            <p class="help-block" translate>
+               ui-externalViewer-openNewWindow-help</p>
+          </div>
+          <div ng-show="mCfg[key]['enabled']">
+            <label class="control-label" translate>
+              ui-externalViewer-valuesSeparator
+            </label>
+            <input type="text"
+                   class="form-control"
+                   data-ng-model="mCfg[key]['valuesSeparator']"/>
+            <p class="help-block" translate>
+               ui-externalViewer-valuesSeparator-help</p>
+          </div>
         </div>
 
 
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <div data-ng-switch-when="editorIndentType">
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-
-        <div class="checkbox">
-          <label>
-            <input type="radio" data-ng-model="mCfg[key]"
-                   value="gn-indent-default"/>
-            <i class="fa fa-fw fa-align-justify"></i>&nbsp;
-            <span data-translate="">ui-editorIndentType-default</span>
-          </label>
-        </div>
-        <div class="checkbox">
-          <label>
-            <input type="radio" data-ng-model="mCfg[key]"
-                   value="gn-indent-colored"/>
-            <i class="fa fa-fw fa-indent"></i>&nbsp;
-            <span data-translate="">ui-editorIndentType-colored</span>
-          </label>
-        </div>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <div data-ng-switch-when="externalViewer">
-        <h3>{{('ui-' + key) | translate}}</h3>
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-        <div>
+        <div data-ng-switch-when="fluidLayout">
           <input type="checkbox"
-                id="ui-externalViewer-enabled"
-                data-ng-model="mCfg[key]['enabled']"/>&nbsp;
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
           <label class="control-label"
-                  for="ui-externalViewer-enabled" translate>
-            ui-externalViewer-enabled
-          </label>
-          <p class="help-block" translate>
-             ui-externalViewer-enabled-help</p>
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
         </div>
-        <div ng-show="mCfg[key]['enabled']">
-          <label class="control-label" translate>
-            ui-externalViewer-baseUrl
-          </label>
-          <input type="text"
-                 class="form-control"
-                 data-ng-model="mCfg[key]['baseUrl']"/>
-          <p class="help-block" translate>
-             ui-externalViewer-baseUrl-help</p>
-        </div>
-        <div ng-show="mCfg[key]['enabled']">
-          <label class="control-label" translate>
-            ui-externalViewer-urlTemplate
-          </label>
-          <input type="text"
-                 class="form-control"
-                 data-ng-model="mCfg[key]['urlTemplate']"/>
-          <p class="help-block" translate>
-             ui-externalViewer-urlTemplate-help</p>
-        </div>
-        <div ng-show="mCfg[key]['enabled']">
+        <div data-ng-switch-when="fluidHeaderLayout">
           <input type="checkbox"
-                id="ui-externalViewer-openNewWindow"
-                data-ng-model="mCfg[key]['openNewWindow']"/>&nbsp;
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
           <label class="control-label"
-                  for="ui-externalViewer-openNewWindow" translate>
-            ui-externalViewer-openNewWindow
-          </label>
-          <p class="help-block" translate>
-             ui-externalViewer-openNewWindow-help</p>
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
         </div>
-        <div ng-show="mCfg[key]['enabled']">
-          <label class="control-label" translate>
-            ui-externalViewer-valuesSeparator
-          </label>
+        <div data-ng-switch-when="fluidEditorLayout">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+        <div data-ng-switch-when="showGNName">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+        <div data-ng-switch-when="humanizeDates">
+          <input type="checkbox"
+                 id="{{key}}-checkbox"
+                 data-ng-model="mCfg[key]"/>&nbsp;
+          <label class="control-label"
+                 for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+          <p class="help-block"
+             data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+            {{('ui-' + key + '-help') | translate}} </p>
+        </div>
+
+
+        <div data-ng-switch-default>
+          <label class="control-label">{{('ui-' + key) | translate}}</label>
           <input type="text"
                  class="form-control"
-                 data-ng-model="mCfg[key]['valuesSeparator']"/>
-          <p class="help-block" translate>
-             ui-externalViewer-valuesSeparator-help</p>
+                 data-ng-model="mCfg[key]"/>
+          <p class="help-block"
+             data-ng-init="helpKey = 'ui-' + key + '-help'"
+             data-ng-show="(helpKey | translate) != helpKey"
+             translate="">
+            {{helpKey}}
+          </p>
         </div>
       </div>
 
+      <div data-ng-if="m === 'global'">
+        <h2 data-translate="" class="gn-margin-bottom">ui-advancedConfig</h2>
 
-      <div data-ng-switch-when="fluidLayout">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
+        <gn-json-edit model="jsonConfig"></gn-json-edit>
+        <textarea name="{{id}}" id="uiconfig" class="hidden">{{jsonConfig}}</textarea>
+        <br/>
+        <button class="btn btn-default"
+                data-ng-click="testClientConfig()">
+          <i class="fa fa-play"/>&nbsp;
+          <span data-translate="">testClientConfig</span>
+        </button>
+        <button class="btn btn-default"
+                data-ng-click="reset()">
+          <i class="fa fa-times"/>&nbsp;
+          <span data-translate="">resetDefaultConfig</span>
+        </button>
       </div>
-      <div data-ng-switch-when="fluidHeaderLayout">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-      <div data-ng-switch-when="fluidEditorLayout">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-      <div data-ng-switch-when="showGNName">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-      <div data-ng-switch-when="humanizeDates">
-        <input type="checkbox"
-               id="{{key}}-checkbox"
-               data-ng-model="mCfg[key]"/>&nbsp;
-        <label class="control-label"
-               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
-      </div>
-
-
-      <div data-ng-switch-default>
-        <label class="control-label">{{('ui-' + key) | translate}}</label>
-        <input type="text"
-               class="form-control"
-               data-ng-model="mCfg[key]"/>
-        <p class="help-block"
-           data-ng-init="helpKey = 'ui-' + key + '-help'"
-           data-ng-show="(helpKey | translate) != helpKey"
-           translate="">
-          {{helpKey}}
-        </p>
-      </div>
-    </div>
-  </fieldset>
-
-
-  <h2 data-translate="" class="gn-margin-bottom">ui-advancedConfig</h2>
-
-  <gn-json-edit model="jsonConfig"></gn-json-edit>
-  <textarea name="{{id}}" id="uiconfig" class="hidden">{{jsonConfig}}</textarea>
-  <br/>
-  <button class="btn btn-default"
-          data-ng-click="testClientConfig()">
-    <i class="fa fa-play"/>&nbsp;
-    <span data-translate="">testClientConfig</span>
-  </button>
-  <button class="btn btn-default"
-          data-ng-click="reset()">
-    <i class="fa fa-times"/>&nbsp;
-    <span data-translate="">resetDefaultConfig</span>
-  </button>
+    </tab>
+  </tabset>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
@@ -1,7 +1,7 @@
-<div class="row">
+<div id="uiSettingsPage" class="row">
     <div class="col-md-12"  data-ng-controller="GnSystemSettingsController">
 
-      <div class="navbar btn-toolbar">
+      <div id="toolbarUiSettings" class="navbar btn-toolbar">
         <form class="form-inline">
           <div class="well well-lg"
                data-ng-cloak=""
@@ -20,7 +20,7 @@
                    title="{{'uiConfiguration-help' | translate}}"
                    data-translate="">chooseAUiConfiguration</label>
             <select id="uiConfigurationList"
-                    class="form-control"
+                    class="form-control bg-warning btn-warning"
                     data-ng-options="c as c.id for c in uiConfigurations | orderBy: 'id'"
                     data-ng-model="uiConfiguration"></select>
           </div>
@@ -36,15 +36,29 @@
                      data-ng-model-options="{debounce: 300}"
                      placeholder="{{'uiConfigurationName' | translate}}"/>
               <span class="input-group-btn">
-                <button class="btn btn-primary"
+                <button class="btn btn-default"
                         type="button"
                         data-ng-disabled="!uiConfigurationIdIsValid"
                         title="{{'createNewUiConfiguration' | translate}}"
                         data-ng-click="createOrUpdateUiConfiguration(false, uiConfigurationId)">
                   <i class="fa fa-plus" aria-hidden="true"></i>
                 </button>
+                <button type="submit" class="btn btn-danger pull-right"
+                        id="gn-btn-settings-delete"
+                        title="{{'deleteUiSettings'|translate}}"
+                        data-ng-disabled="!uiConfiguration"
+                        data-ng-click="deleteUiConfig()">
+                  <span class="fa fa-times"></span>
+                </button>
               </span>
             </div>
+            <button type="submit" class="btn btn-primary pull-right"
+                    id="gn-btn-settings-save"
+                    data-ng-disabled="!gnSettings.$valid"
+                    data-ng-click="updateUiConfig()">
+              <span class="fa fa-save"></span>
+              {{"saveSettings"|translate}}
+            </button>
           </div>
         </form>
       </div>
@@ -58,58 +72,9 @@
                class="pull-right"></div>
         </div>
         <div class="panel-body">
-          <div class="row">
-            <div class="col-lg-6 gn-nopadding-left">
-              <label for="filter-settings" data-translate="">filterSettings</label>
-              <div class="input-group">
-                <span class="input-group-addon"">
-                <i class="fa fa-filter" aria-hidden="true"></i>
-                </span>
-                <input class="form-control"
-                       type="text"
-                       id="filter-settings"
-                       placeholder="{{'filterPlaceHolder' | translate}}"
-                       data-ng-keyup="filterForm($event,'#gn-settings')" />
-                <span class="input-group-btn">
-                <button class="btn btn-default"
-                        type="button"
-                        title="{{'filterReset' | translate}}"
-                        data-ng-click="resetFilter('#gn-settings')">
-                  <i class="fa fa-close" aria-hidden="true"></i>
-                </button>
-              </span>
-              </div>
-            </div>
-            <div class="col-lg-6 gn-nopadding-right">
-              <div class="btn-toolbar">
-                <button type="submit" class="btn btn-primary pull-right"
-                        id="gn-btn-settings-save"
-                        data-ng-disabled="!gnSettings.$valid"
-                        data-ng-click="updateUiConfig()">
-                  <span class="fa fa-save"></span>
-                  {{"saveSettings"|translate}}
-                </button>
-                <button type="submit" class="btn btn-danger pull-right"
-                        id="gn-btn-settings-delete"
-                        data-ng-disabled="!uiConfiguration"
-                        data-ng-click="deleteUiConfig()">
-                  <span class="fa fa-times"></span>
-                  {{"deleteUiSettings"|translate}}
-                </button>
-              </div>
-            </div>
-          </div>
-
           <form id="gn-settings" name="gnSettings" class="form-horizontal">
             <div data-gn-ui-config="uiConfiguration.configuration"></div>
           </form>
-
-          <button type="submit" class="btn btn-primary pull-right"
-                  data-ng-disabled="!gnSettings.$valid"
-                  data-ng-click="updateUiConfig()">
-            <span class="fa fa-save"></span>
-            {{"saveSettings"|translate}}
-          </button>
         </div>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -546,6 +546,98 @@ ul.gn-resultview li.list-group-item {
     [data-ng-controller="GnDashboardRenderController"] {
       margin: -25px -10px -50px -10px;
     }
+
+    // UI settings
+    #uiSettingsPage {
+      padding-top: 40px;
+      @media (max-width: @screen-md-max) {
+        padding-top: 70px;
+      }
+      @media (max-width: @screen-sm-max) {
+        padding-top: 100px;
+      }
+      #toolbarUiSettings {
+        position: fixed;
+        width: calc(~"100vw - @{gn-sidebar-width} - 55px");
+        background-color: #f7f7f7;
+        margin-top: -75px;
+        padding-top: 25px;
+        padding-bottom: 5px;
+        border-bottom: 1px solid @panel-default-border;
+        z-index: 10;
+        @media (max-width: @screen-md-max) {
+          margin-top: -110px;
+          .btn-toolbar {
+            float: left !important;
+            margin-top: 5px;
+          }
+        }
+        @media (max-width: @screen-sm-max) {
+          border-left: none;
+          padding-left: 0;
+          margin-left: -1px;
+          margin-top: -145px;
+          .btn-toolbar {
+            margin-top: 10px;
+            padding-bottom: 5px;
+            .input-group {
+              margin-left: 0;
+            }
+            label {
+              min-width: 100%;
+            }
+          }
+        }
+        @media (max-width: @screen-xs-max) {
+          position: relative;
+          width: 100%;
+          padding-top: 25px;
+          .btn-toolbar {
+            .btn {
+              float: none;
+            }
+            .input-group {
+              width: 100%;
+              float: none;
+            }
+            #gn-btn-settings-save {
+              width: 100%;
+              margin-top: 5px;
+            }
+          }
+        }
+      }
+      #settings-tabset {
+        margin-top: 30px;
+        .nav-pills {
+          .make-md-column(3);
+          .make-md-column-push(9);
+          padding-right: 0;
+          border-left: 1px solid @panel-default-border;
+          > li {
+            float: none;
+          }
+          @media (max-width: @screen-sm-max) {
+            padding-left: 0;
+            margin-bottom: 10px;
+            border: none;
+          }
+        }
+        .tab-content {
+          .make-md-column(9);
+          .make-md-column-pull(3);
+          padding-left: 0;
+        }
+      }
+      @media (max-width: @screen-sm-max) {
+        .form-horizontal {
+          .control-label {
+            text-align: left;
+          }
+        }
+      }
+
+    }
   }
 
   // map for csw harvester


### PR DESCRIPTION
This PR adds a table of contents for the settings in the UI settings page, so you'll be able to find everything a bit faster and in an ordered way.

Furthermore, the buttonbar is fixed, so the `save` is always visible.

![gn-ui-settings](https://user-images.githubusercontent.com/19608667/122394684-8d618080-cf76-11eb-9e24-d91fecc1e262.png)
