### PR TITLE
Add a title to an info block

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -10,7 +10,7 @@
     <div class="panel-heading gn-card-heading">
       <div class="gn-md-title">
         <a href=""
-           title="{{md.title || md.defaultTitle}}"
+           title="{{md.resourceTitle}}"
            gn-metadata-open="md"
            gn-records="searchResults.records"
            gn-formatter="formatter.defaultUrl">


### PR DESCRIPTION
This PR adds a title to an info block: this will show the full name when a long a long name is truncated (see screenshot).

![gn-info-add-title](https://user-images.githubusercontent.com/19608667/129905580-6cf7633d-367c-44ee-8ff6-52cf34fdddd4.png)
