### PR TITLE
Add logic to only run encryptor once on password during the migration.

### DIFF
--- a/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
+++ b/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
@@ -65,6 +65,20 @@ public class EncryptorInitializer {
     @Autowired
     DataSource dataSource;
 
+    private boolean firstInitialSetupFlag;
+
+    /**
+     * Set flag to indicate that a encrypt should be done during initialization
+     * This will cause all fields flag as encrypted to be encrypted.
+     * This should generally only be set during a migration script.
+     *
+     * @param firstInitialSetupFlag indicate that a encrypt should be done during initialization - default false
+     */
+    public void setFirstInitialSetupFlag(boolean firstInitialSetupFlag) {
+        this.firstInitialSetupFlag = firstInitialSetupFlag;
+    }
+
+
     public void init(GeonetworkDataDirectory dataDirectory) throws Exception {
         PropertiesConfiguration conf = getEncryptorPropertiesFile(dataDirectory);
 
@@ -175,7 +189,9 @@ public class EncryptorInitializer {
                 previousEncryptor.initialize();
                 updateDb(previousEncryptor);
             } else {
-                updateDb(null);
+                if (firstInitialSetupFlag) {
+                    updateDb(null);
+                }
             }
         }
 

--- a/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
+++ b/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
@@ -70,7 +70,7 @@ public class EncryptorInitializer {
     /**
      * Set flag to indicate that a encrypt should be done during initialization
      * This will cause all fields flag as encrypted to be encrypted.
-     * This should generally only be set during a migration script.
+     * This should generally only be set during initial setup or migration script.
      *
      * @param firstInitialSetupFlag indicate that a encrypt should be done during initialization - default false
      */

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -409,6 +409,10 @@ public class Geonetwork implements ApplicationHandler {
         final long count = settingRepository.count();
         if (count == 0) {
             try {
+                // Set setFirstInitialSetupFlag to true for the encryptorInitializer as this is a new installation.
+                EncryptorInitializer encryptorInitializer = context.getBean(EncryptorInitializer.class);
+                encryptorInitializer.setFirstInitialSetupFlag(true);
+
                 // import data from init files
                 List<Pair<String, String>> importData = context.getBean("initial-data", List.class);
                 final DbLib dbLib = new DbLib();

--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -270,6 +270,7 @@
       <list>
         <value>java:v3110.UpdateMetadataStatus</value>
         <value>WEB-INF/classes/setup/sql/migrate/v3110/migrate-</value>
+        <value>java:v3110.MigrateEncryptor</value>
       </list>
     </entry>
     <entry key="4.0.0">

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/MigrateEncryptor.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/MigrateEncryptor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2001-2018 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package v3110;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.fao.geonet.DatabaseMigrationTask;
+import org.fao.geonet.EncryptorInitializer;
+import org.springframework.context.ApplicationContext;
+
+
+/**
+ * Class to be executed during the migration which will flag the encryptor to do an password update.
+ *
+ */
+public class MigrateEncryptor extends DatabaseMigrationTask {
+    private EncryptorInitializer encryptorInitializer;
+
+    /**
+     * Override the setContext so do the autowire of the other fields.
+     *
+     * @param applicationContext
+     */
+    @Override
+    public void setContext(ApplicationContext applicationContext) {
+        super.setContext(applicationContext);
+        encryptorInitializer = applicationContext.getBean(EncryptorInitializer.class);
+        encryptorInitializer.setFirstInitialSetupFlag(true);
+    }
+
+    /**
+     * update initial setup flag to indicate that a existing password should be done encrypted.
+     *
+     * @param connection
+     * @throws SQLException
+     */
+    @Override
+    public void update(Connection connection) throws SQLException {
+        encryptorInitializer.setFirstInitialSetupFlag(true);
+    }
+}


### PR DESCRIPTION
Fixes migration issue from #5863 by only allowing the encryptor to be run once during migration.