### PR TITLE
Add a scrollbar to the privileges popup when group names are too long

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -647,6 +647,8 @@ button.active [role=tooltip] {
     max-width: 400px;
   }
   .gn-share-grid {
+    overflow: auto;
+    margin-bottom: 5px;
     tbody {
       max-height: 400px;
       overflow-y: auto;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -90,12 +90,6 @@
   .gn-search-facet {
     padding-bottom: 15px;
   }
-  // modal dialog (wider for for multilingual)
-  @media (min-width: @screen-sm-min) {
-    .modal-dialog {
-      width: 760px;
-    }
-  }
   form.gn-editor {
     // tabs above editor
     .nav {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -21,7 +21,7 @@
 @navbar-default-link-hover-color: @gray-dark;
 @text-muted: #707070;
 // width of modal dialog
-@modal-md: 700px;
+@modal-md: 760px;
 @navbar-default-color: #333;
 // slightly darker primary color, now color contrast on light gray backgrounds is high enough
 @brand-primary: #3277B3;


### PR DESCRIPTION
It can happen that group names are long and can't be displayed on 2 lines because it's one big string without spaces. These long group names push the rest of the content out of the popup.

This PR adds a scrollbar whenever a long group name pushed everything too much to the right.

![gn-groupname](https://user-images.githubusercontent.com/19608667/124275653-1fef4b80-db43-11eb-953a-ea9545a31458.png)


