### PR TITLE
Small UI improvements to the (advanced) search on the search page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchoptions/partials/searchoptions.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchoptions/partials/searchoptions.html
@@ -1,5 +1,4 @@
-<div class="dropdown-header"
-    title="{{'exactMatch-help' | translate}}">
+<div title="{{'exactMatch-help' | translate}}">
   <label>
     <input type="checkbox"
            data-ng-model="exactMatch"
@@ -7,8 +6,7 @@
     <span data-translate="">exactMatch</span>
   </label>
 </div>
-<div class="dropdown-header"
-    title="{{'titleOnly-help' | translate}}">
+<div title="{{'titleOnly-help' | translate}}">
   <label>
     <input type="checkbox"
            data-ng-model="titleOnly"

--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchesbutton.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchesbutton.html
@@ -1,13 +1,12 @@
-<div class="input-group-btn"
-     data-ng-show="featuredSearches.length > 0">
+<div data-ng-show="featuredSearches.length > 0">
   <button type="button"
         class="btn btn-default btn-lg dropdown-toggle"
         data-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false"
         title="{{'featuredUserSearches' | translate}}">
-  <i class="fa fa-star text-muted"></i>
-  <i class="fa fa-caret-down text-muted"></i>
+  <i class="fa fa-star text-warning"></i>
+  <i class="fa fa-caret-down"></i>
   <span class="sr-only" data-translate="">search</span>
   </button>
   <ul class="dropdown-menu">

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -555,5 +555,7 @@
     "clickToDrawABox": "Click once to enable control and draw a box. Click again to stop drawing.",
     "drawRectangle": "Draw extent",
     "clickToClearMapBox": "Click to clear the map box.",
-    "clearRectangle": "Clear extent"
+    "clearRectangle": "Clear extent",
+    "searchOptions": "Search options",
+    "options": "Options"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -178,7 +178,7 @@
 }
 .gn-form-any {
   input.input-lg {
-    height:45px;
+    height: 46px;
     border-radius: 3px;
   }
   .input-group-btn a {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -69,7 +69,7 @@ html, body {
     }
     .btn {
       background-color: @gn-search-button-background-color;
-      border-color: darken(@gn-search-button-background-color, 5%);
+      border-color: @gn-search-button-border-color;
       color: @gn-search-button-color;
       &:hover {
         background-color: darken(@gn-search-button-background-color, 10%);

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -76,6 +76,17 @@ html, body {
         border-color: darken(@gn-search-button-background-color, 15%);
       }
     }
+    .dropdown-menu {
+      margin: 0;
+      border-radius: 0;
+    }
+    .dropdown-menu > li > a {
+      padding: 6px 16px;
+    }
+    .dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus {
+      color: @dropdown-link-hover-color;
+      background-color: @dropdown-link-hover-bg;
+    }
   }
 }
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -114,7 +114,6 @@
         height: 46px;
       }
       input[type="text"].input-lg {
-        border-left-color: #fff;
         box-shadow: none;
         &:focus {
           border-color: @gn-search-outline-color;
@@ -130,9 +129,16 @@
           border-color: darken(@gn-search-button-background-color, 15%);
         }
       }
-      .dropdown-menu > .active > a {
-        background-color: @gn-search-button-background-color;
-        color: @gn-search-button-color;
+      .dropdown-menu {
+        margin: 0;
+        border-radius: 0;
+      }
+      .dropdown-menu > li > a {
+        padding: 6px 16px;
+      }
+      .dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus {
+        color: @dropdown-link-hover-color;
+        background-color: @dropdown-link-hover-bg;
       }
       .btn-reset {
         border-left-color: #fff;
@@ -141,7 +147,9 @@
         }
       }
       .btn-favorites {
-        display: inline-block;
+        .btn {
+          border-right-color: #fff;
+        }
         .text-warning {
           color: #ffc107;
         }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -114,14 +114,16 @@
         height: 46px;
       }
       input[type="text"].input-lg {
+        border-left-color: #fff;
+        box-shadow: none;
         &:focus {
           border-color: @gn-search-outline-color;
           box-shadow: rgba(0, 0, 0, 0.075) 0px 1px 1px inset, rgba(@gn-search-outline-color-red, @gn-search-outline-color-green, @gn-search-outline-color-blue, 0.6) 0px 0px 8px;
         }
       }
