### PR TITLE
Editor / Associated resource / Check null protocol or url

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -171,12 +171,14 @@
               <strong>{{resource.title | gnLocalized: lang}}</strong><br/>
               {{resource.description | gnLocalized: lang}}
 
-              <div data-ng-if="resource.lUrl.match('/doi/') !== null"
+              <div data-ng-if="resource.lUrl !== null
+                               && resource.lUrl.match('/doi/') !== null"
                    data-gn-doi-wizard="gnCurrentEdit.uuid"
                    data-gn-doi-url="resource.lUrl"
                    data-xs-mode="true"></div>
 
-              <div data-ng-if="resource.protocol.match('OGC:WMS') !== null"
+              <div data-ng-if="resource.protocol !== null
+                               && resource.protocol.match('OGC:WMS') !== null"
                    data-gn-wfs-filter-facets=""
                    manager-only="true"
                    data-wfs-url="{{::resource.lUrl}}"


### PR DESCRIPTION
Do not show DOI or WFS harvester widget if fields are null.