### PR TITLE
Make the editor menu scrollable on small screens

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -121,6 +121,9 @@ div[gn-transfer-ownership] * .list-group {
 [ng-app="gn_editor"] {
   .gn-top-bar {
     position: fixed;
+    @media (max-width: @screen-xs-max) {
+      position: relative;
+    }
     top: 0;
     left: 0;
     right: 0;
@@ -133,6 +136,8 @@ div[gn-transfer-ownership] * .list-group {
     left: 20px;
     right: 20px;
     @media (max-width: @screen-xs-max) {
+      position: relative;
+      top: 0;
       left: 0;
       right: 0;
       border-left: 0;
@@ -141,6 +146,13 @@ div[gn-transfer-ownership] * .list-group {
   }
   .gn-editor-board {
     padding-top: 120px;
+    @media (max-width: @screen-xs-max) {
+      padding-top: 0;
+      .container-fluid, .col-sm-12 {
+        padding-left: 0;
+        padding-right: 0;
+      }
+    }
   }
   .gn-editor-container, .gn-batch-editor, #gn-directory-container,
   #gn-new-metadata-container, #gn-import-container {

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
@@ -296,7 +296,6 @@
 
       <form class="navbar-form language-switcher pull-right">
         <span class="gn-menuheader-xs visible-xs"
-              data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && (!shibbolethEnabled || (shibbolethEnabled && !shibbolethHideLogin))"
               data-translate="">language</span>
         <div class="form-group"
             data-gn-language-switcher="lang"

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -141,7 +141,6 @@
 
     <div class="navbar-form navbar-right language-switcher">
       <span class="gn-menuheader-xs visible-xs"
-            data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !isShowLoginAsLink && !isDisableLoginForm"
             data-translate="">language</span>
       <div data-gn-language-switcher="lang"
            data-langs="langs"

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -49,7 +49,7 @@
     &:hover, &:focus {
       background-color: @gn-menubar-background-hover;
     }
-    
+
   }
   .language-switcher {
     .form-control {
@@ -140,7 +140,10 @@
     .navbar-nav .open .dropdown-menu > li > a {
       min-width: 0;
     }
-    .navbar-accessible {
+    .dropdown {
+      button.dropdown-toggle {
+        display: none;
+      }
       .dropdown-menu {
         display: block;
         position: static;
@@ -199,7 +202,6 @@
         margin-left: -1px;
         margin-top: -1px;
         a {
-          color: @gn-menubar-color;
           display: block;
           padding: 7px 20px !important;
           height: auto;
@@ -213,7 +215,6 @@
           .fa {
             display: inline-block;
             font-size: 22px;
-            // margin: 3px auto;
           }
           [data-gnv-layer-indicator] {
             display: none;
@@ -271,6 +272,7 @@
     }
     .language-switcher {
       padding: 10px 15px;
+      float: none !important;
       .form-control {
         width: calc(~"100% - 3px");
       }


### PR DESCRIPTION
Somewhat related to https://github.com/geonetwork/core-geonetwork/pull/5663

The menu on the editor page couldn't be scrolled which meant that the menu options further down the menu couldn't be scrolled. This was caused by the fixed navigation.

This PR makes the `Editor` menu scrollable on small screens. However, this means the 2 menubars on the `Editor` page are not fixed anymore on small screens.

![gn-editor-menu](https://user-images.githubusercontent.com/19608667/124081420-d243e780-da4b-11eb-8312-8c72424c1da3.png)
