### PR TITLE
Add confirm to delete Category and Cancel edits to metadata

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/CategoriesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/CategoriesController.js
@@ -56,6 +56,10 @@
        * Delete a category
        */
       $scope.deleteCategory = function(id) {
+
+        var doDelete = confirm($translate.instant('confirmDeletecategory'));
+
+        if (doDelete) {
         $http.delete('../api/tags/' + id)
             .then(function(r) {
               if (r.status === 204) {
@@ -75,6 +79,7 @@
                 timeout: 0,
                 type: 'danger'});
             });
+        }
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/js/admin/CategoriesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/CategoriesController.js
@@ -51,35 +51,37 @@
         }, 100);
       };
 
+      /**
+       * Ask for confirmation to delete the category
+       */
+      $scope.deleteCategory = function(id) {
+        $scope.delCategoryId = id;
+        $('#gn-confirm-delete-category').modal('show');
+      };
 
       /**
        * Delete a category
        */
-      $scope.deleteCategory = function(id) {
-
-        var doDelete = confirm($translate.instant('confirmDeletecategory'));
-
-        if (doDelete) {
-        $http.delete('../api/tags/' + id)
-            .then(function(r) {
-              if (r.status === 204) {
-                $scope.unselectCategory();
-                loadCategories();
-              } else {
-                $rootScope.$broadcast('StatusUpdated', {
-                  title: $translate.instant('categoryDeleteError'),
-                  error: r.data,
-                  timeout: 0,
-                  type: 'danger'});
-              }
-            }, function(r) {
+      $scope.confirmDeleteCategory = function(id) {
+        $http.delete('../api/tags/' + $scope.delCategoryId)
+          .then(function(r) {
+            if (r.status === 204) {
+              $scope.unselectCategory();
+              loadCategories();
+            } else {
               $rootScope.$broadcast('StatusUpdated', {
                 title: $translate.instant('categoryDeleteError'),
                 error: r.data,
                 timeout: 0,
                 type: 'danger'});
-            });
-        }
+            }
+          }, function(r) {
+            $rootScope.$broadcast('StatusUpdated', {
+              title: $translate.instant('categoryDeleteError'),
+              error: r.data,
+              timeout: 0,
+              type: 'danger'});
+          });
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -561,6 +561,12 @@
       };
 
       $scope.cancel = function(refreshForm) {
+
+        var doCancel = confirm($translate.instant('confirmCancelEdit'));
+
+        if (!doCancel) {
+          return false;
+        }
         $scope.savedStatus = gnCurrentEdit.savedStatus;
         if ($location.search()['justcreated']) {
           // Remove newly created record

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1473,7 +1473,6 @@
     "ui-autoFitOnLayer-help":"If checked, the map will automatically zoom on data when adding a layer from a record. Otherwise, a message will be shown to let the user zoom on data manually.",
     "styleVariable-gnHeaderHeight":"Height",
     "styleVariable-gnSearchBackgroundColor": "Backgound color",
-    "confirmDeletecategory": "Are you sure you want to delete this category?",
-    "confirmCancelEdit": "Do you want to cancel all changes and close the editor?"
+    "confirmDeletecategory": "Are you sure you want to delete this category?"
 }
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1472,6 +1472,7 @@
     "ui-autoFitOnLayer":"Always zoom on data",
     "ui-autoFitOnLayer-help":"If checked, the map will automatically zoom on data when adding a layer from a record. Otherwise, a message will be shown to let the user zoom on data manually.",
     "styleVariable-gnHeaderHeight":"Height",
-    "styleVariable-gnSearchBackgroundColor": "Backgound color"
+    "styleVariable-gnSearchBackgroundColor": "Backgound color",
+    "confirmDeletecategory": "Are you sure you want to delete this category?"
 }
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1473,6 +1473,7 @@
     "ui-autoFitOnLayer-help":"If checked, the map will automatically zoom on data when adding a layer from a record. Otherwise, a message will be shown to let the user zoom on data manually.",
     "styleVariable-gnHeaderHeight":"Height",
     "styleVariable-gnSearchBackgroundColor": "Backgound color",
-    "confirmDeletecategory": "Are you sure you want to delete this category?"
+    "confirmDeletecategory": "Are you sure you want to delete this category?",
+    "confirmCancelEdit": "Do you want to cancel all changes and close the editor?"
 }
 

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -418,5 +418,6 @@
     "badGmlProjectionCode": "  The geometry projection <b>{{srsName}}</b> defined in the XML is not valid. Please edit the xml to fix the srs name or enter a new geometry.\n",
     "draft": "Working copy",
     "link": "Link",
-    "link-text": "Link text"
+    "link-text": "Link text",
+    "confirmCancelEdit": "Do you want to cancel all changes and close the editor?"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -155,7 +155,7 @@ ul.pager {
   margin-bottom: 0px;
 }
 
-#gn-thesaurus-container {
+#gn-thesaurus-container, #gn-categories-container {
   // Fixes gn-modal windows; TODO: fix this globally in gn-popup style
   [gn-modal] {
     max-width: none;

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/categories.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/categories.html
@@ -1,4 +1,5 @@
-<div class="row" data-ng-controller="GnCategoriesController">
+<div class="row" data-ng-controller="GnCategoriesController"
+     id="gn-categories-container">
   <div class="col-lg-5">
     <div class="panel panel-default">
       <div class="panel-heading" data-translate=""> categories</div>
@@ -94,5 +95,11 @@
         </div>
       </div>
     </form>
+  </div>
+
+  <div gn-modal class="gn-confirm-delete"
+       gn-popup-options="{title: 'confirmDialogTitle', confirmCallback: confirmDeleteCategory}"
+       id="gn-confirm-delete-category">
+    <p translate>confirmDeletecategory</p>
   </div>
 </div>


### PR DESCRIPTION
Before this PR you could delete a `category` without confirmation, so an accidental delete wasn't far away. The same could happen when you were editing a metadata record, the `cancel` option cancelled immediately.

This PR adds 2 confirm actions.

**Confirm modal for a `Category`**

![gn-confirm-del-cat](https://user-images.githubusercontent.com/19608667/124764051-ddf44a00-df34-11eb-8459-e1606d8414a0.png)
