### PR TITLE
Used nv-i18n library to add better support for iso639-2/T iso639-2/B support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -491,6 +491,10 @@
       <version>4.3.23</version>
     </dependency>
     <dependency>
+      <groupId>com.neovisionaries</groupId>
+      <artifactId>nv-i18n</artifactId>
+    </dependency>
+    <dependency>
       <groupId>opendap</groupId>
       <artifactId>opendap</artifactId>
       <version>2.1</version>

--- a/core/src/main/java/org/fao/geonet/languages/IsoLanguagesMapper.java
+++ b/core/src/main/java/org/fao/geonet/languages/IsoLanguagesMapper.java
@@ -152,8 +152,8 @@ public class IsoLanguagesMapper {
             // If we could not find the code then just return the original code.
             return iso639_2B;
         } else {
-            return code.getAlpha3().getAlpha3B().name();
-}
+            return code.getAlpha3().getAlpha3T().name();
+        }
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/languages/IsoLanguagesMapper.java
+++ b/core/src/main/java/org/fao/geonet/languages/IsoLanguagesMapper.java
@@ -27,6 +27,7 @@ import org.fao.geonet.repository.IsoLanguageRepository;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.neovisionaries.i18n.LanguageCode;
 
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -139,6 +140,32 @@ public class IsoLanguagesMapper {
             return defaultLang.toLowerCase();
         } else {
             return result;
+        }
+    }
+
+    /**
+     * Convert the iso639_2B to iso639_2T
+     */
+    public static String iso639_2B_to_iso639_2T(String iso639_2B) {
+        LanguageCode code = LanguageCode.getByCode(iso639_2B);
+        if (code == null) {
+            // If we could not find the code then just return the original code.
+            return iso639_2B;
+        } else {
+            return code.getAlpha3().getAlpha3B().name();
+}
+    }
+
+    /**
+     * Convert the iso639_2T to iso639_2B
+     */
+    public static String iso639_2T_to_iso639_2B(String iso639_2T) {
+        LanguageCode code = LanguageCode.getByCode(iso639_2T);
+        if (code == null) {
+            // If we could not find the code then just return the original code.
+            return iso639_2T;
+        } else {
+            return code.getAlpha3().getAlpha3B().name();
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.io.Files;
+import com.neovisionaries.i18n.LanguageCode;
 
 import org.fao.geonet.api.records.attachments.FilesystemStoreResourceContainer;
 import org.fao.geonet.api.records.attachments.Store;
@@ -803,6 +804,30 @@ public final class XslUtil {
     }
 
     /**
+     * Convert the iso639_2B to iso639_2T
+     *
+     * @param iso639_2B The 3 iso lang code B
+     * @return The iso639_2T lang code
+     */
+    public static
+    @Nonnull
+    String iso639_2B_to_iso639_2T(String iso639_2B) {
+        return IsoLanguagesMapper.iso639_2B_to_iso639_2T(iso639_2B);
+    }
+
+    /**
+     * Convert the iso639_2T to iso639_2B
+     *
+     * @param iso639_2T The 3 iso lang code T
+     * @return The iso639_2B lang code
+     */
+    public static
+    @Nonnull
+    String iso639_2T_to_iso639_2B(String iso639_2T) {
+        return IsoLanguagesMapper.iso639_2T_to_iso639_2B(iso639_2T);
+    }
+
+    /**
      * Return 2 iso lang code from a 3 iso lang code. If any error occurs return "".
      *
      * @param iso3LangCode The 2 iso lang code
@@ -815,7 +840,7 @@ public final class XslUtil {
     }
 
     /**
-     * Return 2 iso lang code from a 3 iso lang code. If any error occurs return "".
+     * Return 2 char iso lang code in uppercase from a 3 iso lang code.
      *
      * @param iso3LangCode The 2 iso lang code
      * @return The related 3 iso lang code
@@ -827,44 +852,27 @@ public final class XslUtil {
             if (defaultValue != null) {
                 return defaultValue;
             } else {
-                return twoCharLangCode(Geonet.DEFAULT_LANGUAGE);
+                iso3LangCode = Geonet.DEFAULT_LANGUAGE;
             }
+        }
+        String iso2LangCode = null;
+
+        // Catch language entries longer than 3 characters with a semicolon
+        if (iso3LangCode.length() > 3 && (iso3LangCode.indexOf(';') != -1)) {
+            iso3LangCode = iso3LangCode.substring(0, 3);
+        }
+
+        LanguageCode languageCode = LanguageCode.getByCode(iso3LangCode.toLowerCase());
+        if (languageCode != null) {
+            iso2LangCode = languageCode.name();
+        }
+
+        // Triggers when the language can't be matched to a code
+        if (iso2LangCode == null) {
+            Log.error(Geonet.GEONETWORK, "Cannot convert " + iso3LangCode + " to 2 char iso lang code", new Error());
+            return iso3LangCode.substring(0, 2);
         } else {
-            if (iso3LangCode.equalsIgnoreCase("FRA")) {
-                return "FR";
-            }
-
-            if (iso3LangCode.equalsIgnoreCase("DEU")) {
-                return "DE";
-            }
-            String iso2LangCode = null;
-
-            try {
-                final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
-                /*if the language  is 2 characters long...*/
-                if (iso3LangCode.length() == 2) {
-                    iso2LangCode = iso3LangCode;
-                    /*Catch language entries longer than 3 characters with a semicolon*/
-                } else if (iso3LangCode.length() > 3 && (iso3LangCode.indexOf(';') != -1)) {
-                    iso2LangCode = mapper.iso639_2_to_iso639_1(iso3LangCode.substring(0, 3));
-                    /** This final else works properly for languages with exactly three characters, so
-                     * an exception will occur if gmd:language has more than 3 characters but
-                     * does not have a semicolon.
-                     */
-                } else {
-                    iso2LangCode = mapper.iso639_2_to_iso639_1(iso3LangCode);
-                }
-            } catch (Exception ex) {
-                Log.error(Geonet.GEONETWORK, "Failed to get iso 2 language code for " + iso3LangCode + " caused by " + ex.getMessage());
-
-            }
-            /* Triggers when the language can't be matched to a code */
-            if (iso2LangCode == null) {
-                Log.error(Geonet.GEONETWORK, "Cannot convert " + iso3LangCode + " to 2 char iso lang code", new Error());
-                return iso3LangCode.substring(0, 2);
-            } else {
-                return iso2LangCode;
-            }
+            return iso2LangCode;
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -840,7 +840,7 @@ public final class XslUtil {
     }
 
     /**
-     * Return 2 char iso lang code in uppercase from a 3 iso lang code.
+     * Return 2 char iso lang code from a 3 iso lang code.
      *
      * @param iso3LangCode The 2 iso lang code
      * @return The related 3 iso lang code
@@ -859,7 +859,9 @@ public final class XslUtil {
 
         // Catch language entries longer than 3 characters with a semicolon
         if (iso3LangCode.length() > 3 && (iso3LangCode.indexOf(';') != -1)) {
-            iso3LangCode = iso3LangCode.substring(0, 3);
+            //This will extract text similar to the following "fr;CAN", "fra;CAN", "fr ;CAN"
+            //In the case of "fr;CAN",  fr would be extracted even though it is not a 3 char code - but that is ok because LanguageCode.getByCode supports 2 and 3 char codes.
+            iso3LangCode = iso3LangCode.split(";")[0].trim();
         }
 
         LanguageCode languageCode = LanguageCode.getByCode(iso3LangCode.toLowerCase());

--- a/pom.xml
+++ b/pom.xml
@@ -936,6 +936,11 @@
         <version>${spring.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.neovisionaries</groupId>
+        <artifactId>nv-i18n</artifactId>
+        <version>1.29</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
         <version>${spring.version}</version>

--- a/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java
@@ -53,6 +53,7 @@ import org.fao.geonet.kernel.mef.MEFLib;
 import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.util.XslUtil;
 import org.fao.geonet.utils.Log;
@@ -138,7 +139,8 @@ public class CatalogApi {
     EsHTTPProxy esHTTPProxy;
     @Autowired
     LanguageUtils languageUtils;
-
+    @Autowired
+    IsoLanguagesMapper isoLanguagesMapper;
     /*
      * <p>Retrieve all parameters (except paging parameters) as a string.</p>
      */
@@ -447,7 +449,7 @@ public class CatalogApi {
         });
 
         Locale locale = languageUtils.parseAcceptLanguage(httpRequest.getLocales());
