### PR TITLE
Small adjustments to UI settings in the Admin

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -729,6 +729,7 @@ goog.require('gn_alert');
           }
         },
         'admin': {
+          'enabled': true,
           'appUrl': '../../{{node}}/{{lang}}/admin.console',
           'facetConfig': {
             'availableInServices': {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -638,7 +638,6 @@ goog.require('gn_alert');
             'appUrl': 'https://secure.geonames.org/searchJSON'
         },
         'recordview': {
-          'enabled': true,
           'isSocialbarEnabled': true,
           'showStatusWatermarkFor': 'historicalArchive,obsolete,superseded',
           'showStatusTopBarFor': ''
@@ -770,12 +769,10 @@ goog.require('gn_alert');
             }
           }
         },
-        'signin': {
+        'authentication': {
           'enabled': true,
-          'appUrl': '../../{{node}}/{{lang}}/catalog.signin'
-        },
-        'signout': {
-          'appUrl': '../../signout'
+          'signinUrl': '../../{{node}}/{{lang}}/catalog.signin',
+          'signoutUrl': '../../signout'
         },
         'page': {
           'enabled': true,
@@ -1032,7 +1029,7 @@ goog.require('gn_alert');
       gnConfig.env.defaultNode = defaultNode;
       gnConfig.env.baseURL = detectBaseURL(gnGlobalSettings.gnCfg.baseURLDetector);
 
-      $scope.signoutUrl = gnGlobalSettings.gnCfg.mods.signout.appUrl
+      $scope.signoutUrl = gnGlobalSettings.gnCfg.mods.authentication.signoutUrl
         + '?redirectUrl='
         + window.location.href.slice(
             0,

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -729,7 +729,6 @@ goog.require('gn_alert');
           }
         },
         'admin': {
-          'enabled': true,
           'appUrl': '../../{{node}}/{{lang}}/admin.console',
           'facetConfig': {
             'availableInServices': {

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1479,6 +1479,6 @@
     "styleVariable-gnHeaderHeight":"Height",
     "styleVariable-gnSearchBackgroundColor": "Backgound color",
     "confirmDeletecategory": "Are you sure you want to delete this category?",
-    "ui-mod-page": "Page for displaying 'Page not available'"
+    "ui-mod-page": "Static pages"
 }
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1232,8 +1232,11 @@
     "ui-advancedConfig": "JSON configuration",
     "ui-mod-admin": "Admin console",
     "ui-mod-editor": "Editor application",
-    "ui-mod-signin": "Sign in application",
-    "ui-mod-signout": "Sign out application",
+    "ui-mod-authentication": "Authentication",
+    "ui-signinUrl": "Sign in application URL",
+    "ui-signoutUrl": "Sign out application URL",
+    "ui-signinUrl-help": "URL of the home page. Can contain the following variables between 2 opening and closing '{': <ul><li><strong>node</strong> for the current portal</li><li><strong>lang</strong> for 3 letters language code</li><li> <strong>isoLang</strong> for 2 letters language code.</li></ul>",
+    "ui-signoutUrl-help": "URL of the home page. Can contain the following variables between 2 opening and closing '{': <ul><li><strong>node</strong> for the current portal</li><li><strong>lang</strong> for 3 letters language code</li><li> <strong>isoLang</strong> for 2 letters language code.</li></ul>",
     "ui-mod-global": "General options",
     "ui-humanizeDates": "Humanize dates",
     "ui-humanizeDates-help": "For selected dates, if checked, show the date in human friendly format, for example \"3 days ago\". If not set, show the full date.",
@@ -1475,6 +1478,7 @@
     "ui-autoFitOnLayer-help":"If checked, the map will automatically zoom on data when adding a layer from a record. Otherwise, a message will be shown to let the user zoom on data manually.",
     "styleVariable-gnHeaderHeight":"Height",
     "styleVariable-gnSearchBackgroundColor": "Backgound color",
-    "confirmDeletecategory": "Are you sure you want to delete this category?"
+    "confirmDeletecategory": "Are you sure you want to delete this category?",
+    "ui-mod-page": "Page for displaying 'Page not available'"
 }
 

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
@@ -104,7 +104,7 @@
           </li>
         </ul>
       </li>
-      <li class="dropdown" data-ng-show="user.isUserAdminOrMore()">
+      <li data-ng-if="gnCfg.mods.admin.enabled" class="dropdown" data-ng-show="user.isUserAdminOrMore()">
         <a title="{{'adminConsole' | translate}}"
            href
            class="dropdown-toggle gn-menuheader-xs"

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar-accessible.html
@@ -147,7 +147,7 @@
     </ul>
 
     <div class="navbar-right">
-      <ul data-ng-if="gnCfg.mods.signin.enabled"
+      <ul data-ng-if="gnCfg.mods.authentication.enabled"
           class="nav navbar-nav username-dropdown accessible-dropdown">
         <!-- logged in -->
         <li class="dropdown" data-ng-show="authenticated">
@@ -213,7 +213,7 @@
         <!-- not logged in -->
         <li class="dropdown signin-dropdown"
           data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !isShowLoginAsLink && !isDisableLoginForm">
-          <a href="{{gnCfg.mods.signin.appUrl | signInLink}}"
+          <a href="{{gnCfg.mods.authentication.signinUrl | signInLink}}"
              title="{{'signIn'|translate}}"
              class="dropdown-toggle gn-menuheader-xs"
              data-ng-keypress="$event"

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -148,7 +148,7 @@
       </div>
     </div>
 
-    <ul data-ng-if="gnCfg.mods.signin.enabled"
+    <ul data-ng-if="gnCfg.mods.authentication.enabled"
         class="nav navbar-nav navbar-right username-dropdown">
       <li class="dropdown dropdown-hover open" data-ng-show="authenticated">
         <a data-gn-active-tb-item="{{gnCfg.mods.admin.appUrl}}#/organization/users?userOrGroup={{user.username}}"
@@ -208,7 +208,7 @@
       </li>
       <li class="dropdown dropdown-hover open signin-dropdown"
         data-ng-if="!authenticated && service !== 'catalog.signin' && service !== 'new.account' && !isShowLoginAsLink && !isDisableLoginForm">
-        <a href="{{gnCfg.mods.signin.appUrl | signInLink}}"
+        <a href="{{gnCfg.mods.authentication.signinUrl | signInLink}}"
            title="{{'signIn'|translate}}"
            class="dropdown-toggle gn-menuheader-xs"
            data-ng-keypress="$event"

--- a/web-ui/src/main/resources/catalog/templates/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/top-toolbar.html
@@ -101,7 +101,7 @@
           </li>
         </ul>
       </li>
-      <li class="dropdown dropdown-hover open" data-ng-show="user.isUserAdminOrMore()">
+      <li data-ng-if="gnCfg.mods.admin.enabled" class="dropdown dropdown-hover open" data-ng-show="user.isUserAdminOrMore()">
         <a data-gn-active-tb-item="admin.console"
            title="{{'adminConsole' | translate}}"
            class="dropdown-toggle gn-menuheader-xs"


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/issues/4224

This PR makes small adjustments to UI settings in the Admin:
- recordview always enabled
- signin/signout combined in `authorisation`
- translation for all settings

**The newly combined `signin`/`signout`**
![gn-admin-settings](https://user-images.githubusercontent.com/19608667/125430449-897e954a-bcae-43bb-a07b-7001e4d9bcb5.png)
