### PR TITLE
Editor / Avoid error if records contains multiple all thesaurus block

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-keywords.xsl
@@ -54,11 +54,11 @@
       <!-- Collect the all thesaurus keywords which contains
            the new keyword added by users. -->
       <xsl:variable name="allThesaurusEl"
-                    select="../(gmd:descriptiveKeywords|srv:keywords)[
+                    select="(../(gmd:descriptiveKeywords|srv:keywords)[
                                 contains(@xlink:href, 'thesaurus=external.none.allThesaurus') or
                                 contains(*/gmd:thesaurusName/*/gmd:identifier/*/gmd:code/*,
                                   'external.none.allThesaurus')
-                                ]"/>
+                                ])[1]"/>
 
       <!-- Check if we are in xlink mode or not.
            WARNING: We don't support a mix of keyword in xlink mode
@@ -66,7 +66,6 @@
       -->
       <xsl:variable name="isAllThesaurusXlinked"
                     select="count($allThesaurusEl/@xlink:href) > 0"/>
-
 
 
       <!-- Collect all XLink parameters from the all thesaurus -->


### PR DESCRIPTION
In principle it should not happen unless editor plays with the XML view.
Now, save will take into account the first all thesaurus block and will not fail if many.