### PR TITLE
Pass sortOrder as part of status/search API.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/history/GnHistoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/history/GnHistoryDirective.js
@@ -62,6 +62,7 @@
 
               scope.filter = {
                 types: types,
+                sortOrder: 'DESC',
                 recordFilter: null,
                 from: 0,
                 size: recordByPage
@@ -230,6 +231,7 @@
 
                 scope.filter = {
                   types: types,
+                  sortOrder: 'DESC',
                   ownerFilter: null,
                   authorFilter: null,
                   recordFilter: null,

--- a/web-ui/src/main/resources/catalog/components/history/GnHistoryService.js
+++ b/web-ui/src/main/resources/catalog/components/history/GnHistoryService.js
@@ -59,6 +59,9 @@
               filters.push('type=' + k);
             }
           });
+          if (filter.sortOrder) {
+            filters.push('sortOrder=' + filter.sortOrder);
+          }
           if (filter.authorFilter && filter.authorFilter.id) {
             filters.push('author=' + filter.authorFilter.id);
           }


### PR DESCRIPTION
Due to one of the previous commit to master branch https://github.com/geonetwork/core-geonetwork/pull/5394/files

The issue seems only appears in 3.12 version because the code is only pushed to 3.12 branch (not main).

The issue is if sortOrder are not passed into the API. The API will not return paging mechanism accordingly.

https://github.com/geonetwork/core-geonetwork/blob/56822cadf4ab6f1bf555dccd5c563d8ce19f63ba/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java#L501-L504


So the change in Angular is required.
