### PR TITLE
Updated the index fieldname to match the es index names.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/WatchListNotifier.java
+++ b/core/src/main/java/org/fao/geonet/kernel/WatchListNotifier.java
@@ -68,7 +68,7 @@ public class WatchListNotifier extends QuartzJobBean {
     private String permalinkApp = "catalog.search#/search?_uuid={{filter}}";
 
     @Value("${usersavedselection.watchlist.recordurl}")
-    private String permalinkRecordApp = "api/records/{{index:_uuid}}";
+    private String permalinkRecordApp = "api/records/{{index:uuid}}";
 
     public String getPermalinkApp() {
         return permalinkApp;

--- a/core/src/main/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages.properties
@@ -90,32 +90,32 @@ user_feedback_text=User %s (%s - %s)\n\
   See record %sapi/records/%s
 status_email_text=GeoNetwork user %s (%s) edited metadata record #%s
 # SiteName / Workflow / recordTitle statusName by userName
-status_change_default_email_subject={0} / Workflow / '{{'index:title'}}' {1} by {2}
-status_change_default_email_text={0} modified the status of the record '{{'index:title'}}'.\n\
+status_change_default_email_subject={0} / Workflow / '{{'index:resourceTitleObject'}}' {1} by {2}
+status_change_default_email_text={0} modified the status of the record '{{'index:resourceTitleObject'}}'.\n\
 The status is now: {2}.\n\
  \n\
 Message: \n\
 {1} \n\
  \n\
 View record: \n\
-{7}catalog.search#/metadata/'{{'index:_uuid'}}'
+{7}catalog.search#/metadata/'{{'index:uuid'}}'
 
 # SiteName / Task / recordTitle statusName by userName
-status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{'index:title'}}'
+status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{'index:resourceTitleObject'}}'
 # author
-status_change_doiCreationTask_email_text={0} requested creation of the DOI for the record '{{'index:title'}}'. Could you proceed to the DOI creation by {4}.\n\
+status_change_doiCreationTask_email_text={0} requested creation of the DOI for the record '{{'index:resourceTitleObject'}}'. Could you proceed to the DOI creation by {4}.\n\
 \n\
 Responsible of the task: \n\
 Message: \n\
 {1} \n\
 \n\
 View record: \n\
-{7}catalog.search#/metadata/'{{'index:_uuid'}}'
+{7}catalog.search#/metadata/'{{'index:uuid'}}'
 # TODO: Link to DOI creation panel
 
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
 user_watchlist_subject=%s / %d updates in your watch list since %s
-user_watchlist_message_record=<li><a href="{{link}}">{{index:title}}</a></li>
+user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=The following records have been updated:\n\
       <ul>%s</ul>\n\
       \n\

--- a/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
@@ -85,10 +85,10 @@ Fiches mises à jour : \n\
  \n\
 Consulter les fiches mises à jour : \n\
 %scatalog.search#/search?_status=%s&_statusChangeDate=%s
-status_email_change_details=* {{index:title}} ({{serverurl}}catalog.search#/metadata/{{index:_uuid}})
+status_email_change_details=* {{index:resourceTitleObject}} ({{serverurl}}catalog.search#/metadata/{{index:uuid}})
 api.groups.group_not_found=Le groupe avec l'identifiant ''{0}'' n'a pas \u00E9t\u00E9 trouv\u00E9 dans le catalogue.
 user_watchlist_subject=%s / %d mises à jour dans vos fiches surveill\u00E9es %s
-user_watchlist_message_record=<li><a href="{{link}}">{{index:title}}</a></li>
+user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises à jour :\n\
       <ul>%s</ul>\n\
       \n\

--- a/core/src/test/resources/WEB-INF/config.properties
+++ b/core/src/test/resources/WEB-INF/config.properties
@@ -5,7 +5,7 @@ usersavedselection.watchlist.frequency=0 0 4 * * ?
 usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 
 # Define the link to each record sent by email by the watchlist notifier
-usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}
+usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
 
 es.url=http://localhost:9200

--- a/schemas-test/src/main/webapp/WEB-INF/config.properties
+++ b/schemas-test/src/main/webapp/WEB-INF/config.properties
@@ -5,7 +5,7 @@ usersavedselection.watchlist.frequency=0 0 4 * * ?
 usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 
 # Define the link to each record sent by email by the watchlist notifier
-usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}
+usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
 
 es.url=http://localhost:9200

