### PR TITLE
Add proxy level security support for map services

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderConfiguration.java
@@ -91,7 +91,7 @@ public interface SecurityProviderConfiguration {
 			}
 			return securityProviderConfigurations.get(securityProviderConfigurations.keySet().toArray()[0]);
 		}
-		// If we cannot find SecurityProviderConfiguration then default to false.
+		// If we cannot find SecurityProviderConfiguration then default to null.
 		return null;
 	}
 
@@ -106,6 +106,19 @@ public interface SecurityProviderConfiguration {
      * If the data is coming from the security providers then the security provider then it may make sense to disable the user group updates
      */
     boolean isUserGroupUpdateEnabled();
+
+    static SecurityProviderUtil getSecurityProviderUtil() {
+        Map<String, SecurityProviderUtil> SecurityProviderUtils = ApplicationContextHolder.get().getBeansOfType(SecurityProviderUtil.class);
+
+        if (SecurityProviderUtils != null && SecurityProviderUtils.size() != 0) {
+            if (SecurityProviderUtils.size() != 1) {
+                throw new RuntimeException("Too many security providers utils");
+}
+            return SecurityProviderUtils.get(SecurityProviderUtils.keySet().toArray()[0]);
+        }
+        // If we cannot find SecurityProviderUtil then default to null.
+        return null;
+    }
 }
 
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderConfiguration.java
@@ -113,7 +113,7 @@ public interface SecurityProviderConfiguration {
         if (SecurityProviderUtils != null && SecurityProviderUtils.size() != 0) {
             if (SecurityProviderUtils.size() != 1) {
                 throw new RuntimeException("Too many security providers utils");
-}
+            }
             return SecurityProviderUtils.get(SecurityProviderUtils.keySet().toArray()[0]);
         }
         // If we cannot find SecurityProviderUtil then default to null.

--- a/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.kernel.security;
+
+/**
+ * Some basic configuration utils to be used by all security
+ *
+ */
+public interface SecurityProviderUtil {
+    /**
+     * Retrieve authentication header value
+     * return the authentication header value. In most cases it should be a bearer token header value. i.e. "Bearer ....."
+     */
+    String getSSOAuthenticationHeaderValue();
+}
+
+

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUtil.java
@@ -25,14 +25,17 @@ package org.fao.geonet.kernel.security.keycloak;
 
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.security.SecurityProviderUtil;
 import org.fao.geonet.utils.Log;
+import org.keycloak.adapters.RefreshableKeycloakSecurityContext;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
 import javax.annotation.PostConstruct;
 
-public class KeycloakUtil {
+public class KeycloakUtil implements SecurityProviderUtil {
     public static String signinPath = null;
     private static LoginUrlAuthenticationEntryPoint loginUrlAuthenticationEntryPoint;
 
@@ -61,5 +64,15 @@ public class KeycloakUtil {
             }
         }
         return signinPath;
+    }
+
+    @Override
+    public String getSSOAuthenticationHeaderValue() {
+        if (SecurityContextHolder.getContext().getAuthentication().getDetails() instanceof RefreshableKeycloakSecurityContext) {
+            RefreshableKeycloakSecurityContext refreshableKeycloakSecurityContext =
+                (RefreshableKeycloakSecurityContext) SecurityContextHolder.getContext().getAuthentication().getDetails();
+            return "Bearer " + refreshableKeycloakSecurityContext.getTokenString();
+        }
+        return null;
     }
 }

