### PR TITLE
Indexing / documentStandard is not an array.

### DIFF
--- a/schemas/csw-record/src/main/plugin/csw-record/index-fields/index.xsl
+++ b/schemas/csw-record/src/main/plugin/csw-record/index-fields/index.xsl
@@ -72,7 +72,6 @@
     <!-- Create a first document representing the main record. -->
     <doc>
       <docType>metadata</docType>
-      <documentStandard>dublin-core</documentStandard>
 
       <!-- Index the metadata document as XML -->
       <document>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
@@ -89,7 +89,6 @@
     <!-- Create a first document representing the main record. -->
     <doc>
       <xsl:copy-of select="gn-fn-index:add-field('docType', 'metadata')"/>
-      <xsl:copy-of select="gn-fn-index:add-field('documentStandard', 'dublin-core')"/>
 
       <!-- Index the metadata document as XML -->
       <document>

--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
@@ -41,7 +41,6 @@
   <xsl:template match="/">
     <doc>
       <docType>metadata</docType>
-      <documentStandard>iso19110</documentStandard>
       <resourceType>featureCatalog</resourceType>
       <resourceTitle>
         <xsl:value-of select="/gfc:FC_FeatureCatalogue/gmx:name/gco:CharacterString|


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1701393/125285079-8bdb6c00-e31a-11eb-9350-99145756cf2f.png)

Affects only dublincore and ISO19110.

This can trigger exception when loading advanced view.

