### PR TITLE
Fix: Display the facet filter on a single row

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -42,24 +42,30 @@
       <div class="gn-facet-root-container"
           ng-class="{'collapse': ctrl.fLvlCollapse[facet.key]}">
 
-        <div class="gn-facet-filter"
+        <div class="input-group input-group-sm gn-facet-input-group"
              ng-if="facet.type === 'terms' && facet.includeFilter
                     && (facet.more
                     || facet.include.length > 0
                     || facet.meta && facet.meta.displayFilter)">
-          <span class="fa fa-times-circle clear"
-                data-ng-click="facet.include = '';ctrl.filterTerms(facet);"
-                ng-show="facet.include && facet.include !== ''"
-                title="{{'clear'|translate}}"></span>
+          <span class="input-group-addon" id="sizing-addon3">
+            <span class="fa fa-filter"></span>
+          </span>
           <input title="{{'facetIncludeFilter' | translate}}"
                 ng-model="facet.include"
                 ng-model-options="{debounce: 300}"
                 ng-change="ctrl.filterTerms(facet)"
                 placeholder="{{'filter' | translate}}"
                 autocomplete="nope"
-                class="form-control input-sm gn-facet-filter"
+                class="form-control input-sm"
                 type="text"
                 />
+          <span class="input-group-btn clear"
+                ng-show="facet.include && facet.include !== ''"
+                title="{{'clear'|translate}}">
+            <button class="btn btn-default" type="button" data-ng-click="facet.include = '';ctrl.filterTerms(facet);">
+              <span class="fa fa-times-circle"></span>
+            </button>
+          </span>
         </div>
 
         <div class="gn-facet-container"

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -37,13 +37,13 @@
       display: block;
     }
   }
-  .gn-facet-root-container {
-    input.gn-facet-filter {
-      margin-left: 18px;
-      width: calc(~"100% - 18px");
-      border-color: @panel-default-border;
-    }
-  }
+  //.gn-facet-root-container {
+  //  input.gn-facet-filter {
+  //    margin-left: 18px;
+  //    width: calc(~"100% - 18px");
+  //    border-color: @panel-default-border;
+  //  }
+  //}
   .gn-facet-container {
     margin-left: 15px;
     margin-top: 5px;
@@ -118,33 +118,18 @@
   .gn-facet-more {
     margin-left: 15px;
   }
-  .gn-facet-filter {
-    position: relative;
-    &:before {
-      font-family: FontAwesome;
-      content: "\f0b0";
-      float: right;
-      margin: 0.5em 0.4em 0 0;
-      font-size: 16px;
-      color: #d3d3d3;
-    }
-    .clear {
-      right: 2em;
-      position: absolute;
-      top: .75em;
-      color: #666;
-      &:hover {
-        cursor: pointer;
-        color: #222;
-      }
-    }
-
-    input {
+  .gn-facet-input-group {
+    margin-left: 18px;
+    input, .input-group-addon, .btn {
+      background: none;
       border: none;
       border-bottom: 1px solid #d3d3d3;
       border-radius: 0;
       box-shadow: none;
-      width: 90%;
+    }
+    .input-group-addon {
+      padding-left: 0;
+      padding-right: 0;
     }
   }
   .input-daterange {


### PR DESCRIPTION
The filter box in the facet list on the search page is displayed on 2 lines, this PR displays it on 1 line

**Before: 2 lines**

![gn-facet-before](https://user-images.githubusercontent.com/19608667/122555892-29ed5680-d03b-11eb-82fd-695be0701726.png)

**After: 1 line**

![gn-facet-after](https://user-images.githubusercontent.com/19608667/122555913-2e197400-d03b-11eb-809d-9d2850c6466a.png)
