### PR TITLE
JPA MetadataStatus table upgrade from 3.10.x fails the creation of the foreign key from relatedMetadataStatusId to id column

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql
@@ -26,3 +26,5 @@ INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (63,'spa','Record res
 INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (63,'tur','Record restored.');
 INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (63,'vie','Record restored.');
 
+-- In the JPA table upgrade the foreign key creation fails.
+ALTER TABLE MetadataStatus ADD FOREIGN KEY (relatedMetadataStatusId) REFERENCES MetadataStatus(id);


### PR DESCRIPTION
Seem due to the table structure changes JPA is not able to create the foreign key.

Error logged:

```
08:39:25.402 [main] ERROR org.hibernate.tool.hbm2ddl.SchemaUpdate - HHH000388: Unsuccessful: alter table MetadataStatus add constraint FK_c67at42wmtv1fjvuxpxpl0pff foreign key (relatedMetadataStatusId) references MetadataStatus
08:39:25.413 [main] ERROR org.hibernate.tool.hbm2ddl.SchemaUpdate - ERROR: number of referencing and referenced columns for foreign key disagree
```

This PR adds explicitly the foreign key in the sql migration script