### PR TITLE
lucene search: as metadata id can easily be 400 000 000, if metadata …

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/DuplicateDocFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/DuplicateDocFilter.java
@@ -50,7 +50,9 @@ import java.util.BitSet;
  */
 public class DuplicateDocFilter extends Filter {
 
-    final IntSet hits = new IntBitSet();
+    private static int MAX_METADATA_ID = 500000000;
+
+    final IntSet hits = new IntBitSet(MAX_METADATA_ID);
     private Query _query;
 
     public DuplicateDocFilter(Query query) {


### PR DESCRIPTION
…iterated in ascending id order, avoid system array copy at each iteration.

cf. http://pcj.sourceforge.net/docs/api/bak/pcj/set/IntBitSet.html#IntBitSet(int).

There are cases when iterating the whole metadata collection (search all), in metadata id ascending order (depend upon index, a random way), a lot of time is spent IntBitSet::ensureCapacity performing array copy.

Setting IntBitSet "maximum" to what can be max metadata id avoid it and can dramatically improve search performance in such cases.