### PR TITLE
Move deleteAllByMetadataIdExceptGroupId to @query. Fixes #5674

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
@@ -25,6 +25,7 @@ package org.fao.geonet.kernel.datamanager.base;
 
 import static org.springframework.data.jpa.domain.Specification.where;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -108,7 +109,7 @@ public class BaseMetadataOperations implements IMetadataOperations, ApplicationE
     @Override
     public void deleteMetadataOper(String metadataId, boolean skipAllReservedGroup) throws Exception {
         if (skipAllReservedGroup) {
-            int[] exclude = new int[]{ReservedGroup.all.getId(), ReservedGroup.intranet.getId(), ReservedGroup.guest.getId()};
+            List<Integer> exclude = Arrays.asList(ReservedGroup.all.getId(), ReservedGroup.intranet.getId(), ReservedGroup.guest.getId());
             opAllowedRepo.deleteAllByMetadataIdExceptGroupId(Integer.parseInt(metadataId), exclude);
         } else {
             opAllowedRepo.deleteAllByMetadataId(Integer.parseInt(metadataId));

--- a/domain/src/main/java/org/fao/geonet/repository/OperationAllowedRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/OperationAllowedRepository.java
@@ -25,6 +25,7 @@ package org.fao.geonet.repository;
 
 import java.util.List;
 
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -33,6 +34,7 @@ import org.fao.geonet.domain.OperationAllowedId;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -83,7 +85,7 @@ public interface OperationAllowedRepository extends GeonetRepository<OperationAl
      */
     @Nullable
     OperationAllowed findOneById_GroupIdAndId_MetadataIdAndId_OperationId(int groupId, int metadataId, int operationId);
-   
+
 
     /**
      * Delete all the {@link OperationAllowed} with the given id in the id component selected by the
@@ -120,5 +122,18 @@ public interface OperationAllowedRepository extends GeonetRepository<OperationAl
     @Modifying(clearAutomatically=true)
     @Query("DELETE FROM OperationAllowed where id.groupId = ?1")
     public int deleteAllByGroupId(int id);
+
+    /**
+     * Delete all OperationsAllowed entities with the give metadata and not group ids.
+     *
+     * @param metadataId the metadata id
+     * @param groupIds    the group id
+     */
+    @Nonnegative
+    @Transactional
+    @Modifying(clearAutomatically=true)
+    @Query("DELETE FROM OperationAllowed where metadataId = :metadataId and groupId not in :groupIds")
+    public int deleteAllByMetadataIdExceptGroupId(@Param("metadataId") int metadataId, @Param("groupIds") List<Integer> groupIds);
+
 
 }

--- a/domain/src/main/java/org/fao/geonet/repository/OperationAllowedRepositoryCustom.java
+++ b/domain/src/main/java/org/fao/geonet/repository/OperationAllowedRepositoryCustom.java
@@ -25,7 +25,6 @@ package org.fao.geonet.repository;
 
 import java.util.List;
 
-import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.persistence.metamodel.SingularAttribute;
 
@@ -74,12 +73,4 @@ public interface OperationAllowedRepositoryCustom {
     List<Integer> findAllIds(@Nonnull Specification<OperationAllowed> spec, @Nonnull SingularAttribute<OperationAllowedId,
         Integer> idAttribute);
 
-    /**
-     * Delete all OperationsAllowed entities with the give metadata and group ids.
-     *
-     * @param metadataId the metadata id
-     * @param groupId    the group id
-     */
-    @Nonnegative
-    int deleteAllByMetadataIdExceptGroupId(int metadataId, int[] groupId);
 }

--- a/domain/src/main/java/org/fao/geonet/repository/OperationAllowedRepositoryCustomImpl.java
+++ b/domain/src/main/java/org/fao/geonet/repository/OperationAllowedRepositoryCustomImpl.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.Query;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.ParameterExpression;
@@ -43,8 +42,6 @@ import org.fao.geonet.domain.OperationAllowedId;
 import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.domain.OperationAllowed_;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.base.Optional;
 
@@ -104,27 +101,5 @@ public class OperationAllowedRepositoryCustomImpl implements OperationAllowedRep
         query.select(root.get(OperationAllowed_.id).get(idAttribute));
         query.distinct(true);
         return _entityManager.createQuery(query).getResultList();
-    }
-
-    @Transactional
-    @Override
-    @Modifying(clearAutomatically=true)
-    public int deleteAllByMetadataIdExceptGroupId(int metadataId, int[] groupId) {
-        final String opAllowedEntityName = OperationAllowed.class.getSimpleName();
-        final String metadataIdPath = SortUtils.createPath(OperationAllowed_.id, OperationAllowedId_.metadataId);
-        final String groupIdPath = SortUtils.createPath(OperationAllowed_.id, OperationAllowedId_.groupId);
-        StringBuffer groupExcluded = new StringBuffer();
-        for (int g : groupId) {
-            groupExcluded.append(" and ");
-            groupExcluded.append(groupIdPath);
-            groupExcluded.append(" != ");
-            groupExcluded.append(g);
-        }
-        final Query query = _entityManager.createQuery("DELETE FROM " + opAllowedEntityName + " where " + metadataIdPath + " = "
-            + metadataId + groupExcluded.toString());
-
-        final int affected = query.executeUpdate();
-        return affected;
-
     }
 }

--- a/domain/src/test/java/org/fao/geonet/repository/OperationAllowedRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/OperationAllowedRepositoryTest.java
@@ -30,6 +30,7 @@ import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.repository.specification.OperationAllowedSpecs;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -108,9 +109,9 @@ public class OperationAllowedRepositoryTest extends AbstractOperationsAllowedTes
     public void deleteAllByMetadataIdExceptGroupId() {
         System.out.println("deleteAllByMdIdNotGroup");
         assertEquals(4, _opAllowRepo.count());
-        _opAllowRepo.deleteAllByMetadataIdExceptGroupId(_md1.getId(), new int[]{
+        _opAllowRepo.deleteAllByMetadataIdExceptGroupId(_md1.getId(), Arrays.asList(
             _allGroup.getId()
-        });
+        ));
 
         assertEquals(2, _opAllowRepo.count());
         List<OperationAllowed> opAllowedFound = _opAllowRepo.findAll();


### PR DESCRIPTION
Remove deleteAllByMetadataIdExceptGroupId from custom implementation and use the repository @query instead.

For some reason the older logic was causing transaction issues #5674