### PR TITLE
API / Avoid browser cache issue when the same API Path output various formats

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -53,6 +53,7 @@ import org.springframework.validation.ObjectError;
 
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -334,6 +335,20 @@ public class ApiUtils {
         try (OutputStream out = Files.newOutputStream(outFile)) {
             ImageIO.write(bimg, type, out);
         }
+    }
+
+    /**
+     * Avoid browser cache issue when the same API Path serving various formats.
+     *
+     * eg. go to the API path serving HTML, then go to the main app
+     * which is using the same API path but processing the JSON response.
+     * Browser history back will return to the JSON output instead of the HTML one.
+     *
+     * Use the Vary header to indicate to the browser that the cache depends
+     * on Accept header.
+     */
+    public static void setHeaderVaryOnAccept(HttpServletResponse response) {
+        response.setHeader("Vary", "Accept");
     }
 
     /**

--- a/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.fao.geonet.api.ApiUtils.setHeaderVaryOnAccept;
+
 
 @RequestMapping(value = {
     "/{portal}/api/sources"
@@ -93,8 +95,11 @@ public class SourcesApi {
         @RequestParam(
             value = "group",
             required = false)
-            Integer group
+            Integer group,
+        @Parameter(hidden = true)
+            HttpServletResponse response
     ) throws Exception {
+        setHeaderVaryOnAccept(response);
         if (group != null) {
             return sourceRepository.findByGroupOwner(group);
         } else {
@@ -121,6 +126,7 @@ public class SourcesApi {
         Element sourcesList = new Element("sources");
         sources.stream().map(GeonetEntity::asXml).forEach(sourcesList::addContent);
         response.setContentType(MediaType.TEXT_HTML_VALUE);
+        setHeaderVaryOnAccept(response);
         response.getWriter().write(
             new XsltResponseWriter(null, "portal")
                 .withJson("catalog/locales/en-core.json")


### PR DESCRIPTION
eg.
* go to the API path serving HTML, 
* then go to the main app which is using the same API path but processing the JSON response.
* Browser history back will return to the JSON output instead of the HTML one.

Use the Vary header to indicate to the browser that the cache depends
on Accept header.


It mainly affects portal landing page
http://localhost:8080/geonetwork/srv/api/sources
which I think is the main one served and used in both HTML and JSON format by the browser app.
