### PR TITLE
Reset search parameter after metadata status change to "approved"

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -97,6 +97,11 @@
                 '/status', scope.newStatus
             ).then(
                 function(response) {
+                  //After the new status is approved, the working copy will get deleted and will not get searched.
+                  //The search parameter will need to reset to draft=n
+                  if (angular.isDefined(scope.md.draft) && scope.newStatus.status === "2") {
+                    scope.md.draft = "n";
+                  }
                   gnMetadataManager.updateMdObj(scope.md);
                   scope.$emit('metadataStatusUpdated', true);
                   scope.$emit('StatusUpdated', {


### PR DESCRIPTION
This fix is related to https://github.com/geonetwork/core-geonetwork/issues/5963

The cause is when working copy gets approved, the draft (work copying) will get removed from server side. However the Angular is still trying to pass parameter draft=y (for example: http://localhost:8080/geonetwork/srv/eng/qi?_uuid=8fc530bf-d954-4afd-8f10-43dfced9f6c3&fast=index&_content_type=json&buildSummary=false&_draft=y) to the search engine. As result it is not searchable and page will be stuck.

I modify the Angular code to check if the returning metadata status from the HTTP response if it's "approved", then force the draft parameter to be "n". In reality, once any record is approved, the draft will not exist anymore.