--- a/schemas/iso19115-3.2018/src/main/test/resources/metadata-for-editing.xml
+++ b/schemas/iso19115-3.2018/src/main/test/resources/metadata-for-editing.xml
@@ -46,7 +46,7 @@ La liste des métadonnées concernées par le changement est la suivante:
 %s
 La liste des changements d'état sont accessibles ici :
 %s/../../?s_E__status=%s&amp;s_E__statusChangeDate=%s&amp;s_search</statusSendEmail>
-      <statusMetadataDetails>* {{index:title}} ({{serverurl}}/search?uuid={{index:_uuid}})</statusMetadataDetails>
+      <statusMetadataDetails>* {{index:resourceTitleObject}} ({{serverurl}}/search?uuid={{index:uuid}})</statusMetadataDetails>
       <otherValue>Autre :</otherValue>
       <warning>Attention</warning>
       <isAdmin>Est administrateur ?</isAdmin>

--- a/schemas/iso19115-3.2018/src/main/test/resources/metadata-iso19139-for-editing.xml
+++ b/schemas/iso19115-3.2018/src/main/test/resources/metadata-iso19139-for-editing.xml
@@ -46,7 +46,7 @@ La liste des métadonnées concernées par le changement est la suivante:
 %s
 La liste des changements d'état sont accessibles ici :
 %s/../../?s_E__status=%s&amp;s_E__statusChangeDate=%s&amp;s_search</statusSendEmail>
-      <statusMetadataDetails>* {{index:title}} ({{serverurl}}/search?uuid={{index:_uuid}})</statusMetadataDetails>
+      <statusMetadataDetails>* {{index:resourceTitleObject}} ({{serverurl}}/search?uuid={{index:uuid}})</statusMetadataDetails>
       <otherValue>Autre :</otherValue>
       <warning>Attention</warning>
       <isAdmin>Est administrateur ?</isAdmin>

--- a/services/src/main/webapp/WEB-INF/config.properties
+++ b/services/src/main/webapp/WEB-INF/config.properties
@@ -5,7 +5,7 @@ usersavedselection.watchlist.frequency=0 0 4 * * ?
 usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 
 # Define the link to each record sent by email by the watchlist notifier
-usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}
+usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
 es.url=http://localhost:9200
 es.index.features=features

--- a/services/src/test/resources/WEB-INF/config.properties
+++ b/services/src/test/resources/WEB-INF/config.properties
@@ -5,7 +5,7 @@ usersavedselection.watchlist.frequency=0 0 4 * * ?
 usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 
 # Define the link to each record sent by email by the watchlist notifier
-usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}
+usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
 es.url=http://localhost:9200
 es.port=9200

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -9,7 +9,7 @@ usersavedselection.watchlist.frequency=${savedselection.watchlist.frequency}
 usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 
 # Define the link to each record sent by email by the watchlist notifier
-usersavedselection.watchlist.recordurl=api/records/{{index:_uuid}}
+usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
 es.protocol=${es.protocol}
 es.port=${es.port}


### PR DESCRIPTION
While testing https://github.com/geonetwork/core-geonetwork/pull/5686 I noticed that the metadata tile and uuid from the email messages was null causing the messages not to be parsed correctly.

This change updates the index names to the newer elastic search index names.

Note that I also changed the following.
`    api/records/{{index:uuid}}`
as I'm assuming this uses the same index.  But I'm not exactly sure where this is used so I'm not sure if that changes is correct.
