### PR TITLE
Don't add ?undefined when the URL doesn't contain any parameter

### DIFF
--- a/web-ui/src/main/resources/catalog/components/UrlUtilsService.js
+++ b/web-ui/src/main/resources/catalog/components/UrlUtilsService.js
@@ -53,7 +53,7 @@
 
         this.remove = function(url, params, ignoreCase) {
           var parts = url.split('?');
-          if (parts.length > 0) {
+          if (parts.length > 1) {
             var qs = '&' + parts[1];
             var flags = (ignoreCase) ? 'gi' : 'g';
             qs = qs.replace(


### PR DESCRIPTION
If the URL doesn't contain any query parameter then just leave it unchanged. This fixes a bug that  was adding `?undefined` to the URL when it didn't have any query parameters.

`String.prototype.split()` method always returns an array with at least one element.  In case the separator isn't found it returns an array with the string itself.
