### PR TITLE
french translation improvement for providedBy/sourceCatalog

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
@@ -33,7 +33,7 @@
   <constraintInfo>Contraintes d'accès et d'utilisation</constraintInfo>
   <overviews>Aperçus</overviews>
   <metadataInXML>XML</metadataInXML>
-  <providedBy>Fourni par</providedBy>
+  <providedBy>Catalogue d'origine</providedBy>
   <shareOnSocialSite>Partager</shareOnSocialSite>
   <viewMode>Mode d'affichage</viewMode>
   <linkToPortal>Lien vers le portail</linkToPortal>

--- a/web-ui/src/main/resources/catalog/locales/fr-search.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-search.json
@@ -186,7 +186,7 @@
     "orTypeAServiceUrl": "saisir l'URL d'un service {{type}}",
     "addAllLayersToMap": "Ajouter toutes les {{number}} couches à la carte",
     "downloadsAndResources": "Téléchargements et liens",
-    "sourceCatalog": "Fourni par",
+    "sourceCatalog": "Catalogue d'origine",
     "tempExtent": "Étendue temporelle",
     "more": "plus",
     "less": "moins",


### PR DESCRIPTION
From "Fourni par" (provided by) to "Catalogue d'origine" (source catalog) for both to keep consistency and be clearer for users.