### PR TITLE
Users without groups assigned are listed in the users lists for any UserAdmin

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -142,8 +142,13 @@ public class UsersApi {
             List<User> allUsers = userRepository.findAll(SortUtils.createSort(User_.name));
 
             // Filter users which are not in current user admin groups
-            allUsers.removeIf(u -> !userGroupIds.containsAll(getGroupIds(u.getId())) ||
-                u.getProfile().equals(Profile.Administrator));
+            allUsers.removeIf(u -> {
+                List<Integer> groupIdsForUser = getGroupIds(u.getId());
+
+                return groupIdsForUser.isEmpty() ||
+                    !userGroupIds.containsAll(groupIdsForUser) ||
+                    u.getProfile().equals(Profile.Administrator);
+            });
 //              TODO-API: Check why there was this check on profiles ?
 //                    if (!profileSet.contains(profile))
 //                        alToRemove.add(elRec);


### PR DESCRIPTION
Test to reproduce the issue:

1) Create a group `groupA`.
2) Create a some users in the `groupA` group, including a user with `UserAdmin` profile.
3) Create a user not assigned to any group.
4) Login as `UserAdmin` user in `groupA`
5) Go to the user management --> User created in step 3 is listed, but should not be.
