### PR TITLE
Restyle topics on the Home page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_infolist_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_infolist_default.less
@@ -4,6 +4,9 @@
 // row for the info lists
 .gn-row-info {
   padding: 30px 20px 40px 20px;
+  @media (max-width: @screen-xs-max) {
+    padding: 30px 10px;
+  }
   background-color: @gn-info-background-color;
   .nav-pills {
     text-align: left !important;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -90,3 +90,11 @@ html, body {
   position: absolute;
   z-index: 100;
 }
+
+// no padding for containers on small screens
+@media (max-width: @screen-xs-max) {
+  .container-fluid {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
@@ -2,221 +2,218 @@
 // variables for manipulating the theme
 @import "gn_variables_default.less"; // must be last
 
+// ----- colours
+
+@gn-topic-text: #fff;
+@gn-topic-default: @brand-primary;
+@gn-topic-type: #078A00;
+@gn-ini-grey: #b2b2b2;
+@gn-ini-red: #ea572d;
+@gn-ini-orange: #f59e00;
+@gn-ini-blue: #36a9e1;
+@gn-ini-green: #95c11f;
+@gn-ini-brown: #b17f4a;
+
 // ----- topics
 .gn-row-topics {
   background-color: @gn-topics-background-color;
   padding: 30px 20px 40px 20px;
-  h4 {
-    font-size: 16px;
-    margin-bottom: 20px;
-    label {
-      margin-bottom: 0;
+  h1 {
+    font-size: 20px;
+  }
+  // ----- style radio like `nav-pills`
+  .gn-topic-select {
+    input + span {
+      display: block;
+      padding: 10px 15px;
+      border-radius: 4px;
+      margin-right: 5px;
+      font-weight: normal;
+      color: @link-color;
+      &:hover {
+        background-color: #ddd;
+        cursor: pointer;
+      }
+      &:focus {
+        outline: @gn-outline;
+      }
+    }
+    input:checked + span {
+      background-color: @brand-primary;
+      color: @gn-topic-text;
     }
   }
-  .chips-card {
-    padding-bottom: 0px;
-  }
-}
-
-// badges
-// 
-// ----- image/icon
-.badge-result {
-  border-radius: 20px !important;
-  float: left;
-  height: 40px;
-  line-height: 43px;
-  text-align: center;
-  vertical-align: bottom;
-  width: auto;
-  font-size: 12px;
-  margin-bottom: 10px;
-  margin-right: 10px;
-  background: transparent;
-  a {
-    color: #fff;
-    border-radius: 20px; 
-    padding-right: 10px;
-    &:hover {
-      text-decoration: none;
-    }
-  }
-  .badge {
-    margin-top: -7px;
-    margin-left: -16px;
-    background-color: #4d4c4c;
-    font-weight: normal;
-  }
-}
-// ----- colors
-.badge-result-topic a {
-  background: #2c6ea7;
-  &:hover {
-    background: #215481; 
-  }
-}
-.badge-result-type a {
-  background: #078A00;
-  &:hover {
-    background: #078A00; 
-  }
-}
-.badge-result-inspire {
-  .bg-iti-bu,
-  .bg-iti-15,
-  .bg-iti-cp,
-  .bg-iti-6,
-  .bg-iti-gg,
-  .bg-iti-2,
-  .bg-iti-gn,
-  .bg-iti-3,
-  .bg-iti-oi,
-  .bg-iti-12,
-  .bg-iti-rs,
-  .bg-iti-1 {
-    background: #b2b2b2;
-    &:hover {
-      background: #9e9d9d;
-    }
-  }
-  .bg-iti-am,
-  .bg-iti-24,
-  .bg-iti-au,
-  .bg-iti-4,
-  .bg-iti-hh,
-  .bg-iti-18,
-  .bg-iti-lu,
-  .bg-iti-17,
-  .bg-iti-pd,
-  .bg-iti-23,
-  .bg-iti-su,
-  .bg-iti-14 {
-    background: #ea572d;
-    &:hover {
-      background: #d8481f;
-    }
-  }
-  .bg-iti-ad,
-  .bg-iti-5,
-  .bg-iti-af,
-  .bg-iti-22,
-  .bg-iti-el,
-  .bg-iti-10,
-  .bg-iti-er,
-  .bg-iti-33,
-  .bg-iti-pf,
-  .bg-iti-21,
-  .bg-iti-tn,
-  .bg-iti-7,
-  .bg-iti-us,
-  .bg-iti-19 {
-    background: #f59e00;
-    &:hover {
-      background: #e49300;
-    }
-  }
-  .bg-iti-ac,
-  .bg-iti-26,
-  .bg-iti-ef,
-  .bg-iti-20,
-  .bg-iti-hy,
-  .bg-iti-8,
-  .bg-iti-mf,
-  .bg-iti-27,
-  .bg-iti-of,
-  .bg-iti-28,
-  .bg-iti-sr,
-  .bg-iti-29 {
-    background: #36a9e1;
-    &:hover {
-      background: #1e89bd;
-    }
-  }
-  .bg-iti-br,
-  .bg-iti-30,
-  .bg-iti-hb,
-  .bg-iti-31,
-  .bg-iti-lc,
-  .bg-iti-11,
-  .bg-iti-ps,
-  .bg-iti-9,
-  .bg-iti-sd,
-  .bg-iti-32 {
-    background: #95c11f;
-    &:hover {
-      background: #89b513;
-    }
-  }
-  .bg-iti-ge,
-  .bg-iti-13,
-  .bg-iti-mr,
-  .bg-iti-34,
-  .bg-iti-nz,
-  .bg-iti-25,
-  .bg-iti-so,
-  .bg-iti-16 {
-    background: #b17f4a;
-    &:hover {
-      background: #925c22;
-    }
-  }
-  .badge-icon {
-    i {
-      color: #fff;
-      line-height: 40px;
-    }
-  }
-}
-// ----- icon
-.badge-icon {
-  font-size: 7px;
-  color: #fff;
-  background: #333;
-  background: rgba(51, 51, 51, 0.65);
-  width: 40px;
-  height: 40px;
-  display: block;
-  padding: 0;
-  border-radius: 50%;
-  line-height: 50px;
-  min-width: 0;
-}
-// ----- text
-.badge-text {
-  height: 100%;
-  line-height: 110%;
-  padding-left: 8px;
-  padding-right: 4px;
-  margin-top: 13px;
-  font-size: 13px;
-  max-width: 13vw;
-  white-space: nowrap;
-  color: #fff;
-}
-@media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
-  .gn-row-topics {
-    .badge-text {
-      max-width: 34vw;
-    }
-  }
-  .container {
-    .gn-row-topics {
-      .badge-text {
-        max-width: 26vw;
+  .gn-topic {
+    .panel-body {
+      height: 75px;
+      padding: 0;
+      a {
+        padding: 15px;
+        display: block;
+        color: @gn-topic-text;
+        i {
+          color: @gn-topic-text;
+          margin-top: 5px;
+          // width before the icon is loaded
+          min-width: 28px;
+        }
+        h2 {
+          margin: 0;
+          height: 36px;
+          font-size: 14px;
+          display: table-cell;
+          line-height: 1.3em;
+          vertical-align: middle;
+          font-weight: normal;
+        }
+        &:hover {
+          text-decoration: none;
+        }
       }
     }
   }
 }
-@media (max-width: @screen-xs-max) {
-  .gn-row-topics {
-    .badge-text {
-      max-width: 56vw;
+.gn-topic {
+
+  .panel {
+    background: @gn-topic-default;
+    border-color: darken(@gn-topic-default, 10%);
+    &:hover, .panel-footer {
+      border-color: darken(@gn-topic-default, 10%);
+      background-color: darken(@gn-topic-default, 5%);
+    }
+    .panel-footer {
+      color: @gn-topic-text;
+      i {
+        margin-right: 5px;
+      }
     }
   }
-  .container {
-    .gn-row-topics {
-      .badge-text {
-        max-width: 48vw;
+
+  &.bg-iti-bu,
+  &.bg-iti-15,
+  &.bg-iti-cp,
+  &.bg-iti-6,
+  &.bg-iti-gg,
+  &.bg-iti-2,
+  &.bg-iti-gn,
+  &.bg-iti-3,
+  &.bg-iti-oi,
+  &.bg-iti-12,
+  &.bg-iti-rs,
+  &.bg-iti-1 {
+    .panel {
+      background: @gn-ini-grey;
+      border-color: darken(@gn-ini-grey, 10%);
+      &:hover, .panel-footer {
+        background-color: darken(@gn-ini-grey, 5%);
+        border-color: darken(@gn-ini-grey, 10%);
+      }
+    }
+  }
+
+  &.bg-iti-am,
+  &.bg-iti-24,
+  &.bg-iti-au,
+  &.bg-iti-4,
+  &.bg-iti-hh,
+  &.bg-iti-18,
+  &.bg-iti-lu,
+  &.bg-iti-17,
+  &.bg-iti-pd,
+  &.bg-iti-23,
+  &.bg-iti-su,
+  &.bg-iti-14 {
+    .panel {
+      background: @gn-ini-red;
+      border-color: darken(@gn-ini-red, 10%);
+      &:hover, .panel-footer {
+        background-color: darken(@gn-ini-red, 5%);
+        border-color: darken(@gn-ini-red, 10%);
+      }
+    }
+  }
+
+  &.bg-iti-ad,
+  &.bg-iti-5,
+  &.bg-iti-af,
+  &.bg-iti-22,
+  &.bg-iti-el,
+  &.bg-iti-10,
+  &.bg-iti-er,
+  &.bg-iti-33,
+  &.bg-iti-pf,
+  &.bg-iti-21,
+  &.bg-iti-tn,
+  &.bg-iti-7,
+  &.bg-iti-us,
+  &.bg-iti-19 {
+    .panel {
+      background: @gn-ini-orange;
+      border-color: darken(@gn-ini-orange, 10%);
+      &:hover, .panel-footer {
+        background-color: darken(@gn-ini-orange, 5%);
+        border-color: darken(@gn-ini-orange, 10%);
+      }
+    }
+  }
+
+  &.bg-iti-ac,
+  &.bg-iti-26,
+  &.bg-iti-ef,
+  &.bg-iti-20,
+  &.bg-iti-hy,
+  &.bg-iti-8,
+  &.bg-iti-mf,
+  &.bg-iti-27,
+  &.bg-iti-of,
+  &.bg-iti-28,
+  &.bg-iti-sr,
+  &.bg-iti-29 {
+    .panel {
+      background: @gn-ini-blue;
+      border-color: darken(@gn-ini-blue, 10%);
+      &:hover, .panel-footer {
+        border-color: darken(@gn-ini-blue, 10%);
+        background-color: darken(@gn-ini-blue, 5%);
+      }
+    }
+  }
+
+  &.bg-iti-br,
+  &.bg-iti-30,
+  &.bg-iti-hb,
+  &.bg-iti-31,
+  &.bg-iti-lc,
+  &.bg-iti-11,
+  &.bg-iti-ps,
+  &.bg-iti-9,
+  &.bg-iti-sd,
+  &.bg-iti-32 {
+    .panel {
+      background: @gn-ini-green;
+      border-color: darken(@gn-ini-green, 10%);
+      &:hover, .panel-footer {
+        border-color: darken(@gn-ini-green, 10%);
+        background-color: darken(@gn-ini-green, 5%);
+      }
+    }
+  }
+
+  &.bg-iti-ge,
+  &.bg-iti-13,
+  &.bg-iti-mr,
+  &.bg-iti-34,
+  &.bg-iti-nz,
+  &.bg-iti-25,
+  &.bg-iti-so,
+  &.bg-iti-16 {
+    .panel {
+      background: @gn-ini-brown;
+      border-color: darken(@gn-ini-brown, 10%);
+      &:hover, .panel-footer {
+        border-color: darken(@gn-ini-brown, 10%);
+        background-color: darken(@gn-ini-brown, 5%);
       }
     }
   }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
@@ -42,9 +42,9 @@
         background-color: #ddd;
         cursor: pointer;
       }
-      &:focus {
-        outline: @gn-outline;
-      }
+    }
+    input:focus + span {
+      outline: @gn-outline;
     }
     input:checked + span {
       background-color: @brand-primary;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
@@ -18,6 +18,14 @@
 .gn-row-topics {
   background-color: @gn-topics-background-color;
   padding: 30px 20px 40px 20px;
+  @media (max-width: @screen-xs-max) {
+    padding: 30px 10px;
+  }
+  @media (max-width: 400px) {
+    .col-xs-6 {
+      width: 100% !important;
+    }
+  }
   h1 {
     font-size: 20px;
   }

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -77,92 +77,99 @@
 </div>
 
 
-<div class="row gn-row-topics"
-      data-ng-show="searchInfo.hits.total.value > 0 && searchInfo.aggregations">
+<div class="gn-row-topics"
+     data-ng-show="searchInfo.hits.total.value > 0 && searchInfo.aggregations">
   <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
-    <div class="col-sm-12 col-md-9" data-ng-show="homeFacet.list.length > 0">
-      <h4>
-        <span data-translate="">browseBy</span>
-        <span>
+    <div data-ng-show="homeFacet.list.length > 0">
+      <div class="row">
+        <h1 class="col-md-12">
+          <span data-translate="">browseBy</span>
+        </h1>
+        <div class="gn-topic-select col-md-12">
           <label data-ng-repeat="facetKey in homeFacet.list"
-                  data-ng-init="agg = searchInfo.aggregations[facetKey]"
-                  data-ng-show="agg.buckets.length > 0 && facetKey != homeFacet.lastKey">
+                 data-ng-init="agg = searchInfo.aggregations[facetKey]"
+                 data-ng-show="agg.buckets.length > 0 && facetKey != homeFacet.lastKey">
             <input type="radio" name="homeFacet"
-                    data-ng-model="homeFacet.key"
-                    data-ng-value="facetKey"/>
+                   class="sr-only"
+                   data-ng-model="homeFacet.key"
+                   data-ng-value="facetKey"/>
             <span data-translate="">{{::('facet-' + facetKey) | facetKeyTranslator}}</span>&nbsp;
           </label>
-        </span>
-      </h4>
+        </div>
+      </div>
       <div class="row">
         <span data-ng-show="homeFacet.key !== 'inspireThemeUri'"
               data-ng-init="aggResponse = searchInfo.aggregations[homeFacet.key]"
               data-ng-repeat="facet in searchInfo.aggregations[homeFacet.key].buckets"
-              class="col-xs-12 col-sm-6 col-md-4 chips-card">
-          <div class="badge-result badge-result-topic clearfix">
-            <a class="pull-left clearfix"
-              title="{{facet.key}}"
-              role="link"
-              data-ng-init="field = (aggResponse.meta && aggResponse.meta.field) || homeFacet.key; value = aggResponse.meta && aggResponse.meta.wildcard ? (facet.key + '*') : facet.key"
-              data-ng-href='#/search?query_string={"{{field}}": {"{{value}}": true} }'>
-              <!-- TODOES Link label to icons? -->
-              <span class="badge-icon badge-result-topic pull-left">
-                <i class="fa fa-3x gn-icon gn-icon-{{facet.key.replace('/', '').replace(' ', '')}}"
-                    data-ng-show="homeFacet.key === 'cl_topic.key' || homeFacet.key === 'cl_hierarchyLevel.key'">
+              class="col-xs-12 col-sm-6 col-md-3 col-lg-2 gn-topic">
+          <div class="panel panel-default">
+            <div class="panel-body">
+              <a class="clearfix"
+                title="{{facet.key}}"
+                role="link"
+                data-ng-init="field = (aggResponse.meta && aggResponse.meta.field) || homeFacet.key; value = aggResponse.meta && aggResponse.meta.wildcard ? (facet.key + '*') : facet.key"
+                data-ng-href='#/search?query_string={"{{field}}": {"{{value}}": true} }'>
+                <!-- TODOES Link label to icons? -->
+                <i class="fa fa-2x gn-icon-{{facet.key.replace('/', '').replace(' ', '')}} pull-left"
+                   data-ng-show="homeFacet.key === 'cl_topic.key' || homeFacet.key === 'cl_hierarchyLevel.key'">
                 </i>
-              </span>
-              <span class="badge-text pull-left">
-                <span class="gn-icon-label">{{facet.key | facetTranslator: homeFacet.key | capitalize}}</span>
-              </span>
-            </a>
-            <span class="badge pull-left">{{facet.doc_count}}</span>
+                <h2>
+                  <span class="clamp-2">{{facet.key | facetTranslator: homeFacet.key | capitalize}}</span>
+                </h2>
+              </a>
+            </div>
+            <div class="panel-footer">
+              <i class="fa fa-fw fa-file-text-o"></i>{{facet.doc_count}}
+            </div>
           </div>
         </span>
         <!-- TODOES Sort alpha -->
         <span data-ng-repeat="(key, facet) in searchInfo.aggregations.inspireThemeUri.buckets"
               data-ng-show="homeFacet.key === 'inspireThemeUri'"
               data-ng-init="code = facet.key.slice(facet.key.lastIndexOf('/')+1)"
-              class="col-xs-12 col-sm-6 col-md-4 chips-card">
-          <div class="badge-result badge-result-inspire clearfix">
-            <a class="pull-left clearfix bg-iti-{{::code}}"
-              data-ng-href='#/search?query_string={"inspireThemeUri": {"{{facet.key}}": true} }'>
-              <span class="badge-icon pull-left">
-                <i class="fa fa-3x gn-icon iti-{{::code}}"></i>
-              </span>
-              <span class="badge-text pull-left inspire-{{::code}}-{{iso2lang}}">
-                <span class="full inspire-label"></span>
-              </span>
-            </a>
-            <span class="badge pull-left">{{facet.doc_count}}</span>
+              class="col-xs-12 col-sm-6 col-md-3 col-lg-2 gn-topic bg-iti-{{::code}}">
+          <div class="panel panel-default">
+            <div class="panel-body">
+              <a class=" clearfix"
+                 data-ng-href='#/search?query_string={"inspireThemeUri": {"{{facet.key}}": true} }'>
+                <i class="fa fa-2x gn-icon iti-{{::code}} pull-left"></i>
+                <h2 class="inspire-{{::code}}-{{iso2lang}}">
+                  <span class="inspire-label clamp-2"></span>
+                </h2>
+              </a>
+            </div>
+            <div class="panel-footer">
+              <i class="fa fa-fw fa-file-text-o"></i>{{facet.doc_count}}</div>
           </div>
         </span>
       </div>
     </div>
-    <div class="col-sm-12 col-md-3"
-          data-ng-show="searchInfo.aggregations[homeFacet.lastKey].buckets.length > 0">
-      <h4>
-        <span data-translate="">{{('facet-' + homeFacet.lastKey) | facetKeyTranslator}}</span>
-      </h4>
+    <div data-ng-show="searchInfo.aggregations[homeFacet.lastKey].buckets.length > 0">
       <div class="row">
-          <span data-ng-repeat="(key, facet) in searchInfo.aggregations[homeFacet.lastKey].buckets"
-                data-ng-show="facet.key"
-                class="col-xs-12 col-sm-6 col-md-12 chips-card">
-            <div class="badge-result badge-result-type pull-left">
+        <h1 class="col-md-12" data-translate="">{{('facet-' + homeFacet.lastKey) | facetKeyTranslator}}</h1>
+      </div>
+      <div class="row">
+        <div data-ng-repeat="(key, facet) in searchInfo.aggregations[homeFacet.lastKey].buckets"
+             data-ng-show="facet.key"
+             class="col-xs-12 col-sm-6 col-md-3 col-lg-2 gn-topic">
+          <div class="panel panel-default">
+            <div class="panel-body">
               <a title="{{facet.key}}"
-                class="pull-left clearfix"
-                data-ng-href='#/search?query_string={"{{homeFacet.lastKey}}": {"{{facet.key}}": true} }'>
-                <span class="badge-icon pull-left">
-                  <i class="fa fa-3x gn-icon gn-icon-{{facet.key.replace('/', '').replace(' ', '')}}"
-                      data-ng-show="homeFacet.lastKey === 'topic_text' || homeFacet.lastKey === 'cl_hierarchyLevel.key'">
-                  </i>
-                </span>
-                <span class="badge-text pull-left">
-                  <span class="gn-icon-label">{{facet.key | facetTranslator: homeFacet.key | capitalize}}</span>
-                </span>
+                 class="clearfix"
+                 data-ng-href='#/search?query_string={"{{homeFacet.lastKey}}": {"{{facet.key}}": true} }'>
+                <i class="fa fa-2x gn-icon-{{facet.key.replace('/', '').replace(' ', '')}} pull-left"
+                   data-ng-show="homeFacet.lastKey === 'topic_text' || homeFacet.lastKey === 'cl_hierarchyLevel.key'">
+                </i>
+                <h2>
+                  <span class="clamp-2">{{facet.key | facetTranslator: homeFacet.key | capitalize}}</span>
+                </h2>
               </a>
-              <span class="badge pull-left">{{facet.doc_count}}</span>
             </div>
-          </span>
+            <div class="panel-footer">
+              <i class="fa fa-fw fa-file-text-o"></i>{{facet.doc_count}}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -101,7 +101,7 @@
         <span data-ng-show="homeFacet.key !== 'inspireThemeUri'"
               data-ng-init="aggResponse = searchInfo.aggregations[homeFacet.key]"
               data-ng-repeat="facet in searchInfo.aggregations[homeFacet.key].buckets"
-              class="col-xs-12 col-sm-6 col-md-3 col-lg-2 gn-topic">
+              class="col-xs-6 col-sm-4 col-md-3 col-lg-2 gn-topic">
           <div class="panel panel-default">
             <div class="panel-body">
               <a class="clearfix"
@@ -127,7 +127,7 @@
         <span data-ng-repeat="(key, facet) in searchInfo.aggregations.inspireThemeUri.buckets"
               data-ng-show="homeFacet.key === 'inspireThemeUri'"
               data-ng-init="code = facet.key.slice(facet.key.lastIndexOf('/')+1)"
-              class="col-xs-12 col-sm-6 col-md-3 col-lg-2 gn-topic bg-iti-{{::code}}">
+              class="col-xs-6 col-sm-4 col-md-3 col-lg-2 gn-topic bg-iti-{{::code}}">
           <div class="panel panel-default">
             <div class="panel-body">
               <a class=" clearfix"
@@ -151,7 +151,7 @@
       <div class="row">
         <div data-ng-repeat="(key, facet) in searchInfo.aggregations[homeFacet.lastKey].buckets"
              data-ng-show="facet.key"
-             class="col-xs-12 col-sm-6 col-md-3 col-lg-2 gn-topic">
+             class="col-xs-6 col-sm-4 col-md-3 col-lg-2 gn-topic">
           <div class="panel panel-default">
             <div class="panel-body">
               <a title="{{facet.key}}"


### PR DESCRIPTION
This PR restyles the topics on the homepage. The old styling had its issues, especially the responsiveness proved to be tricky. These topics are restyled, better responsive, numbers are on a different row (so no more badges on another row). Colours are the same.

Some additional changes:
- toggle the type looks the same as other toggle options
- cleanup and simplify css/less
- no columns, each block is full width

**Some screenshots of the new style**
![gn-topics](https://user-images.githubusercontent.com/19608667/125295802-e29a7300-e325-11eb-94d7-0c25339fc870.png)

![gn-topics-inspire](https://user-images.githubusercontent.com/19608667/125295815-e62dfa00-e325-11eb-9532-b8a03f9778a7.png)
