### PR TITLE
Restyle the logo list in the Settings

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/LogoSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/LogoSettingsController.js
@@ -124,6 +124,46 @@
             });
       };
 
+      $scope.filterLogoList = function(e,formId) {
+
+        var filterValue = e.target.value.toLowerCase();
+
+        $(formId + " .list-group-item").filter(function() {
+
+          var filterText = $(this).find('label').text().toLowerCase();
+          var matchStart = filterText.indexOf("" + filterValue.toLowerCase() + "");
+
+          if (matchStart > -1) {
+            $(this).show();
+          } else {
+            $(this).hide();
+          }
+          // check parent
+          // $scope.filterParent($(this));
+        });
+      };
+
+      $scope.resetFilter = function(formId) {
+
+        $(formId + " .list-group-item").each(function() {
+          // clear filter
+          $('#filter-settings').val('');
+          // show the element
+          $(this).show();
+          // show the fieldsets
+          // $(formId + ' fieldset').show();
+        });
+
+      };
+
+      /**
+       * Toggle the logo height
+       * @param  {String} type Type of logo height selected
+       */
+      $scope.toggleLogoHeight = function(type) {
+        $scope.logoheightType = type;
+      };
+
       loadLogo();
     }]);
 

--- a/web-ui/src/main/resources/catalog/js/admin/LogoSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/LogoSettingsController.js
@@ -138,8 +138,6 @@
           } else {
             $(this).hide();
           }
-          // check parent
-          // $scope.filterParent($(this));
         });
       };
 
@@ -150,8 +148,6 @@
           $('#filter-settings').val('');
           // show the element
           $(this).show();
-          // show the fieldsets
-          // $(formId + ' fieldset').show();
         });
 
       };

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1479,6 +1479,7 @@
     "styleVariable-gnHeaderHeight":"Height",
     "styleVariable-gnSearchBackgroundColor": "Backgound color",
     "confirmDeletecategory": "Are you sure you want to delete this category?",
-    "ui-mod-page": "Static pages"
+    "ui-mod-page": "Static pages",
+    "logoHeight": "Logo height"
 }
 

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -19,20 +19,55 @@
   white-space: normal;
 }
 
