### PR TITLE
Fix the filter function for the UI settings

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -363,7 +363,7 @@
 
         $(formId + " .form-group").filter(function() {
 
-          var filterText = $(this).find('label').text().toLowerCase();
+          var filterText = $(this).find("label, h3").text().toLowerCase();
           var matchStart = filterText.indexOf("" + filterValue.toLowerCase() + "");
 
           if (matchStart > -1) {


### PR DESCRIPTION
The filter function for the UI settings was still filtering on `label` elements and not on the newer `h3` elements. This PR fixes this.