### PR TITLE
Use the appropriate port for generating the baseURL by respecting the configured protocol

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
@@ -457,8 +457,13 @@ public class SettingManager {
         String baseURL = pathFinder.getBaseUrl();
         String protocol = getValue(Settings.SYSTEM_SERVER_PROTOCOL);
         String host = getValue(Settings.SYSTEM_SERVER_HOST);
-        String port = getValue(Settings.SYSTEM_SERVER_PORT);
 
+        if("https".equals(protocol)) {
+            String port = getValue(Settings.SYSTEM_SERVER_SECURE_PORT);
+        } else {
+            String port = getValue(Settings.SYSTEM_SERVER_PORT);
+        }
+        
         return protocol + "://" + host + (isPortRequired(protocol, port) ? ":" + port : "");
     }
 


### PR DESCRIPTION
I found this flaw while trying to configure the system correctly and created an issue for it: #5952 

I'm not positive if this is enough to fix the issue though. I don't know Java so please double check and review; don't trust me!