### PR TITLE
Validation / INSPIRE / Fix when setting is 'null'

### DIFF
--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -71,7 +71,7 @@
                     angular.isString(gnConfig['system.inspire.remotevalidation.url']) &&
                     gnCurrentEdit.schema.match(/iso19139|iso19115-3/) != null;
 
-                  scope.validationNode = gnConfig['system.inspire.remotevalidation.nodeid'];
+                  scope.validationNode = gnConfig['system.inspire.remotevalidation.nodeid'] || '';
                 });
               });
 
@@ -82,8 +82,8 @@
                   scope.token = null;
                   var url = '../api/records/' + scope.inspMdUuid +
                     '/validate/inspire?testsuite=' + test;
-                  if (angular.isDefined(scope.validationNode) && scope.validationNode !== '') {
-                    url += '&mode=' + scope.validationNode;
+                  if (angular.isDefined(mode) && mode !== '') {
+                    url += '&mode=' + mode;
                   }
                   $http({
                     method: 'PUT',


### PR DESCRIPTION
Fixes https://github.com/geonetwork/core-geonetwork/issues/5969

Workaround set node id to 'srv' or 'csw' to use the default node for the validation.