### PR TITLE
Add a Bootstrap layout and column to a static page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/page.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/page.html
@@ -1,2 +1,7 @@
-<div gn-static-pages-viewer data-language="{{lang}}"/>
-
+<div class="row">
+  <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
+    <div class="col-md-12">
+      <div gn-static-pages-viewer data-language="{{lang}}"/>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
GeoNetwork has an option to add static pages via the `API`. One of the options is to upload a static `html` page and and the link in menubar.

However this static page is displayed without a layout, so it doesn't really fit with the rest of GeoNetwork.

This PR add a `container`, `row` and `column`

**Before**

![gn-page-before](https://user-images.githubusercontent.com/19608667/125459283-e65ce727-db98-46e2-a3b1-c8df23d562b0.png)

**After**

![gn-page-after](https://user-images.githubusercontent.com/19608667/125459305-c5b747cf-78f8-4fa4-b310-6fd6fa5f33c8.png)
