### PR TITLE
Encryptor env variable should be uppercase

### DIFF
--- a/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
+++ b/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
@@ -328,7 +328,7 @@ public class EncryptorInitializer {
 
         if (StringUtils.isEmpty(propertyValue)) {
             // System environment variable
-            propertyValue = System.getenv(propertyName.replace('.', '_'));
+            propertyValue = System.getenv(propertyName.toUpperCase().replace('.', '_'));
         }
 
         if (StringUtils.isEmpty(propertyValue)) {


### PR DESCRIPTION
Encryptor env variable should be uppercase as this it the general standard for env variables otherwise it will not find the variable on unix