### PR TITLE
Update XslProcessApi to process the draft copies for the metadata in a workflow

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
@@ -367,18 +367,18 @@ public class XslProcessApi {
                     Log.info("org.fao.geonet.services.metadata",
                         "Processing metadata with id:" + id);
 
-                    Element beforeMetadata = dataMan.getMetadata(context, id, false, false, false);
+                    Element beforeMetadata = dataMan.getMetadata(context, String.valueOf(id), false, false, false);
 
-                    XslProcessUtils.process(context, id, process,
+                    XslProcessUtils.process(context, String.valueOf(id), process,
                         true, index, updateDateStamp, xslProcessingReport,
                         siteURL, request.getParameterMap());
 
-                    Element afterMetadata = dataMan.getMetadata(context, id, false, false, false);
+                    Element afterMetadata = dataMan.getMetadata(context, String.valueOf(id), false, false, false);
 
                     XMLOutputter outp = new XMLOutputter();
                     String xmlAfter = outp.outputString(afterMetadata);
                     String xmlBefore = outp.outputString(beforeMetadata);
-                    new RecordProcessingChangeEvent(Long.parseLong(id), this.userId, xmlBefore, xmlAfter, process).publish(appContext);
+                    new RecordProcessingChangeEvent(id, this.userId, xmlBefore, xmlAfter, process).publish(appContext);
                 }
             }
         }

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessApi.java
@@ -41,6 +41,8 @@ import org.fao.geonet.events.history.RecordProcessingChangeEvent;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.MetadataIndexerProcessor;
 import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
@@ -59,6 +61,7 @@ import javax.servlet.http.HttpSession;
 import javax.xml.transform.stream.StreamResult;
 import java.io.StringWriter;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
@@ -348,24 +351,35 @@ public class XslProcessApi {
         @Override
         public void process() throws Exception {
             DataManager dataMan = context.getBean(DataManager.class);
+            IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
+
             ApplicationContext appContext = ApplicationContextHolder.get();
             for (String uuid : this.records) {
-                String id = getDataManager().getMetadataId(uuid);
-                Log.info("org.fao.geonet.services.metadata",
-                    "Processing metadata with id:" + id);
+                List<Integer> idList = metadataUtils.findAllIdsBy(MetadataSpecs.hasMetadataUuid(uuid));
 
-                Element beforeMetadata = dataMan.getMetadata(context, id, false, false, false);
+                // Increase the total records counter when processing a metadata with approved and working copies
+                // as the initial counter doesn't take in account this case
+                if (idList.size() > 1) {
+                    xslProcessingReport.setTotalRecords(xslProcessingReport.getNumberOfRecords() + 1);
+                }
 
-                XslProcessUtils.process(context, id, process,
-                    true, index, updateDateStamp, xslProcessingReport,
-                    siteURL, request.getParameterMap());
+                for (Integer id : idList) {
+                    Log.info("org.fao.geonet.services.metadata",
+                        "Processing metadata with id:" + id);
 
-                Element afterMetadata = dataMan.getMetadata(context, id, false, false, false);
+                    Element beforeMetadata = dataMan.getMetadata(context, id, false, false, false);
 
-                XMLOutputter outp = new XMLOutputter();
-                String xmlAfter = outp.outputString(afterMetadata);
-                String xmlBefore = outp.outputString(beforeMetadata);
-                new RecordProcessingChangeEvent(Long.parseLong(id), this.userId, xmlBefore, xmlAfter, process).publish(appContext);
+                    XslProcessUtils.process(context, id, process,
+                        true, index, updateDateStamp, xslProcessingReport,
+                        siteURL, request.getParameterMap());
+
+                    Element afterMetadata = dataMan.getMetadata(context, id, false, false, false);
+
+                    XMLOutputter outp = new XMLOutputter();
+                    String xmlAfter = outp.outputString(afterMetadata);
+                    String xmlBefore = outp.outputString(beforeMetadata);
+                    new RecordProcessingChangeEvent(Long.parseLong(id), this.userId, xmlBefore, xmlAfter, process).publish(appContext);
+                }
             }
         }
     }


### PR DESCRIPTION
When the workflow is enabled the batch processing works fine in these cases:

- records are in draft
- records approved without working copy


But it's not working fine If the metadata is approved and has a working copy. In this case it's processing all the records, but updating **only** the approved version, not the draft version.

This PR updates the batch processing API to handle both versions of the metadata. For now, in the total number of records are counted the approved and draft versions. This is something to improve in the report, but will require some refactor of the current report.