-      button.btn-primary.btn-lg {
+      .btn-search {
         background-color: @gn-search-button-background-color;
-        border-color: darken(@gn-search-button-background-color, 5%);
+        border-color: @gn-search-button-border-color;
         color: @gn-search-button-color;
         &:hover {
           background-color: darken(@gn-search-button-background-color, 10%);
@@ -131,6 +133,26 @@
       .dropdown-menu > .active > a {
         background-color: @gn-search-button-background-color;
         color: @gn-search-button-color;
+      }
+      .btn-reset {
+        border-left-color: #fff;
+        &:hover {
+          background: transparent;
+        }
+      }
+      .btn-favorites {
+        display: inline-block;
+        .text-warning {
+          color: #ffc107;
+        }
+      }
+      .btn-advanced {
+        &.active {
+          box-shadow: none;
+          background-color: @panel-default-heading-bg;
+          border-color: @input-border;
+          border-bottom-color: @panel-default-heading-bg;
+        }
       }
     }
   }
@@ -167,58 +189,27 @@
 
 // advanced search
 .gn-search-filter {
+  position: absolute;
+  z-index: 10;
+  padding: 15px;
+  background-color: @panel-default-heading-bg;
+  width: calc(~"100% - 30px");
+  border: 1px solid @input-border;
+  border-top: 0;
+  [class*=col-md] {
+    padding-right: 0;
+  }
   .col-md-2 {
     padding-left: 0;
   }
-  .nav-pills li {
-    display: block;
-  }
-  .form-group {
-    margin-bottom: 0;
+  .search-options {
+    label {
+      font-weight: normal;
+    }
   }
   .btn-link {
     padding-left: 0;
     font-size: 14px;
-  }
-  .control-label {
-    padding: 3px 0 2px 0;
-    display: inline;
-    text-align: left;
-    .control-label-span {
-      display: block;
-      margin-bottom: 2px;
-      margin-top: 3px;
-    }
-  }
-  .bootstrap-tagsinput {
-    padding-top: 6px;
-    padding-bottom: 5px;
-    .tagsinput-trigger {
-      top: 34px;
-      right: 25px;
-    }
-    .tagsinput-clear {
-      right: 20px;
-      top: 0px;
-    }
-    .tag {
-      white-space: normal;
-      display: inline-flex;
-      text-align: left;
-      line-height: 1.5em;
-      font-weight: normal;
-      margin-bottom: 3px;
-    }
-    .tt-menu {
-      .tt-dataset {
-        .tt-suggestion {
-          &:hover {
-            cursor: pointer;
-            background-color: @dropdown-link-hover-bg;
-          }
-        }
-      }
-    }
   }
   .gn-search-filter-datepicker {
     margin-bottom: 10px;
@@ -243,83 +234,6 @@ gn-wps-process-form {
     padding: 0px;
   }
 }
-
-// li.list-group-item.gn-map-item {
-//   text-align: center;
-//   font-size: 12px;
-
-//   .gn-md-thumbnail {
-//     display: inline-block;
-//     float: none;
-//     margin: 0px;
-//     background-image: url(../catalog/views/default/images/no-thumbnail.png);
-//     background-size: cover;
-//     background-position: center;
-//     width: auto;
-//     height: auto;
-//   }
-
-//   .gn-img-thumbnail-caption {
-//     height: 40px;
-//     line-height: 1.2em;
-//     overflow: hidden;
-//     position: relative;
-
-//     &::after {
-//       content: '';
-//       position: absolute;
-//       bottom: 0;
-//       left: 0;
-//       right: 0;
-//       height: 12px;
-//       background: linear-gradient(to bottom, fade(@gn-results-background-color, 0%) 0%, @gn-results-background-color 100%);
-//     }
-//   }
-
-//   .gn-top-records [data-gn-results-container]  & {
-//     padding: 14px;
-//     height: 205px;
-
-//     .gn-img-thumbnail-caption {
-//       margin: 5px 0px;
-//     }
-
-//     &:hover {
-//       cursor: pointer;
-
-//       // note, this may not be correct if a theme is applied,
-//       // as the actual result hover color is transparent black
-//       @result-hover-color: rgb(234, 234, 234);
-//       .gn-img-thumbnail-caption::after {
-//         background: linear-gradient(to bottom, fade(@result-hover-color, 0%) 0%, @result-hover-color 100%);
-//       }
-//     }
-//   }
-
-//   [gn-ows-context] ul.gn-resultview & {
-//     padding: 5px;
-//     height: 205px;
-//     text-align: center;
-
-//     .gn-md-thumbnail {
-//       width: 147px;
-//     }
-//     .gn-img-thumbnail-caption {
-//       height: 30px;
-//     }
-
-//     &:hover {
-//       cursor: pointer;
-
-//       // note, this may not be correct if a theme is applied,
-//       // as the actual result hover color is transparent black
-//       @result-hover-color: #f3f3f3;
-//       .gn-img-thumbnail-caption::after {
-//         background: linear-gradient(to bottom, fade(@result-hover-color, 0%) 0%, @result-hover-color 100%);
-//       }
-//     }
-//   }
-// }
 
 // draft
 .see-draft-pill {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_variables_default.less
@@ -52,10 +52,10 @@
 //
 // ----- search input
 @gn-search-background-color: @body-bg;
-
 @gn-search-outline-color: @brand-primary;
-@gn-search-button-background-color: @brand-primary;
-@gn-search-button-color: @btn-primary-color;
+@gn-search-button-background-color: @btn-default-bg;
+@gn-search-button-color: @btn-default-color;
+@gn-search-button-border-color: @btn-default-border;
 
 @gn-search-outline-color-red: red(@gn-search-outline-color);
 @gn-search-outline-color-green: green(@gn-search-outline-color);

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -193,20 +193,6 @@
               }
             }
           }).add({
-            combo: 'enter',
-            description: $translate.instant('hotkeySearchTheCatalog'),
-            allowIn: 'INPUT',
-            callback: function() {
-              $location.search('tab=search');
-            }
-            //}).add({
-            //  combo: 'r',
-            //  description: $translate.instant('hotkeyResetSearch'),
-            //  allowIn: 'INPUT',
-            //  callback: function () {
-            //    $scope.resetSearch();
-            //  }
-          }).add({
             combo: 'm',
             description: $translate.instant('hotkeyMap'),
             callback: function(event) {

--- a/web-ui/src/main/resources/catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html
@@ -1,4 +1,9 @@
-<div class="gn-search-filter col-md-offset-3 col-md-9 advancedSearchForm">
+<div class="gn-search-filter advancedSearchForm">
+  <label data-translate="">options</label>
+  <div class="search-options">
+    <gn-search-options></gn-search-options>
+  </div>
+  <label class="gn-margin-top" data-translate="">advanced</label>
   <div data-ng-if="searchObj.params.resourceTemporalDateRange"
        data-gn-date-range-filter="resourceTemporalDateRange"
        data-field="searchObj.params.resourceTemporalDateRange"

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -27,7 +27,7 @@
               data-typeahead-focus-first="false"
               data-typeahead-wait-ms="300"/>
         <span class="input-group-btn">
-          <a class="btn btn-primary btn-lg"
+          <a class="btn btn-default btn-lg"
               type="button"
               data-ng-disabled="searchInfo.hits.total.value == 0"
               data-ng-href="#/search?any={{homeAnyField}}">

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -10,9 +10,12 @@
       </div>
       <div class="col-md-6">
         <div class="input-group gn-form-any">
+          <div class="input-group-btn">
           <button data-gn-user-searches-list=""
                   data-ng-cloak=""
-                  data-mode="button"/>
+                  data-mode="button"
+                  class="btn-favorites"/>
+          </div>
               <input type="text"
                     class="form-control input-lg"
                     id="gn-any-field"
@@ -30,53 +33,39 @@
                     data-typeahead-wait-ms="600">
 
           <div class="input-group-btn">
-
-            <button type="button"
-                    data-ng-click="triggerSearch()"
-                    title="{{'search' | translate}}"
-                    class="btn btn-primary btn-lg">
-              <i class="fa fa-fw fa-search"></i>
-              <span class="sr-only" data-translate="">search</span>
-            </button>
-
             <button type="button"
                     data-ng-click="resetSearch(searchObj.defaultParams);"
                     title="{{'ClearTitle' | translate}}"
                     data-ng-if="::!isFilterTagsDisplayedInSearch"
-                    class="btn btn-default btn-lg">
-              <i class="fa fa-times text-danger"></i>
+                    class="btn btn-default btn-lg btn-reset">
+              <i class="fa fa-times"></i>
               <span class="sr-only" data-translate="">ClearTitle</span>
             </button>
             <button type="button"
-                    class="btn btn-default btn-lg dropdown-toggle"
-                    data-ng-if="::searchOptions"
-                    data-toggle="dropdown"
-                    aria-haspopup="true" aria-expanded="false">
-              <span class="caret"></span>
+                    data-ng-click="triggerSearch()"
+                    title="{{'search' | translate}}"
+                    class="btn btn-default btn-lg btn-search">
+              <i class="fa fa-search"></i>
+              <span class="sr-only" data-translate="">search</span>
             </button>
-            <ul class="dropdown-menu dropdown-auto"
-                data-ng-if="::searchOptions">
-              <li>
-                <gn-search-options></gn-search-options>
-              </li>
-            </ul>
             <button type="button"
-                    class="btn btn-default btn-lg"
-                    title="{{'advanced' | translate}}"
+                    class="btn btn-default btn-lg btn-advanced"
+                    title="{{'searchOptions' | translate}}"
                     data-ng-model="searchObj.advancedMode"
                     btn-checkbox=""
                     btn-checkbox-true="1"
                     btn-checkbox-false="0">
-              <i class="fa fa-ellipsis-v"></i>
-              <span class="sr-only" data-translate="">advanced</span>
+              <i class="fa fa-fw fa-sliders"></i>
+              <span class="sr-only" data-translate="">searchOptions</span>
             </button>
           </div>
         </div>
+        <div data-ng-show="searchObj.advancedMode">
+          <!--Advanced search form-->
+          <div data-ng-include="advancedSearchTemplate"></div>
+        </div>
       </div>
-      <div data-ng-show="searchObj.advancedMode">
-        <!--Advanced search form-->
-        <div data-ng-include="advancedSearchTemplate"></div>
-      </div>
+
     </div>
   </div>
   <!-- /.gn-top-search -->

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -10,11 +10,10 @@
       </div>
       <div class="col-md-6">
         <div class="input-group gn-form-any">
-          <div class="input-group-btn">
-          <button data-gn-user-searches-list=""
-                  data-ng-cloak=""
-                  data-mode="button"
-                  class="btn-favorites"/>
+          <div data-gn-user-searches-list=""
+               data-ng-cloak=""
+               data-mode="button"
+               class="input-group-btn btn-favorites">
           </div>
               <input type="text"
                     class="form-control input-lg"
@@ -36,7 +35,6 @@
             <button type="button"
                     data-ng-click="resetSearch(searchObj.defaultParams);"
                     title="{{'ClearTitle' | translate}}"
-                    data-ng-if="::!isFilterTagsDisplayedInSearch"
                     class="btn btn-default btn-lg btn-reset">
               <i class="fa fa-times"></i>
               <span class="sr-only" data-translate="">ClearTitle</span>


### PR DESCRIPTION
Small UI improvements to the (advanced) search on the search page in order to get a more uniform view for the search input and the advanced search options.

Changes:
- advanced form is absolute positioned
- search option are now in the advanced search form
- advanced search now labelled 'search options'
- all buttons now have the default style (can be changed through the variables)
- new icon for the advanced panel (like Gmail options)

a11y change:
- removed the `enter` key binding to the search: now you can open the advanced search with the keyboard

**Screenshot of the new style**
![gn-advanced](https://user-images.githubusercontent.com/19608667/127135208-a02fc694-bae9-4978-b44b-dc855cb48b36.png)
