### PR TITLE
Only extractTitles for type METADATA

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -295,7 +295,8 @@ public class BaseMetadataUtils implements IMetadataUtils {
     public LinkedHashMap<String, String> extractTitles(@Nonnull String id) throws Exception {
         AbstractMetadata metadata = findOne(id);
 
-        if (metadata == null)
+        // If metadata not found or it is not a type metadata then return null
+        if (metadata == null || metadata.getDataInfo().getType() != MetadataType.METADATA)
             return null;
 
         Element md = Xml.loadString(metadata.getData(), false);


### PR DESCRIPTION
Only extractTitles for type METADATA

This is to correct a NPE bug that was happening when attempting to load a new Directory/XML snippet.

![image](https://user-images.githubusercontent.com/1868233/127657566-1da322cd-7fae-49ed-b4e7-7e9933dad824.png)
