### PR TITLE
Facet / Add translation sort and filtering support.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -72,7 +72,7 @@
              ng-if="::facet.type !== 'dates' && !(facet.meta && facet.meta.vega)"
              es-facet="::facet"
              es-facet-item="::item"
-             ng-repeat="item in facet.items">
+             ng-repeat="item in facet.items | orderBy:facetSorter(facet, facet.key)">
         </div>
 
         <div class=""

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -129,13 +129,15 @@
     'gnGlobalSettings',
     'gnESClient',
     'gnESFacet',
+    'gnFacetSorter',
     'gnExternalViewer',
     function($scope, $location, $filter,
              suggestService, $http, $translate,
              gnUtilityService, gnSearchSettings, gnViewerSettings,
              gnMap, gnMdView, mdView, gnWmsQueue,
              gnSearchLocation, gnOwsContextService,
-             hotkeys, gnGlobalSettings, gnESClient, gnESFacet, gnExternalViewer) {
+             hotkeys, gnGlobalSettings, gnESClient,
+             gnESFacet, gnFacetSorter, gnExternalViewer) {
 
 
       var viewerMap = gnSearchSettings.viewerMap;
@@ -164,6 +166,8 @@
       $scope.fluidEditorLayout = gnGlobalSettings.gnCfg.mods.editor.fluidEditorLayout;
       $scope.fluidHeaderLayout = gnGlobalSettings.gnCfg.mods.header.fluidHeaderLayout;
       $scope.showGNName = gnGlobalSettings.gnCfg.mods.header.showGNName;
+
+      $scope.facetSorter = gnFacetSorter.sortByTranslation;
 
       $scope.toggleMap = function () {
         $(searchMap.getTargetElement()).toggle();

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -100,7 +100,8 @@
       <div class="row">
         <span data-ng-show="homeFacet.key !== 'inspireThemeUri'"
               data-ng-init="aggResponse = searchInfo.aggregations[homeFacet.key]"
-              data-ng-repeat="facet in searchInfo.aggregations[homeFacet.key].buckets"
+              data-ng-repeat="facet in searchInfo.aggregations[homeFacet.key].buckets
+                                | orderBy:facetSorter(searchInfo.aggregations[homeFacet.key], homeFacet.key) track by facet.key"
               class="col-xs-6 col-sm-4 col-md-3 col-lg-2 gn-topic">
           <div class="panel panel-default">
             <div class="panel-body">


### PR DESCRIPTION
A number of facet are translated client side. When using filter option, it triggers server side filter call using Elasticsearch API. In some case (eg. groupOwner filter) we don't want to filter on id or key but on the label.

Add possibility to:
* sort by translation
* filter on translation

eg. configuration for a groupOwner facet:
```
            'groupOwner': {
              'terms': {
                'field': 'groupOwner',
                'size': 80,
                'include': '.*',
                order : { _key : asc }
              },
              'meta': {
                'orderByTranslation': true,
                'displayFilter': true,
                'filterByTranslation': true,
                'collapsed': true
              }
            },
```

![image](https://user-images.githubusercontent.com/1701393/126196804-35318eb2-64da-437f-b187-46ba4783cc96.png)
