### PR TITLE
Escape login redirect url for keycloak

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
@@ -201,7 +201,7 @@
         </li>
         <li class="open signin-dropdown"
             data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && isShowLoginAsLink">
-          <a href="{{signInFormAction}}?_csrf={{csrf}}&redirectUrl={{redirectUrlAfterSign}}"
+          <a href="{{signInFormAction}}?_csrf={{csrf}}&redirectUrl={{redirectUrlAfterSign | encodeURIComponent}}"
              title="{{'signIn'|translate}}"
              class="gn-menuheader-xs"
              data-ng-keypress="$event"

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -197,7 +197,7 @@
       </li>
       <li class="open signin-dropdown"
           data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && isShowLoginAsLink">
-        <a href="{{signInFormAction}}?_csrf={{csrf}}&redirectUrl={{redirectUrlAfterSign}}"
+        <a href="{{signInFormAction}}?_csrf={{csrf}}&redirectUrl={{redirectUrlAfterSign | encodeURIComponent}}"
            title="{{'signIn'|translate}}"
            class="gn-menuheader-xs"
            data-ng-keypress="$event"


### PR DESCRIPTION
Fix bug with login url not encoding the redirect url.

Before the fix if going to the map page and then reloading the page, it would generate a login link similar to the following.

http://localhost:8080/geonetwork/signin#/map?_csrf=b273c38d-d29c-4e26-ab4c-261c36ee74d3&redirectUrl=http://localhost:8080/geonetwork/srv/eng/catalog.search#/map

After the fix the url will look like this.
  
http://localhost:8080/geonetwork/signin#/map?_csrf=b273c38d-d29c-4e26-ab4c-261c36ee74d3&redirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fgeonetwork%2Fsrv%2Feng%2Fcatalog.search%23%2Fmap

Without this fix extracting the redirectUrl would be incorrect as it would stop at the #.

Please backport this to 3.12.x