### PR TITLE
Metadata detail page - sort keywords / topic categories

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -1032,6 +1032,17 @@
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
 
+      <div data-ng-switch-when="sortKeywordsAlphabetically">
+        <input type="checkbox"
+               id="{{key}}-checkbox"
+               data-ng-model="mCfg[key]"/>&nbsp;
+        <label class="control-label"
+               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
 
       <div data-ng-switch-default>
         <label class="control-label">{{('ui-' + key) | translate}}</label>

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -63,6 +63,7 @@
       $scope.isSocialbarEnabled = gnGlobalSettings.gnCfg.mods.recordview.isSocialbarEnabled;
       $scope.showStatusWatermarkFor = gnGlobalSettings.gnCfg.mods.recordview.showStatusWatermarkFor;
       $scope.showStatusTopBarFor = gnGlobalSettings.gnCfg.mods.recordview.showStatusTopBarFor;
+      $scope.sortKeywordsAlphabetically = gnGlobalSettings.gnCfg.mods.recordview.sortKeywordsAlphabetically;
 
       gnConfigService.load().then(function(c) {
         $scope.isRecordHistoryEnabled = gnConfig['system.metadata.history.enabled'];

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -47,11 +47,11 @@
     '$scope', '$http', '$compile', 'gnSearchSettings', 'gnSearchLocation',
     'gnMetadataActions', 'gnAlertService', '$translate', '$location',
     'gnMdView', 'gnMdViewObj', 'gnMdFormatter', 'gnConfig',
-    'gnGlobalSettings', 'gnConfigService', '$rootScope',
+    'gnGlobalSettings', 'gnConfigService', '$rootScope', '$filter',
     function($scope, $http, $compile, gnSearchSettings, gnSearchLocation,
              gnMetadataActions, gnAlertService, $translate, $location,
              gnMdView, gnMdViewObj, gnMdFormatter, gnConfig,
-             gnGlobalSettings, gnConfigService, $rootScope) {
+             gnGlobalSettings, gnConfigService, $rootScope, $filter) {
 
       $scope.formatter = gnSearchSettings.formatter;
       $scope.gnMetadataActions = gnMetadataActions;
@@ -252,6 +252,10 @@
         }
       }
       $scope.$watch('mdView.recordsLoaded', loadFormatter);
+
+      $scope.sortByCategory = function(cat) {
+        return $filter('translate')('cat-' + cat);
+      };
 
       // Know from what path we come from
       $scope.gnMdViewObj = gnMdViewObj;

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -655,7 +655,8 @@ goog.require('gn_alert');
         'recordview': {
           'isSocialbarEnabled': true,
           'showStatusWatermarkFor': 'historicalArchive,obsolete,superseded',
-          'showStatusTopBarFor': ''
+          'showStatusTopBarFor': '',
+          'sortKeywordsAlphabetically': true
         },
         'editor': {
           'enabled': true,

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1397,6 +1397,8 @@
     "ui-isHeaderFixed-help": "The header is fixed and stays at the top of the page. Attention: when the option [Show the logo in header] is also selected, the header needs a set height. This can be done under [CSS & Style] > [Header] > [Height]",
     "ui-isMenubarAccessible": "Make menubar Accessible",
     "ui-isMenubarAccessible-help": "Make menubar item open on click, not on hover. This means that the menuitems will be accessible by keyboard.",
+    "ui-sortKeywordsAlphabetically": "Sort keywords / categories / topic categories alphabetically",
+    "ui-sortKeywordsAlphabetically-help": "Display the keywords / categories /  topic categories sorted alphabetically. If not enabled are displayed in the order that are assigned to the metadata.",
     "left": "Left",
     "center": "Center",
     "right": "Right",

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -222,6 +222,17 @@
                   <button
                     data-ng-repeat="cat in mdView.current.record.inspireTheme_syn"
                     data-ng-click="filterBy('inspireTheme_syn', cat)"
+                    data-ng-if="!sortKeywordsAlphabetically"
+                    class="btn btn-sm btn-default {{cat.split('|')[0]}} {{cat.split('|')[0]}}-{{langs[lang]}}"
+                    title="{{'clickToFilterOn' | translate}} {{cat.split('|')[1]}}">
+                    <span class="iti-{{cat.split('|')[0]}}"></span>
+                    <!-- TODOES: Restore icon -->{{cat}}
+                  </button>
+
+                  <button
+                    data-ng-repeat="cat in mdView.current.record.inspireTheme_syn | orderBy: 'toString()'"
+                    data-ng-click="filterBy('inspireTheme_syn', cat)"
+                    data-ng-if="sortKeywordsAlphabetically"
                     class="btn btn-sm btn-default {{cat.split('|')[0]}} {{cat.split('|')[0]}}-{{langs[lang]}}"
                     title="{{'clickToFilterOn' | translate}} {{cat.split('|')[1]}}">
                     <span class="iti-{{cat.split('|')[0]}}"></span>
@@ -242,9 +253,21 @@
                     {{('cat-' + cat) | translate}}
                   </button>
 
+                  <hr data-ng-if="mdView.current.record.cat.length > 0 &&
+                        mdView.current.record.cl_topic.length > 0"/>
+
                   <button data-ng-repeat="cat in mdView.current.record.cl_topic track by $index"
                           data-ng-click="filterBy('cl_topic.key', cat.key)"
-                          data-ng-if="cat != ''"
+                          data-ng-if="(cat != '') && !sortKeywordsAlphabetically"
+                          class="btn btn-sm btn-default"
+                          title="{{'clickToFilterOn' | translate}} {{cat.key | translate}}">
+                    <span class="fa gn-icon-{{cat.key}} topic-color"></span>&nbsp;
+                    {{cat.key | translate}}
+                  </button>
+
+                  <button data-ng-repeat="cat in mdView.current.record.cl_topic  | orderBy: 'key | translate'"
+                          data-ng-click="filterBy('cl_topic.key', cat.key)"
+                          data-ng-if="(cat != '') && sortKeywordsAlphabetically"
                           class="btn btn-sm btn-default"
                           title="{{'clickToFilterOn' | translate}} {{cat.key | translate}}">
                     <span class="fa gn-icon-{{cat.key}} topic-color"></span>&nbsp;
@@ -257,7 +280,7 @@
                 <td>
                   <ul>
                     <li data-ng-repeat="k in t.keywords track by $index"
-                        data-ng-if="k"
+                        data-ng-if="(k) && !sortKeywordsAlphabetically"
                         class="tt-cursor">
                         <span data-ng-hide="::!!k.link">{{::k.default | capitalize}}</span>
                         <a href=""
@@ -270,6 +293,22 @@
                            data-ng-click="filterBy('tag.default', k.default)">
                           <i class="fa fa-search"/>
                         </a>
+                    </li>
+
+                    <li data-ng-repeat="k in t.keywords | orderBy: 'default'"
+                        data-ng-if="(k) && sortKeywordsAlphabetically"
+                        class="tt-cursor">
+                      <span data-ng-hide="::!!k.link">{{::k.default | capitalize}}</span>
+                      <a href=""
+                         data-ng-href="{{::k.link}}"
+                         data-ng-show="::!!k.link">
+                        {{::k.default | capitalize}}</a>&nbsp;
+                      <a href=""
+                         title="{{'clickToFilterOn' | translate}} {{::k.default | capitalize}}"
+                         aria-label="{{'clickToFilterOn' | translate}} {{::k.default | capitalize}}"
+                         data-ng-click="filterBy('tag.default', k.default)">
+                        <i class="fa fa-search"/>
+                      </a>
                     </li>
                   </ul>
                 </td>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -247,6 +247,16 @@
                 <td>
                   <button data-ng-repeat="cat in mdView.current.record.cat"
                           data-ng-click="filterBy('cat', cat)"
+                          data-ng-if="!sortKeywordsAlphabetically"
+                          class="btn btn-sm btn-default"
+                          title="{{'clickToFilterOn' | translate}} {{('cat-' + cat) | translate}}">
+                    <span class="fa gn-icon-{{cat}} resource-color"></span>&nbsp;
+                    {{('cat-' + cat) | translate}}
+                  </button>
+
+                  <button data-ng-repeat="cat in mdView.current.record.cat  | orderBy:sortByCategory"
+                          data-ng-click="filterBy('cat', cat)"
+                          data-ng-if="sortKeywordsAlphabetically"
                           class="btn btn-sm btn-default"
                           title="{{'clickToFilterOn' | translate}} {{('cat-' + cat) | translate}}">
                     <span class="fa gn-icon-{{cat}} resource-color"></span>&nbsp;


### PR DESCRIPTION
Setting to sort keywords and categories in the metadata detail page (angularjs view)

![sort-keywords-setting](https://user-images.githubusercontent.com/1695003/130584381-ed94475b-0dc4-44fa-bdf1-28ad664e847c.png)

Keywords alphabetical sort:

![alphabetical-sort](https://user-images.githubusercontent.com/1695003/130585809-ad68f587-8795-4b43-bfb4-0e668d740e81.png)



Keywords order sort:
![order-sort](https://user-images.githubusercontent.com/1695003/130584515-112a8b4f-46f6-4a65-832b-61d6c64c0840.png)