--- a/domain/src/main/java/org/fao/geonet/domain/mapservices/MapService.java
+++ b/domain/src/main/java/org/fao/geonet/domain/mapservices/MapService.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.domain.mapservices;
+
+import javax.annotation.Nonnull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MapService {
+
+    public enum AuthType {
+        /**
+         * Authentication should use a token based on the current authorized user
+         */
+        BEARER(true),   // Authentication should use a token based on the current authorized user
+
+        /**
+         * Authentication should use a username and password based on the supplied
+         * username and password in the configurations. For security reason this cannot be used in public
+         * client and should only be used via proxy
+         */
+        BASIC(false);
+
+        private boolean publicClientAllowed;
+
+        AuthType(boolean publicClientAllowed) {
+            this.publicClientAllowed = publicClientAllowed;
+        }
+
+        public boolean isPublicClientAllowed() {
+            return publicClientAllowed;
+        }
+    }
+
+    public enum UrlType {
+        /**
+         * Type of url - url or regular expression
+         */
+        TEXT,
+        REGEXP;
+    }
+
+    /**
+     * URL used to identify if the map server requires authentication
+     */
+    private String url;
+
+    /**
+     * URLType - either TEXT or REGEXP - default to text
+     */
+    private UrlType urlType = UrlType.TEXT;
+
+    /**
+     * use proxy - used to force authentication to use proxy
+     */
+    private Boolean useProxy = true; // Set proxy default to true
+
+    /**
+     * Auth Type - Identify the authentication type that should be used when sending authentication request for the url
+     */
+    private AuthType authType;
+
+    /**
+     * username and password - server credentials to be used for the authentication type - if required.
+     */
+    private String username;
+    private String password;
+
+    @Nonnull
+    public String getUrl() {
+        return url;
+    }
+
+    @Nonnull
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Nonnull
+    public String getUrlType() {
+        return urlType.toString();
+    }
+
+    @Nonnull
+    public void setUrlType(String urlType) {
+        this.urlType = UrlType.valueOf(urlType);
+    }
+
+    @Nonnull
+    public Boolean getUseProxy() {
+        // As we cannot expose credentials to the public/javascript client , then proxy will always be true
+        if (!authType.isPublicClientAllowed()) {
+            return true;
+        }
+        return useProxy;
+    }
+
+    @Nonnull
+    public void setUseProxy(boolean useProxy) {
+        if (authType != null && !authType.isPublicClientAllowed() && !useProxy) {
+            throw new IllegalArgumentException(String.format("Cannot set \"useProxy=false\". Authentication type %s only supports \"useProxy=true\" for security reasons. (%s)", authType, this));
+        }
+        this.useProxy = useProxy;
+    }
+
+    @Nonnull
+    public String getAuthType() {
+        return authType.toString();
+    }
+
+    @Nonnull
+    public void setAuthType(String authType) {
+        if (authType != null && !AuthType.valueOf(authType).isPublicClientAllowed() && !this.useProxy) {
+            throw new IllegalArgumentException(String.format("Authentication type %s only supports \"useProxy=true\" for security reasons.(%s)", authType, this));
+        }
+
+        this.authType = AuthType.valueOf(authType);
+    }
+
+    @JsonIgnore // Never return username in json results to the api
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @JsonIgnore // Never return password in json results to the api
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return "MapService{" +
+            "url='" + url + '\'' +
+            ", urlType=" + urlType +
+            ", useProxy=" + useProxy +
+            ", authType=" + authType +
+            '}';
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/mapservices/MapServicesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservices/MapServicesApi.java
@@ -1,0 +1,43 @@
+package org.fao.geonet.api.mapservices;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.domain.mapservices.MapService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.List;
+
+@RequestMapping(value = {
+    "/{portal}/api/mapservices"
+})
+@Tag(name = "mapservices",
+    description = "Mapservices related operations")
+@Controller("mapservices")
+public class MapServicesApi {
+    @Operation(
+        summary = "Get mapservices",
+        description = "Return the list of mapservices. mapservices are used to identify secured map services.")
+
+    @RequestMapping(
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.APPLICATION_JSON_VALUE
+        })
+    public
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    List<MapService> getMapservices() throws Exception {
+        @SuppressWarnings("unchecked")
+        List<MapService> mapServiceList = ApplicationContextHolder.get().getBean("securedMapServices", List.class);
+
+        return mapServiceList;
+    }
+}

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -35,6 +35,106 @@
     'gn_esri_service'
   ]);
 
