### PR TITLE
Fix CSW ES mapping for sortBy and bbox

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecords.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/GetRecords.java
@@ -745,11 +745,15 @@ public class GetRecords extends AbstractOperation implements CatalogService {
             // Map CSW search field to index field for sorting.
             // And if not mapped assumes the field is an index field.
             String indexField = _fieldMapper.mapSort(field);
-            sortFields.add(
-                new FieldSortBuilder(StringUtils.isEmpty(indexField) ? field : indexField)
-                    .order(isDescOrder ? SortOrder.DESC : SortOrder.ASC));
+            if(StringUtils.isEmpty(indexField) && field.toLowerCase().equals("relevance")) {
+                indexField = "_score";
+            }
+            if(!StringUtils.isEmpty(indexField)) {
+                sortFields.add(
+                        new FieldSortBuilder(indexField)
+                                .order(isDescOrder ? SortOrder.DESC : SortOrder.ASC));
+            }
         }
-
         return sortFields;
     }
 

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -487,7 +487,7 @@ public class CswFilter2Es extends AbstractFilterVisitor {
         final double y0 = bbox.getMinY();
         final double y1 = bbox.getMaxY();
 
-        final String coordsValue = String.format("[[%f, %f], [%f, %f]]", x0, y0, x1, y1);
+        final String coordsValue = String.format("[[%f, %f], [%f, %f]]", x0, y1, x1, y0);
 
         final String filterSpatial = fillTemplateSpatial("envelope", coordsValue, "intersects");
         stack.push(filterSpatial);

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
@@ -152,7 +152,7 @@ class CswFilter2EsTest {
         // EXPECTED:
         final ObjectNode expected = boolbdr(). //
                 must(array(geoShape("geom", //
-                        envelope(-180d, -90d, 180d, 90d), //
+                        envelope(-180d, 90d, 180d, -90d), //
                         "intersects"))) //
                 . //
                 filter(queryStringPart()). //
@@ -208,7 +208,7 @@ class CswFilter2EsTest {
                 .bld();
 
         final ObjectNode geoShapePart = geoShape("geom", //
-                envelope(-180d, -90d, 180d, 90d), //
+                envelope(-180d, 90d, 180d, -90d), //
                 "intersects");
 
         // EXPECTED:


### PR DESCRIPTION
- [ ] Sort by `_score` when CSW `Relevance` is used
- [ ] Fix bbox coordinates order in ES payload.

I tried to add a test
```java
    public void test_SortBy() throws Exception {
        Element request = new Element("GetRecords", Csw.NAMESPACE_CSW)
                .setAttribute("service", "CSW")
                .setAttribute("version", "2.0.2")
                .setAttribute("resultType", "results")
                .setAttribute("startPosition", "3")
                .setAttribute("maxRecords", "1")
                .setAttribute("outputSchema", "csw:Record")
                .addContent(new Element("Query", Csw.NAMESPACE_CSW)
                        .addContent(new Element("ElementSetName", Csw.NAMESPACE_CSW).setText("summary"))
                        .addContent(new Element("SortBy", Geonet.Namespaces.OGC).setText("summary")
                                .addContent(new Element("PropertyName", Geonet.Namespaces.OGC).setText("relevance")))
                );

        final ServiceContext serviceContext = createServiceContext();
        serviceContext.setLanguage(null);
        List<SortBuilder<FieldSortBuilder>> sortFields = _getRecords.getSortFields(request, serviceContext);
        Assert.assertEquals(1, sortFields.size());

    }
```
But I had an error with the `fieldMapper`, is there an example to mock it in the tests ?