### PR TITLE
Dublin core / Improvements

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -494,7 +494,9 @@ class Harvester extends BaseAligner<OaiPmhParams> implements IHarvester<HarvestR
     catch(Exception e)
     {
             HarvestError harvestError = new HarvestError(context, e);
-            harvestError.setDescription("Raised exception while getting metadata file : "+ e);
+            harvestError.setDescription(String.format(
+                "Raised exception while getting metadata file %s. Error is: %s",
+                ri.id, e.getMessage()));
             this.errors.add(harvestError);
             harvestError.printLog();
             result.unretrievable++;

--- a/schemas/dublin-core/src/main/plugin/dublin-core/extract-gml.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/extract-gml.xsl
@@ -35,7 +35,9 @@
       <xsl:variable name="e" select="substring-after($coverage,'East ')"/>
       <xsl:variable name="east" select="substring-before($e,',')"/>
       <xsl:variable name="w" select="substring-after($coverage,'West ')"/>
-      <xsl:variable name="west" select="substring-before($w,'. ')"/>
+      <xsl:variable name="west" select="if (contains($w, '. '))
+                                        then substring-before($w,'. ')
+                                        else $w"/>
       <xsl:if test="$w!='' and $e!='' and $n!='' and $s!=''">
         <gml:Polygon>
           <gml:exterior>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/extract-relations.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/extract-relations.xsl
@@ -23,14 +23,40 @@
   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dct="http://purl.org/dc/terms/"
                 version="2.0"
                 exclude-result-prefixes="#all">
 
   <xsl:template mode="relation" match="metadata[simpledc]" priority="99">
     <xsl:variable name="links"
-                  select="*/descendant::*
-                        [name(.) = 'dct:references' or name(.) = 'dc:relation']
-                        [starts-with(., 'http') or contains(. , 'resources.get') or contains(., 'file.disclaimer')]"/>
+                  select="*/(dct:references|dc:relation)[not(matches(., '.*(.gif|.png|.jpeg|.jpg)$', 'i'))]"/>
+    <xsl:variable name="overviews"
+                  select="*/(dct:references|dc:relation)[matches(., '.*(.gif|.png|.jpeg|.jpg)$', 'i')]"/>
+
+    <xsl:if test="$overviews">
+      <thumbnails>
+        <xsl:for-each select="$overviews[matches(., '.*(.gif|.png|.jpeg|.jpg)$', 'i')]">
+          <xsl:variable name="name" select="tokenize(., '/')[last()]"/>
+          <item>
+            <id>
+              <xsl:value-of select="."/>
+            </id>
+            <url>
+              <value lang="{$lang}">
+                <xsl:value-of select="."/>
+              </value>
+            </url>
+            <title>
+              <value lang="{$lang}">
+                <xsl:value-of select="$name"/>
+              </value>
+            </title>
+            <type>thumbnail</type>
+          </item>
+        </xsl:for-each>
+      </thumbnails>
+    </xsl:if>
 
     <xsl:if test="$links">
       <onlines>
@@ -51,9 +77,9 @@
               </value>
             </title>
             <xsl:choose>
-              <xsl:when test="contains(. , 'resources.get') or contains(., 'file.disclaimer')">
+              <xsl:when test="matches(. , '/api/records/.*/attachments/')">
                 <protocol>
-                  <xsl:value-of select="'WWW:DOWNLOAD-1.0-http--download'"/>
+                  <xsl:value-of select="'WWW:DOWNLOAD'"/>
                 </protocol>
               </xsl:when>
               <xsl:otherwise>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
@@ -136,6 +136,7 @@
       </xsl:for-each>
 
       <xsl:for-each select="dct:modified[. != '']">
+        <dateStamp><xsl:value-of select="date-util:convertToISOZuluDateTime(normalize-space(.))"/></dateStamp>
 
         <xsl:variable name="revisionDate"
                       select="date-util:convertToISOZuluDateTime(string(current()))"/>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
@@ -53,8 +53,7 @@
     <view name="default" upAndDownControlHidden="true">
       <sidePanel>
         <directive data-gn-validation-report=""/>
-        <directive data-gn-onlinesrc-list=""
-                   data-types="onlines"/>
+        <directive data-gn-onlinesrc-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="default" default="true" mode="flat">
@@ -67,8 +66,7 @@
     <view name="advanced">
       <sidePanel>
         <directive data-gn-validation-report=""/>
-        <directive data-gn-onlinesrc-list=""
-                   data-types="onlines"/>
+        <directive data-gn-onlinesrc-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="advanced" default="true">
@@ -78,8 +76,7 @@
     <view name="xml">
       <sidePanel>
         <directive data-gn-validation-report=""/>
-        <directive data-gn-onlinesrc-list=""
-                   data-types="onlines"/>
+        <directive data-gn-onlinesrc-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="xml" default="true"/>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
@@ -31,11 +31,6 @@
   <xsl:include href="utility-fn.xsl"/>
   <xsl:include href="utility-tpl.xsl"/>
 
-  <!-- Get the main metadata languages -->
-  <xsl:template name="get-dublin-core-language">
-    <xsl:value-of select="$metadata/descendant::node()/dc:language[1]"/>
-  </xsl:template>
-
   <xsl:template name="get-dublin-core-title">
     <xsl:value-of select="$metadata//dc:title"/>
   </xsl:template>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/loc/eng/strings.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/loc/eng/strings.xml
@@ -31,6 +31,10 @@
   <default>Simple</default>
   <advanced>Full</advanced>
 
+  <overviews>Overviews</overviews>
+  <spatialExtent>Spatial extent</spatialExtent>
+  <noThesaurusName>Keywords</noThesaurusName>
+
   <providedBy>Provided by</providedBy>
   <shareOnSocialSite>Share on social sites</shareOnSocialSite>
   <associatedResources>Associated resources</associatedResources>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/loc/fre/strings.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/loc/fre/strings.xml
@@ -30,6 +30,10 @@
   <xml>XML</xml>
   <default>Simple</default>
   <advanced>Complète</advanced>
+  
+  <overviews>Aperçus</overviews>
+  <noThesaurusName>Mots clés</noThesaurusName>
+  <spatialExtent>Étendue spatiale</spatialExtent>
 
   <providedBy>Provided by</providedBy>
   <shareOnSocialSite>Share on social sites</shareOnSocialSite>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/loc/fre/strings.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/loc/fre/strings.xml
@@ -30,7 +30,7 @@
   <xml>XML</xml>
   <default>Simple</default>
   <advanced>Complète</advanced>
-  
+
   <overviews>Aperçus</overviews>
   <noThesaurusName>Mots clés</noThesaurusName>
   <spatialExtent>Étendue spatiale</spatialExtent>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/process/thumbnail-remove.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/process/thumbnail-remove.xsl
@@ -21,16 +21,23 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
-<xsl:stylesheet xmlns:dc="http://purl.org/dc/elements/1.1/"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0"
-                exclude-result-prefixes="#all">
-  <xsl:template name="get-dublin-core-language">
-    <xsl:value-of select="$metadata/descendant::node()/dc:language[1]"/>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                exclude-result-prefixes="#all"
+                version="2.0">
+  <xsl:param name="thumbnail_url"/>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
   </xsl:template>
-  <!-- No multilingual support in Dublin core -->
-  <xsl:template name="get-dublin-core-other-languages-as-json"/>
-  <xsl:template name="get-dublin-core-other-languages"/>
-  <xsl:template name="get-dublin-core-online-source-config"/>
-  <xsl:template name="get-dublin-core-extents-as-json">[]</xsl:template>
+
+  <xsl:template match="geonet:*|
+                       dct:references[text() = $thumbnail_url]|
+                       dc:relation[text() = $thumbnail_url]"
+                priority="2"/>
 </xsl:stylesheet>


### PR DESCRIPTION
* Add support for overview.
 
![image](https://user-images.githubusercontent.com/1701393/127826372-70018063-4077-4fc9-99ae-9405c51a480c.png)

* Use API instead of deprecated resources.get to identify file to download.
* Make advanced view more consistent with other schemas (overview, extent, tags)

![image](https://user-images.githubusercontent.com/1701393/127826352-7ba08469-07dc-46f4-b270-3e8ad76d3655.png)

* Fix ordering on datestamp
* Improve indexing in case of error of types:

```
2021-08-02 10:10:28,482 ERROR [geonetwork.index] - Document with error #oai:archimer.ifremer.fr:62447: ElasticsearchException[Elasticsearch exception [type=mapper_parsing_exception, reason=failed to parse field [geom] of type [geo_shape]]]; nested: ElasticsearchException[Elasticsearch exception [type=parse_exception, reason=expected word but found: '{']];.

2021-08-02 10:39:58,194 ERROR [geonetwork.index] - Parsing invalid JSON node {"default":"JERICO-NEXT TNA FOULSTOP "Fouling Protection for Marine Optical Systems""} for property resourceTitleObject. Error is: Unexpected character ('F' (code 70)): was expecting comma to separate Object entries
 at [Source: (String)"{"default":"JERICO-NEXT TNA FOULSTOP "Fouling Protection for Marine Optical Systems""}"; line: 1, column: 40]
```

