### PR TITLE
Configure how to extract the WMS layer name from metadata online resources to add them to the map viewer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -78,20 +78,8 @@
       <div data-ng-switch-when="addWMSLayersToMap">
         <h3>{{('ui-' + key) | translate}}</h3>
 
-        <label class="control-label" for="{{key + 'mode'}}">{{('ui-' + key + '-mode') | translate}}</label>
-
-        <select data-ng-model="mCfg[key].mode" class="form-control" id="{{key + 'mode'}}">
-          <option value="url">{{('ui-' + key + '-mode-url') | translate}}</option>
-          <option value="resource-name">{{('ui-' + key + '-mode-resourcename') | translate}}</option>
-        </select>
-
-        <p class="help-block"
-           data-ng-show="(('ui-' + key + '-mode-help') | translate) != ('ui-' + key + '-mode-help')"
-           translate>
-          ui-addWMSLayersToMap-mode-help</p>
-
         <label class="control-label" for="{{key + 'urlLayerParam'}}">{{('ui-' + key + '-urlLayerParam') | translate}}</label>
-       
+
         <input type="text"
                id="{{key + 'urlLayerParam'}}"
                data-ng-disabled="mCfg[key].mode == 'resource-name'"

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -75,6 +75,34 @@
           ui-scoreConfig-help</p>
       </div>
 
+      <div data-ng-switch-when="addWMSLayersToMap">
+        <h3>{{('ui-' + key) | translate}}</h3>
+
+        <label class="control-label" for="{{key + 'mode'}}">{{('ui-' + key + '-mode') | translate}}</label>
+
+        <select model="mCfg[key].mode" class="form-control" id="{{key + 'mode'}}">
+          <option value="url">URL</option>
+          <option value="resource-name">Resource name</option>
+        </select>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-mode-help') | translate) != ('ui-' + key + '-mode-help')"
+           translate>
+          ui-addWMSLayersToMap-mode-help</p>
+
+        <label class="control-label" for="{{key + 'urlLayerParam'}}">{{('ui-' + key + '-urlLayerParam') | translate}}</label>
+
+        <input type="text"
+               id="{{key + 'urlLayerParam'}}"
+               class="form-control"
+               data-ng-model="mCfg[key].urlLayerParam"/>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-urlLayerParam-help') | translate) != ('ui-' + key + '-urlLayerParam-help')"
+           translate>
+          ui-addWMSLayersToMap-urlLayerParam-help</p>
+      </div>
+
       <div data-ng-switch-when="autocompleteConfig">
         <label class="control-label">{{('ui-' + key) | translate}}</label>
         <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -80,9 +80,9 @@
 
         <label class="control-label" for="{{key + 'mode'}}">{{('ui-' + key + '-mode') | translate}}</label>
 
-        <select model="mCfg[key].mode" class="form-control" id="{{key + 'mode'}}">
-          <option value="url">URL</option>
-          <option value="resource-name">Resource name</option>
+        <select data-ng-model="mCfg[key].mode" class="form-control" id="{{key + 'mode'}}">
+          <option value="url">{{('ui-' + key + '-mode-url') | translate}}</option>
+          <option value="resource-name">{{('ui-' + key + '-mode-resourcename') | translate}}</option>
         </select>
 
         <p class="help-block"
@@ -91,9 +91,10 @@
           ui-addWMSLayersToMap-mode-help</p>
 
         <label class="control-label" for="{{key + 'urlLayerParam'}}">{{('ui-' + key + '-urlLayerParam') | translate}}</label>
-
+       
         <input type="text"
                id="{{key + 'urlLayerParam'}}"
+               data-ng-disabled="mCfg[key].mode == 'resource-name'"
                class="form-control"
                data-ng-model="mCfg[key].urlLayerParam"/>
 

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -581,6 +581,10 @@ goog.require('gn_alert');
           },
           'savedSelection': {
             'enabled': false
+          },
+          "addWMSLayersToMap": {
+            "mode": "url", // values: resourceName, url
+            "urlLayerParam": "layers"
           }
         },
         'map': {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -583,7 +583,6 @@ goog.require('gn_alert');
             'enabled': false
           },
           "addWMSLayersToMap": {
-            "mode": "url", // values: resourceName, url
             "urlLayerParam": "layers"
           }
         },

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1489,6 +1489,8 @@
     "logoHeight": "Logo height",
     "ui-addWMSLayersToMap": "Add WMS layers from metadata to the map viewer",
     "ui-addWMSLayersToMap-mode": "Extract the layer name from",
+    "ui-addWMSLayersToMap-mode-url": "Resource URL parameter",
+    "ui-addWMSLayersToMap-mode-resourcename": "Resource name",
     "ui-addWMSLayersToMap-mode-help": "Configure how to extract the layer name to add WMS layers from metadata into the map viewer: using the metadata resource name (default) or from a parameter of the metadata resource url",
     "ui-addWMSLayersToMap-urlLayerParam": "URL parameter with the layer name",
     "ui-addWMSLayersToMap-urlLayerParam-help": "When the WMS layer name is configured in the metadata resource url, configure the url parameter that contains the layer name"

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1486,6 +1486,11 @@
     "styleVariable-gnSearchBackgroundColor": "Backgound color",
     "confirmDeletecategory": "Are you sure you want to delete this category?",
     "ui-mod-page": "Static pages",
