### PR TITLE
Remove duplicated org.geotools.xsd:gt-xsd-fes dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -676,11 +676,6 @@
         <version>${geotools.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.geotools.xsd</groupId>
-        <artifactId>gt-xsd-fes</artifactId>
-        <version>${geotools.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.geotools</groupId>
         <artifactId>gt-epsg-extension</artifactId>
         <version>${geotools.version}</version>


### PR DESCRIPTION
Remove duplicated dependency `org.geotools.xsd:gt-xsd-fes` defined in lines https://github.com/geonetwork/core-geonetwork/blob/d1e0483b40a11edbb90fdf26e71c0d37fbb884f5/pom.xml#L631-L635  and https://github.com/geonetwork/core-geonetwork/blob/d1e0483b40a11edbb90fdf26e71c0d37fbb884f5/pom.xml#L678-L682