### PR TITLE
Fix for indenting the 'online resource description`

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -274,7 +274,7 @@
               </div>
               <div data-ng-if="params.linkType.fields.desc.directive === 'gn-multientry-combiner-online-resources-description'">
                 <div data-gn-multientry-combiner-online-resources-description="{{params.linkType.fields.desc.directiveConfig}}"
-                  class="col-sm-12 col-xs-12 gn-value nopadding-in-table"
+                  class="col-sm-9 col-xs-9 gn-value nopadding-in-table"
                     data-label="description" data-ng-required="params.linkType.fields.desc.required" >
                 </div>
               </div>


### PR DESCRIPTION
See: https://github.com/metadata101/iso19139.ca.HNAP/issues/95#issuecomment-834367770

When adding an `online resource` for the HNAP profile the description block is not indented like the rest, this PR fixes this.

**The not indented block**
![gn-not-indented](https://user-images.githubusercontent.com/19608667/122758547-3969db00-d299-11eb-85a5-7ecf2a5c3e30.png)
