### PR TITLE
Add search options

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -555,7 +555,7 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
-      <div data-ng-switch-when="exactMatchToggle">
+      <div data-ng-switch-when="searchOptions">
         <input type="checkbox"
                id="{{key}}-checkbox"
                data-ng-model="mCfg[key]"/>&nbsp;

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -100,7 +100,8 @@
             queryHook.must.push({
               query_string: {
                 fields: ["resourceTitleObject.*"],
-                query: p.any
+                query: gnGlobalSettings.gnCfg.mods.search.queryTitle.replace(
+                  /\$\{any\}/g, escapeSpecialCharacters(p.any))
               }
             });
           } else {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -56,8 +56,11 @@
        *
        * @param queryHook
        * @param p
+       * @param luceneQueryString
+       * @param {boolean} exactMatch search for exact value
+       * @param {boolean} titleOnly search in title only
        */
-      this.buildQueryClauses = function(queryHook, p, luceneQueryString, exactMatch) {
+      this.buildQueryClauses = function(queryHook, p, luceneQueryString, exactMatch, titleOnly) {
         var excludeFields = ['_content_type', 'fast', 'from', 'to', 'bucket',
           'sortBy', 'sortOrder', 'resultType', 'facet.q', 'any', 'geometry', 'query_string',
           'creationDateFrom', 'creationDateTo', 'dateFrom', 'dateTo', 'geom', 'relation',
@@ -70,7 +73,7 @@
             if (queryExpression == null) {
               // var queryBase = '${any} resourceTitleObject.default:(${any})^2',
               var queryBase = '(' + gnGlobalSettings.gnCfg.mods.search.queryBase + ')',
-                  defaultQuery = '${any}';
+                defaultQuery = '${any}';
               if (queryBase.indexOf(defaultQuery) === -1) {
                 console.warn('Check your configuration. Query base \'' +
                   queryBase + '\' MUST contains a \'${any}\' token ' +
@@ -81,8 +84,8 @@
               }
               var searchString = escapeSpecialCharacters(p.any),
                 q = queryBase.replace(
-                      /\$\{any\}/g,
-                      exactMatch === true ? '\"' + searchString + '\"' : searchString);
+                  /\$\{any\}/g,
+                  exactMatch === true ? '\"' + searchString + '\"' : searchString);
               queryStringParams.push(q);
             } else {
               queryStringParams.push(queryExpression[1]);
@@ -92,13 +95,23 @@
           if (luceneQueryString) {
             queryStringParams.push(luceneQueryString);
           }
-          queryHook.must.push({
-            query_string: {
-              query: queryStringParams.join(' AND ').trim()
-            }
-          });
-        }
 
+          if (titleOnly) {
+            queryHook.must.push({
+              query_string: {
+                fields: ["resourceTitleObject.*"],
+                query: p.any
+              }
+            });
+          } else {
+
+            queryHook.must.push({
+              query_string: {
+                query: queryStringParams.join(' AND ').trim()
+              }
+            });
+          }
+        }
         // ranges criteria (for dates)
         if (p.creationDateFrom || p.creationDateTo) {
           queryHook.must.push({
@@ -249,7 +262,7 @@
         }
 
         var queryHook = query.function_score.query.bool;
-        this.buildQueryClauses(queryHook, p, luceneQueryString, searchState.exactMatch);
+        this.buildQueryClauses(queryHook, p, luceneQueryString, searchState.exactMatch, searchState.titleOnly);
 
         if(p.from) {
           params.from = p.from - 1;

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -97,11 +97,13 @@
           }
 
           if (titleOnly) {
+            var query = gnGlobalSettings.gnCfg.mods.search.queryTitle.replace(
+              /\$\{any\}/g, escapeSpecialCharacters(p.any));
+
             queryHook.must.push({
               query_string: {
                 fields: ["resourceTitleObject.*"],
-                query: gnGlobalSettings.gnCfg.mods.search.queryTitle.replace(
-                  /\$\{any\}/g, escapeSpecialCharacters(p.any))
+                query: exactMatch === true ? '\"' + query + '\"' : query
               }
             });
           } else {

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -339,7 +339,6 @@
 
       $scope.$broadcast('beforeSearchReset', preserveGeometrySearch);
 
-      $scope.searchObj.state.exactMatch = false;
       if (searchParams) {
         $scope.searchObj.params = searchParams;
       } else {
@@ -353,8 +352,10 @@
 
       self.resetPagination(customPagination);
       $scope.searchObj.state = {
-        filters: {}
-      }
+        filters: {},
+        exactMatch: false,
+        titleOnly: false
+      };
       $scope.triggerSearch();
       $scope.$broadcast('resetSelection');
     };
@@ -515,7 +516,36 @@
         facet.exclude,
         facetConfigs
       );
-    }
+    };
+
+    /**
+     * @param {boolean} value
+     */
+    this.setExactMatch = function(value) {
+      $scope.searchObj.state.exactMatch = value;
+    };
+
+    /**
+     * @return {boolean}
+     */
+    this.getExactMatch = function() {
+      return $scope.searchObj.state.exactMatch;
+    };
+
+    /**
+     * @param {boolean} value
+     */
+    this.setTitleOnly = function(value) {
+      $scope.searchObj.state.titleOnly = value;
+    };
+
+    /**
+     * @return {boolean}
+     */
+    this.getTitleOnly = function() {
+      return $scope.searchObj.state.titleOnly;
+    };
+
   };
 
   searchFormController['$inject'] = [

--- a/web-ui/src/main/resources/catalog/components/search/searchoptions/SearchOptionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchoptions/SearchOptionsDirective.js
@@ -36,6 +36,23 @@
         templateUrl: '../../catalog/components/search/searchoptions/partials/' +
             'searchoptions.html',
         link: function(scope, element, attrs, controller) {
+          Object.defineProperty(scope, 'exactMatch', {
+            get: function() {
+              return controller.getExactMatch();
+            },
+            set: function(value) {
+              controller.setExactMatch(value);
+            }
+          });
+
+          Object.defineProperty(scope, 'titleOnly', {
+            get: function() {
+              return controller.getTitleOnly();
+            },
+            set: function(value) {
+              controller.setTitleOnly(value);
+            }
+          });
         }
       };
     }]);

