### PR TITLE
EditLib - xml fragment replacement doesn't replace the element attributes. Fixes #5844

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -338,6 +338,13 @@ public class EditLib {
                     LOGGER.debug("Add XML fragment; {} to element with ref: {} replacing content.", fragment, nodeRef);
                     // clean before update
                     el.removeContent();
+                    // attributes
+                    Iterator<Attribute> attributeIterator = el.getAttributes().iterator();
+                    while (attributeIterator.hasNext()) {
+                        Attribute at = attributeIterator.next();
+                        attributeIterator.remove();
+                    }
+
                     fragment = addGmlNamespaceToFragment(fragment);
 
                     // Add content


### PR DESCRIPTION
See #5844