### PR TITLE
Working copy widget doesn't display the validation status properly. Fixes #5825

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -346,7 +346,7 @@ public class EsHTTPProxy {
         // Build filter node
         String esFilter = buildQueryFilter(context,
                                             "",
-                                            esQuery.toString().contains("\"draft\":"));
+                                            esQuery.toString().contains("\"draft\":") || esQuery.toString().contains("draft:"));
         JsonNode nodeFilter = objectMapper.readTree(esFilter);
 
         JsonNode queryNode = esQuery.get("query");


### PR DESCRIPTION
In progress, some additional code uses `gnSearchManagerService.gnSearch` with the old `q` service:

- https://github.com/geonetwork/core-geonetwork/blob/78969535b660a29f6afc43b7cafba20d8e16d418/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js#L199

- https://github.com/geonetwork/core-geonetwork/blob/78969535b660a29f6afc43b7cafba20d8e16d418/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js#L130