### PR TITLE
INSPIRE / Validation from a portal endpoint.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/SelectionDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/SelectionDirective.js
@@ -58,6 +58,7 @@
             scope.isInspireValidationEnabled =
               gnConfig[gnConfig.key.isInspireEnabled] &&
               angular.isString(gnConfig['system.inspire.remotevalidation.url']);
+            scope.validationNode = gnConfig['system.inspire.remotevalidation.nodeid'];
           });
 
           scope.$on('operationOnSelectionStart', function() {

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -110,7 +110,14 @@
            data-ng-if="user.isEditorOrMore() && isInspireValidationEnabled">
         <a href="" data-ng-click="mdService.validateMdInspire(searchResults.selectionBucket)"
                    data-gn-confirm-click="{{'validateSelectedRecordINSPIREConfirm' | translate:searchResults}}">
-          <i class="fa fa-fw fa-check"></i>&nbsp;<span translate>validateInspire</span>
+          <i class="fa fa-fw fa-inspire"></i>&nbsp;<span translate>validateInspire</span>
+        </a>
+      </li>
+      <li  data-ng-show="!excludePattern.test('validate')"
+           data-ng-if="user.isEditorOrMore() && isInspireValidationEnabled && validationNode">
+        <a href="" data-ng-click="mdService.validateMdInspire(searchResults.selectionBucket, validationNode)"
+                   data-gn-confirm-click="{{'validateSelectedRecordINSPIREConfirm' | translate:searchResults}}">
+          <i class="fa fa-fw fa-inspire"></i>&nbsp;<span translate>validateInspireUsingNode</span> {{validationNode}}
         </a>
       </li>
       <!--<li  data-ng-show="!excludePattern.test('validate')"

--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -70,19 +70,20 @@
                     gnConfig[gnConfig.key.isInspireEnabled] &&
                     angular.isString(gnConfig['system.inspire.remotevalidation.url']) &&
                     gnCurrentEdit.schema.match(/iso19139|iso19115-3/) != null;
+
+                  scope.validationNode = gnConfig['system.inspire.remotevalidation.nodeid'];
                 });
               });
 
               scope.validateInspire = function(test, mode) {
 
                 if (scope.isEnabled) {
-
                   scope.isDownloadingRecord = true;
                   scope.token = null;
                   var url = '../api/records/' + scope.inspMdUuid +
                     '/validate/inspire?testsuite=' + test;
-                  if (angular.isDefined(mode)) {
-                    url += '&mode=' + mode;
+                  if (angular.isDefined(scope.validationNode) && scope.validationNode !== '') {
+                    url += '&mode=' + scope.validationNode;
                   }
                   $http({
                     method: 'PUT',
@@ -139,6 +140,15 @@
               }
               scope.checkInBackgroud = function(token) {
                 scope.stop = undefined;
+                if (token === '') {
+                  gnAlertService.addAlert({
+                    msg: $translate.instant('noINSPIRETestTokenAvailable'),
+                    type: 'danger'
+                  });
+                  scope.isDownloadingRecord = false;
+                  scope.isDownloadedRecord = false;
+                  return;
+                }
                 scope.stop = $interval(function() {
                   $http({
                     method: 'GET',

--- a/web-ui/src/main/resources/catalog/components/validationtools/partials/mdValidationTools.html
+++ b/web-ui/src/main/resources/catalog/components/validationtools/partials/mdValidationTools.html
@@ -34,6 +34,16 @@
         <span data-translate="">lastInspireValidationStatus</span>
         <gn-md-type-inspire-validation-widget metadata="md"></gn-md-type-inspire-validation-widget>
       </li>
+      <li role="presentation" data-ng-show="!isDownloadingRecord && validationNode"
+          data-ng-repeat="(key,value) in testsuites">
+        <a role="menuitem" tabindex="-1"
+           data-gn-click-and-spin="validateInspire(key, validationNode)">
+           <i
+             class="fa fa-chevron-right"/>&nbsp;
+          <span>{{key}} ({{'usingCswFromNode' | translate}} {{validationNode}})</span>
+        </a>
+      </li>
+      <li class="divider"/>
       <li role="presentation" data-ng-show="!isDownloadingRecord"
           data-ng-repeat="(key,value) in testsuites">
         <a
@@ -45,13 +55,7 @@
 
           <span>{{key}}</span>
         </a>
-        <!--
-        Validation using main CSW entry point.
-        <a class="btn btn-link pull-right" data-gn-click-and-spin="validateInspire(key, 'srv')">using csw</a>
-        Validation using "inspire" portal CSW entry point (which may post process outputs).
-        <a class="btn btn-link pull-right" data-gn-click-and-spin="validateInspire(key, 'inspire')">using INSPIRE endpoint</a>-->
       </li>
-
       <li role="presentation" data-ng-show="isDownloadingRecord">
         <a
           role="menuitem" tabindex="-1"

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -171,5 +171,10 @@
   "summary": "Summary",
   "metadataRecords": "Metadata records",
   "results": "Results",
-  "format-zip": "ZIP"
+  "format-zip": "ZIP",
+  "usingCswFromNode": "Using portal CSW: ",
+  "validateInspireUsingNode": "Remote INSPIRE validation using portal ",
+  "noINSPIRETestTokenAvailable": "INSPIRE validator returned an empty token. Validation status can't be checked now. Retry later.",
+  "system/inspire/remotevalidation/nodeid": "Portal identifier to use for the validation",
+  "system/inspire/remotevalidation/nodeid-help": "If null, the record is uploaded to the validator, if a node is defined, then the CSW url of this node is used, the validator will make a GetRecordById request to retrieve the record."
 }

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -656,6 +656,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/index/indexingTimeRecordLink', 'false', 2, 9209, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/threadedindexing/maxthreads', '1', 1, 9210, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/url', '', 0, 7211, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/nodeid', '', 0, 7212, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/background', 'osm', 0, 9590, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/width', '500', 0, 9590, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/summaryWidth', '500', 0, 9590, 'n');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
@@ -1,2 +1,4 @@
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/nodeid', '', 0, 7212, 'n');
+
 UPDATE Settings SET value='4.0.6' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
More and more often, end user define a custom INSPIRE portal for being harvested by INSPIRE geoportal. The INSPIRE portal first filter records in the scope of the Directive and may also define post processing to adapt record encoding to INSPIRE rules (see. CSW post processing https://github.com/geonetwork/core-geonetwork/pull/4493).

A nodeid parameter is added to the INSPIRE validation configuration:

![image](https://user-images.githubusercontent.com/1701393/128053966-69444329-6703-4ce8-86da-e21d8a4c7dc2.png)


If the nodeid parameter is not set, then the record XML is sent to the validator for validation. If defined, then the GetRecordById URL of the record in this node is sent to the validator which retrieve the XML (see https://github.com/geonetwork/core-geonetwork/pull/5227).

Validation is available:
* in editor
  * With no nodeid declared
![image](https://user-images.githubusercontent.com/1701393/128053914-a03015da-3a84-4585-823f-1c328707dca7.png)
  * With a nodeid declared in config 
![image](https://user-images.githubusercontent.com/1701393/128053888-5116d5c2-281f-4333-9083-01799335da2c.png)

* on a selection
![image](https://user-images.githubusercontent.com/1701393/128053867-50d50950-2d7a-4aa5-9658-c7c070ad2c7a.png)


Also add error message in case of validator return an empty token.

![image](https://user-images.githubusercontent.com/1701393/128053874-325e4cba-ea63-464f-a7df-9f27ea593d01.png)
