### PR TITLE
Default language for MultilingualFieldDirective.js

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
@@ -74,9 +74,15 @@
           scope.languages = angular.fromJson(attrs.gnMultilingualField);
           var mainLanguage = scope.mainLanguage;
           // Have to map the main language to one of the languages in the inputs
-          if (angular.isDefined(scope.languages[mainLanguage])) {
-            mainLanguage = scope.languages[mainLanguage].substring(1);
-          } else {
+          var langDefined = false;
+          angular.forEach(scope.languages, function(value, key) {
+            if (value.contains(mainLanguage)) {
+              mainLanguage = value.substring(1);
+              langDefined = true;
+            }
+          });
+
+          if (!langDefined) {
             $(element).find(formFieldsSelector).each(function() {
               var lang = $(this).attr('lang');
               if (angular.isDefined(scope.languages[lang])) {


### PR DESCRIPTION
The default language is not working. It always defaulted to "eng" even the metadata profile was "French" profile. Here is the example:

Metadata language as:

![image](https://user-images.githubusercontent.com/74916635/122796521-7ed3db80-d28c-11eb-8037-cc145e3d7a90.png)

One of the MultilingualField
![image](https://user-images.githubusercontent.com/74916635/122796631-9d39d700-d28c-11eb-880e-07fbfbaaf241.png)
