### PR TITLE
Fix NPE pointer error when attempting to reset password as admin user.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -604,10 +604,13 @@ public class UsersApi {
             throw new UserNotFoundEx(Integer.toString(userIdentifier));
         }
 
-        PasswordEncoder encoder = PasswordUtil.encoder(ApplicationContextHolder.get());
+        // If the user is the current users then the user needs to know the old password. (even if the user is an administrator changing their own password)
+        if (myUserId.equals(Integer.toString(userIdentifier))) {
+            PasswordEncoder encoder = PasswordUtil.encoder(ApplicationContextHolder.get());
 
-        if (!encoder.matches(passwordResetDto.getPasswordOld(), user.get().getPassword())) {
-            throw new IllegalArgumentException("The old password is not valid");
+            if (!encoder.matches(passwordResetDto.getPasswordOld(), user.get().getPassword())) {
+                throw new IllegalArgumentException("The old password is not valid");
+            }
         }
 
         String passwordHash = PasswordUtil.encoder(ApplicationContextHolder.get()).encode(


### PR DESCRIPTION
Currently getting NPE when attempting to reset the password as an admin user. 
![image](https://user-images.githubusercontent.com/1868233/124021294-c57ab180-d9c1-11eb-951f-d361804ac158.png)

It seems to be due to supplying an empty old password. (which the admin user should not know)

Admin users should not need to supply the old password when doing a password reset on another user.  But they still need to know the old password if doing the reset on their own account.
