### PR TITLE
Record view / Add conditional formatter support

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -264,6 +264,11 @@
                        id="ui-formatterURL-{{$index}}"
                        data-ng-model="opt.url"/>
               </div>
+
+              <div class="row">
+                <label class="control-label">{{('ui-' + key + '-conditional-views') | translate}}</label>
+                <gn-json-edit height="300" model="opt.views"></gn-json-edit>
+              </div>
             </td>
             <td>
               <a class="btn btn-link text-danger"

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -59,6 +59,7 @@
       'isHarvested',
       'dateStamp',
       'documentStandard',
+      'standardNameObject.default',
       'cl_status*',
       'mdStatus*',
       'recordLink'

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -79,6 +79,53 @@
         }
       });
 
+      function getFormatterForRecord(record) {
+        console.log('getFormatterForRecord', record);
+        var list = [];
+        if (record == null) {
+          return list;
+        }
+        for (var i = 0; i < gnSearchSettings.formatter.list.length; i ++) {
+          var f = gnSearchSettings.formatter.list[i];
+          if (f.views === undefined) {
+            list.push(f);
+          } else {
+            // Check conditional views
+            var isViewSet = false;
+
+            viewLoop:
+            for (var j = 0; j < f.views.length; j ++) {
+              var v = f.views[j];
+
+              if (v.if) {
+                for (var key in v.if) {
+                  if (v.if.hasOwnProperty(key)) {
+                    var values = angular.isArray(v.if[key])
+                      ? v.if[key]
+                      : [v.if[key]]
+
+                    if (values.includes(record[key])) {
+                      list.push({label: f.label, url: v.url});
+                      isViewSet = true;
+                      break viewLoop;
+                    }
+                  }
+                }
+              } else {
+                console.warn('A conditional view MUST have a if property. ' +
+                  'eg. {"if": {"documentStandard": "iso19115-3.2018"}, "url": "..."}')
+              }
+            }
+            if (f.url !== undefined && !isViewSet) {
+              list.push(f);
+            }
+          }
+        }
+        return list;
+      }
+
+      $scope.recordFormatterList = getFormatterForRecord($scope.mdView.current.record);
+
       $scope.search = function(params) {
         $location.path('/search');
         $location.search(params);
@@ -183,8 +230,13 @@
       // in default mode.
       function loadFormatter(n, o) {
         if (n === true) {
-          var f = gnSearchLocation.getFormatterPath();
+          $scope.recordFormatterList = getFormatterForRecord($scope.mdView.current.record);
+
+          var f = gnSearchLocation.getFormatterPath($scope.recordFormatterList[0].url);
           $scope.currentFormatter = '';
+
+          gnMdViewObj.usingFormatter = f !== undefined;
+
           if (f != undefined) {
             $scope.currentFormatter = f.replace(/.*(\/formatters.*)/, '$1');
             $scope.loadFormatter(f);

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -79,8 +79,13 @@
         }
       });
 
+      /**
+       * First matching view for each formatter is returned.
+       *
+       * @param record
+       * @returns {*[]}
+       */
       function getFormatterForRecord(record) {
-        console.log('getFormatterForRecord', record);
         var list = [];
         if (record == null) {
           return list;

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -72,7 +72,6 @@
 
         // Set the route only if not same as before
         formatter = gnSearchLocation.getFormatter();
-        gnMdViewObj.usingFormatter = formatter !== undefined;
 
         gnUtilityService.scrollTo();
 

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -92,10 +92,14 @@
           return undefined;
         }
       };
-      this.getFormatterPath = function() {
+      this.getFormatterPath = function(defaultFormatter) {
         var tokens = $location.path().split('/');
         if (tokens.length > 2 && tokens[3] === 'formatters') {
           return '../api/records/' + $location.url().split(/^metadraf|metadata\//)[1];
+        } else if (tokens.length > 2 && tokens[3] === 'main') {
+          return undefined; // Angular view
+        } else if (defaultFormatter) {
+          return '../api/records/' + $location.url().split(/^metadraf|metadata\//)[1] + defaultFormatter;
         } else {
           return undefined;
         }

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -546,9 +546,6 @@ goog.require('gn_alert');
             }, {
               'label': 'full',
               'url' : '/formatters/xsl-view?root=div&view=xml'
-            }, {
-              'label': 'extra',
-              'url' : '/main'
             }]
           },
           'downloadFormatter': [{

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -526,22 +526,22 @@ goog.require('gn_alert');
           'formatter': {
             'list': [{
               'label': 'defaultView',
-              'views': [ {
-                'if': {
-                  'standardName': 'ISO 19115-3 - Emodnet Checkpoint - Targeted Data Product'
-                },
-                'url' : '/formatters/xsl-view?root=div&view=advanced'
-              }, {
-                'if': {'documentStandard': 'iso19115-3.2018'},
-                'url' : '/dada'
-              }, {
-                'if': {
-                  'standardName': [
-                    'ISO 19115:2003/19139 - EMODNET - BATHYMETRY',
-                    'ISO 19115:2003/19139 - EMODNET - HYDROGRAPHY']
-                },
-                'url' : '/formatters/xsl-view?root=div&view=emodnetHydrography'
-              }],
+              // Conditional views can be used to configure custom
+              // formatter to use depending on metadata properties.
+              // 'views': [ {
+              //   'if': {'standardName': 'ISO 19115-3 - Emodnet Checkpoint - Targeted Data Product'},
+              //   'url' : '/formatters/xsl-view?root=div&view=advanced'
+              // }, {
+              //   'if': {
+              //     'standardName': [
+              //       'ISO 19115:2003/19139 - EMODNET - BATHYMETRY',
+              //       'ISO 19115:2003/19139 - EMODNET - HYDROGRAPHY']
+              //   },
+              //   'url' : '/formatters/xsl-view?root=div&view=emodnetHydrography'
+              // }, {
+              //   'if': {'documentStandard': 'iso19115-3.2018'},
+              //   'url' : '/dada'
+              // }],
               'url' : ''
             }, {
               'label': 'full',

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -526,12 +526,30 @@ goog.require('gn_alert');
           'formatter': {
             'list': [{
               'label': 'defaultView',
+              'views': [ {
+                'if': {
+                  'standardName': 'ISO 19115-3 - Emodnet Checkpoint - Targeted Data Product'
+                },
+                'url' : '/formatters/xsl-view?root=div&view=advanced'
+              }, {
+                'if': {'documentStandard': 'iso19115-3.2018'},
+                'url' : '/dada'
+              }, {
+                'if': {
+                  'standardName': [
+                    'ISO 19115:2003/19139 - EMODNET - BATHYMETRY',
+                    'ISO 19115:2003/19139 - EMODNET - HYDROGRAPHY']
+                },
+                'url' : '/formatters/xsl-view?root=div&view=emodnetHydrography'
+              }],
               'url' : ''
             }, {
               'label': 'full',
-              'url' : '/formatters/xsl-view?root=div&view=advanced'
-            }],
-            defaultUrl: ''
+              'url' : '/formatters/xsl-view?root=div&view=xml'
+            }, {
+              'label': 'extra',
+              'url' : '/main'
+            }]
           },
           'downloadFormatter': [{
             'label': 'exportMEF',

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1191,6 +1191,8 @@
     "ui-resultViewTpls": "List of templates for search results",
     "ui-resultTemplate": "Default template used for search results",
     "ui-formatter": "List of formatter for record view",
+    "ui-formatter-conditional-views": "Conditional views",
+    "ui-formatter-help": "Configure which formatter to use and optionally add conditional views to load formatter depending on record properties. eg. [\n  {\n    \"if\": {\n      \"standardName\": [\n        \"ISO 19115:2003/19139 - EMODNET - BATHYMETRY\",\n        \"ISO 19115:2003/19139 - EMODNET - HYDROGRAPHY\"\n      ]\n    },\n    \"url\": \"/formatters/xsl-view?root=div&view=emodnetHydrography\"}]",
     "ui-downloadFormatter": "List of formatter for record export",
     "ui-linkTypes": "List of link types",
     "ui-mod-map": "Map application",

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -135,7 +135,7 @@
             </button>
             <ul class="dropdown-menu" role="menu">
               <li role="menuitem"
-                  data-ng-repeat="f in formatter.list"
+                  data-ng-repeat="f in recordFormatterList"
                   data-ng-class="currentFormatter === f.url ? 'disabled' : ''">
                 <a href=""
                    gn-metadata-open="mdView.current.record"


### PR DESCRIPTION
When a catalogue manage a variety of projects, partners, standards or types of records, it may make sense to configure different default views based on record properties because each records may have different goals.

```json
"list": [{
    "label": "defaultView",
    "views": [ {
      "if": {"standardName": "ISO 19115-3 - Emodnet Checkpoint - Targeted Data Product"},
      "url" : "/formatters/xsl-view?root=div&view=advanced"
    }, {
      "if": {
        "standardName": [
          "ISO 19115:2003/19139 - EMODNET - BATHYMETRY",
          "ISO 19115:2003/19139 - EMODNET - HYDROGRAPHY"]
      },
      "url" : "/formatters/xsl-view?root=div&view=emodnetHydrography"
    }],
    "url" : ""
```


![image](https://user-images.githubusercontent.com/1701393/125034889-71db2880-e091-11eb-88b7-05dfa3792ecc.png)



Supported by https://sextant.ifremer.fr/Donnees/Catalogue