### PR TITLE
Editor / Associated resources / Do not add wildcard on all search

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1587,8 +1587,12 @@
 
                   // Append * for like search
                   scope.updateParams = function() {
-                    scope.searchObj.params.any =
-                        '*' + scope.searchObj.any + '*';
+                    var addWildcard = scope.searchObj.any.indexOf('"') === -1
+                      && scope.searchObj.any.indexOf('*') === -1
+                      && scope.searchObj.any.indexOf('q(') !== 0;
+                    scope.searchObj.params.any = addWildcard
+                      ? '*' + scope.searchObj.any + '*'
+                      : scope.searchObj.any;
                   };
 
                   /**
@@ -1731,8 +1735,12 @@
                     if (scope.searchObj.any == '') {
                       scope.$broadcast('resetSearch');
                     } else {
-                      scope.searchObj.params.any =
-                      '*' + scope.searchObj.any + '*';
+                      var addWildcard = scope.searchObj.any.indexOf('"') === -1
+                        && scope.searchObj.any.indexOf('*') === -1
+                        && scope.searchObj.any.indexOf('q(') !== 0;
+                      scope.searchObj.params.any = addWildcard
+                        ? '*' + scope.searchObj.any + '*'
+                        : scope.searchObj.any;
                     }
                   };
 


### PR DESCRIPTION
The point here is to allow user to make more strict search using phrase query (with `"`) or use query expression (with `q()`) or define where to use wildcard.

Before
![image](https://user-images.githubusercontent.com/1701393/123921946-d6a6cc80-d987-11eb-8ae8-018bf64e17b6.png)

After with phrase query
![image](https://user-images.githubusercontent.com/1701393/123921974-db6b8080-d987-11eb-8b84-9213c4649541.png)

After with query expression `q(+resourceTitleObject.default:("corine land cover 2012" AND "version 18"))`
![image](https://user-images.githubusercontent.com/1701393/123922301-2f766500-d988-11eb-997e-d0950798b22e.png)

