### PR TITLE
3.12.x.error.message.editor.controller.after.metadata.remove

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -125,8 +125,11 @@
               });
               deferred.resolve(data);
             }, function(reason) {
+              //check if reason.data.error is defined
+              var errorMsg = reason.data.error==null? reason.data.message : reason.data.error.message;
+
               $rootScope.$broadcast('StatusUpdated', {
-                title: $translate.instant(reason.data.message),
+                title: $translate.instant(errorMsg),
                 timeout: 0,
                 type: 'danger'
               });

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -126,7 +126,7 @@
               deferred.resolve(data);
             }, function(reason) {
               $rootScope.$broadcast('StatusUpdated', {
-                title: $translate.instant(reason.data.error.message),
+                title: $translate.instant(reason.data.message),
                 timeout: 0,
                 type: 'danger'
               });

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -554,11 +554,20 @@
                 closeEditor();
               }, function(reason) {
                 //check if reason.data.error is defined
-                var errorMsg = reason.data.error==null? reason.data.message : reason.data.error.message;
+                var errorMsg;
+                var errorDescription;
+                if (reason.data.error==null) {
+                  errorMsg = reason.data.message;
+                  errorDescription = reason.data.description;
+                } else {
+                  errorMsg = reason.data.error.message;
+                  errorDescription = reason.data.error.description;
+                }
+
 
                 $rootScope.$broadcast('StatusUpdated', {
                   title: $translate.instant(errorMsg),
-                  error: reason.data.error.description,
+                  error: errorDescription,
                   timeout: 0,
                   type: 'danger'
                 });

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -554,7 +554,7 @@
                 closeEditor();
               }, function(reason) {
                 $rootScope.$broadcast('StatusUpdated', {
-                  title: $translate.instant(reason.data.error.message),
+                  title: $translate.instant(reason.data.message),
                   error: reason.data.error.description,
                   timeout: 0,
                   type: 'danger'

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -553,8 +553,11 @@
                 });
                 closeEditor();
               }, function(reason) {
+                //check if reason.data.error is defined
+                var errorMsg = reason.data.error==null? reason.data.message : reason.data.error.message;
+
                 $rootScope.$broadcast('StatusUpdated', {
-                  title: $translate.instant(reason.data.message),
+                  title: $translate.instant(errorMsg),
                   error: reason.data.error.description,
                   timeout: 0,
                   type: 'danger'


### PR DESCRIPTION
The reason.data.error is not a valid according to ApiError class/JSON.

https://github.com/geonetwork/core-geonetwork/blob/d4ace21808deb147933e7b42daecc7b38c59c188/services/src/main/java/org/fao/geonet/api/ApiError.java#L36

Here is what the response JSON looks like:

![image](https://user-images.githubusercontent.com/74916635/132358574-6d3de4f7-ad4e-4439-9633-52c3390c0273.png)


So the HTTP500 will not be recognized in the popup error window. The simple fix I propose is to do "reason.data.message" instead.