-        String language = LanguageUtils.locale2gnCode(locale.getISO3Language());
+        String language = isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
         language = XslUtil.twoCharLangCode(language, "eng").toLowerCase();
 
         new XsltResponseWriter("env", "search")

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -111,6 +111,9 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
     @Autowired
     LanguageUtils languageUtils;
 
+    @Autowired
+    IsoLanguagesMapper isoLanguagesMapper;
+
     /**
      * Map (canonical path to formatter dir -> Element containing all xml files in Formatter
      * bundle's loc directory)
@@ -240,10 +243,9 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
             formatType = FormatType.xml;
         }
 
-
-        String language = LanguageUtils.locale2gnCode(locale.getISO3Language());
+        String language = isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
         if (StringUtils.isNotEmpty(iso3lang)) {
-            language = LanguageUtils.locale2gnCode(iso3lang);
+            language = isoLanguagesMapper.iso639_2T_to_iso639_2B(iso3lang);
         }
 
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, servletRequest);
@@ -302,7 +304,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
                 context.getBean(DataManager.class).increasePopularity(context, String.valueOf(metadata.getId()));
             }
             writeOutResponse(context, metadataUuid,
-                LanguageUtils.locale2gnCode(locale.getISO3Language()),
+                isoLanguagesMapper.iso639_2B_to_iso639_2T(locale.getISO3Language()),
                 request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
         }
     }

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -304,7 +304,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
                 context.getBean(DataManager.class).increasePopularity(context, String.valueOf(metadata.getId()));
             }
             writeOutResponse(context, metadataUuid,
-                isoLanguagesMapper.iso639_2B_to_iso639_2T(locale.getISO3Language()),
+                isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language()),
                 request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
         }
     }

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
@@ -299,9 +299,9 @@ public class SchemaLocalizations {
             return null;
         }
         List<IsoLanguage> lang;
-        if (value.equals("deu")) {
-            value = "ger";
-        }
+
+        // ensure the code is in iso-639-2/B
+        value = IsoLanguagesMapper.iso639_2T_to_iso639_2B(value);
 
         if (value.length() == 2) {
             lang = this.languageRepo.findAllByShortCode(value.toLowerCase());

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
@@ -25,6 +25,8 @@ package org.fao.geonet.api.tools.i18n;
 
 import java.util.*;
 
+import org.fao.geonet.languages.IsoLanguagesMapper;
+
 /**
  * Created by francois on 05/02/16.
  */
