### PR TITLE
Update iso19139 template for uuidref attribute to apply only for srv:operatesOn element

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -31,6 +31,7 @@
                 xmlns:gml320="http://www.opengis.net/gml"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:tr="java:org.fao.geonet.api.records.formatters.SchemaLocalizations"
                 xmlns:gn-fn-render="http://geonetwork-opensource.org/xsl/functions/render"
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
@@ -983,7 +984,7 @@
 
   <!-- Link to other metadata records -->
   <xsl:template mode="render-field"
-                match="*[@uuidref]"
+                match="srv:operatesOn[@uuidref]"
                 priority="100">
     <xsl:variable name="nodeName" select="name()"/>
 


### PR DESCRIPTION
`uuidref` attribute is valid for example in `gmd:onLine`:

```
<gmd:onLine uuidref="a36f5989-29c6-4555-aa6e-1c037a86f278">
```

The current formatter  http://localhost:8080/geonetwork/srv/eng/catalog.search#/metadata/2eb34f7c-ef72-40a5-a777-c27d059667a6/formatters/xsl-view?root=div&view=advanced, fails if the uuidref is applied to "unexcepted" elements. Afaik the template is intended only to match the `srv:operatesOn` element:

```
Error on line 1012 of view.xsl:
  XTTE0790: An empty sequence is not allowed as the first argument of gn-fn-render:getMetadataTitle()
2021-08-19 09:08:24,108 ERROR [jeeves] - Error occurred within a transaction
; SystemID: file:///xxxx/WEB-INF/data/config/schema_plugins/iso19139/formatter/xsl-view/view.xsl; Line#: 1012; Column#: -1
net.sf.saxon.trans.XPathException: An empty sequence is not allowed as the first argument of gn-fn-render:getMetadataTitle()
```

This pull request limits the scope of the template to the `srv:operatesOn` element.