### PR TITLE
"padding-bottom: 150px" for ".gn-editor-sidebar" CSS class.

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -964,7 +964,7 @@ gn-draft-validation-widget {
     right: 0;
     overflow: auto;
     max-height: 100%;
-    padding-bottom: 110px;
+    padding-bottom: 150px;
   }
 }
 


### PR DESCRIPTION
The issue is this padding-bottom property was overwritten by each other.
![image](https://user-images.githubusercontent.com/74916635/129391252-b6304226-9302-4890-b73e-0b7db5a7f541.png)


So the result is the side bar shrank and the user has to scroll down/up in order to browse the whole drop down menu of "Add resource".

![image](https://user-images.githubusercontent.com/74916635/129391381-1c428adb-32a0-4458-979c-21552cd0b9b3.png)
