### PR TITLE
Remove metadata online resource - fix resource name comparison

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/onlinesrc-remove.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/onlinesrc-remove.xsl
@@ -29,7 +29,7 @@
   <xsl:template match="gn:*|
     mrd:onLine[
     normalize-space(cit:CI_OnlineResource/cit:linkage/gco:CharacterString) = $url and
-    normalize-space(cit:CI_OnlineResource/cit:name/gco:CharacterString) = $name]|
+    normalize-space(cit:CI_OnlineResource/cit:name/gco:CharacterString) = normalize-space($name)]|
     mrd:onLine[
     normalize-space(cit:CI_OnlineResource/cit:linkage/gco:CharacterString) = $url and
     normalize-space(cit:CI_OnlineResource/cit:protocol/gco:CharacterString) = 'WWW:DOWNLOAD-1.0-http--download']|

--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-remove.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-remove.xsl
@@ -42,7 +42,7 @@ Stylesheet used to remove a reference to a online resource.
 
   <!-- Remove geonet:* elements. -->
   <xsl:template
-    match="geonet:*|gmd:onLine[normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:name/gco:CharacterString) = $name]"
+    match="geonet:*|gmd:onLine[normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:name/gco:CharacterString) = normalize-space($name)]"
     priority="2"/>
   <xsl:template
     match="geonet:*|gmd:onLine[normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and count(gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup[gmd:LocalisedCharacterString = $name]) > 0]"


### PR DESCRIPTION
Apply `normalize-space` to both sides of the comparison, otherwise if the resource name has extra spaces between words, the comparison was not matching the resource.