### PR TITLE
HTML / Page tab title empty

### DIFF
--- a/web/src/main/webapp/xslt/base-layout-nojs.xsl
+++ b/web/src/main/webapp/xslt/base-layout-nojs.xsl
@@ -41,7 +41,7 @@
   <xsl:template match="/">
     <xsl:call-template name="render-html">
       <xsl:with-param name="title"
-                      select="concat($env/system/site/name, ' - ', $env/system/site/organization)"/>
+                      select="concat($env//system/site/name, ' - ', $env//system/site/organization)"/>
       <xsl:with-param name="content">
         <xsl:apply-templates mode="content" select="."/>
       </xsl:with-param>


### PR DESCRIPTION
Avoid ` - ` as page header on simple HTML page eg. http://localhost:8080/geonetwork/srv/api/sources

![image](https://user-images.githubusercontent.com/1701393/127975189-d2593ed0-b060-4eb7-9f75-d08e8c304167.png)
