### PR TITLE
ldapsync - do not add a criteria on users if usernames is empty

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPSynchronizerJob.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPSynchronizerJob.java
@@ -172,11 +172,15 @@ public class LDAPSynchronizerJob extends QuartzJobBean {
         final UserRepository userRepository = applicationContext.getBean(UserRepository.class);
         final UserGroupRepository userGroupRepository = applicationContext.getBean(UserGroupRepository.class);
         final IMetadataUtils metadataRepository = applicationContext.getBean(IMetadataUtils.class);
-        final Specification<User> spec = Specification.where(
+        Specification<User> spec = Specification.where(
             UserSpecs.hasAuthType(LDAPConstants.LDAP_FLAG)
-        ).and(
-            Specification.not(UserSpecs.userIsNameNotOneOf(usernames))
         );
+
+        if (! usernames.isEmpty()) {
+         spec = spec.and(
+                Specification.not(UserSpecs.userIsNameNotOneOf(usernames))
+            );
+        }
 
         final List<User> usersFound = userRepository.findAll(spec);
         Collection<Integer> userIds = Collections2.transform(usersFound, new Function<User, Integer>() {


### PR DESCRIPTION
Adding a criteria with a `IN()` / `NOT IN()` construct, and passing an empty
collection will result to an invalid generated SQL statement, as the IN
/ NOT IN filter will be empty (e.g. `SELECT ... WHERE .. IN ();`).

Avoiding to add an extra criteria if usernames is empty.

Tests: runtime, without the modification, an exception is thrown because
of invalid SQL sent to our postgresql, ok with the current one.

Testsuite ok:

```
$ mvn clean install
[...]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for GeoNetwork opensource 4.0.6-SNAPSHOT:
[INFO] 
[INFO] GeoNetwork opensource .............................. SUCCESS [  0.486 s]
[INFO] GeoNetwork common utils ............................ SUCCESS [  6.014 s]
[INFO] Caching xslt module ................................ SUCCESS [  0.113 s]
[INFO] ArcSDE module (dummy-api) .......................... SUCCESS [  0.143 s]
[INFO] GeoNetwork domain .................................. SUCCESS [  7.773 s]
[INFO] Oaipmh modules ..................................... SUCCESS [  0.279 s]
[INFO] GeoNetwork Events .................................. SUCCESS [  0.147 s]
[INFO] GeoNetwork schema plugins .......................... SUCCESS [  0.014 s]
[INFO] GeoNetwork schema plugins core ..................... SUCCESS [  0.240 s]
[INFO] GeoNetwork schema plugin for ISO19139/119 standards  SUCCESS [  3.198 s]
[INFO] Index module ....................................... SUCCESS [  0.390 s]
* [INFO] GeoNetwork core .................................... SUCCESS [01:04 min]
[INFO] GeoNetwork Events .................................. SUCCESS [  0.315 s]
[INFO] GeoNetwork schema plugin for Dublin Core records retrieved by CSW SUCCESS [  0.080 s]
[INFO] GeoNetwork schema plugin for Dublin Core standard .. SUCCESS [  0.140 s]
[INFO] GeoNetwork schema plugin for ISO19110 standard ..... SUCCESS [  0.139 s]
[INFO] GeoNetwork schema plugin for ISO19115-3:2018 standard SUCCESS [  0.378 s]
[INFO] GeoNetwork CSW server .............................. SUCCESS [  7.963 s]
[INFO] GeoNetwork harvesters .............................. SUCCESS [  6.769 s]
[INFO] GeoNetwork health monitor .......................... SUCCESS [  0.403 s]
[INFO] GeoNetwork Digital Object Identifier (DOI) client .. SUCCESS [  0.369 s]
[INFO] GeoNetwork services ................................ SUCCESS [ 30.108 s]
[INFO] Geonetwork Web Resources 4 Java .................... SUCCESS [  5.340 s]
[INFO] GeoNetwork INSPIRE Atom ............................ SUCCESS [  0.742 s]
[INFO] GeoNetwork index using Elasticsearch ............... SUCCESS [  0.007 s]
[INFO] GeoNetwork dashboard app based on Kibana ........... SUCCESS [  0.022 s]
[INFO] Release module ..................................... SUCCESS [  0.028 s]
[INFO] gn-messaging ....................................... SUCCESS [  0.128 s]
[INFO] gn-workers ......................................... SUCCESS [  0.006 s]
[INFO] WFS features harvester ............................. SUCCESS [  0.602 s]
[INFO] gn-camelPeriodicProducer ........................... SUCCESS [ 25.848 s]
[INFO] gn-es-test ......................................... SUCCESS [  0.762 s]
[INFO] GeoNetwork Slave ................................... SUCCESS [  0.380 s]
[INFO] Tests for schema plugins ........................... SUCCESS [  4.741 s]
[INFO] GeoNetwork user interface module ................... SUCCESS [  2.704 s]
[INFO] GeoNetwork Web module .............................. SUCCESS [ 53.343 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:44 min
[INFO] Finished at: 2021-09-28T12:23:03+02:00

```