### PR TITLE
Break words in table on the record view page

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -476,6 +476,7 @@ ul.container-list {
     }
     td {
       padding-left: 40px;
+      word-break: break-word;
       ul {
         padding-left: 0;
       }


### PR DESCRIPTION
Not all texts can be displayed on multiple lines automatically, for instance with log links without spaces and `-` characters. When this happens the text breaks out of the table.

This PR adds a line of `css` to break words inside table cells when needed.

**Before:**

![gn-break-before](https://user-images.githubusercontent.com/19608667/127163251-e0fff5c8-54ad-4b70-944a-55b2f722c824.png)

**After:**

![gn-break-after](https://user-images.githubusercontent.com/19608667/127163283-8f0f1f4b-f208-4e25-8319-6e6470a11795.png)
