### PR TITLE
Fit view to exact extent (fixes issue #5791)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -248,7 +248,7 @@
               if (type !== this.SEARCH_MAP) {
                 // Because search map is fit by result md bbox
                 var newPromise = map.get('sizePromise').then(function () {
-                  map.getView().fit(config.extent, map.getSize(), {nearest: true});
+                  map.getView().fit(config.extent, map.getSize());
                 });
 
                 map.set('sizePromise', newPromise);


### PR DESCRIPTION
Removed `{nearest: true}` option from OpenLayers `fit()` function call. 
After that I was no longer able to reproduce the issue described in #5791, so I guess that fixed it.