### PR TITLE
iso19139 full view - codelist elements - display the codelistValue translation only if the element has a text also

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -361,7 +361,29 @@
        gco:Angle|gmx:FileName|
        gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|
        gco:LocalName|gmd:PT_FreeText|
-       gco:Date|gco:DateTime|*/@codeListValue]|*[gts:TM_PeriodDuration != '']"
+       gco:Date|gco:DateTime|*[gts:TM_PeriodDuration != '']"
+                priority="50">
+    <xsl:param name="fieldName" select="''" as="xs:string"/>
+
+    <xsl:if test="normalize-space(string-join(*, '')) != ''">
+      <dl>
+        <dt>
+          <xsl:call-template name="render-field-label">
+            <xsl:with-param name="fieldName" select="$fieldName"/>
+            <xsl:with-param name="languages" select="$allLanguages"/>
+          </xsl:call-template>
+        </dt>
+        <dd><xsl:comment select="name()"/>
+          <xsl:apply-templates mode="render-value" select="*|*/@codeListValue"/>
+          <xsl:apply-templates mode="render-value" select="@*"/>
+        </dd>
+      </dl>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Codelist elements -->
+  <xsl:template mode="render-field"
+                match="*[*/@codeListValue]"
                 priority="50">
     <xsl:param name="fieldName" select="''" as="xs:string"/>
 
@@ -374,7 +396,14 @@
           </xsl:call-template>
         </dt>
         <dd><xsl:comment select="name()"/>
-          <xsl:apply-templates mode="render-value" select="*|*/@codeListValue"/>
+          <xsl:choose>
+            <xsl:when test="normalize-space(*/@codeListValue) != ''">
+              <xsl:apply-templates mode="render-value" select="*/@codeListValue"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:apply-templates mode="render-value" select="*"/>
+            </xsl:otherwise>
+          </xsl:choose>
           <xsl:apply-templates mode="render-value" select="@*"/>
         </dd>
       </dl>


### PR DESCRIPTION
Some schemas based on iso19139 add a text as part of the codelist elements: 

```
<gmd:status>
  <gmd:MD_ProgressCode codeListValue="completed" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode">compleet</gmd:MD_ProgressCode>
</gmd:status>
```

This causes that the full view display for the elements the `codeListValue` translation and also the text value:

![codelist-1](https://user-images.githubusercontent.com/1695003/123947251-78d2ae80-d9a0-11eb-8c44-8c21449c57ae.png)


With this change, only  the `codeListValue` translation is displayed:

![codelist-2](https://user-images.githubusercontent.com/1695003/123947257-7a9c7200-d9a0-11eb-9999-e00ee9320bdd.png)


