### PR TITLE
Fix bug in keycloak signin link

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
@@ -199,9 +199,20 @@
             </li>
           </ul>
         </li>
+        <li class="open signin-dropdown"
+            data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && isShowLoginAsLink">
+          <a href="{{signInFormAction}}?_csrf={{csrf}}&redirectUrl={{redirectUrlAfterSign}}"
+             title="{{'signIn'|translate}}"
+             class="gn-menuheader-xs"
+             data-ng-keypress="$event"
+             id="signinLink">
+            <span class="fa fa-fw fa-sign-in hidden-sm"></span>
+            {{'signIn' | translate}}
+          </a>
+        </li>
         <!-- not logged in -->
         <li class="dropdown signin-dropdown"
-          data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && (!shibbolethEnabled || (shibbolethEnabled && !shibbolethHideLogin))">
+          data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !isShowLoginAsLink && !isDisableLoginForm">
           <a href="{{gnCfg.mods.signin.appUrl | signInLink}}"
              title="{{'signIn'|translate}}"
              class="dropdown-toggle gn-menuheader-xs"


### PR DESCRIPTION
This PR is the same as PR #5630 but applies changes to the main branch instead of the 3.12.x branch.

Looks like some changes were skipped as part of #5518 and it was still referencing old variables that existed prior to #4931

This fixes the login link so that it works correctly with keycloak.
The changes that had been applied to top-toolbar.html for #4931 have been applied to top-toolbar-accessible.html

I applied the changes to 3.12.x branch as that was the branch I was working on and I'm not sure if the 3.12.x changes have been merged into main yet. If needed, I can change the PR so that it is against main.