### PR TITLE
User Profile Readonly for keycloak users 

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderConfiguration.java
@@ -94,6 +94,18 @@ public interface SecurityProviderConfiguration {
 		// If we cannot find SecurityProviderConfiguration then default to false.
 		return null;
 	}
+
+    /**
+     * Check if the user profile should be updatable.
+     * If the data is coming from the security providers then the security provider then it may make sense to disable the profile update
+     */
+    boolean isUserProfileUpdateEnabled();
+
+    /**
+     * Check if the user group should be updatable.
+     * If the data is coming from the security providers then the security provider then it may make sense to disable the user group updates
+     */
+    boolean isUserGroupUpdateEnabled();
 }
 
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakConfiguration.java
@@ -139,6 +139,18 @@ public class KeycloakConfiguration implements SecurityProviderConfiguration {
         }
         this.loginType=parsedLoginType.toString();
     }
+
+    @Override
+    public boolean isUserProfileUpdateEnabled() {
+        // If updating profile from the security provider then disable the profile updates in the interface
+        return !updateProfile;
+    }
+
+    @Override
+    public boolean isUserGroupUpdateEnabled() {
+        // If updating group from the security provider then disable the group updates in the interface
+        return !updateGroup;
+    }
 }
 
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserConfiguration.java
@@ -207,5 +207,21 @@ public class ShibbolethUserConfiguration implements SecurityProviderConfiguratio
             return LoginType.FORM.toString();
         }
     }
+
+    @Override
+    public boolean isUserProfileUpdateEnabled() {
+        // TODO: returning true to keep old functionality the same.  Need someone to test Shibboleth functionality to validate if disabling the userProfileUpdate is desired.
+        return true;
+        // If updating profile from the security provider then disable the profile updates in the interface
+        //return !updateProfile;
+    }
+
+    @Override
+    public boolean isUserGroupUpdateEnabled() {
+        // TODO: returning true to keep old functionality the same.  Need someone to test Shibboleth functionality to validate if disabling the userProfileUpdate is desired.
+        return true;
+        // If updating group from the security provider then disable the group updates in the interface
+        //return !updateGroup;
+    }
 }
 

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -520,6 +520,29 @@ public final class XslUtil {
         return false;
     }
 
