### PR TITLE
Update doc url to point to 3.10.x documentation

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -314,7 +314,7 @@ goog.require('gn_alert');
       requireProxy: [],
       gnCfg: angular.copy(defaultConfig),
       gnUrl: '',
-      docUrl: 'https://geonetwork-opensource.org/manuals/3.8.x/',
+      docUrl: 'https://geonetwork-opensource.org/manuals/3.10.x/',
       //docUrl: '../../doc/',
       modelOptions: {
         updateOn: 'default blur',


### PR DESCRIPTION
Update doc url to point to 3.10.x documents for the 3.10.x branch.

Related to #5366

This PR only affects the 3.10.x branch. Other branches should point to different versions.