### PR TITLE
Refactor - autowire settingManager bean to make code cleaner.

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -37,6 +37,7 @@ import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,6 +68,9 @@ import javax.annotation.Nullable;
 public class FilesystemStore extends AbstractStore {
     public static final String DEFAULT_FILTER = "*.*";
 
+    @Autowired
+    SettingManager settingManager;
+
     public FilesystemStore() {
     }
 
@@ -74,7 +78,6 @@ public class FilesystemStore extends AbstractStore {
     public List<MetadataResource> getResources(ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility,
                                                String filter, Boolean approved) throws Exception {
         int metadataId = canDownload(context, metadataUuid, visibility, approved);
-        SettingManager settingManager = context.getBean(SettingManager.class);
 
         Path metadataDir = Lib.resource.getMetadataDir(getDataDirectory(context), metadataId);
         Path resourceTypeDir = metadataDir.resolve(visibility.toString());
@@ -146,7 +149,6 @@ public class FilesystemStore extends AbstractStore {
     private MetadataResource getResourceDescription(final ServiceContext context, final String metadataUuid,
                                                     final MetadataResourceVisibility visibility, final Path filePath, Boolean approved)
             throws IOException {
-        SettingManager settingManager = context.getBean(SettingManager.class);
         Integer metadataId = null;
 
         try {
@@ -179,7 +181,6 @@ public class FilesystemStore extends AbstractStore {
             }
         }
 
-        SettingManager settingManager = context.getBean(SettingManager.class);
         return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid, settingManager.getNodeURL() + "api/records/", approved);
     }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -74,11 +74,13 @@ public class JCloudStore extends AbstractStore {
     @Autowired
     JCloudConfiguration jCloudConfiguration;
 
+    @Autowired
+    SettingManager settingManager;
+
     @Override
     public List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid,
                                                final MetadataResourceVisibility visibility, String filter, Boolean approved) throws Exception {
         final int metadataId = canDownload(context, metadataUuid, visibility, approved);
-        final SettingManager settingManager = context.getBean(SettingManager.class);
 
         final String resourceTypeDir = getMetadataDir(context, metadataId) + jCloudConfiguration.getFolderDelimiter() + visibility.toString() + jCloudConfiguration.getFolderDelimiter();
 
@@ -107,7 +109,7 @@ public class JCloudStore extends AbstractStore {
                 Path keyPath = new File(storageMetadata.getName()).toPath().getFileName();
                 if (storageMetadata.getType() == StorageType.BLOB && matcher.matches(keyPath)){
                     final String filename = getFilename(storageMetadata.getName());
-                    MetadataResource resource = createResourceDescription(context, settingManager, metadataUuid, visibility, filename, storageMetadata, metadataId, approved);
+                    MetadataResource resource = createResourceDescription(context, metadataUuid, visibility, filename, storageMetadata, metadataId, approved);
                     resourceList.add(resource);
                 }
             }
@@ -120,7 +122,7 @@ public class JCloudStore extends AbstractStore {
         return resourceList;
     }
 
-    private MetadataResource createResourceDescription(final ServiceContext context, final SettingManager settingManager, final String metadataUuid,
+    private MetadataResource createResourceDescription(final ServiceContext context, final String metadataUuid,
                                                        final MetadataResourceVisibility visibility, final String resourceId,
                                                        StorageMetadata storageMetadata, int metadataId, boolean approved) {
         String filename = getFilename(metadataUuid, resourceId);
@@ -150,8 +152,7 @@ public class JCloudStore extends AbstractStore {
         try {
             final Blob object = jCloudConfiguration.getClient().getBlobStore().getBlob(
                 jCloudConfiguration.getContainerName(), getKey(context, metadataUuid, metadataId, visibility, resourceId));
-            final SettingManager settingManager = context.getBean(SettingManager.class);
-            return new ResourceHolderImpl(object, createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId,
+            return new ResourceHolderImpl(object, createResourceDescription(context, metadataUuid, visibility, resourceId,
                 object.getMetadata(), metadataId, approved));
         } catch (ContainerNotFoundException e) {
             Log.warning(Geonet.RESOURCES, String.format("Error getting metadata resource. '%s' not found for metadata '%s'", resourceId, metadataUuid));
@@ -175,7 +176,6 @@ public class JCloudStore extends AbstractStore {
     public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,
                                         final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility, Boolean approved)
             throws Exception {
-        final SettingManager settingManager = context.getBean(SettingManager.class);
         final int metadataId = canEdit(context, metadataUuid, approved);
         String key = getKey(context, metadataUuid, metadataId, visibility, filename);
 
@@ -191,14 +191,13 @@ public class JCloudStore extends AbstractStore {
         jCloudConfiguration.getClient().getBlobStore().putBlob(jCloudConfiguration.getContainerName(), blob, multipart());
         Blob blobResults = jCloudConfiguration.getClient().getBlobStore().getBlob(jCloudConfiguration.getContainerName(), key);
 
-        return createResourceDescription(context, settingManager, metadataUuid, visibility, filename, blobResults.getMetadata(), metadataId, approved);
+        return createResourceDescription(context, metadataUuid, visibility, filename, blobResults.getMetadata(), metadataId, approved);
 
     }
 
     @Override
     public MetadataResource patchResourceStatus(final ServiceContext context, final String metadataUuid, final String resourceId,
                                                 final MetadataResourceVisibility visibility, Boolean approved) throws Exception {
-        SettingManager settingManager = context.getBean(SettingManager.class);
         int metadataId = canEdit(context, metadataUuid, approved);
 
         String sourceKey = null;
@@ -213,7 +212,7 @@ public class JCloudStore extends AbstractStore {
                         break;
                     } else {
                         // already the good visibility
-                        return createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId, storageMetadata, metadataId, approved);
+                        return createResourceDescription(context, metadataUuid, visibility, resourceId, storageMetadata, metadataId, approved);
                     }
                 }
             } catch (ContainerNotFoundException ignored) {
@@ -228,7 +227,7 @@ public class JCloudStore extends AbstractStore {
 
             Blob blobResults = jCloudConfiguration.getClient().getBlobStore().getBlob(jCloudConfiguration.getContainerName(), destKey);
 
-            return createResourceDescription(context, settingManager, metadataUuid, visibility, resourceId, blobResults.getMetadata(), metadataId, approved);
+            return createResourceDescription(context, metadataUuid, visibility, resourceId, blobResults.getMetadata(), metadataId, approved);
         } else {
             Log.warning(Geonet.RESOURCES,
                 String.format("Could not update permissions. Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid));
@@ -307,14 +306,13 @@ public class JCloudStore extends AbstractStore {
                                                    final MetadataResourceVisibility visibility, final String filename, Boolean approved) throws Exception {
         int metadataId = getAndCheckMetadataId(metadataUuid, approved);
         final String key = getKey(context, metadataUuid, metadataId, visibility, filename);
-        SettingManager settingManager = context.getBean(SettingManager.class);
         try {
             final Blob object = jCloudConfiguration.getClient().getBlobStore().getBlob(jCloudConfiguration.getContainerName(), key);
             if (object == null) {
                 return null;
             } else {
                 final StorageMetadata metadata = object.getMetadata();
-                return createResourceDescription(context, settingManager, metadataUuid, visibility, filename, metadata, metadataId, approved);
+                return createResourceDescription(context, metadataUuid, visibility, filename, metadata, metadataId, approved);
             }
         } catch (ContainerNotFoundException e) {
             return null;
@@ -326,7 +324,6 @@ public class JCloudStore extends AbstractStore {
 
         int metadataId = getAndCheckMetadataId(metadataUuid, approved);
 
-        SettingManager settingManager = context.getBean(SettingManager.class);
         return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid, settingManager.getNodeURL() + "api/records/", approved);
     }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -55,11 +55,13 @@ public class S3Store extends AbstractStore {
     @Autowired
     S3Credentials s3;
 
+    @Autowired
+    SettingManager settingManager;
+
     @Override
     public List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid,
             final MetadataResourceVisibility visibility, String filter, Boolean approved) throws Exception {
         final int metadataId = canEdit(context, metadataUuid, approved);
-        final SettingManager settingManager = context.getBean(SettingManager.class);
 
         final String resourceTypeDir = getMetadataDir(metadataId) + "/" + visibility.toString();
 
@@ -76,7 +78,7 @@ public class S3Store extends AbstractStore {
             final String filename = getFilename(key);
             Path keyPath = new File(filename).toPath().getFileName();
             if (matcher.matches(keyPath)) {
-                MetadataResource resource = createResourceDescription(settingManager, metadataUuid, visibility, filename, object.getSize(),
+                MetadataResource resource = createResourceDescription(metadataUuid, visibility, filename, object.getSize(),
                                                                       object.getLastModified(), metadataId, approved);
                 resourceList.add(resource);
             }
@@ -87,7 +89,7 @@ public class S3Store extends AbstractStore {
         return resourceList;
     }
 
-    private MetadataResource createResourceDescription(final SettingManager settingManager, final String metadataUuid,
+    private MetadataResource createResourceDescription(final String metadataUuid,
             final MetadataResourceVisibility visibility, final String resourceId, long size, Date lastModification, int metadataId, boolean approved) {
         return new FilesystemStoreResource(metadataUuid, metadataId, getFilename(metadataUuid, resourceId),
                                            settingManager.getNodeURL() + "api/records/", visibility, size, lastModification, approved);
@@ -106,8 +108,7 @@ public class S3Store extends AbstractStore {
         try {
             final S3Object object = s3.getClient().getObject(
                 s3.getBucket(), getKey(metadataUuid, metadataId, visibility, resourceId));
-            final SettingManager settingManager = context.getBean(SettingManager.class);
-            return new ResourceHolderImpl(object, createResourceDescription(settingManager, metadataUuid, visibility, resourceId,
+            return new ResourceHolderImpl(object, createResourceDescription(metadataUuid, visibility, resourceId,
                                                                             object.getObjectMetadata().getContentLength(),
                                                                             object.getObjectMetadata().getLastModified(), metadataId, approved));
         } catch (AmazonServiceException ignored) {
@@ -131,7 +132,6 @@ public class S3Store extends AbstractStore {
     public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,
             final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility, Boolean approved)
             throws Exception {
-        final SettingManager settingManager = context.getBean(SettingManager.class);
         final int metadataId = canEdit(context, metadataUuid, approved);
         String key = getKey(metadataUuid, metadataId, visibility, filename);
         ObjectMetadata metadata = new ObjectMetadata();
@@ -139,14 +139,13 @@ public class S3Store extends AbstractStore {
             metadata.setLastModified(changeDate);
         }
         final PutObjectResult putAnswer = s3.getClient().putObject(s3.getBucket(), key, is, metadata);
-        return createResourceDescription(settingManager, metadataUuid, visibility, filename, putAnswer.getMetadata().getContentLength(),
+        return createResourceDescription(metadataUuid, visibility, filename, putAnswer.getMetadata().getContentLength(),
                                          putAnswer.getMetadata().getLastModified(), metadataId, approved);
     }
 
     @Override
     public MetadataResource patchResourceStatus(final ServiceContext context, final String metadataUuid, final String resourceId,
             final MetadataResourceVisibility visibility, Boolean approved) throws Exception {
-        SettingManager settingManager = context.getBean(SettingManager.class);
         int metadataId = canEdit(context, metadataUuid, approved);
 
         String sourceKey = null;
@@ -160,7 +159,7 @@ public class S3Store extends AbstractStore {
                     break;
                 } else {
                     // already the good visibility
-                    return createResourceDescription(settingManager, metadataUuid, visibility, resourceId, metadata.getContentLength(),
+                    return createResourceDescription(metadataUuid, visibility, resourceId, metadata.getContentLength(),
                                                      metadata.getLastModified(), metadataId, approved);
                 }
             } catch (AmazonServiceException ignored) {
@@ -172,7 +171,7 @@ public class S3Store extends AbstractStore {
             final CopyObjectResult copyResult = s3.getClient().copyObject(
                 s3.getBucket(), sourceKey, s3.getBucket(), destKey);
             s3.getClient().deleteObject(s3.getBucket(), sourceKey);
-            return createResourceDescription(settingManager, metadataUuid, visibility, resourceId, metadata.getContentLength(),
+            return createResourceDescription(metadataUuid, visibility, resourceId, metadata.getContentLength(),
                                              copyResult.getLastModifiedDate(), metadataId, approved);
         } else {
             throw new ResourceNotFoundException(
@@ -233,10 +232,9 @@ public class S3Store extends AbstractStore {
             final MetadataResourceVisibility visibility, final String filename, Boolean approved) throws Exception {
         int metadataId = getAndCheckMetadataId(metadataUuid, approved);
         final String key = getKey(metadataUuid, metadataId, visibility, filename);
-        SettingManager settingManager = context.getBean(SettingManager.class);
         try {
             final ObjectMetadata metadata = s3.getClient().getObjectMetadata(s3.getBucket(), key);
-            return createResourceDescription(settingManager, metadataUuid, visibility, filename, metadata.getContentLength(),
+            return createResourceDescription(metadataUuid, visibility, filename, metadata.getContentLength(),
                                              metadata.getLastModified(), metadataId, approved);
         } catch (AmazonServiceException e) {
             return null;
@@ -248,7 +246,6 @@ public class S3Store extends AbstractStore {
 
         int metadataId = getAndCheckMetadataId(metadataUuid, approved);
 
-        SettingManager settingManager = context.getBean(SettingManager.class);
         return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid, settingManager.getNodeURL() + "api/records/", approved);
     }
 


### PR DESCRIPTION
As identified in PR 5686, the file stores can be cleaner by autowiring the settingManager.

This PR is to refactor the code to autiwire the settingManager bean.

Please back port this change to 3.12.x