-.gn-logo-list {
-  .panel {
-    height: 220px;
-
+[data-ng-controller="GnLogoSettingsController"] {
+  .progress {
+    height: 10px;
+    margin-bottom: 0;
+  }
+  .gn-logo-list {
     .panel-body {
-      padding: 2px 5px 5px 5px;
-      img{
-        max-height: 125px;
-        max-width: 100%;
+      .list-group {
+        @media (min-width: @screen-lg-min) {
+          column-count: 2;
+          column-fill: balance;
+        }
+        .list-group-item {
+          break-inside: avoid;
+          img {
+            margin-right: 10px;
+          }
+          label {
+            margin: 0;
+          }
+          &:hover {
+            background-color: @list-group-hover-bg;
+          }
+        }
+        &.gn-logo-height-small {
+          .list-group-item {
+            img {
+              max-height: 40px;
+            }
+          }
+        }
+        &.gn-logo-height-medium {
+          .list-group-item {
+            img {
+              max-height: 100px;
+            }
+          }
+        }
+        &.gn-logo-height-large {
+          .list-group-item {
+            img {
+              max-height: 150px;
+            }
+          }
+        }
       }
     }
   }
 }
-
 .bootstrap-table {
   a {
     word-break: break-all;

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/logo.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/logo.html
@@ -20,6 +20,14 @@
         <div class="panel-body">
           <form id="fileupload" action="{{'../api/logos?_csrf=' + csrf}}" method="POST"
                 enctype="multipart/form-data" data-file-upload="logoUploadOptions">
+            <div class="fade" data-ng-class="{in: active()}">
+              <!-- The global progress bar -->
+              <div class="progress progress-striped active" data-file-upload-progress="progress()"
+                   data-file-upload-done="loadLogo()">
+                <div class="progress-bar progress-bar-success" data-ng-style="{width: num + '%'}"/>
+              </div>
+              <div class="progress-extended">&nbsp;</div>
+            </div>
             <span class="btn btn-success btn-block fileinput-button"
                   ng-class="{disabled: disabled}">
               <i class="fa fa-plus fa-white"/>
@@ -29,15 +37,6 @@
                      multiple="true"
                      autofocus="" ng-disabled="disabled"/>
             </span>
-
-            <div class="col-lg-5 fade" data-ng-class="{in: active()}">
-              <!-- The global progress bar -->
-              <div class="progress progress-striped active" data-file-upload-progress="progress()"
-                   data-file-upload-done="loadLogo()">
-                <div class="progress-bar progress-bar-success" data-ng-style="{width: num + '%'}"/>
-              </div>
-              <div class="progress-extended">&nbsp;</div>
-            </div>
             <p class="help-block" data-translate="">logoUploadHelp</p>
           </form>
         </div>
@@ -48,30 +47,90 @@
   <div class="row">
     <div class="col-md-12">
       <div class="panel panel-default gn-logo-list">
-        <div class="panel-heading">
+        <div class="panel-heading clearfix">
           <span data-translate="">defineCatalogLogo</span>
         </div>
-        <div class="row panel-body">
-          <div class="col-lg-3" data-ng-repeat="l in logos | orderBy:l">
-            <div class="panel panel-default">
-              <div class="panel-heading">{{l.split(".").slice(0, -1).join(".")}}</div>
-              <div class="panel-body text-center">
-                <div class="caption">
-                  <p>
-                    <a class="btn btn-link fa fa-picture-o" title="{{'useLogoForCatalog' | translate}}"
-                      data-ng-click="setCatalogLogo(l, false)"/>
-                    <a class="btn btn-link fa fa-bookmark"
-                      title="{{'useLogoForCatalogFavicon' | translate}}"
-                      data-ng-click="setCatalogLogo(l, true)"/>
-                    <a class="btn btn-link fa fa-times" title="{{'removeLogo' | translate}}"
-                      data-ng-click="removeLogo(l)"/>
-                  </p>
-                </div>
-                <img data-ng-src="{{logoPath}}{{l}}" alt="{{l}}"/>
-              </div>
-              </div>
+        <div class="panel-body">
+          <div class="row gn-margin-bottom">
+            <div class="col-md-6 gn-nopadding-left">
+            <label for="filter-settings" data-translate="">filterSettings</label>
+            <div class="input-group">
+              <span class="input-group-addon">
+                <i class="fa fa-filter" aria-hidden="true"></i>
+              </span>
+              <input class="form-control"
+                     type="text"
+                     id="filter-settings"
+                     placeholder="{{'filterPlaceHolder' | translate}}"
+                     data-ng-keyup="filterLogoList($event,'#gn-logo-list')" />
+              <span class="input-group-btn">
+                <button class="btn btn-default"
+                        type="button"
+                        title="{{'filterReset' | translate}}"
+                        data-ng-click="resetFilter('#gn-logo-list')">
+                  <i class="fa fa-close" aria-hidden="true"></i>
+                </button>
+              </span>
+            </div>
           </div>
+            <div class="col-md-6 gn-nopadding-right">
+              <div class="pull-right">
+                <!-- toggle buttons -->
+                <label for="logoheight-toggle-buttons" data-translate="">logoHeight</label><br>
+                <div id="logoheight-toggle-buttons" class="btn-group" data-toggle="buttons">
+                  <button type="button" class="btn btn-default"
+                          data-ng-click="toggleLogoHeight('small')"
+                          data-ng-model="logoheightType"
+                          data-ng-class="{'active': logoheightType === 'small' || logoheightType === undefined}"
+                          aria-label="{{'logoHeightSmall' | translate}}">
+                    <i class="fa fa-th" aria-hidden="true"></i>
+                  </button>
+                  <button type="button" class="btn btn-default"
+                          data-ng-click="toggleLogoHeight('medium')"
+                          data-ng-model="logoheightType"
+                          data-ng-class="{'active': logoheightType === 'medium'}"
+                          aria-label="{{'logoHeightMedium' | translate}}">
+                    <i class="fa fa-th-large" aria-hidden="true"></i>
+                  </button>
+                  <button type="button" class="btn btn-default"
+                          data-ng-click="toggleLogoHeight('large')"
+                          data-ng-model="logoheightType"
+                          data-ng-class="{'active': logoheightType === 'large'}"
+                          aria-label="{{'logoHeightLarge' | translate}}">
+                    <i class="fa fa-stop" aria-hidden="true"></i>
+                  </button>
+                </div>
+                <!-- /toggle buttons -->
+              </div>
+            </div>
+          </div>
+          <div class="list-group" id="gn-logo-list" data-ng-class="{'gn-logo-height-small': logoheightType === 'small' || logoheightType === undefined, 'gn-logo-height-medium': logoheightType === 'medium', 'gn-logo-height-large': logoheightType === 'large'}">
+            <div class="list-group-item clearfix" data-ng-repeat="l in logos | orderBy:l">
+              <img data-ng-src="{{logoPath}}{{l}}" alt="{{l}}"/>
+
+              <label>{{l.split(".").slice(0, -1).join(".")}}</label>
+              <div class="btn-group pull-right" role="group">
+                <a class="btn btn-default"
+                   title="{{'useLogoForCatalog' | translate}}"
+                   data-ng-click="setCatalogLogo(l, false)">
+                  <i class="fa fa-picture-o"></i>
+                </a>
+                <a class="btn btn-default"
+                   title="{{'useLogoForCatalogFavicon' | translate}}"
+                   data-ng-click="setCatalogLogo(l, true)">
+                  <i class="fa fa-bookmark"></i>
+                </a>
+                <a class="btn btn-default"
+                   title="{{'removeLogo' | translate}}"
+                   data-ng-click="removeLogo(l)">
+                  <i class="fa fa-times text-danger"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+          <!-- /.list-group -->
         </div>
+        <!-- /.panel-body -->
       </div>
     </div>
   </div>


### PR DESCRIPTION
The logo list in the admin settings can grow very large. This PR restyles the list a bit and adds a couple of views for the icon height: `small`, `medium` and `large`. Furthermore a filter option is added to filter the logos on their name.

On larger screens the list is displayed on 2 columns.

**Screenshot of 2 columns**

![gn-logo-2cols](https://user-images.githubusercontent.com/19608667/126326496-c96af0f0-03c8-4101-b7b2-4aeddf769e6e.png)

**Screenshot of medium height icons on smaller screen**

![gn-logo-medium](https://user-images.githubusercontent.com/19608667/126326468-e2e26ec8-8daf-443f-8df1-0f41c14550ac.png)
