### PR TITLE
Display topic categories tooltips in the metadata editor when tooltips are enabled

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/topiccategory/TopicCategoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/topiccategory/TopicCategoryDirective.js
@@ -63,6 +63,7 @@
              scope.initialTopicCategories = [];
              var xpathBySchema = {
                'iso19139': {
+                 name: 'gmd:topicCategory',
                  xpath: 'gmd:identificationInfo/*/gmd:topicCategory',
                  tpl: '<gmd:topicCategory ' +
                  'xmlns:gmd="http://www.isotc211.org/2005/gmd">' +
@@ -70,6 +71,7 @@
                  '</gmd:topicCategory>'
                },
                'iso19115-3': {
+                 name: 'mri:topicCategory',
                  xpath: 'mdb:identificationInfo/*/mri:topicCategory',
                  tpl: '<mri:topicCategory xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0">' +
                         '<mri:MD_TopicCategoryCode>{{t}}</mri:MD_TopicCategoryCode>\n' +
@@ -79,12 +81,17 @@
 
              var schema = gnCurrentEdit.schema;
 
+             scope.gnCurrentEdit = gnCurrentEdit;
+             scope.schema = schema;
+
              // By convention schema extension will have
              // an identifier of the form {baseSchemaId}.{extensionId}
              var schemaForXpath = (gnCurrentEdit.schema.indexOf(".") !== -1) ?
                gnCurrentEdit.schema.split('.')[0] :
                gnCurrentEdit.schema;
              scope.xpath = xpathBySchema[schemaForXpath].xpath;
+
+             scope.elementName = xpathBySchema[schemaForXpath].name;
 
              // Initial values are comma separated encoded
              if (scope.values) {

--- a/web-ui/src/main/resources/catalog/components/edit/topiccategory/partials/topiccategory.html
+++ b/web-ui/src/main/resources/catalog/components/edit/topiccategory/partials/topiccategory.html
@@ -1,5 +1,5 @@
 <span data-ng-class="required ? 'gn-required' : ''">
-  <label class="col-sm-2 control-label">
+  <label class="col-sm-2 control-label" data-gn-field-tooltip="{{schema}}|{{elementName}}">
     {{label}}
   </label>
   <div class="col-sm-9 gn-value"


### PR DESCRIPTION
When the tooltips are enabled in the metadata editor with the mode (`displayTooltipsMode`) as `icon`, the topic categories directive was not displaying the tooltip icon next to the field.

With this change, the icon is displayed, similar as for other fields in the editor:

![topic-categories-tooltips-editor](https://user-images.githubusercontent.com/1695003/131338231-4d3c6a47-138c-4621-8436-85d26a3b99e8.png)

