### PR TITLE
Admin / Users / Fix the users that a UserAdmin can manage

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/specification/UserGroupSpecs.java
+++ b/domain/src/main/java/org/fao/geonet/repository/specification/UserGroupSpecs.java
@@ -23,11 +23,19 @@
 
 package org.fao.geonet.repository.specification;
 
-import org.fao.geonet.domain.*;
+import org.fao.geonet.domain.Group_;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.ReservedGroup;
+import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.domain.UserGroupId_;
+import org.fao.geonet.domain.UserGroup_;
 import org.springframework.data.jpa.domain.Specification;
 
-import javax.persistence.criteria.*;
-
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 import java.util.HashSet;
 import java.util.List;
 
@@ -86,6 +94,24 @@ public final class UserGroupSpecs {
             }
         };
     }
+
+    /**
+     * Specification for retrieving all the userGroups of a given user with a given profile.
+     *
+     * @param userId  the user id.
+     * @param profile the user profile. The exact profile, it doesn't run a hierarchical search.
+     * @return the query.
+     */
+    public static Specification<UserGroup> hasUserIdAndProfile(final int userId, final Profile profile) {
+        return (root, query, cb) -> {
+            Path<Profile> profileIdAttributePath = root.get(UserGroup_.id).get(UserGroupId_.profile);
+            Path<Integer> userIdAttributePath = root.get(UserGroup_.id).get(UserGroupId_.userId);
+            Predicate profileIdEqualPredicate = cb.equal(profileIdAttributePath, cb.literal(profile));
+            Predicate userIdEqualsPredicate = cb.equal(userIdAttributePath, cb.literal(userId));
+            return cb.and(profileIdEqualPredicate, userIdEqualsPredicate);
+        };
+    }
+
 
     /**
      * Specification for testing if the UserGroup is (or is not) a reserved group.

--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -38,7 +38,6 @@ import org.fao.geonet.api.users.model.PasswordResetDto;
 import org.fao.geonet.api.users.model.UserDto;
 import org.fao.geonet.api.users.validation.PasswordResetDtoValidator;
 import org.fao.geonet.api.users.validation.UserDtoValidator;
-import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.exceptions.UserNotFoundEx;
 import org.fao.geonet.kernel.DataManager;
@@ -76,6 +75,7 @@ import java.util.*;
 import static org.fao.geonet.kernel.setting.Settings.SYSTEM_USERS_IDENTICON;
 import static org.fao.geonet.repository.specification.UserGroupSpecs.hasProfile;
 import static org.fao.geonet.repository.specification.UserGroupSpecs.hasUserId;
+import static org.fao.geonet.repository.specification.UserGroupSpecs.hasUserIdAndProfile;
 import static org.springframework.data.jpa.domain.Specification.where;
 
 @RequestMapping(value = {
@@ -135,27 +135,26 @@ public class UsersApi {
         Profile profile = session.getProfile();
 
         if (profile == Profile.Administrator) {
+            // Get all users
             return userRepository.findAll(SortUtils.createSort(User_.name));
         } else if (profile != Profile.UserAdmin) {
+            // Return only the current user
             return userRepository.findAll(UserSpecs.hasUserId(session.getUserIdAsInt()));
         } else if (profile == Profile.UserAdmin) {
+            // Return all the users belonging to a group where the current user is UserAdmin
             int userId = session.getUserIdAsInt();
-            final List<Integer> userGroupIds =
-                getGroupIds(userId);
+            final List<Integer> userGroupIds = getGroupIdsWhereUserIsUserAdmin(userId);
 
             List<User> allUsers = userRepository.findAll(SortUtils.createSort(User_.name));
 
-            // Filter users which are not in current user admin groups
-            allUsers.removeIf(u -> {
-                List<Integer> groupIdsForUser = getGroupIds(u.getId());
+            // Filter users that are not in current userAdmin groups or are administrators
+            allUsers.removeIf(u ->
+                    userGroupIds.stream().noneMatch(getGroupIds(u.getId())::contains) ||
+                    u.getProfile().equals(Profile.Administrator));
 
-                return groupIdsForUser.isEmpty() ||
-                    !userGroupIds.containsAll(groupIdsForUser) ||
-                    u.getProfile().equals(Profile.Administrator);
-            });
-//              TODO-API: Check why there was this check on profiles ?
-//                    if (!profileSet.contains(profile))
-//                        alToRemove.add(elRec);
+            // TODO-API: Check why there was this check on profiles ?
+            //  if (!profileSet.contains(profile))
+            //  alToRemove.add(elRec);
 
             return allUsers;
         }
@@ -728,6 +727,11 @@ public class UsersApi {
     private List<Integer> getGroupIds(int userId) {
         return userGroupRepository.findGroupIds(hasUserId(userId));
     }
+
+    private List<Integer> getGroupIdsWhereUserIsUserAdmin(int userId) {
+        return userGroupRepository.findGroupIds(hasUserIdAndProfile(userId, Profile.UserAdmin));
+    }
+
 
     private void setUserGroups(final User user, List<GroupElem> userGroups)
         throws Exception {


### PR DESCRIPTION
A _UserAdmin_ user _UA_ can manage any user _U_ belonging to a group where _UA_ has the _UserAdmin_ role and _U_ is not an _Administrator_.

This commit fix the previous implementation where a _UserAdmin_  _UA_ only could manage the user _U_ if
_U_ was member of **ALL** the groups that had _UA_ as member.