### PR TITLE
[3.12.x] Always show label on the Validate button in the editor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/validationtools/partials/mdValidationTools.html
+++ b/web-ui/src/main/resources/catalog/components/validationtools/partials/mdValidationTools.html
@@ -1,73 +1,60 @@
-<span>
+<div class="btn-group">
   <button type="button" class="btn btn-default navbar-btn"
-          data-ng-show="!isInspireValidationEnabled"
-          title="{{'validate'|translate}}"
+          title="{{'validate-help'|translate}}"
           data-gn-click-and-spin="save(true, true)">
-    <i class="fa fa-check"/>&nbsp;
+    <i data-ng-show="!isDownloadingRecord" class="fa fa-check"/>
+    <i data-ng-show="isDownloadingRecord" class="fa fa-spinner fa-spin"/>
     <span class="visible-lg" data-translate=""
           title="{{'validate-help' | translate}}">validate</span>
   </button>
-
-
-  <div class="btn-group" data-ng-show="isInspireValidationEnabled">
-    <button class="btn btn-default dropdown-toggle" type="button"
-            data-toggle="dropdown" aria-expanded="true">
-      <i data-ng-show="!isDownloadingRecord" class="fa fa-check"/>
-      <i
-        data-ng-show="isDownloadingRecord" class="fa fa-spinner fa-spin"/>
-      <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu" role="menu">
-      <li role="presentation"><a role="menuitem" tabindex="-1"
-                                 data-gn-click-and-spin="save(true, true)"
-                                 title="{{'validate-help' | translate}}">
-        <i class="fa fa-check"/>&nbsp;
-          <span
-            class="visible-lg" data-translate="">validate</span>
-      </a>
-      </li>
-      <li class="divider"></li>
-      <li class="dropdown-header">
-        <span class="visible-lg"
-              data-translate="">validate-inspire</span></li>
-      <li class="dropdown-header">
-        <span data-translate="">lastInspireValidationStatus</span>
-        <gn-md-type-inspire-validation-widget metadata="md"></gn-md-type-inspire-validation-widget>
-      </li>
-      <li role="presentation" data-ng-show="!isDownloadingRecord"
-          data-ng-repeat="(key,value) in testsuites">
-        <a
-          role="menuitem" tabindex="-1"
-          data-gn-click-and-spin="validateInspire(key)"
-          title="{{'validate-inspire-help' | translate}} {{value.join(', ')}}">
-          <i
-            class="fa fa-chevron-right"/>&nbsp;
-
-          <span>{{key}}</span>
-      </a>
-      </li>
-
-      <li role="presentation" data-ng-show="isDownloadingRecord">
-        <a
-          role="menuitem" tabindex="-1"
-          data-gn-click-and-spin="validateInspire()"
-          title="{{'validate-inspire-help' | translate}}">
+  <button class="btn btn-default navbar-btn dropdown-toggle"
+          type="button"
+          data-toggle="dropdown"
+          aria-expanded="true"
+          data-ng-show="isInspireValidationEnabled">
+    <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" role="menu" data-ng-show="isInspireValidationEnabled">
+    <li class="dropdown-header">
+      <span class="visible-lg"
+            data-translate="">validate-inspire</span></li>
+    <li class="dropdown-header">
+      <span data-translate="">lastInspireValidationStatus</span>
+      <gn-md-type-inspire-validation-widget metadata="md"></gn-md-type-inspire-validation-widget>
+    </li>
+    <li role="presentation" data-ng-show="!isDownloadingRecord"
+        data-ng-repeat="(key,value) in testsuites">
+      <a
+        role="menuitem" tabindex="-1"
+        data-gn-click-and-spin="validateInspire(key)"
+        title="{{'validate-inspire-help' | translate}} {{value.join(', ')}}">
         <i
-          class="fa fa-spinner fa-spin"/>&nbsp;
-          <span class="visible-lg"
-                data-translate="">reportGeneration</span>
-      </a>
-      </li>
-      <li role="presentation" data-ng-show="isDownloadedRecord">
-        <a role="menuitem"
-           tabindex="-1" target="_blank" href="{{reportURL}}"
-           title="{{'validate-inspire-help' | translate}}">
-          <i
-            class="fa fa-fw fa-file fa-inspire"/>&nbsp;
-          <span class="visible-lg"
-                data-translate="">reportLink</span> - {{reportStatus}}
-      </a>
-      </li>
-    </ul>
-  </div>
-</span>
+          class="fa fa-chevron-right"/>&nbsp;
+
+        <span>{{key}}</span>
+    </a>
+    </li>
+
+    <li role="presentation" data-ng-show="isDownloadingRecord">
+      <a
+        role="menuitem" tabindex="-1"
+        data-gn-click-and-spin="validateInspire()"
+        title="{{'validate-inspire-help' | translate}}">
+      <i
+        class="fa fa-spinner fa-spin"/>&nbsp;
+        <span class="visible-lg"
+              data-translate="">reportGeneration</span>
+    </a>
+    </li>
+    <li role="presentation" data-ng-show="isDownloadedRecord">
+      <a role="menuitem"
+         tabindex="-1" target="_blank" href="{{reportURL}}"
+         title="{{'validate-inspire-help' | translate}}">
+        <i
+          class="fa fa-fw fa-file fa-inspire"/>&nbsp;
+        <span class="visible-lg"
+              data-translate="">reportLink</span> - {{reportStatus}}
+    </a>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
The `Validate` button on the toolbar in the editor sometimes misses a label, this happens when `Inspire` is enabled and an Inspire validator is entered in the admin display.

This PR splits the button, the `Validate` button with label is always visible, Inspire or no Inspire. When Inspire is enabled the dropdown menu is shown, but now without the `Validate` option because that's already in the main button.

<img width="431" alt="gn-validate-button-label" src="https://user-images.githubusercontent.com/19608667/134494718-ad0e929b-cb8d-4f40-abc5-2cb2af766a76.png">


Changes:
Add a split button for `Validate` in the 'edit' toolbar so the label is always displayed (wether the submenu is there or not).