### PR TITLE
Small fix for long titles on `Topic` blocks

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
@@ -73,6 +73,7 @@
           line-height: 1.3em;
           vertical-align: middle;
           font-weight: normal;
+          word-break: break-all;
         }
         &:hover {
           text-decoration: none;


### PR DESCRIPTION
Long titles on the `Topic` blocks (on the homepage) without spaces were not displayed correctly, the change in this PR will fix this.

**Before**
<img width="803" alt="gn-long-title-before" src="https://user-images.githubusercontent.com/19608667/133082507-54ebf40b-efe0-47b4-b24b-cd622713a90f.png">

**After**
<img width="805" alt="gn-long-title-after" src="https://user-images.githubusercontent.com/19608667/133082531-af9142f2-a73f-4ebc-9cb0-9071995a9fc3.png">
