### PR TITLE
Metadata editor - option to disable OGC Capabilites layer processing in the online resource panel.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1109,21 +1109,22 @@
 
                 function checkIsOgc(protocol) {
 
-                  if (protocol && protocol.indexOf('OGC:WMS') >= 0) {
-                    return 'WMS';
+                  if (scope.config.loadMapCapabilities !== "false") {
+                    if (protocol && protocol.indexOf('OGC:WMS') >= 0) {
+                      return 'WMS';
+                    }
+                    else if (protocol && protocol.indexOf('OGC:WFS') >= 0) {
+                      return 'WFS';
+                    }
+                    else if (protocol && protocol.indexOf('OGC:WMTS') >= 0) {
+                      return 'WMTS';
+                    }
+                    else if (protocol && protocol.indexOf('OGC:WCS') >= 0) {
+                      return 'WCS';
+                    }
                   }
-                  else if (protocol && protocol.indexOf('OGC:WFS') >= 0) {
-                    return 'WFS';
-                  }
-                  else if (protocol && protocol.indexOf('OGC:WMTS') >= 0) {
-                    return 'WMTS';
-                  }
-                  else if (protocol && protocol.indexOf('OGC:WCS') >= 0) {
-                    return 'WCS';
-                  }
-                  else {
-                    return null;
-                  }
+
+                  return null;
                 }
 
                 /**


### PR DESCRIPTION
To disable the automatic processing, configure in the schemas file `config/associated-panel/default.json` the setting `loadMapCapabilities` to false, any other value will allow the OGC Capabilities layer processing:

```json
{
  "config": {
    "display": "radio",
    "loadMapCapabilities": "false",
```

No changes are required in the schemas, as by default the map layers processing is enabled.


GeoNetwork adds the layer name in the `gmd:name` field, this is a convention used in GeoNetwork, but some schemas like https://github.com/metadata101/iso19139.ca.HNAP use other convention that causes the online resource to be broken when edited if the GeoNetwork process the OGC layers.

This is a temporary fix to avoid the previous issue, until the online resource panel is extended to provide the flexibility to configure how to store the layer information in each metadata schema.

![map-service-online-resource](https://user-images.githubusercontent.com/1695003/122713093-6ef4d100-d265-11eb-96a9-fca3b5d77161.png)