@@ -52,20 +54,10 @@ public class LanguageUtils {
 //        }
 //    }
 
-    static public String locale2gnCode(String code) {
-        if (code.equals("fra")) {
-            return "fre";
-        } else if (code.equals("slk")) { // transforms ISO 639-2/T into ISO 639-2/B
-            return "slo";
-        } else {
-            return code;
-        }
-    }
-
     public Locale parseAcceptLanguage(final Enumeration<Locale> listOfLocales) {
         while (listOfLocales.hasMoreElements()) {
             Locale l = listOfLocales.nextElement();
-            if (iso3code.contains(locale2gnCode(l.getISO3Language()))) {
+            if (iso3code.contains(IsoLanguagesMapper.iso639_2T_to_iso639_2B(l.getISO3Language()))) {
                 return l;
             }
         }
@@ -74,7 +66,7 @@ public class LanguageUtils {
 
     public String getIso3langCode(Enumeration<Locale> locales) {
         Locale l = parseAcceptLanguage(locales);
-        return locale2gnCode(l.getISO3Language());
+        return IsoLanguagesMapper.iso639_2T_to_iso639_2B(l.getISO3Language());
     }
 
     public Locale parseAcceptLanguage(final Locale locale) {

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
@@ -32,6 +32,7 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -68,6 +69,8 @@ public class TranslationApi implements ApplicationContextAware {
     TranslationsRepository translationsRepository;
     @Autowired
     TranslationPackBuilder translationPackBuilder;
+    @Autowired
+    IsoLanguagesMapper isoLanguagesMapper;
 
     private ApplicationContext context;
 
@@ -134,7 +137,7 @@ public class TranslationApi implements ApplicationContextAware {
         ServletRequest request
     ) throws Exception {
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
-        String language = languageUtils.locale2gnCode(locale.getISO3Language());
+        String language = isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
         List<Translations> translations = translationsRepository.findAllByFieldName(key);
         if(translations.size() == 0) {
             throw new ResourceNotFoundException(String.format(
@@ -157,7 +160,7 @@ public class TranslationApi implements ApplicationContextAware {
         ServletRequest request
     ) throws Exception {
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
-        String language = languageUtils.locale2gnCode(locale.getISO3Language());
+        String language = isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
         return translationPackBuilder.getAllDbTranslations(language);
 
     }
@@ -179,7 +182,7 @@ public class TranslationApi implements ApplicationContextAware {
         ServletRequest request
     ) throws Exception {
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
-        String language = languageUtils.locale2gnCode(locale.getISO3Language());
+        String language = isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
         return translationPackBuilder.getDbTranslation(language, type);
     }
 
@@ -222,7 +225,7 @@ public class TranslationApi implements ApplicationContextAware {
     ) throws Exception {
         final ServiceContext context = ApiUtils.createServiceContext(httpRequest);
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
-        String language = languageUtils.locale2gnCode(locale.getISO3Language());
+        String language = isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
         return translationPackBuilder.getPack(language, pack, context);
     }
 


### PR DESCRIPTION
I had noticed that there were a few cases where languages were being converted from  iso639-2/T iso639-2/B but there were not handling all languages.  Applied a new consistent converted using the nv-i18n library.