### PR TITLE
Resources / Load using relative path (and fix PDF missing CSS resources)

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
@@ -101,9 +101,13 @@ public class XsltFormatter implements FormatterImpl {
         // Some XSLT are used by both formatters and Jeeves and Spring MVC services
         Element translations = new Element("translations");
         Element gui = new Element("gui");
-        gui.addContent(new Element("url").setText(fparams.url + "../.."));
+        String baseUrl = settingManager.getBaseURL();
+        String context = baseUrl.replace(settingManager.getServerURL(), "");
+        gui.addContent(new Element("url").setText(
+            context.substring(0, context.length() - 1)
+        ));
         gui.addContent(new Element("nodeUrl").setText(settingManager.getNodeURL()));
-        gui.addContent(new Element("baseUrl").setText(settingManager.getBaseURL()));
+        gui.addContent(new Element("baseUrl").setText(baseUrl));
         gui.addContent(new Element("serverUrl").setText(settingManager.getServerURL()));
         gui.addContent(new Element("language").setText(fparams.context.getLanguage()));
         gui.addContent(new Element("reqService").setText("md.format.html"));

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -40,40 +40,36 @@
   </xsl:variable>
 
   <xsl:template name="css-load">
-    <!--
-            TODO : less compilation
-            <link href="style/app.css" rel="stylesheet" media="screen" />
--->
-    <link href="{/root/gui/baseUrl}static/gn_fonts.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+    <link href="{/root/gui/url}/static/gn_fonts.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
           media="screen"/>
 
-    <link href="{/root/gui/baseUrl}static/{$customFilename}.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+    <link href="{/root/gui/url}/static/{$customFilename}.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
           media="screen"/>
 
-    <link href="{/root/gui/baseUrl}static/bootstrap-table.min.css?v={$buildNumber}" rel="stylesheet"
+    <link href="{/root/gui/url}/static/bootstrap-table.min.css?v={$buildNumber}" rel="stylesheet"
           media="screen"></link>
 
-    <link href="{/root/gui/baseUrl}static/gn_pickers.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+    <link href="{/root/gui/url}/static/gn_pickers.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
           media="screen"/>
 
-    <link href="{/root/gui/baseUrl}static/gn_inspire.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+    <link href="{/root/gui/url}/static/gn_inspire.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
           media="screen"/>
 
     <xsl:if test="$withD3">
-      <link href="{/root/gui/baseUrl}static/nv.d3.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+      <link href="{/root/gui/url}/static/nv.d3.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
             media="screen"/>
     </xsl:if>
 
-    <link href="{/root/gui/baseUrl}static/ng-skos.css?v={$buildNumber}" rel="stylesheet" media="screen"></link>
-    <link href="{/root/gui/baseUrl}static/{/root/gui/nodeId}_custom_style.css?v={$buildNumber}&amp;{$minimizedParam}"
+    <link href="{/root/gui/url}/static/ng-skos.css?v={$buildNumber}" rel="stylesheet" media="screen"></link>
+    <link href="{/root/gui/url}/static/{/root/gui/nodeId}_custom_style.css?v={$buildNumber}&amp;{$minimizedParam}"
           rel="stylesheet" media="screen"/>
   </xsl:template>
 
   <xsl:template name="css-load-nojs">
-    <link href="{/root/gui/baseUrl}static/{$customFilename}.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+    <link href="{/root/gui/url}/static/{$customFilename}.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
           media="screen"/>
 
-    <link href="{/root/gui/baseUrl}static/gn_metadata_pdf.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+    <link href="{/root/gui/url}/static/gn_metadata_pdf.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
           media="print"/>
   </xsl:template>
 
@@ -200,7 +196,7 @@
     <xsl:choose>
       <xsl:when test="/root/request/debug">
         <!-- Use Closure to load the application scripts -->
-        <script src="{/root/gui/baseUrl}static/closure_deps.js?v={$buildNumber}"></script>
+        <script src="{/root/gui/url}/static/closure_deps.js?v={$buildNumber}"></script>
         <script>
           goog.require('<xsl:value-of select="$angularModule"/>');
         </script>
@@ -210,13 +206,13 @@
         <xsl:choose>
           <xsl:when test="$is3DModeAllowed">
             <script src="{$uiResourcesPath}lib/olcesium/Cesium/Cesium.js?v={$buildNumber}"></script>
-            <script src="{/root/gui/baseUrl}static/lib3d.js?v={$buildNumber}"></script>
+            <script src="{/root/gui/url}/static/lib3d.js?v={$buildNumber}"></script>
           </xsl:when>
           <xsl:otherwise>
-            <script src="{/root/gui/baseUrl}static/lib.js?v={$buildNumber}"></script>
+            <script src="{/root/gui/url}/static/lib.js?v={$buildNumber}"></script>
           </xsl:otherwise>
         </xsl:choose>
-        <script src="{/root/gui/baseUrl}static/{$angularModule}.js?v={$buildNumber}&amp;{$minimizedParam}"></script>
+        <script src="{/root/gui/url}/static/{$angularModule}.js?v={$buildNumber}&amp;{$minimizedParam}"></script>
       </xsl:otherwise>
     </xsl:choose>
 


### PR DESCRIPTION
Relates to https://github.com/geonetwork/core-geonetwork/pull/5888 and specifically to https://github.com/geonetwork/core-geonetwork/pull/5888/commits/aa976e8e64bb8788d617fb165befb3cfeb70dd11.

PDF print was not able to load CSS due to use of relative path with '../..'.
Using complete URL was fixing the issue but was also causing a new issue when you start the app on a port which is not the one define in database. The app was not able to load resources.

Restore relative path for HTML page and cleanup the relative path for the PDF mode.