### PR TITLE
Check for Service Context language placeholder in AbstractStore implementations

### DIFF
--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -551,11 +551,12 @@ public class ServiceManager {
 
         HttpServletRequest request = getCurrentHttpRequest();
         if( request != null ) {
+            String iso3langCode = getIso3langCode( request.getLocale() );
             // reuse user session from http request
-            context = createServiceContext(name, "?", request);
+            context = createServiceContext(name, iso3langCode, request);
         }
         else {
-            // Not in an http request, creating a temporary user session wiht provided userId
+            // Not in an http request, creating a temporary user session with provided userId
             context = createServiceContext(name, applicationContext);
 
             UserRepository userRepository = applicationContext.getBean(UserRepository.class);
@@ -569,6 +570,33 @@ public class ServiceManager {
         context.setAsThreadLocal();
 
         return context;
+    }
+
+    /**
+     * Provide best-guess language code (covering special case for 'fra' and 'slk' locales).
+     * <p>
+     * Logic matches LanguageUtils from module services.
+     * </p>
+     *
+     * @param locale Locale used to obtain {@link Locale#getISO3Language()} three-letter abbreviation
+     * @return language code, or "?" for unknown
+     */
+    private static String getIso3langCode(Locale locale){
+        if( locale == null ){
+            return "?";
+        }
+        String iso3language = locale.getISO3Language();
+        String code;
+        if(iso3language.equalsIgnoreCase("fra")){
+            code = "fre";
+        }
+        else if (iso3language.equals("slk")){
+            code = "slo";
+        }
+        else {
+            code = iso3language;
+        }
+        return code;
     }
 
     /**

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -49,6 +49,7 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.Util;
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.exceptions.JeevesException;
 import org.fao.geonet.exceptions.NotAllowedEx;
@@ -583,7 +584,7 @@ public class ServiceManager {
      */
     private static String getIso3langCode(Locale locale){
         if( locale == null ){
-            return "?";
+            return Geonet.UNSPECIFIED_LANGUAGE;
         }
         String iso3language = locale.getISO3Language();
         String code;

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -586,7 +586,7 @@ public class CMISStore extends AbstractStore {
 
             if (metadataResourceExternalManagementPropertiesUrl.contains("{lang}") || metadataResourceExternalManagementPropertiesUrl.contains("{ISO3lang}")) {
                 final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
-                String contextLang = context.getLanguage() == null ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
+                String contextLang = (context.getLanguage() == null || "?".equals(context.getLanguage())) ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
                 String lang;
                 String iso3Lang;
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -586,7 +586,9 @@ public class CMISStore extends AbstractStore {
 
             if (metadataResourceExternalManagementPropertiesUrl.contains("{lang}") || metadataResourceExternalManagementPropertiesUrl.contains("{ISO3lang}")) {
                 final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
-                String contextLang = (context.getLanguage() == null || "?".equals(context.getLanguage())) ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
+                String contextLang = (context.getLanguage() == null || Geonet.UNSPECIFIED_LANGUAGE.equals(context.getLanguage()))
+                    ? Geonet.DEFAULT_LANGUAGE
+                    : context.getLanguage();
                 String lang;
                 String iso3Lang;
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -439,7 +439,9 @@ public class JCloudStore extends AbstractStore {
 
             if (metadataResourceExternalManagementPropertiesUrl.contains("{lang}") || metadataResourceExternalManagementPropertiesUrl.contains("{ISO3lang}")) {
                 final IsoLanguagesMapper mapper = context.getBean(IsoLanguagesMapper.class);
-                String contextLang = (context.getLanguage() == null || "?".equals(context.getLanguage())) ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
+                String contextLang = (context.getLanguage() == null || Geonet.UNSPECIFIED_LANGUAGE.equals(context.getLanguage()))
+                    ? Geonet.DEFAULT_LANGUAGE
+                    : context.getLanguage();
                 String lang;
                 String iso3Lang;
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -439,7 +439,7 @@ public class JCloudStore extends AbstractStore {
 
             if (metadataResourceExternalManagementPropertiesUrl.contains("{lang}") || metadataResourceExternalManagementPropertiesUrl.contains("{ISO3lang}")) {
                 final IsoLanguagesMapper mapper = context.getBean(IsoLanguagesMapper.class);
-                String contextLang = context.getLanguage() == null ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
+                String contextLang = (context.getLanguage() == null || "?".equals(context.getLanguage())) ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
                 String lang;
                 String iso3Lang;
 

--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -31,7 +31,7 @@ import javax.xml.XMLConstants;
 import jeeves.constants.Jeeves;
 
 /**
- * TODO javadoc.
+ * GeoNetwork constants.
  */
 public final class Geonet {
 
@@ -41,6 +41,7 @@ public final class Geonet {
     public static final String CONTEXT_NAME = "contextName";
     // TODO make this configurable
     public static final String DEFAULT_LANGUAGE = "eng";
+    public static final String UNSPECIFIED_LANGUAGE = "?";
 
     public static final String CC_API_REST_URL = "http://api.creativecommons.org/rest/1.5/simple/chooser";
     public static final String LUCENE_LOCALE_KEY = "_locale";

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -255,7 +255,7 @@ public class ApiUtils {
      */
     static public ServiceContext createServiceContext(HttpServletRequest request) {
         String iso3langCode = ApplicationContextHolder.get().getBean(LanguageUtils.class)
-            .getIso3langCode(request.getLocales());
+            .iso3code(request.getLocales());
         return createServiceContext(request, iso3langCode);
     }
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -566,7 +566,7 @@ public class MetadataApi {
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
 
-        String language = languageUtils.getIso3langCode(request.getLocales());
+        String language = languageUtils.iso3code(request.getLocales());
 
         // TODO PERF: ByPass XSL processing and create response directly
         // At least for related metadata and keep XSL only for links

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -266,7 +266,7 @@ public class MetadataWorkflowApi {
                                      @ApiIgnore
                                      @ApiParam(hidden = true) HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request,
-            languageUtils.getIso3langCode(request.getLocales()));
+            languageUtils.iso3code(request.getLocales()));
 
         boolean isMdWorkflowEnable = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
 
@@ -364,7 +364,7 @@ public class MetadataWorkflowApi {
     public void setStatus(@ApiParam(value = API_PARAM_RECORD_UUID, required = true) @PathVariable String metadataUuid,
             @ApiParam(value = "Metadata status", required = true) @RequestBody(required = true) MetadataStatusParameter status,
             HttpServletRequest request) throws Exception {
-      try (ServiceContext context = ApiUtils.createServiceContext(request, languageUtils.getIso3langCode(request.getLocales()))) {
+      try (ServiceContext context = ApiUtils.createServiceContext(request, languageUtils.iso3code(request.getLocales()))) {
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, context);
         boolean isMdWorkflowEnable = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
 

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -557,7 +557,7 @@ public class MetadataEditingApi {
         gui.addContent(new Element("currTab").setText(tab));
         // This flag is used to generate top tool bar or not
         gui.addContent(new Element("reqService").setText(embedded ? "embedded" : "md.edit"));
-        String iso3langCode = languageUtils.getIso3langCode(request.getLocales());
+        String iso3langCode = languageUtils.iso3code(request.getLocales());
         gui.addContent(new Element("language").setText(iso3langCode));
         gui.addContent(getSchemaStrings(schema, context));
 

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -277,8 +277,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         if (formatType == null) {
             formatType = FormatType.xml;
         }
-
-        String language = LanguageUtils.locale2gnCode(locale.getISO3Language());
+        String language = LanguageUtils.iso3code(locale);
         if (StringUtils.isNotEmpty(iso3lang)) {
             language = LanguageUtils.locale2gnCode(iso3lang);
         }
@@ -340,7 +339,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
                 context.getBean(DataManager.class).increasePopularity(context, String.valueOf(metadata.getId()));
             }
             writeOutResponse(context, metadataUuid,
-                LanguageUtils.locale2gnCode(locale.getISO3Language()),
+                LanguageUtils.iso3code(locale),
                 request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
         }
       }

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
@@ -126,7 +126,7 @@ public class SchemaLocalizations {
         final ServiceContext serviceContext = ServiceContext.get();
         final String lang3 = serviceContext != null ?
             serviceContext.getLanguage() :
-            appContext.getBean(LanguageUtils.class).getIso3langCode(request.getLocales());
+            appContext.getBean(LanguageUtils.class).iso3code(request.getLocales());
         return create(schema, lang3);
     }
 

--- a/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
@@ -146,7 +146,7 @@ public class RegionsApi {
         HttpServletRequest request) throws Exception {
 
       try (ServiceContext context = ApiUtils.createServiceContext(request)) {
-        String language = languageUtils.getIso3langCode(request.getLocales());
+        String language = languageUtils.iso3code(request.getLocales());
         Collection<RegionsDAO> daos = ApplicationContextHolder.get().getBeansOfType(RegionsDAO.class).values();
         List<Category> response = new ArrayList<>();
         for (RegionsDAO dao : daos) {

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -217,7 +217,7 @@ public class SiteApi {
         }
         if (source != null) {
             final List<Setting> settings = response.getSettings();
-            String iso3langCode = languageUtils.getIso3langCode(request.getLocales());
+            String iso3langCode = languageUtils.iso3code(request.getLocales());
 
             settings.add(
                 new Setting().setName(Settings.NODE_DEFAULT)

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
@@ -52,28 +52,41 @@ public class LanguageUtils {
 //        }
 //    }
 
+    /**
+     * Review provided, and return the first supported one (or default language if none are acceptable).
+     * @param listOfLocales Locales to parse
+     * @return supported locale from the provided list, or default language if none are acceptable
+     */
     public Locale parseAcceptLanguage(final Enumeration<Locale> listOfLocales) {
         while (listOfLocales.hasMoreElements()) {
-            Locale l = listOfLocales.nextElement();
-            if (iso3code.contains(locale2gnCode(l.getISO3Language()))) {
-                return l;
+            Locale locale = listOfLocales.nextElement();
+            if (iso3code.contains(iso3code(locale))) {
+                return locale;
             }
         }
         return Locale.forLanguageTag(defaultLanguage);
     }
-
+    /**
+     * Review provided, and return the iso3code of the first selected one.
+     * @param locales Locales to check
+     * @return iso3code of the selected locale, or iso3code of the default language if none are acceptable
+     */
     public String getIso3langCode(Enumeration<Locale> locales) {
-        Locale l = parseAcceptLanguage(locales);
-        return locale2gnCode(l.getISO3Language());
+        Locale locale = parseAcceptLanguage(locales);
+        return iso3code(locale);
     }
 
     /**
      * Translate locale three-letter abbreviation to language code (providing a special case for 'fra' and 'slk' locales.
      *
-     * @param code Locale {@link Locale#getISO3Language()} three-letter abbreviation
-     * @return language code
+     * @param locale Locale, the {@link Locale#getISO3Language()} three-letter abbreviation is adjusted to an iso3code
+     * @return iso3code bsaed on {@link Locale#getISO3Language()}, converting fra to fre or slk to slo as required.
      */
-    static public String locale2gnCode (String code) {
+    static String iso3code(Locale locale) {
+        if( locale == null ){
+            return null;
+        }
+        String code = locale.getISO3Language();
         if (code.equals("fra")) {
             return "fre";
         } else if (code.equals("slk")) { // transforms ISO 639-2/T into ISO 639-2/B
@@ -83,6 +96,11 @@ public class LanguageUtils {
         }
     }
 
+    /**
+     * Review provided locale, and check if it is supported.
+     * @param locale Locale to check
+     * @return  provided locale if acceptable, or the default language as a fallback
+     */
     public Locale parseAcceptLanguage(final Locale locale) {
         Vector<Locale> locales = new Vector<>();
         locales.add(locale);

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
@@ -54,6 +54,7 @@ public class LanguageUtils {
 
     /**
      * Review provided, and return the first supported one (or default language if none are acceptable).
+     *
      * @param listOfLocales Locales to parse
      * @return supported locale from the provided list, or default language if none are acceptable
      */
@@ -66,34 +67,51 @@ public class LanguageUtils {
         }
         return Locale.forLanguageTag(defaultLanguage);
     }
+    @Deprecated
+    public String getIso3langCode(Enumeration<Locale> locales){
+        return iso3code(locales);
+    }
+
     /**
      * Review provided, and return the iso3code of the first selected one.
+     *
      * @param locales Locales to check
      * @return iso3code of the selected locale, or iso3code of the default language if none are acceptable
      */
-    public String getIso3langCode(Enumeration<Locale> locales) {
+    public String iso3code(Enumeration<Locale> locales) {
         Locale locale = parseAcceptLanguage(locales);
         return iso3code(locale);
     }
 
     /**
-     * Translate locale three-letter abbreviation to language code (providing a special case for 'fra' and 'slk' locales.
+     * Converts from {@link Locale#getISO3Language()} 639-2/T langauge code into GeoNetwork ISO Language 639-2/B representation.
      *
-     * @param locale Locale, the {@link Locale#getISO3Language()} three-letter abbreviation is adjusted to an iso3code
-     * @return iso3code bsaed on {@link Locale#getISO3Language()}, converting fra to fre or slk to slo as required.
+     * @param isoLanguage_638_2_T_code Java {@link Locale#getISO3Language()} 639-2/T language code
+     * @return Geonetwork ISO 639-2/B language code
      */
-    static String iso3code(Locale locale) {
-        if( locale == null ){
-            return null;
-        }
-        String code = locale.getISO3Language();
-        if (code.equals("fra")) {
+    public static String locale2gnCode(String isoLanguage_638_2_T_code){
+        if (isoLanguage_638_2_T_code.equals("fra")) {
             return "fre";
-        } else if (code.equals("slk")) { // transforms ISO 639-2/T into ISO 639-2/B
+        } else if (isoLanguage_638_2_T_code.equals("slk")) { // transforms ISO 639-2/T into ISO 639-2/B
             return "slo";
         } else {
-            return code;
+            return isoLanguage_638_2_T_code;
         }
+    }
+
+    /**
+     * Obtain into GeoNetwork ISO Language 639-2/B representation for locale.
+     *
+     * Translate locale three-letter abbreviation to language code (providing a special case for 'fra' and 'slk' locales.
+     *
+     * @param locale Locale, providing {@link Locale#getISO3Language()} 639-2/T language code
+     * @return Geonetwork ISO 639-2/B language code
+     */
+    public static String iso3code(Locale locale) {
+        if (locale == null){
+            return null;
+        }
+        return locale2gnCode(locale.getISO3Language());
     }
 
     /**

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
@@ -67,6 +67,12 @@ public class LanguageUtils {
         return locale2gnCode(l.getISO3Language());
     }
 
+    /**
+     * Translate locale three-letter abbreviation to language code (providing a special case for 'fra' and 'slk' locales.
+     *
+     * @param code Locale {@link Locale#getISO3Language()} three-letter abbreviation
+     * @return language code
+     */
     static public String locale2gnCode (String code) {
         if (code.equals("fra")) {
             return "fre";

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
@@ -128,8 +128,7 @@ public class TranslationApi implements ApplicationContextAware {
 
         validateParameters(type);
 
-        Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
-        String language = languageUtils.locale2gnCode(locale.getISO3Language());
+        String language = languageUtils.iso3code(request.getLocales());
 
         if (type == null || type.contains("StatusValue")) {
             List<StatusValue> valueList = statusValueRepository.findAll();


### PR DESCRIPTION
ServiceContext makes use of `?` when the current language cannot be determined. This occurs when a ServiceContext has been generated for use in a background process and does not have direct access to an HTTPRequest (from the user initiating the activity).

This pull request asks AbstractStore implementations to check for both `?` and `null`, and make use of the default language when running in a background process.

See https://github.com/geonetwork/core-geonetwork/issues/5939 for background information.