+    /**
+     * Check if user profile update is enabled.
+     */
+    public static boolean isUserProfileUpdateEnabled() {
+        SecurityProviderConfiguration securityProviderConfiguration = SecurityProviderConfiguration.get();
+
+        if (securityProviderConfiguration != null) {
+            return securityProviderConfiguration.isUserProfileUpdateEnabled();
+        }
+        return true;
+    }
+
+    /**
+     * Check if user group update is enabled.
+     */
+    public static boolean isUserGroupUpdateEnabled() {
+        SecurityProviderConfiguration securityProviderConfiguration = SecurityProviderConfiguration.get();
+
+        if (securityProviderConfiguration != null) {
+            return securityProviderConfiguration.isUserGroupUpdateEnabled();
+        }
+        return true;
+    }
 
     /**
      * get security provider

--- a/core/src/main/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages.properties
@@ -48,6 +48,7 @@ password_forgotten_message=You have requested to change your %s password. \n\
 user_has_no_email='%s' has no email.
 user_not_found=No user found with username '%s'.
 user_from_ldap_cant_get_password=User '%s' is authenticated using LDAP. Password can't be sent by email.
+security_provider_unsupported_functionality="Functionality not supported by the security provider"
 user_password_sent='%s' should receive a password change email soon.
 user_password_changed='%s' password was updated.
 user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.

--- a/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
@@ -40,6 +40,7 @@ password_forgotten_message=Vous avez demand\u00E9 une r\u00E9initialisation de v
 user_has_no_email='%s' n'a pas d'adresse mail.
 user_not_found=Pas d'utilisateur trouv\u00E9 avec le nom '%s'.
 user_from_ldap_cant_get_password=L'utilisateur '%s' est authentifi\u00E9 \u00E0 partir d'un annuaire LDAP. Le mot de passe ne peut \u00EAtre r\u00E9initialiser par email.
+security_provider_unsupported_functionality="Fonctionnalit\u00E9 non support\u00E9 par le fournisseur de s\u00E9curit\u00E9"
 user_password_sent='%s' devrait prochainement recevoir le lien pour la r\u00E9initialisation.
 user_password_changed=Le mot de passe de '%s' a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.

--- a/services/src/main/java/org/fao/geonet/api/users/PasswordApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/PasswordApi.java
@@ -32,6 +32,7 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.User;
+import org.fao.geonet.kernel.security.SecurityProviderConfiguration;
 import org.fao.geonet.kernel.security.ldap.LDAPConstants;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
@@ -73,6 +74,9 @@ public class PasswordApi {
     @Autowired
     SettingManager sm;
 
+    @Autowired(required=false)
+    SecurityProviderConfiguration securityProviderConfiguration;
+
     @io.swagger.v3.oas.annotations.Operation(summary = "Update user password",
         description = "Get a valid changekey by email first and then update your password.")
     @RequestMapping(
@@ -94,6 +98,10 @@ public class PasswordApi {
         throws Exception {
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
+
+        if (securityProviderConfiguration != null && !securityProviderConfiguration.isUserProfileUpdateEnabled()) {
+            return new ResponseEntity<>(messages.getString("security_provider_unsupported_functionality"), HttpStatus.PRECONDITION_FAILED);
+        }
 
         ServiceContext context = ApiUtils.createServiceContext(request);
 
@@ -183,6 +191,10 @@ public class PasswordApi {
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         String language = locale.getISO3Language();
         ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
+
+        if (securityProviderConfiguration != null && !securityProviderConfiguration.isUserProfileUpdateEnabled()) {
+            return new ResponseEntity<>(messages.getString("security_provider_unsupported_functionality"), HttpStatus.PRECONDITION_FAILED);
+        }
 
         ServiceContext serviceContext = ApiUtils.createServiceContext(request);
 

--- a/services/src/main/java/org/fao/geonet/api/users/RegisterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/RegisterApi.java
@@ -32,6 +32,7 @@ import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.api.users.model.UserRegisterDto;
 import org.fao.geonet.api.users.recaptcha.RecaptchaChecker;
 import org.fao.geonet.domain.*;
+import org.fao.geonet.kernel.security.SecurityProviderConfiguration;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.GroupRepository;
@@ -68,6 +69,9 @@ public class RegisterApi {
     @Autowired
     LanguageUtils languageUtils;
 
+    @Autowired(required=false)
+    SecurityProviderConfiguration securityProviderConfiguration;
+
     @io.swagger.v3.oas.annotations.Operation(summary = "Create user account",
         description = "User is created with a registered user profile. username field is ignored and the email is used as " +
             "username. Password is sent by email. Catalog administrator is also notified.")
@@ -90,6 +94,10 @@ public class RegisterApi {
 
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
+
+        if (securityProviderConfiguration != null && !securityProviderConfiguration.isUserProfileUpdateEnabled()) {
+            return new ResponseEntity<>(messages.getString("security_provider_unsupported_functionality"), HttpStatus.PRECONDITION_FAILED);
+        }
 
         ServiceContext context = ApiUtils.createServiceContext(request);
 

--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -43,6 +43,7 @@ import org.fao.geonet.domain.*;
 import org.fao.geonet.exceptions.UserNotFoundEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.security.SecurityProviderConfiguration;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.repository.*;
 import org.fao.geonet.repository.specification.MetadataSpecs;
@@ -105,6 +106,9 @@ public class UsersApi {
 
     @Autowired
     LanguageUtils languageUtils;
+
+    @Autowired(required=false)
+    SecurityProviderConfiguration securityProviderConfiguration;
 
     private BufferedImage pixel;
 
@@ -401,12 +405,16 @@ public class UsersApi {
         @Parameter(hidden = true)
             HttpSession httpSession
     ) throws Exception {
+        Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
+        ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
+
+        if (securityProviderConfiguration != null && !securityProviderConfiguration.isUserProfileUpdateEnabled()) {
+            return new ResponseEntity<>(messages.getString("security_provider_unsupported_functionality"), HttpStatus.PRECONDITION_FAILED);
+        }
+
         Profile profile = Profile.findProfileIgnoreCase(userDto.getProfile());
         UserSession session = ApiUtils.getUserSession(httpSession);
         Profile myProfile = session.getProfile();
-
-        Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
-        ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
 
         if (profile == Profile.Administrator) {
             checkIfAtLeastOneAdminIsEnabled(userDto, userRepository);
@@ -479,6 +487,8 @@ public class UsersApi {
         @Parameter(hidden = true)
             HttpSession httpSession
     ) throws Exception {
+        Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
+        ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
 
         Profile profile = Profile.findProfileIgnoreCase(userDto.getProfile());
 
@@ -546,10 +556,18 @@ public class UsersApi {
             }
         }
 
-        fillUserFromParams(user, userDto);
+        if (securityProviderConfiguration == null || securityProviderConfiguration.isUserProfileUpdateEnabled()) {
+            fillUserFromParams(user, userDto);
+        } else {
+            // If profile update is not enabled then the only thing that can be changed it enabling/disabling the user.
+            user.setEnabled(userDto.isEnabled());
+        }
 
         user = userRepository.save(user);
-        setUserGroups(user, groups);
+
+        if (securityProviderConfiguration == null || securityProviderConfiguration.isUserGroupUpdateEnabled()) {
+            setUserGroups(user, groups);
+        }
 
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
@@ -582,6 +600,9 @@ public class UsersApi {
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", locale);
 
+        if (securityProviderConfiguration != null && !securityProviderConfiguration.isUserProfileUpdateEnabled()) {
+            return new ResponseEntity<>(messages.getString("security_provider_unsupported_functionality"), HttpStatus.PRECONDITION_FAILED);
+        }
 
         // Validate passwordResetDto data
         PasswordResetDtoValidator passwordResetValidator = new PasswordResetDtoValidator();

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -798,6 +798,8 @@ goog.require('gn_alert');
       current: null,
       isDisableLoginForm: false,
       isShowLoginAsLink: false,
+      isUserProfileUpdateEnabled: true,
+      isUserGroupUpdateEnabled: true,
       init: function(config, gnUrl, gnViewerSettings, gnSearchSettings) {
         // start from the default config to make sure every field is present
         // and override with config arg if required
@@ -1045,6 +1047,8 @@ goog.require('gn_alert');
       $scope.isDebug = window.location.search.indexOf('debug') !== -1;
       $scope.isDisableLoginForm = gnGlobalSettings.isDisableLoginForm;
       $scope.isShowLoginAsLink = gnGlobalSettings.isShowLoginAsLink;
+      $scope.isUserProfileUpdateEnabled = gnGlobalSettings.isUserProfileUpdateEnabled;
+      $scope.isUserGroupUpdateEnabled = gnGlobalSettings.isUserGroupUpdateEnabled;
       $scope.isExternalViewerEnabled = gnExternalViewer.isEnabled();
       $scope.externalViewerUrl = gnExternalViewer.getBaseUrl();
 

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -66,6 +66,7 @@
           $scope.gnConfig = gnConfig;
           $scope.isDisableLoginForm = gnGlobalSettings.isDisableLoginForm;
           $scope.isShowLoginAsLink = gnGlobalSettings.isShowLoginAsLink;
+         $scope.isUserProfileUpdateEnabled = gnGlobalSettings.isUserProfileUpdateEnabled;
 
          $scope.passwordMinLength =
            Math.min(gnConfig['system.security.passwordEnforcement.minLength'], 6);

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -53,7 +53,7 @@
         </span>
         <div class="btn-toolbar">
           <button type="button" class="btn btn-default pull-right"
-                  data-ng-hide="userSelected.security.authtype == 'LDAP' || isDisableLoginForm"
+                  data-ng-hide="hideResetPassword() || isDisableLoginForm"
                   data-ng-click="resetPassword(userSelected.id)">
             <i class="fa fa-lock fa-fw"></i> <span data-translate=""
           >resetPassword</span></button>

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -30,7 +30,7 @@
 
         <button type="button" class="btn btn-primary btn-block" id="gn-btn-user-add"
                 data-ng-click="addUser()"
-                data-ng-show="user.isUserAdminOrMore()">
+                data-ng-show="user.isUserAdminOrMore() && isUserProfileUpdateEnabled">
           <i class="fa fa-plus"/>
           <span data-translate="">newUser</span>
         </button>
@@ -43,8 +43,9 @@
     <div class="panel panel-default">
       <div class="panel-heading"
            title="{{searchResults.count > 0 ? ('cantDeleteUserHavingRecords' | translate) : ''}}">
-        <span data-ng-hide="userSelected.id == ''" data-translate="">updateUser</span>
-        <span data-ng-hide="userSelected.id != ''" data-translate="">newUser</span>
+        <span data-ng-hide="userSelected.id == '' || !isUserProfileUpdateEnabled" data-translate="">updateUser</span>
+        <span data-ng-hide="userSelected.id != '' || !isUserProfileUpdateEnabled" data-translate="">newUser</span>
+        <span data-ng-hide="isUserProfileUpdateEnabled" data-translate="">user</span>
         <strong>{{userSelected.name}} {{userSelected.surname}}</strong>
         ({{userSelected.profile | translate}})
         <span data-ng-show="userSelected.security.authtype.length > 0">
@@ -52,7 +53,7 @@
         </span>
         <div class="btn-toolbar">
           <button type="button" class="btn btn-default pull-right"
-                  data-ng-hide="hideResetPassword()"
+                  data-ng-hide="userSelected.security.authtype == 'LDAP' || isDisableLoginForm"
                   data-ng-click="resetPassword(userSelected.id)">
             <i class="fa fa-lock fa-fw"></i> <span data-translate=""
           >resetPassword</span></button>
@@ -102,7 +103,7 @@
                        data-gn-duplicate-check="userSelected.username"
                        data-gn-duplicate-check-apply="userOperation == 'newuser'"
                        data-gn-duplicate-check-remote="../api/users/properties/userid?exist={value}"
-                       data-ng-disabled="!user.isUserAdminOrMore()"
+                       data-ng-disabled="!user.isUserAdminOrMore() || !isUserProfileUpdateEnabled"
                        autocomplete="off"/>
                 <p class="help-block" data-translate="">usernameHelp</p>
                 <p class="help-block"
@@ -162,14 +163,16 @@
               <div class="col-sm-9">
                 <input type="text" name="name" class="form-control"
                        data-ng-model="userSelected.name"
-                       data-ng-required="true"/>
+                       data-ng-required="true"
+                       data-ng-disabled="!isUserProfileUpdateEnabled"/>
               </div>
             </div>
             <div data-ng-class="userSelected.surname == '' ? 'has-error' : ''" class="form-group">
               <label class="control-label col-sm-3" data-translate="">surname</label>
               <div class="col-sm-9">
                 <input type="text" name="surname" class="form-control"
-                       data-ng-model="userSelected.surname" data-ng-required=""/>
+                       data-ng-model="userSelected.surname" data-ng-required=""
+                       data-ng-disabled="!isUserProfileUpdateEnabled"/>
               </div>
             </div>
             <div
@@ -178,7 +181,8 @@
               <label class="control-label col-sm-3" data-translate="">email</label>
               <div class="col-sm-9">
                 <input type="email" name="email" class="form-control"
-                       data-ng-model="userSelected.emailAddresses[0]" data-ng-required="true"/>
+                       data-ng-model="userSelected.emailAddresses[0]" data-ng-required="true"
+                       data-ng-disabled="!isUserProfileUpdateEnabled"/>
                 <p class="help-block" data-translate="">configureYourAvatar</p>
               </div>
             </div>
@@ -187,7 +191,8 @@
               <!-- TODO : Add org list -->
               <div class="col-sm-9">
                 <input type="text" name="org" class="form-control"
-                       data-ng-model="userSelected.organisation"/>
+                       data-ng-model="userSelected.organisation"
+                       data-ng-disabled="!isUserProfileUpdateEnabled"/>
               </div>
             </div>
 
@@ -198,7 +203,8 @@
                 <label class="control-label col-sm-3" data-translate="">address</label>
                 <div class="col-sm-9">
                   <input type="text" name="address" class="form-control"
-                         data-ng-model="userSelected.addresses[0].address"/>
+                         data-ng-model="userSelected.addresses[0].address"
+                         data-ng-disabled="!isUserProfileUpdateEnabled"/>
                 </div>
               </div>
 
@@ -206,7 +212,8 @@
                 <label class="control-label col-sm-3" data-translate="">zip</label>
                 <div class="col-sm-9">
                   <input type="text" name="zip" class="form-control"
-                         data-ng-model="userSelected.addresses[0].zip"/>
+                         data-ng-model="userSelected.addresses[0].zip"
+                         data-ng-disabled="!isUserProfileUpdateEnabled"/>
                 </div>
               </div>
 
@@ -215,7 +222,8 @@
                 <label class="control-label col-sm-3" data-translate="">state</label>
                 <div class="col-sm-9">
                   <input type="text" name="state" class="form-control"
-                         data-ng-model="userSelected.addresses[0].state"/>
+                         data-ng-model="userSelected.addresses[0].state"
+                         data-ng-disabled="!isUserProfileUpdateEnabled"/>
                 </div>
               </div>
 
@@ -224,7 +232,8 @@
                 <label class="control-label col-sm-3" data-translate="">city</label>
                 <div class="col-sm-9">
                   <input type="text" name="city" class="form-control"
-                         data-ng-model="userSelected.addresses[0].city"/>
+                         data-ng-model="userSelected.addresses[0].city"
+                         data-ng-disabled="!isUserProfileUpdateEnabled"/>
                 </div>
               </div>
 
@@ -234,13 +243,14 @@
                 <div class="col-sm-9">
                   <input type="text" name="country" class="form-control"
                          data-ng-model="userSelected.addresses[0].country"
-                         data-gn-country-picker=""/>
+                         data-gn-country-picker=""
+                         data-ng-disabled="!isUserProfileUpdateEnabled"/>
                 </div>
               </div>
             </fieldset>
 
 
-            <fieldset data-ng-if="!user.isUserAdminOrMore()">
+            <fieldset data-ng-if="!user.isUserAdminOrMore() && isUserGroupUpdateEnabled">
               <legend data-translate="profile"></legend>
 
               <div data-ng-if="groupsByProfile['RegisteredUser'].length > 0">
@@ -265,7 +275,7 @@
               </div>
             </fieldset>
 
-            <fieldset data-ng-if="user.isUserAdminOrMore()">
+            <fieldset data-ng-if="user.isUserAdminOrMore() && isUserGroupUpdateEnabled">
               <legend data-translate="">defineUserGroupsPerProfile</legend>
               <input type="hidden" name="profile" data-ng-model="userSelected.profile"
                      value="{{userSelected.profile}}"/>

--- a/web-ui/src/main/resources/catalog/templates/signin.html
+++ b/web-ui/src/main/resources/catalog/templates/signin.html
@@ -86,7 +86,7 @@
         <div class="panel-body text-muted">
 
           <!-- register -->
-          <div data-ng-show="gnConfig[gnConfig.key.isSelfRegisterEnabled]">
+          <div data-ng-show="gnConfig[gnConfig.key.isSelfRegisterEnabled] && isUserProfileUpdateEnabled">
             <b data-translate="">needAnAccount</b>
             <p data-translate="">needAnAccountInfo</p>
             <p>
@@ -95,7 +95,7 @@
           </div>
 
           <!-- forgot passpword -->
-          <div data-ng-show="gnConfig['system.feedback.mailServer.hostIsDefined']">
+          <div data-ng-show="gnConfig['system.feedback.mailServer.hostIsDefined'] && isUserProfileUpdateEnabled">
             <b data-translate="">forgetDetails</b>
             <span data-ng-show="sendPassword === false">
               <p data-translate="">forgetDetailsInfo</p>

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -281,6 +281,18 @@
       <script type="text/javascript" src="{$uiResourcesPath}lib/angular.ext/ui-ace.js?v={$buildNumber}"></script>
     </xsl:if>
 
+    <!-- Load variables that are required for user group profile management. -->
+    <xsl:if test="$angularApp = 'gn_admin'">
+      <script type="text/javascript">
+        var module = angular.module('<xsl:value-of select="$angularApp"/>');
+        module.config(['gnGlobalSettings',
+        function(gnGlobalSettings) {
+        gnGlobalSettings.isDisableLoginForm = <xsl:value-of select="$isDisableLoginForm"/>;
+        gnGlobalSettings.isUserProfileUpdateEnabled = <xsl:value-of select="$isUserProfileUpdateEnabled"/>;
+        gnGlobalSettings.isUserGroupUpdateEnabled = <xsl:value-of select="$isUserGroupUpdateEnabled"/>;
+        }]);
+      </script>
+    </xsl:if>
 
     <script type="text/javascript">
       var module = angular.module('<xsl:value-of select="$angularApp"/>');

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -238,7 +238,7 @@
       <link rel="stylesheet" href="{$uiResourcesPath}lib/d3_timeseries/nv.d3.min.css"/>
     </xsl:if>
 
-    <xsl:if test="$angularApp = 'gn_search' or $angularApp = 'gn_login'">
+    <xsl:if test="$angularApp = 'gn_search' or $angularApp = 'gn_login' or $angularApp = 'gn_admin'">
       <script type="text/javascript">
         var module = angular.module('<xsl:value-of select="$angularApp"/>');
         module.config(['gnGlobalSettings',
@@ -246,6 +246,7 @@
         gnGlobalSettings.isDisableLoginForm = <xsl:value-of select="$isDisableLoginForm"/>;
         gnGlobalSettings.isShowLoginAsLink = <xsl:value-of select="$isShowLoginAsLink"/>;
         gnGlobalSettings.isUserProfileUpdateEnabled = <xsl:value-of select="$isUserProfileUpdateEnabled"/>;
+        gnGlobalSettings.isUserGroupUpdateEnabled = <xsl:value-of select="$isUserGroupUpdateEnabled"/>;
         }]);
       </script>
 
@@ -280,19 +281,6 @@
     <xsl:if test="$angularApp = 'gn_editor' or $angularApp = 'gn_admin'">
       <script type="text/javascript" src="{$uiResourcesPath}lib/ace/ace.js?v={$buildNumber}"></script>
       <script type="text/javascript" src="{$uiResourcesPath}lib/angular.ext/ui-ace.js?v={$buildNumber}"></script>
-    </xsl:if>
-
-    <!-- Load variables that are required for user group profile management. -->
-    <xsl:if test="$angularApp = 'gn_admin'">
-      <script type="text/javascript">
-        var module = angular.module('<xsl:value-of select="$angularApp"/>');
-        module.config(['gnGlobalSettings',
-        function(gnGlobalSettings) {
-        gnGlobalSettings.isDisableLoginForm = <xsl:value-of select="$isDisableLoginForm"/>;
-        gnGlobalSettings.isUserProfileUpdateEnabled = <xsl:value-of select="$isUserProfileUpdateEnabled"/>;
-        gnGlobalSettings.isUserGroupUpdateEnabled = <xsl:value-of select="$isUserGroupUpdateEnabled"/>;
-        }]);
-      </script>
     </xsl:if>
 
     <script type="text/javascript">

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -245,6 +245,7 @@
         function(gnGlobalSettings) {
         gnGlobalSettings.isDisableLoginForm = <xsl:value-of select="$isDisableLoginForm"/>;
         gnGlobalSettings.isShowLoginAsLink = <xsl:value-of select="$isShowLoginAsLink"/>;
+        gnGlobalSettings.isUserProfileUpdateEnabled = <xsl:value-of select="$isUserProfileUpdateEnabled"/>;
         }]);
       </script>
 

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -71,6 +71,12 @@
   <xsl:variable name="isShowLoginAsLink"
                 select="util:isShowLoginAsLink()"/>
 
+  <xsl:variable name="isUserProfileUpdateEnabled"
+                select="util:isUserProfileUpdateEnabled()"/>
+
+  <xsl:variable name="isUserGroupUpdateEnabled"
+                select="util:isUserGroupUpdateEnabled()"/>
+
   <!-- Define which JS module to load using Closure -->
   <xsl:variable name="angularApp" select="
     if ($service = 'admin.console') then 'gn_admin'


### PR DESCRIPTION
The user profile editing needs to be disabled if login user is Keycloak/"none local user" and the application authentication is done via keycloak. The editing should happen in Keycloak instead of Geonetwork.

Here is the example:
![image](https://user-images.githubusercontent.com/74916635/122954427-6d063d00-d34d-11eb-9677-c5fb7d447910.png)

As result, the enable/disable will still allowed. There are two extra env variable to pass into SecurityConfiguration as control flag: UPDATEPROFILE and UPDATEGROUP