### PR TITLE
Document use of Elasticsearch 7.6.2 via Apache License 2.0, with a note on license change for 7.11.0 onward

### DIFF
--- a/es/README.md
+++ b/es/README.md
@@ -2,10 +2,10 @@
 
 ## Manual installation
 
-1. Download Elasticsearch (up to 7.10.2 for Geonetwork 4.0.x) from https://www.elastic.co/downloads/elasticsearch
-and copy to the ES module. eg. es/elasticsearch-7.10.2
+1. Download Elasticsearch (use 7.6.2 for Geonetwork 4.0.x) from https://www.elastic.co/downloads/elasticsearch
+and copy to the ES module. eg. es/elasticsearch-7.6.2
    
-   .. info:: Elasticsearch 7.10.2 is available using the Apache 2.0 open source license. Newer versions of Elasticsearch use the Server Side Public License, see [faq](https://www.elastic.co/pricing/faq/licensing).
+   > info: Elasticsearch 7.6.2 is available using the Apache 2.0 open source license. Version 7.10.2 has a known [date_range](https://github.com/elastic/elasticsearch/issues/69012) issue. Newer versions of Elasticsearch from 7.11.0 use the Server Side Public License, see [faq](https://www.elastic.co/pricing/faq/licensing).
  
 2. Start ES using:
 
@@ -37,13 +37,13 @@ and copy to the ES module. eg. es/elasticsearch-7.10.2
 1. Use docker pull to download the image (you can check version in the :file:`pom.xml` file):
 
    ```
-   docker pull docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+   docker pull docker.elastic.co/elasticsearch/elasticsearch:7.6.2
    ```
 
 2. Use docker run, leaving 9200 available:
 
    ```
-   docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+   docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
    ```
    
 
@@ -158,4 +158,12 @@ To turn off this check:
 
 ```
  curl -XPUT http://localhost:9200/_cluster/settings -H 'Content-Type: application/json' -d '{ "transient" : { "cluster.routing.allocation.disk.threshold_enabled" : false } }' 
+```
+
+## Blocked by index read-only / allow delete
+
+To recover:
+
+```
+curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_all/_settings -d '{"index.blocks.read_only_allow_delete": null}'
 ```

--- a/es/README.md
+++ b/es/README.md
@@ -149,3 +149,13 @@ field expansion for [*] matches too many fields, limit: 1024
 An option is to restrict `queryBase` to limit the number of field to query on. `any:(${any}) resourceTitleObject.default:(${any})^2` is a good default. Using `${any}` will probably trigger the error if the number of records is high.
 
 The other option is to increase `indices.query.bool.max_clause_count`.
+
+## Disk space threshold
+
+The server application will refuse to write new content unless there is enough free space available (by default 1/4 of your hard drive).
+
+To turn off this check:
+
+```
+ curl -XPUT http://localhost:9200/_cluster/settings -H 'Content-Type: application/json' -d '{ "transient" : { "cluster.routing.allocation.disk.threshold_enabled" : false } }' 
+```

--- a/es/README.md
+++ b/es/README.md
@@ -2,8 +2,10 @@
 
 ## Manual installation
 
-1. Download Elasticsearch (at least 7.6.2 for Geonetwork 4.0.x) from https://www.elastic.co/downloads/elasticsearch
-and copy to the ES module. eg. es/elasticsearch-7.6.2
+1. Download Elasticsearch (up to 7.10.2 for Geonetwork 4.0.x) from https://www.elastic.co/downloads/elasticsearch
+and copy to the ES module. eg. es/elasticsearch-7.10.2
+   
+   .. info:: Elasticsearch 7.10.2 is available using the Apache 2.0 open source license. Newer versions of Elasticsearch use the Server Side Public License, see [faq](https://www.elastic.co/pricing/faq/licensing).
  
 2. Start ES using:
 
@@ -35,14 +37,15 @@ and copy to the ES module. eg. es/elasticsearch-7.6.2
 1. Use docker pull to download the image (you can check version in the :file:`pom.xml` file):
 
    ```
-   docker pull docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+   docker pull docker.elastic.co/elasticsearch/elasticsearch:7.10.2
    ```
 
-2. Use docker run, leacing 9200 available:
+2. Use docker run, leaving 9200 available:
 
    ```
-   docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+   docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.10.2
    ```
+   
 
 3. Check that elasticsearch is running by visiting http://localhost:9200 in a browser
 

--- a/es/docker-compose.yml
+++ b/es/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -18,7 +18,7 @@ services:
     ports:
       - "9200:9200"
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.10.2
+    image: docker.elastic.co/kibana/kibana:7.6.2
     container_name: kibana
     ports:
       - "5601:5601"

--- a/es/docker-compose.yml
+++ b/es/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -18,7 +18,7 @@ services:
     ports:
       - "9200:9200"
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.6.2
+    image: docker.elastic.co/kibana/kibana:7.10.2
     container_name: kibana
     ports:
       - "5601:5601"

--- a/es/es-dashboards/README.md
+++ b/es/es-dashboards/README.md
@@ -2,7 +2,9 @@
 
 ## Manual installation
 
-Download Kibana from https://www.elastic.co/downloads/kibana. For Geonetwork 3.8.x download at least version 7.2.1
+Download Kibana from https://www.elastic.co/downloads/kibana. For Geonetwork 4.0.x use up to 7.10.2.
+
+.. info:: Elasticsearch 7.10.2 is available using the Apache 2.0 open source license. Newer versions of Elasticsearch use the Server Side Public License, see [faq](https://www.elastic.co/pricing/faq/licensing).
 
 Set Kibana base path and index name in config/kibana.yml:
 
@@ -10,7 +12,6 @@ Set Kibana base path and index name in config/kibana.yml:
 server.basePath: "/geonetwork/dashboards"
 server.rewriteBasePath: false
 kibana.index: ".dashboards"
-
 ```
 
 Adapt if needed ```elasticsearch.url``` and ```server.host```.

--- a/es/es-dashboards/README.md
+++ b/es/es-dashboards/README.md
@@ -2,26 +2,26 @@
 
 ## Manual installation
 
-Download Kibana from https://www.elastic.co/downloads/kibana. For Geonetwork 4.0.x use up to 7.10.2.
+1. Download Kibana from https://www.elastic.co/downloads/kibana. For Geonetwork 4.0.x use 7.6.2.
 
-.. info:: Elasticsearch 7.10.2 is available using the Apache 2.0 open source license. Newer versions of Elasticsearch use the Server Side Public License, see [faq](https://www.elastic.co/pricing/faq/licensing).
+   > info: Elasticsearch 7.6.2 is available using the Apache 2.0 open source license. Version 7.10.2 has a known [date_range](https://github.com/elastic/elasticsearch/issues/69012) issue. Newer versions of Elasticsearch from 7.11.0 use the Server Side Public License, see [faq](https://www.elastic.co/pricing/faq/licensing).
 
-Set Kibana base path and index name in config/kibana.yml:
+2. Set Kibana base path and index name in config/kibana.yml:
 
-```
-server.basePath: "/geonetwork/dashboards"
-server.rewriteBasePath: false
-kibana.index: ".dashboards"
-```
+   ```shell script
+   server.basePath: "/geonetwork/dashboards"
+   server.rewriteBasePath: false
+   kibana.index: ".dashboards"
+   ```
 
-Adapt if needed ```elasticsearch.url``` and ```server.host```.
+   Adapt if needed ```elasticsearch.url``` and ```server.host```.
 
-Start Kibana manually:
+3. Start Kibana manually:
 
-```
-cd kibana/bin
-./kibana
-```
+   ```shell script
+   cd kibana/bin
+   ./kibana
+   ```
 
 ## Maven installation
 
@@ -33,14 +33,14 @@ cd kibana/bin
 
 2. Use maven to download:
 
-   ```
+   ```shell script
    cd es/es-dashboard
    mvn install -Pkb-download
    ```
 
 3. Run locally:
 
-   ```
+   ```shell script
    mvn exec:exec -Dkb-start
    ```
 
@@ -48,7 +48,7 @@ cd kibana/bin
 
 1. Use docer compose with the provided [docker-compose.yml](docker-compose.yml):
 
-   ```
+   ```shell script
    cd es
    docker-compose up
    ```
@@ -62,13 +62,13 @@ cd kibana/bin
 
 1. Kibana should be running from:
 
-   ```
+   ```shell script
    http://localhost:5601
    ```
 
 2. And should be visible within the geonetwork interface at:
  
-   ```
+   ```shell script
    http://localhost:8080/geonetwork/dashboards
    ```
 
@@ -81,7 +81,9 @@ Visit Kibana in a browser using one of the above links and go to 'Saved Objects'
 
 ### Production Use
 
-Kibana can be installed from the debian files, and 7.3.2 is confirmed as working with Geonetwork 3.8.x.
+Kibana can be installed from the debian files:
+
+* 7.3.2 is confirmed as working with Geonetwork 3.8.x
 
 Set Kibana to start when the server starts up, using the instructions at https://www.elastic.co/guide/en/kibana/current/start-stop.html
 

--- a/pom.xml
+++ b/pom.xml
@@ -1444,7 +1444,7 @@
     <jetty.port>8080</jetty.port>
     <jetty.stop.port>8090</jetty.stop.port>
 
-    <es.version>7.11.1</es.version>
+    <es.version>7.10.2</es.version> <!-- Up to 7.10.2 via Apache License 2.0 -->
     <es.platform>linux-x86_64</es.platform>
     <es.installer.extension>tar.gz</es.installer.extension>
     <es.protocol>http</es.protocol>

--- a/pom.xml
+++ b/pom.xml
@@ -1444,7 +1444,10 @@
     <jetty.port>8080</jetty.port>
     <jetty.stop.port>8090</jetty.stop.port>
 
-    <es.version>7.10.2</es.version> <!-- Up to 7.10.2 via Apache License 2.0 -->
+    <!-- 7.11.0 onward no longer use Apache License 2.0 -->
+    <!-- 7.10.2 known date_range issue                  -->
+    <!-- 7.6.2 tested -->
+    <es.version>7.6.2</es.version>
     <es.platform>linux-x86_64</es.platform>
     <es.installer.extension>tar.gz</es.installer.extension>
     <es.protocol>http</es.protocol>


### PR DESCRIPTION
See https://www.elastic.co/pricing/faq/licensing for Elasticsearch license change from 7.11 onward.

Update: 7.10.2 has a known date_time issue, alternatives include:

* https://github.com/elastic/elasticsearch/tree/v7.9.3 has date_range fix
* https://github.com/elastic/elasticsearch/tree/v7.6.2 Already used across the codebase, so it must be tested
* https://github.com/elastic/elasticsearch/tree/v7.5.2 Used in some early examples