### PR TITLE
Indexing / Do not add twice indexingDate field

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -359,14 +359,12 @@ public class EsSearchManager implements ISearchManager {
     public UpdateResponse updateField(String id, String field, Object value) throws Exception {
         Map<String, Object> updates = new HashMap<>(2);
         updates.put(getPropertyName(field), value);
-        updates.put("indexingDate", new Date());
         return updateFields(id, updates);
     }
 
     public void updateFieldAsynch(String id, String field, Object value) throws Exception {
         Map<String, Object> updates = new HashMap<>(2);
         updates.put(getPropertyName(field), value);
-        updates.put("indexingDate", new Date());
         updateFieldsAsynch(id, updates);
     }
 


### PR DESCRIPTION
If added twice, the index value will be an array and cardinality of indexingDate is 1..1. Must be a string.