### PR TITLE
Record view / More like this improvements.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -96,7 +96,11 @@
             'morelikethis.html';
         },
         link: function(scope, element, attrs, controller) {
+          var initSize = 6;
           scope.similarDocuments = [];
+          scope.size = initSize;
+          scope.pageSize = 5;
+          scope.maxSize = 19;
           var moreLikeThisQuery = {};
           angular.copy(gnGlobalSettings.gnCfg.mods.search.moreLikeThisConfig, moreLikeThisQuery);
           var query = {
@@ -108,6 +112,7 @@
                 'cl_status*'
               ]
             },
+            "size": scope.size,
             "query": {
               "bool": {
                 "must": [
@@ -118,6 +123,11 @@
             }
           };
 
+          scope.moreRecords = function() {
+            query.size += scope.pageSize;
+            scope.size = query.size;
+            loadMore();
+          }
           function loadMore() {
             if (scope.md == null) {
               return;
@@ -129,6 +139,8 @@
           }
           scope.$watch('md', function() {
             scope.similarDocuments = [];
+            scope.size = initSize;
+            query.size = initSize;
             loadMore();
           });
 

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/morelikethis.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/morelikethis.html
@@ -1,4 +1,4 @@
-<div>
+<div data-ng-if="similarDocuments.hits.length > 2">
   <h4>
     <i class="fa fa-fw fa-copy"></i>
     <span data-translate="">moreLikeThis</span>
@@ -10,15 +10,21 @@
        data-ng-hide="md.uuid === record._source.uuid">
       <span>
         {{record._source.resourceTitleObject.default}}<br/>
-        <div data-ng-if="record._source.cl_status_text.length > 0"
-             title="{{record._source.cl_status_text[0]}}"
-             class="gn-status gn-status-{{record._source.cl_status[0]}}">{{record._source.cl_status_text[0]}}
+        <div data-ng-if="record._source.cl_status.length > 0"
+             title="{{record._source.cl_status[0].key | translate}}"
+             class="gn-status gn-status-{{record._source.cl_status[0].key}}">{{record._source.cl_status[0].key | translate}}
         </div>
       </span>
       <div class="flex-spacer flex-grow"></div>
-      <img data-ng-if="record._source.overview"
+      <img data-ng-if="record._source.overview && record._source.overview[0]"
            style="max-width: 95px;"
-           data-ng-src="{{record._source.overview.url || record._source.overview[0].url}}?size=95">
+           data-ng-src="{{record._source.overview[0].data || (record._source.overview[0].url | thumbnailUrlSize)}}">
+    </a>
+    <a class="list-group-item flex-row flex-align-center"
+       data-ng-if="size < maxSize
+                   && similarDocuments.hits.length == size"
+       data-ng-click="moreRecords()">
+      <i class="fa fa-fw fa-ellipsis-h"/>
     </a>
   </div>
 </div>


### PR DESCRIPTION
* Can browse more similar records (until limit is reached)
* Use overview dataurl when available
* Fix status badge
* Stop browsing if no more similar records

![image](https://user-images.githubusercontent.com/1701393/126359235-2f030154-500b-4ae5-8eda-7ee4b9b6ee73.png)


Default configuration is quite open, a more strict one can be (if catalogue is in english and titles are really similar):
```json
'moreLikeThisConfig': {
            "more_like_this" : {
              "fields" : [
                "resourceTitleObject.langeng"
              ],
              "like" : null,
              "min_term_freq" : 1,
              "min_word_length" : 3,
              "max_query_terms" : 35,
              "analyzer": "english",
              "minimum_should_match": "70%"
            }
          }
```