### PR TITLE
Add metadataPreRemove Event and publish this event during delete record.

### DIFF
--- a/events/src/main/java/org/fao/geonet/events/md/MetadataPreRemove.java
+++ b/events/src/main/java/org/fao/geonet/events/md/MetadataPreRemove.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.events.md;
+
+import org.fao.geonet.domain.AbstractMetadata;
+
+public class MetadataPreRemove extends MetadataEvent {
+    private static final long serialVersionUID = -2853271533747137586L;
+
+    public MetadataPreRemove(AbstractMetadata md) {
+        super(md);
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -64,6 +64,7 @@ import org.fao.geonet.domain.utils.ObjectJSONUtils;
 import org.fao.geonet.events.history.RecordCreateEvent;
 import org.fao.geonet.events.history.RecordDeletedEvent;
 import org.fao.geonet.events.history.RecordImportedEvent;
+import org.fao.geonet.events.md.MetadataPreRemove;
 import org.fao.geonet.exceptions.BadFormatEx;
 import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.exceptions.XSDValidationErrorEx;
@@ -215,6 +216,9 @@ public class MetadataInsertDeleteApi {
             approved=false;
         }
 
+        MetadataPreRemove preRemoveEvent = new MetadataPreRemove(metadata);
+        appContext.publishEvent(preRemoveEvent);
+
         store.delResources(context, metadata.getUuid(), approved);
         RecordDeletedEvent recordDeletedEvent = triggerDeletionEvent(request, metadata.getId() + "");
         metadataManager.deleteMetadata(context, metadata.getId() + "");
@@ -264,6 +268,9 @@ public class MetadataInsertDeleteApi {
                         && metadata.getDataInfo().getType() != MetadataType.TEMPLATE_OF_SUB_TEMPLATE && withBackup) {
                     MetadataUtils.backupRecord(metadata, context);
                 }
+
+                MetadataPreRemove preRemoveEvent = new MetadataPreRemove(metadata);
+                appContext.publishEvent(preRemoveEvent);
 
                 store.delResources(context, metadata.getUuid());
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -206,6 +206,9 @@ public class MetadataInsertDeleteApi {
         SearchManager searchManager = appContext.getBean(SearchManager.class);
         Store store = context.getBean("resourceStore", Store.class);
 
+        MetadataPreRemove preRemoveEvent = new MetadataPreRemove(metadata);
+        appContext.publishEvent(preRemoveEvent);
+
         if (metadata.getDataInfo().getType() != MetadataType.SUB_TEMPLATE
                 && metadata.getDataInfo().getType() != MetadataType.TEMPLATE_OF_SUB_TEMPLATE && withBackup) {
             MetadataUtils.backupRecord(metadata, context);
@@ -215,9 +218,6 @@ public class MetadataInsertDeleteApi {
         if (metadata instanceof MetadataDraft) {
             approved=false;
         }
-
-        MetadataPreRemove preRemoveEvent = new MetadataPreRemove(metadata);
-        appContext.publishEvent(preRemoveEvent);
 
         store.delResources(context, metadata.getUuid(), approved);
         RecordDeletedEvent recordDeletedEvent = triggerDeletionEvent(request, metadata.getId() + "");
@@ -264,13 +264,13 @@ public class MetadataInsertDeleteApi {
                     || metadataDraftRepository.findOneByUuid(uuid) != null) {
                 report.addNotEditableMetadataId(metadata.getId());
             } else {
+                MetadataPreRemove preRemoveEvent = new MetadataPreRemove(metadata);
+                appContext.publishEvent(preRemoveEvent);
+
                 if (metadata.getDataInfo().getType() != MetadataType.SUB_TEMPLATE
                         && metadata.getDataInfo().getType() != MetadataType.TEMPLATE_OF_SUB_TEMPLATE && withBackup) {
                     MetadataUtils.backupRecord(metadata, context);
                 }
-
-                MetadataPreRemove preRemoveEvent = new MetadataPreRemove(metadata);
-                appContext.publishEvent(preRemoveEvent);
 
                 store.delResources(context, metadata.getUuid());
 


### PR DESCRIPTION
The issue is we are customizing the recordDeletedEvent or MetadataRemove event listener to prevent the deletion if some condition is not met. Once the transaction failed, metadata will remain. However all store resources are deleted and there is no way to revert back. I attempt to put the store.delete 

https://github.com/geonetwork/core-geonetwork/blob/d4ace21808deb147933e7b42daecc7b38c59c188/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java#L193

below the deleteMetadata method
https://github.com/geonetwork/core-geonetwork/blob/d4ace21808deb147933e7b42daecc7b38c59c188/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java#L195

to delay the deletion. It will mess up the transaction.

So I decided to add new MetadataPreRemove event type and will use this event listener to do the transaction handling.