+  module.factory('gnMapServicesCache',
+    ['gnGlobalSettings',
+      function(gnGlobalSettings) {
+        var mapservicesCache = null;
+
+        return {
+          getMapservices: function() {
+            if (mapservicesCache === null) {
+              var client = new XMLHttpRequest();
+              client.open('GET', '../api/mapservices', false);
+              client.setRequestHeader("accept", "application/json");
+              client.send();
+              if (client.status === 200) {
+                mapservicesCache = JSON.parse(client.responseText);
+              }
+            }
+            return mapservicesCache;
+          },
+
+          getMapservice: function(url) {
+            var mapservices = this.getMapservices();
+            if (mapservices !== null) {
+              for (var j = 0; j < mapservices.length; j++){
+                if ((mapservices[j].urlType='TEXT' && url.indexOf(mapservices[j].url) === 0) ||
+                    (mapservices[j].urlType='REGEXP') && (new RegExp(mapservices[j].url)).test(url)) {
+                  return mapservices[j];
+                }
+              }
+            }
+            return null;
+          },
+
+          getAuthorizationHeaderValue: function(mapservice) {
+            if (mapservice.authType === 'BEARER') {
+              // keycloak public client is the only supported bearer token at this time.
+              if (keycloak) {
+                if (keycloak.token) {
+                  return "Bearer " + keycloak.token;
+                } else {
+                  console.log("No token available. Will perform anonymous request")
+                }
+              } else {
+                console.log("No public client available to retreive token. Will perform anonymous request")
+              }
+            } else {
+              // For basic auth, we need to use proxy for security reasons as the username and password is not availabe in java.
+              // return 'Basic ' + btoa(user + ':' + pass);
+              return null;
+            }
+          },
+
+          // As this is a authorized mapservice lets use the authization load function for loading the images/tiles
+          authorizationLoadFunction: function(tile, src) {
+            var srcUrl = src;
+            var mapservice = this.getMapservice(srcUrl);
+            if (mapservice !== null) {
+              // If we are using a proxy then adjust the url.
+              if (mapservice.useProxy) {
+                // Proxy calls should have been handled withtout load function . So it this occures just log a warning and set the proxy url
+                console.log("Warning: attempting to get Using authorized Map service to get tile/image via proxy - this should have already been handled.")
+                tile.getImage().src  = gnGlobalSettings.proxyUrl + encodeURIComponent(srcUrl);
+              } else {
+                // Todo future add client side authentication request.
+                // For now set the src without authentication
+                tile.getImage().src = srcUrl
+              }
+            } else {
+              // Not a registered mapservice so just use the existing url
+              tile.getImage().src = srcUrl;
+            }
+          },
+
+
+          authorizationFunctionLegend: function(mapservice, legendUrl) {
+            var srcUrl = legendUrl.OnlineResource;
+
+            var mapservice = this.getMapservice(srcUrl);
+            if (mapservice !== null) {
+              // If we are using a proxy then adjust the url.
+              if (mapservice.useProxy) {
+                // Proxy calls should have been handled withtout load function . So it this occures just log a warning and set the proxy url
+                console.log("Warning: attempting to get Using authorized Map service to get legend/image via proxy - this should have already been handled.")
+                legendUrl.OnlineResource = gnGlobalSettings.proxyUrl + encodeURIComponent(srcUrl);
+                legend = data;
+              } else {
+                // Todo future add client side authentication request.
+                // For now set the src without authentication
+                legendUrl.OnlineResource = srcUrl
+                legend = srcUrl;
+              }
+            } else {
+              // Not a registered mapservice so just use the existing url
+              legendUrl.OnlineResource = srcUrl
+              legend = srcUrl;
+            }
+          }
+        };
+      }
+    ]);
+
   /**
    * @ngdoc service
    * @kind function
@@ -66,11 +166,12 @@
       'gnAlertService',
       '$http',
       'gnEsriUtils',
+      'gnMapServicesCache',
       function(olDecorateLayer, gnOwsCapabilities, gnConfig, $log,
           gnSearchLocation, $rootScope, gnUrlUtils, $q, $translate,
           gnWmsQueue, gnMetadataManager, Metadata, gnWfsService,
           gnGlobalSettings, gnViewerSettings, gnViewerService, gnAlertService,
-          $http, gnEsriUtils) {
+          $http, gnEsriUtils, gnMapServicesCache) {
 
         /**
          * @description
@@ -720,6 +821,21 @@
 
             var loadFunction;
 
+            // If this is an authorized mapservice then we need to adjust the url or add auth headers
+            // Only check http url and exclude any urls like data: which should not be changed. Also, there is not need to check prox urls.
+            if (options.url !== null && options.url.startsWith("http") && !options.url.startsWith(gnGlobalSettings.proxyUrl)) {
+               var mapservice = gnMapServicesCache.getMapservice(options.url);
+               if (mapservice !== null) {
+                  if (mapservice.useProxy) {
+                     // If we are using a proxy then adjust the url.
+                     options.url = gnGlobalSettings.proxyUrl + encodeURIComponent(options.url);
+                  } else {
+                     // If not using the proxy then we need to use a custom loadFunction to set the authentication header
+                     loadFunction = gnMapServicesCache.authorizationLoadFunction;
+                  }
+               }
+            }
+
             var source, olLayer;
             if (gnViewerSettings.singleTileWMS) {
               var config = {
@@ -897,7 +1013,23 @@
               }
 
               if (legendUrl) {
-                legend = legendUrl.OnlineResource;
+
+                // If this is an authorized mapservice then we need to adjust the url or add auth headers
+                // Only check http url and exclude any urls like data: which should not be changed. Also, there is not need to check prox urls.
+                if (legendUrl !== null && legendUrl.OnlineResource !== null && legendUrl.OnlineResource.startsWith("http") && !legendUrl.OnlineResource.startsWith(gnGlobalSettings.proxyUrl)) {
+                   var mapservice = gnMapServicesCache.getMapservice(legendUrl.OnlineResource);
+                   if (mapservice !== null) {
+                      if (mapservice.useProxy) {
+                         // If we are using a proxy then adjust the url.
+                         legendUrl.OnlineResource= gnGlobalSettings.proxyUrl + encodeURIComponent(legendUrl.OnlineResource);
+                       } else {
+                         // If not using the proxy then we need to use a custom loadFunction to set the authentication header
+                         legendUrl.OnlineResource = gnMapServicesCache.authorizationFunctionLegend(mapservice, legendUrl);
+                       }
+                   }
+                }
+
+                legend = legendUrl.OnlineResource
               }
 
               if (angular.isDefined(getCapLayer.Attribution)) {

--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -25,8 +25,9 @@
   goog.provide('gn_cors_interceptor');
 
   goog.require('gn_urlutils_service');
+  goog.require('gn_map_service');
 
-  var module = angular.module('gn_cors_interceptor', ['gn_urlutils_service']);
+  var module = angular.module('gn_cors_interceptor', ['gn_urlutils_service', 'gn_map_service']);
 
   /**
    * CORS Interceptor
@@ -44,8 +45,9 @@
         'gnGlobalSettings',
         'gnLangs',
         'gnUrlUtils',
+        'gnMapServicesCache',
         '$templateCache',
-        function($q, $injector, gnGlobalSettings, gnLangs, gnUrlUtils, $templateCache) {
+        function($q, $injector, gnGlobalSettings, gnLangs, gnUrlUtils, gnMapServicesCache, $templateCache) {
           return {
             request: function(config) {
               // Do not manipulate url which are available in the template
@@ -57,6 +59,28 @@
                   config.url.indexOf(gnGlobalSettings.gnUrl) === 0 ||
                   (config.url.indexOf('http') !== 0 &&
                   config.url.indexOf('//') !== 0);
+
+              // If this is an authorized mapservice then we need to adjust the url or add auth headers
+              // Only check http url and exclude any urls like data: which should not be changed. Also, there is not need to check prox urls.
+              if (config.url !== null && config.url.startsWith("http") && !config.url.startsWith(gnGlobalSettings.proxyUrl)) {
+                 var mapservice = gnMapServicesCache.getMapservice(config.url);
+                 if (mapservice !== null) {
+                    if (mapservice.useProxy) {
+                       // If we are using a proxy then add it to the list of required proxies.
+                       if ($.inArray(url, gnGlobalSettings.requireProxy) === -1) {
+                         var url = config.url.split('/');
+                         url = url[0] + '/' + url[1] + '/' + url[2] + '/';
+                         gnGlobalSettings.requireProxy.push(url);
+                       }
+                    } else {
+                       // If we are not using a proxy then add the headers.
+                       // Note that is may still end up using the proxy if there is a cors issue.
+                       if (gnMapServicesCache.getAuthorizationHeaderValue(mapservice)) {
+                          config.headers['Authorization'] = gnMapServicesCache.getAuthorizationHeaderValue(mapservice);
+                       }
+                    }
+                 }
+              }
 
               //Add language headers manually or some servers fail
               if (isGnUrl && gnLangs.current &&

--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -66,7 +66,7 @@
                  var mapservice = gnMapServicesCache.getMapservice(config.url);
                  if (mapservice !== null) {
                     if (mapservice.useProxy) {
-                       // If we are using a proxy then add it to the list of required proxies.
+                       // If we need to use the proxy then add it to requireProxy list.
                        if ($.inArray(url, gnGlobalSettings.requireProxy) === -1) {
                          var url = config.url.split('/');
                          url = url[0] + '/' + url[1] + '/' + url[2] + '/';

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -175,8 +175,11 @@
             layer.getSource().updateParams({'STYLES': style.Name});
 
             // If this is an authorized mapservice then we need to adjust the url or add auth headers
-            // Only check http url and exclude any urls like data: which should not be changed. Also, there is not need to check prox urls.
-            if (style.LegendURL[0] !== null && style.LegendURL[0].OnlineResource !== null && style.LegendURL[0].OnlineResource.startsWith("http") && !style.LegendURL[0].OnlineResource.startsWith(gnGlobalSettings.proxyUrl)) {
+            // Only check http url and exclude any urls like data: which should not be changed. Also, there is not need to check proxy urls.
+            if (style.LegendURL[0] !== null &&
+              style.LegendURL[0].OnlineResource !== null &&
+              style.LegendURL[0].OnlineResource.startsWith("http") &&
+              !style.LegendURL[0].OnlineResource.startsWith(gnGlobalSettings.proxyUrl)) {
               var mapservice = gnMapServicesCache.getMapservice(style.LegendURL[0].OnlineResource);
 
               if (mapservice !== null) {
@@ -188,11 +191,11 @@
                   urlGetLegend = gnGlobalSettings.proxyUrl + encodeURIComponent(urlGetLegend);
                 } else {
                   // If not using the proxy then we need to use a custom loadFunction to set the authentication header
-                  var headerDict
+                  var headerDict;
                   if (gnMapServicesCache.getAuthorizationHeaderValue(mapservice)) {
                     headerDict = {
                       "Authorization": gnMapServicesCache.getAuthorizationHeaderValue(mapservice)
-                    }
+                    };
 
                     var requestOptions = {
                       headers: new Headers(headerDict),

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -141,7 +141,10 @@
    */
   module.directive('gnLayermanagerItem', [
     'gnMdView',
-    function(gnMdView) {
+    '$http',
+    'gnGlobalSettings',
+    'gnMapServicesCache',
+    function(gnMdView, $http, gnGlobalSettings, gnMapServicesCache) {
       return {
         require: '^gnLayermanager',
         restrict: 'A',
@@ -170,6 +173,55 @@
           };
           scope.setLayerStyle = function(layer, style) {
             layer.getSource().updateParams({'STYLES': style.Name});
+
+            // If this is an authorized mapservice then we need to adjust the url or add auth headers
+            // Only check http url and exclude any urls like data: which should not be changed. Also, there is not need to check prox urls.
+            if (style.LegendURL[0] !== null && style.LegendURL[0].OnlineResource !== null && style.LegendURL[0].OnlineResource.startsWith("http") && !style.LegendURL[0].OnlineResource.startsWith(gnGlobalSettings.proxyUrl)) {
+              var mapservice = gnMapServicesCache.getMapservice(style.LegendURL[0].OnlineResource);
+
+              if (mapservice !== null) {
+                // If this is an authorized mapservice then use authorization
+                var urlGetLegend = style.LegendURL[0].OnlineResource;
+
+                if (mapservice.useProxy) {
+                  // If we are using a proxy then adjust the url.
+                  urlGetLegend = gnGlobalSettings.proxyUrl + encodeURIComponent(urlGetLegend);
+                } else {
+                  // If not using the proxy then we need to use a custom loadFunction to set the authentication header
+                  var headerDict
+                  if (gnMapServicesCache.getAuthorizationHeaderValue(mapservice)) {
+                    headerDict = {
+                      "Authorization": gnMapServicesCache.getAuthorizationHeaderValue(mapservice)
+                    }
+
+                    var requestOptions = {
+                      headers: new Headers(headerDict),
+                      responseType: "blob"
+                    };
+                    legendPromise = $http.get(urlGetLegend, requestOptions).success(function (data, status, headers, config) {
+                      var contentType = headers('content-type');
+                      if (contentType.indexOf('image') === 0) {
+                        // encode data to base 64 url
+                        fileReader = new FileReader();
+                        fileReader.onload = function () {
+                          style.LegendURL[0].OnlineResource = fileReader.result;
+                          layer.set('legend', fileReader.result);
+                          layer.set('currentStyle', style);
+                        };
+                        fileReader.readAsDataURL(data);
+                      } else {
+                        console.log("Error getting legend image (" + contentType + ")");
+                        console.log(this.responseText);
+                      }
+                    }).error(function (data, status, headers, config) {
+                      console.log("Error getting legend image");
+                      console.log(this.responseText);
+                    });
+                    return legendPromise;
+                  }
+                }
+              }
+            }
             layer.set('legend', style.LegendURL[0].OnlineResource);
             layer.set('currentStyle', style);
           };

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -179,4 +179,16 @@
 
   <bean id="encryptorInitialiser"
         class="org.fao.geonet.EncryptorInitializer" />
+
+  <!-- Secured map services configuration -->
+  <!-- For security reasons BASIC auth will only allow userProxy=true as we don't want to expose the credentials in the javascript client -->
+  <util:list id="securedMapServices" value-type="org.fao.geonet.domain.mapservices.MapService">
+    <!-- Sample secured map services -->
+    <!--bean class="org.fao.geonet.domain.mapservices.MapService"
+          p:url="http://map1.com" p:useProxy="true" p:authType="BEARER"/-->
+
+    <!--bean class="org.fao.geonet.domain.mapservices.MapService"
+          p:url="http:\/\/map1[A-Z].com" p:useProxy="true" p:authType="BASIC" p:urlType="REGEXP" p:username="test" p:password="testpass"/-->
+  </util:list>
+
 </beans>


### PR DESCRIPTION
Add proxy mapviewer support for connecting to a secured map.

There are 2 methods for connecting to mapviewer securely.  

- Proxy which is simpler to implement however requires more hops to get the data so it is a little more slower. It is also the only option when connecting using basic auth for security reasons.

- Client side which is the faster option however more difficult to implement.

The first release will only include the proxy option and the client side option will be a separate PR in the future.

In our case, both geoserver and geonetwork are secured by keycloak security so we generally focused on using bearer token for the request. This allowed for better SSO integration.  Have not fully tested using basic authentication however that should work with mapservers that support basic authentication. 

To test, you need to add the mapservers that will require security in web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
