### PR TITLE
Record view / Group not set in prod mode

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -183,7 +183,6 @@
       // in default mode.
       function loadFormatter(n, o) {
         if (n === true) {
-          getRecordGroup();
           var f = gnSearchLocation.getFormatterPath();
           $scope.currentFormatter = '';
           if (f != undefined) {
@@ -199,15 +198,5 @@
       $scope.$watch('gnMdViewObj.from', function(v) {
         $scope.fromView = v ? v.substring(1) : v;
       });
-
-      function getRecordGroup() {
-        if ($scope.gnMdViewObj.current.record
-          && $scope.gnMdViewObj.current.record.groupOwner) {
-          $http.get('../api/groups/' + $scope.gnMdViewObj.current.record.groupOwner,
-            {cache: true}).success(function(data) {
-            $scope.recordGroup = data;
-          });
-        }
-      }
     }]);
 })();

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -183,6 +183,7 @@
       // in default mode.
       function loadFormatter(n, o) {
         if (n === true) {
+          getRecordGroup();
           var f = gnSearchLocation.getFormatterPath();
           $scope.currentFormatter = '';
           if (f != undefined) {
@@ -199,12 +200,14 @@
         $scope.fromView = v ? v.substring(1) : v;
       });
 
-      if ($scope.gnMdViewObj.current.record
-        && $scope.gnMdViewObj.current.record.groupOwner) {
-        $http.get('../api/groups/' + $scope.gnMdViewObj.current.record.groupOwner,
-          {cache: true}).success(function(data) {
-          $scope.recordGroup = data;
-        });
+      function getRecordGroup() {
+        if ($scope.gnMdViewObj.current.record
+          && $scope.gnMdViewObj.current.record.groupOwner) {
+          $http.get('../api/groups/' + $scope.gnMdViewObj.current.record.groupOwner,
+            {cache: true}).success(function(data) {
+            $scope.recordGroup = data;
+          });
+        }
       }
     }]);
 })();

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -24,7 +24,41 @@
 (function() {
   goog.provide('gn_utility_directive');
 
-  var module = angular.module('gn_utility_directive', [
+
+  var module = angular.module('gn_utility_directive', []);
+
+  module.directive('gnRecordOriginLogo', [
+    'gnConfig', 'gnConfigService', 'gnGlobalSettings', '$http',
+    function(gnConfig, gnConfigService, gnGlobalSettings, $http) {
+      return {
+        restrict: 'A',
+        replace: true,
+        scope: {
+          md: '=gnRecordOriginLogo'
+        },
+        templateUrl: '../../catalog/components/utility/' +
+          'partials/recordOriginLogo.html',
+        link: function(scope, element, attrs) {
+          gnConfigService.load().then(function(c) {
+            scope.recordGroup = null;
+            scope.gnUrl = gnGlobalSettings.gnUrl;
+            scope.isPreferGroupLogo = gnConfig['system.metadata.prefergrouplogo'];
+
+            function getRecordGroup() {
+              if (scope.md
+                && scope.md.groupOwner) {
+                $http.get('../api/groups/' + scope.md.groupOwner,
+                  {cache: true}).success(function (data) {
+                  scope.recordGroup = data;
+                });
+              }
+            }
+
+            scope.$watch('md', getRecordGroup);
+          });
+        }
+      };
+    }
   ]);
 
   module.directive('gnConfirmClick', [

--- a/web-ui/src/main/resources/catalog/components/utility/partials/recordOriginLogo.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/recordOriginLogo.html
@@ -1,0 +1,11 @@
+<div>
+  <img data-ng-if="isPreferGroupLogo && recordGroup.logo"
+     data-ng-src="{{gnUrl}}../images/harvesting/{{recordGroup.logo}}"
+     title="{{recordGroup.label | gnLocalized}}"
+     aria-label="{{recordGroup.label | gnLocalized}}"
+     class="gn-source-logo"/>
+  <img data-ng-if="!isPreferGroupLogo"
+       data-ng-src="{{gnUrl}}../images/logos/{{md.sourceCatalogue}}.png"
+       aria-label="{{'sourceCatalog' | translate}}"
+       class="gn-source-logo"/>
+</div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -636,15 +636,7 @@
               <i class="fa fa-fw fa-cog"></i>
               <span data-translate="">sourceCatalog</span>
             </h2>
-            <img data-ng-if="isPreferGroupLogo && recordGroup.logo"
-                 data-ng-src="{{gnUrl}}../images/harvesting/{{recordGroup.logo}}"
-                 title="{{recordGroup.label | gnLocalized}}"
-                 aria-label="{{recordGroup.label | gnLocalized}}"
-                 class="gn-source-logo"/>
-            <img data-ng-if="!isPreferGroupLogo"
-                 data-ng-src="{{gnUrl}}../images/logos/{{mdView.current.record.sourceCatalogue}}.png"
-                aria-label="{{'sourceCatalog' | translate}}"
-                class="gn-source-logo"/>
+            <div data-gn-record-origin-logo="mdView.current.record"/>
           </section>
 
           <section class="gn-md-side-calendar">


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/5742

Add utility directive to reuse group logo anywhere eg. in search results

![image](https://user-images.githubusercontent.com/1701393/126165812-4b3c4851-66bd-4c5e-89ff-a63a4a4d89bc.png)


using 

```html
        <div data-gn-record-origin-logo="md"/>
```