### PR TITLE
Update the filter for INSPIRE Atom dataset feed to support the remote operatesOn indexing format

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
@@ -524,7 +524,7 @@ public class InspireAtomUtil {
 
         String serviceMdUuid = null;
         Document luceneParamSearch = createDefaultLuceneSearcherParams();
-        luceneParamSearch.getRootElement().addContent(new Element("operatesOn").setText(datasetMd.getUuid() + " or " + spIdentifier));
+        luceneParamSearch.getRootElement().addContent(new Element("operatesOn").setText(datasetMd.getUuid() + "* or " + spIdentifier + "*"));
         luceneParamSearch.getRootElement().addContent(new Element("serviceType").setText("download"));
 
         try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {


### PR DESCRIPTION
The requests to describe a local INSPIRE Atom dataset return a 404, for example:

http://localhost:8080/geonetwork/srv/atom/describe/dataset?spatial_dataset_identifier_code=fb0b0639-1d91-4fb5-b53d-47e32f35df6e&language=de

This is caused by the changes in the `operatesOn` format to track remote links. See https://github.com/geonetwork/core-geonetwork/blob/c170ffac76995b5c857c5adbccfe0a09041ca382/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl#L1125-L1213