### PR TITLE
Correct the OpenAPI document so that it does not generate errors

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -376,6 +376,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
      * up-to-date and if maximum performance is required.
      */
     @RequestMapping(value = "/{portal}/{lang}/md.format.public.{type}")
+    @io.swagger.v3.oas.annotations.Operation(hidden = true)
     public HttpEntity<byte[]> getCachedPublicMetadata(
         @PathVariable final String lang,
         @PathVariable final String type,

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/Resource.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/Resource.java
@@ -50,6 +50,7 @@ import static com.google.common.io.Files.getFileExtension;
 public class Resource extends AbstractFormatService {
 
     @RequestMapping(value = "/{portal}/{lang}/md.formatter.resource")
+    @io.swagger.v3.oas.annotations.Operation(hidden = true)
     public void exec(
         @RequestParam(Params.ID) String xslid,
         @RequestParam(Params.FNAME) String fileName,


### PR DESCRIPTION
Correct the OpenAPI document so that it does not generate errors that were identified in #5431

The corrections was the following.

- Hide some API's from the swagger document. If the api's should be visible then we will need to update them so that /{portal} is not in the mapping.

- Added logic to handle api extension field.  Other option could have been to remove the {extension} from the mapping.


