### PR TITLE
Plugin / SchemaLocation is removed on save in ISO19139 (not in other plugins).

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/update-fixed-info.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/update-fixed-info.xsl
@@ -23,27 +23,33 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/"
-                xmlns:dct="http://purl.org/dc/terms/" version="1.0">
-
-  <!-- ================================================================= -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:java="java:org.fao.geonet.util.XslUtil"
+                version="2.0"
+                exclude-result-prefixes="java">
 
   <xsl:template match="/root">
     <xsl:apply-templates select="simpledc"/>
   </xsl:template>
 
-  <!-- ================================================================= -->
-
   <xsl:template match="@*|node()">
-    <xsl:copy>
+    <xsl:copy copy-namespaces="no">
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
 
-  <!-- ================================================================= -->
+  <xsl:template match="@xsi:schemaLocation">
+    <xsl:if test="java:getSettingValue('system/metadata/validation/removeSchemaLocation') = 'false'">
+      <xsl:copy-of select="."/>
+    </xsl:if>
+  </xsl:template>
 
   <xsl:template match="simpledc">
     <simpledc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <xsl:apply-templates select="@*"/>
       <xsl:apply-templates select="dc:*[name(.)!='dc:identifier']"/>
       <xsl:apply-templates select="dct:*[name(.)!='dct:modified']"/>
       <xsl:choose>

--- a/schemas/iso19110/src/main/plugin/iso19110/update-fixed-info.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/update-fixed-info.xsl
@@ -29,6 +29,8 @@
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gml="http://www.opengis.net/gml"
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:java="java:org.fao.geonet.util.XslUtil"
                 version="2.0"
                 exclude-result-prefixes="#all"
 >
@@ -39,7 +41,11 @@
     <xsl:apply-templates select="gfc:FC_FeatureCatalogue|gfc:FC_FeatureType"/>
   </xsl:template>
 
-  <!-- =================================================================-->
+  <xsl:template match="@xsi:schemaLocation">
+    <xsl:if test="java:getSettingValue('system/metadata/validation/removeSchemaLocation') = 'false'">
+      <xsl:copy-of select="."/>
+    </xsl:if>
+  </xsl:template>
 
   <xsl:template match="gfc:FC_FeatureCatalogue|gfc:FC_FeatureType[not(parent::node())]">
     <xsl:copy>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -68,6 +68,12 @@
     <xsl:apply-templates select="mdb:MD_Metadata"/>
   </xsl:template>
 
+  <xsl:template match="@xsi:schemaLocation">
+    <xsl:if test="java:getSettingValue('system/metadata/validation/removeSchemaLocation') = 'false'">
+      <xsl:copy-of select="."/>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="mdb:MD_Metadata">
     <xsl:copy copy-namespaces="no">
       <xsl:apply-templates select="@*"/>


### PR DESCRIPTION

Make things consistent based on https://github.com/geonetwork/core-geonetwork/commit/f38ae66b84a2ccc93fb2de9efabbac164dc0c492
'If true, the schemaLocation attribute in root element of the metadata is removed during validation and on metadata save.'.