### PR TITLE
services - being able to externalize the logging configurations outside of the webapp

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/LoggingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/LoggingApi.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
-import org.fao.geonet.api.API;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.site.model.ListLogFilesResponse;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
@@ -91,8 +91,15 @@ public class LoggingApi {
     ) throws Exception {
         java.util.List<ListLogFilesResponse.LogFileResponse> logFileList =
             new ArrayList<>();
-        String classesFolder = dataDirectory.getWebappDir() + "/WEB-INF/classes";
-        File folder = new File(classesFolder);
+        String loggingConfigurationFolder = dataDirectory.getWebappDir() + "/WEB-INF/classes";
+        // overrides if a "loggingConfigurationPath" bean is available
+        try {
+            loggingConfigurationFolder = (String) ApplicationContextHolder.get().getBean("loggingConfigurationPath");
+        } catch (Exception e) {
+            // stick with the folder in the classpath.
+        }
+
+        File folder = new File(loggingConfigurationFolder);
 
         if (folder != null && folder.isDirectory()) {
             Pattern pattern = Pattern.compile(regexp, Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
With the suggested modifications, we can define a bean as a string in
any XML configuration files, e.g.:

```
  <bean id="loggingConfigurationPath" class="java.lang.String">
    <constructor-arg value="/etc/geonetwork/log4j"/>
  </bean>
```

Then having a `/etc/geonetwork/log4j/` directory with some log4j
configurations like the default ones from the WEB-INF/classes
subdirectory, we can externalize from the webapp the logging
configuration.

Not having the previous bean defined will fall back onto the current
behaviour (e.g. using the files from the classpath).

the main advantage of this approach is that we can customize the logging
configuration without having to recompile GeoNetwork. We can even add
new configurations without atering the webapp content.

Tests:
* runtime tested in a docker composition (adding the bean into WEB-INF/config-spring-geonetwork.xml)
* `mvn clean test` from the service module OK. I'm wondering if it would deserve an extra integration tests actually.


