### PR TITLE
Overview / Removal / Do not delete attachement from other records

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -292,7 +292,7 @@
 
             scope.removeOverview = function(thumbnail) {
               var url = thumbnail.url[gnCurrentEdit.mdLanguage];
-              if (url.match(".*/api/records/(.*)/attachments/.*") == null) {
+              if (url.match(".*/api/records/" + gnCurrentEdit.uuid + "/attachments/.*") == null) {
                 // An external URL
                 gnOnlinesrc.removeThumbnail(thumbnail).then(function() {
                   // and update list.


### PR DESCRIPTION
In some cases, an overview may be targeting another record in the same catalogue (eg. export/import a record with a new UUID).
When removing an overview in the duplicated record, removing the overview was removing the original record attachement (if user has privilege to do so). 

Check that the target overview is related to current record under editing and if not, only remove the link in the XML (not the attachement).