-    "logoHeight": "Logo height"
+    "logoHeight": "Logo height",
+    "ui-addWMSLayersToMap": "Add WMS layers from metadata to the map viewer",
+    "ui-addWMSLayersToMap-mode": "Extract the layer name from",
+    "ui-addWMSLayersToMap-mode-help": "Configure how to extract the layer name to add WMS layers from metadata into the map viewer: using the metadata resource name (default) or from a parameter of the metadata resource url",
+    "ui-addWMSLayersToMap-urlLayerParam": "URL parameter with the layer name",
+    "ui-addWMSLayersToMap-urlLayerParam-help": "When the WMS layer name is configured in the metadata resource url, configure the url parameter that contains the layer name"
 }
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1488,11 +1488,7 @@
     "ui-mod-page": "Static pages",
     "logoHeight": "Logo height",
     "ui-addWMSLayersToMap": "Add WMS layers from metadata to the map viewer",
-    "ui-addWMSLayersToMap-mode": "Extract the layer name from",
-    "ui-addWMSLayersToMap-mode-url": "Resource URL parameter",
-    "ui-addWMSLayersToMap-mode-resourcename": "Resource name",
-    "ui-addWMSLayersToMap-mode-help": "Configure how to extract the layer name to add WMS layers from metadata into the map viewer: using the metadata resource name (default) or from a parameter of the metadata resource url",
     "ui-addWMSLayersToMap-urlLayerParam": "URL parameter with the layer name",
-    "ui-addWMSLayersToMap-urlLayerParam-help": "When the WMS layer name is configured in the metadata resource url, configure the url parameter that contains the layer name"
+    "ui-addWMSLayersToMap-urlLayerParam-help": "If the WMS layer name is configured in the metadata resource url, configure the url parameter that contains the layer name."
 }
 

--- a/web-ui/src/main/resources/catalog/views/api/index_debug.html
+++ b/web-ui/src/main/resources/catalog/views/api/index_debug.html
@@ -149,6 +149,10 @@
             "downloads": ["DOWNLOAD"],
             "layers":["OGC"],
             "maps": ["ows"]
+          },
+          "addWMSLayersToMap": {
+            "mode": "resourceName", // values: resourceName, url
+            "urlLayerParam": ""
           }
         },
         "map": {

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -170,7 +170,6 @@
 
       $scope.facetSorter = gnFacetSorter.sortByTranslation;
 
-      $scope.addToMapLayerNameMode = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.mode;
       $scope.addToMapLayerNameUrlParam = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam;
 
       $scope.toggleMap = function () {
@@ -293,7 +292,7 @@
 
           var name;
 
-          if ( $scope.addToMapLayerNameMode == 'url') {
+          if ( $scope.addToMapLayerNameUrlParam !== '') {
             var params = gnUrlUtils.parseKeyValue(
               config.url.split('?')[1]);
             name = params[$scope.addToMapLayerNameUrlParam];

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -131,13 +131,14 @@
     'gnESFacet',
     'gnFacetSorter',
     'gnExternalViewer',
+    'gnUrlUtils',
     function($scope, $location, $filter,
              suggestService, $http, $translate,
              gnUtilityService, gnSearchSettings, gnViewerSettings,
              gnMap, gnMdView, mdView, gnWmsQueue,
              gnSearchLocation, gnOwsContextService,
              hotkeys, gnGlobalSettings, gnESClient,
-             gnESFacet, gnFacetSorter, gnExternalViewer) {
+             gnESFacet, gnFacetSorter, gnExternalViewer, gnUrlUtils) {
 
 
       var viewerMap = gnSearchSettings.viewerMap;
@@ -168,6 +169,9 @@
       $scope.showGNName = gnGlobalSettings.gnCfg.mods.header.showGNName;
 
       $scope.facetSorter = gnFacetSorter.sortByTranslation;
+
+      $scope.addToMapLayerNameMode = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.mode;
+      $scope.addToMapLayerNameUrlParam = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam;
 
       $scope.toggleMap = function () {
         $(searchMap.getTargetElement()).toggle();
@@ -286,7 +290,21 @@
           };
 
           var title = link.title;
-          var name = link.name;
+
+          var name;
+
+          if ( $scope.addToMapLayerNameMode == 'url') {
+            var params = gnUrlUtils.parseKeyValue(
+              config.url.split('?')[1]);
+            name = params[$scope.addToMapLayerNameUrlParam];
+
+            if (angular.isUndefined(name)) {
+              name = link.name;
+            }
+          } else {
+            name = link.name;
+          }
+
           if (angular.isObject(link.title)) {
             title = $filter('gnLocalized')(link.title);
           }


### PR DESCRIPTION
Currently the add to map feature for WMS layers expects the layer name defined in the online resource name of the metadata.  

Sometimes the layer name in the WMS service is not descriptive, like ESRI WMS that uses a number and users encode the layer name as part of the online resource url instead.

Example (`layers` parameter has the layer name):

 https://maps-cartes.ec.gc.ca/arcgis/services/CriticalHabitatAlanticHabitatEnPerilAtlantique/MapServer/WMSServer?request=GetCapabilities&service=WMS&layers=16&legend_format=image/png&feature_info_type=text/html



This PR allows to configure both modes:

- Resource name (default)

![add-wms-layer-resourcename-config](https://user-images.githubusercontent.com/1695003/136502401-1191e4ec-f106-4665-9517-cb9c42dcb8c0.png)

- URL

Should be configured the url parameters with the layer name

![add-wms-layer-url-config](https://user-images.githubusercontent.com/1695003/136502424-20e7f482-26e4-4e1d-8967-b8ef60466088.png)