--- a/web-ui/src/main/resources/catalog/components/search/searchoptions/SearchOptionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchoptions/SearchOptionsDirective.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_searchoptions_directive');
+
+  var module = angular.module('gn_searchoptions_directive', []);
+
+  module.directive('gnSearchOptions', [function() {
+
+      return {
+        restrict: 'E',
+        require: '^ngSearchForm',
+        scope: {
+        },
+        templateUrl: '../../catalog/components/search/searchoptions/partials/' +
+            'searchoptions.html',
+        link: function(scope, element, attrs, controller) {
+        }
+      };
+    }]);
+})();

--- a/web-ui/src/main/resources/catalog/components/search/searchoptions/SearchOptionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchoptions/SearchOptionsDirective.js
@@ -36,6 +36,12 @@
         templateUrl: '../../catalog/components/search/searchoptions/partials/' +
             'searchoptions.html',
         link: function(scope, element, attrs, controller) {
+          // this enables to keep the dropdown active when we click on the label
+          element.find('label > span').each(function(i, e) {
+            $(e).on('click', function () {
+              $(e).parent().find('input').focus();
+            });
+          });
           Object.defineProperty(scope, 'exactMatch', {
             get: function() {
               return controller.getExactMatch();

--- a/web-ui/src/main/resources/catalog/components/search/searchoptions/SearchOptionsModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchoptions/SearchOptionsModule.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+(function() {
+  goog.provide('gn_searchoptions');
+
+  goog.require('gn_searchoptions_directive');
+
+  angular.module('gn_searchoptions', [
+    'gn_searchoptions_directive'
+  ]);
+})();

--- a/web-ui/src/main/resources/catalog/components/search/searchoptions/partials/searchoptions.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchoptions/partials/searchoptions.html
@@ -1,0 +1,18 @@
+<div class="dropdown-header"
+    title="{{'exactMatch-help' | translate}}">
+  <label>
+    <input type="checkbox"
+           data-ng-model="searchObj.state.exactMatch"
+           aria-label="{{'exactMatch' | translate}}">
+    <span data-translate="">exactMatch</span>
+  </label>
+</div>
+<div class="dropdown-header"
+    title="{{'titleOnly-help' | translate}}">
+  <label>
+    <input type="checkbox"
+           data-ng-model="searchObj.state.titleOnly"
+           aria-label="{{'titleOnly' | translate}}">
+    <span data-translate="">titleOnly</span>
+  </label>
+</div>

--- a/web-ui/src/main/resources/catalog/components/search/searchoptions/partials/searchoptions.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchoptions/partials/searchoptions.html
@@ -2,7 +2,7 @@
     title="{{'exactMatch-help' | translate}}">
   <label>
     <input type="checkbox"
-           data-ng-model="searchObj.state.exactMatch"
+           data-ng-model="exactMatch"
            aria-label="{{'exactMatch' | translate}}">
     <span data-translate="">exactMatch</span>
   </label>
@@ -11,7 +11,7 @@
     title="{{'titleOnly-help' | translate}}">
   <label>
     <input type="checkbox"
-           data-ng-model="searchObj.state.titleOnly"
+           data-ng-model="titleOnly"
            aria-label="{{'titleOnly' | translate}}">
     <span data-translate="">titleOnly</span>
   </label>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -148,8 +148,7 @@ goog.require('gn_alert');
           // Full text but more boost on title match
           'queryBase': 'any:(${any}) resourceTitleObject.\\*:(${any})^2',
           'queryTitle': '${any}',
-          'exactMatchToggle': true,
-          'exactTitleToggle': true,
+          'searchOptions': true,
           // Score query may depend on where we are in the app?
           'scoreConfig': {
             // Score experiments:

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -147,7 +147,9 @@ goog.require('gn_alert');
           // 'queryBase': '${any}',
           // Full text but more boost on title match
           'queryBase': 'any:(${any}) resourceTitleObject.\\*:(${any})^2',
+          'queryTitle': '${any}',
           'exactMatchToggle': true,
+          'exactTitleToggle': true,
           // Score query may depend on where we are in the app?
           'scoreConfig': {
             // Score experiments:

--- a/web-ui/src/main/resources/catalog/js/GnModule.js
+++ b/web-ui/src/main/resources/catalog/js/GnModule.js
@@ -43,7 +43,7 @@
   goog.require('gn_search_manager');
   goog.require('gn_utility');
   goog.require('gn_openlayers');
-
+  goog.require('gn_searchoptions');
 
   /**
    * GnModule just manage angular injection with
@@ -71,7 +71,8 @@
     'gn_cors_interceptor',
     'gn_openlayers',
     'gn_indexingtask',
-    'gn_batchtask'
+    'gn_batchtask',
+    'gn_searchoptions'
   ]);
 
 })();

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -110,6 +110,8 @@
   "searchInvalidResponse": "Query returned an invalid response. Check the console for details.",
   "exactMatch": "Exact match",
   "exactMatch-help": "Exact match means that '\"' are added to the search terms.",
+  "titleOnly": "Search in title only",
+  "titleOnly-help": "Search in title only.",
   "wfsIndexingEndDate": "Last indexing date",
   "wfsIndexingScheduled": "Scheduled?",
   "wfsIndexingNewSchedule": "Add WFS harvester",

--- a/web-ui/src/main/resources/catalog/locales/fr-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-v4.json
@@ -110,6 +110,8 @@
   "searchInvalidResponse": "La réponse du service de recherche est invalide. Vérifier la console.",
   "exactMatch": "Correspondance exacte",
   "exactMatch-help": "Correspondance exacte signifie que des \\\"' sont ajoutés autour des termes recherchés.",
+  "titleOnly": "Rechercher uniquement dans le titre",
+  "titleOnly-help": "Rechercher uniquement dans le titre.",
   "wfsIndexingEndDate": "Dernière exécution",
   "wfsIndexingScheduled": "Planifié ?",
   "wfsIndexingNewSchedule": "Ajouter un moissoneur",

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -207,6 +207,9 @@
       .text-overflow();
     }
   }
+  .dropdown-menu.dropdown-auto {
+    width: auto;
+  }
   [data-gn-user-searches-list] .dropdown-menu {
     width: auto;
   }

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -148,6 +148,7 @@
       $scope.showStatusFooterFor = gnGlobalSettings.gnCfg.mods.search.showStatusFooterFor;
       $scope.exactMatchToggle = gnGlobalSettings.gnCfg.mods.search.exactMatchToggle;
       $scope.exactTitleToggle = gnGlobalSettings.gnCfg.mods.search.exactTitleToggle;
+      $scope.searchOptions = gnGlobalSettings.gnCfg.mods.search.searchOptions;
       $scope.gnWmsQueue = gnWmsQueue;
       $scope.$location = $location;
       $scope.activeTab = '/home';

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -147,6 +147,7 @@
       $scope.isFilterTagsDisplayedInSearch = gnGlobalSettings.gnCfg.mods.search.isFilterTagsDisplayedInSearch;
       $scope.showStatusFooterFor = gnGlobalSettings.gnCfg.mods.search.showStatusFooterFor;
       $scope.exactMatchToggle = gnGlobalSettings.gnCfg.mods.search.exactMatchToggle;
+      $scope.exactTitleToggle = gnGlobalSettings.gnCfg.mods.search.exactTitleToggle;
       $scope.gnWmsQueue = gnWmsQueue;
       $scope.$location = $location;
       $scope.activeTab = '/home';

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -49,21 +49,15 @@
             </button>
             <button type="button"
                     class="btn btn-default btn-lg dropdown-toggle"
-                    data-ng-if="::exactMatchToggle"
+                    data-ng-if="::searchOptions"
                     data-toggle="dropdown"
                     aria-haspopup="true" aria-expanded="false">
               <span class="caret"></span>
             </button>
-            <ul class="dropdown-menu"
-                data-ng-if="::exactMatchToggle">
-              <li class="dropdown-header"
-                  title="{{'exactMatch-help' | translate}}">
-                <label>
-                  <input type="checkbox"
-                         data-ng-model="searchObj.state.exactMatch"
-                         aria-label="{{'exactMatch' | translate}}">
-                  <span data-translate="">exactMatch</span>
-                </label>
+            <ul class="dropdown-menu dropdown-auto"
+                data-ng-if="::searchOptions">
+              <li>
+                <gn-search-options></gn-search-options>
               </li>
             </ul>
             <button type="button"


### PR DESCRIPTION
Enables to have two search options 
- exactMatch (cf https://github.com/geonetwork/core-geonetwork/pull/5072/files)
- title only (it will look for all the resourceTitleObject language keys => so the search value will be checked in all avalaible languages) 

![image](https://user-images.githubusercontent.com/10759614/123604221-f066d900-d7fa-11eb-847a-fecba4315644.png)
