### PR TITLE
Encryption / Application fails to start if encryption error on harvester passwords

### DIFF
--- a/domain/src/main/java/org/fao/geonet/entitylistener/HarvesterSettingValueSetter.java
+++ b/domain/src/main/java/org/fao/geonet/entitylistener/HarvesterSettingValueSetter.java
@@ -24,8 +24,11 @@
 package org.fao.geonet.entitylistener;
 
 import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.Logger;
 import org.fao.geonet.domain.HarvesterSetting;
+import org.fao.geonet.utils.Log;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 
@@ -34,6 +37,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  */
 public class HarvesterSettingValueSetter implements GeonetworkEntityListener<HarvesterSetting> {
+    protected Logger log = Log.createLogger("geonetwork.domain");
+
     @Autowired
     private StandardPBEStringEncryptor encryptor;
 
@@ -44,24 +49,32 @@ public class HarvesterSettingValueSetter implements GeonetworkEntityListener<Har
 
     @Override
     public void handleEvent(final PersistentEventType type, final HarvesterSetting entity) {
-        if (type == PersistentEventType.PrePersist) {
-            if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getValue())) {
-                entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
-            } else {
-                entity.setStoredValue(entity.getValue());
-            }
+        try {
+            if (type == PersistentEventType.PrePersist) {
+                if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getValue())) {
+                    entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
+                } else {
+                    entity.setStoredValue(entity.getValue());
+                }
 
-        } else if (type == PersistentEventType.PreUpdate) {
-            if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getValue())) {
-                entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
-            }
+            } else if (type == PersistentEventType.PreUpdate) {
+                if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getValue())) {
+                    entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
+                }
 
-        } else if ((type == PersistentEventType.PostLoad) ||  (type == PersistentEventType.PostUpdate)) {
-            if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getStoredValue())) {
-                entity.setValue(this.encryptor.decrypt(entity.getStoredValue()));
-            } else {
-                entity.setValue(entity.getStoredValue());
+            } else if ((type == PersistentEventType.PostLoad) || (type == PersistentEventType.PostUpdate)) {
+                if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getStoredValue())) {
+                    entity.setValue(this.encryptor.decrypt(entity.getStoredValue()));
+                } else {
+                    entity.setValue(entity.getStoredValue());
+                }
             }
+        } catch (EncryptionOperationNotPossibleException exception) {
+            log.error(String.format(
+                "Encryption error on harvester settings password. Error is: %s. " +
+                    "Check that encryptor.properties file match your database.",
+                exception.getMessage()
+            ));
         }
     }
 }


### PR DESCRIPTION
…ter passwords

Application completely fails to start due to encryption errors
```
2021-07-21 09:11:50,530 INFO  [geonetwork.encryptor] - Password database encryptor initialized - Keep the file /data/dev/gn/eea/web/src/main/webapp/WEB-INF/data/config/encryptor.properties safe and make a backup. When upgrading to a newer version of GeoNetwork the file must be restored, otherwise GeoNetwork will not be able to decrypt passwords already stored in the database.
2021-07-21 09:11:55,023 ERROR [jeeves.engine] - Raised exception while starting the application. Fix the error and restart.
2021-07-21 09:11:55,023 ERROR [jeeves.engine] -    Handler   : org.fao.geonet.Geonetwork
2021-07-21 09:11:55,023 ERROR [jeeves.engine] -    Exception : org.jasypt.exceptions.EncryptionOperationNotPossibleException
2021-07-21 09:11:55,023 ERROR [jeeves.engine] -    Message   : null
2021-07-21 09:11:55,025 ERROR [jeeves.engine] -    Stack     : org.jasypt.exceptions.EncryptionOperationNotPossibleException
	at org.jasypt.encryption.pbe.StandardPBEByteEncryptor.decrypt(StandardPBEByteEncryptor.java:1059)
	at org.jasypt.encryption.pbe.StandardPBEStringEncryptor.decrypt(StandardPBEStringEncryptor.java:738)
	at org.fao.geonet.entitylistener.HarvesterSettingValueSetter.handleEvent(HarvesterSettingValueSetter.java:67)
	at org.fao.geonet.entitylistener.HarvesterSettingValueSetter.handleEvent(HarvesterSettingValueSetter.java:39)
```

This happens if one harvester has a password set and the encryptor.properties file is lost.

A workaround is to unset password using 

```sql
UPDATE harvestersettings SET value = '', encrypted = 'y' WHERE name = 'password';
UPDATE settings SET value = '', encrypted = 'y' WHERE name LIKE '%password';
```